### PR TITLE
SF-460: Fix clipping of text size menu when sharing is disabled

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -20,17 +20,12 @@
       }
     }
   }
-  #questions-panel {
-  }
   #text-panel {
     display: flex;
     flex-direction: column;
     flex: 1;
     height: 100%;
     width: 100%;
-    @include media-breakpoint-up(md) {
-      overflow: hidden;
-    }
     .chapter-select {
       cursor: pointer;
     }


### PR DESCRIPTION
Fixes SF-460, where the menu for setting the text size was clipped when sharing was disabled. 

I thought the CSS I was removing might be used for something else, but after asking @nigel-wells about it, it appears it is no longer needed. As far as I can tell everything still looks correct in mobile and desktop view, for Chrome and Firefox.

Before | After
-----|-----
![Screenshot from 2019-09-03 18-38-41](https://user-images.githubusercontent.com/6140710/64213563-6f975a00-ce7b-11e9-8044-c75a379acdae.png) | ![Screenshot from 2019-09-03 18-37-47](https://user-images.githubusercontent.com/6140710/64213567-73c37780-ce7b-11e9-8ab5-92c56d998135.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/238)
<!-- Reviewable:end -->
