### PR TITLE
SF-554 and SF-555 Add type attribute to buttons

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -48,7 +48,7 @@
                 Logged in as
                 <div fxLayout="row" fxLayoutAlign="start center">
                   <span fxFlex>&nbsp;</span>
-                  <button id="edit-name-btn" mdcIconButton (click)="editName(currentUser.displayName)">
+                  <button id="edit-name-btn" mdcIconButton type="button" (click)="editName(currentUser.displayName)">
                     <mdc-icon>edit</mdc-icon>
                   </button>
                   <strong class="user-menu-name">{{ currentUser.displayName }}</strong>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -2,7 +2,7 @@
   <mdc-icon fxFlex="32px">library_books</mdc-icon>
   <h2 fxFlex>Texts with Questions</h2>
   <div fxFlexAlign="center" *ngIf="isProjectAdmin; else overallProgressChart">
-    <button *ngIf="!isLoading" mdc-button (click)="questionDialog()" id="add-question-button">
+    <button *ngIf="!isLoading" mdc-button type="button" (click)="questionDialog()" id="add-question-button">
       <mdc-icon>post_add</mdc-icon> <span fxHide.xs>Add question</span>
     </button>
   </div>
@@ -73,7 +73,7 @@
             <mdc-list-item *ngFor="let questionDoc of getQuestionDocs(getTextDocId(text.bookNum, chapter.number))">
               <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
                 <span fxFlex="16px" class="indent"></span>
-                <button fxFlex="64px" mdc-button (click)="questionDialog(questionDoc)" class="edit-btn">
+                <button fxFlex="64px" mdc-button type="button" (click)="questionDialog(questionDoc)" class="edit-btn">
                   <mdc-icon>edit</mdc-icon>
                 </button>
                 v{{ questionDoc.data?.verseRef.verseNum }} -&nbsp;
@@ -87,6 +87,7 @@
                 <span fxFlex="64px" fxLayoutAlign="end center">
                   <button
                     mdc-button
+                    type="button"
                     (click)="setQuestionArchiveStatus(questionDoc, true)"
                     title="Archive"
                     class="archive-btn"
@@ -241,6 +242,7 @@
                 <span fxFlex="64px" fxLayoutAlign="end center">
                   <button
                     mdc-button
+                    type="button"
                     (click)="setQuestionArchiveStatus(questionDoc, false)"
                     title="Republish"
                     class="publish-btn"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -99,6 +99,7 @@
         fxHide.xl
         [fxShow]="scriptureText.value"
         [fxHide.lt-xl]="!canShowScriptureInput"
+        type="button"
         (click)="resetScriptureText()"
         icon="refresh"
         class="try-again"
@@ -124,8 +125,10 @@
       Please enter a valid scripture reference in the select text tab
     </div>
     <div class="form-actions">
-      <button mdc-button (click)="hideAnswerForm()" id="cancel-answer">Cancel</button>
-      <button mdc-button primary form="answer-form" id="save-answer" (click)="submit()">Save Answer</button>
+      <button mdc-button type="button" (click)="hideAnswerForm()" id="cancel-answer">Cancel</button>
+      <button mdc-button primary form="answer-form" id="save-answer" type="submit" (click)="submit()">
+        Save Answer
+      </button>
     </div>
   </form>
 </div>
@@ -148,10 +151,22 @@
         <app-checking-audio-player *ngIf="answer.audioUrl" [source]="answer.audioUrl"></app-checking-audio-player>
         <div class="answer-footer">
           <div class="actions">
-            <button *ngIf="canEditAnswer(answer)" mdc-button (click)="editAnswer(answer)" class="answer-edit">
+            <button
+              *ngIf="canEditAnswer(answer)"
+              mdc-button
+              type="button"
+              (click)="editAnswer(answer)"
+              class="answer-edit"
+            >
               Edit
             </button>
-            <button *ngIf="canDeleteAnswer(answer)" mdc-button (click)="deleteAnswer(answer)" class="answer-delete">
+            <button
+              *ngIf="canDeleteAnswer(answer)"
+              mdc-button
+              type="button"
+              (click)="deleteAnswer(answer)"
+              class="answer-delete"
+            >
               Delete
             </button>
           </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comment-form/checking-comment-form.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comment-form/checking-comment-form.component.html
@@ -11,7 +11,7 @@
     <mdc-helper-text validation>You need to enter your comment before saving</mdc-helper-text>
   </mdc-form-field>
   <div class="form-actions">
-    <button mdc-button (click)="submitCancel()" class="cancel-comment">Cancel</button>
-    <button mdc-button primary form="comment-form" class="save-comment">Save Comment</button>
+    <button mdc-button type="button" (click)="submitCancel()" class="cancel-comment">Cancel</button>
+    <button mdc-button primary form="comment-form" type="submit" class="save-comment">Save Comment</button>
   </div>
 </form>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.html
@@ -10,10 +10,22 @@
     <span class="comment-text">{{ comment.text }}</span> <span class="divider">-</span>
     <app-checking-owner [ownerRef]="comment.ownerRef" [dateTime]="comment.dateCreated"></app-checking-owner>
     <div class="actions">
-      <button *ngIf="canEditComment(comment)" mdc-button (click)="editComment(comment)" class="comment-edit">
+      <button
+        *ngIf="canEditComment(comment)"
+        mdc-button
+        type="button"
+        (click)="editComment(comment)"
+        class="comment-edit"
+      >
         Edit
       </button>
-      <button *ngIf="canDeleteComment(comment)" mdc-button (click)="deleteComment(comment)" class="comment-delete">
+      <button
+        *ngIf="canDeleteComment(comment)"
+        mdc-button
+        type="button"
+        (click)="deleteComment(comment)"
+        class="comment-delete"
+      >
         Delete
       </button>
     </div>
@@ -33,6 +45,7 @@
 <button
   *ngIf="!commentFormVisible && commentCount > maxCommentsToShow && !showAllComments"
   mdc-button
+  type="button"
   (click)="showComments()"
   class="show-all-comments"
 >
@@ -41,6 +54,7 @@
 <button
   *ngIf="!commentFormVisible && (commentCount <= maxCommentsToShow || showAllComments) && canAddComment"
   mdc-button
+  type="button"
   (click)="showCommentForm()"
   class="add-comment"
 >

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-combined/checking-audio-combined.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-combined/checking-audio-combined.component.html
@@ -13,6 +13,7 @@
       *ngIf="!source"
       mdc-button
       ngfSelect
+      type="button"
       [(file)]="uploadAudioFile"
       (fileChange)="prepareAudioFileUpload()"
       accept="audio/*"
@@ -21,7 +22,14 @@
       <mdc-icon>cloud_upload</mdc-icon>
       <span fxShow fxHide.lt-sm>Upload Audio File</span> <span fxHide fxShow.xs>Upload</span>
     </button>
-    <button *ngIf="source" fxHide.xs mdc-button (click)="resetAudioAttachment()" class="remove-audio-file">
+    <button
+      *ngIf="source"
+      fxHide.xs
+      mdc-button
+      type="button"
+      (click)="resetAudioAttachment()"
+      class="remove-audio-file"
+    >
       <mdc-icon>delete</mdc-icon>
       Remove Audio File
     </button>
@@ -29,6 +37,7 @@
       *ngIf="source"
       mdc-icon-button
       fxHide.gt-xs
+      type="button"
       (click)="resetAudioAttachment()"
       icon="delete"
       class="remove-audio-file"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="hasSource" class="player">
-  <button *ngIf="!isPlaying" mdc-icon-button icon="play_arrow" (click)="play()" class="play"></button>
-  <button *ngIf="isPlaying" mdc-icon-button icon="pause" (click)="pause()" class="pause"></button>
+  <button *ngIf="!isPlaying" mdc-icon-button icon="play_arrow" type="button" (click)="play()" class="play"></button>
+  <button *ngIf="isPlaying" mdc-icon-button icon="pause" type="button" (click)="pause()" class="pause"></button>
   <div class="current-time">{{ currentTime | audioTime }}</div>
   <mdc-slider class="slider" min="0" max="100" step="1" [value]="seek" (input)="seeking($event)"></mdc-slider>
   <div class="duration">{{ duration | audioTime }}</div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.html
@@ -3,6 +3,7 @@
     *ngIf="!isRecording"
     mdc-button
     primary
+    type="button"
     (click)="startRecording()"
     class="record"
     [disabled]="microphonePermission === false"
@@ -10,16 +11,23 @@
     <mdc-icon>mic</mdc-icon>
     Record
   </button>
-  <button *ngIf="isRecording" mdc-button (click)="stopRecording()" class="stop-recording">
+  <button *ngIf="isRecording" mdc-button type="button" (click)="stopRecording()" class="stop-recording">
     <mdc-icon>stop</mdc-icon>
     Stop Recording
   </button>
 </ng-container>
 <div *ngIf="hasAudioAttachment" class="has-attachment">
-  <button mdc-button fxHide.xs (click)="resetRecording()" class="try-again">
+  <button mdc-button fxHide.xs type="button" (click)="resetRecording()" class="try-again">
     <mdc-icon>refresh</mdc-icon>
     Try Again
   </button>
-  <button mdc-icon-button fxHide.gt-xs (click)="resetRecording()" icon="refresh" class="try-again"></button>
+  <button
+    mdc-icon-button
+    fxHide.gt-xs
+    type="button"
+    (click)="resetRecording()"
+    icon="refresh"
+    class="try-again"
+  ></button>
   <app-checking-audio-player [source]="audioUrl"></app-checking-audio-player>
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -108,13 +108,14 @@
         </div>
       </div>
       <div *ngIf="questionsPanel.activeQuestionDoc" id="project-navigation">
-        <button mdc-button *ngIf="!this.isDrawerPermanent" (click)="toggleDrawer()">
+        <button mdc-button *ngIf="!this.isDrawerPermanent" type="button" (click)="toggleDrawer()">
           <span class="mdc-button__label">View Questions</span>
         </button>
         <div class="d-flex justify-content-end">
           <button
             mdc-button
             fxHide.xs
+            type="button"
             (click)="questionsPanel.previousQuestion()"
             [disabled]="!questionsPanel.checkCanChangeQuestion(-1)"
             class="prev-question"
@@ -124,6 +125,7 @@
           <button
             mdc-button
             fxHide.xs
+            type="button"
             (click)="questionsPanel.nextQuestion()"
             [disabled]="!questionsPanel.checkCanChangeQuestion(1)"
             class="next-question"
@@ -133,6 +135,7 @@
           <button
             mdc-icon-button
             fxHide.gt-xs
+            type="button"
             (click)="questionsPanel.previousQuestion()"
             [disabled]="!questionsPanel.checkCanChangeQuestion(-1)"
             class="prev-question"
@@ -141,6 +144,7 @@
           <button
             mdc-icon-button
             fxHide.gt-xs
+            type="button"
             (click)="questionsPanel.nextQuestion()"
             [disabled]="!questionsPanel.checkCanChangeQuestion(1)"
             class="next-question"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/font-size/font-size.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/font-size/font-size.component.html
@@ -1,6 +1,7 @@
 <div mdcMenuSurfaceAnchor #fontSizeAnchor>
   <button
     mdc-icon-button
+    type="button"
     (click)="fontSizeSurface.open = !fontSizeSurface.open"
     icon="format_size"
     id="font-size-toggle"
@@ -8,6 +9,7 @@
   <mdc-menu-surface #fontSizeSurface [anchorElement]="fontSizeAnchor" anchorCorner="bottomEnd" id="font-menu-surface">
     <div class="buttons-group">
       <button
+        type="button"
         (click)="decreaseFontSize()"
         [disabled]="fontSize === min"
         mdc-icon-button
@@ -16,6 +18,7 @@
       ></button>
       <button
         mdc-icon-button
+        type="button"
         (click)="increaseFontSize()"
         [disabled]="fontSize === max"
         icon="add"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-answered-dialog/question-answered-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-answered-dialog/question-answered-dialog.component.html
@@ -4,8 +4,8 @@
       <mdc-dialog-title>Question already has an answer</mdc-dialog-title>
       <mdc-dialog-content>Consider creating a new question instead of editing this question.</mdc-dialog-content>
       <mdc-dialog-actions>
-        <button mdcDialogButton mdcDialogAction="accept">Edit Anyway</button>
-        <button mdcDialogButton mdcDialogAction="close">cancel</button>
+        <button mdcDialogButton type="button" mdcDialogAction="accept">Edit Anyway</button>
+        <button mdcDialogButton type="button" mdcDialogAction="close">cancel</button>
       </mdc-dialog-actions>
     </mdc-dialog-surface>
   </mdc-dialog-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
@@ -70,8 +70,10 @@
         </form>
       </mdc-dialog-content>
       <mdc-dialog-actions>
-        <button mdcDialogButton mdcDialogAction="close" id="question-cancel-btn">Cancel</button>
-        <button mdc-button primary form="question-form" id="question-save-btn" (click)="submit()">Save</button>
+        <button mdcDialogButton mdcDialogAction="close" type="button" id="question-cancel-btn">Cancel</button>
+        <button mdc-button primary form="question-form" type="submit" id="question-save-btn" (click)="submit()">
+          Save
+        </button>
       </mdc-dialog-actions>
     </mdc-dialog-surface>
   </mdc-dialog-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
@@ -2,7 +2,7 @@
 <div class="content" [ngSwitch]="state">
   <div *ngSwitchCase="'login'" class="paratext-login-container">
     <div mdcBody1>You must login with your Paratext account to connect to a project.</div>
-    <button mdc-button id="paratext-login-button" (click)="logInWithParatext()">
+    <button mdc-button id="paratext-login-button" type="button" (click)="logInWithParatext()">
       <img src="/assets/paratext_logo.png" alt="Paratext Logo" class="paratext-logo" /> Log in with Paratext
     </button>
   </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-deleted-dialog/project-deleted-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-deleted-dialog/project-deleted-dialog.component.html
@@ -3,7 +3,7 @@
     <mdc-dialog-surface>
       <mdc-dialog-title>The project has been deleted or is no longer accessible.</mdc-dialog-title>
       <mdc-dialog-actions>
-        <button id="ok-button" mdcDialogButton mdcDialogAction="accept">OK</button>
+        <button id="ok-button" mdcDialogButton type="button" mdcDialogAction="accept">OK</button>
       </mdc-dialog-actions>
     </mdc-dialog-surface>
   </mdc-dialog-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.html
@@ -16,8 +16,15 @@
         </mdc-form-field>
       </mdc-dialog-content>
       <mdc-dialog-actions>
-        <button mdcDialogButton id="cancel-btn" mdcDialogAction="cancel">Cancel</button>
-        <button mdc-button id="project-delete-btn" outlined mdcDialogAction="accept" [disabled]="deleteDisabled">
+        <button mdcDialogButton type="button" id="cancel-btn" mdcDialogAction="cancel">Cancel</button>
+        <button
+          mdc-button
+          type="button"
+          id="project-delete-btn"
+          outlined
+          mdcDialogAction="accept"
+          [disabled]="deleteDisabled"
+        >
           <span fxHide.lt-sm>I understand the consequences, delete this project</span>
           <span fxHide fxShow.xs>Delete this project</span>
         </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -35,7 +35,13 @@
               project is setup as a <b>Daughter Translation</b> in Paratext.
             </div>
             <div *ngIf="!isLoading && !isLoggedInToParatext" class="paratext-login-container">
-              <button class="action-button" mdc-button (click)="logInWithParatext()" id="btn-log-in-settings">
+              <button
+                class="action-button"
+                mdc-button
+                type="button"
+                (click)="logInWithParatext()"
+                id="btn-log-in-settings"
+              >
                 <img src="/assets/paratext_logo.png" alt="Paratext Logo" class="paratext-logo" /> Log in to Paratext
               </button>
               <span class="more-options">to enable <b>Translate Suggestions</b> and see more options</span>
@@ -158,7 +164,14 @@
         <a [routerLink]="['/projects', projectId, 'sync']">Synchronize</a> first before deleting.
       </p>
       <div fxLayout="row" fxLayoutAlign="end stretch">
-        <button id="delete-btn" mdc-button unelevated (click)="openDeleteProjectDialog()" [disabled]="isLoading">
+        <button
+          id="delete-btn"
+          mdc-button
+          unelevated
+          type="button"
+          (click)="openDeleteProjectDialog()"
+          [disabled]="isLoading"
+        >
           Delete this project
         </button>
       </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.html
@@ -2,6 +2,7 @@
   mdc-icon-button
   appBlurOnClick
   icon="keyboard_arrow_left"
+  type="button"
   (click)="prevChapter()"
   [disabled]="isPrevChapterDisabled()"
   title="Previous chapter"
@@ -10,6 +11,7 @@
   mdc-icon-button
   appBlurOnClick
   icon="keyboard_arrow_right"
+  type="button"
   (click)="nextChapter()"
   [disabled]="isNextChapterDisabled()"
   title="Next chapter"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
@@ -28,7 +28,7 @@
           <span *ngIf="email.hasError('pattern') || email.hasError('email')">Email address is invalid</span>
         </mdc-helper-text>
       </mdc-form-field>
-      <button id="send-btn" mdc-button (click)="sendEmail()" [disabled]="isSubmitted">
+      <button id="send-btn" mdc-button type="submit" (click)="sendEmail()" [disabled]="isSubmitted">
         {{ isAlreadyInvited ? "Resend" : "Send" }}
       </button>
     </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
@@ -9,7 +9,7 @@
         ></app-share-control>
       </mdc-dialog-content>
       <mdc-dialog-actions align="end">
-        <button id="close-btn" mdcDialogButton mdcDialogAction="close">Done</button>
+        <button id="close-btn" mdcDialogButton type="button" mdcDialogAction="close">Done</button>
       </mdc-dialog-actions>
     </mdc-dialog-surface>
   </mdc-dialog-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share.component.html
@@ -1,5 +1,6 @@
 <button
   *ngIf="isSharingEnabled"
+  type="button"
   (click)="openDialog()"
   mdc-icon-button
   icon="share"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/start/start.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/start/start.component.html
@@ -1,6 +1,8 @@
 <div fxLayout="column" fxLayoutAlign="center center">
   <p mdcBody1>Looks like you aren't connected to any projects yet.</p>
   <p>
-    <button mdc-button primary [routerLink]="['/connect-project']"><mdc-icon>add</mdc-icon>Connect Project</button>
+    <button mdc-button primary type="button" [routerLink]="['/connect-project']">
+      <mdc-icon>add</mdc-icon>Connect Project
+    </button>
   </p>
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
@@ -6,6 +6,7 @@
         *ngIf="!isLoggedIntoParatext && !isLoading"
         class="action-button"
         mdc-button
+        type="button"
         (click)="logInWithParatext()"
         id="btn-log-in"
       >
@@ -17,6 +18,7 @@
           class="action-button"
           mdc-button
           primary
+          type="button"
           (click)="syncProject()"
           [disabled]="isLoading"
           id="btn-sync"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -6,6 +6,7 @@
       <div class="toolbar-separator">&nbsp;</div>
       <button
         mdcIconButton
+        type="button"
         title="Enable/disable suggestions"
         [on]="translationSuggestionsUserEnabled"
         (change)="translationSuggestionsUserEnabled = !$event.value"
@@ -19,6 +20,7 @@
           mdc-icon-button
           icon="linear_scale"
           title="Adjust suggestion confidence"
+          type="button"
           (click)="suggestionsMenu.open = !suggestionsMenu.open"
           [class.mdc-icon-button--activated]="suggestionsMenu.open"
         ></button>
@@ -49,6 +51,7 @@
         mdc-icon-button
         appBlurOnClick
         icon="swap_horiz"
+        type="button"
         (click)="isTargetTextRight = !isTargetTextRight"
         title="Swap source and target"
       ></button>
@@ -91,7 +94,13 @@
   <div *ngIf="showTrainingProgress" class="training-progress" mdcElevation="2">
     <div class="training-title" fxLayout="row" fxLayoutAlign="space-between center">
       <div mdcSubtitle1>Training</div>
-      <button id="training-close-button" mdc-icon-button icon="close" (click)="closeTrainingProgress()"></button>
+      <button
+        id="training-close-button"
+        mdc-icon-button
+        icon="close"
+        type="button"
+        (click)="closeTrainingProgress()"
+      ></button>
     </div>
     <mdc-list-divider></mdc-list-divider>
     <div class="training-content" fxLayout="row" fxLayoutAlign="space-between center" fxLayoutGap="5px">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
@@ -66,7 +66,14 @@
     <mdc-list-divider></mdc-list-divider>
     <mdc-card-actions>
       <mdc-card-action-buttons>
-        <button id="retrain-button" mdc-button mdcCardAction="button" [disabled]="isTraining" (click)="startTraining()">
+        <button
+          id="retrain-button"
+          mdc-button
+          mdcCardAction="button"
+          [disabled]="isTraining"
+          type="button"
+          (click)="startTraining()"
+        >
           {{ isTraining ? "Training..." : "Retrain" }}
         </button>
       </mdc-card-action-buttons>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
@@ -60,6 +60,7 @@
               icon="clear"
               class="remove-user"
               *ngIf="!userRow.isInvitee && !isCurrentUser(userRow)"
+              type="button"
               (click)="removeProjectUser(userRow.id)"
               title="Remove from project"
             ></button>
@@ -73,6 +74,7 @@
               outlined
               color="warn"
               class="cancel-invite"
+              type="button"
               (click)="uninviteProjectUser(userRow.user.email)"
             >
               Cancel invite
@@ -85,6 +87,7 @@
               *ngIf="userRow.isInvitee"
               fxHide
               fxShow.lt-sm
+              type="button"
               (click)="uninviteProjectUser(userRow.user.email)"
               title="Cancel invite"
             ></button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.html
@@ -12,7 +12,9 @@
           <mdc-text-field [formControl]="name" id="name-input" label="Your name"></mdc-text-field>
         </mdc-form-field>
       </mdc-dialog-content>
-      <mdc-dialog-actions> <button mdcDialogButton (click)="closeDialog()">Confirm</button> </mdc-dialog-actions>
+      <mdc-dialog-actions>
+        <button mdcDialogButton type="submit" (click)="closeDialog()">Confirm</button>
+      </mdc-dialog-actions>
     </mdc-dialog-surface>
   </mdc-dialog-container>
 </mdc-dialog>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.html
@@ -12,7 +12,9 @@
         >
         <pre [fxShow]="showDetails">{{ data.stack }}</pre>
       </mdc-dialog-content>
-      <mdc-dialog-actions> <button default mdcDialogButton mdcDialogAction="close">Close</button> </mdc-dialog-actions>
+      <mdc-dialog-actions>
+        <button default mdcDialogButton type="button" mdcDialogAction="close">Close</button>
+      </mdc-dialog-actions>
     </mdc-dialog-surface>
   </mdc-dialog-container>
 </mdc-dialog>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/message-dialog/message-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/message-dialog/message-dialog.component.html
@@ -2,7 +2,9 @@
   <mdc-dialog-container>
     <mdc-dialog-surface>
       <mdc-dialog-title>{{ message }}</mdc-dialog-title>
-      <mdc-dialog-actions> <button mdcDialogButton mdcDialogAction="close">Dismiss</button> </mdc-dialog-actions>
+      <mdc-dialog-actions>
+        <button mdcDialogButton type="button" mdcDialogAction="close">Dismiss</button>
+      </mdc-dialog-actions>
     </mdc-dialog-surface>
   </mdc-dialog-container>
 </mdc-dialog>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-delete-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-delete-dialog.component.html
@@ -12,8 +12,10 @@
         </div>
       </mdc-dialog-content>
       <mdc-dialog-actions>
-        <button mdcDialogButton mdcDialogAction="close" id="confirm-button-no">Cancel</button>
-        <button mdcDialogButton default mdcDialogAction="confirmed" id="confirm-button-yes">Delete</button>
+        <button mdcDialogButton type="button" mdcDialogAction="close" id="confirm-button-no">Cancel</button>
+        <button mdcDialogButton default type="button" mdcDialogAction="confirmed" id="confirm-button-yes">
+          Delete
+        </button>
       </mdc-dialog-actions>
     </mdc-dialog-surface>
   </mdc-dialog-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.html
@@ -39,7 +39,7 @@
       </ng-container>
       <ng-container matColumnDef="remove">
         <td mat-cell *matCellDef="let userRow" class="remove-cell">
-          <button mdc-icon-button class="remove-user" (click)="removeUser(userRow.id, userRow.user)">
+          <button mdc-icon-button class="remove-user" type="button" (click)="removeUser(userRow.id, userRow.user)">
             <mdc-icon>clear</mdc-icon>
           </button>
         </td>


### PR DESCRIPTION
* Hitting the enter key while editing a form field can lead to unexpected results.
* Adding a type attribute to each button will explicitly allow a user to simulate submitting a form
* or prevent a click event from firing unexpectedly on the first button of the page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/304)
<!-- Reviewable:end -->
