### PR TITLE
Redact Auth0 access token from error reports

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-reporting-service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-reporting-service.spec.ts
@@ -1,0 +1,38 @@
+import { ErrorReportingService } from './error-reporting.service';
+
+interface Breadcrumb {
+  type: string;
+  metaData: {
+    from: string;
+    to: string;
+  };
+}
+
+describe('ErrorReportingService', () => {
+  it('should redact the access_token from the breadcrumb URL', async () => {
+    const breadcrumbs: Breadcrumb[] = [
+      {
+        type: 'navigation',
+        metaData: {
+          from: '/somewhere&access_token=thing',
+          to: '/projects'
+        }
+      },
+      {
+        type: 'navigation',
+        metaData: {
+          from: '/projects#access_token=secret',
+          to: '/'
+        }
+      }
+    ];
+
+    const report = { breadcrumbs };
+
+    ErrorReportingService.beforeSend(report);
+    expect(report.breadcrumbs[0].metaData.from).toEqual('/somewhere&access_token=thing');
+    expect(report.breadcrumbs[0].metaData.to).toEqual('/projects');
+    expect(report.breadcrumbs[1].metaData.from).toEqual('/projects#access_token=redacted_for_error_report');
+    expect(report.breadcrumbs[1].metaData.to).toEqual('/');
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-reporting.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-reporting.service.ts
@@ -19,12 +19,27 @@ export class ErrorReportingService {
       notifyReleaseStages: ['live', 'qa'],
       releaseStage: environment.releaseStage,
       autoNotify: false,
-      trackInlineScripts: false
+      trackInlineScripts: false,
+      beforeSend: ErrorReportingService.beforeSend
     };
     if (environment.releaseStage === 'dev') {
       config.logger = null;
     }
     return bugsnag(config);
+  }
+
+  static beforeSend(report: any) {
+    report.breadcrumbs = report.breadcrumbs.map((breadcrumb: any) => {
+      if (
+        breadcrumb.type === 'navigation' &&
+        breadcrumb.metaData &&
+        typeof breadcrumb.metaData.from === 'string' &&
+        breadcrumb.metaData.from.includes('/projects#access_token=')
+      ) {
+        breadcrumb.metaData.from = '/projects#access_token=redacted_for_error_report';
+      }
+      return breadcrumb;
+    });
   }
 
   private readonly bugsnagClient = ErrorReportingService.createBugsnagClient();


### PR DESCRIPTION
When Bugsnag reports the breadcrumbs that lead up to an event, it includes the redirect from `/projects#access_token=some_token`. Access tokens shouldn't be ending up in our error reports, especially since errors could become issues in Jira, where they would be public.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/300)
<!-- Reviewable:end -->
