### PR TITLE
Only offer to show more in error handler when stack exists

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.html
@@ -7,7 +7,7 @@
         <p>
           To report an issue, email <a target="_blank" [href]="issueMailTo">{{ issueEmail }}</a>
         </p>
-        <a (click)="toggleStack()">{{ showDetails ? "Hide" : "Show" }} details</a>
+        <a (click)="toggleStack()" [fxShow]="data.stack">{{ showDetails ? "Hide" : "Show" }} details</a>
         <pre [fxShow]="showDetails">{{ data.stack }}</pre>
       </mdc-dialog-content>
       <mdc-dialog-actions> <button default mdcDialogButton mdcDialogAction="close">Close</button> </mdc-dialog-actions>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.spec.ts
@@ -3,11 +3,14 @@ import { OverlayContainer } from '@angular-mdc/web';
 import { Component, NgModule } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { ErrorComponent } from './error.component';
+import { ErrorAlert, ErrorComponent } from './error.component';
 
 describe('ErrorComponent', () => {
   it('should display error dialog', () => {
-    const env = new TestEnvironment();
+    const env = new TestEnvironment({
+      message: 'The error message',
+      stack: 'The error stack'
+    });
 
     expect(env.errorMessage.textContent).toBe('The error message');
     expect(env.showDetails.textContent).toBe('Show details');
@@ -24,6 +27,17 @@ describe('ErrorComponent', () => {
 
     env.closeButton.click();
   });
+
+  it('should only offer to show more when a stack trace is available', () => {
+    const env = new TestEnvironment({
+      message: 'Testing without stack'
+    });
+
+    expect(env.errorMessage.textContent).toBe('Testing without stack');
+    expect(env.showDetails.style.display).toBe('none');
+    expect(env.stackTrace.style.display).toBe('none');
+    env.closeButton.click();
+  });
 });
 
 @NgModule({
@@ -37,17 +51,12 @@ class TestEnvironment {
   fixture: ComponentFixture<DialogOpenerComponent>;
   element: HTMLElement;
 
-  constructor() {
+  constructor(dialogData: ErrorAlert) {
     TestBed.configureTestingModule({
       declarations: [DialogOpenerComponent],
       imports: [DialogTestModule]
     });
-    TestBed.get(MdcDialog).open(ErrorComponent, {
-      data: {
-        message: 'The error message',
-        stack: 'The error stack'
-      }
-    });
+    TestBed.get(MdcDialog).open(ErrorComponent, { data: dialogData });
     this.fixture = TestBed.createComponent(DialogOpenerComponent);
     this.element = TestBed.get(OverlayContainer).getContainerElement();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.ts
@@ -4,7 +4,7 @@ import { environment } from 'src/environments/environment';
 
 export interface ErrorAlert {
   message: string;
-  stack: string;
+  stack?: string;
 }
 
 @Component({


### PR DESCRIPTION
Previously the error dialog would offer to "Show more" regardless of whether it actually had a stack trace to show. In some cases (e.g. network errors) there is no stack trace that can be shown, so this is unhelpful and makes the error dialog appear to be broken, in addition to whatever error just happened.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/259)
<!-- Reviewable:end -->
