### PR TITLE
Don't show reference field as invalid when reference dialog is open

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -115,6 +115,11 @@ export class QuestionDialogComponent implements OnInit {
 
   /** Edit text of control using Scripture chooser dialog. */
   openScriptureChooser(control: AbstractControl) {
+    if (this.scriptureStart.value === '') {
+      // the input element is losing focus, but the input is still being interacted with, so errors shouldn't be shown
+      this.scriptureStart.markAsUntouched();
+    }
+
     const currentVerseSelection = verseRefToVerseRefData(VerseRef.fromStr(control.value, ScrVers.English));
 
     let rangeStart: VerseRefData;


### PR DESCRIPTION
Previously, when using the dialog box to select a reference, the reference input field was shown with a red border. This is because it's gained and lost focus without a valid input. The solution I'm using is to mark it as untouched if the dialog is opened while the input is empty. This may seem a little hacky, but I think it correctly reflects the semantics of the situation. The input field *has* lost focus, but it's lost focus to an element that is used to fill the field. The user is still interacting with it, so in a more useful sense it still has the focus.

Fixes SF-340.

Old behavior:

![scriptureRefWarning](https://user-images.githubusercontent.com/6140710/63624368-249f5c00-c5ca-11e9-894d-9f319a6ffc31.PNG)


Integration tests are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/202)
<!-- Reviewable:end -->
