### PR TITLE
SF-64 Fix PT login auth access cancel

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -103,17 +103,17 @@ export class AuthService {
   }
 
   private async tryLogIn(): Promise<boolean> {
-    let authResult = await this.parseHash();
-    if (!(await this.handleAuth(authResult))) {
-      this.clearState();
-      try {
+    try {
+      let authResult = await this.parseHash();
+      if (!(await this.handleAuth(authResult))) {
+        this.clearState();
         authResult = await this.checkSession();
         if (!(await this.handleAuth(authResult))) {
           return false;
         }
-      } catch (err) {
-        return false;
       }
+    } catch (err) {
+      return false;
     }
     return true;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
+import { NoticeService } from 'xforge-common/notice.service';
 import { ErrorComponent } from './error.component';
 
 describe('ErrorComponent', () => {
@@ -26,13 +27,17 @@ class TestEnvironment {
   component: ErrorComponent;
 
   mockedActivatedRoute: ActivatedRoute = mock(ActivatedRoute);
+  mockedNoticeService: NoticeService = mock(NoticeService);
 
   constructor() {
     when(this.mockedActivatedRoute.queryParams).thenReturn(
       of({ stack: 'Some made up component', errorCode: 'Error: 404: Not found' })
     );
     TestBed.configureTestingModule({
-      providers: [{ provide: ActivatedRoute, useFactory: () => instance(this.mockedActivatedRoute) }],
+      providers: [
+        { provide: ActivatedRoute, useFactory: () => instance(this.mockedActivatedRoute) },
+        { provide: NoticeService, useFactory: () => instance(this.mockedNoticeService) }
+      ],
       declarations: [ErrorComponent]
     });
     this.fixture = TestBed.createComponent(ErrorComponent);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { first } from 'rxjs/operators';
+import { NoticeService } from 'xforge-common/notice.service';
 
 @Component({
   selector: 'app-error',
@@ -12,10 +13,11 @@ export class ErrorComponent implements OnInit {
   errorCode: string = 'Error: No error code';
   showDetails: boolean = false;
 
-  constructor(private readonly activatedRoute: ActivatedRoute) {}
+  constructor(private readonly activatedRoute: ActivatedRoute, private readonly noticeService: NoticeService) {}
 
   ngOnInit() {
     this.activatedRoute.queryParams.pipe(first()).subscribe(params => {
+      this.noticeService.loadingFinished();
       this.stack = params['stack'];
       if (params['errorCode']) {
         this.errorCode = params['errorCode'];


### PR DESCRIPTION
* when logging in with Paratext, if the authorize app page is cancelled it now returns to the login
* also fixed error page still showing the loading bar

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/90)
<!-- Reviewable:end -->
