### PR TITLE
Filter by displayName on system administration users page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
@@ -55,7 +55,11 @@ export class UserService {
     return combineLatest(debouncedTerm$, queryParameters$, reload$).pipe(
       switchMap(([term, queryParameters]) => {
         const query = {
-          $or: [{ name: { $regex: `.*${term}.*`, $options: 'i' } }, { email: { $regex: `.*${term}.*`, $options: 'i' } }]
+          $or: [
+            { name: { $regex: `.*${term}.*`, $options: 'i' } },
+            { email: { $regex: `.*${term}.*`, $options: 'i' } },
+            { displayName: { $regex: `.*${term}.*`, $options: 'i' } }
+          ]
         };
         return from(this.realtimeService.onlineQuery<UserDoc>(UserDoc.COLLECTION, query, queryParameters));
       })


### PR DESCRIPTION
Hitherto the filter input on the admin page has filtered on name and email, but not displayName.

Unfortunately the searching feature relies on Mongo's `$regex` operator, rather than looking for an exact string match. I don't know a good solution to this. The email addresses I use locally are in the form of `a+b@example.com`. The `.` will match any character, and the `+` is interpreted as an operator, so even exact search terms sometimes don't match. This isn't a huge deal since it's on the system admin page, but it definitely feels wrong.

I looked into adding tests for this, but the way we mock the search feature of the user service, it doesn't even consider the query, so without major changes, the test would just be testing itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/241)
<!-- Reviewable:end -->
