### PR TITLE
SF-345 Implement specific person sharing

### DIFF
--- a/src/SIL.XForge/AssemblyInfo.cs
+++ b/src/SIL.XForge/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SIL.XForge.Tests")]

--- a/src/SIL.XForge/Models/ProjectEntity.cs
+++ b/src/SIL.XForge/Models/ProjectEntity.cs
@@ -15,6 +15,8 @@ namespace SIL.XForge.Models
         public abstract ProjectRoles Roles { get; }
         public bool ShareEnabled { get; set; } = true;
         public string ShareLevel { get; set; } = SharingLevel.Specific;
+        /// <summary>Outstanding project access shares to specific people, represented by an email address and code pair.</summary>
+        public Dictionary<string, string> ShareKeys { get; set; } = new Dictionary<string, string>();
 
 
         public bool TryGetRole(string userId, out string role)

--- a/src/SIL.XForge/Utils/ISecurityUtils.cs
+++ b/src/SIL.XForge/Utils/ISecurityUtils.cs
@@ -1,0 +1,7 @@
+namespace SIL.XForge.Utils
+{
+    public interface ISecurityUtils
+    {
+        string GenerateKey();
+    }
+}

--- a/src/SIL.XForge/Utils/SecurityUtils.cs
+++ b/src/SIL.XForge/Utils/SecurityUtils.cs
@@ -1,0 +1,28 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace SIL.XForge.Utils
+{
+    /// <summary>Security related utilities</summary>
+    public class SecurityUtils : ISecurityUtils
+    {
+        /// <summary>Return a random 16-character base-36 string.</summary>
+        public string GenerateKey()
+        {
+            char[] chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890".ToCharArray();
+            byte[] data = new byte[1];
+            using (var crypto = new RNGCryptoServiceProvider())
+            {
+                crypto.GetNonZeroBytes(data);
+                data = new byte[16];
+                crypto.GetNonZeroBytes(data);
+            }
+            var key = new StringBuilder(16);
+            foreach (byte b in data)
+            {
+                key.Append(chars[b % (chars.Length)]);
+            }
+            return key.ToString();
+        }
+    }
+}

--- a/test/SIL.XForge.Tests/Controllers/ProjectsRpcControllerTests.cs
+++ b/test/SIL.XForge.Tests/Controllers/ProjectsRpcControllerTests.cs
@@ -1,8 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Options;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using NUnit.Framework;
 using EdjCase.JsonRpc.Core;
@@ -11,6 +12,7 @@ using SIL.XForge.Configuration;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
 using SIL.XForge.Services;
+using SIL.XForge.Utils;
 
 namespace SIL.XForge.Controllers
 {
@@ -22,6 +24,7 @@ namespace SIL.XForge.Controllers
         private const string Project03 = "project03";
         private const string User01 = "user01";
         private const string User02 = "user02";
+        private const string User03 = "user03";
 
         [Test]
         public async Task Invite_ProjectAdminSharingDisabled_UserInvited()
@@ -32,6 +35,58 @@ namespace SIL.XForge.Controllers
             const string email = "newuser@example.com";
             RpcMethodSuccessResult result = await env.Controller.Invite(email) as RpcMethodSuccessResult;
             Assert.That(result, Is.Not.Null);
+            await env.EmailService.Received().SendEmailAsync(Arg.Is(email), Arg.Any<string>(),
+                Arg.Is<string>(body => body.Contains($"http://localhost/projects/{Project01}?sharing=true&shareKey=1234abc")
+                && body.Contains("link will only work for this email address")));
+        }
+
+        [Test]
+        public async Task Invite_SpecificSharingEnabled_UserInvited()
+        {
+            var env = new TestEnvironment();
+            env.SetUser(User01, SystemRoles.User);
+            env.SetProject(Project03);
+            const string email = "newuser@example.com";
+            RpcMethodSuccessResult result = await env.Controller.Invite(email) as RpcMethodSuccessResult;
+            Assert.That(result, Is.Not.Null);
+            await env.EmailService.Received().SendEmailAsync(Arg.Is(email), Arg.Any<string>(),
+                Arg.Is<string>(body => body.Contains($"http://localhost/projects/{Project03}?sharing=true&shareKey=1234abc")
+                && body.Contains("link will only work for this email address")));
+
+            // Code was recorded in database
+            var project = env.Projects.Get(Project03);
+            Assert.That(project.ShareKeys.ContainsValue("1234abc"));
+            Assert.That(project.ShareKeys[email], Is.EqualTo("1234abc"));
+        }
+
+        [Test]
+        public async Task Invite_SpecificSharingEnabled_UserInvitedTwiceButWithSameCode()
+        {
+            var env = new TestEnvironment();
+            env.SetUser(User01, SystemRoles.User);
+            env.SetProject(Project03);
+            const string email = "newuser@example.com";
+
+            var project = env.Projects.Get(Project03);
+            Assert.That(project.ShareKeys.ContainsKey(email), Is.False, "setup");
+
+            env.SecurityUtils.GenerateKey().Returns("1111", "3333");
+            RpcMethodSuccessResult result = await env.Controller.Invite(email) as RpcMethodSuccessResult;
+            Assert.That(result, Is.Not.Null);
+            await env.EmailService.Received().SendEmailAsync(Arg.Is(email), Arg.Any<string>(),
+                Arg.Is<string>(body => body.Contains($"http://localhost/projects/{Project03}?sharing=true&shareKey=1111")));
+
+            // Code was recorded in database
+            project = env.Projects.Get(Project03);
+            Assert.That(project.ShareKeys.ContainsKey(email), Is.True);
+
+            result = await env.Controller.Invite(email) as RpcMethodSuccessResult;
+            Assert.That(result, Is.Not.Null);
+            // Invitation email was sent again, but with first code
+            await env.EmailService.Received().SendEmailAsync(Arg.Is(email), Arg.Any<string>(),
+                Arg.Is<string>(body => body.Contains($"http://localhost/projects/{Project03}?sharing=true&shareKey=1111")));
+
+            Assert.That(project.ShareKeys[email], Is.EqualTo("1111"), "Code should not have been changed");
         }
 
         [Test]
@@ -44,7 +99,8 @@ namespace SIL.XForge.Controllers
             RpcMethodSuccessResult result = await env.Controller.Invite(email) as RpcMethodSuccessResult;
             Assert.That(result, Is.Not.Null);
             await env.EmailService.Received().SendEmailAsync(Arg.Is(email), Arg.Any<string>(),
-                Arg.Is<string>(body => body.Contains($"http://localhost/projects/{Project02}?sharing=true")));
+                Arg.Is<string>(body => body.Contains($"http://localhost/projects/{Project02}?sharing=true")
+                && body.Contains("link can be shared with others")));
         }
 
         [Test]
@@ -57,14 +113,38 @@ namespace SIL.XForge.Controllers
             RpcMethodErrorResult result = await env.Controller.Invite(email) as RpcMethodErrorResult;
             Assert.That(result.ErrorCode, Is.EqualTo((int)RpcErrorCode.InvalidRequest),
                 "The user should be forbidden from inviting other users");
+            await env.EmailService.DidNotReceiveWithAnyArgs().SendEmailAsync(default, default, default);
         }
+
+        [Test]
+        public async Task Invite_SpecificSharingEnabled_ProjectUserNotInvited()
+        {
+            var env = new TestEnvironment();
+            env.SetUser(User01, SystemRoles.User);
+            env.SetProject(Project03);
+            const string email = "user01@example.com";
+            var project = env.Projects.Get(Project03);
+
+            Assert.That(project.Users.Any(pu => pu.UserRef == User01), Is.True, "setup - user should already be a project user");
+
+            var result = await env.Controller.Invite(email) as RpcMethodSuccessResult;
+            Assert.That(result, Is.Not.Null);
+            project = env.Projects.Get(Project03);
+            Assert.That(project.Users.Any(pu => pu.UserRef == User01), Is.True, "user should still be a project user");
+
+            Assert.That(project.ShareKeys.ContainsKey(email), Is.False, "no sharekey should have been added");
+
+            // Email should not have been sent
+            await env.EmailService.DidNotReceiveWithAnyArgs().SendEmailAsync(default, default, default);
+        }
+
 
         [Test]
         public async Task CheckLinkSharing_LinkSharingDisabled_ForbiddenError()
         {
             var env = new TestEnvironment();
             env.SetUser(User02, SystemRoles.User);
-            env.SetProject(Project03);
+            env.SetProject(Project01);
             RpcMethodErrorResult result = await env.Controller.CheckLinkSharing() as RpcMethodErrorResult;
             Assert.That(result.ErrorCode, Is.EqualTo((int)RpcErrorCode.InvalidRequest),
                 "The user should be forbidden to join the project");
@@ -76,19 +156,77 @@ namespace SIL.XForge.Controllers
             var env = new TestEnvironment();
             env.SetUser(User02, SystemRoles.User);
             env.SetProject(Project02);
+            var project = env.Projects.Get(Project02);
+            Assert.That(project.Users.Any(pu => pu.UserRef == User02), Is.False, "setup");
             RpcMethodSuccessResult result = await env.Controller.CheckLinkSharing() as RpcMethodSuccessResult;
             Assert.That(result, Is.Not.Null);
-            TestProjectEntity project = env.Projects.Get(Project02);
+            project = env.Projects.Get(Project02);
             Assert.That(project.Users.Any(pu => pu.UserRef == User02), Is.True);
+        }
+
+        [Test]
+        public async Task CheckLinkSharing_SpecificSharingUnexpectedEmail_ForbiddenError()
+        {
+            var env = new TestEnvironment();
+            env.SetUser(User03, SystemRoles.User);
+            env.SetProject(Project03);
+            var project = env.Projects.Get(Project03);
+
+            Assert.That(project.Users.Any(pu => pu.UserRef == User03), Is.False, "setup");
+            Assert.That(project.ShareKeys.ContainsKey("user03@example.com"), Is.False, "setup");
+
+            RpcMethodErrorResult result = await env.Controller.CheckLinkSharing("somecode") as RpcMethodErrorResult;
+            Assert.That(result.ErrorCode, Is.EqualTo((int)RpcErrorCode.InvalidRequest),
+                "The user should be forbidden to join the project: Email address was not in ShareKeys list.");
+        }
+
+        [Test]
+        public async Task CheckLinkSharing_SpecificSharingAndWrongCode_ForbiddenError()
+        {
+            var env = new TestEnvironment();
+            env.SetUser(User02, SystemRoles.User);
+            env.SetProject(Project03);
+            var project = env.Projects.Get(Project03);
+
+            Assert.That(project.Users.Any(pu => pu.UserRef == User02), Is.False, "setup");
+            Assert.That(project.ShareKeys.ContainsKey("user02@example.com"), Is.True, "setup");
+
+            RpcMethodErrorResult result = await env.Controller.CheckLinkSharing("badcode") as RpcMethodErrorResult;
+            Assert.That(result.ErrorCode, Is.EqualTo((int)RpcErrorCode.InvalidRequest),
+                "The user should be forbidden to join the project: Email address was in ShareKeys list, but wrong code was given.");
+        }
+
+        [Test]
+        public async Task CheckLinkSharing_SpecificSharingAndRightKey_UserJoined()
+        {
+            var env = new TestEnvironment();
+            env.SetUser(User02, SystemRoles.User);
+            env.SetProject(Project03);
+            var project = env.Projects.Get(Project03);
+
+            Assert.That(project.Users.Any(pu => pu.UserRef == User02), Is.False, "setup");
+            Assert.That(project.ShareKeys.ContainsValue("key1234"), Is.True, "setup");
+            Assert.That(project.ShareKeys.Count, Is.EqualTo(3), "setup");
+
+            RpcMethodSuccessResult result = await env.Controller.CheckLinkSharing("key1234") as RpcMethodSuccessResult;
+
+            Assert.That(result, Is.Not.Null);
+            project = env.Projects.Get(Project03);
+            Assert.That(project.Users.Any(pu => pu.UserRef == User02), Is.True, "User should have been added to project");
+            Assert.That(project.ShareKeys.ContainsValue("key1234"), Is.False, "Code should have been removed from project");
         }
 
         private class TestEnvironment
         {
+            public ISecurityUtils SecurityUtils { get; }
             public TestEnvironment(bool isResetLinkExpired = false)
             {
                 UserAccessor = Substitute.For<IUserAccessor>();
                 UserAccessor.Name.Returns("User 01");
                 HttpRequestAccessor = Substitute.For<IHttpRequestAccessor>();
+
+                SecurityUtils = Substitute.For<ISecurityUtils>();
+                SecurityUtils.GenerateKey().Returns("1234abc");
 
                 Projects = new MemoryRepository<TestProjectEntity>(new[]
                 {
@@ -140,7 +278,12 @@ namespace SIL.XForge.Controllers
                             }
                         },
                         ShareEnabled = true,
-                        ShareLevel = SharingLevel.Specific
+                        ShareLevel = SharingLevel.Specific,
+                        ShareKeys = new Dictionary<string, string> {
+                            { "bob@example.com", "key1111" },
+                            { "user02@example.com", "key1234" },
+                            { "bill@example.com", "key2222" }
+                        }
                     }
                 });
 
@@ -148,11 +291,18 @@ namespace SIL.XForge.Controllers
                 {
                     new User
                     {
-                        Id = User01
+                        Id = User01,
+                        Email = "user01@example.com"
                     },
                     new User
                     {
-                        Id = User02
+                        Id = User02,
+                        Email = "user02@example.com"
+                    },
+                    new User
+                    {
+                        Id = User03,
+                        Email = "user03@example.com"
                     }
                 });
                 var options = Substitute.For<IOptions<SiteOptions>>();
@@ -167,6 +317,7 @@ namespace SIL.XForge.Controllers
 
                 Controller = new TestProjectsRpcController(UserAccessor, HttpRequestAccessor, Projects, Users,
                     EmailService, options);
+                Controller.SecurityUtils = SecurityUtils;
             }
 
             public void SetUser(string userId, string role)

--- a/test/SIL.XForge.Tests/Utils/SecurityTests.cs
+++ b/test/SIL.XForge.Tests/Utils/SecurityTests.cs
@@ -1,0 +1,19 @@
+using NUnit.Framework;
+
+namespace SIL.XForge.Utils
+{
+    [TestFixture]
+    public class SecurityTests
+    {
+        [Test]
+        public void GenerateKey_GeneratesDifferentKeys()
+        {
+            var security = new SecurityUtils();
+            var first = security.GenerateKey();
+            var second = security.GenerateKey();
+            Assert.That(first, Is.Not.EqualTo(0), "unlikely");
+            Assert.That(first, Is.Not.EqualTo(second), "unlikely");
+            Assert.That(first.Length, Is.EqualTo(16), "unexpected length");
+        }
+    }
+}


### PR DESCRIPTION
The GenerateKey implementation was duplicated from a prior Security class in this repo's history.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/117)
<!-- Reviewable:end -->
