### PR TITLE
SF-621 Add scripture text selection dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking.module.ts
@@ -6,6 +6,7 @@ import { AngularSplitModule } from 'angular-split';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { XForgeCommonModule } from 'xforge-common/xforge-common.module';
 import { SharedModule } from '../shared/shared.module';
+import { TextChooserDialogComponent } from '../text-chooser-dialog/text-chooser-dialog.component';
 import { CheckingOverviewComponent } from './checking-overview/checking-overview.component';
 import { CheckingRoutingModule } from './checking-routing.module';
 import { CheckingAnswersComponent } from './checking/checking-answers/checking-answers.component';
@@ -42,7 +43,8 @@ import { QuestionDialogComponent } from './question-dialog/question-dialog.compo
     CheckingAudioPlayerComponent,
     AudioTimePipe,
     CheckingAudioCombinedComponent,
-    QuestionAnsweredDialogComponent
+    QuestionAnsweredDialogComponent,
+    TextChooserDialogComponent
   ],
   imports: [
     CheckingRoutingModule,
@@ -54,6 +56,6 @@ import { QuestionDialogComponent } from './question-dialog/question-dialog.compo
     ngfModule
   ],
   exports: [CheckingAudioRecorderComponent, CheckingAudioPlayerComponent],
-  entryComponents: [QuestionDialogComponent, QuestionAnsweredDialogComponent]
+  entryComponents: [QuestionDialogComponent, QuestionAnsweredDialogComponent, TextChooserDialogComponent]
 })
 export class CheckingModule {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -63,80 +63,28 @@
       ></app-checking-audio-combined>
     </div>
     <div
-      [fxShow]="answerTabs.activeTabIndex === 3 || answerTabs.activeTabIndex === 4"
+      [fxHide]="!(answerTabs.activeTabIndex === 3 || answerTabs.activeTabIndex === 4)"
       class="answer-tab answer-select-text"
+      [class.text-selected]="selectedText"
     >
-      <mdc-form-field class="scripture-start" [fxHide.lt-xl]="canShowScriptureInput">
-        <mdc-text-field
-          label="Start reference"
-          type="text"
-          formControlName="scriptureStart"
-          outlined
-          [errorStateMatcher]="startReferenceMatcher"
-          id="scripture-start"
-          (input)="updateScriptureEndEnabled()"
-          (change)="extractScriptureText()"
-        >
-          <mdc-icon mdcTextFieldIcon trailing clickable (click)="openScriptureChooser(scriptureStart)"
-            >expand_more</mdc-icon
-          >
-        </mdc-text-field>
-        <mdc-helper-text validation id="question-scripture-start-helper-text">
-          <span *ngIf="scriptureStart.hasError('verseFormat')">e.g. JHN 3:16</span>
-          <span *ngIf="scriptureStart.hasError('verseRange')">Must be a verse in the question's book and chapter</span>
-          <span *ngIf="answerForm.hasError('startReferenceRequired')">Start reference required</span>
-        </mdc-helper-text>
-      </mdc-form-field>
-      <mdc-form-field class="scripture-end" [fxHide.lt-xl]="canShowScriptureInput">
-        <mdc-text-field
-          label="End reference"
-          type="text"
-          formControlName="scriptureEnd"
-          outlined
-          [errorStateMatcher]="parentAndStartMatcher"
-          id="scripture-end"
-          (change)="extractScriptureText()"
-        >
-          <mdc-icon mdcTextFieldIcon trailing clickable (click)="openScriptureChooser(scriptureEnd)"
-            >expand_more</mdc-icon
-          >
-        </mdc-text-field>
-        <mdc-helper-text validation>
-          <span *ngIf="scriptureEnd.hasError('verseFormat')">e.g. JHN 3:16</span>
-          <span *ngIf="scriptureEnd.hasError('verseRange')">Must be inside verse range</span>
-          <span *ngIf="answerForm.hasError('verseDifferentBookOrChapter')">Must be the same book and chapter </span>
-          <span *ngIf="answerForm.hasError('verseBeforeStart')">Must be after <b>Scripture reference</b></span>
-        </mdc-helper-text>
-      </mdc-form-field>
-      <button
-        mdc-icon-button
-        fxHide.xl
-        [fxShow]="scriptureText.value"
-        [fxHide.lt-xl]="!canShowScriptureInput"
-        type="button"
-        (click)="resetScriptureText()"
-        icon="refresh"
-        class="try-again"
-      ></button>
-      <mdc-form-field [fxShow]="scriptureText.value" [fxHide.lt-xl]="!canShowScriptureInput" class="scripture-text">
-        <mdc-text-field
-          label="Scripture"
-          type="text"
-          formControlName="scriptureText"
-          outlined
-          readonly
-          (change)="checkScriptureText()"
-        ></mdc-text-field>
-      </mdc-form-field>
+      <p [fxHide]="!selectedText" [fxHide.lt-xl]="!canShowScriptureInput" class="scripture-text">
+        {{ selectedText }} <span class="answer-scripture-verse">{{ scriptureTextVerseRef(verseRef) }}</span>
+      </p>
+      <p [fxHide]="!!selectedText" class="scripture-text-blank">No scripture selected yet.</p>
+      <div class="buttons-wrapper">
+        <button
+          mdc-icon-button
+          *ngIf="selectedText"
+          type="button"
+          (click)="clearSelection()"
+          icon="clear"
+          class="clear-selection"
+        ></button>
+        <button type="button" (click)="selectScripture()" mdc-button primary>Select verses</button>
+      </div>
     </div>
     <div *ngIf="answerFormSubmitAttempted && answerText.invalid" class="form-helper-text">
       You need to enter your answer or record your answer before saving
-    </div>
-    <div
-      *ngIf="answerFormSubmitAttempted && hasScriptureReferenceError && answerTabs.activeTabIndex !== 2"
-      class="form-helper-text"
-    >
-      Please enter a valid scripture reference in the select text tab
     </div>
     <div class="form-actions">
       <button mdc-button type="button" (click)="hideAnswerForm()" id="cancel-answer">Cancel</button>
@@ -169,7 +117,7 @@
         <div *ngIf="answer.text" class="answer-text">{{ answer.text }}</div>
         <div *ngIf="answer.scriptureText" class="answer-scripture">
           <span class="answer-scripture-text">{{ answer.scriptureText }}</span>
-          <span class="answer-scripture-verse">{{ scriptureTextVerseRef(answer) }}</span>
+          <span class="answer-scripture-verse">{{ scriptureTextVerseRef(answer.verseRef) }}</span>
         </div>
         <app-checking-audio-player *ngIf="answer.audioUrl" [source]="answer.audioUrl"></app-checking-audio-player>
         <div class="answer-footer">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
@@ -43,7 +43,6 @@
 }
 #answer-form {
   .answer-tab {
-    min-height: 100px;
     padding: 10px 0;
     display: flex;
     align-items: center;
@@ -53,23 +52,14 @@
       }
     }
     &.answer-select-text {
+      color: var(--mdc-theme-primary);
       align-items: flex-start;
-      .scripture-start {
-        margin-right: 15px;
+      .buttons-wrapper {
+        display: flex;
+        align-items: center;
       }
-      @include media-breakpoint-up(lg) {
-        .scripture-start,
-        .scripture-end {
-          max-width: 175px;
-        }
-      }
-      mdc-text-field {
-        mdc-icon {
-          background: #fff;
-        }
-      }
-      .scripture-text {
-        margin-left: 15px;
+      .scripture-text-blank {
+        font-style: italic;
       }
     }
   }
@@ -102,6 +92,24 @@
     }
   }
 }
+
+.answer-select-text {
+  display: flex;
+  justify-content: space-between;
+  flex-direction: row;
+  &.text-selected {
+    flex-direction: column;
+  }
+  .buttons-wrapper {
+    align-self: flex-end;
+    flex-shrink: 0;
+  }
+  .scripture-text-blank,
+  .scripture-text {
+    margin: 0;
+  }
+}
+
 .answers-container {
   .answer {
     display: flex;
@@ -164,12 +172,6 @@
         & + app-checking-audio-player {
           margin-top: 10px;
         }
-        .answer-scripture-verse {
-          font-size: 0.8em;
-          padding-left: 5px;
-          display: inline-block;
-          font-style: italic;
-        }
       }
 
       app-checking-audio-player {
@@ -187,4 +189,11 @@
       }
     }
   }
+}
+
+.answer-scripture-verse {
+  font-size: 0.8em;
+  padding-left: 5px;
+  display: inline-block;
+  font-style: italic;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -10,17 +10,17 @@ import { SFProjectRole } from 'realtime-server/lib/scriptureforge/models/sf-proj
 import { fromVerseRef, toVerseRef, VerseRefData } from 'realtime-server/lib/scriptureforge/models/verse-ref-data';
 import { Canon } from 'realtime-server/lib/scriptureforge/scripture-utils/canon';
 import { VerseRef } from 'realtime-server/lib/scriptureforge/scripture-utils/verse-ref';
-import {
-  TextChooserDialogComponent,
-  TextChooserDialogData,
-  TextSelection
-} from 'src/app/text-chooser-dialog/text-chooser-dialog.component';
 import { NoticeService } from 'xforge-common/notice.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { UserService } from 'xforge-common/user.service';
 import { QuestionDoc } from '../../../core/models/question-doc';
 import { SFProjectUserConfigDoc } from '../../../core/models/sf-project-user-config-doc';
 import { TextsByBookId } from '../../../core/models/texts-by-book-id';
+import {
+  TextChooserDialogComponent,
+  TextChooserDialogData,
+  TextSelection
+} from '../../../text-chooser-dialog/text-chooser-dialog.component';
 import { QuestionAnsweredDialogComponent } from '../../question-answered-dialog/question-answered-dialog.component';
 import { QuestionDialogData } from '../../question-dialog/question-dialog.component';
 import { QuestionDialogService } from '../../question-dialog/question-dialog.service';
@@ -214,7 +214,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
   }
 
   ngOnInit(): void {
-    this.updateValidationRules();
+    this.applyTextAudioValidators();
   }
 
   clearSelection() {
@@ -346,7 +346,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
 
   processAudio(audio: AudioAttachment) {
     this.audio = audio;
-    this.updateValidationRules();
+    this.applyTextAudioValidators();
   }
 
   scriptureTextVerseRef(verse: VerseRef | VerseRefData): string {
@@ -373,7 +373,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
       await this.audioCombinedComponent.audioRecorderComponent.stopRecording();
       this.noticeService.show('The recording for your answer was automatically stopped.');
     }
-    this.updateValidationRules();
+    this.applyTextAudioValidators();
     this.answerFormSubmitAttempted = true;
     if (this.answerForm.invalid) {
       return;
@@ -436,7 +436,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     });
   }
 
-  private updateValidationRules(): void {
+  private applyTextAudioValidators(): void {
     if (this.audio.url) {
       this.answerText.clearValidators();
     } else {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -1,4 +1,4 @@
-import { MdcDialog, MdcDialogConfig, MdcDialogRef } from '@angular-mdc/web/dialog';
+import { MdcDialog } from '@angular-mdc/web/dialog';
 import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { AbstractControl, FormControl, FormGroup, Validators } from '@angular/forms';
 import cloneDeep from 'lodash/cloneDeep';
@@ -7,30 +7,20 @@ import { Answer } from 'realtime-server/lib/scriptureforge/models/answer';
 import { SFProject } from 'realtime-server/lib/scriptureforge/models/sf-project';
 import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/scriptureforge/models/sf-project-rights';
 import { SFProjectRole } from 'realtime-server/lib/scriptureforge/models/sf-project-role';
-import {
-  fromVerseRef,
-  toStartAndEndVerseRefs,
-  toVerseRef,
-  VerseRefData
-} from 'realtime-server/lib/scriptureforge/models/verse-ref-data';
+import { fromVerseRef, toVerseRef, VerseRefData } from 'realtime-server/lib/scriptureforge/models/verse-ref-data';
 import { Canon } from 'realtime-server/lib/scriptureforge/scripture-utils/canon';
 import { VerseRef } from 'realtime-server/lib/scriptureforge/scripture-utils/verse-ref';
+import {
+  TextChooserDialogComponent,
+  TextChooserDialogData,
+  TextSelection
+} from 'src/app/text-chooser-dialog/text-chooser-dialog.component';
 import { NoticeService } from 'xforge-common/notice.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { UserService } from 'xforge-common/user.service';
 import { QuestionDoc } from '../../../core/models/question-doc';
 import { SFProjectUserConfigDoc } from '../../../core/models/sf-project-user-config-doc';
 import { TextsByBookId } from '../../../core/models/texts-by-book-id';
-import {
-  ScriptureChooserDialogComponent,
-  ScriptureChooserDialogData
-} from '../../../scripture-chooser-dialog/scripture-chooser-dialog.component';
-import {
-  ParentAndStartErrorStateMatcher,
-  SFValidators,
-  StartReferenceRequiredErrorStateMatcher
-} from '../../../shared/sfvalidators';
-import { combineVerseRefStrs } from '../../../shared/utils';
 import { QuestionAnsweredDialogComponent } from '../../question-answered-dialog/question-answered-dialog.component';
 import { QuestionDialogData } from '../../question-dialog/question-dialog.component';
 import { QuestionDialogService } from '../../question-dialog/question-dialog.service';
@@ -70,6 +60,7 @@ enum LikeAnswerResponse {
 export class CheckingAnswersComponent extends SubscriptionDisposable implements OnInit {
   @ViewChild(CheckingAudioCombinedComponent, { static: false }) audioCombinedComponent?: CheckingAudioCombinedComponent;
   @Input() project?: SFProject;
+  @Input() projectId?: string;
   @Input() projectUserConfigDoc?: SFProjectUserConfigDoc;
   @Input() textsByBookId?: TextsByBookId;
   @Input() set questionDoc(questionDoc: QuestionDoc | undefined) {
@@ -80,8 +71,6 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     if (this.projectUserConfigDoc != null && this.projectUserConfigDoc.data != null) {
       this.userAnswerRefsRead = cloneDeep(this.projectUserConfigDoc.data.answerRefsRead);
     }
-    // Validation is dependent on the chapter of the current question.
-    this.updateValidationRules();
 
     this.showRemoteAnswers();
     if (questionDoc == null) {
@@ -102,21 +91,16 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
   @Output() commentAction: EventEmitter<CommentAction> = new EventEmitter<CommentAction>();
 
   activeAnswer?: Answer;
-  answerForm = new FormGroup(
-    {
-      answerText: new FormControl(),
-      scriptureStart: new FormControl(),
-      scriptureEnd: new FormControl(),
-      scriptureText: new FormControl()
-    },
-    [SFValidators.verseStartBeforeEnd, SFValidators.requireIfEndReferenceProvided]
-  );
+  answerForm = new FormGroup({
+    answerText: new FormControl(),
+    scriptureText: new FormControl()
+  });
   answerFormVisible: boolean = false;
   answerFormSubmitAttempted: boolean = false;
-  parentAndStartMatcher = new ParentAndStartErrorStateMatcher();
-  startReferenceMatcher = new StartReferenceRequiredErrorStateMatcher();
   /** IDs of answers to show to user (so, excluding unshown incoming answers). */
   answersToShow: string[] = [];
+  selectedText?: string;
+  verseRef?: VerseRef;
 
   private _questionDoc?: QuestionDoc;
   private userAnswerRefsRead: string[] = [];
@@ -166,12 +150,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
   }
 
   get canShowScriptureInput(): boolean {
-    return !!(
-      this.scriptureStart.valid &&
-      this.scriptureEnd.valid &&
-      this.scriptureEnd.value &&
-      this.scriptureText.value
-    );
+    return !!this.selectedText;
   }
 
   get currentUserTotalAnswers(): number {
@@ -205,27 +184,6 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     return this._questionDoc;
   }
 
-  get scriptureStart(): AbstractControl {
-    return this.answerForm.controls.scriptureStart;
-  }
-
-  get scriptureEnd(): AbstractControl {
-    return this.answerForm.controls.scriptureEnd;
-  }
-  get scriptureText(): AbstractControl {
-    return this.answerForm.controls.scriptureText;
-  }
-
-  get hasScriptureReferenceError(): boolean {
-    return (
-      this.scriptureStart.invalid ||
-      this.scriptureEnd.invalid ||
-      this.answerForm.hasError('verseBeforeStart') ||
-      this.answerForm.hasError('verseDifferentBookOrChapter') ||
-      this.answerForm.hasError('startReferenceRequired')
-    );
-  }
-
   get totalAnswersHeading(): string {
     if (this.canSeeOtherUserResponses || !this.canAddAnswer) {
       return this.answers.length + ' Answers';
@@ -257,21 +215,11 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
 
   ngOnInit(): void {
     this.updateValidationRules();
-    this.subscribe(this.scriptureStart.valueChanges, () => {
-      if (this.scriptureStart.valid) {
-        this.extractScriptureText();
-      } else {
-        this.scriptureText.reset();
-      }
-      // update enabled/disabled state for scriptureEnd
-      this.updateScriptureEndEnabled();
-    });
-    this.subscribe(this.scriptureEnd.valueChanges, () => {
-      if (this.scriptureEnd.valid) {
-        this.extractScriptureText();
-      }
-    });
-    this.updateScriptureEndEnabled();
+  }
+
+  clearSelection() {
+    this.selectedText = '';
+    this.verseRef = undefined;
   }
 
   archiveQuestion(): void {
@@ -279,12 +227,6 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
       op.set<boolean>(qd => qd.isArchived, true);
       op.set(qd => qd.dateArchived!, new Date().toJSON());
     });
-  }
-
-  checkScriptureText(): void {
-    if (!this.scriptureText.value) {
-      this.resetScriptureText();
-    }
   }
 
   deleteAnswer(answer: Answer) {
@@ -303,13 +245,9 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     this.activeAnswer = cloneDeep(answer);
     this.audio.url = this.activeAnswer.audioUrl;
     if (this.activeAnswer.verseRef != null) {
-      const { startVerseRef, endVerseRef } = toStartAndEndVerseRefs(this.activeAnswer.verseRef);
-      this.scriptureStart.setValue(startVerseRef.toString());
-      if (endVerseRef != null) {
-        this.scriptureEnd.setValue(endVerseRef.toString());
-      }
+      this.verseRef = toVerseRef(this.activeAnswer.verseRef);
     }
-    this.scriptureText.setValue(this.activeAnswer.scriptureText);
+    this.selectedText = this.activeAnswer.scriptureText;
     this.showAnswerForm();
   }
 
@@ -334,24 +272,24 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     await this.questionDialogService.questionDialog(data, this._questionDoc);
   }
 
-  extractScriptureText() {
-    if (this.checkingTextComponent == null) {
-      return;
-    }
-    const verseRef = this.getVerseRef();
-    const verses = [];
-    if (verseRef != null) {
-      for (const verseInRange of verseRef.allVerses()) {
-        verses.push(
-          this.checkingTextComponent.textComponent.getSegmentText(`verse_${verseInRange.chapter}_${verseInRange.verse}`)
-        );
+  selectScripture() {
+    const verseRef = this._questionDoc!.data!.verseRef;
+    const dialogData: TextChooserDialogData = {
+      bookNum: (this.verseRef && this.verseRef.bookNum) || verseRef.bookNum,
+      chapterNum: (this.verseRef && this.verseRef.chapterNum) || verseRef.chapterNum,
+      textsByBookId: this.textsByBookId!,
+      projectId: this.projectId!,
+      selectedText: this.selectedText || '',
+      selectedVerses: this.verseRef
+    };
+    const dialogRef = this.dialog.open(TextChooserDialogComponent, { data: dialogData });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result != null && result !== 'close') {
+        const selection = result as TextSelection;
+        this.verseRef = toVerseRef(selection.verses);
+        this.selectedText = selection.text;
       }
-    }
-    this.scriptureText.setValue(verses.length ? verses.join(' ') : null);
-  }
-
-  updateScriptureEndEnabled() {
-    this.scriptureStart.value && this.scriptureStart.valid ? this.scriptureEnd.enable() : this.scriptureEnd.disable();
+    });
   }
 
   canEditAnswer(answer: Answer): boolean {
@@ -380,6 +318,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     this.answerFormVisible = false;
     this.answerFormSubmitAttempted = false;
     this.activeAnswer = undefined;
+    this.clearSelection();
     this.audio = {};
     this.answerForm.reset();
     this.action.emit({
@@ -405,56 +344,16 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     return answer.likes.some(like => like.ownerRef === this.userService.currentUserId);
   }
 
-  openScriptureChooser(control: AbstractControl) {
-    let currentVerseSelection: VerseRef | undefined;
-    if (control.value != null) {
-      const { verseRef } = VerseRef.tryParse(control.value);
-      if (verseRef.valid) {
-        currentVerseSelection = verseRef;
-      }
-    }
-
-    let rangeStart: VerseRef | undefined;
-    if (control !== this.scriptureStart && this.scriptureStart.value != null) {
-      const { verseRef } = VerseRef.tryParse(this.scriptureStart.value);
-      if (verseRef.valid) {
-        rangeStart = verseRef;
-      }
-    }
-
-    const dialogConfig: MdcDialogConfig<ScriptureChooserDialogData> = {
-      data: { input: currentVerseSelection, booksAndChaptersToShow: this.currentBookAndChapter, rangeStart }
-    };
-
-    const dialogRef = this.dialog.open(ScriptureChooserDialogComponent, dialogConfig) as MdcDialogRef<
-      ScriptureChooserDialogComponent,
-      VerseRef | 'close'
-    >;
-    dialogRef.afterClosed().subscribe(result => {
-      if (result != null && result !== 'close') {
-        control.setValue(result.toString());
-        control.markAsTouched();
-        control.markAsDirty();
-      }
-    });
-  }
-
   processAudio(audio: AudioAttachment) {
     this.audio = audio;
     this.updateValidationRules();
   }
 
-  resetScriptureText() {
-    this.scriptureText.reset();
-    this.scriptureStart.reset();
-    this.scriptureEnd.reset();
-  }
-
-  scriptureTextVerseRef(answer: Answer): string {
-    if (answer.verseRef == null) {
+  scriptureTextVerseRef(verse: VerseRef | VerseRefData): string {
+    if (verse == null) {
       return '';
     }
-    const verseRef = toVerseRef(answer.verseRef);
+    const verseRef = verse instanceof VerseRef ? verse : toVerseRef(verse);
     return `(${verseRef.toString()})`;
   }
 
@@ -527,32 +426,22 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
   }
 
   private emitAnswerToSave() {
-    const verseRef = this.getVerseRef();
     this.action.emit({
       action: 'save',
       text: this.answerText.value,
       answer: this.activeAnswer,
       audio: this.audio,
-      scriptureText: this.scriptureText.value != null ? this.scriptureText.value : undefined,
-      verseRef: verseRef == null ? undefined : fromVerseRef(verseRef)
+      scriptureText: this.selectedText || undefined,
+      verseRef: this.verseRef == null ? undefined : fromVerseRef(this.verseRef)
     });
   }
 
   private updateValidationRules(): void {
-    this.scriptureStart.setValidators([SFValidators.verseStr(this.currentBookAndChapter)]);
-    this.scriptureStart.updateValueAndValidity();
-    this.scriptureEnd.setValidators([SFValidators.verseStr(this.currentBookAndChapter)]);
-    this.scriptureEnd.updateValueAndValidity();
-
     if (this.audio.url) {
       this.answerText.clearValidators();
     } else {
       this.answerText.setValidators(Validators.required);
     }
     this.answerText.updateValueAndValidity();
-  }
-
-  private getVerseRef(): VerseRef | undefined {
-    return combineVerseRefStrs(this.scriptureStart.value, this.scriptureEnd.value);
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -107,6 +107,7 @@
                     [checkingTextComponent]="textPanel"
                     [project]="projectDoc?.data"
                     [textsByBookId]="textsByBookId"
+                    [projectId]="projectDoc?.id"
                     [questionDoc]="questionsPanel.activeQuestionDoc"
                     [projectUserConfigDoc]="projectUserConfigDoc"
                     (action)="answerAction($event)"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -22,7 +22,6 @@ import { getTextDocId, TextData } from 'realtime-server/lib/scriptureforge/model
 import { Canon } from 'realtime-server/lib/scriptureforge/scripture-utils/canon';
 import * as RichText from 'rich-text';
 import { of } from 'rxjs';
-import { TextChooserDialogComponent, TextSelection } from 'src/app/text-chooser-dialog/text-chooser-dialog.component';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import { AvatarTestingModule } from 'xforge-common/avatar/avatar-testing.module';
 import { Snapshot } from 'xforge-common/models/snapshot';
@@ -42,6 +41,7 @@ import { SF_REALTIME_DOC_TYPES } from '../../core/models/sf-realtime-doc-types';
 import { Delta, TextDoc } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { SharedModule } from '../../shared/shared.module';
+import { TextChooserDialogComponent, TextSelection } from '../../text-chooser-dialog/text-chooser-dialog.component';
 import { QuestionAnsweredDialogComponent } from '../question-answered-dialog/question-answered-dialog.component';
 import { QuestionDialogService } from '../question-dialog/question-dialog.service';
 import { CheckingAnswersComponent } from './checking-answers/checking-answers.component';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1,6 +1,4 @@
 import { MdcDialog, MdcDialogRef } from '@angular-mdc/web/dialog';
-import { MdcListItem } from '@angular-mdc/web/list';
-import { MdcMenuSelectedEvent } from '@angular-mdc/web/menu';
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -24,6 +22,7 @@ import { getTextDocId, TextData } from 'realtime-server/lib/scriptureforge/model
 import { Canon } from 'realtime-server/lib/scriptureforge/scripture-utils/canon';
 import * as RichText from 'rich-text';
 import { of } from 'rxjs';
+import { TextChooserDialogComponent, TextSelection } from 'src/app/text-chooser-dialog/text-chooser-dialog.component';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import { AvatarTestingModule } from 'xforge-common/avatar/avatar-testing.module';
 import { Snapshot } from 'xforge-common/models/snapshot';
@@ -62,6 +61,7 @@ const mockedProjectService = mock(SFProjectService);
 const mockedNoticeService = mock(NoticeService);
 const mockedActivatedRoute = mock(ActivatedRoute);
 const mockedMdcDialog = mock(MdcDialog);
+const mockedTextChooserDialogComponent = mock(TextChooserDialogComponent);
 const mockedQuestionDialogService = mock(QuestionDialogService);
 
 function createUser(id: string, role: string, nameConfirmed: boolean = true): UserInfo {
@@ -118,6 +118,7 @@ describe('CheckingComponent', () => {
       { provide: SFProjectService, useMock: mockedProjectService },
       { provide: NoticeService, useMock: mockedNoticeService },
       { provide: MdcDialog, useMock: mockedMdcDialog },
+      { provide: TextChooserDialogComponent, useMock: mockedTextChooserDialogComponent },
       { provide: QuestionDialogService, useMock: mockedQuestionDialogService }
     ]
   }));
@@ -498,83 +499,23 @@ describe('CheckingComponent', () => {
 
     it('can add scripture to an answer', fakeAsync(() => {
       const env = new TestEnvironment(CHECKER_USER);
+      const selection: TextSelection = {
+        verses: { bookNum: 43, chapterNum: 2, verseNum: 2, verse: '2-5' },
+        text: 'The selected text',
+        startClipped: true,
+        endClipped: false
+      };
+      when(env.mockedTextChooserDialogComponent.afterClosed()).thenReturn(of(selection));
       env.selectQuestion(1);
       env.clickButton(env.addAnswerButton);
       env.setTextFieldValue(env.yourAnswerField, 'Answer question');
       env.clickButton(env.selectTextTab);
-      expect(env.scriptureText).toBe(null);
+      expect(env.scriptureText).toBeFalsy();
       // Add scripture
-      env.setTextFieldValue(env.scriptureStartField, 'JHN 1:3');
-      expect(env.scriptureText).toBe('target: chapter 1, verse 3.');
-      env.setTextFieldValue(env.scriptureEndField, 'JHN 1:4');
-      expect(env.scriptureText).toBe('target: chapter 1, verse 3. target: chapter 1, verse 4.');
+      env.clickButton(env.selectVersesButton);
+      expect(env.scriptureText).toBe('The selected text (JHN 2:2-5)');
       env.clickButton(env.saveAnswerButton);
-      env.waitForSliderUpdate();
-      expect(env.getAnswerScriptureText(0)).toBe('target: chapter 1, verse 3. target: chapter 1, verse 4.(JHN 1:3-4)');
-    }));
-
-    it('starts with end reference disabled', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
-      env.selectQuestion(1);
-      env.clickButton(env.addAnswerButton);
-      env.clickButton(env.selectTextTab);
-      expect(env.scriptureText).toBeNull();
-      expect(env.component.answersPanel!.scriptureStart.disabled).toBe(false);
-      expect(env.component.answersPanel!.scriptureEnd.disabled).toBe(true);
-      env.setTextFieldValue(env.scriptureStartField, 'JHN 1:1');
-      expect(env.component.answersPanel!.scriptureEnd.enabled).toBe(true);
-    }));
-
-    it('out-of-chapter reference is invalid', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
-      env.selectQuestion(1);
-      env.clickButton(env.addAnswerButton);
-      env.setTextFieldValue(env.yourAnswerField, 'Answer question');
-      env.clickButton(env.selectTextTab);
-      expect(env.scriptureText).toBeNull();
-      // Specify reference that is not for chapter of question.
-      env.setTextFieldValue(env.scriptureStartField, 'JHN 2:3');
-      expect(env.scriptureText).toEqual('');
-      expect(env.component.answersPanel!.scriptureStart.valid).toBe(false);
-
-      // Typing correct values should clear error and fetch Scripture
-      env.setTextFieldValue(env.scriptureStartField, 'JHN 1:3');
-      expect(env.scriptureText).toEqual('target: chapter 1, verse 3.');
-      env.setTextFieldValue(env.scriptureEndField, 'JHN 1:4');
-      expect(env.scriptureText).toEqual('target: chapter 1, verse 3. target: chapter 1, verse 4.');
-      expect(env.component.answersPanel!.scriptureStart.valid).toBe(true);
-
-      env.clickButton(env.saveAnswerButton);
-      env.waitForSliderUpdate();
-      expect(env.getAnswerScriptureText(0)).toBe('target: chapter 1, verse 3. target: chapter 1, verse 4.(JHN 1:3-4)');
-    }));
-
-    it('out-of-chapter detection is based on question chapter, not viewed chapter', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
-
-      // Answer a question in chapter 2.
-      const questionNumberInWebpageList =
-        env.questions.findIndex(questionElement =>
-          env.getQuestionText(questionElement).includes('Question relating to chapter 2')
-        ) + 1;
-      env.selectQuestion(questionNumberInWebpageList);
-      env.clickButton(env.addAnswerButton);
-      env.setTextFieldValue(env.yourAnswerField, 'Answer question');
-
-      // Set checking area's Scripture view to another chapter than what the question is referencing
-      env.selectChapterFromMenu(1);
-
-      env.clickButton(env.selectTextTab);
-
-      // Enter a Scripture reference that is in the chapter that the question refers to,
-      // but not in the chapter of the Scripture view that the user is seeing on the checking component.
-      env.setTextFieldValue(env.scriptureStartField, 'JHN 2:3');
-      env.setTextFieldValue(env.scriptureEndField, 'JHN 2:4');
-      expect(env.component.answersPanel!.scriptureStart.valid).toBe(true);
-      expect(env.component.answersPanel!.scriptureEnd.valid).toBe(true);
-
-      env.clickButton(env.saveAnswerButton);
-      env.waitForSliderUpdate();
+      expect(env.getAnswerScriptureText(0)).toBe('The selected text(JHN 2:2-5)');
     }));
 
     it('can remove scripture from an answer', fakeAsync(() => {
@@ -583,9 +524,9 @@ describe('CheckingComponent', () => {
       expect(env.getAnswerScriptureText(0)).toBe('Quoted scripture(JHN 1:1)');
       env.clickButton(env.getAnswerEditButton(0));
       env.clickButton(env.selectTextTab);
-      env.setTextFieldValue(env.scriptureTextField, '');
-      env.clickButton(env.saveAnswerButton);
       env.waitForSliderUpdate();
+      env.clickButton(env.clearScriptureButton);
+      env.clickButton(env.saveAnswerButton);
       expect(env.getAnswerScripture(0)).toBeFalsy();
     }));
 
@@ -602,39 +543,6 @@ describe('CheckingComponent', () => {
       expect(env.getAnswerEditButton(0)).toBeNull();
       env.selectQuestion(7);
       expect(env.getAnswerEditButton(0)).not.toBeNull();
-    }));
-
-    it('shows error messages when answer form is invalid', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
-      env.selectQuestion(1);
-      env.clickButton(env.addAnswerButton);
-      env.setTextFieldValue(env.yourAnswerField, 'Answer the question');
-      env.clickButton(env.selectTextTab);
-      env.setTextFieldValue(env.scriptureStartField, 'BAD VERSE');
-      env.clickButton(env.answerTextTab);
-      env.clickButton(env.saveAnswerButton);
-      tick(100);
-      expect(env.component.answersPanel!.answerForm.invalid).toBe(true);
-      expect(env.answerFormErrors.length).toEqual(1);
-      expect(env.answerFormErrors[0].nativeElement.textContent).toContain('Please enter a valid scripture reference');
-      env.clickButton(env.selectTextTab);
-      env.setTextFieldValue(env.scriptureStartField, 'JHN 1:2');
-      env.component.answersPanel!.scriptureStart.markAsTouched();
-      env.setTextFieldValue(env.scriptureEndField, 'JHN 1:');
-      expect(env.scriptureEndField.classes['mdc-text-field--invalid']).toBe(false);
-      env.setTextFieldValue(env.scriptureEndField, 'JHN 1:1');
-      // If start reference is set and touched, and the end reference is valid but incompatible, it should show invalid
-      expect(env.scriptureEndField.classes['mdc-text-field--invalid']).toBe(true);
-      env.clickButton(env.answerTextTab);
-      expect(env.answerFormErrors.length).toEqual(1);
-      expect(env.component.answersPanel!.answerForm.hasError('verseBeforeStart'));
-      expect(env.answerFormErrors[0].nativeElement.textContent).toContain('Please enter a valid scripture reference');
-      env.clickButton(env.selectTextTab);
-      env.setTextFieldValue(env.scriptureEndField, 'BAD FORMAT');
-      env.clickButton(env.answerTextTab);
-      expect(env.answerFormErrors.length).toEqual(1);
-      expect(env.component.answersPanel!.scriptureEnd.hasError('verseFormat'));
-      expect(env.answerFormErrors[0].nativeElement.textContent).toContain('Please enter a valid scripture reference');
     }));
 
     it('error about "answer or recording required" goes away after add recording', fakeAsync(() => {
@@ -654,40 +562,6 @@ describe('CheckingComponent', () => {
 
       // We made a recording, so we should not be showing a validation error.
       expect(env.component.answersPanel!.answerForm.valid).toBe(true);
-    }));
-
-    it('generate correct verse ref when start and end mismatch only by case', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
-      env.selectQuestion(1);
-      env.clickButton(env.addAnswerButton);
-      env.setTextFieldValue(env.yourAnswerField, 'Answer question');
-      env.clickButton(env.selectTextTab);
-      expect(env.scriptureText).toBe(null);
-      // Add scripture
-      env.setTextFieldValue(env.scriptureStartField, 'JHN 1:3');
-      expect(env.scriptureText).toBe('target: chapter 1, verse 3.');
-      env.setTextFieldValue(env.scriptureEndField, 'jhn 1:3');
-      expect(env.scriptureText).toBe('target: chapter 1, verse 3.');
-      env.clickButton(env.saveAnswerButton);
-      env.waitForSliderUpdate();
-      expect(env.getAnswerScriptureText(0)).toBe('target: chapter 1, verse 3.(JHN 1:3)');
-    }));
-
-    it('generate correct verse ref when start and end mismatch only by insignificant zero', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
-      env.selectQuestion(1);
-      env.clickButton(env.addAnswerButton);
-      env.setTextFieldValue(env.yourAnswerField, 'Answer question');
-      env.clickButton(env.selectTextTab);
-      expect(env.scriptureText).toBe(null);
-      // Add scripture
-      env.setTextFieldValue(env.scriptureStartField, 'JHN 1:3');
-      expect(env.scriptureText).toBe('target: chapter 1, verse 3.');
-      env.setTextFieldValue(env.scriptureEndField, 'JHN 1:03');
-      expect(env.scriptureText).toBe('target: chapter 1, verse 3.');
-      env.clickButton(env.saveAnswerButton);
-      env.waitForSliderUpdate();
-      expect(env.getAnswerScriptureText(0)).toBe('target: chapter 1, verse 3.(JHN 1:3)');
     }));
 
     it('new answers from other users are not displayed until requested', fakeAsync(() => {
@@ -915,6 +789,7 @@ class TestEnvironment {
   public project01WritingSystemTag = 'en';
 
   readonly mockedAnsweredDialogRef: MdcDialogRef<QuestionAnsweredDialogComponent> = mock(MdcDialogRef);
+  readonly mockedTextChooserDialogComponent: MdcDialogRef<TextChooserDialogComponent> = mock(MdcDialogRef);
   private readonly adminProjectUserConfig: SFProjectUserConfig = {
     ownerRef: ADMIN_USER.id,
     projectRef: 'project01',
@@ -1111,7 +986,7 @@ class TestEnvironment {
   }
 
   get audioTab(): DebugElement {
-    return this.fixture.debugElement.query(By.css('#answer-form mdc-tab:nth-child(2)'));
+    return this.fixture.debugElement.query(By.css('#answer-form mdc-tab[label="Record/Upload"]'));
   }
 
   get removeAudioButton(): DebugElement {
@@ -1126,32 +1001,25 @@ class TestEnvironment {
     return this.fixture.debugElement.query(By.css('mdc-text-field[formControlName="answerText"]'));
   }
 
-  get answerTextTab(): DebugElement {
-    return this.fixture.debugElement.query(By.css('#answer-form mdc-tab:nth-child(1)'));
-  }
-
   get answerFormErrors(): DebugElement[] {
     return this.fixture.debugElement.queryAll(By.css('#answer-form .form-helper-text'));
   }
 
-  get scriptureStartField(): DebugElement {
-    return this.fixture.debugElement.query(By.css('mdc-text-field[formControlName="scriptureStart"]'));
-  }
-
-  get scriptureEndField(): DebugElement {
-    return this.fixture.debugElement.query(By.css('mdc-text-field[formControlName="scriptureEnd"]'));
-  }
-
-  get scriptureTextField(): DebugElement {
-    return this.fixture.debugElement.query(By.css('mdc-text-field[formControlName="scriptureText"]'));
-  }
-
   get scriptureText(): string | null {
-    return this.component.answersPanel!.scriptureText.value;
+    const scriptureText = document.querySelector('.scripture-text');
+    return scriptureText == null ? null : scriptureText.textContent!.trim();
+  }
+
+  get clearScriptureButton(): DebugElement {
+    return this.fixture.debugElement.query(By.css('.clear-selection'));
   }
 
   get selectTextTab(): DebugElement {
-    return this.fixture.debugElement.query(By.css('#answer-form mdc-tab:nth-child(3)'));
+    return this.fixture.debugElement.query(By.css('#answer-form mdc-tab[label="Select Text"]'));
+  }
+
+  get selectVersesButton(): DebugElement {
+    return this.fixture.debugElement.query(By.css('.answer-select-text button[primary]'));
   }
 
   get showUnreadAnswersButton(): DebugElement {
@@ -1299,11 +1167,6 @@ class TestEnvironment {
       data: newQuestion
     });
     this.realtimeService.updateAllSubscribeQueries();
-  }
-
-  selectChapterFromMenu(chapter: number) {
-    const eventData: MdcMenuSelectedEvent = { index: 0, source: { value: chapter } as MdcListItem };
-    this.component.onChapterSelect(eventData);
   }
 
   /** To use if the Stop Recording button isn't showing up in the test DOM. */
@@ -1524,6 +1387,9 @@ class TestEnvironment {
     );
 
     when(mockedMdcDialog.open(QuestionAnsweredDialogComponent)).thenReturn(instance(this.mockedAnsweredDialogRef));
+    when(mockedMdcDialog.open(TextChooserDialogComponent, anything())).thenReturn(
+      instance(this.mockedTextChooserDialogComponent)
+    );
   }
 
   private createTextDataForChapter(chapter: number): TextData {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -50,7 +50,7 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
   @Input() isReadOnly: boolean = true;
   @Input() placeholder = 'Loading...';
   @Input() markInvalid: boolean = false;
-  @Input() mode: 'normal' | 'dialog' = 'normal';
+  @Input() multiSegmentSelection = false;
   @Output() updated = new EventEmitter<TextUpdatedEvent>(true);
   @Output() segmentRefChange = new EventEmitter<string>();
   @Output() loaded = new EventEmitter(true);
@@ -549,23 +549,20 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
     if (sel == null) {
       return;
     }
-    let newSel: RangeStatic;
+    let newSel: RangeStatic | undefined;
     if (this._segment.text === '') {
       // always select at the beginning if blank
       newSel = { index: this._segment.range.index, length: 0 };
-      if (sel.index !== newSel.index || sel.length !== newSel.length) {
-        this._editor.setSelection(newSel, 'user');
-      }
-    } else if (this.mode === 'normal') {
+    } else if (!this.multiSegmentSelection) {
       // selections outside of the text chooser dialog are not permitted to extend across segments
       const newStart = Math.max(sel.index, this._segment.range.index);
       const oldEnd = sel.index + sel.length;
       const segEnd = this._segment.range.index + this._segment.range.length;
       const newEnd = Math.min(oldEnd, segEnd);
       newSel = { index: newStart, length: Math.max(0, newEnd - newStart) };
-      if (sel.index !== newSel.index || sel.length !== newSel.length) {
-        this._editor.setSelection(newSel, 'user');
-      }
+    }
+    if (newSel != null && (sel.index !== newSel.index || sel.length !== newSel.length)) {
+      this._editor.setSelection(newSel, 'user');
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -470,7 +470,9 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
       this.setHighlightMarkerPosition();
     }
 
-    Promise.resolve().then(() => this.adjustSelection());
+    if (!this.isReadOnly) {
+      Promise.resolve().then(() => this.adjustSelection());
+    }
     this.updated.emit({ delta, prevSegment, segment: this._segment });
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.html
@@ -8,7 +8,7 @@
           <h2>{{ bookName }} {{ chapterNum }}</h2>
           <mdc-icon>keyboard_arrow_down</mdc-icon>
         </div>
-        <app-text #scriptureText [id]="textDocId" mode="dialog"></app-text>
+        <app-text #scriptureText [id]="textDocId" multiSegmentSelection="true"></app-text>
         <p class="selection-preview">
           {{ selectedText }} <span class="selection-reference">{{ referenceForDisplay }}</span>
         </p>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.html
@@ -1,0 +1,23 @@
+<mdc-dialog>
+  <mdc-dialog-container>
+    <mdc-dialog-surface>
+      <mdc-dialog-title>Select scripture to attach to your answer</mdc-dialog-title>
+      <mdc-dialog-content>
+        <div class="select-chapter" (click)="openScriptureChooser()">
+          <mdc-icon>library_books</mdc-icon>
+          <h2>{{ bookName }} {{ chapterNum }}</h2>
+          <mdc-icon>keyboard_arrow_down</mdc-icon>
+        </div>
+        <app-text #scriptureText [id]="textDocId" mode="dialog"></app-text>
+        <p class="selection-preview">
+          {{ selectedText }} <span class="selection-reference">{{ referenceForDisplay }}</span>
+        </p>
+        <span class="error-message" *ngIf="errorMessage">{{ errorMessage }}</span>
+      </mdc-dialog-content>
+      <mdc-dialog-actions>
+        <button mdcDialogAction="close" type="button" mdc-button>Cancel</button>
+        <button type="submit" mdc-button primary default (click)="submit()">Save</button>
+      </mdc-dialog-actions>
+    </mdc-dialog-surface>
+  </mdc-dialog-container>
+</mdc-dialog>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.scss
@@ -1,0 +1,34 @@
+.select-chapter {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  margin: 0.5em 0 0.5em 0;
+  font-size: 0.9em;
+
+  h2 {
+    display: inline;
+    margin: 0 0 0 0.3em;
+  }
+}
+
+app-text {
+  max-height: calc(100vh - 400px);
+  min-height: 300px;
+}
+
+.selection-reference {
+  font-style: italic;
+}
+
+.error-message {
+  color: var(--mdc-theme-error);
+  font-size: 0.85em;
+}
+
+::ng-deep quill-editor {
+  overflow-y: scroll;
+}
+
+::ng-deep app-text quill-editor > .ql-container > .ql-editor {
+  padding: 0 1em 1em;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.scss
@@ -12,7 +12,8 @@
 }
 
 app-text {
-  max-height: calc(100vh - 400px);
+  display: block;
+  max-height: calc(100vh - 25rem);
   min-height: 300px;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
@@ -1,0 +1,468 @@
+import { MdcDialog, MdcDialogRef } from '@angular-mdc/web/dialog';
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { CommonModule } from '@angular/common';
+import { Component, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
+import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
+import { CheckingShareLevel } from 'realtime-server/lib/scriptureforge/models/checking-config';
+import { SFProject } from 'realtime-server/lib/scriptureforge/models/sf-project';
+import { SFProjectRole } from 'realtime-server/lib/scriptureforge/models/sf-project-role';
+import { getTextDocId } from 'realtime-server/lib/scriptureforge/models/text-data';
+import { TextInfo } from 'realtime-server/lib/scriptureforge/models/text-info';
+import { VerseRef } from 'realtime-server/lib/scriptureforge/scripture-utils/verse-ref';
+import * as RichText from 'rich-text';
+import { of } from 'rxjs';
+import { anything, instance, mock, spy, when } from 'ts-mockito';
+import { TestRealtimeService } from 'xforge-common/test-realtime.service';
+import { configureTestingModule } from 'xforge-common/test-utils';
+import { UICommonModule } from 'xforge-common/ui-common.module';
+import { CheckingModule } from '../checking/checking.module';
+import { SFProjectDoc } from '../core/models/sf-project-doc';
+import { SF_REALTIME_DOC_TYPES } from '../core/models/sf-realtime-doc-types';
+import { Delta, TextDoc } from '../core/models/text-doc';
+import { SFProjectService } from '../core/sf-project.service';
+import { ScriptureChooserDialogComponent } from '../scripture-chooser-dialog/scripture-chooser-dialog.component';
+import { TextChooserDialogComponent, TextChooserDialogData, TextSelection } from './text-chooser-dialog.component';
+
+const mockedProjectService = mock(SFProjectService);
+const originalAddEventListener = document.addEventListener;
+const originalGetSelection = document.getSelection;
+
+describe('TextChooserDialogComponent', () => {
+  configureTestingModule(() => ({
+    imports: [DialogTestModule],
+    providers: [{ provide: SFProjectService, useMock: mockedProjectService }]
+  }));
+
+  afterEach(() => {
+    document.addEventListener = originalAddEventListener;
+    document.getSelection = originalGetSelection;
+  });
+
+  it('allows switching chapters', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.fixture.detectChanges();
+    flush();
+    expect(env.headingText).toEqual('Matthew 1');
+    env.selectChapter.click();
+    env.fixture.detectChanges();
+    expect(env.headingText).toEqual('Luke 1');
+    env.cancelButton.click();
+    flush();
+  }));
+
+  it('shows an error if save is clicked with no text selected', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.fixture.detectChanges();
+    flush();
+    expect(env.errorMessage).toBeNull();
+    env.saveButton.click();
+    env.fixture.detectChanges();
+    expect(env.errorMessage.textContent).toEqual('Select text to attach to your answer.');
+    env.cancelButton.click();
+    flush();
+  }));
+
+  it('allows selecting text', fakeAsync(async () => {
+    const selectionChangedPromise = TestEnvironment.setUpSelectionChange();
+    const env = new TestEnvironment(
+      TestEnvironment.defaultDialogData,
+      [
+        {
+          startOffset: 1,
+          endOffset: 10
+        }
+      ],
+      'verse_1_2',
+      'verse_1_3',
+      'changed'
+    );
+    env.fixture.detectChanges();
+    flush();
+    expect(env.selectedText).toEqual('');
+    (await selectionChangedPromise)();
+    env.fixture.detectChanges();
+    expect(env.selectedText).toEqual('target: chapter (MAT 1:3)');
+    env.cancelButton.click();
+    flush();
+  }));
+
+  it("doesn't require the user to modify an existing selection", fakeAsync(async () => {
+    const env = new TestEnvironment({
+      bookNum: 40,
+      chapterNum: 1,
+      projectId: TestEnvironment.PROJECT01,
+      textsByBookId: TestEnvironment.textsByBookId,
+      selectedText: 'previously selected text',
+      selectedVerses: {
+        bookNum: 43,
+        chapterNum: 1,
+        verseNum: 2,
+        verse: '2-3'
+      }
+    });
+    env.fixture.detectChanges();
+    flush();
+    expect(env.selectedText).toEqual('previously selected text (JHN 1:2-3)');
+    env.saveButton.click();
+    expect(await env.resultPromise).toEqual('close');
+  }));
+
+  it('is cancelable', fakeAsync(async () => {
+    const env = new TestEnvironment();
+    env.fixture.detectChanges();
+    flush();
+    env.cancelButton.click();
+    flush();
+    expect(await env.resultPromise).toEqual('close');
+  }));
+
+  it("doesn't clear the selection if the user selects nothing or white space", fakeAsync(async () => {
+    const selectionChangedPromise = TestEnvironment.setUpSelectionChange();
+    const env = new TestEnvironment(
+      {
+        bookNum: 40,
+        chapterNum: 1,
+        projectId: TestEnvironment.PROJECT01,
+        textsByBookId: TestEnvironment.textsByBookId,
+        selectedText: 'previously selected text',
+        selectedVerses: {
+          bookNum: 41,
+          chapterNum: 1,
+          verseNum: 2,
+          verse: '2-3'
+        }
+      },
+      [
+        {
+          startOffset: 0,
+          endOffset: 1
+        },
+        {
+          startOffset: 0,
+          endOffset: 0
+        }
+      ],
+      'verse_1_2',
+      'verse_1_3',
+      '\n '
+    );
+    env.fixture.detectChanges();
+    flush();
+    (await selectionChangedPromise)();
+    env.fixture.detectChanges();
+    expect(env.selectedText).toEqual('previously selected text (MRK 1:2-3)');
+    env.cancelButton.click();
+    flush();
+  }));
+
+  it('expands the selection to whole words', fakeAsync(async () => {
+    const selectionChangedPromise = TestEnvironment.setUpSelectionChange();
+    const env = new TestEnvironment(
+      TestEnvironment.defaultDialogData,
+      [
+        {
+          startOffset: 13,
+          endOffset: 1
+        }
+      ],
+      'verse_1_4',
+      'verse_1_5',
+      'changed'
+    );
+    env.fixture.detectChanges();
+    flush();
+    (await selectionChangedPromise)();
+    env.fixture.detectChanges();
+    expect(env.selectedText).toEqual('chapter 1, verse 4. rest of verse 4 target (MAT 1:4-5)');
+    env.cancelButton.click();
+    flush();
+  }));
+
+  it('indicates when not all segments of the end verse were selected', fakeAsync(async () => {
+    const selectionChangedPromise = TestEnvironment.setUpSelectionChange();
+    const env = new TestEnvironment(
+      TestEnvironment.defaultDialogData,
+      [
+        {
+          startOffset: 3,
+          endOffset: 28
+        }
+      ],
+      'verse_1_3',
+      'verse_1_4',
+      'changed'
+    );
+    env.fixture.detectChanges();
+    flush();
+    (await selectionChangedPromise)();
+    env.fixture.detectChanges();
+    expect(env.selectedText).toEqual('target: chapter 1, verse 3. target: chapter 1, verse 4. (MAT 1:3-4)');
+    env.saveButton.click();
+    expect(await env.resultPromise).toEqual({
+      verses: { bookNum: 40, chapterNum: 1, verseNum: 3, verse: '3-4' },
+      text: 'target: chapter 1, verse 3. target: chapter 1, verse 4.',
+      startClipped: false,
+      endClipped: true
+    });
+  }));
+
+  it('indicates when not all segments of the start verse were selected', fakeAsync(async () => {
+    const selectionChangedPromise = TestEnvironment.setUpSelectionChange();
+    const env = new TestEnvironment(
+      TestEnvironment.defaultDialogData,
+      [
+        {
+          startOffset: 0,
+          endOffset: 19
+        }
+      ],
+      'verse_1_4/p_1',
+      'verse_1_5',
+      'changed'
+    );
+    env.fixture.detectChanges();
+    flush();
+    (await selectionChangedPromise)();
+    env.fixture.detectChanges();
+    expect(env.selectedText).toEqual('rest of verse 4 target: chapter 1, (MAT 1:4-5)');
+    env.saveButton.click();
+    expect(await env.resultPromise).toEqual({
+      verses: { bookNum: 40, chapterNum: 1, verseNum: 4, verse: '4-5' },
+      text: 'rest of verse 4 target: chapter 1,',
+      startClipped: true,
+      endClipped: false
+    });
+  }));
+
+  it('indicates when the segments were only partially selected', fakeAsync(async () => {
+    const selectionChangedPromise = TestEnvironment.setUpSelectionChange();
+    const env = new TestEnvironment(
+      TestEnvironment.defaultDialogData,
+      [
+        {
+          startOffset: 6,
+          endOffset: 17
+        }
+      ],
+      'verse_1_4',
+      'verse_1_5',
+      'changed'
+    );
+    env.fixture.detectChanges();
+    flush();
+    (await selectionChangedPromise)();
+    env.fixture.detectChanges();
+    expect(env.selectedText).toEqual(': chapter 1, verse 4. rest of verse 4 target: chapter 1 (MAT 1:4-5)');
+    env.saveButton.click();
+    expect(await env.resultPromise).toEqual({
+      verses: { bookNum: 40, chapterNum: 1, verseNum: 4, verse: '4-5' },
+      text: ': chapter 1, verse 4. rest of verse 4 target: chapter 1',
+      startClipped: true,
+      endClipped: true
+    });
+  }));
+});
+
+@Directive({
+  // ts lint complains that a directive should be used as an attribute
+  // tslint:disable-next-line:directive-selector
+  selector: 'viewContainerDirective'
+})
+class ViewContainerDirective {
+  constructor(public viewContainerRef: ViewContainerRef) {}
+}
+
+@Component({
+  selector: 'app-view-container',
+  template: '<viewContainerDirective></viewContainerDirective>'
+})
+class ChildViewContainerComponent {
+  @ViewChild(ViewContainerDirective, { static: true }) viewContainer!: ViewContainerDirective;
+
+  get childViewContainer(): ViewContainerRef {
+    return this.viewContainer.viewContainerRef;
+  }
+}
+
+@NgModule({
+  imports: [CommonModule, UICommonModule, CheckingModule],
+  exports: [ViewContainerDirective, ChildViewContainerComponent, ScriptureChooserDialogComponent],
+  declarations: [ViewContainerDirective, ChildViewContainerComponent, ScriptureChooserDialogComponent],
+  entryComponents: [ChildViewContainerComponent, TextChooserDialogComponent, ScriptureChooserDialogComponent]
+})
+class DialogTestModule {}
+
+class TestEnvironment {
+  static PROJECT01: string = 'project01';
+  static matthewText: TextInfo = {
+    bookNum: 40,
+    hasSource: false,
+    chapters: [{ number: 1, lastVerse: 25, isValid: true }, { number: 3, lastVerse: 17, isValid: true }]
+  };
+  static textsByBookId = { ['MAT']: TestEnvironment.matthewText };
+  static testProject: SFProject = {
+    paratextId: 'pt01',
+    shortName: 'P01',
+    name: 'Project 01',
+    writingSystem: { tag: 'en' },
+    translateConfig: { translationSuggestionsEnabled: false },
+    checkingConfig: {
+      usersSeeEachOthersResponses: true,
+      checkingEnabled: true,
+      shareEnabled: true,
+      shareLevel: CheckingShareLevel.Anyone
+    },
+    texts: [TestEnvironment.matthewText],
+    sync: { queuedCount: 0 },
+    userRoles: {
+      user01: SFProjectRole.ParatextAdministrator
+    }
+  };
+
+  static defaultDialogData = {
+    bookNum: 40,
+    chapterNum: 1,
+    projectId: TestEnvironment.PROJECT01,
+    textsByBookId: TestEnvironment.textsByBookId
+  };
+
+  static setUpSelectionChange(): Promise<() => any> {
+    return new Promise(resolve => {
+      document.addEventListener = (_event: string, handler: any) => {
+        if (_event === 'selectionchange') {
+          resolve(handler);
+        } else {
+          originalAddEventListener.bind(document)(_event, handler);
+        }
+      };
+    });
+  }
+
+  readonly fixture: ComponentFixture<ChildViewContainerComponent>;
+  readonly overlayContainerElement: HTMLElement;
+  readonly realtimeService = new TestRealtimeService(SF_REALTIME_DOC_TYPES);
+
+  readonly mockedScriptureChooserMdcDialogRef = mock(MdcDialogRef);
+
+  readonly resultPromise: Promise<TextSelection | 'close'>;
+
+  constructor(
+    dialogData?: TextChooserDialogData,
+    ranges: { startOffset: number; endOffset: number }[] = [],
+    startSegment = 'verse_1_1',
+    endSegment = 'verse_1_2',
+    selection = ''
+  ) {
+    document.getSelection = () => {
+      return {
+        toString: () => selection,
+        rangeCount: ranges.length,
+        getRangeAt: (index: number) => ranges[index],
+        containsNode: (node: Node): boolean => {
+          const segments = Array.from(this.editor.querySelectorAll(`usx-segment[data-segment^="verse_"]`));
+          let startingSegmentReached = false;
+          for (const segment of segments) {
+            if (segment.getAttribute('data-segment') === startSegment) {
+              startingSegmentReached = true;
+            }
+            if (startingSegmentReached && segment.contains(node)) {
+              return true;
+            }
+            if (segment.getAttribute('data-segment') === endSegment) {
+              break;
+            }
+          }
+          return false;
+        }
+      } as Selection;
+    };
+
+    this.fixture = TestBed.createComponent(ChildViewContainerComponent);
+
+    const config: TextChooserDialogData = dialogData || TestEnvironment.defaultDialogData;
+
+    this.addTextDoc(config.bookNum);
+
+    this.realtimeService.addSnapshot<SFProject>(SFProjectDoc.COLLECTION, {
+      id: TestEnvironment.PROJECT01,
+      data: TestEnvironment.testProject
+    });
+
+    when(mockedProjectService.get(anything())).thenCall(id =>
+      this.realtimeService.subscribe(SFProjectDoc.COLLECTION, id)
+    );
+    when(mockedProjectService.getText(anything())).thenCall(id =>
+      this.realtimeService.subscribe(TextDoc.COLLECTION, id.toString())
+    );
+
+    const dialogRef = TestBed.get(MdcDialog).open(TextChooserDialogComponent, { data: config });
+    this.resultPromise = dialogRef.afterClosed().toPromise();
+
+    this.overlayContainerElement = TestBed.get(OverlayContainer).getContainerElement();
+
+    // Set up MdcDialog mocking after it's already used above in creating the component.
+    const dialogSpy = spy(dialogRef.componentInstance.dialog);
+    when(dialogSpy.open(anything(), anything())).thenReturn(instance(this.mockedScriptureChooserMdcDialogRef));
+    const chooserDialogResult = new VerseRef('LUK', '1', '2');
+    when(this.mockedScriptureChooserMdcDialogRef.afterClosed()).thenReturn(of(chooserDialogResult));
+  }
+
+  get saveButton(): HTMLButtonElement {
+    return this.select('button[type="submit"]') as HTMLButtonElement;
+  }
+
+  get cancelButton(): HTMLButtonElement {
+    return this.select('button[data-mdc-dialog-action="close"]') as HTMLButtonElement;
+  }
+
+  get headingText() {
+    return this.select('.select-chapter h2').textContent!;
+  }
+
+  get selectChapter() {
+    return this.select('.select-chapter') as HTMLButtonElement;
+  }
+
+  get errorMessage() {
+    return this.select('.error-message');
+  }
+
+  get selectedText() {
+    // trim because template adds white space around the text
+    return this.select('.selection-preview').textContent!.trim();
+  }
+
+  get editor() {
+    return this.select('quill-editor');
+  }
+
+  select(query: string) {
+    return this.overlayContainerElement.querySelector(query)!;
+  }
+
+  private addTextDoc(bookNum: number): void {
+    const delta = new Delta();
+    delta.insert({ chapter: { number: '1', style: 'c' } });
+    delta.insert({ blank: true }, { segment: 'p_1' });
+    delta.insert({ verse: { number: '1', style: 'v' } });
+    delta.insert('target: chapter 1, verse 1.', { segment: 'verse_1_1' });
+    delta.insert({ verse: { number: '2', style: 'v' } });
+    delta.insert({ blank: true }, { segment: 'verse_1_2' });
+    delta.insert('\n', { para: { style: 'p' } });
+    delta.insert({ blank: true }, { segment: 'verse_1_2/p_1' });
+    delta.insert({ verse: { number: '3', style: 'v' } });
+    delta.insert(`target: chapter 1, verse 3.`, { segment: 'verse_1_3' });
+    delta.insert({ verse: { number: '4', style: 'v' } });
+    delta.insert(`target: chapter 1, verse 4.`, { segment: 'verse_1_4' });
+    delta.insert('\n', { para: { style: 'p' } });
+    delta.insert(`rest of verse 4`, { segment: 'verse_1_4/p_1' });
+    delta.insert({ verse: { number: '5', style: 'v' } });
+    delta.insert(`target: chapter 1, `, { segment: 'verse_1_5' });
+    delta.insert('\n', { para: { style: 'p' } });
+    this.realtimeService.addSnapshot(TextDoc.COLLECTION, {
+      id: getTextDocId(TestEnvironment.PROJECT01, bookNum, 1, 'target'),
+      type: RichText.type.name,
+      data: delta
+    });
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
@@ -20,7 +20,6 @@ import { SFProjectDoc } from '../core/models/sf-project-doc';
 import { SF_REALTIME_DOC_TYPES } from '../core/models/sf-realtime-doc-types';
 import { Delta, TextDoc } from '../core/models/text-doc';
 import { SFProjectService } from '../core/sf-project.service';
-import { ScriptureChooserDialogComponent } from '../scripture-chooser-dialog/scripture-chooser-dialog.component';
 import { TextChooserDialogComponent, TextChooserDialogData, TextSelection } from './text-chooser-dialog.component';
 
 const mockedProjectService = mock(SFProjectService);
@@ -286,9 +285,9 @@ class ChildViewContainerComponent {
 
 @NgModule({
   imports: [CommonModule, UICommonModule, CheckingModule],
-  exports: [ViewContainerDirective, ChildViewContainerComponent, ScriptureChooserDialogComponent],
-  declarations: [ViewContainerDirective, ChildViewContainerComponent, ScriptureChooserDialogComponent],
-  entryComponents: [ChildViewContainerComponent, TextChooserDialogComponent, ScriptureChooserDialogComponent]
+  exports: [ViewContainerDirective, ChildViewContainerComponent],
+  declarations: [ViewContainerDirective, ChildViewContainerComponent],
+  entryComponents: [ChildViewContainerComponent, TextChooserDialogComponent]
 })
 class DialogTestModule {}
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
@@ -148,7 +148,21 @@ export class TextChooserDialogComponent implements OnDestroy {
     document.removeEventListener('selectionchange', this.selectionChangeHandler);
   }
 
-  private expandSelection(selection: Selection, segments: Element[]) {
+  /**
+   * Given the user's selection and the USX segment dom elements that are part of the selection:
+   * - Expands the selection to the nearest word boundaries
+   * - Determines whether the start and end verses were clipped, so that e.g. ellipses can be displayed at the start
+   *   and/or end the selection. If only white space was clipped it is not counted as being clipped.
+   * - Normalizes whitespace between segments to a single space.
+   */
+  private expandSelection(
+    selection: Selection,
+    segments: Element[]
+  ): {
+    result: string;
+    startClipped: boolean;
+    endClipped: boolean;
+  } {
     // all selected verses except the first and last
     const centralSelection = segments
       .filter((_el, index) => index !== 0 && index !== segments.length - 1)

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
@@ -1,0 +1,217 @@
+import { MDC_DIALOG_DATA, MdcDialog, MdcDialogConfig, MdcDialogRef } from '@angular-mdc/web';
+import { Component, ElementRef, Inject, OnDestroy, Optional, ViewChild } from '@angular/core';
+import { toVerseRef, VerseRefData } from 'realtime-server/lib/scriptureforge/models/verse-ref-data';
+import { Canon } from 'realtime-server/lib/scriptureforge/scripture-utils/canon';
+import { VerseRef } from 'realtime-server/lib/scriptureforge/scripture-utils/verse-ref';
+import { TextDocId } from '../core/models/text-doc';
+import { TextsByBookId } from '../core/models/texts-by-book-id';
+import {
+  ScriptureChooserDialogComponent,
+  ScriptureChooserDialogData
+} from '../scripture-chooser-dialog/scripture-chooser-dialog.component';
+import { TextComponent } from '../shared/text/text.component';
+
+export interface TextChooserDialogData {
+  bookNum: number;
+  chapterNum: number;
+  projectId: string;
+  textsByBookId: TextsByBookId;
+  selectedText?: string;
+  selectedVerses?: VerseRefData;
+}
+
+export interface TextSelection {
+  verses: VerseRefData;
+  text: string;
+  // whether or not the starting verse was fully selected (useful for knowing whether to show e.g. an ellipsis)
+  startClipped: boolean;
+  endClipped: boolean;
+}
+
+@Component({
+  templateUrl: './text-chooser-dialog.component.html',
+  styleUrls: ['./text-chooser-dialog.component.scss']
+})
+export class TextChooserDialogComponent implements OnDestroy {
+  @ViewChild(TextComponent, { static: true }) textComponent?: TextComponent;
+  @ViewChild(TextComponent, { static: false, read: ElementRef }) scriptureText!: ElementRef;
+  selectedText?: string;
+  errorMessage?: string;
+  bookNum: number;
+  chapterNum: number;
+  textDocId: TextDocId;
+
+  private rawTextSelection = '';
+  private selectionChangeHandler = this.updateSelection.bind(this);
+  private selectedVerses?: VerseRefData;
+  private selectionChanged = false;
+  private startClipped = false;
+  private endClipped = false;
+
+  constructor(
+    private readonly dialogRef: MdcDialogRef<TextChooserDialogComponent>,
+    readonly dialog: MdcDialog,
+    @Optional() @Inject(MDC_DIALOG_DATA) private readonly data: TextChooserDialogData
+  ) {
+    // caniuse doesn't have complete data for the selection events api, but testing on BrowserStack shows the event is
+    // fired at least as far back as iOS v7 on Safari 7.
+    // Edge 42 with EdgeHTML 17 also fires the events.
+    // Firefox and Chrome also support it. We can degrade gracefully by getting the selection when the dialog closes.
+    document.addEventListener('selectionchange', this.selectionChangeHandler);
+
+    this.bookNum = this.data.bookNum;
+    this.chapterNum = this.data.chapterNum;
+    this.selectedText = this.data.selectedText;
+    this.selectedVerses = this.data.selectedVerses;
+
+    this.textDocId = new TextDocId(this.data.projectId, this.bookNum, this.chapterNum);
+  }
+
+  get bookName(): string {
+    return Canon.bookNumberToEnglishName(this.bookNum);
+  }
+
+  updateSelection() {
+    const selection = document.getSelection();
+    const rawSelection = (selection || '').toString();
+    if (selection != null && rawSelection.trim() !== '' && rawSelection !== this.rawTextSelection) {
+      // all non-empty verse elements in the selection
+      const segments = Array.from(this.getSegments()).filter(
+        segment => selection.containsNode(segment, true) && segment.querySelector('usx-blank') == null
+      );
+
+      if (segments.length === 0) {
+        return;
+      }
+
+      const firstVerseNum = this.getVerseFromElement(segments[0]);
+      const lastVerseNum = this.getVerseFromElement(segments[segments.length - 1]);
+      const expansion = this.expandSelection(selection, segments);
+      this.selectedText = expansion.result;
+      this.startClipped = expansion.startClipped;
+      this.endClipped = expansion.endClipped;
+
+      this.selectedVerses = {
+        bookNum: this.bookNum,
+        chapterNum: this.chapterNum,
+        verseNum: firstVerseNum,
+        verse: firstVerseNum === lastVerseNum ? firstVerseNum.toString() : firstVerseNum + '-' + lastVerseNum
+      };
+      this.rawTextSelection = rawSelection;
+      this.selectionChanged = true;
+      this.errorMessage = '';
+    }
+  }
+
+  openScriptureChooser() {
+    const dialogConfig: MdcDialogConfig<ScriptureChooserDialogData> = {
+      data: { booksAndChaptersToShow: this.data.textsByBookId, includeVerseSelection: false }
+    };
+
+    const dialogRef = this.dialog.open(ScriptureChooserDialogComponent, dialogConfig) as MdcDialogRef<
+      ScriptureChooserDialogComponent,
+      VerseRef | 'close'
+    >;
+    dialogRef.afterClosed().subscribe(result => {
+      if (result != null && result !== 'close') {
+        this.bookNum = result.bookNum;
+        this.chapterNum = result.chapterNum;
+        this.textDocId = new TextDocId(this.data.projectId, this.bookNum, this.chapterNum);
+      }
+    });
+  }
+
+  get referenceForDisplay() {
+    return this.selectedVerses ? `(${toVerseRef(this.selectedVerses)})` : '';
+  }
+
+  submit() {
+    this.updateSelection();
+    if (this.selectedVerses != null) {
+      if (this.selectionChanged) {
+        const selection: TextSelection = {
+          verses: this.selectedVerses,
+          text: this.selectedText!,
+          startClipped: this.startClipped,
+          endClipped: this.endClipped
+        };
+        this.dialogRef.close(selection);
+      } else {
+        this.dialogRef.close('close');
+      }
+    } else {
+      this.errorMessage = 'Select text to attach to your answer.';
+    }
+  }
+
+  ngOnDestroy() {
+    document.removeEventListener('selectionchange', this.selectionChangeHandler);
+  }
+
+  private expandSelection(selection: Selection, segments: Element[]) {
+    // all selected verses except the first and last
+    const centralSelection = segments
+      .filter((_el, index) => index !== 0 && index !== segments.length - 1)
+      .map(el => (el.textContent || '').trim())
+      .join(' ');
+
+    const startRange = selection.getRangeAt(0);
+    const endRange = selection.getRangeAt(selection.rangeCount - 1);
+    const startOffset = startRange.startOffset;
+    const endOffset = endRange.endOffset;
+    const startNodeText = segments[0].textContent!;
+    const endNodeText = segments[segments.length - 1].textContent!;
+    const startText = startNodeText.substring(startOffset);
+    const endText = endNodeText.substring(0, endOffset);
+
+    let startTrimLength = startText.length - startText.trimLeft().length;
+    if (startTrimLength === 0 && startText !== '') {
+      // Find the last word boundary that isn't the end of the string. This works because * is greedy.
+      startTrimLength =
+        /[\s\S]*\b(?=[\s\S])/.exec(startNodeText.substring(0, startOffset + 1))![0].length - startOffset;
+    }
+    let endTrimLength = endText.length - endText.trimRight().length;
+    if (endTrimLength === 0 && endText !== '') {
+      endTrimLength = -Math.max(0, endNodeText.substring(endOffset - 1).search(/[\s\S]\b/));
+    }
+
+    let result = [startNodeText, centralSelection, segments.length === 1 ? '' : endNodeText].filter(s => s).join(' ');
+    result = result
+      .substring(startOffset + startTrimLength, result.length - endNodeText.length + endOffset - endTrimLength)
+      .trim();
+
+    const startStartSegmentClipped =
+      startOffset + startTrimLength > startNodeText.length - startNodeText.trimLeft().length;
+    const endSegmentClipped = endOffset + endTrimLength < endNodeText.trimRight().length;
+
+    const firstVerseSegments = Array.from(this.getSegments(this.getVerseFromElement(segments[0]))).filter(
+      el => (el.textContent || '').trim() !== ''
+    );
+    const lastVerseSegments = Array.from(
+      this.getSegments(this.getVerseFromElement(segments[segments.length - 1]))
+    ).filter(el => (el.textContent || '').trim() !== '');
+
+    const startClipped =
+      startStartSegmentClipped || (firstVerseSegments.length !== 0 && !firstVerseSegments[0].contains(segments[0]));
+    const endClipped =
+      endSegmentClipped ||
+      (lastVerseSegments.length !== 0 &&
+        !lastVerseSegments[lastVerseSegments.length - 1].contains(segments[segments.length - 1]));
+
+    return {
+      result,
+      startClipped,
+      endClipped
+    };
+  }
+
+  private getVerseFromElement(element: Element): number {
+    return parseInt(element.getAttribute('data-segment')!.split('_', 3)[2], 10);
+  }
+
+  private getSegments(verse?: number) {
+    return Array.from(
+      (this.scriptureText.nativeElement as HTMLElement).querySelectorAll('usx-segment[data-segment^=verse_]')
+    ).filter(el => (verse == null ? true : verse === this.getVerseFromElement(el)));
+  }
+}


### PR DESCRIPTION
Replaces the start verse and end verse scripture selection method in the answers component with a dialog that allows selecting text with the mouse.

---

### The new select text tab
The layout looks pretty bad to me (the buttons in particular). I'm hoping it can be improved.

![Screen Shot 2019-11-05 at 11 44 43](https://user-images.githubusercontent.com/6140710/68227634-14d8c680-ffc2-11e9-80bd-324f327e1990.png)

---

### The dialog, when first opened

![Screen Shot 2019-11-05 at 11 45 05](https://user-images.githubusercontent.com/6140710/68227633-14d8c680-ffc2-11e9-9d5c-e267d09af598.png)

---

### Selecting text
The gray selection color is due to the dialog losing focus when I took the screenshot, and is my system default, not a style set in CSS. Notice that the selection is expanded to word boundaries.

![Screen Shot 2019-11-05 at 11 45 23](https://user-images.githubusercontent.com/6140710/68227632-14d8c680-ffc2-11e9-8810-4cfe4258ed58.png)

---

### Attempting to save with nothing selected

![Screen Shot 2019-11-05 at 11 45 51](https://user-images.githubusercontent.com/6140710/68227631-14403000-ffc2-11e9-83f8-c20976f6983b.png)

---

### Text selection tab with text selected 
Again, this doesn't look like a very nice layout to me.

![Screen Shot 2019-11-05 at 11 46 33](https://user-images.githubusercontent.com/6140710/68227630-14403000-ffc2-11e9-949f-c4ad3670e1f1.png)

This is a draft pull request because two tests are failing, and I don't know how to fix them. It's caused by this change in `text.component.ts`:

``` diff
-    Promise.resolve().then(() => this.adjustSelection());
+    if (!this.isReadOnly) {
+      Promise.resolve().then(() => this.adjustSelection());
+    }
```
This is necessary to allow text to be selected across verses. The tests that fail are `delete all text from non-verse paragraph segment` and `delete all text from verse paragraph segment` in `editor.component.spec.ts`. They both fail with `Expected true to be undefined.` I might be able to poke around and make a change that would get them to pass, but I wouldn't have the confidence that the tests were still testing what they are supposed to test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/396)
<!-- Reviewable:end -->
