### PR TITLE
SF-570 Restrict flexbox into narrow viewport

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -1,4 +1,4 @@
-<div fxLayout="column" fxLayoutAlign="space-between start" fxLayoutGap="2rem" class="container">
+<div fxLayout="column" fxLayoutGap="2rem" class="container">
   <div mdcHeadline4>Settings</div>
   <div>
     <div mdcHeadline6>Tools</div>


### PR DESCRIPTION
It was going slightly too far to the right.

---
Tested in Firefox and Chromium, in 320px wide and really wide.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/323)
<!-- Reviewable:end -->
