### PR TITLE
Resolve HelpHero warnings and enable auto-start on every page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -15,6 +15,7 @@ import { UserService } from 'xforge-common/user.service';
 import { nameof } from 'xforge-common/utils';
 import { version } from '../../../version.json';
 import { environment } from '../environments/environment';
+import { HelpHeroService } from './core/help-hero.service.js';
 import { SFProject } from './core/models/sfproject';
 import { SFProjectDataDoc } from './core/models/sfproject-data-doc.js';
 import { canTranslate, SFProjectRoles } from './core/models/sfproject-roles.js';
@@ -54,6 +55,7 @@ export class AppComponent extends SubscriptionDisposable implements OnInit {
     private readonly router: Router,
     private readonly authService: AuthService,
     private readonly locationService: LocationService,
+    private readonly helpHeroService: HelpHeroService,
     private readonly userService: UserService,
     private readonly noticeService: NoticeService,
     media: MediaObserver,
@@ -279,6 +281,8 @@ export class AppComponent extends SubscriptionDisposable implements OnInit {
           }
         }
       );
+      // tell HelpHero to remember this user to make sure we won't show them an identical tour again later
+      this.helpHeroService.setIdentity(this.userService.currentUserId);
     }
     this.noticeService.loadingFinished();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -498,6 +498,9 @@ export class CheckingComponent extends SubscriptionDisposable implements OnInit 
   }
 
   private startUserOnboardingTour() {
+    // tell HelpHero to remember this user to make sure we won't show them the tour again later
+    this.helpHeroService.setIdentity(this.projectCurrentUser.id);
+
     // HelpHero user-onboarding tour setup
     const isProjectAdmin: boolean = this.projectCurrentUser.role === SFProjectRoles.ParatextAdministrator;
     const isDiscussionEnabled: boolean = this.project.usersSeeEachOthersResponses;
@@ -508,9 +511,6 @@ export class CheckingComponent extends SubscriptionDisposable implements OnInit 
       discussionEnabled: isDiscussionEnabled,
       invitingEnabled: isInvitingEnabled
     });
-
-    // tell HelpHero to remember this user to make sure we won't show them the tour again later
-    this.helpHeroService.setIdentity(this.projectCurrentUser.id);
 
     // start the Community Checking tour
     if (isProjectAdmin) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -611,15 +611,15 @@ export class EditorComponent extends SubscriptionDisposable implements OnInit, O
   }
 
   private startUserOnboardingTour() {
+    // tell HelpHero to remember this user to make sure we won't show them the tour again later
+    this.helpHeroService.setIdentity(this.projectUser.id);
+
     // HelpHero user-onboarding tour setup
     const isProjectAdmin: boolean = this.projectUser.role === SFProjectRoles.ParatextAdministrator;
 
     this.helpHeroService.setProperty({
       isAdmin: isProjectAdmin
     });
-
-    // tell HelpHero to remember this user to make sure we won't show them the tour again later
-    this.helpHeroService.setIdentity(this.projectUser.id);
 
     // Start the Translate tour
     if (isProjectAdmin) {


### PR DESCRIPTION
# Overview
- Add HelpHeroService to AppComponent to allow tours to auto-start on any page
- Resolves the following wrong-order warnings:
![Screenshot from 2019-07-17 14-55-19](https://user-images.githubusercontent.com/10179226/61358064-b74e2c00-a8a3-11e9-9e5c-24cb1595511f.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/120)
<!-- Reviewable:end -->

