### PR TITLE
SF-617 Buffer new unread answers

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -149,6 +149,11 @@
 <div class="answers-container">
   <ng-container *ngIf="!answerFormVisible && answers.length > 0 && (currentUserTotalAnswers > 0 || !canAddAnswer)">
     <h3>{{ totalAnswersHeading }}</h3>
+    <div *ngIf="remoteAnswersCount > 0">
+      <button mdc-button id="show-unread-answers-button" (click)="showRemoteAnswers()">
+        show {{ remoteAnswersCount }} more unread answers
+      </button>
+    </div>
     <div class="answer" *ngFor="let answer of answers" [ngClass]="{ 'answer-unread': !hasUserReadAnswer(answer) }">
       <div *ngIf="canSeeOtherUserResponses" class="like">
         <button

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -688,6 +688,58 @@ describe('CheckingComponent', () => {
       expect(env.getAnswerScriptureText(0)).toBe('target: chapter 1, verse 3.(JHN 1:3)');
     }));
 
+    it('new answers from other users are not displayed until requested', fakeAsync(() => {
+      const env = new TestEnvironment(CHECKER_USER);
+      env.selectQuestion(7);
+      env.answerQuestion('New answer from current user');
+
+      // Answers in HTML.
+      expect(env.answers.length).toEqual(2, 'setup');
+      // Answers in code.
+      expect(env.component.answersPanel!.answers.length).toEqual(2, 'setup');
+
+      expect(env.showUnreadAnswersButton).toBeNull();
+
+      // Another user on another computer adds a new answer.
+      const date = new Date();
+      date.setDate(date.getDate() - 1);
+      const dateCreated = date.toJSON();
+      env.component.answersPanel!.questionDoc!.submitJson0Op(
+        op =>
+          op.insert(q => q.answers, 0, {
+            dataId: 'newAnswer1',
+            // Another user
+            ownerRef: CLEAN_CHECKER_USER.id,
+            text: 'new answer from another user',
+            verseRef: { chapterNum: 1, verseNum: 1, bookNum: 43 },
+            scriptureText: 'Quoted scripture',
+            likes: [],
+            dateCreated: dateCreated,
+            dateModified: dateCreated,
+            audioUrl: 'file://audio.mp3',
+            comments: []
+          }),
+        // Another user
+        false
+      );
+      tick();
+      env.fixture.detectChanges();
+
+      // The new answer does not show up yet.
+      expect(env.answers.length).toEqual(2);
+      expect(env.component.answersPanel!.answers.length).toEqual(2);
+
+      // But a show-unread-answers control appears.
+      expect(env.showUnreadAnswersButton).not.toBeNull();
+      expect(env.showUnreadAnswersButton.nativeElement.innerText).toContain(' 1 ', 'should have shown unread count');
+
+      // Clicking makes the answer appear and the control go away.
+      env.clickButton(env.showUnreadAnswersButton);
+      expect(env.answers.length).toEqual(3);
+      expect(env.component.answersPanel!.answers.length).toEqual(3);
+      expect(env.showUnreadAnswersButton).toBeNull();
+    }));
+
     describe('Comments', () => {
       it('can comment on an answer', fakeAsync(() => {
         const env = new TestEnvironment(CHECKER_USER);
@@ -1094,6 +1146,10 @@ class TestEnvironment {
 
   get selectTextTab(): DebugElement {
     return this.fixture.debugElement.query(By.css('#answer-form mdc-tab:nth-child(3)'));
+  }
+
+  get showUnreadAnswersButton(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#show-unread-answers-button'));
   }
 
   getLikeTotal(index: number): number {


### PR DESCRIPTION
* When a user views a question, record the IDs of each current answer
in a list of answers to show.
* If the user has not yet answered the question, then add any newly-
received answers to the list, so that when the user answers the
question, all answers will be displayed.
* After the user answers the question, buffer any newly-received
answers from other users, and don't display them until the user clicks
a link to reveal them.
* The show-answers link is currently at the top of the question list
but needs moved out.

----

I struggled to find just the right terminology, or to apply it in consistent ways that were helpful. This patch isn't really "buffering" answers, so much as "holding them back" or not letting them in yet. I will welcome improved terminology suggestions :)

Followup PRs will need to include: 
- Moving the show-answer link out of the list of answers.
- Buffering comments.

See attached animation with the functionality from this patch:

![show-answers2](https://user-images.githubusercontent.com/7265309/67898797-9d6ce800-fb26-11e9-8e0a-a0c6da1f5313.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/391)
<!-- Reviewable:end -->
