### PR TITLE
Fix reporting of non-error promise rejections

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
@@ -33,7 +33,10 @@ export class ExceptionHandlingService implements ErrorHandler {
     if (typeof error !== 'object' || error === null) {
       error = new Error('Unkown error: ' + String(error));
     }
-    error = error.rejection && error.rejection.message ? error.rejection : error;
+
+    // If a promise was rejected with an error, we want to report that error, because it has a useful stack trace
+    // If it was rejected with something other than an error we can't just report that object to Bugsnag
+    error = error.rejection && error.rejection.message && error.rejection.stack ? error.rejection : error;
 
     // There's no exact science here. We're looking for XMLHttpRequests that failed, but not due to HTTP response codes.
     if (error.error && error.error.target instanceof XMLHttpRequest && error.error.target.status === 0) {


### PR DESCRIPTION
A Bugsnag report shows Bugsnag threw an error because `notify()` was called with a non-error object. In general, if a promise rejection is unhandled and the rejection is an error, we want to report the rejection. But if it's rejected with a non-error object, then we want to report the error that is reporting the rejection (the "Possibly unhandled rejection" error).

There are multiple reasons for this, but the main one is that we want to see the stack trace associated with the original error that the promise was rejected with--not some stack trace to the deepest recesses of the promise implementation we are using.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/281)
<!-- Reviewable:end -->
