### PR TITLE
SF-406 Autofill email on login page for users invited to projects

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.guard.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.guard.ts
@@ -15,7 +15,8 @@ export class AuthGuard implements CanActivate {
     return this.allowTransition().pipe(
       tap(isLoggedIn => {
         if (!isLoggedIn) {
-          this.authService.logIn(this.locationService.pathname + this.locationService.search);
+          const email = this.locationService.searchParams.get('email');
+          this.authService.logIn(this.locationService.pathname + this.locationService.search, email);
         }
       })
     );

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -96,9 +96,9 @@ export class AuthService {
     });
   }
 
-  logIn(returnUrl: string): void {
+  logIn(returnUrl: string, defaultEmail?: string): void {
     const state: AuthState = { returnUrl };
-    const options: AuthorizeOptions = { state: JSON.stringify(state) };
+    const options: AuthorizeOptions = { state: JSON.stringify(state), login_hint: defaultEmail };
     this.auth0.authorize(options);
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/location.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/location.service.ts
@@ -36,6 +36,14 @@ export class LocationService {
     return window.location.search;
   }
 
+  get searchParams(): Map<string, string> {
+    const map = new Map<string, string>();
+    new URLSearchParams(this.search).forEach((value, key) => {
+      map.set(key, value);
+    });
+    return map;
+  }
+
   go(url: string): void {
     window.location.href = url;
   }

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -297,7 +297,7 @@ namespace SIL.XForge.Scripture.Services
                 if (projectSecret == null)
                     projectSecret = await ProjectSecrets.GetAsync(projectId);
                 string key = projectSecret.ShareKeys.Single(sk => sk.Email == email).Key;
-                url = $"{siteOptions.Origin}projects/{projectId}?sharing=true&shareKey={key}";
+                url = $"{siteOptions.Origin}projects/{projectId}?sharing=true&shareKey={key}&email={Uri.EscapeDataString(email)}";
                 additionalMessage = "This link will only work for this email address.";
             }
             else


### PR DESCRIPTION
When users click an invite link to a project, the email address is now auto-filled.  

![auth0](https://user-images.githubusercontent.com/6140710/66967454-00527f80-f04f-11e9-8765-feef832ffe6b.png)

Unfortunately it still goes to the log in tab instead of the sign up tab. Setting `login_hint` to `signUp` changes this, but that's the same property we use to set the default email address (setting it to `signUp` sets the default tab; setting it to anything else sets the default email). If we can edit the code on the universal login page this will be trivial to fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/357)
<!-- Reviewable:end -->
