### PR TITLE
Reorder items on help menu

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -21,8 +21,6 @@
           <mdc-menu #helpMenu [anchorCorner]="'bottomStart'" [anchorElement]="helpMenuAnchor">
             <mdc-list-group>
               <mdc-list>
-                <div class="mdc-list-group__subheader">Product version: v{{ version }}</div>
-                <mdc-list-divider></mdc-list-divider>
                 <mdc-list-item> <a target="_blank" [href]="helpsPage"> Help</a> </mdc-list-item>
                 <mdc-list-item name="issues">
                   <a target="_blank" [href]="issueMailTo">
@@ -34,6 +32,8 @@
                     </mdc-list-item-text>
                   </a>
                 </mdc-list-item>
+                <mdc-list-divider></mdc-list-divider>
+                <div class="mdc-list-group__subheader">Product version: v{{ version }}</div>
               </mdc-list>
             </mdc-list-group>
           </mdc-menu>


### PR DESCRIPTION
This just changes the order of the help menu entries, putting the version at the end. It's an absolutely trivial change to something that just struck me as a bit off.

Before | After
-----|-----
![Screen Shot 2019-08-29 at 15 57 57](https://user-images.githubusercontent.com/6140710/63972016-d5e43d00-ca75-11e9-9139-6119e58601e7.png) | ![Screen Shot 2019-08-29 at 15 55 21](https://user-images.githubusercontent.com/6140710/63972030-dc72b480-ca75-11e9-9a8b-714c311e007d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/225)
<!-- Reviewable:end -->
