### PR TITLE
Fix data corruption when USX contains no paras

### DIFF
--- a/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
@@ -316,7 +316,7 @@ namespace SIL.XForge.Scripture.Services
         public XElement ToUsx(XElement oldUsxElem, IEnumerable<Delta> chapterDeltas)
         {
             var newUsxElem = new XElement(oldUsxElem);
-            newUsxElem.Elements().Where(e => e.Name.LocalName != "book").Remove();
+            newUsxElem.Nodes().Where(n => !(n is XElement) || ((XElement)n).Name.LocalName != "book").Remove();
             foreach (Delta chapterDelta in chapterDeltas)
                 ProcessDelta(newUsxElem, chapterDelta);
             return newUsxElem;

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -479,7 +479,7 @@ namespace SIL.XForge.Scripture.Services
             };
 
             var mapper = new DeltaUsxMapper();
-            XElement newUsxElem = mapper.ToUsx(Usx("PHM"), deltas);
+            XElement newUsxElem = mapper.ToUsx(Usx("PHM", Chapter("1"), "Text"), deltas);
 
             XElement expected = Usx("PHM",
                 Chapter("1"),


### PR DESCRIPTION
- remove all nodes except book elements from old USX

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/382)
<!-- Reviewable:end -->
