### PR TITLE
SF-359 List invitees in system admin user list

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.ts
@@ -15,6 +15,8 @@ function getDocKey(collection: string, id: string): string {
 
 export interface QueryResults<T extends RealtimeDoc> {
   docs: T[];
+  /** The number of docs that would have been returned if the
+   * query did not filter via 'skip' and 'limit' for pagination. */
   totalPagedCount: number;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.html
@@ -8,16 +8,18 @@
   </mdc-form-field>
 </div>
 <div *ngIf="!isLoading">
-  <div *ngIf="length > 0">
+  <div *ngIf="totalRecordCount > 0">
     <table mat-table fxFill id="users-table" [dataSource]="userRows">
       <ng-container matColumnDef="avatar">
         <td mat-cell *matCellDef="let userRow; let i = index">
-          <div *ngIf="userRow.active"><app-avatar [user]="userRow.user" size="32" [round]="false"> </app-avatar></div>
+          <div *ngIf="!userRow.isInvitee">
+            <app-avatar [user]="userRow.user" size="32" [round]="false"> </app-avatar>
+          </div>
         </td>
       </ng-container>
       <ng-container matColumnDef="name">
         <td mat-cell *matCellDef="let userRow">
-          <div *ngIf="userRow.active">
+          <div *ngIf="!userRow.isInvitee">
             <strong *ngIf="userRow.user.displayName !== userRow.user.email">{{ userRow.user.displayName }}</strong>
             <div
               *ngIf="userRow.user.name !== userRow.user.displayName && userRow.user.name !== userRow.user.email"
@@ -26,7 +28,7 @@
               {{ userRow.user.name }}
             </div>
           </div>
-          <div *ngIf="!userRow.active">Awaiting response from</div>
+          <div *ngIf="userRow.isInvitee">Awaiting response from</div>
           {{ userRow.user.email }}
         </td>
       </ng-container>
@@ -44,7 +46,7 @@
       <ng-container matColumnDef="remove">
         <td mat-cell *matCellDef="let userRow" class="remove-cell">
           <button
-            *ngIf="userRow.active"
+            *ngIf="!userRow.isInvitee"
             mdc-icon-button
             class="remove-user"
             (click)="removeUser(userRow.id, userRow.user)"
@@ -54,25 +56,25 @@
 
           <!-- 2 buttons below are 1 button displayed mutually exclusively, different style on breakpoints -->
           <button
-            *ngIf="!userRow.active"
+            *ngIf="userRow.isInvitee"
             fxHide.lt-sm
             fxShow
             mdc-button
             outlined
             color="warn"
             class="cancel-invite"
-            (click)="removeUser(userRow.id, userRow.user)"
+            (click)="uninviteUser(userRow.projectDocs[0].id, userRow.user.email)"
           >
             Cancel invite
           </button>
           <button
-            *ngIf="!userRow.active"
+            *ngIf="userRow.isInvitee"
             fxHide
             fxShow.lt-sm
             mdc-icon-button
             color="warn"
             class="cancel-invite"
-            (click)="removeUser(userRow.id, userRow.user)"
+            (click)="uninviteUser(userRow.projectDocs[0].id, userRow.user.email)"
           >
             <mdc-icon>clear</mdc-icon>
           </button>
@@ -84,12 +86,12 @@
 
     <mat-paginator
       [pageIndex]="pageIndex"
-      [length]="length"
+      [length]="totalRecordCount"
       [pageSize]="pageSize"
       [pageSizeOptions]="[5, 10, 20, 50, 100]"
       (page)="updatePage($event.pageIndex, $event.pageSize)"
     >
     </mat-paginator>
   </div>
-  <div *ngIf="length === 0" id="no-users-label">No users found</div>
+  <div *ngIf="totalRecordCount === 0" id="no-users-label">No users found</div>
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/users/collaborators/collaborators.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/users/collaborators/collaborators.component.spec.ts
@@ -95,6 +95,9 @@ describe('CollaboratorsComponent', () => {
     expect(env.cancelInviteButtonOnRow(inviteeRow)).toBeTruthy();
   }));
 
+  // Not specifying behaviour for when current user is not a project admin,
+  // since currently this component is only accessed by admins.
+
   it('should uninvite user from project', fakeAsync(() => {
     const env = new TestEnvironment();
     when(env.mockedProjectService.onlineInvitedUsers(env.project01Id)).thenResolve(['alice@a.aa']);

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -147,7 +147,7 @@ namespace SIL.XForge.Scripture.Controllers
         {
             try
             {
-                await _projectService.UninviteUserAsync(UserId, projectId, emailToUninvite);
+                await _projectService.UninviteUserAsync(UserId, projectId, emailToUninvite, SystemRole);
                 return Ok();
             }
             catch (ForbiddenException)

--- a/src/SIL.XForge/Services/IProjectService.cs
+++ b/src/SIL.XForge/Services/IProjectService.cs
@@ -11,7 +11,7 @@ namespace SIL.XForge.Services
         Task UpdateRoleAsync(string curUserId, string systemRole, string projectId, string projectRole);
         Task<bool> InviteAsync(string curUserId, string projectId, string email);
         Task<bool> IsAlreadyInvitedAsync(string curUserId, string projectId, string email);
-        Task UninviteUserAsync(string curUserId, string projectId, string email);
+        Task UninviteUserAsync(string curUserId, string projectId, string email, string userSystemRole = null);
         Task CheckLinkSharingAsync(string curUserId, string projectId, string shareKey = null);
         Task<string[]> InvitedUsersAsync(string curUserId, string projectId, string curUserSystemRole = null);
         Task<Uri> SaveAudioAsync(string curUserId, string projectId, string dataId, string extension,

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -142,10 +142,11 @@ namespace SIL.XForge.Services
         }
 
         /// <summary>Cancel an outstanding project invitation.</summary>
-        public async Task UninviteUserAsync(string curUserId, string projectId, string emailToUninvite)
+        public async Task UninviteUserAsync(string curUserId, string projectId, string emailToUninvite, string userSystemRole = null)
         {
             TModel project = await GetProjectAsync(projectId);
-            if (!IsProjectAdmin(project, curUserId))
+            if (!IsProjectAdmin(project, curUserId)
+            && !IsSystemAdministrator(userSystemRole))
                 throw new ForbiddenException();
 
             if (!await IsAlreadyInvitedAsync(curUserId, projectId, emailToUninvite))


### PR DESCRIPTION
- Rename user row active to isInvitee and invert.
- Handle uninviting user from system admin user list.
- Allow system administrators to uninvite.
- Show invited users in system admin user list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/220)
<!-- Reviewable:end -->
