### PR TITLE
Ensure use roles see relevant buttons (SF-279)

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -8,7 +8,13 @@
 >
   <div class="question">{{ question.text }}</div>
   <div *ngIf="!answerFormVisible" class="actions">
-    <button *ngIf="!currentUserTotalAnswers" mdc-button primary (click)="showAnswerForm()" id="add-answer">
+    <button
+      *ngIf="!currentUserTotalAnswers && !isAdministrator"
+      mdc-button
+      primary
+      (click)="showAnswerForm()"
+      id="add-answer"
+    >
       Add Answer
     </button>
   </div>
@@ -32,9 +38,9 @@
   </form>
 </div>
 <div class="answers-container">
-  <ng-container *ngIf="!answerFormVisible && currentUserTotalAnswers">
-    <h3>{{ question.answers.length }} Answers</h3>
-    <div class="answer" *ngFor="let answer of question.answers">
+  <ng-container *ngIf="!answerFormVisible && answers.length && (currentUserTotalAnswers || isAdministrator)">
+    <h3>{{ totalAnswersHeading }}</h3>
+    <div class="answer" *ngFor="let answer of answers">
       <div class="like">
         <mdc-icon id="like-answer" (click)="likeAnswer(answer)">thumb_up</mdc-icon
         ><span class="like-count">{{ answer.likes.length }}</span>
@@ -65,6 +71,7 @@
           ></app-checking-owner>
         </div>
         <app-checking-comments
+          [projectCurrentUser]="projectCurrentUser"
           (action)="submitCommentAction($event)"
           [comments]="getComments(answer)"
           [answer]="answer"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -26,6 +26,7 @@
                 (update)="questionUpdated($event)"
                 (changed)="questionChanged($event)"
                 [questions]="questions"
+                [project]="project"
                 [projectCurrentUser]="projectCurrentUser"
               ></app-checking-questions>
             </div>
@@ -82,6 +83,7 @@
               <as-split-area size="0">
                 <div *ngIf="questionsPanel.activeQuestion" id="answer-panel" #answerPanelContainer>
                   <app-checking-answers
+                    [project]="project"
                     [question]="questionsPanel.activeQuestion"
                     [comments]="comments"
                     [projectCurrentUser]="projectCurrentUser"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sfproject-roles.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sfproject-roles.ts
@@ -2,5 +2,6 @@ export { ProjectRole, ProjectRoles } from 'xforge-common/models/project-role';
 
 export enum SFProjectRoles {
   ParatextAdministrator = 'pt_administrator',
-  ParatextTranslator = 'pt_translator'
+  ParatextTranslator = 'pt_translator',
+  Reviewer = 'sf_reviewer'
 }


### PR DESCRIPTION
- Admins can now only delete other users answers and comments
- Admins can no longer answer their own questions
- Admins will always see answers without needing their own answer
- Heading for answers changed for users when they don't have access to view all user answers
- Only admins will see unread answers/comment notification in the questions panel
- Users can now only see their answers when project settings are set to not allow answers visible to everyone

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/58)
<!-- Reviewable:end -->
