### PR TITLE
Make setter function in checking.component.ts idempotent

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -88,7 +88,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
   text: TextInfo;
   textDocId: TextDocId;
 
-  private _book: number = 0;
+  private _book: number;
   private _isDrawerPermanent: boolean = true;
   private _chapter: number;
   private questionsQuery: RealtimeQuery<QuestionDoc>;
@@ -109,12 +109,12 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
     super(noticeService);
   }
 
-  get book(): number {
+  private get book(): number {
     return this._book;
   }
 
-  set book(book: number) {
-    if (!this.questionDocs.length) {
+  private set book(book: number) {
+    if (!this.questionDocs.length || book === this.book) {
       return;
     }
     let defaultChapter = 1;
@@ -432,12 +432,8 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
   }
 
   questionChanged(questionDoc: QuestionDoc) {
-    if (questionDoc.verseRef.bookNum !== this.book) {
-      this.book = questionDoc.verseRef.bookNum;
-    }
-    if (this.questionsPanel.activeQuestionChapter !== this.chapter) {
-      this.chapter = this.questionsPanel.activeQuestionChapter;
-    }
+    this.book = questionDoc.verseRef.bookNum;
+    this.chapter = this.questionsPanel.activeQuestionChapter;
     this.calculateScriptureSliderPosition(true);
     this.refreshSummary();
     this.collapseDrawer();
@@ -449,7 +445,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
         question: undefined,
         textsByBookId: this.textsByBookId,
         projectId: this.projectDoc.id,
-        defaultVerse: new VerseRef(this._book, this._chapter, 1)
+        defaultVerse: new VerseRef(this.book, this.chapter, 1)
       }
     };
     const dialogRef = this.dialog.open(QuestionDialogComponent, config) as MdcDialogRef<


### PR DESCRIPTION
While trying to troubleshot an unrelated issue I came across this code that seemed redundant:
``` js
if (questionDoc.verseRef.bookNum !== this.book) {
  this.book = questionDoc.verseRef.bookNum;
}
if (this.questionsPanel.activeQuestionChapter !== this.chapter) {
  this.chapter = this.questionsPanel.activeQuestionChapter;
}
```
Generally you shouldn't have to check that `a != b` before setting `a = b`, since the operation should be idempotent. Checking the setter for `this.chapter`, it is idempotent, so we can safely set `this.chapter` without first checking its value. The setter for `this.book` isn't idempotent, but I think it can be, and that's the change I made. I could be wrong about that though, in which case my change may have actually modified the behavior by making it return immediately if the value doesn't need to be changed.

I realize nothing is actually broken and therefore this isn't of high priority, but I do think we're setting ourselves up for trouble if our setters aren't idempotent, or if our getters have side-effects. If we need to update a value and the operation can't be idempotent, then I think it's better to use a regular function since it doesn't have the same semantic implications and won't conflict with developers' assumptions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/334)
<!-- Reviewable:end -->
