### PR TITLE
Notify user of network errors via snackbar rather than dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
@@ -6,6 +6,7 @@ import { ErrorReportingService } from './error-reporting.service';
 import { ErrorComponent } from './error/error.component';
 import { ExceptionHandlingService } from './exception-handling-service';
 import { UserDoc } from './models/user-doc';
+import { NoticeService } from './notice.service';
 import { UserService } from './user.service';
 
 describe('ExceptionHandlingService', () => {
@@ -76,6 +77,7 @@ class TestEnvironment {
   mockedMdcDialog = mock(MdcDialog);
   mockedUserService = mock(UserService);
   mockedErrorReportingService = mock(ErrorReportingService);
+  mockedNoticeService = mock(NoticeService);
   errorReports: { error: any; opts: any; cb: any }[] = [];
   service: ExceptionHandlingService;
   rejectUser = false;
@@ -95,7 +97,8 @@ class TestEnvironment {
     this.service = new ExceptionHandlingService(
       instance(this.mockedMdcDialog),
       instance(this.mockedUserService),
-      instance(this.mockedErrorReportingService)
+      instance(this.mockedErrorReportingService),
+      instance(this.mockedNoticeService)
     );
 
     when(this.mockedMdcDialog.open(anything(), anything())).thenReturn({

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
@@ -1,5 +1,5 @@
 import { MdcDialog } from '@angular-mdc/web';
-import { ErrorHandler, Injectable } from '@angular/core';
+import { ErrorHandler, Injectable, NgZone } from '@angular/core';
 import cloneDeep from 'lodash/cloneDeep';
 import { User } from 'realtime-server/lib/common/models/user';
 import { environment } from '../environments/environment';
@@ -23,6 +23,7 @@ export class ExceptionHandlingService implements ErrorHandler {
 
   constructor(
     private readonly dialog: MdcDialog,
+    private readonly ngZone: NgZone,
     private readonly userService: UserService,
     private readonly errorReportingService: ErrorReportingService,
     private readonly noticeService: NoticeService
@@ -36,7 +37,9 @@ export class ExceptionHandlingService implements ErrorHandler {
 
     // There's no exact science here. We're looking for XMLHttpRequests that failed, but not due to HTTP response codes.
     if (error.error && error.error.target instanceof XMLHttpRequest && error.error.target.status === 0) {
-      this.noticeService.show('A network request failed. Some functionality may be unavailable.');
+      this.ngZone.run(() =>
+        this.noticeService.show('A network request failed. Some functionality may be unavailable.')
+      );
       return;
     }
 


### PR DESCRIPTION
The way I tested this was by killing the server. I assume this is similar to network errors where the server is unavailable for other reasons (e.g. the user's internet being down). It doesn't appear that there is a robust way to determine whether an error was caused by network issues.

Note that this will have merge conflicts with #272 (i.e., neither has merge conflicts with master right now, but once one is merged, the other will have conflicts with master). Since that is a very high priority PR, it's probably best to let that one be merged before this one. The merge conflicts won't be great; I just don't want the other PR to be slowed down at all. In the meantime this can be reviewed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/274)
<!-- Reviewable:end -->
