### PR TITLE
SF-581 Answers should not be shown unread after canceling answer edit

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -237,6 +237,8 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
   }
 
   editAnswer(answer: Answer) {
+    // update read answers list so when the answers are rendered again after editing they won't be shown as unread
+    this.userAnswerRefsRead = cloneDeep(this.projectUserConfigDoc.data.answerRefsRead);
     this.activeAnswer = cloneDeep(answer);
     this.audio.url = this.activeAnswer.audioUrl;
     if (this.activeAnswer.verseRef != null) {
@@ -425,10 +427,6 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
   }
 
   private emitAnswerToSave() {
-    if (this.activeAnswer) {
-      // If editing an answer, ensure answers read is current
-      this.userAnswerRefsRead = cloneDeep(this.projectUserConfigDoc.data.answerRefsRead);
-    }
     this.action.emit({
       action: 'save',
       text: this.answerText.value,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -304,6 +304,19 @@ describe('CheckingComponent', () => {
       expect(env.getAnswerText(0)).toBe('Edited question 7 answer');
     }));
 
+    it('still shows answers as read after canceling an edit', fakeAsync(() => {
+      env.setupData(env.checkerUser);
+      env.selectQuestion(7);
+      env.answerQuestion('Answer question 7');
+      expect(env.getAnswer(1).classes['answer-unread']).toBe(true);
+      env.clickButton(env.getAnswerEditButton(0));
+      env.setTextFieldValue(env.yourAnswerField, 'Edited question 7 answer');
+      env.clickButton(env.cancelAnswerButton);
+      env.waitForSliderUpdate();
+      expect(env.getAnswer(1).classes['answer-unread']).toBe(false);
+      expect(env.getAnswerText(0)).toBe('Answer question 7');
+    }));
+
     it('can remove audio from answer', fakeAsync(() => {
       env.setupData(env.checkerUser);
       env.selectQuestion(6);


### PR DESCRIPTION
Previously, if users started editing their answer and then canceled the edit, the other answers could be shown as unread.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/333)
<!-- Reviewable:end -->
