### PR TITLE
Fix layout of app-checking-text in question dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.scss
@@ -1,5 +1,4 @@
 app-checking-text {
-  position: absolute;
   height: 100%;
   width: 100%;
   display: flex;


### PR DESCRIPTION
This was broken by me in 73f2e2466129270b2b00538553700c508c3288d7.

As far as I can tell, there are only two places this component is used, and both of them are now rendered correctly in both Firefox and Chromium.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/237)
<!-- Reviewable:end -->
