### PR TITLE
Remove userService.getCurrentUser() request (Fix SF-563)

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1,6 +1,6 @@
 import { MdcDialogRef, MdcListItem, MdcMenuSelectedEvent } from '@angular-mdc/web';
 import { DebugElement } from '@angular/core';
-import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
@@ -1009,9 +1009,7 @@ class TestEnvironment {
     inputElem.value = value;
     inputElem.dispatchEvent(new Event('input'));
     inputElem.dispatchEvent(new Event('change'));
-    this.fixture.detectChanges();
-    tick();
-    flush();
+    this.waitForSliderUpdate();
   }
 
   getShowAllCommentsButton(answerIndex: number): DebugElement {
@@ -1228,7 +1226,9 @@ class TestEnvironment {
         data: user.user
       }
     ]);
-    when(mockedUserService.getCurrentUser()).thenReturn(this.realtimeService.subscribe(UserDoc.COLLECTION, user.id));
+    when(mockedUserService.getCurrentUser()).thenCall(() =>
+      this.realtimeService.subscribe(UserDoc.COLLECTION, user.id)
+    );
 
     this.realtimeService.addSnapshots<User>(UserProfileDoc.COLLECTION, [
       {


### PR DESCRIPTION
* Use the currentUserId from the userService instead
  of making a call to the backend to get a user
* Take a user as @Input from the parent component for
  use in the calls that need a real user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/311)
<!-- Reviewable:end -->
