### PR TITLE
SF-365 End reference disabled after using scripture chooser dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -59,7 +59,7 @@
           formControlName="scriptureStart"
           outlined
           id="scripture-start"
-          (input)="this.scriptureStart.valid ? this.scriptureEnd.enable() : this.scriptureEnd.disable()"
+          (input)="updateScriptureEndEnabled()"
           (change)="extractScriptureText()"
         >
           <mdc-icon mdcTextFieldIcon trailing clickable (click)="openScriptureChooser(scriptureStart)"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -211,6 +211,10 @@ export class CheckingAnswersComponent implements OnInit {
     this.scriptureText.setValue(verses.length ? verses.join(' ') : null);
   }
 
+  updateScriptureEndEnabled() {
+    this.scriptureStart.valid ? this.scriptureEnd.enable() : this.scriptureEnd.disable();
+  }
+
   getComments(answer: Answer): Comment[] {
     return this.comments
       .filter(comment => comment.answerRef === answer.id)
@@ -269,6 +273,7 @@ export class CheckingAnswersComponent implements OnInit {
         control.markAsTouched();
         control.markAsDirty();
         this.extractScriptureText();
+        this.updateScriptureEndEnabled();
       }
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
@@ -14,7 +14,7 @@
                 formControlName="scriptureStart"
                 outlined
                 id="scripture-start"
-                (input)="this.scriptureStart.valid ? this.scriptureEnd.enable() : this.scriptureEnd.disable()"
+                (input)="updateScriptureEndEnabled()"
               >
                 <mdc-icon mdcTextFieldIcon trailing clickable (click)="openScriptureChooser(scriptureStart)"
                   >expand_more</mdc-icon

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -139,6 +139,10 @@ export class QuestionDialogComponent extends SubscriptionDisposable implements O
     };
   }
 
+  updateScriptureEndEnabled() {
+    this.scriptureStart.valid ? this.scriptureEnd.enable() : this.scriptureEnd.disable();
+  }
+
   async submit() {
     if (this.audio.status === 'recording') {
       await this.audioCombinedComponent.audioRecorderComponent.stopRecording();
@@ -180,6 +184,7 @@ export class QuestionDialogComponent extends SubscriptionDisposable implements O
         control.markAsTouched();
         control.markAsDirty();
         control.setValue(verseRefDataToString(result));
+        this.updateScriptureEndEnabled();
       }
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -558,7 +558,7 @@ export class EditorComponent extends DataLoadingComponent implements OnInit, OnD
     if (sourceSegment === this.source.segmentText) {
       this.translationSession = translationSession;
       const finish = performance.now();
-      console.log('Translated segment, length: %d, time: %dms', words.length, finish - start);
+      console.log(`Translated segment, length: ${words.length}, time: ${finish - start}ms`);
     }
   }
 


### PR DESCRIPTION
If an invalid reference is supplied and then the scripture chooser dialog is used, the end reference input should be enabled again. Previously it would remain disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/224)
<!-- Reviewable:end -->
