### PR TITLE
User Entry Unit Test Fix

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-user-entry.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-user-entry.component.spec.ts
@@ -162,8 +162,8 @@ describe('System Administration User Entry Component', () => {
       expect(env.updateButton.nativeElement.textContent).toContain('Update');
       expect(env.title.nativeElement.textContent).toContain('Account details');
       expect(env.component.showActivateDeActivatePanel).toBe(true);
-      expect(env.dateCreated.nativeElement.textContent).toContain('01 January 2019');
-      expect(env.lastLogin.nativeElement.textContent).toContain('01 February 2019');
+      expect(env.dateCreated.nativeElement.textContent).toMatch(new RegExp('.*0(1|2) January 2019'));
+      expect(env.lastLogin.nativeElement.textContent).toMatch(new RegExp('.*0(1|2) February 2019'));
     }));
 
     it('should update user if form is valid', fakeAsync(() => {


### PR DESCRIPTION
- Depending on the timezone of the machine running the tests the actual result my difer from the expected result. Have switched to use a regular expression to cover both options

I realize probably only affects me in NZ but it reports an error everytime I run my tests which is distracting :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2)
<!-- Reviewable:end -->
