### PR TITLE
Fix SF-381 (Clean up tour triggers)

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -498,9 +498,6 @@ export class CheckingComponent extends SubscriptionDisposable implements OnInit 
   }
 
   private startUserOnboardingTour() {
-    // tell HelpHero to remember this user to make sure we won't show them the tour again later
-    this.helpHeroService.setIdentity(this.projectCurrentUser.id);
-
     // HelpHero user-onboarding tour setup
     const isProjectAdmin: boolean = this.projectCurrentUser.role === SFProjectRoles.ParatextAdministrator;
     const isDiscussionEnabled: boolean = this.project.usersSeeEachOthersResponses;
@@ -508,37 +505,8 @@ export class CheckingComponent extends SubscriptionDisposable implements OnInit 
 
     this.helpHeroService.setProperty({
       isAdmin: isProjectAdmin,
-      discussionEnabled: isDiscussionEnabled,
-      invitingEnabled: isInvitingEnabled
+      isDiscussionEnabled,
+      isInvitingEnabled
     });
-
-    // start the Community Checking tour
-    if (isProjectAdmin) {
-      // start Admin tour
-      this.helpHeroService.startTour('sLbG6FRjjVo', { skipIfAlreadySeen: true });
-    } else if (isDiscussionEnabled) {
-      // start Reviewer tour w/ discussion
-      this.helpHeroService.startTour('39HmnsRplaw', { skipIfAlreadySeen: true });
-      this.helpHeroService.on('tour_completed', () => {
-        if (isInvitingEnabled) {
-          // run invite section of the tour
-          this.helpHeroService.startTour('MexTla8sdju', { skipIfAlreadySeen: true });
-          this.helpHeroService.on('tour_completed', () => {
-            // show end of Reviewer tour
-            this.helpHeroService.startTour('dUubb24GYZs', { skipIfAlreadySeen: true });
-          });
-        } else {
-          // show end of Reviewer tour
-          this.helpHeroService.startTour('dUubb24GYZs', { skipIfAlreadySeen: true });
-        }
-      });
-    } else {
-      // start Reviewer tour (w/o discussion)
-      this.helpHeroService.startTour('1ikmHlDXktB', { skipIfAlreadySeen: true });
-      this.helpHeroService.on('tour_completed', () => {
-        // show end of Reviewer tour
-        this.helpHeroService.startTour('dUubb24GYZs', { skipIfAlreadySeen: true });
-      });
-    }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -611,21 +611,11 @@ export class EditorComponent extends SubscriptionDisposable implements OnInit, O
   }
 
   private startUserOnboardingTour() {
-    // tell HelpHero to remember this user to make sure we won't show them the tour again later
-    this.helpHeroService.setIdentity(this.projectUser.id);
-
     // HelpHero user-onboarding tour setup
     const isProjectAdmin: boolean = this.projectUser.role === SFProjectRoles.ParatextAdministrator;
 
     this.helpHeroService.setProperty({
       isAdmin: isProjectAdmin
     });
-
-    // Start the Translate tour
-    if (isProjectAdmin) {
-      this.helpHeroService.startTour('YjhplnLK8XH', { skipIfAlreadySeen: true }); // start Admin tour
-    } else {
-      this.helpHeroService.startTour('EbFyorsmloj', { skipIfAlreadySeen: true }); // start Translator tour
-    }
   }
 }


### PR DESCRIPTION
# Overview
This PR addresses the following error message:
![Screenshot from 2019-07-17 15-13-59](https://user-images.githubusercontent.com/10179226/61367542-0ac97580-a8b6-11e9-8ce7-267da369365d.png)

Since HelpHero added a "skip" funnel feature, we don't need all of this manual flow-control, and so I deleted it. It seems like manually triggering tours causes this error, so I am switching to have HelpHero auto-start tours.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/121)
<!-- Reviewable:end -->
