### PR TITLE
Update VSCode Extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,11 +2,12 @@
   // See http://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
   "recommendations": [
-    "msjsdiag.debugger-for-chrome",
+    "angular.ng-template",
     "EditorConfig.editorconfig",
-    "eg2.tslint",
     "esbenp.prettier-vscode",
+    "formulahendry.dotnet-test-explorer",
     "ms-vscode.csharp",
-    "formulahendry.dotnet-test-explorer"
+    "ms-vscode.vscode-typescript-tslint-plugin",
+    "msjsdiag.debugger-for-chrome"
   ]
 }


### PR DESCRIPTION
* The eg2.tslint extension by Erich Gamma has been deprecated in favor of the ms-vscode.vscode-typescript-tslint-plugin extension maintained by the official Microsoft VS Code team.
* Add Angular Language Service - checks TS in HTML files, can Ctrl + click on methods, etc, in HMTL files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/53)
<!-- Reviewable:end -->
