### PR TITLE
Update vagrant instructions and provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,21 +98,16 @@ Create a directory to manage the development machine, such as `xforge`. Checkout
 
 Run `vagrant up`. This will download, initialize, and run the development machine. The machine is about 5GB, so expect the download to take a while.
 
-In the guest development machine, do the following additional steps that may not yet be performed by the vagrant provisioner:
+In the guest development machine, do the following additional steps:
 
 ```shell
-sudo n lts
-cd ~/src/web-xforge/
-dotnet clean
-cd ~/src/web-xforge/src/SIL.XForge.Scripture/ClientApp
-npm i
-cd ~/src/web-xforge/src/RealtimeServer
-npm i
+sudo apt update
+sudo apt upgrade
 cd ~/src/web-xforge/src/SIL.XForge.Scripture
 dotnet run
 ```
 
-In the guest development machine, after compiling and running Scripture Forge, browse to http://localhost:5000 and log in.
+In the guest development machine, browse to http://localhost:5000/projects and log in.
 
 #### Local Linux Development Setup
 

--- a/deploy/vagrant_xenial_gui/Vagrantfile
+++ b/deploy/vagrant_xenial_gui/Vagrantfile
@@ -47,6 +47,22 @@ Vagrant.configure("2") do |config|
     cd ~/src/web-xforge/deploy
     tryharderto ansible-playbook playbook_bionic.yml --limit localhost
 
+    sudo n lts
+
+    cd ~/src/web-xforge/
+    dotnet clean
+    # Remove orphaned? dotnet process.
+    sleep 10s
+    pkill dotnet
+    rm -rf /tmp/NuGetScratch/lock
+
+    cd ~/src/web-xforge/src/SIL.XForge.Scripture/ClientApp
+    npm i
+    cd ~/src/web-xforge/src/RealtimeServer
+    npm i
+    cd ~/src/web-xforge/src/SIL.XForge.Scripture
+    dotnet build
+
     # Remove canary
     rm ~/Desktop/development-tools/warning-not-provisioned.txt
     echo Provisioning finished successfully.


### PR DESCRIPTION
---

I was in the neighborhood and so did some updates to the vagrant instructions and provisioning. 

I didn't look into why `dotnet clean` left a dotnet process around with no parent other than to observe that it only happened when run from the provisioning script, not when run by hand in a terminal. I don't consider the `pkill` and `rm` steps to be very elegant but they result in a working system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/331)
<!-- Reviewable:end -->
