### PR TITLE
Miscellaneous error reporting changes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/angular.json
+++ b/src/SIL.XForge.Scripture/ClientApp/angular.json
@@ -68,7 +68,7 @@
               ],
               "optimization": true,
               "outputHashing": "all",
-              "sourceMap": false,
+              "sourceMap": true,
               "extractCss": true,
               "namedChunks": false,
               "aot": true,

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.html
@@ -7,7 +7,9 @@
         <p>
           To report an issue, email <a target="_blank" [href]="issueMailTo">{{ issueEmail }}</a>
         </p>
-        <a (click)="toggleStack()" [fxShow]="data.stack">{{ showDetails ? "Hide" : "Show" }} details</a>
+        <a (click)="this.showDetails = !this.showDetails" [fxShow]="data.stack"
+          >{{ showDetails ? "Hide" : "Show" }} details</a
+        >
         <pre [fxShow]="showDetails">{{ data.stack }}</pre>
       </mdc-dialog-content>
       <mdc-dialog-actions> <button default mdcDialogButton mdcDialogAction="close">Close</button> </mdc-dialog-actions>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.spec.ts
@@ -1,6 +1,6 @@
 import { MdcDialog } from '@angular-mdc/web';
 import { OverlayContainer } from '@angular-mdc/web';
-import { Component, NgModule } from '@angular/core';
+import { Component, NgModule, NgZone } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { ErrorAlert, ErrorComponent } from './error.component';
@@ -58,9 +58,11 @@ class TestEnvironment {
       declarations: [DialogOpenerComponent],
       imports: [DialogTestModule]
     });
-    TestBed.get(MdcDialog).open(ErrorComponent, { data: dialogData });
-    this.fixture = TestBed.createComponent(DialogOpenerComponent);
-    this.element = TestBed.get(OverlayContainer).getContainerElement();
+    TestBed.get(NgZone).run(() => {
+      TestBed.get(MdcDialog).open(ErrorComponent, { data: dialogData });
+      this.fixture = TestBed.createComponent(DialogOpenerComponent);
+      this.element = TestBed.get(OverlayContainer).getContainerElement();
+    });
   }
 
   get errorMessage(): HTMLElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.ts
@@ -1,5 +1,5 @@
 import { MDC_DIALOG_DATA, MdcDialogRef } from '@angular-mdc/web';
-import { Component, Inject, NgZone } from '@angular/core';
+import { Component, Inject } from '@angular/core';
 import { environment } from 'src/environments/environment';
 
 export interface ErrorAlert {
@@ -16,11 +16,7 @@ export class ErrorComponent {
   issueEmail = environment.issueEmail;
   showDetails: boolean = false;
 
-  constructor(
-    public dialogRef: MdcDialogRef<ErrorComponent>,
-    @Inject(MDC_DIALOG_DATA) public data: ErrorAlert,
-    private readonly zone: NgZone
-  ) {}
+  constructor(public dialogRef: MdcDialogRef<ErrorComponent>, @Inject(MDC_DIALOG_DATA) public data: ErrorAlert) {}
 
   get issueMailTo(): string {
     return encodeURI(
@@ -28,11 +24,5 @@ export class ErrorComponent {
         this.data.eventId
       } (included so we can provide better support)`
     );
-  }
-
-  toggleStack() {
-    this.zone.run(() => {
-      this.showDetails = !this.showDetails;
-    });
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
@@ -111,12 +111,14 @@ export class ExceptionHandlingService implements ErrorHandler {
 
   private showAlert() {
     if (!this.dialogOpen && this.alertQueue.length) {
-      this.dialogOpen = true;
-      const dialog = this.dialog.open(ErrorComponent, { data: this.alertQueue[this.alertQueue.length - 1] });
-      dialog.afterClosed().subscribe(() => {
-        this.alertQueue.pop();
-        this.dialogOpen = false;
-        this.showAlert();
+      this.ngZone.run(() => {
+        this.dialogOpen = true;
+        const dialog = this.dialog.open(ErrorComponent, { data: this.alertQueue[this.alertQueue.length - 1] });
+        dialog.afterClosed().subscribe(() => {
+          this.alertQueue.pop();
+          this.dialogOpen = false;
+          this.showAlert();
+        });
       });
     }
   }


### PR DESCRIPTION
- Launching of the error reporting component is now wrapped in a call to `ngZone.run`, so `ngZone.run` no longer has to be called inside the error component itself.
- Source maps are enabled in staging so Bugsnag can use them to show where an error occurred.
- Errors are reported to Bugsnag before logging them in the console. This is to prevent the logging from showing up as breadcrumbs in Bugsnag, where it is just noise. I've also wrapped this with try/finally so that the error dialog, reporting to Bugsnag, and logging to the console all happen independently of each other (one can throw an exception and the other two will still run).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/278)
<!-- Reviewable:end -->
