### PR TITLE
SF-616 Incorrect styling of rtl languages

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.scss
@@ -10,6 +10,18 @@ app-text {
   flex-direction: column;
   flex: 1;
 }
+.ltr .highlight-segment-target[data-question='true'] {
+  margin-left: 1.5em;
+  &:before {
+    left: -1.75em;
+  }
+}
+.rtl .highlight-segment-target[data-question='true'] {
+  margin-right: 1.5em;
+  &:before {
+    right: -1.75em;
+  }
+}
 .ql-container {
   .highlight-marker {
     display: none;
@@ -26,8 +38,6 @@ app-text {
       cursor: pointer;
 
       &[data-question='true'] {
-        margin-left: 1.5em;
-
         &:before {
           content: '?';
           border-radius: 50%;
@@ -40,8 +50,8 @@ app-text {
           background: var(--mdc-theme-secondary);
           font-weight: bold;
           position: absolute;
-          left: -1.75em;
           top: 0;
+          text-indent: 0;
         }
       }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
@@ -143,7 +143,7 @@ export class CheckingTextComponent extends SubscriptionDisposable {
       const element = this.textComponent.editor.container.querySelector('usx-segment[data-segment="' + segment + '"]');
       if (element == null) {
         continue;
-      } else if (element.querySelector('usx-blank')) {
+      } else if (element.querySelector('usx-blank') !== null) {
         continue;
       }
       const range = this.textComponent.getSegmentRange(segment);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
@@ -122,7 +122,7 @@ export class CheckingTextComponent extends SubscriptionDisposable {
         segments.push(segment);
       }
       // Check for similar segments like this verse i.e. verse_1_2/q1
-      for (const similarSegment of this.textComponent.getSegmentSimilarRange(segment)) {
+      for (const similarSegment of this.textComponent.getRelatedSegmentRefs(segment)) {
         if (!segments.includes(similarSegment)) {
           segments.push(similarSegment);
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
@@ -121,6 +121,12 @@ export class CheckingTextComponent extends SubscriptionDisposable {
       if (!segments.includes(segment)) {
         segments.push(segment);
       }
+      // Check for similar segments like this verse i.e. verse_1_2/q1
+      for (const similarSegment of this.textComponent.getSegmentSimilarRange(segment)) {
+        if (!segments.includes(similarSegment)) {
+          segments.push(similarSegment);
+        }
+      }
     }
     return segments;
   }
@@ -134,6 +140,12 @@ export class CheckingTextComponent extends SubscriptionDisposable {
       if (!this.textComponent.hasSegmentRange(segment)) {
         continue;
       }
+      const element = this.textComponent.editor.container.querySelector('usx-segment[data-segment="' + segment + '"]');
+      if (element == null) {
+        continue;
+      } else if (element.querySelector('usx-blank')) {
+        continue;
+      }
       const range = this.textComponent.getSegmentRange(segment);
       this.textComponent.toggleHighlight(toggle, range);
       if (this.mode === 'dialog') {
@@ -141,10 +153,6 @@ export class CheckingTextComponent extends SubscriptionDisposable {
       }
       if (!toggle) {
         continue;
-      }
-      const element = this.textComponent.editor.container.querySelector('usx-segment[data-segment=' + segment + ']');
-      if (element == null) {
-        return;
       }
       this.clickSubs.push(
         this.subscribe(fromEvent<MouseEvent>(element, 'click'), event => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -188,12 +188,12 @@ export class TextViewModel {
     return this._segments.has(ref);
   }
 
-  getSegmentRange(ref: string): RangeStatic | undefined {
-    return this._segments.get(ref);
+  getRelatedSegmentRefs(ref: string): string[] {
+    return Array.from(this._segments.keys()).filter(r => r.indexOf(ref + '/') === 0);
   }
 
-  getSegmentSimilarRange(ref: string): string[] {
-    return Array.from(this._segments.keys()).filter(r => r.indexOf(ref) === 0);
+  getSegmentRange(ref: string): RangeStatic | undefined {
+    return this._segments.get(ref);
   }
 
   getSegmentText(ref: string): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -192,6 +192,10 @@ export class TextViewModel {
     return this._segments.get(ref);
   }
 
+  getSegmentSimilarRange(ref: string): string[] {
+    return Array.from(this._segments.keys()).filter(r => r.indexOf(ref) === 0);
+  }
+
   getSegmentText(ref: string): string {
     const editor = this.checkEditor();
     const range = this.getSegmentRange(ref);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
@@ -7,7 +7,7 @@
   (onEditorCreated)="onEditorCreated($event)"
   (onContentChanged)="onContentChanged($event.delta, $event.source)"
   (onSelectionChanged)="onSelectionChanged()"
-  [ngClass]="{ 'template-editor': !readOnlyEnabled }"
+  [ngClass]="{ 'template-editor': !readOnlyEnabled, ltr: isLtr, rtl: isRtl }"
   dir="auto"
   [lang]="lang"
 >

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -56,6 +56,7 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
   @Output() loaded = new EventEmitter(true);
   lang: string = '';
 
+  private _direction: string | null = null;
   private _editorStyles: any = { fontSize: '1rem' };
   private readonly DEFAULT_MODULES: any = {
     toolbar: false,
@@ -120,6 +121,10 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
 
   constructor(private readonly projectService: SFProjectService) {
     super();
+  }
+
+  get direction(): string | null {
+    return this._direction;
   }
 
   get id(): TextDocId | undefined {
@@ -212,6 +217,14 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
     this.applyEditorStyles();
   }
 
+  get isLtr(): boolean {
+    return this.direction === 'ltr';
+  }
+
+  get isRtl(): boolean {
+    return this.direction === 'rtl';
+  }
+
   get isSelectionAtSegmentEnd(): boolean {
     if (this.editor == null || this.segment == null) {
       return false;
@@ -288,6 +301,10 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
     return this.viewModel.getSegmentRange(ref);
   }
 
+  getSegmentSimilarRange(ref: string): string[] {
+    return this.viewModel.getSegmentSimilarRange(ref);
+  }
+
   getSegmentText(ref: string): string {
     return this.viewModel.getSegmentText(ref);
   }
@@ -353,6 +370,8 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
 
     this.loaded.emit();
     this.applyEditorStyles();
+    // Get the computed direction the browser decided to use for quill for the current text
+    this.setDirection();
   }
 
   private isBackspaceAllowed(range: RangeStatic): boolean {
@@ -398,6 +417,15 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
     const prevRef = this.viewModel.getPrevSegmentRef(this._segment.ref);
     if (prevRef != null) {
       this.setSegment(prevRef, undefined, true, end);
+    }
+  }
+
+  private setDirection() {
+    // As the browser is automatically applying ltr/rtl we need to ask it which one it is using
+    // This value can then be used for other purposes i.e. CSS styles
+    const quill = document.querySelector('quill-editor');
+    if (quill !== null) {
+      this._direction = window.getComputedStyle(quill).direction;
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -301,8 +301,8 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
     return this.viewModel.getSegmentRange(ref);
   }
 
-  getSegmentSimilarRange(ref: string): string[] {
-    return this.viewModel.getSegmentSimilarRange(ref);
+  getRelatedSegmentRefs(ref: string): string[] {
+    return this.viewModel.getRelatedSegmentRefs(ref);
   }
 
   getSegmentText(ref: string): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/usx-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/usx-styles.scss
@@ -135,31 +135,6 @@ usx-para {
     margin-bottom: 0.25em;
   }
 
-  &[data-style='li'] {
-    padding-left: 3em;
-  }
-
-  &[data-style='q'],
-  &[data-style='q1'] {
-    margin-left: 7.5em;
-    text-indent: -6em;
-  }
-
-  &[data-style='q2'] {
-    margin-left: 7.5em;
-    text-indent: -4.5em;
-  }
-
-  &[data-style='q3'] {
-    margin-left: 7.5em;
-    text-indent: -3em;
-  }
-
-  &[data-style='q4'] {
-    margin-left: 1.25em;
-    text-indent: -1.5em;
-  }
-
   &[data-style='qc'] {
     text-align: center;
   }
@@ -172,22 +147,6 @@ usx-para {
     font-style: italic;
   }
 
-  &[data-style='qm'],
-  &[data-style='qm1'] {
-    margin-left: 6em;
-    text-indent: -4.5em;
-  }
-
-  &[data-style='qm2'] {
-    margin-left: 6em;
-    text-indent: -3em;
-  }
-
-  &[data-style='qm3'] {
-    margin-left: 6em;
-    text-indent: -1.5em;
-  }
-
   &[data-style='b'] {
     font-size: 0.8em;
   }
@@ -195,6 +154,94 @@ usx-para {
   &[data-style='r'] {
     font-style: italic;
     text-align: center;
+  }
+}
+.ltr {
+  usx-para {
+    &[data-style='li'] {
+      padding-left: 3em;
+    }
+
+    &[data-style='q'],
+    &[data-style='q1'] {
+      margin-left: 7.5em;
+      text-indent: -6em;
+    }
+
+    &[data-style='q2'] {
+      margin-left: 7.5em;
+      text-indent: -4.5em;
+    }
+
+    &[data-style='q3'] {
+      margin-left: 7.5em;
+      text-indent: -3em;
+    }
+
+    &[data-style='q4'] {
+      margin-left: 1.25em;
+      text-indent: -1.5em;
+    }
+
+    &[data-style='qm'],
+    &[data-style='qm1'] {
+      margin-left: 6em;
+      text-indent: -4.5em;
+    }
+
+    &[data-style='qm2'] {
+      margin-left: 6em;
+      text-indent: -3em;
+    }
+
+    &[data-style='qm3'] {
+      margin-left: 6em;
+      text-indent: -1.5em;
+    }
+  }
+}
+.rtl {
+  usx-para {
+    &[data-style='li'] {
+      padding-right: 3em;
+    }
+
+    &[data-style='q'],
+    &[data-style='q1'] {
+      margin-right: 7.5em;
+      text-indent: 6em;
+    }
+
+    &[data-style='q2'] {
+      margin-right: 7.5em;
+      text-indent: 4.5em;
+    }
+
+    &[data-style='q3'] {
+      margin-right: 7.5em;
+      text-indent: 3em;
+    }
+
+    &[data-style='q4'] {
+      margin-right: 1.25em;
+      text-indent: 1.5em;
+    }
+
+    &[data-style='qm'],
+    &[data-style='qm1'] {
+      margin-right: 6em;
+      text-indent: 4.5em;
+    }
+
+    &[data-style='qm2'] {
+      margin-right: 6em;
+      text-indent: 3em;
+    }
+
+    &[data-style='qm3'] {
+      margin-right: 6em;
+      text-indent: 1.5em;
+    }
   }
 }
 


### PR DESCRIPTION
- Added functions to text component to determine if the browser has applied LTR or RTL for quill
- Adjusted margins set for USX styles to take in to account LTR or RTL
- Highlighting question segments now also highlights similar verses i.e. verse_1_2/q1 and ignores segments that are blank

A discussion needs to be had around indenting and margins as, at least ont he project I've tested on, they look a little out of control and get worse the smaller the viewport. Might need to make use of vw and other @media queries
![image](https://user-images.githubusercontent.com/17464863/67445727-69974b80-f66a-11e9-9c19-6e4cf47f08d4.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/376)
<!-- Reviewable:end -->
