### PR TITLE
Fix production build router guard dependency injection errors

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/project-router.guard.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/project-router.guard.ts
@@ -9,16 +9,8 @@ import { SFProjectDoc } from '../core/models/sf-project-doc';
 import { canAccessTranslateApp } from '../core/models/sf-project-role-info';
 import { SFProjectService } from '../core/sf-project.service';
 
-@Injectable({
-  providedIn: 'root'
-})
 abstract class RouterGuard implements CanActivate {
-  constructor(
-    public readonly authGuard: AuthGuard,
-    public readonly userService: UserService,
-    public readonly projectService: SFProjectService,
-    public readonly router: Router
-  ) {}
+  constructor(protected authGuard: AuthGuard, protected projectService: SFProjectService) {}
 
   canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
     const projectId = 'projectId' in next.params ? next.params['projectId'] : '';
@@ -43,6 +35,10 @@ abstract class RouterGuard implements CanActivate {
   providedIn: 'root'
 })
 export class SFAdminAuthGuard extends RouterGuard {
+  constructor(authGuard: AuthGuard, projectService: SFProjectService, private userService: UserService) {
+    super(authGuard, projectService);
+  }
+
   check(projectDoc: SFProjectDoc): boolean {
     return (
       projectDoc.data != null &&
@@ -55,6 +51,10 @@ export class SFAdminAuthGuard extends RouterGuard {
   providedIn: 'root'
 })
 export class CheckingAuthGuard extends RouterGuard {
+  constructor(authGuard: AuthGuard, projectService: SFProjectService, private router: Router) {
+    super(authGuard, projectService);
+  }
+
   check(projectDoc: SFProjectDoc): boolean {
     if (projectDoc.data != null && projectDoc.data.checkingConfig.checkingEnabled) {
       return true;
@@ -68,6 +68,15 @@ export class CheckingAuthGuard extends RouterGuard {
   providedIn: 'root'
 })
 export class TranslateAuthGuard extends RouterGuard {
+  constructor(
+    authGuard: AuthGuard,
+    projectService: SFProjectService,
+    private userService: UserService,
+    private router: Router
+  ) {
+    super(authGuard, projectService);
+  }
+
   check(projectDoc: SFProjectDoc): boolean {
     if (projectDoc.data != null) {
       const role = projectDoc.data.userRoles[this.userService.currentUserId] as SFProjectRole;


### PR DESCRIPTION
The latest build of QA has the following errors:
```
TypeError: Cannot read property 'canActivate' of undefined
TypeError: Cannot read property 'allowTransition' of undefined
```

These errors were introduced in e8fe19cf0e94a92603b5790a068a90f37e7ab755 (#354).

The way I used dependency injection worked in development builds, but broke in production builds, likely due to the AOT compiler. It appears the classes were constructed with undefined arguments.

To test this you'll need to run `ng serve --prod`. This often results in a `JavaScript heap out of memory` error. You can increase the memory limit by running it as `node --max-old-space-size=4096 ~/bin/ng serve --prod`. It's a pretty slow build.

In order to get things working with the production build, you'll need to edit `environment.prod.ts`, and at the very least update `authDomain` to the value in `environment.ts` to get Auth0 to work. Some other things (e.g. websockets) will still be broken, but the page should function fine.

You may want to run a build on master to reproduce the problem before checking that this fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/366)
<!-- Reviewable:end -->
