### PR TITLE
Disallow blank names, fixes SF-390

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.spec.ts
@@ -27,6 +27,20 @@ describe('CheckingNameDialogComponent', () => {
     expect(env.component.confirmedName).toBe('Follow The Leader');
   });
 
+  it('should not allow the name to be blank', () => {
+    const env = new TestEnvironment();
+    env.openDialog();
+    expect(env.component.confirmedName).toBeUndefined();
+    env.setTextFieldValue(env.nameInput, '');
+    env.confirmButton.click();
+    env.fixture.detectChanges();
+    expect(env.component.confirmedName).toBeUndefined();
+    env.setTextFieldValue(env.nameInput, ' ');
+    env.confirmButton.click();
+    env.fixture.detectChanges();
+    expect(env.component.confirmedName).toBeUndefined();
+  });
+
   it('shows messages in a confirmation context', () => {
     const env = new TestEnvironment();
     env.component.isConfirmContext = true;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.ts
@@ -1,6 +1,6 @@
 import { MDC_DIALOG_DATA, MdcDialogRef } from '@angular-mdc/web';
 import { Component, Inject } from '@angular/core';
-import { FormControl } from '@angular/forms';
+import { FormControl, Validators } from '@angular/forms';
 
 @Component({
   templateUrl: './edit-name-dialog.component.html'
@@ -12,10 +12,13 @@ export class EditNameDialogComponent {
     public dialogRef: MdcDialogRef<EditNameDialogComponent>,
     @Inject(MDC_DIALOG_DATA) public data: { name: string; isConfirmation: boolean }
   ) {
+    this.name.setValidators([Validators.required, Validators.pattern(/\S/)]);
     this.name.setValue(data.name);
   }
 
   closeDialog() {
-    this.dialogRef.close(this.name.value);
+    if (this.name.valid) {
+      this.dialogRef.close(this.name.value);
+    }
   }
 }


### PR DESCRIPTION
The "Update your name" dialog now requires that the name not be blank, and not consist merely of white space. No errors are shown until the user tries to save it or leaves the textbox.

@irahopkinson On the card you mentioned that "There is already code for checking the validity of this elsewhere." I looked high and low and couldn't find any validation of the name, on either the front end or the back end. That comment was about a month ago, so perhaps it changed between now and then?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/189)
<!-- Reviewable:end -->
