### PR TITLE
SF-614 Jump to newly added question

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -516,7 +516,8 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
         dateCreated: currentDate,
         dateModified: currentDate
       };
-      await this.projectService.createQuestion(this.projectDoc.id, question);
+      const newQuestion = await this.projectService.createQuestion(this.projectDoc.id, question);
+      this.questionsPanel.activateQuestion(newQuestion);
     });
   }
 


### PR DESCRIPTION
* When adding a question in the checking.component (not checking-
overview), select that question after adding it. This may result in
switching to another book or chapter.
* Tested on laptop and phone sizes. Tested from All Questions area and
from one book to another.

----

Screenshot showing that the Mat 1:2 question was jumped to, when I added it while looking at Genesis 1.

![Selection_052](https://user-images.githubusercontent.com/7265309/67247630-34e38400-f41f-11e9-90d9-42a3ad3ea54b.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/368)
<!-- Reviewable:end -->
