### PR TITLE
Use XFValidators in EditNameDialogComponent

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.ts
@@ -1,6 +1,7 @@
 import { MDC_DIALOG_DATA, MdcDialogRef } from '@angular-mdc/web';
 import { Component, Inject } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
+import { XFValidators } from 'xforge-common/xfvalidators';
 
 @Component({
   templateUrl: './edit-name-dialog.component.html'
@@ -12,7 +13,7 @@ export class EditNameDialogComponent {
     public dialogRef: MdcDialogRef<EditNameDialogComponent>,
     @Inject(MDC_DIALOG_DATA) public data: { name: string; isConfirmation: boolean }
   ) {
-    this.name.setValidators([Validators.required, Validators.pattern(/\S/)]);
+    this.name.setValidators([Validators.required, XFValidators.someNonWhitespace]);
     this.name.setValue(data.name);
   }
 


### PR DESCRIPTION
A short while ago I added validators to `edit-name-dialog.component.ts`. It turns out we already have the same validator in XFValidators. This PR just changes it to use that canonical validator instead of a custom regex.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/209)
<!-- Reviewable:end -->
