### PR TITLE
Set "Cache-Control" to "must-revalidate" for static files

### DIFF
--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -117,14 +117,13 @@ namespace SIL.XForge.Scripture
             app.UseStaticFiles(new StaticFileOptions
             {
                 // this will allow files without extensions to be served, which is necessary for LetsEncrypt
-                ServeUnknownFileTypes = true
+                ServeUnknownFileTypes = true,
+                OnPrepareResponse = ctx =>
+                {
+                    ctx.Context.Response.Headers.Add("Cache-Control", "must-revalidate");
+                }
             });
             IOptions<SiteOptions> siteOptions = app.ApplicationServices.GetService<IOptions<SiteOptions>>();
-            app.UseStaticFiles(new StaticFileOptions
-            {
-                FileProvider = new PhysicalFileProvider(Path.Combine(siteOptions.Value.SharedDir, "avatars")),
-                RequestPath = "/assets/avatars"
-            });
             app.UseStaticFiles(new StaticFileOptions
             {
                 FileProvider = new PhysicalFileProvider(Path.Combine(siteOptions.Value.SiteDir, "audio")),


### PR DESCRIPTION
By default ASP.NET Core sets the `ETag` and `Last-Modified` headers when serving static files. When these headers exist, a browser should send a request to the server with the `If-None-Match` or `If-Modified-Since` headers set. The server can use these headers to determine if the file has changed and then send a `200` and the content if the file has changed or a `304` if the file has not. Unexpectedly, Chrome does not send a request with `If-None-Match` or `If-Modified-Since` headers set and just gets the file from the disk cache. You can find out more about the behavior of Chrome [here](https://gertjans.home.xs4all.nl/javascript/cache-control.html).

I believe that updating the server to set the `Cache-Control` header to `must-revalidate` should fix the problem. This should cause Chrome to make a network request with the `If-None-Match` or `If-Modified-Since` headers set in most situations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/342)
<!-- Reviewable:end -->
