### PR TITLE
Possibly fix undefined ExceptionHandlingService

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
@@ -49,7 +49,7 @@ import { UsersModule } from './users/users.module';
     UICommonModule,
     XForgeCommonModule
   ],
-  providers: [DatePipe, { provide: ErrorHandler, useExisting: ExceptionHandlingService }],
+  providers: [DatePipe, { provide: ErrorHandler, useClass: ExceptionHandlingService }],
   entryComponents: [
     DeleteProjectDialogComponent,
     ProjectDeletedDialogComponent,


### PR DESCRIPTION
Some errors have been resulting in `TypeError: Cannot read property 'handleError' of undefined` in Chromium, or `TypeError: "_this._exceptionHandler is undefined"` in Firefox.

This error occurs when certain exceptions are thrown, and mask the error that lead to it. An example of this is SF-563, which @jasonleenaylor fixed in #311 (not yet merged at the time of writing).

@jasonleenaylor and I investigated this, and as best as I can tell, this is what is happening:
- An error is thrown (due to a bug)
- Angular attempts to report it to the error handling service, but its error handler is undefined. Angular has a default error handler, so this is not the default state Angular should be in.
- This throws an exception (`"_this._exceptionHandler is undefined"`)
- Angular reports this exception to the actual error handler, which then handles it properly.

When I originally wrote the exception handling service, I assumed it would be a singleton. This was important because we only want to init Bugsnag once. It turned out it was not a singleton; it was being instantiated twice. The Angular guide has [an article about singleton services](https://angular.io/guide/singleton-services), which states that there are two ways to make a service a singleton:
> - Declare root for the value of the @<!-- -->Injectable() providedIn property
> - Include the service in the AppModule or in a module that is only imported by the AppModule

We were doing both, but it was still instantiated twice. @ddaspit figured out how to keep a second instance from being created by using `{ provide: ErrorHandler, useExisting: ExceptionHandlingService }`.

It appears that in the current state Angular somehow has two error handlers, one undefined, and the other working as expected. If I change `useExisting` to `useClass`, two instances are created, and the undefined error goes away.

But there's another way to solve it, that I don't understand. If I remove UserService *and* NoticeService from the constructor for ExceptionHandlingService, then only once instance is created, even when using `useClass`, and Angular seems perfectly happy with only having one error handler. I haven't been able to figure out what these services have to do with the creation of the second error handling service.

All I've done in this PR is change `useExisting` to `useClass`. The result is that two exception handling services are created, and both work fine. In the past this was not acceptable because it would have inited Bugsnag twice, but after the refactor to put Bugsnag in ErrorReportingService, multiple instances of the exception handler can be created without causing problems.

I believe my code fixes the problem, but I'm marking this as a draft PR because I can't understand what is going on, at all. I'm fine with it being merged, assuming whoever merges it either understands the issue, or is merging it despite not understanding the issue. This PR comes with no warranty, including any implied warranty of merchantability or fitness for a particular purpose.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/313)
<!-- Reviewable:end -->
