### PR TITLE
SF-345

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
@@ -109,6 +109,16 @@ describe('ProjectComponent', () => {
     verify(env.mockedRouter.navigate(deepEqual(['./', 'translate', 'text02']), anything())).once();
     expect().nothing();
   }));
+
+  it('check sharing link passes shareKey', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.setProjectData({ selectedTask: 'translate' });
+    env.setLinkSharing(true, 'secret123');
+    env.fixture.detectChanges();
+    tick();
+
+    verify(env.mockedSFProjectService.onlineCheckLinkSharing('project01', 'secret123')).once();
+  }));
 });
 
 class TestEnvironment {
@@ -128,6 +138,7 @@ class TestEnvironment {
     when(this.mockedActivatedRoute.snapshot).thenReturn(snapshot);
     when(this.mockedUserService.currentUserId).thenReturn('user01');
     when(this.mockedSFProjectService.onlineCheckLinkSharing('project01')).thenResolve();
+    when(this.mockedSFProjectService.onlineCheckLinkSharing('project01', anything())).thenResolve();
     this.setLinkSharing(false);
 
     TestBed.configureTestingModule({
@@ -221,9 +232,9 @@ class TestEnvironment {
     this.setProjectDataDoc();
   }
 
-  setLinkSharing(enabled: boolean): void {
+  setLinkSharing(enabled: boolean, shareKey?: string): void {
     const snapshot = new ActivatedRouteSnapshot();
-    snapshot.queryParams = { sharing: enabled ? 'true' : undefined };
+    snapshot.queryParams = { sharing: enabled ? 'true' : undefined, shareKey: shareKey ? shareKey : undefined };
     when(this.mockedActivatedRoute.snapshot).thenReturn(snapshot);
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
@@ -35,7 +35,14 @@ export class ProjectComponent extends SubscriptionDisposable implements OnInit {
           // if the link has sharing turned on, check if the current user needs to be added to the project
           const sharing = this.route.snapshot.queryParams['sharing'] as string;
           if (sharing === 'true') {
-            return from(this.projectService.onlineCheckLinkSharing(projectId)).pipe(map(() => projectId));
+            const shareKey = this.route.snapshot.queryParams['shareKey'] as string;
+            let linkSharing: Promise<void>;
+            if (!!shareKey) {
+              linkSharing = this.projectService.onlineCheckLinkSharing(projectId, shareKey);
+            } else {
+              linkSharing = this.projectService.onlineCheckLinkSharing(projectId);
+            }
+            return from(linkSharing).pipe(map(() => projectId));
           } else {
             return of(projectId);
           }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/project.service.ts
@@ -68,8 +68,9 @@ export abstract class ProjectService<T extends Project = Project> extends Resour
     return this.jsonApiService.onlineInvoke(this.identity(id), 'invite', { email });
   }
 
-  onlineCheckLinkSharing(id: string): Promise<void> {
-    return this.jsonApiService.onlineInvoke(this.identity(id), 'checkLinkSharing');
+  /** Get added into project, with optionally specified shareKey code. */
+  onlineCheckLinkSharing(id: string, shareKey?: string): Promise<void> {
+    return this.jsonApiService.onlineInvoke(this.identity(id), 'checkLinkSharing', { shareKey });
   }
 
   onlineGet(id: string, include?: string[][]): QueryObservable<T> {


### PR DESCRIPTION
To not accidentally store it using the wrong structure.

For example, object name "bob@example.com" with value "1234" should
not accidentally be stored as

"bob@example": {
    "com": "1234"
}

Replacing the dot in the object name helps our library store it at the
intended level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/132)
<!-- Reviewable:end -->
