### PR TITLE
Add Bugsnag error reporting to error handling service

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/angular.json
+++ b/src/SIL.XForge.Scripture/ClientApp/angular.json
@@ -50,7 +50,7 @@
               ],
               "optimization": true,
               "outputHashing": "all",
-              "sourceMap": false,
+              "sourceMap": true,
               "extractCss": true,
               "namedChunks": false,
               "aot": true,

--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -1953,6 +1953,54 @@
         }
       }
     },
+    "@bugsnag/browser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-6.4.0.tgz",
+      "integrity": "sha512-f6KUTIQ4hvJ35MxU35ORsyWwbLPxQ/vFOJdmYwvqrpH1FJSMJjTEmjW4pZbXY0iFkyJ0utYdMVek4ezY7xLtJg=="
+    },
+    "@bugsnag/core": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-6.4.0.tgz",
+      "integrity": "sha512-BfjW7TM17OiiUxSkhcdS7BDgyaJpfnE+siZ+9i8miDH1oIdb8H6w9dXuFv58r9r+JEF11GzhrPOA7XIwEIorAg==",
+      "requires": {
+        "@bugsnag/cuid": "^3.0.0",
+        "@bugsnag/safe-json-stringify": "4.0.0",
+        "error-stack-parser": "^2.0.3",
+        "iserror": "0.0.2",
+        "stack-generator": "^2.0.3"
+      }
+    },
+    "@bugsnag/cuid": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.0.tgz",
+      "integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg=="
+    },
+    "@bugsnag/js": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-6.4.0.tgz",
+      "integrity": "sha512-4wcNz3fY4Cos3JPWxHz0IADRqFVIIPclX5peihQmSRJgPqpKuZlnwNVzIpp3VPw00cHjEAXKKID7CCv9NuQObA==",
+      "requires": {
+        "@bugsnag/browser": "^6.4.0",
+        "@bugsnag/node": "^6.4.0"
+      }
+    },
+    "@bugsnag/node": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-6.4.0.tgz",
+      "integrity": "sha512-vr/1u59oQ0batGfPGzlk9Mhg2n7TV/pwEpbaYBA8nsdMF3wiEsJkvpkq1tvixOSClzdVfI1h85v1IrHOFOgXaQ==",
+      "requires": {
+        "byline": "^5.0.0",
+        "error-stack-parser": "^2.0.2",
+        "iserror": "^0.0.2",
+        "pump": "^3.0.0",
+        "stack-generator": "^2.0.3"
+      }
+    },
+    "@bugsnag/safe-json-stringify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-4.0.0.tgz",
+      "integrity": "sha512-eb0yG+PNTdpRXIhfEq4IFi2wBfpE1DjrAlkyehinu9RxE1PKteqJioLmfQjvkG3UviGu/k5pcamYMxNuCAMIoQ=="
+    },
     "@material/animation": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@material/animation/-/animation-1.0.0.tgz",
@@ -3992,6 +4040,11 @@
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
     },
+    "byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -5329,7 +5382,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -5453,6 +5505,14 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.3.tgz",
+      "integrity": "sha512-vRC4rKv87twMZy92X4+TmUdv3iYMsmePbpG/YguHsfzmZ8bYJZYYep7yrXH09yFUaCEPKgNK5X79+Yq7hwLVOA==",
+      "requires": {
+        "stackframe": "^1.0.4"
       }
     },
     "es-abstract": {
@@ -8031,6 +8091,11 @@
       "requires": {
         "buffer-alloc": "^1.2.0"
       }
+    },
+    "iserror": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
+      "integrity": "sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U="
     },
     "isexe": {
       "version": "2.0.0",
@@ -13694,7 +13759,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -14469,7 +14533,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -16145,6 +16208,19 @@
         "figgy-pudding": "^3.5.1"
       }
     },
+    "stack-generator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.3.tgz",
+      "integrity": "sha512-kdzGoqrnqsMxOEuXsXyQTmvWXZmG0f3Ql2GDx5NtmZs59sT2Bt9Vdyq0XdtxUi58q/+nxtbF9KOQ9HkV1QznGg==",
+      "requires": {
+        "stackframe": "^1.0.4"
+      }
+    },
+    "stackframe": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
+      "integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw=="
+    },
     "staged-git-files": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.2.tgz",
@@ -17600,8 +17676,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
       "version": "3.3.3",

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -32,6 +32,8 @@
     "@angular/pwa": "^0.803.2",
     "@angular/router": "^8.2.4",
     "@angular/service-worker": "^8.2.4",
+    "@bugsnag/core": "^6.4.0",
+    "@bugsnag/js": "^6.4.0",
     "@sillsdev/machine": "^2.1.0-34",
     "angular-file": "^0.5.9",
     "angular-split": "^3.0.2",

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -74,7 +74,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   }
 
   get issueMailTo(): string {
-    return encodeURI('mailto:' + environment.issueEmail + '?subject=Scripture Forge v2 Issue');
+    return encodeURI(`mailto:${environment.issueEmail}?subject=${environment.siteName} issue`);
   }
 
   get helpsPage(): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
@@ -4,9 +4,11 @@ import { ErrorHandler, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ServiceWorkerModule } from '@angular/service-worker';
-import { BugsnagProvider, ExceptionHandlingService } from 'xforge-common/exception-handling-service';
+import bugsnag, { Bugsnag } from '@bugsnag/js';
+import { ExceptionHandlingService } from 'xforge-common/exception-handling-service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { xForgeCommonEntryComponents, XForgeCommonModule } from 'xforge-common/xforge-common.module';
+import { version } from '../../../version.json';
 import { environment } from '../environments/environment';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -22,6 +24,22 @@ import { StartComponent } from './start/start.component';
 import { SyncComponent } from './sync/sync.component';
 import { TranslateModule } from './translate/translate.module';
 import { UsersModule } from './users/users.module';
+
+function createBugsnagClient(): Bugsnag.Client {
+  const config: Bugsnag.IConfig = {
+    apiKey: environment.bugsnagApiKey,
+    appVersion: version,
+    appType: 'angular',
+    notifyReleaseStages: ['live', 'qa'],
+    releaseStage: environment.releaseStage,
+    autoNotify: false,
+    trackInlineScripts: false
+  };
+  if (environment.releaseStage === 'dev') {
+    config.logger = null;
+  }
+  return bugsnag(config);
+}
 
 @NgModule({
   declarations: [
@@ -49,7 +67,11 @@ import { UsersModule } from './users/users.module';
     UICommonModule,
     XForgeCommonModule
   ],
-  providers: [DatePipe, { provide: ErrorHandler, useClass: ExceptionHandlingService }, BugsnagProvider],
+  providers: [
+    DatePipe,
+    { provide: ErrorHandler, useExisting: ExceptionHandlingService },
+    { provide: Bugsnag.Client, useFactory: createBugsnagClient }
+  ],
   entryComponents: [
     DeleteProjectDialogComponent,
     ProjectDeletedDialogComponent,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
@@ -4,11 +4,10 @@ import { ErrorHandler, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ServiceWorkerModule } from '@angular/service-worker';
-import bugsnag, { Bugsnag } from '@bugsnag/js';
+import { Bugsnag } from '@bugsnag/js';
 import { ExceptionHandlingService } from 'xforge-common/exception-handling-service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { xForgeCommonEntryComponents, XForgeCommonModule } from 'xforge-common/xforge-common.module';
-import { version } from '../../../version.json';
 import { environment } from '../environments/environment';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -24,22 +23,6 @@ import { StartComponent } from './start/start.component';
 import { SyncComponent } from './sync/sync.component';
 import { TranslateModule } from './translate/translate.module';
 import { UsersModule } from './users/users.module';
-
-function createBugsnagClient(): Bugsnag.Client {
-  const config: Bugsnag.IConfig = {
-    apiKey: environment.bugsnagApiKey,
-    appVersion: version,
-    appType: 'angular',
-    notifyReleaseStages: ['live', 'qa'],
-    releaseStage: environment.releaseStage,
-    autoNotify: false,
-    trackInlineScripts: false
-  };
-  if (environment.releaseStage === 'dev') {
-    config.logger = null;
-  }
-  return bugsnag(config);
-}
 
 @NgModule({
   declarations: [
@@ -70,7 +53,7 @@ function createBugsnagClient(): Bugsnag.Client {
   providers: [
     DatePipe,
     { provide: ErrorHandler, useExisting: ExceptionHandlingService },
-    { provide: Bugsnag.Client, useFactory: createBugsnagClient }
+    { provide: Bugsnag.Client, useFactory: ExceptionHandlingService.createBugsnagClient }
   ],
   entryComponents: [
     DeleteProjectDialogComponent,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
@@ -4,7 +4,7 @@ import { ErrorHandler, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ServiceWorkerModule } from '@angular/service-worker';
-import { ExceptionHandlingService } from 'xforge-common/exception-handling-service';
+import { BugsnagProvider, ExceptionHandlingService } from 'xforge-common/exception-handling-service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { xForgeCommonEntryComponents, XForgeCommonModule } from 'xforge-common/xforge-common.module';
 import { environment } from '../environments/environment';
@@ -49,7 +49,7 @@ import { UsersModule } from './users/users.module';
     UICommonModule,
     XForgeCommonModule
   ],
-  providers: [DatePipe, { provide: ErrorHandler, useClass: ExceptionHandlingService }],
+  providers: [DatePipe, { provide: ErrorHandler, useClass: ExceptionHandlingService }, BugsnagProvider],
   entryComponents: [
     DeleteProjectDialogComponent,
     ProjectDeletedDialogComponent,

--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.defaults.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.defaults.ts
@@ -1,0 +1,32 @@
+import { clone, merge } from 'lodash';
+
+const defaults = {
+  pwaTest: false,
+  issueEmail: 'scriptureforgeissues@sil.org',
+  siteName: 'Scripture Forge',
+  audience: 'https://scriptureforge.org/',
+  scope: 'sf_data',
+  siteId: 'sf',
+  assets: {
+    audio: '/assets/audio/'
+  },
+  helps: 'https://help.scriptureforge.org/#t=Overview/Getting_Started.htm',
+  bugsnagApiKey: 'b72a46a8924a3cd161d4c5534287923c'
+};
+
+const production = merge(clone(defaults), {
+  production: true,
+  realtimePort: undefined as number,
+  realtimeUrl: '/realtime-api/'
+});
+
+const development = merge(clone(defaults), {
+  production: false,
+  realtimePort: 5003,
+  realtimeUrl: '/',
+  authDomain: 'sil-appbuilder.auth0.com',
+  authClientId: 'aoAGb9Yx1H5WIsvCW6JJCteJhSa37ftH',
+  releaseStage: 'dev'
+});
+
+export { production, development };

--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.defaults.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.defaults.ts
@@ -1,4 +1,5 @@
-import { clone, merge } from 'lodash';
+import clone from 'lodash/clone';
+import merge from 'lodash/merge';
 
 const defaults = {
   pwaTest: false,

--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.prod.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.prod.ts
@@ -1,17 +1,7 @@
-export const environment = {
-  production: true,
-  pwaTest: false,
-  issueEmail: 'scriptureforgeissues@sil.org',
-  siteName: 'Scripture Forge',
-  realtimePort: undefined as number,
-  realtimeUrl: '/realtime-api/',
+import { production } from './environment.defaults';
+
+export const environment = Object.assign(production, {
+  releaseStage: 'live',
   authDomain: 'login.languagetechnology.org',
-  authClientId: 'tY2wXn40fsL5VsPM4uIHNtU6ZUEXGeFn',
-  audience: 'https://scriptureforge.org/',
-  scope: 'sf_data',
-  siteId: 'sf',
-  assets: {
-    audio: '/assets/audio/'
-  },
-  helps: 'https://help.scriptureforge.org/#t=Overview/Getting_Started.htm'
-};
+  authClientId: 'tY2wXn40fsL5VsPM4uIHNtU6ZUEXGeFn'
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.pwa-test.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.pwa-test.ts
@@ -1,17 +1,3 @@
-export const environment = {
-  production: false,
-  pwaTest: true,
-  issueEmail: 'scriptureforgeissues@sil.org',
-  siteName: 'Scripture Forge',
-  realtimePort: 5003,
-  realtimeUrl: '/',
-  authDomain: 'sil-appbuilder.auth0.com',
-  authClientId: 'aoAGb9Yx1H5WIsvCW6JJCteJhSa37ftH',
-  audience: 'https://scriptureforge.org/',
-  scope: 'sf_data',
-  siteId: 'sf',
-  assets: {
-    audio: '/assets/audio/'
-  },
-  helps: 'https://help.scriptureforge.org/#t=Overview/Getting_Started.htm'
-};
+import { development } from './environment.defaults';
+
+export const environment = Object.assign(development, { pwaTest: true });

--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.staging.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.staging.ts
@@ -1,17 +1,7 @@
-export const environment = {
-  production: true,
-  pwaTest: false,
-  issueEmail: 'scriptureforgeissues@sil.org',
-  siteName: 'Scripture Forge',
-  realtimePort: undefined as number,
-  realtimeUrl: '/realtime-api/',
+import { production } from './environment.defaults';
+
+export const environment = Object.assign(production, {
+  releaseStage: 'qa',
   authDomain: 'dev-sillsdev.auth0.com',
-  authClientId: '4eHLjo40mAEGFU6zUxdYjnpnC1K1Ydnj',
-  audience: 'https://scriptureforge.org/',
-  scope: 'sf_data',
-  siteId: 'sf',
-  assets: {
-    audio: '/assets/audio/'
-  },
-  helps: 'https://help.scriptureforge.org/#t=Overview/Getting_Started.htm'
-};
+  authClientId: '4eHLjo40mAEGFU6zUxdYjnpnC1K1Ydnj'
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.ts
@@ -4,20 +4,6 @@
 // `ng build --configuration=pwaTest` then `environment.pwa-test.ts` will be used instead.
 // The list of which env maps to which file can be found in `angular.json`.
 
-export const environment = {
-  production: false,
-  pwaTest: false,
-  issueEmail: 'scriptureforgeissues@sil.org',
-  siteName: 'Scripture Forge',
-  realtimePort: 5003,
-  realtimeUrl: '/',
-  authDomain: 'sil-appbuilder.auth0.com',
-  authClientId: 'aoAGb9Yx1H5WIsvCW6JJCteJhSa37ftH',
-  audience: 'https://scriptureforge.org/',
-  scope: 'sf_data',
-  siteId: 'sf',
-  assets: {
-    audio: '/assets/audio/'
-  },
-  helps: 'https://help.scriptureforge.org/#t=Overview/Getting_Started.htm'
-};
+import { development } from './environment.defaults';
+
+export const environment = development;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.spec.ts
@@ -9,7 +9,8 @@ describe('ErrorComponent', () => {
   it('should display error dialog', () => {
     const env = new TestEnvironment({
       message: 'The error message',
-      stack: 'The error stack'
+      stack: 'The error stack',
+      eventId: '0'
     });
 
     expect(env.errorMessage.textContent).toBe('The error message');
@@ -30,7 +31,8 @@ describe('ErrorComponent', () => {
 
   it('should only offer to show more when a stack trace is available', () => {
     const env = new TestEnvironment({
-      message: 'Testing without stack'
+      message: 'Testing without stack',
+      eventId: '1'
     });
 
     expect(env.errorMessage.textContent).toBe('Testing without stack');

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.ts
@@ -5,6 +5,7 @@ import { environment } from 'src/environments/environment';
 export interface ErrorAlert {
   message: string;
   stack?: string;
+  eventId: string;
 }
 
 @Component({
@@ -22,7 +23,11 @@ export class ErrorComponent {
   ) {}
 
   get issueMailTo(): string {
-    return encodeURI('mailto:' + environment.issueEmail + '?subject=Scripture Forge v2 Issue');
+    return encodeURI(
+      `mailto:${environment.issueEmail}?subject=${environment.siteName} issue&body=\n\nError id: ${
+        this.data.eventId
+      } (included so we can provide better support)`
+    );
   }
 
   toggleStack() {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
@@ -1,0 +1,148 @@
+import { MdcDialog, MdcDialogRef } from '@angular-mdc/web';
+import { Client as BugsnagClient, INotifyOpts } from '@bugsnag/core';
+import { User } from 'realtime-server/lib/common/models/user';
+import { Observable } from 'rxjs';
+import { anything, instance, mock, reset, when } from 'ts-mockito';
+import { ErrorComponent } from './error/error.component';
+import { ExceptionHandlingService } from './exception-handling-service';
+import { UserDoc } from './models/user-doc';
+import { UserService } from './user.service';
+
+describe('ExceptionHandlingService', () => {
+  it('should not crash on anything', async () => {
+    const env = new TestEnvironment();
+    const values = [undefined, null, NaN, Infinity, -1, 0, Symbol(), [] as any[], '', new Error()];
+    await Promise.all(values.map(value => env.service.handleError(value)));
+    expect(env.bugsnagReports.length).toBe(values.length);
+  });
+
+  it('should unwrap a rejection from a promise', async () => {
+    const env = new TestEnvironment();
+    await env.service.handleError({
+      message: 'This is the outer message',
+      stack: 'Stack trace trace to promise implementation',
+      rejection: {
+        message: 'Original error',
+        stack: 'Original stack trace'
+      }
+    });
+
+    expect(env.oneAndOnlyReport.error.message).toBe('Original error');
+    expect(env.oneAndOnlyReport.error.stack).toBe('Original stack trace');
+    expect(env.oneAndOnlyReport.opts.user.id).toBe('some id');
+    expect(env.oneAndOnlyReport.opts.metaData.eventId).toMatch(/[\da-f]{24}/);
+  });
+
+  it('should handle undefined users', async () => {
+    const env = new TestEnvironment();
+    env.userDoc = undefined;
+    await env.service.handleError({
+      message: 'Error message',
+      stack: 'Some stack trace'
+    });
+
+    expect(env.oneAndOnlyReport.error).toBeDefined();
+    expect(env.oneAndOnlyReport.opts.metaData).toBeDefined();
+    expect(env.oneAndOnlyReport.opts.user).toBeUndefined();
+  });
+
+  it('should handle user object being unavailable', done => {
+    jasmine.clock().install();
+    jasmine.clock().mockDate();
+    const env = new TestEnvironment();
+    env.timeoutUser = true;
+    env.service.handleError(new Error('Some error')).then(() => {
+      expect(env.oneAndOnlyReport.error).toBeDefined();
+      expect(env.oneAndOnlyReport.opts).toBeDefined();
+      expect(env.oneAndOnlyReport.opts.user).toBeUndefined();
+      done();
+    });
+    jasmine.clock().tick(3000);
+    jasmine.clock().uninstall();
+  });
+
+  it('should handle promise for user being rejected', async () => {
+    const env = new TestEnvironment();
+    env.rejectUser = true;
+    await env.service.handleError(new Error('Misspelled word error'));
+
+    expect(env.oneAndOnlyReport.error).toBeDefined();
+    expect(env.oneAndOnlyReport.opts).toBeDefined();
+    expect(env.oneAndOnlyReport.opts.user).toBeUndefined();
+  });
+});
+
+class MockBugsnagProvider {
+  constructor(private _bugsnag: BugsnagClient) {}
+  bugsnag = () => {
+    return this._bugsnag;
+  };
+}
+
+class MockBugsnagClient {
+  notify = (error: any, opts?: any, cb?: any): void => {};
+}
+
+class TestEnvironment {
+  mockedMdcDialog = mock(MdcDialog);
+  mockedUserService = mock(UserService);
+  mockedBugsnagClient = mock(MockBugsnagClient);
+  bugsnagReports: { error: any; opts: any; cb: any }[] = [];
+  mockBugsnagProvider = new MockBugsnagProvider(instance(this.mockedBugsnagClient) as BugsnagClient);
+  service: ExceptionHandlingService;
+  rejectUser = false;
+  timeoutUser = false;
+
+  userDoc = {
+    data: {
+      authId: 'a',
+      name: 'b',
+      displayName: 'c',
+      email: 'd'
+    } as Readonly<User>,
+    id: 'some id'
+  } as UserDoc;
+
+  constructor() {
+    this.userDoc.data['random'] = Math.random();
+    delete ExceptionHandlingService['bugsnagClient'];
+    this.service = new ExceptionHandlingService(
+      instance(this.mockedMdcDialog),
+      instance(this.mockedUserService),
+      this.mockBugsnagProvider
+    );
+
+    when(this.mockedMdcDialog.open(anything(), anything())).thenReturn({
+      afterClosed: () => {
+        return {
+          subscribe: (cb: () => void) => {
+            setTimeout(cb, 0);
+          }
+        } as Observable<{}>;
+      }
+    } as MdcDialogRef<ErrorComponent, {}>);
+
+    when(this.mockedUserService.getCurrentUser()).thenCall(() => {
+      return new Promise((resolve, reject) => {
+        if (!this.timeoutUser) {
+          this.rejectUser ? reject() : resolve(this.userDoc);
+        }
+      });
+    });
+
+    when(this.mockedBugsnagClient.notify(anything(), anything(), anything())).thenCall(
+      (error: any, opts: INotifyOpts, cb: any) => {
+        this.bugsnagReports.push({
+          error,
+          opts,
+          cb
+        });
+      }
+    );
+  }
+
+  get oneAndOnlyReport() {
+    expect(this.bugsnagReports.length).toEqual(1);
+    return this.bugsnagReports[this.bugsnagReports.length - 1];
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
@@ -1,9 +1,10 @@
 import { MdcDialog } from '@angular-mdc/web';
 import { ErrorHandler, Injectable } from '@angular/core';
-import { Bugsnag } from '@bugsnag/js';
+import bugsnag, { Bugsnag } from '@bugsnag/js';
 import cloneDeep from 'lodash/cloneDeep';
 import { User } from 'realtime-server/lib/common/models/user';
 import { environment } from 'src/environments/environment';
+import { version } from '../../../version.json';
 import { ErrorAlert, ErrorComponent } from './error/error.component';
 import { UserDoc } from './models/user-doc';
 import { UserService } from './user.service';
@@ -15,6 +16,22 @@ type BugsnagStyleUser = User & { id: string };
   providedIn: 'root'
 })
 export class ExceptionHandlingService implements ErrorHandler {
+  static createBugsnagClient(): Bugsnag.Client {
+    const config: Bugsnag.IConfig = {
+      apiKey: environment.bugsnagApiKey,
+      appVersion: version,
+      appType: 'angular',
+      notifyReleaseStages: ['live', 'qa'],
+      releaseStage: environment.releaseStage,
+      autoNotify: false,
+      trackInlineScripts: false
+    };
+    if (environment.releaseStage === 'dev') {
+      config.logger = null;
+    }
+    return bugsnag(config);
+  }
+
   private alertQueue: ErrorAlert[] = [];
   private dialogOpen = false;
   private currentUser: UserDoc;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
@@ -1,21 +1,55 @@
 import { MdcDialog } from '@angular-mdc/web';
 import { ErrorHandler, Injectable } from '@angular/core';
+import { Client as BugsnagClient } from '@bugsnag/core';
+import bugsnag from '@bugsnag/js';
+import { cloneDeep } from 'lodash';
+import { User } from 'realtime-server/lib/common/models/user';
+import { environment } from 'src/environments/environment';
+import { version } from '../../../version.json';
 import { ErrorAlert, ErrorComponent } from './error/error.component';
+import { UserDoc } from './models/user-doc';
+import { UserService } from './user.service';
+import { objectId, promiseTimeout } from './utils';
+
+type BugsnagStyleUser = User & { id: string };
 
 @Injectable()
 export class ExceptionHandlingService implements ErrorHandler {
+  private static bugsnagClient: BugsnagClient;
+
   private alertQueue: ErrorAlert[] = [];
   private dialogOpen = false;
+  private currentUser: UserDoc;
+  private constructionTime = Date.now();
 
-  constructor(private readonly dialog: MdcDialog) {}
-
-  handleError(error: any) {
-    let message = error.rejection ? error.rejection.message || error.rejection : error.message;
-    if (typeof message === 'string') {
-      message = message.split('\n')[0];
-    } else {
-      message = 'Unknown error';
+  constructor(
+    private readonly dialog: MdcDialog,
+    private userService: UserService,
+    private bugsnagProvider: BugsnagProvider
+  ) {
+    if (!ExceptionHandlingService.bugsnagClient) {
+      ExceptionHandlingService.bugsnagClient = bugsnagProvider.bugsnag({
+        apiKey: environment.bugsnagApiKey,
+        appVersion: version,
+        appType: 'angular',
+        notifyReleaseStages: ['live', 'qa'],
+        releaseStage: environment.releaseStage,
+        autoNotify: false,
+        trackInlineScripts: false
+      });
     }
+  }
+
+  async handleError(error: any) {
+    if (typeof error !== 'object' || error === null) {
+      error = new Error('Unkown error: ' + String(error));
+    }
+    error = error.rejection && error.rejection.message ? error.rejection : error;
+
+    console.log(`Error occured. Reporting to Bugsnag with release stage set to ${environment.releaseStage}:`);
+    console.error(error);
+
+    let message = typeof error.message === 'string' ? error.message.split('\n')[0] : 'Unknown error';
 
     if (
       message.includes('A mutation operation was attempted on a database that did not allow mutations.') &&
@@ -24,24 +58,74 @@ export class ExceptionHandlingService implements ErrorHandler {
       message = 'Firefox private browsing mode is not supported because IndexedDB is not avilable.';
     }
 
-    this.handleAlert({ message, stack: error.stack });
-    // Using console.error results in logging 'Error: "[object Object]"', which isn't very helpful
-    throw error;
+    const eventId = objectId();
+    this.handleAlert({ message, stack: error.stack, eventId });
+    this.reportToBugsnag(error, await this.getUserForBugsnag(), eventId);
+  }
+
+  /**
+   * Returns a promise that will resolve to a BugsnagStyleUser representing the current user, or, if the user isn't
+   * available within a reasonable time (within three seconds of the service being constructed), it will resolve with
+   * null.
+   */
+  private async getUserForBugsnag(): Promise<BugsnagStyleUser | undefined> {
+    if (!this.currentUser) {
+      try {
+        this.currentUser = await promiseTimeout(
+          this.userService.getCurrentUser(),
+          Math.max(0, this.constructionTime + 3000 - Date.now())
+        );
+        if (!this.currentUser) {
+          return undefined;
+        }
+      } catch {
+        return undefined;
+      }
+    }
+    const user = cloneDeep(this.currentUser.data);
+    user['id'] = this.currentUser.id;
+    return user as BugsnagStyleUser;
+  }
+
+  private reportToBugsnag(error: any, user: BugsnagStyleUser, eventId: string) {
+    ExceptionHandlingService.bugsnagClient.notify(
+      error,
+      {
+        user,
+        metaData: {
+          eventId
+        }
+      },
+      err => {
+        if (err) {
+          console.error('Reporting error to Bugsnag failed:');
+          console.error(err);
+        }
+      }
+    );
   }
 
   private handleAlert(error: ErrorAlert) {
-    this.alertQueue.unshift(error);
-    this.showAlert();
+    if (!this.alertQueue.some(alert => alert.message === error.message)) {
+      this.alertQueue.unshift(error);
+      this.showAlert();
+    }
   }
 
   private showAlert() {
     if (!this.dialogOpen && this.alertQueue.length) {
       this.dialogOpen = true;
-      const dialog = this.dialog.open(ErrorComponent, { data: this.alertQueue.pop() });
+      const dialog = this.dialog.open(ErrorComponent, { data: this.alertQueue[this.alertQueue.length - 1] });
       dialog.afterClosed().subscribe(() => {
+        this.alertQueue.pop();
         this.dialogOpen = false;
         this.showAlert();
       });
     }
   }
+}
+
+// Wrap bugsnag in class so it can be injected more easily
+export class BugsnagProvider {
+  bugsnag = bugsnag;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -113,3 +113,12 @@ export function getObjValue<TRoot, T>(
 export function getObjPath<TRoot, T>(proxy: ObjProxyArg<TRoot, T>): Array<string | number> {
   return getPath(proxy) as Array<string | number>;
 }
+
+export function promiseTimeout<T>(promise: Promise<T>, timeout: number) {
+  return Promise.race([
+    promise,
+    new Promise<never>((_resolve, reject) => {
+      setTimeout(reject, timeout);
+    })
+  ]);
+}


### PR DESCRIPTION
Implements basic error reporting to Bugsnag from the front end.

## Notes
- I have a ton of list items here, so checkboxes are for keeping track of which things are resolved. Some things should probably be put off until after merging, though we'll have to decide which ones.
- We now have a coresponding project on Bugsnag. I've sent a few errors in order to test it out and verify what will show up on Bugsnag.
- I've generated an "error id" for each event we send to Bugsnag. If the user clicks the mailto link to send an email, the error id is included so we can cross-reference issue reports with Bugsnag events.

## Deviations from SF-203 (potential to-dos)
- [x] Do we provide next steps when we notify users of an error? This was suggested in SF-203, but I wasn't sure what that would look like in practice, so I left it out. There is, of course, the close button (so the user can try to keep working), and the link to send an email.
- [x] The service reports errors on both live and qa because Bugsnag understands release stages and will allow us to easily filter. Hopefully this will help us to catch bugs on qa before they hit live.
- [x] I haven't actually done anything to prevent reporting of spurious errors during logout. Ideally I think we should be extremely selective about the errors we filter out, so that we don't accidentally fail to report errors that weren't the ones we intended to ignore. I'm not sure exactly how to approach this one at this point.

## To-do
- [x] How should API key be referenced? I'm guessing we don't want to hard-code it, even though it's not secret. I just left a placeholder, and for that reason (and others) this is a draft PR. In my testing I used the actual API key and sent some events to verify things were working properly.
- [x] Can we enable source maps in production (qa and live), specifying a sourceMappingURL and making sure source contents are in the source maps as well? Stack traces are almost impossible to interpret otherwise. This is what we do on languageforge.org. It only adds a few bytes to the files served to users, and Bugsnag will then fetch the source maps. This isn't the only way to use source maps with Bugsnag, but I think it's the simplest and least likely to cause problems.
- [x] Currently Bugsnag is loaded twice because the service is constructed twice. I haven't been able to figure out why that is. This doesn't really cause a problem (errors are still only reported once), but there are still two instances that log stuff to the console. I found this behaviour surprising because I thought services were singletons. The only solution I was able to come up with was making several properties static, but I wasn't sure that was the right solution.
- [x] Currently this doesn't handle network errors. I'm a little concerned about reporting all network errors (I get a ton of `can't establish a connection to the server at wss://` locally, often two on each page load).
- [x] This needs tests, which I still plan to write.

## Outstanding questions (further research for me, or things others may know)
- [x] This just handles the front end. Are we all set on the back end? I found a Bugsnag error handler there, which is supposed to send reports in live and qa, but it's obviously not doing that, since Scripture Forge v2 wasn't even a project on Bugsnag until a couple days ago.
- [x] Are we OK with the way I've detected the release stage, by looking for a host that ends with `.org` or contains `qa.`? This would break if we ever changed URLs, but I like that it doesn't require some config to be set during deployment, as that's certain to be forgotten at some point and result in errors being reported to the wrong release stage (Case in point: 95% of errors from Language Forge are reported on an "unknown" release, which isn't very helpful. Usually we want to see errors since last release. I'd hate to see a similar thing happen to the release stage).
- [x] Does Angular catch all errors for us? Bugsnag's default mode is to redefine every global event handler (and probably some other things), so that they can catch errors (`window.onerror` is not very useful for error reporting). I disabled this mode because I *think* Angular and/or Zone.js does something similar, and I didn't like the idea of them both trying to do that. They might not clash, but if they did it could cause some weird situations. Right now I'm just assuming Angular finds all errors that happen and passes them off to the error handling service. On Language Forge we let Bugsnag do it's normal thing, and most errors are counted as "handled" (meaning Bugsnag didn't have to catch them because Angular caught them before they got that high in the stack). We do have a few that are "unhandled" though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/243)
<!-- Reviewable:end -->
