### PR TITLE
Set HTML lang attribute for Scripture text area

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -826,6 +826,12 @@ describe('CheckingComponent', () => {
       env.fixture.detectChanges();
       expect(env.currentQuestion).toBe(4);
     }));
+
+    it('quill editor element lang attribute is set from project language', fakeAsync(() => {
+      const env = new TestEnvironment(CHECKER_USER);
+      const quillElementLang = env.quillEditorElement.getAttribute('lang');
+      expect(quillElementLang).toEqual(env.project01WritingSystemTag);
+    }));
   });
 });
 
@@ -839,6 +845,8 @@ class TestEnvironment {
   readonly component: CheckingComponent;
   readonly fixture: ComponentFixture<CheckingComponent>;
   questionReadTimer: number = 2000;
+
+  public project01WritingSystemTag = 'en';
 
   readonly mockedQuestionDialogRef: MdcDialogRef<QuestionDialogComponent> = mock(MdcDialogRef);
   private readonly adminProjectUserConfig: SFProjectUserConfig = {
@@ -894,7 +902,7 @@ class TestEnvironment {
     paratextId: 'pt01',
     shortName: 'P01',
     writingSystem: {
-      tag: 'en'
+      tag: this.project01WritingSystemTag
     },
     sync: {
       queuedCount: 0
@@ -1014,6 +1022,10 @@ class TestEnvironment {
 
   get quillEditor(): HTMLElement {
     return <HTMLElement>document.getElementsByClassName('ql-container')[0];
+  }
+
+  get quillEditorElement(): HTMLElement {
+    return <HTMLElement>document.getElementsByTagName('quill-editor')[0];
   }
 
   get recordButton(): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -16,6 +16,7 @@ import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
+import { SFProjectDoc } from '../../core/models/sf-project-doc';
 import { SF_REALTIME_DOC_TYPES } from '../../core/models/sf-realtime-doc-types';
 import { Delta, TextDoc, TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
@@ -549,6 +550,7 @@ class TestEnvironment {
     when(mockedProjectService.getText(anything())).thenCall(id =>
       this.realtimeService.subscribe(TextDoc.COLLECTION, id.toString())
     );
+    when(mockedProjectService.get(anything())).thenResolve({} as SFProjectDoc);
     this.fixture.detectChanges();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
@@ -9,5 +9,6 @@
   (onSelectionChanged)="onSelectionChanged()"
   [ngClass]="{ 'template-editor': !readOnlyEnabled }"
   dir="auto"
+  [lang]="lang"
 >
 </quill-editor>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -54,6 +54,7 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
   @Output() updated = new EventEmitter<TextUpdatedEvent>(true);
   @Output() segmentRefChange = new EventEmitter<string>();
   @Output() loaded = new EventEmitter(true);
+  lang: string = '';
 
   private _editorStyles: any = { fontSize: '1rem' };
   private readonly DEFAULT_MODULES: any = {
@@ -140,6 +141,7 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
         }
         this.bindQuill();
       }
+      this.setLangFromText();
     }
   }
 
@@ -573,5 +575,18 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
     } else if (this.viewModel.isEmpty) {
       this.placeholder = 'This book is empty. Add chapters in Paratext.';
     }
+  }
+
+  private async setLangFromText() {
+    if (this.id == null) {
+      return;
+    }
+
+    const project = (await this.projectService.get(this.id.projectId)).data;
+    if (project == null) {
+      return;
+    }
+
+    this.lang = project.writingSystem.tag;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/translate-metrics-session.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/translate-metrics-session.spec.ts
@@ -6,6 +6,7 @@ import { anything, deepEqual, instance, mock, objectContaining, resetCalls, veri
 import { CommandError, CommandErrorCode } from 'xforge-common/command.service';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
+import { SFProjectDoc } from '../../core/models/sf-project-doc';
 import { SF_REALTIME_DOC_TYPES } from '../../core/models/sf-realtime-doc-types';
 import { Delta, TextDoc, TextDocId } from '../../core/models/text-doc';
 import { TranslateMetrics } from '../../core/models/translate-metrics';
@@ -350,6 +351,7 @@ class TestEnvironment {
       this.realtimeService.subscribe(TextDoc.COLLECTION, id.toString())
     );
     when(mockedSFProjectService.onlineAddTranslateMetrics('project01', anything())).thenResolve();
+    when(mockedSFProjectService.get(anything())).thenResolve({} as SFProjectDoc);
 
     this.sourceFixture = TestBed.createComponent(TextComponent);
     this.source = this.sourceFixture.componentInstance;


### PR DESCRIPTION

* Telling the browser what language a text is may help with
    hyphenation, etc.
* The language code is fetched from the project writing system tag. It
    needs to be a BCP 47 language tag.
* Because of challenges in making a text.component.spec.ts, the test
    was put in checking.component.spec.ts, which doesn't necessarily cover
    usage from other areas like editor.component.ts.

----
Here is a screenshot of `lang` having been added to the translate component.

![Selection_050](https://user-images.githubusercontent.com/7265309/67049450-7dcfcb80-f0f3-11e9-8940-e9664b5594c6.png)
----

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/358)
<!-- Reviewable:end -->
