### PR TITLE
SF-359 Don't provide specific sysadmin access for invitee listing

### DIFF
--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -180,7 +180,7 @@ namespace SIL.XForge.Scripture.Controllers
         {
             try
             {
-                return Ok(await _projectService.InvitedUsersAsync(UserId, projectId, SystemRole));
+                return Ok(await _projectService.InvitedUsersAsync(UserId, projectId));
             }
             catch (ForbiddenException)
             {

--- a/src/SIL.XForge/Services/IProjectService.cs
+++ b/src/SIL.XForge/Services/IProjectService.cs
@@ -13,7 +13,7 @@ namespace SIL.XForge.Services
         Task<bool> IsAlreadyInvitedAsync(string curUserId, string projectId, string email);
         Task UninviteUserAsync(string curUserId, string projectId, string email);
         Task CheckLinkSharingAsync(string curUserId, string projectId, string shareKey = null);
-        Task<string[]> InvitedUsersAsync(string curUserId, string projectId, string curUserSystemRole = null);
+        Task<string[]> InvitedUsersAsync(string curUserId, string projectId);
         Task<Uri> SaveAudioAsync(string curUserId, string projectId, string dataId, string extension,
             Stream inputStream);
         Task DeleteAudioAsync(string curUserId, string projectId, string ownerId, string dataId);

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -174,12 +174,11 @@ namespace SIL.XForge.Services
         }
 
         /// <summary>Return list of email addresses with outstanding invitations</summary>
-        public async Task<string[]> InvitedUsersAsync(string curUserId, string projectId, string userSystemRole = null)
+        public async Task<string[]> InvitedUsersAsync(string curUserId, string projectId)
         {
             TModel project = await GetProjectAsync(projectId);
 
-            if (!IsProjectAdmin(project, curUserId)
-             && !IsSystemAdministrator(userSystemRole))
+            if (!IsProjectAdmin(project, curUserId))
                 throw new ForbiddenException();
 
             TSecret projectSecret = await ProjectSecrets.GetAsync(projectId);
@@ -319,11 +318,6 @@ namespace SIL.XForge.Services
         }
 
         protected abstract Task<Attempt<string>> TryGetProjectRoleAsync(TModel project, string userId);
-
-        private static bool IsSystemAdministrator(string userSystemRole)
-        {
-            return userSystemRole == SystemRole.SystemAdmin;
-        }
 
         private async Task<TModel> GetProjectAsync(string projectId)
         {

--- a/test/SIL.XForge.Tests/Services/ProjectServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/ProjectServiceTests.cs
@@ -378,7 +378,7 @@ namespace SIL.XForge.Services
         }
 
         [Test]
-        public async Task InvitedUsers_SystemAdmin_Reports()
+        public async Task InvitedUsers_SystemAdmin_NoSpecialAccess()
         {
             var env = new TestEnvironment();
 
@@ -386,23 +386,17 @@ namespace SIL.XForge.Services
             Assert.That(env.GetProject(Project03).UserRoles.ContainsKey(User04), Is.False, "test setup");
             Assert.That(env.GetUser(User04).Role, Is.EqualTo(SystemRole.SystemAdmin), "test setup");
 
-            var invitees = (await env.Service.InvitedUsersAsync(User04, Project03, env.GetUser(User04).Role));
-            Assert.That(invitees.Length, Is.EqualTo(3));
-            string[] expectedEmailList = { "bob@example.com", "user02@example.com", "bill@example.com" };
-            foreach (var expectedEmail in expectedEmailList)
-            {
-                Assert.That(Array.Exists(invitees, invitee => invitee == expectedEmail));
-            }
+            Assert.ThrowsAsync<ForbiddenException>(() => (env.Service.InvitedUsersAsync(User04, Project03)), "should have been forbidden");
         }
 
         [Test]
         public void InvitedUsers_NonProjectAdmin_Forbidden()
         {
             var env = new TestEnvironment();
-            // User02 is not a system admin or an admin on Project01
+            // User02 is not an admin on Project01
             Assert.That(env.GetProject(Project01).UserRoles[User02], Is.Not.EqualTo(TestProjectRole.Administrator), "test setup");
             Assert.That(env.GetUser(User02).Role, Is.Not.EqualTo(SystemRole.SystemAdmin), "test setup");
-            Assert.ThrowsAsync<ForbiddenException>(() => env.Service.InvitedUsersAsync(User02, Project01, env.GetUser(User02).Role), "should have been forbidden");
+            Assert.ThrowsAsync<ForbiddenException>(() => env.Service.InvitedUsersAsync(User02, Project01), "should have been forbidden");
         }
 
         [Test]


### PR DESCRIPTION
Remove unneeded system role argument.

---
In discussion, the system admin user listing area will not show invitees. This begins to address that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/248)
<!-- Reviewable:end -->
