### PR TITLE
SF-500 Remove share key when user connects to a project

### DIFF
--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -103,7 +103,7 @@ namespace SIL.XForge.Scripture.Services
                 await ProjectSecrets.InsertAsync(new SFProjectSecret { Id = projectDoc.Id });
 
                 IDocument<User> userDoc = await conn.FetchAsync<User>(curUserId);
-                await AddUserToProjectAsync(conn, projectDoc, userDoc, SFProjectRole.Administrator);
+                await AddUserToProjectAsync(conn, projectDoc, userDoc, SFProjectRole.Administrator, false);
 
                 if (project.TranslateConfig.TranslationSuggestionsEnabled)
                 {
@@ -393,7 +393,7 @@ namespace SIL.XForge.Scripture.Services
                             && p.ShareKeys.Any(sk => sk.Email == currentUserEmail && sk.Key == shareKey),
                         update => update.RemoveAll(p => p.ShareKeys, sk => sk.Email == currentUserEmail));
                     if (projectSecret != null)
-                        await AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole);
+                        await AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole, false);
                     else
                         throw new ForbiddenException();
                 }
@@ -405,9 +405,9 @@ namespace SIL.XForge.Scripture.Services
         }
 
         protected override async Task AddUserToProjectAsync(IConnection conn, IDocument<SFProject> projectDoc,
-            IDocument<User> userDoc, string projectRole)
+            IDocument<User> userDoc, string projectRole, bool removeShareKeys = true)
         {
-            await base.AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole);
+            await base.AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole, removeShareKeys);
             IDocument<SFProjectUserConfig> projectUserConfigDoc = await conn.CreateAsync<SFProjectUserConfig>(
                 SFProjectUserConfig.GetDocId(projectDoc.Id, userDoc.Id),
                 new SFProjectUserConfig { ProjectRef = projectDoc.Id, OwnerRef = userDoc.Id });

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -140,9 +140,14 @@ namespace SIL.XForge.Services
         }
 
         protected virtual async Task AddUserToProjectAsync(IConnection conn, IDocument<TModel> projectDoc,
-            IDocument<User> userDoc, string projectRole)
+            IDocument<User> userDoc, string projectRole, bool removeShareKeys = true)
         {
             await projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.UserRoles[userDoc.Id], projectRole));
+            if (removeShareKeys)
+            {
+                await ProjectSecrets.UpdateAsync(p => p.Id == projectDoc.Id,
+                    update => update.RemoveAll(p => p.ShareKeys, sk => sk.Email == userDoc.Data.Email));
+            }
             string siteId = SiteOptions.Value.Id;
             await userDoc.SubmitJson0OpAsync(op => op.Add(u => u.Sites[siteId].Projects, projectDoc.Id));
         }


### PR DESCRIPTION
* Users specifically invited to a project but joins by an
* alternative method will have their share key removed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/273)
<!-- Reviewable:end -->
