### PR TITLE
SF-579 Update validation in response to audio changes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -358,6 +358,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
 
   processAudio(audio: AudioAttachment) {
     this.audio = audio;
+    this.updateValidationRules();
   }
 
   resetScriptureText() {


### PR DESCRIPTION
So we don't continue to say there's no audio if there is audio.

I would have liked to stop recording using the Stop Recording button
but had trouble getting it to show up in the DOM when running tests.

-------

 ### I would be glad for help or direction to use the actual Stop Recording button.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/348)
<!-- Reviewable:end -->
