### PR TITLE
Switch question when switching books

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -52,7 +52,7 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
 
   @Input() set questions(questions: Readonly<Question[]>) {
     if (questions.length) {
-      if (this.activeQuestion == null) {
+      if (this.activeQuestion == null || !questions.some(question => question.id === this.activeQuestion.id)) {
         this.activateQuestion(questions[Object.keys(questions)[0]]);
       }
     } else {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.spec.ts
@@ -39,6 +39,10 @@ describe('CheckingNameDialogComponent', () => {
     env.confirmButton.click();
     env.fixture.detectChanges();
     expect(env.component.confirmedName).toBeUndefined();
+    env.setTextFieldValue(env.nameInput, 'Bob');
+    env.confirmButton.click();
+    env.fixture.detectChanges();
+    expect(env.component.confirmedName).toBe('Bob');
   });
 
   it('shows messages in a confirmation context', () => {


### PR DESCRIPTION
This is the second part of a fix for SF-421. The first part is #199. Both are related to audio not pausing, but I've kept them separate due to being fundamentally unrelated.

When switching books, the list of questions and the text are updated, but until now the question itself has not been updated. For that reason the audio didn't pause when switching books. It didn't have anything to do directly with audio though.

I also modified the edit-name-dialog test to close the dialog at the end of the test.

Integration tests are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/200)
<!-- Reviewable:end -->
