### PR TITLE
Fix README instructions for clone before Vagrant install

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ Hardware-assisted virtualization (VT-x or AMD-V) needs to be enabled in your BIO
 
 Create a directory to manage the development machine, such as `xforge`. Checkout the xforge git repository to access (and later receive updates to) the vagrant development machine configuration file:
 
-    git clone https://github.com/sillsdev/web-xforge.git
-    cd web-xforge.git/deploy/vagrant_xenial_gui
+    git clone https://github.com/sillsdev/web-xforge
+    cd web-xforge/deploy/vagrant_xenial_gui
 
 Run `vagrant up`. This will download, initialize, and run the development machine. The machine is about 5GB, so expect the download to take a while.
 


### PR DESCRIPTION
Cloning a repo that ends with `.git` results in a directory without `.git` on the end. The instructions for the Vagrant install try to `cd` to `web-xforge.git`, but they should `cd` to `web-xforge`.

I ran into this because I started to try the Vagrant install before I realized bionic was now supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/173)
<!-- Reviewable:end -->
