### PR TITLE
Show relevant question icons within the scripture text panel (SF-154)

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/verse-ref-data.ts
+++ b/src/RealtimeServer/scriptureforge/models/verse-ref-data.ts
@@ -1,33 +1,6 @@
-import { VerseRef } from './scripture/verse-ref';
-
 export interface VerseRefData {
   book?: string;
   chapter?: string;
   verse?: string;
   versification?: string;
-}
-
-export class VerseRefFunctions {
-  static fromData(verseRefData: VerseRefData): VerseRef {
-    let result: string = verseRefData.book ? verseRefData.book : '';
-    result += verseRefData.chapter ? ' ' + verseRefData.chapter : '';
-    result += verseRefData.verse ? ':' + verseRefData.verse : '';
-    return VerseRef.fromStr(result);
-  }
-
-  static verseRefDataToString(verseRefData: VerseRefData): string {
-    let result: string = verseRefData.book ? verseRefData.book : '';
-    result += verseRefData.chapter ? ' ' + verseRefData.chapter : '';
-    result += verseRefData.verse ? ':' + verseRefData.verse : '';
-    return result;
-  }
-
-  static verseRefToVerseRefData(input: VerseRef): VerseRefData {
-    const refData: VerseRefData = {};
-    refData.book = input.book;
-    refData.chapter = input.chapter;
-    refData.verse = input.verse;
-    refData.versification = input.versification.name;
-    return refData;
-  }
 }

--- a/src/RealtimeServer/scriptureforge/models/verse-ref-data.ts
+++ b/src/RealtimeServer/scriptureforge/models/verse-ref-data.ts
@@ -1,6 +1,33 @@
+import { VerseRef } from './scripture/verse-ref';
+
 export interface VerseRefData {
   book?: string;
   chapter?: string;
   verse?: string;
   versification?: string;
+}
+
+export class VerseRefFunctions {
+  static fromData(verseRefData: VerseRefData): VerseRef {
+    let result: string = verseRefData.book ? verseRefData.book : '';
+    result += verseRefData.chapter ? ' ' + verseRefData.chapter : '';
+    result += verseRefData.verse ? ':' + verseRefData.verse : '';
+    return VerseRef.fromStr(result);
+  }
+
+  static verseRefDataToString(verseRefData: VerseRefData): string {
+    let result: string = verseRefData.book ? verseRefData.book : '';
+    result += verseRefData.chapter ? ' ' + verseRefData.chapter : '';
+    result += verseRefData.verse ? ':' + verseRefData.verse : '';
+    return result;
+  }
+
+  static verseRefToVerseRefData(input: VerseRef): VerseRefData {
+    const refData: VerseRefData = {};
+    refData.book = input.book;
+    refData.chapter = input.chapter;
+    refData.verse = input.verse;
+    refData.versification = input.versification.name;
+    return refData;
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -8,7 +8,7 @@ import { Question } from 'realtime-server/lib/scriptureforge/models/question';
 import { SFProject } from 'realtime-server/lib/scriptureforge/models/sf-project';
 import { SFProjectRole } from 'realtime-server/lib/scriptureforge/models/sf-project-role';
 import { TextInfo, TextsByBook } from 'realtime-server/lib/scriptureforge/models/text-info';
-import { VerseRefData, VerseRefFunctions } from 'realtime-server/lib/scriptureforge/models/verse-ref-data';
+import { VerseRefData } from 'realtime-server/lib/scriptureforge/models/verse-ref-data';
 import { AccountService } from 'xforge-common/account.service';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -20,6 +20,10 @@ import {
 } from '../../../scripture-chooser-dialog/scripture-chooser-dialog.component';
 import { ScrVers } from '../../../shared/scripture-utils/scr-vers';
 import { VerseRef } from '../../../shared/scripture-utils/verse-ref';
+import {
+  verseRefDataToString,
+  verseRefToVerseRefData
+} from '../../../shared/scripture-utils/verse-ref-data-converters';
 import { SFValidators } from '../../../shared/sfvalidators';
 import { CheckingAudioCombinedComponent } from '../checking-audio-combined/checking-audio-combined.component';
 import { AudioAttachment } from '../checking-audio-recorder/checking-audio-recorder.component';
@@ -184,8 +188,8 @@ export class CheckingAnswersComponent implements OnInit {
   editAnswer(answer: Answer) {
     this.activeAnswer = cloneDeep(answer);
     this.audio.url = this.activeAnswer.audioUrl;
-    this.scriptureStart.setValue(VerseRefFunctions.verseRefDataToString(this.activeAnswer.scriptureStart));
-    this.scriptureEnd.setValue(VerseRefFunctions.verseRefDataToString(this.activeAnswer.scriptureEnd));
+    this.scriptureStart.setValue(verseRefDataToString(this.activeAnswer.scriptureStart));
+    this.scriptureEnd.setValue(verseRefDataToString(this.activeAnswer.scriptureEnd));
     this.scriptureText.setValue(this.activeAnswer.scriptureText);
     this.showAnswerForm();
   }
@@ -246,15 +250,11 @@ export class CheckingAnswersComponent implements OnInit {
   }
 
   openScriptureChooser(control: AbstractControl) {
-    const currentVerseSelection = VerseRefFunctions.verseRefToVerseRefData(
-      VerseRef.fromStr(control.value, ScrVers.English)
-    );
+    const currentVerseSelection = verseRefToVerseRefData(VerseRef.fromStr(control.value, ScrVers.English));
 
     let rangeStart: VerseRefData;
     if (control !== this.scriptureStart) {
-      rangeStart = VerseRefFunctions.verseRefToVerseRefData(
-        VerseRef.fromStr(this.scriptureStart.value, ScrVers.English)
-      );
+      rangeStart = verseRefToVerseRefData(VerseRef.fromStr(this.scriptureStart.value, ScrVers.English));
     }
 
     const dialogConfig: MdcDialogConfig<ScriptureChooserDialogData> = {
@@ -264,7 +264,7 @@ export class CheckingAnswersComponent implements OnInit {
     const dialogRef = this.dialog.open(ScriptureChooserDialogComponent, dialogConfig);
     dialogRef.afterClosed().subscribe((result: VerseRefData) => {
       if (result !== 'close') {
-        control.setValue(VerseRefFunctions.verseRefDataToString(result));
+        control.setValue(verseRefDataToString(result));
         control.markAsTouched();
         control.markAsDirty();
         this.extractScriptureText();
@@ -285,7 +285,7 @@ export class CheckingAnswersComponent implements OnInit {
   scriptureTextVerseRef(answer: Answer): string {
     return (
       '(' +
-      VerseRefFunctions.verseRefDataToString(answer.scriptureStart) +
+      verseRefDataToString(answer.scriptureStart) +
       (answer.scriptureEnd.verse && answer.scriptureStart.verse !== answer.scriptureEnd.verse
         ? '-' + answer.scriptureEnd.verse
         : '') +
@@ -342,8 +342,8 @@ export class CheckingAnswersComponent implements OnInit {
       answer: this.activeAnswer,
       audio: this.audio,
       scriptureText: this.scriptureText.value,
-      scriptureStart: VerseRefFunctions.verseRefToVerseRefData(this.scriptureStartVerseRef),
-      scriptureEnd: VerseRefFunctions.verseRefToVerseRefData(this.scriptureEndVerseRef)
+      scriptureStart: verseRefToVerseRefData(this.scriptureStartVerseRef),
+      scriptureEnd: verseRefToVerseRefData(this.scriptureEndVerseRef)
     });
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -8,7 +8,7 @@ import { Question } from 'realtime-server/lib/scriptureforge/models/question';
 import { SFProject } from 'realtime-server/lib/scriptureforge/models/sf-project';
 import { SFProjectRole } from 'realtime-server/lib/scriptureforge/models/sf-project-role';
 import { TextInfo, TextsByBook } from 'realtime-server/lib/scriptureforge/models/text-info';
-import { VerseRefData } from 'realtime-server/lib/scriptureforge/models/verse-ref-data';
+import { VerseRefData, VerseRefFunctions } from 'realtime-server/lib/scriptureforge/models/verse-ref-data';
 import { AccountService } from 'xforge-common/account.service';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -42,22 +42,6 @@ export interface AnswerAction {
   styleUrls: ['./checking-answers.component.scss']
 })
 export class CheckingAnswersComponent implements OnInit {
-  private static verseRefDataToString(verseRefData: VerseRefData): string {
-    let result: string = verseRefData.book ? verseRefData.book : '';
-    result += verseRefData.chapter ? ' ' + verseRefData.chapter : '';
-    result += verseRefData.verse ? ':' + verseRefData.verse : '';
-    return result;
-  }
-
-  private static verseRefToVerseRefData(input: VerseRef): VerseRefData {
-    const refData: VerseRefData = {};
-    refData.book = input.book;
-    refData.chapter = input.chapter;
-    refData.verse = input.verse;
-    refData.versification = input.versification.name;
-    return refData;
-  }
-
   @ViewChild(CheckingAudioCombinedComponent) audioCombinedComponent: CheckingAudioCombinedComponent;
   @Input() project: SFProject;
   @Input() projectUserConfigDoc: SFProjectUserConfigDoc;
@@ -200,8 +184,8 @@ export class CheckingAnswersComponent implements OnInit {
   editAnswer(answer: Answer) {
     this.activeAnswer = cloneDeep(answer);
     this.audio.url = this.activeAnswer.audioUrl;
-    this.scriptureStart.setValue(CheckingAnswersComponent.verseRefDataToString(this.activeAnswer.scriptureStart));
-    this.scriptureEnd.setValue(CheckingAnswersComponent.verseRefDataToString(this.activeAnswer.scriptureEnd));
+    this.scriptureStart.setValue(VerseRefFunctions.verseRefDataToString(this.activeAnswer.scriptureStart));
+    this.scriptureEnd.setValue(VerseRefFunctions.verseRefDataToString(this.activeAnswer.scriptureEnd));
     this.scriptureText.setValue(this.activeAnswer.scriptureText);
     this.showAnswerForm();
   }
@@ -262,13 +246,13 @@ export class CheckingAnswersComponent implements OnInit {
   }
 
   openScriptureChooser(control: AbstractControl) {
-    const currentVerseSelection = CheckingAnswersComponent.verseRefToVerseRefData(
+    const currentVerseSelection = VerseRefFunctions.verseRefToVerseRefData(
       VerseRef.fromStr(control.value, ScrVers.English)
     );
 
     let rangeStart: VerseRefData;
     if (control !== this.scriptureStart) {
-      rangeStart = CheckingAnswersComponent.verseRefToVerseRefData(
+      rangeStart = VerseRefFunctions.verseRefToVerseRefData(
         VerseRef.fromStr(this.scriptureStart.value, ScrVers.English)
       );
     }
@@ -280,7 +264,7 @@ export class CheckingAnswersComponent implements OnInit {
     const dialogRef = this.dialog.open(ScriptureChooserDialogComponent, dialogConfig);
     dialogRef.afterClosed().subscribe((result: VerseRefData) => {
       if (result !== 'close') {
-        control.setValue(CheckingAnswersComponent.verseRefDataToString(result));
+        control.setValue(VerseRefFunctions.verseRefDataToString(result));
         control.markAsTouched();
         control.markAsDirty();
         this.extractScriptureText();
@@ -301,7 +285,7 @@ export class CheckingAnswersComponent implements OnInit {
   scriptureTextVerseRef(answer: Answer): string {
     return (
       '(' +
-      CheckingAnswersComponent.verseRefDataToString(answer.scriptureStart) +
+      VerseRefFunctions.verseRefDataToString(answer.scriptureStart) +
       (answer.scriptureEnd.verse && answer.scriptureStart.verse !== answer.scriptureEnd.verse
         ? '-' + answer.scriptureEnd.verse
         : '') +
@@ -358,8 +342,8 @@ export class CheckingAnswersComponent implements OnInit {
       answer: this.activeAnswer,
       audio: this.audio,
       scriptureText: this.scriptureText.value,
-      scriptureStart: CheckingAnswersComponent.verseRefToVerseRefData(this.scriptureStartVerseRef),
-      scriptureEnd: CheckingAnswersComponent.verseRefToVerseRefData(this.scriptureEndVerseRef)
+      scriptureStart: VerseRefFunctions.verseRefToVerseRefData(this.scriptureStartVerseRef),
+      scriptureEnd: VerseRefFunctions.verseRefToVerseRefData(this.scriptureEndVerseRef)
     });
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.html
@@ -1,1 +1,1 @@
-<app-text [isReadOnly]="true" [id]="id"></app-text>
+<app-text [isReadOnly]="true" [id]="id" (loaded)="highlightQuestions()"></app-text>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.scss
@@ -10,3 +10,44 @@ app-text {
   flex-direction: column;
   flex: 1;
 }
+.ql-container {
+  .highlight-marker {
+    display: none;
+  }
+  .ql-editor {
+    .highlight-para-target {
+      > usx-para-contents {
+        box-shadow: unset;
+      }
+    }
+    .highlight-segment-target {
+      box-shadow: 2px 4px 4px -4px #bfb092;
+      position: relative;
+      cursor: pointer;
+
+      &[data-question='true'] {
+        margin-left: 1.5em;
+
+        &:before {
+          content: '?';
+          border-radius: 50%;
+          width: 1.5em;
+          height: 1.5em;
+          font-size: 0.8em;
+          display: flex;
+          align-content: center;
+          justify-content: center;
+          background: var(--mdc-theme-secondary);
+          font-weight: bold;
+          position: absolute;
+          left: -1.75em;
+          top: 0;
+        }
+      }
+
+      &[data-selected='true'] {
+        background: yellow;
+      }
+    }
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
@@ -1,22 +1,172 @@
-import { Component, Input, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, Output, ViewChild, ViewEncapsulation } from '@angular/core';
 
+import { fromEvent } from 'rxjs';
+import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
+import { Question } from '../../../core/models/question';
 import { TextDocId } from '../../../core/models/text-doc-id';
+import { VerseRefData, VerseRefFunctions } from '../../../core/models/verse-ref-data';
+import { Segment } from '../../../shared/text/segment';
 import { TextComponent } from '../../../shared/text/text.component';
 
 @Component({
   selector: 'app-checking-text',
   templateUrl: './checking-text.component.html',
-  styleUrls: ['./checking-text.component.scss']
+  styleUrls: ['./checking-text.component.scss'],
+  encapsulation: ViewEncapsulation.None
 })
-export class CheckingTextComponent {
+export class CheckingTextComponent extends SubscriptionDisposable {
   @ViewChild(TextComponent) textComponent: TextComponent;
-  @Input() id: TextDocId;
 
-  constructor() {}
+  @Input() set activeQuestion(question: Readonly<Question>) {
+    if (this.activeQuestion && this.isEditorLoaded) {
+      this.selectActiveQuestion(this.activeQuestion, false);
+      this.selectActiveQuestion(question, true);
+    }
+    this._activeQuestion = question;
+  }
+  @Input() id: TextDocId;
+  @Output() questionClicked: EventEmitter<Question> = new EventEmitter<Question>();
+  @Input() questions: Readonly<Question[]> = [];
+
+  private _activeQuestion: Readonly<Question>;
+  private _editorLoaded = false;
+
+  get activeQuestion(): Readonly<Question> {
+    return this._activeQuestion;
+  }
+
+  get isEditorLoaded(): boolean {
+    return this._editorLoaded;
+  }
 
   applyFontChange(fontSize: string) {
     this.textComponent.editorStyles = {
       fontSize: fontSize
     };
+  }
+
+  highlightQuestions() {
+    this._editorLoaded = true;
+    if (this.questions) {
+      const segments: string[] = [];
+      for (const question of this.questions) {
+        const questionSegments = this.getQuestionSegments(question);
+        if (questionSegments.length) {
+          this.setupQuestionSegments([questionSegments[0]]);
+          for (const segment of questionSegments) {
+            if (!segments.includes(segment)) {
+              segments.push(segment);
+            }
+          }
+        }
+      }
+      this.highlightSegments(segments);
+      if (this.activeQuestion) {
+        this.selectActiveQuestion(this.activeQuestion, true);
+      }
+    }
+  }
+
+  private getQuestionSegments(question: Question): string[] {
+    const segments: string[] = [];
+    let segment = '';
+    if (question.scriptureStart) {
+      const verseStart = VerseRefFunctions.fromData(question.scriptureStart);
+      let verseEnd = VerseRefFunctions.fromData(question.scriptureEnd);
+      if (!verseEnd.book) {
+        verseEnd = verseStart;
+      }
+      for (let verse = verseStart.verseNum; verse <= verseEnd.verseNum; verse++) {
+        segment = this.getSegment(verseStart.chapterNum, verse);
+        if (!segments.includes(segment)) {
+          segments.push(segment);
+        }
+      }
+    }
+    return segments;
+  }
+
+  private getSegment(chapter: number, verse: number) {
+    return 'verse_' + chapter + '_' + verse;
+  }
+
+  private highlightSegments(segments: string[]) {
+    for (const segment of segments) {
+      if (!this.textComponent.hasSegmentRange(segment)) {
+        continue;
+      }
+      const segmentRef = new Segment(this.id.bookId, segment);
+      const range = this.textComponent.getSegmentRange(segmentRef.ref);
+      const text = this.textComponent.editor.getText(range.index, range.length);
+      segmentRef.update(text, range);
+      this.textComponent.toggleHighlight(true, segmentRef);
+      const element = this.textComponent.editor.container.querySelector(
+        'usx-segment[data-segment=' + segmentRef.ref + ']'
+      );
+      this.subscribe(fromEvent(element, 'click'), (event: MouseEvent) => {
+        let target = event.target;
+        if (target['offsetParent']['nodeName'] === 'USX-SEGMENT') {
+          target = target['offsetParent'];
+        }
+        if (target['nodeName'] === 'USX-SEGMENT') {
+          const clickSegment = target['attributes']['data-segment'].value;
+          const segmentParts = clickSegment.split('_', 3);
+          const verseRefData: VerseRefData = {
+            book: this.id.bookId,
+            chapter: segmentParts[1],
+            verse: segmentParts[2]
+          };
+          this.segmentClicked(verseRefData);
+        }
+      });
+    }
+  }
+
+  private segmentClicked(verseRefData: VerseRefData) {
+    const verseRef = VerseRefFunctions.fromData(verseRefData);
+    for (const question of this.questions) {
+      const verseStart = VerseRefFunctions.fromData(question.scriptureStart);
+      let verseEnd = VerseRefFunctions.fromData(question.scriptureEnd);
+      if (!verseEnd.book) {
+        verseEnd = verseStart;
+      }
+      if (
+        verseStart.chapterNum === verseRef.chapterNum &&
+        verseStart.verseNum <= verseRef.verseNum &&
+        verseEnd.verseNum >= verseRef.verseNum
+      ) {
+        this.questionClicked.emit(question);
+      }
+    }
+  }
+
+  private setupQuestionSegments(segments: string[]) {
+    for (const segment of segments) {
+      if (!this.textComponent.hasSegmentRange(segment)) {
+        continue;
+      }
+      const range = this.textComponent.getSegmentRange(segment);
+      Promise.resolve().then(() => {
+        this.textComponent.editor.formatText(range.index, range.length, 'data-question', 'true', 'silent');
+      });
+    }
+  }
+
+  private selectActiveQuestion(question: Question, toggle: boolean) {
+    for (const segment of this.getQuestionSegments(question)) {
+      if (!this.textComponent.hasSegmentRange(segment)) {
+        continue;
+      }
+      const range = this.textComponent.getSegmentRange(segment);
+      Promise.resolve().then(() => {
+        this.textComponent.editor.formatText(
+          range.index,
+          range.length,
+          'data-selected',
+          toggle ? 'true' : false,
+          'silent'
+        );
+      });
+    }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
@@ -5,7 +5,6 @@ import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { Question } from '../../../core/models/question';
 import { TextDocId } from '../../../core/models/text-doc-id';
 import { VerseRefData, VerseRefFunctions } from '../../../core/models/verse-ref-data';
-import { Segment } from '../../../shared/text/segment';
 import { TextComponent } from '../../../shared/text/text.component';
 
 @Component({
@@ -95,14 +94,9 @@ export class CheckingTextComponent extends SubscriptionDisposable {
       if (!this.textComponent.hasSegmentRange(segment)) {
         continue;
       }
-      const segmentRef = new Segment(this.id.bookId, segment);
-      const range = this.textComponent.getSegmentRange(segmentRef.ref);
-      const text = this.textComponent.editor.getText(range.index, range.length);
-      segmentRef.update(text, range);
-      this.textComponent.toggleHighlight(true, segmentRef);
-      const element = this.textComponent.editor.container.querySelector(
-        'usx-segment[data-segment=' + segmentRef.ref + ']'
-      );
+      const range = this.textComponent.getSegmentRange(segment);
+      this.textComponent.toggleHighlight(true, range);
+      const element = this.textComponent.editor.container.querySelector('usx-segment[data-segment=' + segment + ']');
       this.subscribe(fromEvent(element, 'click'), (event: MouseEvent) => {
         let target = event.target;
         if (target['offsetParent']['nodeName'] === 'USX-SEGMENT') {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
@@ -1,10 +1,10 @@
 import { Component, EventEmitter, Input, Output, ViewChild, ViewEncapsulation } from '@angular/core';
-
+import { Question } from 'realtime-server/lib/scriptureforge/models/question';
+import { VerseRefData } from 'realtime-server/lib/scriptureforge/models/verse-ref-data';
 import { fromEvent } from 'rxjs';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
-import { Question } from '../../../core/models/question';
 import { TextDocId } from '../../../core/models/text-doc-id';
-import { VerseRefData, VerseRefFunctions } from '../../../core/models/verse-ref-data';
+import { verseRefDataToVerseRef } from '../../../shared/scripture-utils/verse-ref-data-converters';
 import { TextComponent } from '../../../shared/text/text.component';
 
 @Component({
@@ -19,7 +19,9 @@ export class CheckingTextComponent extends SubscriptionDisposable {
   @Input() set activeQuestion(question: Readonly<Question>) {
     if (this.activeQuestion && this.isEditorLoaded) {
       this.selectActiveQuestion(this.activeQuestion, false);
-      this.selectActiveQuestion(question, true);
+      if (question != null) {
+        this.selectActiveQuestion(question, true);
+      }
     }
     this._activeQuestion = question;
   }
@@ -70,8 +72,8 @@ export class CheckingTextComponent extends SubscriptionDisposable {
     const segments: string[] = [];
     let segment = '';
     if (question.scriptureStart) {
-      const verseStart = VerseRefFunctions.fromData(question.scriptureStart);
-      let verseEnd = VerseRefFunctions.fromData(question.scriptureEnd);
+      const verseStart = verseRefDataToVerseRef(question.scriptureStart);
+      let verseEnd = verseRefDataToVerseRef(question.scriptureEnd);
       if (!verseEnd.book) {
         verseEnd = verseStart;
       }
@@ -117,10 +119,10 @@ export class CheckingTextComponent extends SubscriptionDisposable {
   }
 
   private segmentClicked(verseRefData: VerseRefData) {
-    const verseRef = VerseRefFunctions.fromData(verseRefData);
+    const verseRef = verseRefDataToVerseRef(verseRefData);
     for (const question of this.questions) {
-      const verseStart = VerseRefFunctions.fromData(question.scriptureStart);
-      let verseEnd = VerseRefFunctions.fromData(question.scriptureEnd);
+      const verseStart = verseRefDataToVerseRef(question.scriptureStart);
+      let verseEnd = verseRefDataToVerseRef(question.scriptureEnd);
       if (!verseEnd.book) {
         verseEnd = verseStart;
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -78,7 +78,13 @@
             >
               <as-split-area size="100">
                 <div class="panel-content" #scripturePanelContainer>
-                  <app-checking-text #textPanel [id]="textDocId"></app-checking-text>
+                  <app-checking-text
+                    #textPanel
+                    [id]="textDocId"
+                    [activeQuestion]="questionsPanel.activeQuestion"
+                    [questions]="publicQuestions"
+                    (questionClicked)="questionsPanel.activateQuestion($event)"
+                  ></app-checking-text>
                 </div>
               </as-split-area>
               <as-split-area size="0">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -162,7 +162,8 @@ describe('CheckingComponent', () => {
         ownerRef: env.adminUser.id,
         text: 'Admin just added a question.',
         answers: [],
-        scriptureStart: { book: 'JHN', chapter: '1', verse: '10', versification: 'English' }
+        scriptureStart: { book: 'JHN', chapter: '1', verse: '10', versification: 'English' },
+        scriptureEnd: { book: 'JHN', chapter: '1', verse: '11', versification: 'English' }
       };
       const textDocId = new TextDocId('project01', 'JHN', 1);
       env.component.checkingData.questionListDocs[textDocId.toString()].submitJson0Op(
@@ -471,6 +472,15 @@ describe('CheckingComponent', () => {
       expect(editor.style.fontSize).toBe('1.1rem');
       env.clickButton(env.decreaseFontSizeButton);
       expect(editor.style.fontSize).toBe('1rem');
+    }));
+
+    it('can select a question from the text', fakeAsync(() => {
+      env.setupAdminScenarioData();
+      env.quillEditor.querySelector('usx-segment[data-segment=verse_1_3]').dispatchEvent(new Event('click'));
+      env.waitForSliderUpdate();
+      tick(env.questionReadTimer);
+      env.fixture.detectChanges();
+      expect(env.currentQuestion).toBe(4);
     }));
   });
 });
@@ -868,6 +878,8 @@ class TestEnvironment {
       answers: [],
       isArchived: true
     });
+    questionData1[3].scriptureStart.verse = '3';
+    questionData1[3].scriptureEnd.verse = '4';
     questionData1[5].answers.push({
       id: 'a6Id',
       ownerRef: this.reviewerUser.id,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/forms';
 import { Question } from 'realtime-server/lib/scriptureforge/models/question';
 import { TextsByBook } from 'realtime-server/lib/scriptureforge/models/text-info';
-import { VerseRefData, VerseRefFunctions } from 'realtime-server/lib/scriptureforge/models/verse-ref-data';
+import { VerseRefData } from 'realtime-server/lib/scriptureforge/models/verse-ref-data';
 import { NoticeService } from 'xforge-common/notice.service';
 import { XFValidators } from 'xforge-common/xfvalidators';
 import {
@@ -21,6 +21,7 @@ import {
 } from '../../scripture-chooser-dialog/scripture-chooser-dialog.component';
 import { ScrVers } from '../../shared/scripture-utils/scr-vers';
 import { VerseRef } from '../../shared/scripture-utils/verse-ref';
+import { verseRefDataToString, verseRefToVerseRefData } from '../../shared/scripture-utils/verse-ref-data-converters';
 import { SFValidators } from '../../shared/sfvalidators';
 import { CheckingAudioCombinedComponent } from '../checking/checking-audio-combined/checking-audio-combined.component';
 import { AudioAttachment } from '../checking/checking-audio-recorder/checking-audio-recorder.component';
@@ -79,10 +80,10 @@ export class QuestionDialogComponent implements OnInit {
     if (this.data && this.data.question) {
       const question = this.data.question;
       if (question.scriptureStart) {
-        this.scriptureStart.setValue(VerseRefFunctions.verseRefDataToString(question.scriptureStart));
+        this.scriptureStart.setValue(verseRefDataToString(question.scriptureStart));
       }
       if (question.scriptureEnd) {
-        this.scriptureEnd.setValue(VerseRefFunctions.verseRefDataToString(question.scriptureEnd));
+        this.scriptureEnd.setValue(verseRefDataToString(question.scriptureEnd));
       }
       if (question.text) {
         this.questionText.setValue(question.text);
@@ -112,15 +113,11 @@ export class QuestionDialogComponent implements OnInit {
 
   /** Edit text of control using Scripture chooser dialog. */
   openScriptureChooser(control: AbstractControl) {
-    const currentVerseSelection = VerseRefFunctions.verseRefToVerseRefData(
-      VerseRef.fromStr(control.value, ScrVers.English)
-    );
+    const currentVerseSelection = verseRefToVerseRefData(VerseRef.fromStr(control.value, ScrVers.English));
 
     let rangeStart: VerseRefData;
     if (control !== this.scriptureStart) {
-      rangeStart = VerseRefFunctions.verseRefToVerseRefData(
-        VerseRef.fromStr(this.scriptureStart.value, ScrVers.English)
-      );
+      rangeStart = verseRefToVerseRefData(VerseRef.fromStr(this.scriptureStart.value, ScrVers.English));
     }
 
     const dialogConfig: MdcDialogConfig<ScriptureChooserDialogData> = {
@@ -132,7 +129,7 @@ export class QuestionDialogComponent implements OnInit {
       if (result !== 'close') {
         control.markAsTouched();
         control.markAsDirty();
-        control.setValue(VerseRefFunctions.verseRefDataToString(result));
+        control.setValue(verseRefDataToString(result));
       }
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/forms';
 import { Question } from 'realtime-server/lib/scriptureforge/models/question';
 import { TextsByBook } from 'realtime-server/lib/scriptureforge/models/text-info';
-import { VerseRefData } from 'realtime-server/lib/scriptureforge/models/verse-ref-data';
+import { VerseRefData, VerseRefFunctions } from 'realtime-server/lib/scriptureforge/models/verse-ref-data';
 import { NoticeService } from 'xforge-common/notice.service';
 import { XFValidators } from 'xforge-common/xfvalidators';
 import {
@@ -43,22 +43,6 @@ export interface QuestionDialogResult {
   styleUrls: ['./question-dialog.component.scss']
 })
 export class QuestionDialogComponent implements OnInit {
-  private static verseRefDataToString(verseRefData: VerseRefData): string {
-    let result: string = verseRefData.book ? verseRefData.book : '';
-    result += verseRefData.chapter ? ' ' + verseRefData.chapter : '';
-    result += verseRefData.verse ? ':' + verseRefData.verse : '';
-    return result;
-  }
-
-  private static verseRefToVerseRefData(input: VerseRef): VerseRefData {
-    const refData: VerseRefData = {};
-    refData.book = input.book;
-    refData.chapter = input.chapter;
-    refData.verse = input.verse;
-    refData.versification = input.versification.name;
-    return refData;
-  }
-
   @ViewChild(CheckingAudioCombinedComponent) audioCombinedComponent: CheckingAudioCombinedComponent;
   modeLabel = this.data && this.data.editMode ? 'Edit' : 'New';
   parentAndStartMatcher = new ParentAndStartErrorStateMatcher();
@@ -95,10 +79,10 @@ export class QuestionDialogComponent implements OnInit {
     if (this.data && this.data.question) {
       const question = this.data.question;
       if (question.scriptureStart) {
-        this.scriptureStart.setValue(QuestionDialogComponent.verseRefDataToString(question.scriptureStart));
+        this.scriptureStart.setValue(VerseRefFunctions.verseRefDataToString(question.scriptureStart));
       }
       if (question.scriptureEnd) {
-        this.scriptureEnd.setValue(QuestionDialogComponent.verseRefDataToString(question.scriptureEnd));
+        this.scriptureEnd.setValue(VerseRefFunctions.verseRefDataToString(question.scriptureEnd));
       }
       if (question.text) {
         this.questionText.setValue(question.text);
@@ -128,13 +112,13 @@ export class QuestionDialogComponent implements OnInit {
 
   /** Edit text of control using Scripture chooser dialog. */
   openScriptureChooser(control: AbstractControl) {
-    const currentVerseSelection = QuestionDialogComponent.verseRefToVerseRefData(
+    const currentVerseSelection = VerseRefFunctions.verseRefToVerseRefData(
       VerseRef.fromStr(control.value, ScrVers.English)
     );
 
     let rangeStart: VerseRefData;
     if (control !== this.scriptureStart) {
-      rangeStart = QuestionDialogComponent.verseRefToVerseRefData(
+      rangeStart = VerseRefFunctions.verseRefToVerseRefData(
         VerseRef.fromStr(this.scriptureStart.value, ScrVers.English)
       );
     }
@@ -148,7 +132,7 @@ export class QuestionDialogComponent implements OnInit {
       if (result !== 'close') {
         control.markAsTouched();
         control.markAsDirty();
-        control.setValue(QuestionDialogComponent.verseRefDataToString(result));
+        control.setValue(VerseRefFunctions.verseRefDataToString(result));
       }
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/scripture-utils/verse-ref-data-converters.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/scripture-utils/verse-ref-data-converters.ts
@@ -1,0 +1,22 @@
+import { VerseRefData } from 'realtime-server/lib/scriptureforge/models/verse-ref-data';
+import { VerseRef } from './verse-ref';
+
+export function verseRefDataToVerseRef(verseRefData: VerseRefData): VerseRef {
+  return VerseRef.fromStr(verseRefDataToString(verseRefData));
+}
+
+export function verseRefDataToString(verseRefData: VerseRefData): string {
+  let result: string = verseRefData.book ? verseRefData.book : '';
+  result += verseRefData.chapter ? ' ' + verseRefData.chapter : '';
+  result += verseRefData.verse ? ':' + verseRefData.verse : '';
+  return result;
+}
+
+export function verseRefToVerseRefData(input: VerseRef): VerseRefData {
+  return {
+    book: input.book,
+    chapter: input.chapter,
+    verse: input.verse,
+    versification: input.versification.name
+  };
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -388,6 +388,14 @@ export function registerScripture(): void {
     scope: Parchment.Scope.BLOCK
   });
 
+  const CheckingQuestionData = new QuillParchment.Attributor.Attribute('data-question', 'data-question', {
+    scope: Parchment.Scope.INLINE
+  });
+
+  const CheckingSelectedData = new QuillParchment.Attributor.Attribute('data-selected', 'data-selected', {
+    scope: Parchment.Scope.INLINE
+  });
+
   class DisableHtmlClipboard extends QuillClipboard {
     onPaste(e: ClipboardEvent): void {
       if (e.defaultPrevented || !this.quill.isEnabled()) {
@@ -418,6 +426,8 @@ export function registerScripture(): void {
   Quill.register('formats/highlight-segment', HighlightSegmentClass);
   Quill.register('attributors/class/highlight-para', HighlightParaClass);
   Quill.register('formats/highlight-para', HighlightParaClass);
+  Quill.register('formats/data-question', CheckingQuestionData);
+  Quill.register('formats/data-selected', CheckingSelectedData);
   Quill.register('blots/verse', VerseEmbed);
   Quill.register('blots/blank', BlankEmbed);
   Quill.register('blots/note', NoteEmbed);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -149,8 +149,7 @@ export class TextViewModel {
     return formats['highlight-segment'] != null;
   }
 
-  toggleHighlight(segment: Segment, value: TextType | boolean): void {
-    const range = segment.range;
+  toggleHighlight(range: RangeStatic, value: TextType | boolean): void {
     if (range.length > 0) {
       // this changes the underlying HTML, which can mess up some Quill events, so defer this call
       Promise.resolve().then(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -240,6 +240,10 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
     return range == null ? '' : this._editor.getText(range.index, range.length);
   }
 
+  hasSegmentRange(ref: string): boolean {
+    return this.viewModel.hasSegmentRange(ref);
+  }
+
   onContentChanged(delta: DeltaStatic, source: Sources): void {
     this.viewModel.update(delta, source);
     if (this.viewModel.isEmpty) {
@@ -253,6 +257,18 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
 
   onSelectionChanged(): void {
     this.update();
+  }
+
+  toggleHighlight(value: boolean, segment?: Segment): void {
+    this.viewModel.toggleHighlight(segment ? segment : this._segment, value ? this._id.textType : false);
+
+    if (this._id.textType === 'target') {
+      if (value) {
+        this.highlightMarker.style.visibility = '';
+      } else {
+        this.highlightMarker.style.visibility = 'hidden';
+      }
+    }
   }
 
   private applyEditorStyles() {
@@ -407,18 +423,6 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
     }
     if (sel.index !== newSel.index || sel.length !== newSel.length) {
       this._editor.setSelection(newSel, 'user');
-    }
-  }
-
-  private toggleHighlight(value: boolean): void {
-    this.viewModel.toggleHighlight(this._segment, value ? this._id.textType : false);
-
-    if (this._id.textType === 'target') {
-      if (value) {
-        this.highlightMarker.style.visibility = '';
-      } else {
-        this.highlightMarker.style.visibility = 'hidden';
-      }
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -259,8 +259,8 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
     this.update();
   }
 
-  toggleHighlight(value: boolean, segment?: Segment): void {
-    this.viewModel.toggleHighlight(segment ? segment : this._segment, value ? this._id.textType : false);
+  toggleHighlight(value: boolean, range?: RangeStatic): void {
+    this.viewModel.toggleHighlight(range ? range : this._segment.range, value ? this._id.textType : false);
 
     if (this._id.textType === 'target') {
       if (value) {
@@ -345,7 +345,7 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
         if (this._highlightSegment) {
           // ensure that the currently selected segment is highlighted
           if (!this.viewModel.isHighlighted(this._segment)) {
-            this.viewModel.toggleHighlight(this._segment, this._id.textType);
+            this.viewModel.toggleHighlight(this._segment.range, this._id.textType);
           }
         }
       }


### PR DESCRIPTION
- Question icon now appears next to verse in Quill editor
- Verse range is underlined in Quill editor relating to questions
- Clicking a question in the Quill editor will now select the question to answer
- Active question will now highlight a question in the Quill editor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/184)
<!-- Reviewable:end -->
