### PR TITLE
Fix text corruption when USX is NFD

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1432,17 +1432,19 @@ class TestEnvironment {
   private createTextDataForChapter(chapter: number): TextData {
     const delta = new Delta();
     delta.insert({ chapter: { number: chapter.toString(), style: 'c' } });
+    delta.insert({ blank: true }, { segment: 'p_1' });
     delta.insert({ verse: { number: '1', style: 'v' } });
     delta.insert(`target: chapter ${chapter}, verse 1.`, { segment: `verse_${chapter}_1` });
     delta.insert({ verse: { number: '2', style: 'v' } });
-    delta.insert({ blank: 'normal' }, { segment: `verse_${chapter}_2` });
+    delta.insert({ blank: true }, { segment: `verse_${chapter}_2` });
     delta.insert('\n', { para: { style: 'p' } });
+    delta.insert({ blank: true }, { segment: `verse_${chapter}_2/p_1` });
     delta.insert({ verse: { number: '3', style: 'v' } });
     delta.insert(`target: chapter ${chapter}, verse 3.`, { segment: `verse_${chapter}_3` });
     delta.insert({ verse: { number: '4', style: 'v' } });
     delta.insert(`target: chapter ${chapter}, verse 4.`, { segment: `verse_${chapter}_4` });
     delta.insert('\n', { para: { style: 'p' } });
-    delta.insert({ blank: 'initial' }, { segment: `verse_${chapter}_4/p_1` });
+    delta.insert({ blank: true }, { segment: `verse_${chapter}_4/p_1` });
     delta.insert({ verse: { number: '5', style: 'v' } });
     delta.insert(`target: chapter ${chapter}, `, { segment: `verse_${chapter}_5` });
     delta.insert('\n', { para: { style: 'p' } });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -619,17 +619,19 @@ class TestEnvironment {
   private addTextDoc(bookNum: number): void {
     const delta = new Delta();
     delta.insert({ chapter: { number: '1', style: 'c' } });
+    delta.insert({ blank: true }, { segment: 'p_1' });
     delta.insert({ verse: { number: '1', style: 'v' } });
     delta.insert('target: chapter 1, verse 1.', { segment: 'verse_1_1' });
     delta.insert({ verse: { number: '2', style: 'v' } });
-    delta.insert({ blank: 'normal' }, { segment: 'verse_1_2' });
+    delta.insert({ blank: true }, { segment: 'verse_1_2' });
     delta.insert('\n', { para: { style: 'p' } });
+    delta.insert({ blank: true }, { segment: 'verse_1_2/p_1' });
     delta.insert({ verse: { number: '3', style: 'v' } });
     delta.insert(`target: chapter 1, verse 3.`, { segment: 'verse_1_3' });
     delta.insert({ verse: { number: '4', style: 'v' } });
     delta.insert(`target: chapter 1, verse 4.`, { segment: 'verse_1_4' });
     delta.insert('\n', { para: { style: 'p' } });
-    delta.insert({ blank: 'initial' }, { segment: 'verse_1_4/p_1' });
+    delta.insert({ blank: true }, { segment: 'verse_1_4/p_1' });
     delta.insert({ verse: { number: '5', style: 'v' } });
     delta.insert(`target: chapter 1, `, { segment: 'verse_1_5' });
     delta.insert('\n', { para: { style: 'p' } });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/text-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/text-doc.ts
@@ -6,6 +6,7 @@ import {
   TextType
 } from 'realtime-server/lib/scriptureforge/models/text-data';
 import { RealtimeDoc } from 'xforge-common/models/realtime-doc';
+import { isInitialSegment } from '../../shared/utils';
 
 export const Delta: new (ops?: DeltaOperation[] | { ops: DeltaOperation[] }) => DeltaStatic = Quill.import('delta');
 
@@ -39,8 +40,9 @@ export class TextDoc extends RealtimeDoc<TextData, TextData> {
     if (this.data != null && this.data.ops != null) {
       for (const op of this.data.ops) {
         if (op.attributes && op.attributes.segment) {
-          if (op.insert.blank) {
-            if (op.insert.blank === 'normal') {
+          if (op.insert.blank != null) {
+            const segRef: string = op.attributes != null ? op.attributes.segment : '';
+            if (!isInitialSegment(segRef)) {
               blank++;
             }
           } else {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -1,5 +1,6 @@
 import Parchment from 'parchment';
 import Quill, { Clipboard, DeltaOperation, DeltaStatic, Module } from 'quill';
+import { isInitialSegment } from '../utils';
 
 const Delta: new () => DeltaStatic = Quill.import('delta');
 
@@ -100,24 +101,28 @@ export function registerScripture(): void {
     static blotName = 'blank';
     static tagName = 'usx-blank';
 
-    static create(value: string): Node {
+    static create(value: boolean): Node {
       const node = super.create(value) as HTMLElement;
-      node.setAttribute(customAttributeName('type'), value);
-      let text: string = '';
-      switch (value) {
-        case 'initial':
-          text = NBSP.repeat(2);
-          break;
-        case 'normal':
-          text = NBSP.repeat(8);
-          break;
-      }
-      node.innerText = text;
+      node.innerText = NBSP.repeat(8);
       return node;
     }
 
-    static value(node: HTMLElement): any {
-      return node.getAttribute(customAttributeName('type'));
+    static value(_node: HTMLElement): boolean {
+      return true;
+    }
+
+    contentNode!: HTMLElement;
+
+    format(name: string, value: any): void {
+      if (name === SegmentInline.blotName && value != null) {
+        const ref = value as string;
+        let text: string = NBSP.repeat(8);
+        if (isInitialSegment(ref)) {
+          text = NBSP;
+        }
+        this.contentNode.innerText = text;
+      }
+      super.format(name, value);
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -509,7 +509,7 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
   }
 
   private adjustSelection(): void {
-    if (this._editor == null || !this._editor.hasFocus() || this._segment == null) {
+    if (this._editor == null || this._segment == null) {
       return;
     }
     const sel = this._editor.getSelection();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -36,3 +36,7 @@ export function combineVerseRefStrs(startStr?: string, endStr?: string): VerseRe
   }
   return range.verseRef;
 }
+
+export function isInitialSegment(ref: string): boolean {
+  return /(^|\/)[pmq]\d?_/.test(ref);
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
@@ -300,26 +300,27 @@ class TestEnvironment {
   private addTextDoc(id: TextDocId): void {
     const delta = new Delta();
     delta.insert({ chapter: { number: id.chapterNum.toString(), style: 'c' } });
+    delta.insert({ blank: true }, { segment: 'p_1' });
     delta.insert({ verse: { number: '1', style: 'v' } });
     delta.insert(`chapter ${id.chapterNum}, verse 1.`, { segment: `verse_${id.chapterNum}_1` });
     delta.insert({ verse: { number: '2', style: 'v' } });
-    delta.insert({ blank: 'normal' }, { segment: `verse_${id.chapterNum}_2` });
+    delta.insert({ blank: true }, { segment: `verse_${id.chapterNum}_2` });
     delta.insert({ verse: { number: '3', style: 'v' } });
     delta.insert(`chapter ${id.chapterNum}, verse 3.`, { segment: `verse_${id.chapterNum}_3` });
     delta.insert({ verse: { number: '4', style: 'v' } });
-    delta.insert({ blank: 'normal' }, { segment: `verse_${id.chapterNum}_4` });
+    delta.insert({ blank: true }, { segment: `verse_${id.chapterNum}_4` });
     delta.insert({ verse: { number: '5', style: 'v' } });
     delta.insert(`chapter ${id.chapterNum}, verse 5.`, { segment: `verse_${id.chapterNum}_5` });
     delta.insert({ verse: { number: '6', style: 'v' } });
-    delta.insert({ blank: 'normal' }, { segment: `verse_${id.chapterNum}_6` });
+    delta.insert({ blank: true }, { segment: `verse_${id.chapterNum}_6` });
     delta.insert({ verse: { number: '7', style: 'v' } });
     delta.insert(`chapter ${id.chapterNum}, verse 7.`, { segment: `verse_${id.chapterNum}_7` });
     delta.insert({ verse: { number: '8', style: 'v' } });
-    delta.insert({ blank: 'normal' }, { segment: `verse_${id.chapterNum}_8` });
+    delta.insert({ blank: true }, { segment: `verse_${id.chapterNum}_8` });
     delta.insert({ verse: { number: '9', style: 'v' } });
     delta.insert(`chapter ${id.chapterNum}, verse 9.`, { segment: `verse_${id.chapterNum}_9` });
     delta.insert({ verse: { number: '10', style: 'v' } });
-    delta.insert({ blank: 'normal' }, { segment: `verse_${id.chapterNum}_10` });
+    delta.insert({ blank: true }, { segment: `verse_${id.chapterNum}_10` });
     delta.insert('\n', { para: { style: 'p' } });
     this.realtimeService.addSnapshot(TextDoc.COLLECTION, {
       id: id.toString(),

--- a/src/SIL.XForge.Scripture/Services/DeltaUsxExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxExtensions.cs
@@ -23,10 +23,8 @@ namespace SIL.XForge.Scripture.Services
 
         public static Delta InsertBlank(this Delta delta, string segRef)
         {
-            string type = segRef.Contains("/p") || segRef.Contains("/m") ? "initial" : "normal";
-
             var attrs = new JObject(new JProperty("segment", segRef));
-            return delta.Insert(new { blank = type }, attrs);
+            return delta.Insert(new { blank = true }, attrs);
         }
 
         public static Delta InsertEmbed(this Delta delta, string type, JObject obj, string segRef = null,

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -246,7 +246,8 @@ namespace SIL.XForge.Scripture.Services
                 HttpResponseMessage response = await client.SendAsync(request);
                 if (response.IsSuccessStatusCode)
                 {
-                    return await response.Content.ReadAsStringAsync();
+                    string responseContent = await response.Content.ReadAsStringAsync();
+                    return responseContent.Normalize();
                 }
                 else if (response.StatusCode == HttpStatusCode.Unauthorized)
                 {

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -29,6 +29,7 @@ namespace SIL.XForge.Scripture.Services
         {
             var delta = Delta.New()
                 .InsertChapter("1")
+                .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertText("Verse text.", "verse_1_1")
                 .InsertPara("p")
@@ -50,6 +51,7 @@ namespace SIL.XForge.Scripture.Services
         {
             var delta = Delta.New()
                 .InsertChapter("1")
+                .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertBlank("verse_1_1")
                 .InsertVerse("2")
@@ -85,6 +87,7 @@ namespace SIL.XForge.Scripture.Services
         {
             var delta = Delta.New()
                 .InsertChapter("1")
+                .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertText("This is some ", "verse_1_1")
                 .InsertChar("bold", "bd", "verse_1_1")
@@ -110,6 +113,7 @@ namespace SIL.XForge.Scripture.Services
         {
             var delta = Delta.New()
                 .InsertChapter("1")
+                .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertText("This is a verse with a footnote", "verse_1_1")
                 .InsertNote(Delta.New()
@@ -151,6 +155,7 @@ namespace SIL.XForge.Scripture.Services
         {
             var delta = Delta.New()
                 .InsertChapter("1")
+                .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertText("This is a verse with a figure", "verse_1_1")
                 .InsertFigure("file.jpg", "col", "PHM 1:1", "Caption", "verse_1_1")
@@ -176,6 +181,7 @@ namespace SIL.XForge.Scripture.Services
         {
             var delta = Delta.New()
                 .InsertChapter("1")
+                .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertChar("1", new[] { "bd", "sup" }, "verse_1_1")
                 .InsertChar("This is", "bd", "verse_1_1")
@@ -207,6 +213,7 @@ namespace SIL.XForge.Scripture.Services
         {
             var delta = Delta.New()
                 .InsertChapter("1")
+                .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertText("This is a verse with a footnote", "verse_1_1")
                 .InsertNote(Delta.New()
@@ -248,6 +255,7 @@ namespace SIL.XForge.Scripture.Services
         {
             var delta = Delta.New()
                 .InsertChapter("1")
+                .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertText("This is a verse with a line break", "verse_1_1")
                 .InsertOptBreak("verse_1_1")
@@ -272,6 +280,7 @@ namespace SIL.XForge.Scripture.Services
         {
             var delta = Delta.New()
                 .InsertChapter("1")
+                .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertText("This is a verse with a milestone", "verse_1_1")
                 .InsertMilestone("ts", "verse_1_1")
@@ -296,15 +305,19 @@ namespace SIL.XForge.Scripture.Services
         {
             var delta = Delta.New()
                 .InsertChapter("1")
+                .InsertText("Before verse.", "cell_1_1_1")
                 .InsertVerse("1")
                 .InsertText("This is verse ", "verse_1_1")
                 .InsertChar("1", "it", "verse_1_1")
                 .InsertText(".", "verse_1_1")
                 .InsertCell(1, 1, "tc1", "start")
+                .InsertBlank("cell_1_1_2")
                 .InsertVerse("2")
                 .InsertText("This is verse 2.", "verse_1_2")
                 .InsertCell(1, 1, "tc2", "start")
+                .InsertBlank("cell_1_2_1")
                 .InsertCell(1, 2, "tc1", "start")
+                .InsertBlank("cell_1_2_2")
                 .InsertVerse("3")
                 .InsertText("This is verse 3.", "verse_1_3")
                 .InsertCell(1, 2, "tc2", "start");
@@ -316,7 +329,7 @@ namespace SIL.XForge.Scripture.Services
                 Chapter("1"),
                 Table(
                     Row(
-                        Cell("tc1", "start", Verse("1"), "This is verse ", Char("it", "1"), "."),
+                        Cell("tc1", "start", "Before verse.", Verse("1"), "This is verse ", Char("it", "1"), "."),
                         Cell("tc2", "start", Verse("2"), "This is verse 2.")),
                     Row(
                         Cell("tc1", "start"),
@@ -329,18 +342,23 @@ namespace SIL.XForge.Scripture.Services
         {
             var delta = Delta.New()
                 .InsertChapter("1")
+                .InsertText("Before verse.", "cell_1_1_1")
                 .InsertVerse("1")
                 .InsertText("This is verse ", "verse_1_1")
                 .InsertChar("1", "it", "verse_1_1")
                 .InsertText(".", "verse_1_1")
                 .InsertCell(1, 1, "tc1", "start")
+                .InsertBlank("cell_1_1_2")
                 .InsertVerse("2")
                 .InsertText("This is verse 2.", "verse_1_2")
                 .InsertCell(1, 1, "tc2", "start")
+                .InsertBlank("cell_1_2_1")
                 .InsertCell(1, 2, "tc1", "start")
+                .InsertBlank("cell_1_2_2")
                 .InsertVerse("3")
                 .InsertText("This is verse 3.", "verse_1_3")
                 .InsertCell(1, 2, "tc2", "start")
+                .InsertBlank("p_1")
                 .InsertVerse("4")
                 .InsertText("This is verse 4.", "verse_1_4")
                 .InsertPara("p");
@@ -352,7 +370,7 @@ namespace SIL.XForge.Scripture.Services
                 Chapter("1"),
                 Table(
                     Row(
-                        Cell("tc1", "start", Verse("1"), "This is verse ", Char("it", "1"), "."),
+                        Cell("tc1", "start", "Before verse.", Verse("1"), "This is verse ", Char("it", "1"), "."),
                         Cell("tc2", "start", Verse("2"), "This is verse 2.")),
                     Row(
                         Cell("tc1", "start"),
@@ -366,27 +384,35 @@ namespace SIL.XForge.Scripture.Services
         {
             var delta = Delta.New()
                 .InsertChapter("1")
+                .InsertBlank("cell_1_1_1")
                 .InsertVerse("1")
                 .InsertText("This is verse 1.", "verse_1_1")
                 .InsertCell(1, 1, "tc1", "start")
+                .InsertBlank("cell_1_1_2")
                 .InsertVerse("2")
                 .InsertText("This is verse 2.", "verse_1_2")
                 .InsertCell(1, 1, "tc2", "start")
+                .InsertBlank("cell_1_2_1")
                 .InsertVerse("3")
                 .InsertText("This is verse 3.", "verse_1_3")
                 .InsertCell(1, 2, "tc1", "start")
+                .InsertBlank("cell_1_2_2")
                 .InsertVerse("4")
                 .InsertText("This is verse 4.", "verse_1_4")
                 .InsertCell(1, 2, "tc2", "start")
+                .InsertBlank("cell_2_1_1")
                 .InsertVerse("5")
                 .InsertText("This is verse 5.", "verse_1_5")
                 .InsertCell(2, 1, "tc1", "start")
+                .InsertBlank("cell_2_1_2")
                 .InsertVerse("6")
                 .InsertText("This is verse 6.", "verse_1_6")
                 .InsertCell(2, 1, "tc2", "start")
+                .InsertBlank("cell_2_2_1")
                 .InsertVerse("7")
                 .InsertText("This is verse 7.", "verse_1_7")
                 .InsertCell(2, 2, "tc1", "start")
+                .InsertBlank("cell_2_2_2")
                 .InsertVerse("8")
                 .InsertText("This is verse 8.", "verse_1_8")
                 .InsertCell(2, 2, "tc2", "start");
@@ -417,7 +443,9 @@ namespace SIL.XForge.Scripture.Services
         public void ToUsx_ConsecutiveSameStyleEmptyParas()
         {
             var delta = Delta.New()
+                .InsertBlank("p_1")
                 .InsertPara("p")
+                .InsertBlank("p_2")
                 .InsertPara("p");
 
             var mapper = new DeltaUsxMapper();
@@ -481,6 +509,37 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
+        public void ToUsx_BlankLine()
+        {
+            var delta = Delta.New()
+                .InsertChapter("1")
+                .InsertBlank("p_1")
+                .InsertVerse("1")
+                .InsertBlank("verse_1_1")
+                .InsertVerse("2")
+                .InsertBlank("verse_1_2")
+                .InsertPara("p")
+                .InsertPara("b")
+                .InsertBlank("p_2")
+                .InsertVerse("3")
+                .InsertBlank("verse_1_3")
+                .InsertPara("p");
+
+            var mapper = new DeltaUsxMapper();
+            XElement newUsxElem = mapper.ToUsx("2.5", "PHM", null, new[] { delta });
+
+            XElement expected = Usx("PHM",
+                Chapter("1"),
+                Para("p",
+                    Verse("1"),
+                    Verse("2")),
+                Para("b"),
+                Para("p",
+                    Verse("3")));
+            Assert.IsTrue(XNode.DeepEquals(newUsxElem, expected));
+        }
+
+        [Test]
         public void ToDelta_EmptySegments()
         {
             XElement usxElem = Usx("PHM",
@@ -498,6 +557,7 @@ namespace SIL.XForge.Scripture.Services
 
             var expected = Delta.New()
                 .InsertChapter("1")
+                .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertBlank("verse_1_1")
                 .InsertVerse("2")
@@ -543,6 +603,7 @@ namespace SIL.XForge.Scripture.Services
                 .InsertText("Philemon", "mt_1")
                 .InsertPara("mt")
                 .InsertChapter("1")
+                .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertBlank("verse_1_1")
                 .InsertVerse("2")
@@ -550,12 +611,14 @@ namespace SIL.XForge.Scripture.Services
                 .InsertPara("p")
                 .InsertBlank("s_1")
                 .InsertPara("s")
+                .InsertBlank("p_2")
                 .InsertVerse("3")
                 .InsertBlank("verse_1_3")
                 .InsertPara("p");
 
             var expectedChapter2 = Delta.New()
                 .InsertChapter("2")
+                .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertBlank("verse_2_1")
                 .InsertVerse("2")
@@ -563,6 +626,7 @@ namespace SIL.XForge.Scripture.Services
                 .InsertPara("p")
                 .InsertBlank("s_1")
                 .InsertPara("s")
+                .InsertBlank("p_2")
                 .InsertVerse("3")
                 .InsertBlank("verse_2_3")
                 .InsertPara("p");
@@ -598,6 +662,7 @@ namespace SIL.XForge.Scripture.Services
 
             var expected = Delta.New()
                 .InsertChapter("1")
+                .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertText("This is a verse with a footnote", "verse_1_1")
                 .InsertNote(Delta.New()
@@ -632,6 +697,7 @@ namespace SIL.XForge.Scripture.Services
 
             var expected = Delta.New()
                 .InsertChapter("1")
+                .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertText("This is a verse with a figure", "verse_1_1")
                 .InsertFigure("file.jpg", "col", "PHM 1:1", "Caption", "verse_1_1")
@@ -662,6 +728,7 @@ namespace SIL.XForge.Scripture.Services
 
             var expected = Delta.New()
                 .InsertChapter("1")
+                .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertChar("1", new[] { "bd", "sup" }, "verse_1_1")
                 .InsertChar("This is", "bd", "verse_1_1")
@@ -699,6 +766,7 @@ namespace SIL.XForge.Scripture.Services
 
             var expected = Delta.New()
                 .InsertChapter("1")
+                .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertText("This is a verse with a footnote", "verse_1_1")
                 .InsertNote(Delta.New()
@@ -733,6 +801,7 @@ namespace SIL.XForge.Scripture.Services
 
             var expected = Delta.New()
                 .InsertChapter("1")
+                .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertText("This is a verse with a line break", "verse_1_1")
                 .InsertOptBreak("verse_1_1")
@@ -759,6 +828,7 @@ namespace SIL.XForge.Scripture.Services
 
             var expected = Delta.New()
                 .InsertChapter("1")
+                .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertText("This is a verse with a line break", "verse_1_1")
                 .InsertMilestone("ts", "verse_1_1")
@@ -776,7 +846,7 @@ namespace SIL.XForge.Scripture.Services
                 Chapter("1"),
                 Table(
                     Row(
-                        Cell("tc1", "start", Verse("1"), "This is verse ", Char("it", "1"), "."),
+                        Cell("tc1", "start", "Before verse.", Verse("1"), "This is verse ", Char("it", "1"), "."),
                         Cell("tc2", "start", Verse("2"), "This is verse 2.")),
                     Row(
                         Cell("tc1", "start"),
@@ -787,15 +857,19 @@ namespace SIL.XForge.Scripture.Services
 
             var expected = Delta.New()
                 .InsertChapter("1")
+                .InsertText("Before verse.", "cell_1_1_1")
                 .InsertVerse("1")
                 .InsertText("This is verse ", "verse_1_1")
                 .InsertChar("1", "it", "verse_1_1")
                 .InsertText(".", "verse_1_1")
                 .InsertCell(1, 1, "tc1", "start")
+                .InsertBlank("cell_1_1_2")
                 .InsertVerse("2")
                 .InsertText("This is verse 2.", "verse_1_2")
                 .InsertCell(1, 1, "tc2", "start")
+                .InsertBlank("cell_1_2_1")
                 .InsertCell(1, 2, "tc1", "start")
+                .InsertBlank("cell_1_2_2")
                 .InsertVerse("3")
                 .InsertText("This is verse 3.", "verse_1_3")
                 .InsertCell(1, 2, "tc2", "start");
@@ -811,7 +885,7 @@ namespace SIL.XForge.Scripture.Services
                 Chapter("1"),
                 Table(
                     Row(
-                        Cell("tc1", "start", Verse("1"), "This is verse ", Char("it", "1"), "."),
+                        Cell("tc1", "start", "Before verse.", Verse("1"), "This is verse ", Char("it", "1"), "."),
                         Cell("tc2", "start", Verse("2"), "This is verse 2.")),
                     Row(
                         Cell("tc1", "start"),
@@ -823,18 +897,23 @@ namespace SIL.XForge.Scripture.Services
 
             var expected = Delta.New()
                 .InsertChapter("1")
+                .InsertText("Before verse.", "cell_1_1_1")
                 .InsertVerse("1")
                 .InsertText("This is verse ", "verse_1_1")
                 .InsertChar("1", "it", "verse_1_1")
                 .InsertText(".", "verse_1_1")
                 .InsertCell(1, 1, "tc1", "start")
+                .InsertBlank("cell_1_1_2")
                 .InsertVerse("2")
                 .InsertText("This is verse 2.", "verse_1_2")
                 .InsertCell(1, 1, "tc2", "start")
+                .InsertBlank("cell_1_2_1")
                 .InsertCell(1, 2, "tc1", "start")
+                .InsertBlank("cell_1_2_2")
                 .InsertVerse("3")
                 .InsertText("This is verse 3.", "verse_1_3")
                 .InsertCell(1, 2, "tc2", "start")
+                .InsertBlank("p_1")
                 .InsertVerse("4")
                 .InsertText("This is verse 4.", "verse_1_4")
                 .InsertPara("p");
@@ -868,27 +947,35 @@ namespace SIL.XForge.Scripture.Services
 
             var expected = Delta.New()
                 .InsertChapter("1")
+                .InsertBlank("cell_1_1_1")
                 .InsertVerse("1")
                 .InsertText("This is verse 1.", "verse_1_1")
                 .InsertCell(1, 1, "tc1", "start")
+                .InsertBlank("cell_1_1_2")
                 .InsertVerse("2")
                 .InsertText("This is verse 2.", "verse_1_2")
                 .InsertCell(1, 1, "tc2", "start")
+                .InsertBlank("cell_1_2_1")
                 .InsertVerse("3")
                 .InsertText("This is verse 3.", "verse_1_3")
                 .InsertCell(1, 2, "tc1", "start")
+                .InsertBlank("cell_1_2_2")
                 .InsertVerse("4")
                 .InsertText("This is verse 4.", "verse_1_4")
                 .InsertCell(1, 2, "tc2", "start")
+                .InsertBlank("cell_2_1_1")
                 .InsertVerse("5")
                 .InsertText("This is verse 5.", "verse_1_5")
                 .InsertCell(2, 1, "tc1", "start")
+                .InsertBlank("cell_2_1_2")
                 .InsertVerse("6")
                 .InsertText("This is verse 6.", "verse_1_6")
                 .InsertCell(2, 1, "tc2", "start")
+                .InsertBlank("cell_2_2_1")
                 .InsertVerse("7")
                 .InsertText("This is verse 7.", "verse_1_7")
                 .InsertCell(2, 2, "tc1", "start")
+                .InsertBlank("cell_2_2_2")
                 .InsertVerse("8")
                 .InsertText("This is verse 8.", "verse_1_8")
                 .InsertCell(2, 2, "tc2", "start");
@@ -968,6 +1055,7 @@ namespace SIL.XForge.Scripture.Services
 
             var expected = Delta.New()
                 .InsertChapter("1")
+                .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertBlank("verse_1_1")
                 .InsertVerse("2")
@@ -981,6 +1069,39 @@ namespace SIL.XForge.Scripture.Services
                 .InsertVerse("3")
                 .InsertBlank("verse_1_3")
                 .InsertPara("");
+
+            Assert.IsTrue(newDeltas[1].Delta.DeepEquals(expected));
+            Assert.That(newDeltas[1].LastVerse, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void ToDelta_BlankLine()
+        {
+            XElement usxElem = Usx("PHM",
+                Chapter("1"),
+                Para("p",
+                    Verse("1"),
+                    Verse("2")),
+                Para("b"),
+                Para("p",
+                    Verse("3")));
+
+            var mapper = new DeltaUsxMapper();
+            IReadOnlyDictionary<int, (Delta Delta, int LastVerse)> newDeltas = mapper.ToChapterDeltas(usxElem);
+
+            var expected = Delta.New()
+                .InsertChapter("1")
+                .InsertBlank("p_1")
+                .InsertVerse("1")
+                .InsertBlank("verse_1_1")
+                .InsertVerse("2")
+                .InsertBlank("verse_1_2")
+                .InsertPara("p")
+                .InsertPara("b")
+                .InsertBlank("p_2")
+                .InsertVerse("3")
+                .InsertBlank("verse_1_3")
+                .InsertPara("p");
 
             Assert.IsTrue(newDeltas[1].Delta.DeepEquals(expected));
             Assert.That(newDeltas[1].LastVerse, Is.EqualTo(3));


### PR DESCRIPTION
- normalize all data from PT API data to NFC
- insert blanks at the beginning of all paras
- insert blanks at the beginning of all cells
- remove type attribute from blanks
- determine size of blank from segment ref
- handle blank line style

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/359)
<!-- Reviewable:end -->
