### PR TITLE
SF-341 Mark control as touched+dirty after chooser, to show messages

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -172,6 +172,31 @@ describe('QuestionDialogComponent', () => {
     expect(env.component.scriptureStart.value).toEqual('LUK 1:2');
   }));
 
+  // Needed for validation error messages to appear
+  it('control marked as touched+dirty after reference chooser', fakeAsync(() => {
+    const env = new TestEnvironment();
+    flush();
+    // scriptureStart control starts off untouched+undirty and changes
+    env.component.scriptureStart.setValue('MAT 3:4');
+    expect(env.component.scriptureStart.touched).toBe(false);
+    expect(env.component.scriptureStart.dirty).toBe(false);
+    env.clickElement(env.scriptureStartInputIcon);
+    flush();
+
+    expect(env.component.scriptureStart.touched).toBe(true);
+    expect(env.component.scriptureStart.dirty).toBe(true);
+
+    // scriptureEnd changes the same
+    env.component.scriptureEnd.setValue('MAT 3:4');
+    expect(env.component.scriptureEnd.touched).toBe(false);
+    expect(env.component.scriptureEnd.dirty).toBe(false);
+    env.clickElement(env.scriptureEndInputIcon);
+    flush();
+
+    expect(env.component.scriptureEnd.touched).toBe(true);
+    expect(env.component.scriptureEnd.dirty).toBe(true);
+  }));
+
   it('passes start reference to end-reference chooser', fakeAsync(() => {
     const env = new TestEnvironment();
     flush();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -131,6 +131,8 @@ export class QuestionDialogComponent implements OnInit {
     const dialogRef = this.dialog.open(ScriptureChooserDialogComponent, dialogConfig);
     dialogRef.afterClosed().subscribe((result: VerseRefData) => {
       if (result !== 'close') {
+        control.markAsTouched();
+        control.markAsDirty();
         control.setValue(QuestionDialogComponent.verseRefDataToString(result));
       }
     });


### PR DESCRIPTION
For the validation error messages to appear.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/84)
<!-- Reviewable:end -->
