### PR TITLE
Configure lgtm to analyze C# without building the project

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,4 @@
+extraction:
+  csharp:
+    index:
+      buildless: true


### PR DESCRIPTION
Currently lgtm has not been analyzing C# due to an error when it tries to build it. This leaves us with several options:
1. Leave as-is, with no C# analysis.
2. Install the `node` and `npm` packages so it can build the C# (the reason it needs these is that `SIL.XForge.Scripture.csproj` specifies that `npm run build` and similar commands have to be run before buildilng). Installing the versions of the `node` and `npm` packages that are available in the repos resulted in `Maximum call stack size exceeded` (for unknown reasons), and would add additional time to the build.
3. Modify the offending `.csproj` file, or add another , so that lgtm builds without having to run node and npm.
4. Have lgtm skip the offending project file.
5. Have lgtm analyze C# files without building them. According to [the docs](https://lgtm.com/help/lgtm/csharp-extraction#customizing-index), "This is less precise than built extraction, but usually returns useful results."

This PR opts for #<!-- -->5, though an argument could be made for others (which would likely be more work).

Test builds with a custom `lgtm.yml` file can be run here, without the need to check them in to a repo: https://lgtm.com/builds/test/g/sillsdev/web-xforge

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/367)
<!-- Reviewable:end -->
