### PR TITLE
Improve styling of home page footer

### DIFF
--- a/src/SIL.XForge.Scripture/wwwroot/css/sf.css
+++ b/src/SIL.XForge.Scripture/wwwroot/css/sf.css
@@ -205,11 +205,15 @@
   background-color: #005c97;
   padding-left: 8px;
   padding-right: 8px;
-  padding-bottom: 5px;
+  padding-bottom: 1em;
 }
 
 #sil {
   width: 100px;
+}
+
+#icons {
+  padding: 0 1em;
 }
 
 #payap {
@@ -224,6 +228,10 @@
 #sil img {
   width: 100%;
   height: auto;
+}
+
+#copyright, #copyright a {
+  color: white;
 }
 
 @media screen and (max-width: 600px) {


### PR DESCRIPTION
My Paratext account isn't confirmed yet, so I've just been looking for low-hanging fruit on the pages I have access to. The screenshots were taken in responsive design mode to keep them small, but there's no substantial difference in appearance between this and a large screen.

Before | After
-----|-----
![Screen Shot 2019-08-13 at 16 30 43](https://user-images.githubusercontent.com/6140710/62976074-d6c86e00-bde9-11e9-9cf0-5d2e0cb6577c.png) | ![Screen Shot 2019-08-13 at 16 29 05](https://user-images.githubusercontent.com/6140710/62976081-db8d2200-bde9-11e9-8a17-ea16ee9c96f8.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/174)
<!-- Reviewable:end -->
