### PR TITLE
SF-615 Support right to left languages in quill editor

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
@@ -8,5 +8,6 @@
   (onContentChanged)="onContentChanged($event.delta, $event.source)"
   (onSelectionChanged)="onSelectionChanged()"
   [ngClass]="{ 'template-editor': !readOnlyEnabled }"
+  dir="auto"
 >
 </quill-editor>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.scss
@@ -10,6 +10,7 @@ quill-editor {
       width: 100%;
       word-break: break-word;
       padding: 15px 35px;
+      text-align: start;
     }
   }
 }


### PR DESCRIPTION
* rtl languages will be detected in the browser dependent on content

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/356)
<!-- Reviewable:end -->
