### PR TITLE
Convert error component to dialog and address SF-408

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app-routing.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app-routing.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { AuthGuard } from 'xforge-common/auth.guard';
-import { ErrorComponent } from 'xforge-common/error/error.component';
 import { SystemAdminAuthGuard } from 'xforge-common/system-admin-auth.guard';
 import { SystemAdministrationComponent } from 'xforge-common/system-administration/system-administration.component';
 import { UsersComponent } from 'xforge-common/users/users.component';
@@ -14,7 +13,6 @@ import { SyncComponent } from './sync/sync.component';
 
 const routes: Routes = [
   { path: 'connect-project', component: ConnectProjectComponent, canActivate: [AuthGuard] },
-  { path: 'error', component: ErrorComponent },
   { path: 'projects/:projectId/settings', component: SettingsComponent, canActivate: [SFAdminAuthGuard] },
   { path: 'projects/:projectId/sync', component: SyncComponent, canActivate: [SFAdminAuthGuard] },
   { path: 'projects/:projectId/users', component: UsersComponent, canActivate: [SFAdminAuthGuard] },

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.html
@@ -1,6 +1,16 @@
-<div fxLayout="column" fxLayoutAlign="start center" class="container">
-  <h1>An error has occurred.</h1>
-  <h3 id="error-code">{{ errorCode }}</h3>
-  <span><a (click)="showDetails = !showDetails" class="text-blue">Click for details</a></span>
-  <pre *ngIf="showDetails">{{ stack }}</pre>
-</div>
+<mdc-dialog>
+  <mdc-dialog-container>
+    <mdc-dialog-surface>
+      <mdc-dialog-title>An error has occurred</mdc-dialog-title>
+      <mdc-dialog-content>
+        <p>{{ data.message }}</p>
+        <p>
+          To report an issue, email <a target="_blank" [href]="issueMailTo">{{ issueEmail }}</a>
+        </p>
+        <a (click)="toggleStack()">{{ showDetails ? "Hide" : "Show" }} details</a>
+        <pre [fxShow]="showDetails">{{ data.stack }}</pre>
+      </mdc-dialog-content>
+      <mdc-dialog-actions> <button default mdcDialogButton mdcDialogAction="close">Close</button> </mdc-dialog-actions>
+    </mdc-dialog-surface>
+  </mdc-dialog-container>
+</mdc-dialog>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.scss
@@ -1,4 +1,4 @@
-.text-blue {
+a {
   color: #2d73b9;
   cursor: pointer;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.ts
@@ -1,27 +1,33 @@
-import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
-import { first } from 'rxjs/operators';
-import { NoticeService } from 'xforge-common/notice.service';
+import { MDC_DIALOG_DATA, MdcDialogRef } from '@angular-mdc/web';
+import { Component, Inject, NgZone } from '@angular/core';
+import { environment } from 'src/environments/environment';
+
+export interface ErrorAlert {
+  message: string;
+  stack: string;
+}
 
 @Component({
-  selector: 'app-error',
   templateUrl: './error.component.html',
   styleUrls: ['./error.component.scss']
 })
-export class ErrorComponent implements OnInit {
-  stack: string;
-  errorCode: string = 'Error: No error code';
+export class ErrorComponent {
+  issueEmail = environment.issueEmail;
   showDetails: boolean = false;
 
-  constructor(private readonly activatedRoute: ActivatedRoute, private readonly noticeService: NoticeService) {}
+  constructor(
+    public dialogRef: MdcDialogRef<ErrorComponent>,
+    @Inject(MDC_DIALOG_DATA) public data: ErrorAlert,
+    private readonly zone: NgZone
+  ) {}
 
-  ngOnInit() {
-    this.activatedRoute.queryParams.pipe(first()).subscribe(params => {
-      this.noticeService.loadingFinished();
-      this.stack = params['stack'];
-      if (params['errorCode']) {
-        this.errorCode = params['errorCode'];
-      }
+  get issueMailTo(): string {
+    return encodeURI('mailto:' + environment.issueEmail + '?subject=Scripture Forge v2 Issue');
+  }
+
+  toggleStack() {
+    this.zone.run(() => {
+      this.showDetails = !this.showDetails;
     });
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime-offline-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime-offline-store.ts
@@ -82,6 +82,9 @@ export class RealtimeOfflineStore {
       return this.openDBPromise;
     }
     this.openDBPromise = new Promise<void>((resolve, reject) => {
+      if (!window.indexedDB) {
+        return reject(new Error('IndexedDB is not avilable in this browser. Please use a different browser.'));
+      }
       const request = window.indexedDB.open(DATABASE_NAME);
       request.onerror = () => reject(request.error);
       request.onsuccess = () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/xforge-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/xforge-common.module.ts
@@ -49,6 +49,7 @@ export const xForgeCommonEntryComponents = [EditNameDialogComponent, ShareDialog
   ],
   declarations: componentExports,
   exports: componentExports,
+  entryComponents: [ErrorComponent],
   providers: [{ provide: HTTP_INTERCEPTORS, useClass: AuthHttpInterceptor, multi: true }]
 })
 export class XForgeCommonModule {}


### PR DESCRIPTION
This PR addresses SF-408, an error in Firefox private browsing due to IndexedDB being unavailable (`window.indexedDB` is defined, but attempting to use it throws an error). While ideally we wouldn't depend so heavily on IndexedDB that everything breaks when it's unavailable, for now the best approach is to inform users that they need to use another browser or exit private browsing mode.

The best way I could think of to handle this is to deal with the error in the exception handling service and change the message to something more helpful if the problem is IndexedDB in Firefox. I'm not sure it's an ideal solution, but I don't think there's a way to detect this until the exception is actually thrown (Actually, it starts as a promise rejection. I'm unsure whether it's thrown at any point, but it ends up in the exception handler).

While working on this I converted the error handling component to a dialog, rather than a component rendered at `/error`. This has two large advantages:
- Since many errors are not fatal (the page may continue mostly working), it allows the user to close the dialog and attempt to continue working, rather than redirecting them to an error page.
- Refreshing the page will not just show the error again. Previously, because we redirected to `/error?stack=...`, refreshing the page would show the error again, giving the impression that the error kept recurring. The dialog preserves the ability to refresh the page and try again. This even threw me off a few times while developing.

This also fixes a weird bug where the show/hide stacktrace link didn't work, though it would after refreshing the page. For some reason I had to use `ChangeDetectorRef.detectChanges()` after the click event to get Angular to actually update the dialog. I haven't been able to figure out why this is. I thought perhaps it had something to do with the error having occurred, but it turns out the behavior is the same in the tests, where I'm not actually throwing an error.

All integration tests are passing.

![Screen Shot 2019-09-04 at 22 07 30-fullpage resized](https://user-images.githubusercontent.com/6140710/64307228-700b2000-cf63-11e9-993d-c04cbf9c7f78.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/240)
<!-- Reviewable:end -->
