### PR TITLE
Refactor Unit Tests

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -1,6 +1,6 @@
 import { MdcDialogRef, MdcList, OverlayContainer } from '@angular-mdc/web';
 import { CommonModule, Location } from '@angular/common';
-import { Component, CUSTOM_ELEMENTS_SCHEMA, DebugElement, NgModule } from '@angular/core';
+import { Component, DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { Route, Router } from '@angular/router';
@@ -10,6 +10,7 @@ import { of } from 'rxjs';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { AccountService } from 'xforge-common/account.service';
 import { AuthService } from 'xforge-common/auth.service';
+import { AvatarTestingModule } from 'xforge-common/avatar/avatar-testing.module';
 import { LocationService } from 'xforge-common/location.service';
 import { User } from 'xforge-common/models/user';
 import { UserDoc } from 'xforge-common/models/user-doc';
@@ -195,7 +196,7 @@ const ROUTES: Route[] = [
 ];
 
 @NgModule({
-  imports: [UICommonModule, CommonModule],
+  imports: [CommonModule, UICommonModule],
   declarations: [ProjectDeletedDialogComponent],
   entryComponents: [ProjectDeletedDialogComponent],
   exports: [ProjectDeletedDialogComponent]
@@ -278,8 +279,7 @@ class TestEnvironment {
 
     TestBed.configureTestingModule({
       declarations: [AppComponent, MockComponent],
-      imports: [UICommonModule, DialogTestModule, RouterTestingModule.withRoutes(ROUTES)],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      imports: [AvatarTestingModule, DialogTestModule, UICommonModule, RouterTestingModule.withRoutes(ROUTES)],
       providers: [
         { provide: AccountService, useFactory: () => instance(this.mockedAccountService) },
         { provide: AuthService, useFactory: () => instance(this.mockedAuthService) },
@@ -370,7 +370,9 @@ class TestEnvironment {
   }
 
   selectProject(projectId: string): void {
-    this.component.projectSelect.setSelectionByValue(projectId);
+    this.fixture.ngZone.run(() => {
+      this.component.projectSelect.setSelectionByValue(projectId);
+    });
     this.wait();
   }
 
@@ -385,7 +387,9 @@ class TestEnvironment {
     if (isLocal) {
       this.currentUserDoc.data.sites.sf.currentProjectId = null;
     }
-    this.project01DocAdapter.delete();
+    this.fixture.ngZone.run(() => {
+      this.project01DocAdapter.delete();
+    });
     this.wait();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-owner/checking-owner.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-owner/checking-owner.component.spec.ts
@@ -4,12 +4,12 @@ import { By } from '@angular/platform-browser';
 import { AvatarService } from 'ngx-avatar';
 import * as OTJson0 from 'ot-json0';
 import { instance, mock, when } from 'ts-mockito';
+import { AvatarTestingModule } from 'xforge-common/avatar/avatar-testing.module';
 import { UserProfileDoc } from 'xforge-common/models/user-profile-doc';
 import { MemoryRealtimeDocAdapter } from 'xforge-common/realtime-doc-adapter';
 import { RealtimeOfflineStore } from 'xforge-common/realtime-offline-store';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
-import { XForgeCommonModule } from 'xforge-common/xforge-common.module';
 import { CheckingOwnerComponent } from './checking-owner.component';
 
 describe('CheckingOwnerComponent', () => {
@@ -88,7 +88,7 @@ class TestEnvironment {
     );
     TestBed.configureTestingModule({
       declarations: [HostComponent, CheckingOwnerComponent],
-      imports: [UICommonModule, XForgeCommonModule],
+      imports: [AvatarTestingModule, UICommonModule],
       providers: [
         { provide: UserService, useFactory: () => instance(this.mockedUserService) },
         { provide: AvatarService, useFactory: () => instance(this.mockedAvatarService) }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-combined/checking-audio-combined.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-combined/checking-audio-combined.component.spec.ts
@@ -1,7 +1,6 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-
 import { ngfModule } from 'angular-file';
 import * as OTJson0 from 'ot-json0';
 import { instance, mock, when } from 'ts-mockito';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1,21 +1,29 @@
 import { MdcDialogRef } from '@angular-mdc/web';
-import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ngfModule } from 'angular-file';
 import { AngularSplitModule } from 'angular-split';
 import * as OTJson0 from 'ot-json0';
 import * as RichText from 'rich-text';
 import { of } from 'rxjs';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import { AccountService } from 'xforge-common/account.service';
+import { AvatarTestingModule } from 'xforge-common/avatar/avatar-testing.module';
 import { EditNameDialogComponent } from 'xforge-common/edit-name-dialog/edit-name-dialog.component';
 import { SharingLevel } from 'xforge-common/models/sharing-level';
 import { User } from 'xforge-common/models/user';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { UserProfileDoc } from 'xforge-common/models/user-profile-doc';
+import { ProjectService } from 'xforge-common/project.service';
 import { MemoryRealtimeDocAdapter } from 'xforge-common/realtime-doc-adapter';
 import { RealtimeOfflineStore } from 'xforge-common/realtime-offline-store';
+import { ShareControlComponent } from 'xforge-common/share/share-control.component';
+import { ShareDialogComponent } from 'xforge-common/share/share-dialog.component';
+import { ShareComponent } from 'xforge-common/share/share.component';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
 import { Comment } from '../../core/models/comment';
@@ -35,6 +43,9 @@ import { CheckingAnswersComponent } from './checking-answers/checking-answers.co
 import { CheckingCommentFormComponent } from './checking-answers/checking-comments/checking-comment-form/checking-comment-form.component';
 import { CheckingCommentsComponent } from './checking-answers/checking-comments/checking-comments.component';
 import { CheckingOwnerComponent } from './checking-answers/checking-owner/checking-owner.component';
+import { CheckingAudioCombinedComponent } from './checking-audio-combined/checking-audio-combined.component';
+import { AudioTimePipe, CheckingAudioPlayerComponent } from './checking-audio-player/checking-audio-player.component';
+import { CheckingAudioRecorderComponent } from './checking-audio-recorder/checking-audio-recorder.component';
 import { CheckingQuestionsComponent } from './checking-questions/checking-questions.component';
 import { CheckingTextComponent } from './checking-text/checking-text.component';
 import { CheckingComponent } from './checking.component';
@@ -388,11 +399,12 @@ class TestEnvironment {
   fixture: ComponentFixture<CheckingComponent>;
   questionReadTimer: number = 2000;
 
-  mockedCheckingNameDialogRef: MdcDialogRef<EditNameDialogComponent>;
-  mockedAccountService: AccountService;
-  mockedRealtimeOfflineStore: RealtimeOfflineStore;
-  mockedUserService: UserService;
-  mockedProjectService: SFProjectService;
+  readonly mockedCheckingNameDialogRef: MdcDialogRef<EditNameDialogComponent> = mock(MdcDialogRef);
+  readonly mockedAccountService = mock(AccountService);
+  readonly mockedRealtimeOfflineStore = mock(RealtimeOfflineStore);
+  readonly mockedUserService = mock(UserService);
+  readonly mockedProjectService = mock(SFProjectService);
+
   adminUser = this.createUser('01', SFProjectRoles.ParatextAdministrator);
   reviewerUser = this.createUser('02', SFProjectRoles.Reviewer);
   cleanReviewUser = this.createUser('03', SFProjectRoles.Reviewer, false);
@@ -440,25 +452,33 @@ class TestEnvironment {
   };
 
   constructor() {
-    this.mockedCheckingNameDialogRef = mock(MdcDialogRef);
-    this.mockedAccountService = mock(AccountService);
-    this.mockedRealtimeOfflineStore = mock(RealtimeOfflineStore);
-    this.mockedUserService = mock(UserService);
-    this.mockedProjectService = mock(SFProjectService);
-
     TestBed.configureTestingModule({
       declarations: [
+        AudioTimePipe,
         CheckingAnswersComponent,
+        CheckingAudioCombinedComponent,
+        CheckingAudioPlayerComponent,
+        CheckingAudioRecorderComponent,
         CheckingCommentFormComponent,
         CheckingCommentsComponent,
         CheckingComponent,
         CheckingOwnerComponent,
         CheckingQuestionsComponent,
         CheckingTextComponent,
-        FontSizeComponent
+        FontSizeComponent,
+        ShareComponent,
+        ShareControlComponent,
+        ShareDialogComponent
       ],
-      schemas: [NO_ERRORS_SCHEMA],
-      imports: [UICommonModule, AngularSplitModule.forRoot(), SharedModule],
+      imports: [
+        AngularSplitModule.forRoot(),
+        ngfModule,
+        NoopAnimationsModule,
+        RouterTestingModule,
+        AvatarTestingModule,
+        SharedModule,
+        UICommonModule
+      ],
       providers: [
         {
           provide: ActivatedRoute,
@@ -466,6 +486,7 @@ class TestEnvironment {
         },
         { provide: AccountService, useFactory: () => instance(this.mockedAccountService) },
         { provide: UserService, useFactory: () => instance(this.mockedUserService) },
+        { provide: ProjectService, useFactory: () => instance(this.mockedProjectService) },
         { provide: SFProjectService, useFactory: () => instance(this.mockedProjectService) }
       ]
     });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -1,9 +1,10 @@
 import { OverlayContainer } from '@angular-mdc/web';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { DebugElement, NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
+import { DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import * as OTJson0 from 'ot-json0';
 import { BehaviorSubject, of } from 'rxjs';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
@@ -17,7 +18,7 @@ import { MemoryRealtimeDocAdapter } from 'xforge-common/realtime-doc-adapter';
 import { RealtimeOfflineStore } from 'xforge-common/realtime-offline-store';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
-import { XForgeCommonModule } from 'xforge-common/xforge-common.module';
+import { WriteStatusComponent } from 'xforge-common/write-status/write-status.component';
 import { SFProject } from '../core/models/sfproject';
 import { SFProjectDoc } from '../core/models/sfproject-doc';
 import { SFProjectService } from '../core/sfproject.service';
@@ -386,8 +387,8 @@ class TestEnvironment {
     );
     when(this.mockedUserService.getCurrentUser()).thenResolve(this.currentUserDoc);
     TestBed.configureTestingModule({
-      imports: [DialogTestModule, HttpClientTestingModule, UICommonModule, XForgeCommonModule],
-      declarations: [SettingsComponent],
+      imports: [DialogTestModule, HttpClientTestingModule, RouterTestingModule, UICommonModule],
+      declarations: [SettingsComponent, WriteStatusComponent],
       providers: [
         { provide: ActivatedRoute, useFactory: () => instance(this.mockedActivatedRoute) },
         { provide: AuthService, useFactory: () => instance(this.mockedAuthService) },
@@ -395,10 +396,7 @@ class TestEnvironment {
         { provide: ParatextService, useFactory: () => instance(this.mockedParatextService) },
         { provide: SFProjectService, useFactory: () => instance(this.mockedSFProjectService) },
         { provide: UserService, useFactory: () => instance(this.mockedUserService) }
-      ],
-      // The RouterTestingModule is needed to test routerLink in the html, but this is causing an
-      // error with RouterLinkWithHref, so this allows us to skip using the RouterTestingModule.
-      schemas: [NO_ERRORS_SCHEMA]
+      ]
     });
     this.fixture = TestBed.createComponent(SettingsComponent);
     this.component = this.fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
@@ -19,11 +19,11 @@
     </div>
     <mdc-list-divider></mdc-list-divider>
     <mdc-list *ngIf="texts != null" twoLine [interactive]="false">
-      <mdc-list-item *ngFor="let textProgress of texts">
+      <mdc-list-item *ngFor="let textProgress of texts" [routerLink]="['./', textProgress.text.bookId]">
         <mdc-icon mdcListItemGraphic>book</mdc-icon>
-        <mdc-list-item-text [secondaryText]="textProgress.translated + ' of ' + textProgress.total + ' segments'"
-          ><a [routerLink]="['./', textProgress.text.bookId]">{{ textProgress.text.name }}</a></mdc-list-item-text
-        >
+        <mdc-list-item-text [secondaryText]="textProgress.translated + ' of ' + textProgress.total + ' segments'">{{
+          textProgress.text.name
+        }}</mdc-list-item-text>
         <div class="progress" mdcListItemMeta [title]="textProgress.percentage + '%'">
           <canvas
             baseChart

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
@@ -17,13 +17,15 @@ mdc-card {
     padding: 8px 16px;
   }
 
-  a {
-    color: black;
-  }
-
   mdc-list {
     @include mdc-list-item-graphic-ink-color(rgba(0, 0, 0, 0.6));
     overflow-y: auto;
+    mdc-list-item {
+      cursor: pointer;
+      &:hover {
+        background-color: lighten($sf_grey, 75%);
+      }
+    }
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
@@ -1,8 +1,9 @@
 import { MdcLinearProgress } from '@angular-mdc/web';
-import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute, Params } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { ProgressStatus, RemoteTranslationEngine } from '@sillsdev/machine';
 import * as OTJson0 from 'ot-json0';
 import * as RichText from 'rich-text';
@@ -95,13 +96,12 @@ class TestEnvironment {
     when(this.mockedRemoteTranslationEngine.listenForTrainingStatus()).thenReturn(defer(() => this.trainingProgress$));
     TestBed.configureTestingModule({
       declarations: [TranslateOverviewComponent],
-      imports: [UICommonModule],
+      imports: [RouterTestingModule, UICommonModule],
       providers: [
         { provide: ActivatedRoute, useFactory: () => instance(this.mockedActivatedRoute) },
         { provide: SFProjectService, useFactory: () => instance(this.mockedSFProjectService) },
         { provide: NoticeService, useFactory: () => instance(this.mockedNoticeService) }
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
+      ]
     });
 
     this.fixture = TestBed.createComponent(TranslateOverviewComponent);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar-testing.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar-testing.component.ts
@@ -5,7 +5,7 @@ import { User } from '../models/user';
   selector: 'app-avatar',
   template: '<img [width]="size" [height]="size" />'
 })
-export class MockAvatarComponent {
+export class AvatarTestingComponent {
   @Input() round: boolean = false;
   @Input() size: number = 32;
   @Input() user: Partial<User>;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar-testing.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar-testing.module.ts
@@ -1,0 +1,8 @@
+import { NgModule } from '@angular/core';
+import { AvatarTestingComponent } from './avatar-testing.component';
+
+@NgModule({
+  declarations: [AvatarTestingComponent],
+  exports: [AvatarTestingComponent]
+})
+export class AvatarTestingModule {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/mock-avatar.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/mock-avatar.module.ts
@@ -1,8 +1,0 @@
-import { NgModule } from '@angular/core';
-import { MockAvatarComponent } from './mock-avatar.component';
-
-@NgModule({
-  declarations: [MockAvatarComponent],
-  exports: [MockAvatarComponent]
-})
-export class MockAvatarModule {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-delete-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-delete-dialog.component.spec.ts
@@ -1,16 +1,9 @@
 import { MdcDialog, MdcDialogConfig, MdcDialogRef } from '@angular-mdc/web';
 import { CommonModule } from '@angular/common';
-import {
-  Component,
-  CUSTOM_ELEMENTS_SCHEMA,
-  DebugElement,
-  Directive,
-  NgModule,
-  ViewChild,
-  ViewContainerRef
-} from '@angular/core';
+import { Component, DebugElement, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { AvatarTestingModule } from '../avatar/avatar-testing.module';
 import { UICommonModule } from '../ui-common.module';
 import { SaDeleteDialogComponent, SaDeleteUserDialogData } from './sa-delete-dialog.component';
 
@@ -52,8 +45,7 @@ class ChildViewContainerComponent {
 }
 
 @NgModule({
-  imports: [CommonModule, UICommonModule],
-  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  imports: [AvatarTestingModule, CommonModule, UICommonModule],
   declarations: [ViewContainerDirective, ChildViewContainerComponent, SaDeleteDialogComponent],
   exports: [ViewContainerDirective, ChildViewContainerComponent, SaDeleteDialogComponent],
   entryComponents: [ChildViewContainerComponent, SaDeleteDialogComponent]

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.spec.ts
@@ -1,6 +1,6 @@
 import { MdcDialog, MdcDialogRef } from '@angular-mdc/web';
 import { OverlayContainer } from '@angular/cdk/overlay';
-import { CUSTOM_ELEMENTS_SCHEMA, DebugElement, getDebugNode, NgModule } from '@angular/core';
+import { DebugElement, getDebugNode, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -9,16 +9,17 @@ import * as OTJson0 from 'ot-json0';
 import { combineLatest, Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
-import { UserDoc } from 'xforge-common/models/user-doc';
-import { NoticeService } from 'xforge-common/notice.service';
-import { RealtimeOfflineStore } from 'xforge-common/realtime-offline-store';
-import { QueryParameters, QueryResults } from 'xforge-common/realtime.service';
 import { environment } from '../../environments/environment';
+import { AvatarTestingModule } from '../avatar/avatar-testing.module';
 import { Project } from '../models/project';
 import { ProjectDoc } from '../models/project-doc';
 import { User } from '../models/user';
+import { UserDoc } from '../models/user-doc';
+import { NoticeService } from '../notice.service';
 import { ProjectService } from '../project.service';
 import { MemoryRealtimeDocAdapter } from '../realtime-doc-adapter';
+import { RealtimeOfflineStore } from '../realtime-offline-store';
+import { QueryParameters, QueryResults } from '../realtime.service';
 import { UICommonModule } from '../ui-common.module';
 import { UserService } from '../user.service';
 import { SaDeleteDialogComponent } from './sa-delete-dialog.component';
@@ -118,8 +119,7 @@ class TestProjectDoc extends ProjectDoc {
 }
 
 @NgModule({
-  imports: [NoopAnimationsModule, UICommonModule],
-  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  imports: [NoopAnimationsModule, AvatarTestingModule, UICommonModule],
   exports: [SaDeleteDialogComponent],
   declarations: [SaDeleteDialogComponent],
   entryComponents: [SaDeleteDialogComponent]
@@ -147,9 +147,8 @@ class TestEnvironment {
   constructor() {
     when(this.mockedMdcDialog.open(anything(), anything())).thenReturn(instance(this.mockedDeleteUserDialogRef));
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, RouterTestingModule, UICommonModule, DialogTestModule],
+      imports: [NoopAnimationsModule, RouterTestingModule, AvatarTestingModule, UICommonModule, DialogTestModule],
       declarations: [SaUsersComponent],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA],
       providers: [
         { provide: MdcDialog, useFactory: () => instance(this.mockedMdcDialog) },
         { provide: NoticeService, useFactory: () => instance(this.mockedNoticeService) },

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/users/collaborators/collaborators.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/users/collaborators/collaborators.component.spec.ts
@@ -10,7 +10,7 @@ import { LocationService } from 'xforge-common/location.service';
 import { ProjectDoc } from 'xforge-common/models/project-doc';
 import { RealtimeOfflineStore } from 'xforge-common/realtime-offline-store';
 import { ShareControlComponent } from 'xforge-common/share/share-control.component';
-import { MockAvatarModule } from '../../avatar/mock-avatar.module';
+import { AvatarTestingModule } from '../../avatar/avatar-testing.module';
 import { Project } from '../../models/project';
 import { NONE_ROLE, ProjectRole } from '../../models/project-role';
 import { User } from '../../models/user';
@@ -143,7 +143,7 @@ class TestEnvironment {
     this.addUserProfile('user03', { name: 'User 03' });
     TestBed.configureTestingModule({
       declarations: [CollaboratorsComponent, ShareControlComponent],
-      imports: [NoopAnimationsModule, MockAvatarModule, UICommonModule],
+      imports: [NoopAnimationsModule, AvatarTestingModule, UICommonModule],
       providers: [
         { provide: ActivatedRoute, useFactory: () => instance(this.mockedActivatedRoute) },
         { provide: LocationService, useFactory: () => instance(this.mockedLocationService) },


### PR DESCRIPTION
* remove NO_ERRORS_SCHEMA
* remove CUSTOM_ELEMENTS_SCHEMA
* remove XForgeCommonModule

Note: NO_ERRORS_SCHEMA and CUSTOM_ELEMENTS_SCHEMA should not be used in tests because it might mask real errors. `XForgeCommonModule` should never be used in tests because it includes the `AvatarComponent` which accesses the internet. Use the `AvatarTestingModule` if needed instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/146)
<!-- Reviewable:end -->
