### PR TITLE
SF-551 Adjust icon, wording, to clarify Adding question on xs

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -3,7 +3,7 @@
   <h2 fxFlex>Texts with Questions</h2>
   <div fxFlexAlign="center" *ngIf="isProjectAdmin; else overallProgressChart">
     <button *ngIf="!isLoading" mdc-button (click)="questionDialog()" id="add-question-button">
-      <mdc-icon>note_add</mdc-icon> <span fxHide.xs>Add question</span>
+      <mdc-icon>post_add</mdc-icon> <span fxHide.xs>Add question</span>
     </button>
   </div>
   <ng-template #overallProgressChart>
@@ -111,7 +111,7 @@
   id="no-questions-label"
 >
   <p>
-    There are no published questions. <span *ngIf="isProjectAdmin">Click <b>Add question</b>.</span>
+    There are no published questions. <span *ngIf="isProjectAdmin">Click <b>Add question</b>, above.</span>
   </p>
 </div>
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
@@ -1,3 +1,15 @@
+@import '~src/global';
+
+#add-question-button mdc-icon {
+  // Bigger icon if shown without label on smaller devices
+  @include media-breakpoint-only(xs) {
+    font-size: 24px;
+    // Vertically align it better with the 'Texts and Questions' icon.
+    padding-bottom: 10px;
+    box-sizing: initial;
+  }
+}
+
 .mdc-list-item {
   cursor: pointer;
   .audio-icon {


### PR DESCRIPTION
* There isn't a perfect icon for this, but I think post_add is better.
* Part of the problem seems to be that the icon, without its label, is
too small. So increasing the size of the icon when it doesn't have a
label in xs.
* Editing the instruction to make it more clear.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/299)
<!-- Reviewable:end -->
