### PR TITLE
SF-468: Target editor does not display full width when no source

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -67,7 +67,7 @@
         ></app-text>
       </div>
     </div>
-    <div class="text-area" ngClass.xs="text-area-full-width" [class.text-area-full-width]="!hasSource">
+    <div class="text-area" [ngClass.gt-xs]="{ 'text-area-full-width': !hasSource }" ngClass.xs="text-area-full-width">
       <div class="language-label" fxHide.xs mdcSubtitle1>{{ targetLabel }}</div>
       <div #targetContainer class="text-container" [style.height]="textHeight">
         <app-text


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/255)
<!-- Reviewable:end -->
