### PR TITLE
Question icon does not navigate to an appropriate question and answer (SF-452)

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
@@ -156,19 +156,27 @@ export class CheckingTextComponent extends SubscriptionDisposable {
 
   private segmentClicked(verseRefData: VerseRefData) {
     const verseRef = verseRefDataToVerseRef(verseRefData);
+    let bestMatch: ScriptureReference = {};
+
     for (const reference of this.references) {
       const verseStart = verseRefDataToVerseRef(reference.scriptureStart);
       let verseEnd = verseRefDataToVerseRef(reference.scriptureEnd);
       if (!verseEnd.book) {
         verseEnd = verseStart;
       }
-      if (
+      if (verseStart.chapterNum === verseRef.chapterNum && verseStart.verseNum === verseRef.verseNum) {
+        bestMatch = reference;
+        break;
+      } else if (
         verseStart.chapterNum === verseRef.chapterNum &&
         verseStart.verseNum <= verseRef.verseNum &&
         verseEnd.verseNum >= verseRef.verseNum
       ) {
-        this.referenceClicked.emit(reference);
+        bestMatch = reference;
       }
+    }
+    if (bestMatch) {
+      this.referenceClicked.emit(bestMatch);
     }
   }
 


### PR DESCRIPTION
- Check for an exact match for clicking on a verse/question icon
- Have a fallback for a best match for a verse in the middle of a question

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/235)
<!-- Reviewable:end -->
