### PR TITLE
Fix layout of checking-text component during loading

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.scss
@@ -1,4 +1,4 @@
-:host {
+app-checking-text {
   position: absolute;
   height: 100%;
   width: 100%;


### PR DESCRIPTION
## Before:
![Screenshot from 2019-08-29 17-08-21](https://user-images.githubusercontent.com/6140710/63976882-5871fa00-ca80-11e9-9809-bb4e01380b18.png)

## After:
![Screenshot from 2019-08-30 09-29-09](https://user-images.githubusercontent.com/6140710/64024572-b813e800-cb08-11e9-9d59-eb4b882536a0.png)

This restores the previous CSS that was applied to the `app-checking-text` element before the disabling of CSS view encapsulation for this component in d2aa29639912fbce452070239f3b4eca2b9e17f8.  The `:host` selector didn't get updated to `app-checking-text`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/227)
<!-- Reviewable:end -->
