### PR TITLE
SF-471: Handle name confirm dialog in HelpHero tour

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -11,6 +11,7 @@ import { TextInfo } from 'realtime-server/lib/scriptureforge/models/text-info';
 import { Canon } from 'realtime-server/lib/scriptureforge/scripture-utils/canon';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
+import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { UserService } from 'xforge-common/user.service';
 import { objectId } from 'xforge-common/utils';
@@ -38,6 +39,7 @@ interface Summary {
   styleUrls: ['./checking.component.scss']
 })
 export class CheckingComponent extends DataLoadingComponent implements OnInit, OnDestroy {
+  userDoc: UserDoc;
   @ViewChild('answerPanelContainer', { static: false }) set answersPanelElement(
     answersPanelContainerElement: ElementRef
   ) {
@@ -173,6 +175,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
         this._chapter = undefined;
         this.chapter = 1;
 
+        this.userDoc = await this.userService.getCurrentUser();
         this.startUserOnboardingTour(); // start HelpHero tour for the Community Checking feature
         this.loadingFinished();
       }
@@ -497,11 +500,13 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
       this.projectDoc.data.userRoles[this.userService.currentUserId] === SFProjectRole.ParatextAdministrator;
     const isDiscussionEnabled: boolean = this.projectDoc.data.checkingConfig.usersSeeEachOthersResponses;
     const isInvitingEnabled: boolean = this.projectDoc.data.checkingConfig.shareEnabled;
+    const isNameConfirmed = this.userDoc.data.isDisplayNameConfirmed;
 
     this.helpHeroService.setProperty({
       isAdmin: isProjectAdmin,
       isDiscussionEnabled,
-      isInvitingEnabled
+      isInvitingEnabled,
+      isNameConfirmed
     });
   }
 }


### PR DESCRIPTION
Most of the work to fix the HelpHero tour was in the HelpHero editor itself. The one thing that needed to change in our code was that we need set a user property that indicates whether the user's name has been confirmed. When the tour runs we use this to determine whether the name confirmation dialog will open.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/268)
<!-- Reviewable:end -->
