### PR TITLE
SF-433 Use "displayName" for user

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -49,10 +49,10 @@
                 Logged in as
                 <div fxLayout="row" fxLayoutAlign="start center">
                   <span fxFlex>&nbsp;</span>
-                  <button id="edit-name-btn" mdcIconButton (click)="editName(currentUser.name)">
+                  <button id="edit-name-btn" mdcIconButton (click)="editName(currentUser.displayName)">
                     <mdc-icon>edit</mdc-icon>
                   </button>
-                  <strong class="user-menu-name">{{ currentUser.name }}</strong>
+                  <strong class="user-menu-name">{{ currentUser.displayName }}</strong>
                 </div>
               </div>
               <mdc-list-divider></mdc-list-divider>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -180,10 +180,10 @@ describe('AppComponent', () => {
     it('updates user with name', fakeAsync(() => {
       const env = new TestEnvironment();
       env.init();
-      env.updateName('Updated Name');
+      env.updateDisplayName('Updated Name');
       tick();
       verify(env.mockedAccountService.openNameDialog(anything(), anything()));
-      expect(env.currentUserName).toEqual('Updated Name');
+      expect(env.currentUserDisplayName).toEqual('Updated Name');
     }));
   });
 });
@@ -241,7 +241,7 @@ class TestEnvironment {
   constructor() {
     this.currentUserDoc = new UserDoc(
       new MemoryRealtimeDocAdapter('user01', OTJson0.type, {
-        name: 'User 01',
+        displayName: 'User 01',
         sites: {
           sf: {
             currentProjectId: 'project01',
@@ -369,8 +369,8 @@ class TestEnvironment {
     return this.currentUserDoc.data.sites.sf.currentProjectId;
   }
 
-  get currentUserName(): string {
-    return this.currentUserDoc.data.name;
+  get currentUserDisplayName(): string {
+    return this.currentUserDoc.data.displayName;
   }
 
   init(): void {
@@ -426,8 +426,8 @@ class TestEnvironment {
     this.wait();
   }
 
-  updateName(name: string) {
-    when(this.mockedNameDialogRef.afterClosed()).thenReturn(of(name));
+  updateDisplayName(displayName: string) {
+    when(this.mockedNameDialogRef.afterClosed()).thenReturn(of(displayName));
     this.component.editName('User 01');
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -305,10 +305,10 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       });
   }
 
-  editName(currentName: string): void {
-    const dialogRef = this.accountService.openNameDialog(currentName, false);
+  editName(currentDisplayName: string): void {
+    const dialogRef = this.accountService.openNameDialog(currentDisplayName, false);
     dialogRef.afterClosed().subscribe(response => {
-      this.currentUserDoc.submitJson0Op(op => op.set(u => u.name, response as string));
+      this.currentUserDoc.submitJson0Op(op => op.set(u => u.displayName, response as string));
     });
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -616,8 +616,8 @@ class TestEnvironment {
     return {
       id: 'user' + id,
       user: {
-        name: 'User ' + id,
-        isNameConfirmed: nameConfirmed
+        displayName: 'User ' + id,
+        isDisplayNameConfirmed: nameConfirmed
       },
       role
     };

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -326,16 +326,16 @@ export class CheckingAnswersComponent implements OnInit {
     if (this.answerForm.invalid) {
       return;
     }
-    if (this.user.data.isNameConfirmed) {
+    if (this.user.data.isDisplayNameConfirmed) {
       this.emitAnswerToSave();
       this.hideAnswerForm();
       return;
     }
-    const dialogRef = this.accountService.openNameDialog(this.user.data.name, true);
+    const dialogRef = this.accountService.openNameDialog(this.user.data.displayName, true);
     dialogRef.afterClosed().subscribe(async response => {
       await this.user.submitJson0Op(op => {
-        op.set(u => u.name, response as string);
-        op.set<boolean>(u => u.isNameConfirmed, true);
+        op.set(u => u.displayName, response as string);
+        op.set<boolean>(u => u.isDisplayNameConfirmed, true);
       });
       this.emitAnswerToSave();
       this.hideAnswerForm();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-owner/checking-owner.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-owner/checking-owner.component.spec.ts
@@ -82,7 +82,7 @@ class TestEnvironment {
   constructor() {
     when(this.mockedUserService.getProfile('user01')).thenResolve(
       new UserProfileDoc(
-        new MemoryRealtimeDocAdapter('user01', OTJson0.type, { name: 'User 01', role: 'user' }),
+        new MemoryRealtimeDocAdapter('user01', OTJson0.type, { displayName: 'User 01', role: 'user' }),
         instance(this.mockedRealtimeOfflineStore)
       )
     );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-owner/checking-owner.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-owner/checking-owner.component.ts
@@ -25,7 +25,7 @@ export class CheckingOwnerComponent implements OnInit {
     if (this.ownerDoc == null) {
       return '';
     }
-    return this.userService.currentUserId === this.ownerDoc.id ? 'Me' : this.ownerDoc.data.name;
+    return this.userService.currentUserId === this.ownerDoc.id ? 'Me' : this.ownerDoc.data.displayName;
   }
 
   get owner(): User {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.ts
@@ -34,7 +34,7 @@ export class CheckingAudioRecorderComponent implements OnInit, OnDestroy {
   }
 
   get recodingFileName(): string {
-    return this.user.data.name + '.webm';
+    return this.user.data.displayName + '.webm';
   }
 
   ngOnDestroy(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -182,7 +182,7 @@ describe('CheckingComponent', () => {
       env.setupReviewerScenarioData(env.cleanReviewUser);
       env.selectQuestion(2);
       env.answerQuestion('Answering question 2 should pop up a dialog');
-      verify(env.mockedAccountService.openNameDialog(env.cleanReviewUser.user.name, true)).once();
+      verify(env.mockedAccountService.openNameDialog(env.cleanReviewUser.user.displayName, true)).once();
       expect(env.answers.length).toEqual(1);
       expect(env.getAnswerText(0)).toBe('Answering question 2 should pop up a dialog');
     }));
@@ -929,7 +929,7 @@ class TestEnvironment {
       instance(this.mockedCheckingNameDialogRef)
     );
 
-    when(this.mockedCheckingNameDialogRef.afterClosed()).thenReturn(of(user.user.name));
+    when(this.mockedCheckingNameDialogRef.afterClosed()).thenReturn(of(user.user.displayName));
   }
 
   private initComponentEnviroment(): void {
@@ -947,8 +947,8 @@ class TestEnvironment {
     return {
       id: 'user' + id,
       user: {
-        name: 'User ' + id,
-        isNameConfirmed: nameConfirmed
+        displayName: 'User ' + id,
+        isDisplayNameConfirmed: nameConfirmed
       },
       role
     };

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.ts
@@ -16,6 +16,6 @@ export class AvatarComponent {
   }
 
   get name(): string {
-    return this.user ? this.user.name : '';
+    return this.user ? this.user.displayName : '';
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/user.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/user.ts
@@ -31,7 +31,8 @@ export interface User {
   paratextId?: string;
   avatarUrl?: string;
   role?: string;
-  isNameConfirmed?: boolean;
+  displayName?: string;
+  isDisplayNameConfirmed?: boolean;
   mobilePhone?: string;
   contactMethod?: 'email' | 'sms' | 'emailSms';
   birthday?: string;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-delete-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-delete-dialog.component.spec.ts
@@ -66,7 +66,7 @@ class TestEnvironment {
     const viewContainerRef = this.fixture.componentInstance.childViewContainer;
     const config: MdcDialogConfig<SaDeleteUserDialogData> = {
       viewContainerRef,
-      data: { user: { name: 'Billy T James' } }
+      data: { user: { displayName: 'Billy T James' } }
     };
     this.dialogRef = TestBed.get(MdcDialog).open(SaDeleteDialogComponent, config);
     this.afterCloseCallback = jasmine.createSpy('afterClose callback');

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.html
@@ -18,7 +18,13 @@
       <ng-container matColumnDef="name">
         <td mat-cell *matCellDef="let userRow">
           <div *ngIf="userRow.active">
-            <strong>{{ userRow.user.name }}</strong>
+            <strong *ngIf="userRow.user.displayName !== userRow.user.email">{{ userRow.user.displayName }}</strong>
+            <div
+              *ngIf="userRow.user.name !== userRow.user.displayName && userRow.user.name !== userRow.user.email"
+              class="name-label"
+            >
+              {{ userRow.user.name }}
+            </div>
           </div>
           <div *ngIf="!userRow.active">Awaiting response from</div>
           {{ userRow.user.email }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.spec.ts
@@ -55,18 +55,21 @@ describe('SaUsersComponent', () => {
     expect(env.noUsersLabel).toBeNull();
     expect(env.userRows.length).toEqual(3);
 
-    expect(env.cell(0, 1).query(By.css('strong')).nativeElement.innerText).toEqual('User 01');
-    expect(env.cell(0, 2).query(By.css('a')).nativeElement.text).toEqual('Project 01');
+    expect(env.cellDisplayName(0, 1).innerText).toEqual('User01');
+    expect(env.cellName(0, 1).innerText).toEqual('User 01');
+    expect(env.cellProjectLink(0, 2).text).toEqual('Project 01');
     expect(env.removeUserButtonOnRow(0)).toBeTruthy();
     expect(env.cancelInviteButtonOnRow(0)).toBeFalsy();
 
-    expect(env.cell(1, 1).query(By.css('strong')).nativeElement.innerText).toEqual('User 02');
-    expect(env.cell(1, 2).query(By.css('a'))).toBeNull();
+    expect(env.cellDisplayName(1, 1).innerText).toEqual('User 02');
+    expect(env.cellName(1, 1)).toBeNull();
+    expect(env.cellProjectLink(1, 2)).toBeNull();
     expect(env.removeUserButtonOnRow(1)).toBeTruthy();
     expect(env.cancelInviteButtonOnRow(1)).toBeFalsy();
 
-    expect(env.cell(2, 1).query(By.css('strong')).nativeElement.innerText).toEqual('User 03');
-    expect(env.cell(2, 2).query(By.css('a')).nativeElement.text).toEqual('Project 01');
+    expect(env.cellDisplayName(2, 1).innerText).toEqual('User 03');
+    expect(env.cellName(2, 1)).toBeNull();
+    expect(env.cellProjectLink(2, 2).text).toEqual('Project 01');
     expect(env.removeUserButtonOnRow(2)).toBeTruthy();
     expect(env.cancelInviteButtonOnRow(2)).toBeFalsy();
   }));
@@ -139,9 +142,22 @@ class TestEnvironment {
   readonly mockedProjectService = mock(ProjectService);
 
   private readonly userDocs: UserDoc[] = [
-    this.createUserDoc('user01', { name: 'User 01', sites: { [environment.siteId]: { projects: ['project01'] } } }),
-    this.createUserDoc('user02', { name: 'User 02', sites: { [environment.siteId]: { projects: [] } } }),
-    this.createUserDoc('user03', { name: 'User 03', sites: { [environment.siteId]: { projects: ['project01'] } } })
+    this.createUserDoc('user01', {
+      name: 'User 01',
+      displayName: 'User01',
+      sites: { [environment.siteId]: { projects: ['project01'] } }
+    }),
+    this.createUserDoc('user02', {
+      name: 'User 02',
+      displayName: 'User 02',
+      sites: { [environment.siteId]: { projects: [] } }
+    }),
+    this.createUserDoc('user03', {
+      name: 'user03@example.com',
+      displayName: 'User 03',
+      email: 'user03@example.com',
+      sites: { [environment.siteId]: { projects: ['project01'] } }
+    })
   ];
 
   constructor() {
@@ -199,6 +215,21 @@ class TestEnvironment {
 
   cell(row: number, column: number): DebugElement {
     return this.userRows[row].children[column];
+  }
+
+  cellDisplayName(row: number, column: number): HTMLElement {
+    const element = this.cell(row, column).query(By.css('strong'));
+    return element != null ? element.nativeElement : element;
+  }
+
+  cellName(row: number, column: number): HTMLElement {
+    const element = this.cell(row, column).query(By.css('.name-label'));
+    return element != null ? element.nativeElement : element;
+  }
+
+  cellProjectLink(row: number, column: number): HTMLAnchorElement {
+    const element = this.cell(row, column).query(By.css('a'));
+    return element != null ? element.nativeElement : element;
   }
 
   removeUserButtonOnRow(row: number): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/users/collaborators/collaborators.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/users/collaborators/collaborators.component.html
@@ -31,12 +31,14 @@
         </ng-container>
         <ng-container matColumnDef="name">
           <td mat-cell *matCellDef="let userRow">
-            <div *ngIf="userRow.active">
-              <strong>{{ userRow.user?.name }}</strong>
-              <span *ngIf="isCurrentUser(userRow)" class="current-user-label">&nbsp;me</span>
+            <div *ngIf="userRow.active" class="display-name-label">
+              {{ userRow.user?.displayName }}
+              <strong *ngIf="isCurrentUser(userRow)" class="current-user-label">&nbsp;me</strong>
             </div>
-            <div *ngIf="!userRow.active">Awaiting response from</div>
-            {{ userRow.user?.email }}
+            <div *ngIf="!userRow.active">
+              Awaiting response from
+              <div>{{ userRow.user?.email }}</div>
+            </div>
           </td>
         </ng-container>
         <ng-container matColumnDef="projects">

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/users/collaborators/collaborators.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/users/collaborators/collaborators.component.spec.ts
@@ -53,18 +53,18 @@ describe('CollaboratorsComponent', () => {
     expect(env.noUsersLabel).toBeNull();
     expect(env.userRows.length).toEqual(3);
 
-    expect(env.cell(0, 1).query(By.css('strong')).nativeElement.innerText).toEqual('User 01');
-    expect(env.cell(0, 2).query(By.css('em')).nativeElement.innerText).toEqual('Administrator');
+    expect(env.cellDisplayName(0, 1).innerText).toEqual('User 01');
+    expect(env.cellRole(0, 2).innerText).toEqual('Administrator');
     expect(env.removeUserButtonOnRow(0)).toBeTruthy();
     expect(env.cancelInviteButtonOnRow(0)).toBeFalsy();
 
-    expect(env.cell(1, 1).query(By.css('strong')).nativeElement.innerText).toEqual('User 02');
-    expect(env.cell(1, 2).query(By.css('em')).nativeElement.innerText).toEqual('User');
+    expect(env.cellDisplayName(1, 1).innerText).toEqual('User 02');
+    expect(env.cellRole(1, 2).innerText).toEqual('User');
     expect(env.removeUserButtonOnRow(1)).toBeTruthy();
     expect(env.cancelInviteButtonOnRow(1)).toBeFalsy();
 
-    expect(env.cell(2, 1).query(By.css('strong')).nativeElement.innerText).toEqual('User 03');
-    expect(env.cell(2, 2).query(By.css('em')).nativeElement.innerText).toEqual('User');
+    expect(env.cellDisplayName(2, 1).innerText).toEqual('User 03');
+    expect(env.cellRole(2, 2).innerText).toEqual('User');
     expect(env.removeUserButtonOnRow(2)).toBeTruthy();
     expect(env.cancelInviteButtonOnRow(2)).toBeFalsy();
   }));
@@ -138,9 +138,9 @@ class TestEnvironment {
     when(this.mockedProjectService.onlineInvite('project01', anything())).thenResolve();
     when(this.mockedNoticeService.show(anything())).thenResolve();
     when(this.mockedLocationService.origin).thenReturn('https://scriptureforge.org');
-    this.addUserProfile('user01', { name: 'User 01' });
-    this.addUserProfile('user02', { name: 'User 02' });
-    this.addUserProfile('user03', { name: 'User 03' });
+    this.addUserProfile('user01', { displayName: 'User 01' });
+    this.addUserProfile('user02', { displayName: 'User 02' });
+    this.addUserProfile('user03', { displayName: 'User 03' });
     TestBed.configureTestingModule({
       declarations: [CollaboratorsComponent, ShareControlComponent],
       imports: [NoopAnimationsModule, AvatarTestingModule, UICommonModule],
@@ -193,6 +193,14 @@ class TestEnvironment {
 
   cell(row: number, column: number): DebugElement {
     return this.userRows[row].children[column];
+  }
+
+  cellDisplayName(row: number, column: number): HTMLElement {
+    return this.cell(row, column).query(By.css('.display-name-label')).nativeElement;
+  }
+
+  cellRole(row: number, column: number): HTMLElement {
+    return this.cell(row, column).query(By.css('em')).nativeElement;
   }
 
   removeUserButtonOnRow(row: number): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/users/collaborators/collaborators.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/users/collaborators/collaborators.component.ts
@@ -79,7 +79,7 @@ export class CollaboratorsComponent extends DataLoadingComponent implements OnIn
         ? this._userRows.filter(userRow => {
             return (
               userRow.user &&
-              ((userRow.user.name && userRow.user.name.includes(this.term)) ||
+              ((userRow.user.displayName && userRow.user.displayName.includes(this.term)) ||
                 (userRow.roleName && userRow.roleName.includes(this.term)))
             );
           })

--- a/src/SIL.XForge/Models/User.cs
+++ b/src/SIL.XForge/Models/User.cs
@@ -10,7 +10,8 @@ namespace SIL.XForge.Models
         public string Role { get; set; }
         public string AvatarUrl { get; set; }
         public string ParatextId { get; set; }
-        public bool IsNameConfirmed { get; set; }
+        public string DisplayName { get; set; }
+        public bool IsDisplayNameConfirmed { get; set; }
         public string MobilePhone { get; set; }
 
         /// <summary>

--- a/src/SIL.XForge/Realtime/Server/src/realtime-server.ts
+++ b/src/SIL.XForge/Realtime/Server/src/realtime-server.ts
@@ -22,7 +22,7 @@ const XF_ROLE_CLAIM = 'http://xforge.org/role';
 const SYSTEM_ADMIN_ROLE = 'system_admin';
 
 const USER_PROFILE_FIELDS: ProjectionFields = {
-  name: true,
+  displayName: true,
   avatarUrl: true
 };
 

--- a/src/SIL.XForge/Services/UserService.cs
+++ b/src/SIL.XForge/Services/UserService.cs
@@ -42,13 +42,15 @@ namespace SIL.XForge.Services
             using (IConnection conn = await _realtimeService.ConnectAsync())
             {
                 DateTime now = DateTime.UtcNow;
-                IDocument<User> userDoc = await conn.FetchOrCreateAsync<User>(userId,
-                    () => new User { AuthId = (string)userProfile["user_id"] });
+                string name = (string)userProfile["name"];
+                IDocument<User> userDoc = await conn.FetchOrCreateAsync<User>(userId, () => new User
+                {
+                    AuthId = (string)userProfile["user_id"],
+                    DisplayName = string.IsNullOrWhiteSpace(name) || emailRegex.IsMatch(name) ?
+                        (string)userProfile["nickname"] : name
+                });
                 await userDoc.SubmitJson0OpAsync(op =>
                     {
-                        string name = emailRegex.IsMatch((string)userProfile["name"])
-                            ? ((string)userProfile["name"]).Substring(0, ((string)userProfile["name"]).IndexOf('@'))
-                            : (string)userProfile["name"];
                         op.Set(u => u.Name, name);
                         op.Set(u => u.Email, (string)userProfile["email"]);
                         op.Set(u => u.AvatarUrl, (string)userProfile["picture"]);

--- a/test/SIL.XForge.Tests/Services/UserServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/UserServiceTests.cs
@@ -57,15 +57,31 @@ namespace SIL.XForge.Services
         }
 
         [Test]
-        public async Task PushAuthUserProfile_NewUser_NameExtracted()
+        public async Task PushAuthUserProfile_NewUser_NickNameExtracted()
         {
             var env = new TestEnvironment();
 
             JObject userProfile = env.CreateUserProfile("user03", "auth03", env.IssuedAt);
             userProfile["name"] = "usernew@example.com";
+            userProfile["nickname"] = "usernew";
             await env.Service.UpdateUserFromProfileAsync("user03", userProfile);
             User user3 = env.GetUser("user03");
-            Assert.That(user3.Name, Is.EqualTo("usernew"));
+            Assert.That(user3.DisplayName, Is.EqualTo("usernew"));
+            UserSecret userSecret = env.UserSecrets.Get("user03");
+            Assert.That(userSecret.ParatextTokens.RefreshToken, Is.EqualTo("new_refresh_token"));
+        }
+
+        [Test]
+        public async Task PushAuthUserProfile_NewUser_NameExtracted()
+        {
+            var env = new TestEnvironment();
+
+            JObject userProfile = env.CreateUserProfile("user03", "auth03", env.IssuedAt);
+            userProfile["name"] = "User New";
+            userProfile["nickname"] = "usernew";
+            await env.Service.UpdateUserFromProfileAsync("user03", userProfile);
+            User user3 = env.GetUser("user03");
+            Assert.That(user3.DisplayName, Is.EqualTo("User New"));
             UserSecret userSecret = env.UserSecrets.Get("user03");
             Assert.That(userSecret.ParatextTokens.RefreshToken, Is.EqualTo("new_refresh_token"));
         }


### PR DESCRIPTION
* use "displayName" instead of "name"
* populate "displayName" from "name" or "nickname" only on create. Nickname already contains the correct value from Auth0

The "name" field is overwritten from Auth0 on login so we store our own value that can be modified in "displayName".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/185)
<!-- Reviewable:end -->
