### PR TITLE
SF-634: Notes not properly round-tripped during sync

### DIFF
--- a/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
@@ -465,6 +465,8 @@ namespace SIL.XForge.Scripture.Services
 
                 }
             }
+            while (curCharAttrs.Count > 0)
+                CharEnded(childNodes, curCharAttrs);
             if (curTableAttrs != null)
             {
                 RowEnded(childNodes, ref curRowAttrs);

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -123,8 +123,7 @@ namespace SIL.XForge.Scripture.Services
                     .Insert(". ")
                     .InsertChar("John 1:1", "xt")
                     .Insert(" and ")
-                    .InsertChar("Mark 1:1", "xt")
-                    .Insert("."), "f", "+", "verse_1_1")
+                    .InsertChar("Mark 1:1", "xt"), "f", "+", "verse_1_1")
                 .InsertText(", so that we can test it.", "verse_1_1")
                 .InsertPara("p")
                 .Insert("\n");
@@ -144,8 +143,7 @@ namespace SIL.XForge.Scripture.Services
                         ". ",
                         Char("xt", "John 1:1"),
                         " and ",
-                        Char("xt", "Mark 1:1"),
-                        "."),
+                        Char("xt", "Mark 1:1")),
                     ", so that we can test it."));
             Assert.IsTrue(XNode.DeepEquals(newUsxElem, expected));
         }
@@ -653,8 +651,7 @@ namespace SIL.XForge.Scripture.Services
                         ". ",
                         Char("xt", "John 1:1"),
                         " and ",
-                        Char("xt", "Mark 1:1"),
-                        "."),
+                        Char("xt", "Mark 1:1")),
                     ", so that we can test it."));
 
             var mapper = new DeltaUsxMapper();
@@ -672,8 +669,7 @@ namespace SIL.XForge.Scripture.Services
                     .Insert(". ")
                     .InsertChar("John 1:1", "xt")
                     .Insert(" and ")
-                    .InsertChar("Mark 1:1", "xt")
-                    .Insert("."), "f", "+", "verse_1_1")
+                    .InsertChar("Mark 1:1", "xt"), "f", "+", "verse_1_1")
                 .InsertText(", so that we can test it.", "verse_1_1")
                 .InsertPara("p");
 


### PR DESCRIPTION
- properly handle a char element as the last node in a note element

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/377)
<!-- Reviewable:end -->
