### PR TITLE
Autofocus text fields

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -36,6 +36,7 @@
     <div [fxShow]="answerTabs.activeTabIndex === 0" class="answer-tab answer-text">
       <mdc-form-field>
         <mdc-text-field
+          appAutofocus
           label="Your Answer"
           type="text"
           formControlName="answerText"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comment-form/checking-comment-form.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comment-form/checking-comment-form.component.html
@@ -1,6 +1,7 @@
 <form [formGroup]="commentForm" (ngSubmit)="submit()" autocomplete="off" id="comment-form">
   <mdc-form-field fluid>
     <mdc-text-field
+      appAutofocus
       label="Your Comment"
       type="text"
       formControlName="commentText"

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/autofocus.directive.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/autofocus.directive.ts
@@ -1,0 +1,16 @@
+import { MdcTextField } from '@angular-mdc/web';
+import { AfterViewInit, Directive } from '@angular/core';
+
+/**
+ * Auto focuses MdcTextField and MdcTextarea. HTML autofocus attribute does not work for dynamically generated content.
+ */
+@Directive({
+  selector: '[appAutofocus]'
+})
+export class AutofocusDirective implements AfterViewInit {
+  constructor(private readonly component: MdcTextField) {}
+
+  ngAfterViewInit() {
+    setTimeout(() => this.component.focus(), 0);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/share/share-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/share/share-dialog.component.html
@@ -9,7 +9,7 @@
         ></app-share-control>
       </mdc-dialog-content>
       <mdc-dialog-actions align="end">
-        <button id="close-btn" default mdcDialogButton mdcDialogAction="close">Done</button>
+        <button id="close-btn" mdcDialogButton mdcDialogAction="close">Done</button>
       </mdc-dialog-actions>
     </mdc-dialog-surface>
   </mdc-dialog-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -34,6 +34,7 @@ import {
 } from '@angular/material';
 import { ChartsModule } from 'ng2-charts';
 
+import { AutofocusDirective } from './autofocus.directive';
 import { BlurOnClickDirective } from './blur-on-click.directive';
 
 const modules = [
@@ -126,9 +127,9 @@ const appFlexLayoutBreakPoints = [
 ];
 
 @NgModule({
-  declarations: [BlurOnClickDirective],
+  declarations: [BlurOnClickDirective, AutofocusDirective],
   imports: modules,
-  exports: [...modules, BlurOnClickDirective],
+  exports: [...modules, BlurOnClickDirective, AutofocusDirective],
   providers: [{ provide: BREAKPOINT, useValue: appFlexLayoutBreakPoints, multi: true }]
 })
 export class UICommonModule {}


### PR DESCRIPTION
Answer and comment fields are focused using a new appAutofocus directive.

The email input in the share dialog is focused by removing the "default" attribute from the dialog's submit button, so it wouldn't steal focus from the input.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/208)
<!-- Reviewable:end -->
