### PR TITLE
SF-615 Support right to left languages in checking app

### DIFF
--- a/src/RealtimeServer/common/models/writing-system.ts
+++ b/src/RealtimeServer/common/models/writing-system.ts
@@ -1,3 +1,4 @@
 export interface WritingSystem {
   tag: string;
+  isRightToLeft: boolean;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.scss
@@ -15,6 +15,10 @@ app-text {
     display: none;
   }
   .ql-editor {
+    &.rtl-style {
+      direction: rtl;
+      text-align: right;
+    }
     .highlight-para-target {
       > usx-para-contents {
         box-shadow: unset;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/paratext-project.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/paratext-project.ts
@@ -6,4 +6,5 @@ export interface ParatextProject {
   projectId?: string;
   isConnectable: boolean;
   isConnected: boolean;
+  isRightToLeft: boolean;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -283,7 +283,8 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
           shortName: curSource.shortName,
           languageTag: curSource.writingSystem.tag,
           isConnectable: false,
-          isConnected: false
+          isConnected: false,
+          isRightToLeft: curSource.writingSystem.isRightToLeft
         });
       }
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -78,6 +78,7 @@ export class TextViewModel {
   private remoteChangesSub?: Subscription;
   private onCreateSub?: Subscription;
   private textDoc?: TextDoc;
+  private _isRightToLeft: boolean = false;
 
   constructor() {}
 
@@ -97,6 +98,10 @@ export class TextViewModel {
     return textData.ops == null || textData.ops.length === 0;
   }
 
+  set isRightToLeft(value: boolean) {
+    this._isRightToLeft = value;
+  }
+
   bind(textDoc: TextDoc): void {
     const editor = this.checkEditor();
     if (this.textDoc != null) {
@@ -105,6 +110,9 @@ export class TextViewModel {
 
     this.textDoc = textDoc;
     editor.setContents(this.textDoc.data as DeltaStatic);
+    if (this._isRightToLeft) {
+      document.getElementsByClassName('ql-editor')[0].classList.add('rtl-style');
+    }
     editor.history.clear();
     this.remoteChangesSub = this.textDoc.remoteChanges$.subscribe(ops => editor.updateContents(ops as DeltaStatic));
     this.onCreateSub = this.textDoc.create$.subscribe(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -166,6 +166,14 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
     }
   }
 
+  async isRightToLeft(): Promise<boolean> {
+    if (this._id == null) {
+      return false;
+    }
+    const projectDoc = await this.projectService.get(this._id.projectId);
+    return projectDoc != null ? (projectDoc.data != null ? projectDoc.data.writingSystem.isRightToLeft : false) : false;
+  }
+
   get segmentRef(): string {
     if (this._segment == null) {
       return this.initialSegmentRef == null ? '' : this.initialSegmentRef;
@@ -346,6 +354,7 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
     }
     this.placeholder = 'Loading...';
     const textDoc = await this.projectService.getText(this._id);
+    this.viewModel.isRightToLeft = await this.isRightToLeft();
     this.viewModel.bind(textDoc);
     this.updatePlaceholderText();
 

--- a/src/SIL.XForge.Scripture/Models/ParatextProject.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextProject.cs
@@ -9,5 +9,6 @@ namespace SIL.XForge.Scripture.Models
         public string ProjectId { get; set; }
         public bool IsConnectable { get; set; }
         public bool IsConnected { get; set; }
+        public bool IsRightToLeft { get; set; }
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -120,7 +120,8 @@ namespace SIL.XForge.Scripture.Services
                     LanguageTag = (string)projectObj["language_ldml"],
                     ProjectId = projectId,
                     IsConnectable = isConnectable,
-                    IsConnected = isConnected
+                    IsConnected = isConnected,
+                    IsRightToLeft = true // This should be looked up for each individual project
                 });
             }
             return projects.OrderBy(p => p.Name, StringComparer.InvariantCulture).ToArray();

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -83,7 +83,7 @@ namespace SIL.XForge.Scripture.Services
                 ParatextId = settings.ParatextId,
                 Name = ptProject.Name,
                 ShortName = ptProject.ShortName,
-                WritingSystem = new WritingSystem { Tag = ptProject.LanguageTag },
+                WritingSystem = new WritingSystem { Tag = ptProject.LanguageTag, IsRightToLeft = ptProject.IsRightToLeft },
                 TranslateConfig = new TranslateConfig
                 {
                     TranslationSuggestionsEnabled = settings.TranslationSuggestionsEnabled,

--- a/src/SIL.XForge/Models/WritingSystem.cs
+++ b/src/SIL.XForge/Models/WritingSystem.cs
@@ -3,5 +3,6 @@ namespace SIL.XForge.Models
     public class WritingSystem
     {
         public string Tag { get; set; }
+        public bool IsRightToLeft { get; set; }
     }
 }


### PR DESCRIPTION
We have found that the checking app only needs to have the text direction and the text align adjusted to support a right-to-left language. This still requires that we can assess the language direction from the paratext server or similar. We aren't sure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/355)
<!-- Reviewable:end -->
