### PR TITLE
SF-406 Send users to the signup page when they use a share link

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.guard.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.guard.ts
@@ -15,7 +15,8 @@ export class AuthGuard implements CanActivate {
     return this.allowTransition().pipe(
       tap(isLoggedIn => {
         if (!isLoggedIn) {
-          this.authService.logIn(this.locationService.pathname + this.locationService.search);
+          const signUp = next.queryParams['sharing'] === 'true';
+          this.authService.logIn(this.locationService.pathname + this.locationService.search, signUp);
         }
       })
     );

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -96,9 +96,12 @@ export class AuthService {
     });
   }
 
-  logIn(returnUrl: string): void {
+  logIn(returnUrl: string, signUp?: boolean): void {
     const state: AuthState = { returnUrl };
     const options: AuthorizeOptions = { state: JSON.stringify(state) };
+    if (signUp) {
+      options.login_hint = 'signUp';
+    }
     this.auth0.authorize(options);
   }
 


### PR DESCRIPTION
After further discussion it was decided not to auto-fill the email address or figure out if the user already has an account. Instead, all share links will go to the signup page if the user isn't logged in already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/379)
<!-- Reviewable:end -->
