### PR TITLE
SF-667: Backend i18n

### DIFF
--- a/src/SIL.XForge.Scripture/Resources/SharedResource.en.resx
+++ b/src/SIL.XForge.Scripture/Resources/SharedResource.en.resx
@@ -1,0 +1,150 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InviteEmailOption" xml:space="preserve">
+    <value>Enter your email address and a new password for your {0} account and click Sign up.</value>
+  </data>
+  <data name="InviteGoogleOption" xml:space="preserve">
+    <value>Click {0}Sign up with Google{1} and follow the instructions to access {2} using an existing Google account (such as Gmail), or</value>
+  </data>
+  <data name="InviteGreeting" xml:space="preserve">
+    <value>Hello,{0}{1} invites you to join the {2} project on {3}.{0}Just click the link below, choose how to log in, and you will be ready to start.{0}{0}To join, go to {4}</value>
+  </data>
+  <data name="InviteInstructions" xml:space="preserve">
+    <value>If you are not already a {0} user, then after clicking the link, click {1}Sign Up{2} and do one of the following:</value>
+  </data>
+  <data name="InviteLinkSharingOff" xml:space="preserve">
+    <value>This link will only work for this email address.</value>
+  </data>
+  <data name="InviteLinkSharingOn" xml:space="preserve">
+    <value>This link can be shared with others so they can join the project too.</value>
+  </data>
+  <data name="InvitePTOption" xml:space="preserve">
+    <value>Click {0}Sign up with Paratext{1} and follow the instructions to access {2} using an existing Paratext account, or</value>
+  </data>
+  <data name="InviteSignature" xml:space="preserve">
+    <value>Regards,{0}The {1} team</value>
+  </data>
+  <data name="InviteSubject" xml:space="preserve">
+    <value>You've been invited to the project {0} on {1}</value>
+  </data>
+  <data name="UserMissing" xml:space="preserve">
+    <value>The user does not exist.</value>
+  </data>
+</root>

--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -41,6 +41,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Update="Resources\SharedResource.en.resx">
+      <Generator></Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="usx-sf.xsd">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/SIL.XForge.Scripture/SharedResource.cs
+++ b/src/SIL.XForge.Scripture/SharedResource.cs
@@ -1,0 +1,25 @@
+namespace SIL.XForge.Scripture
+{
+    /// <summary>
+    /// This class holds the Keys for looking up localizable strings in the IStringLocalizer.
+    /// It also provides the class which IStringLocalizer uses to find the .resx files with the strings
+    /// Every string in the Keys class here should also be present in the Resources\SharedResource.en.resx
+    /// with the english translation as the value.
+    /// </summary>
+    public class SharedResource
+    {
+        public static class Keys
+        {
+            public static string UserMissing = "UserMissing";
+            public static string InviteSubject = "InviteSubject";
+            public static string InviteGreeting = "InviteGreeting";
+            public static string InviteInstructions = "InviteInstructions";
+            public static string InvitePTOption = "InvitePTOption";
+            public static string InviteGoogleOption = "InviteGoogleOption";
+            public static string InviteEmailOption = "InviteEmailOption";
+            public static string InviteSignature = "InviteSignature";
+            public static string InviteLinkSharingOn = "InviteLinkSharingOn";
+            public static string InviteLinkSharingOff = "InviteLinkSharingOff";
+        }
+    }
+}

--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SpaServices.AngularCli;
 using Microsoft.Extensions.Configuration;
@@ -79,6 +82,8 @@ namespace SIL.XForge.Scripture
 
             services.AddSFDataAccess(Configuration);
 
+            services.AddLocalization(options => options.ResourcesPath = "Resources");
+
             services.AddMvc()
                 .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
 
@@ -113,6 +118,17 @@ namespace SIL.XForge.Scripture
                 app.UseDeveloperExceptionPage();
 
             app.UseExceptionLogging();
+
+            // Add new cultures here as they are localized
+            var supportedCultures = new List<CultureInfo> {new CultureInfo("en-US")};
+            app.UseRequestLocalization(new RequestLocalizationOptions
+            {
+                DefaultRequestCulture = new RequestCulture("en-US"),
+                // Formatting numbers, dates, etc.
+                SupportedCultures = supportedCultures,
+                // UI strings that we have localized.
+                SupportedUICultures = supportedCultures
+            });
 
             app.UseStaticFiles(new StaticFileOptions
             {

--- a/src/SIL.XForge.Scripture/appsettings.json
+++ b/src/SIL.XForge.Scripture/appsettings.json
@@ -1,7 +1,8 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Warning",
+      "Microsoft.AspNetCore.Localization": "Error"
     }
   },
   "AllowedHosts": "*",

--- a/test/SIL.XForge.Scripture.Tests/I18N/SharedResourceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/I18N/SharedResourceTests.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+
+namespace SIL.XForge.Scripture.I18N
+{
+	[TestFixture]
+	public class SharedResourceTests
+	{
+		/// <summary>
+		///     This test will use reflection to find all the string properties in the SharedResource Keys class.
+		///     Then it will verify that each of those keys are present in the english .resx file
+		/// </summary>
+		[Test]
+		public void VerifyAllSharedPropsAreInEnglishResx()
+		{
+			var options = Options.Create(new LocalizationOptions {ResourcesPath = "Resources"});
+			var factory = new ResourceManagerStringLocalizerFactory(options, NullLoggerFactory.Instance);
+			var localizer = new StringLocalizer<SharedResource>(factory);
+
+			var sharedResourceAsm = Assembly.Load("SIL.XForge.Scripture");
+			Assert.NotNull(sharedResourceAsm, "Um, what did you refactor?");
+			var sharedResourceClass = sharedResourceAsm.GetType("SIL.XForge.Scripture.SharedResource");
+			var sharedKeys = sharedResourceClass?.GetNestedType("Keys");
+			Assert.NotNull(sharedKeys, "Um, what did you refactor?");
+			// grab all the localization keys from SharedResource.Keys static class
+			var publicProps = sharedKeys.GetFields(BindingFlags.Public | BindingFlags.Static);
+			foreach (var propInfo in publicProps.Where(x => x.FieldType == typeof(string)))
+			{
+			    var keyValue = (string)propInfo.GetValue(null);
+				var englishStringFromResource = localizer.GetString(keyValue);
+				// verify that each key is found
+				Assert.IsFalse(englishStringFromResource.ResourceNotFound,
+					"Missing english string from .resx for " + propInfo.Name);
+			}
+
+			Assert.AreEqual(publicProps.Length, localizer.GetAllStrings().Count(),
+				"There are extra strings in the SharedResources.en.resx which are not in the SharedResource.Keys class");
+		}
+	}
+}

--- a/test/SIL.XForge.Scripture.Tests/SIL.XForge.Scripture.Tests.csproj
+++ b/test/SIL.XForge.Scripture.Tests/SIL.XForge.Scripture.Tests.csproj
@@ -14,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using NUnit.Framework;
@@ -16,6 +19,7 @@ using SIL.XForge.Scripture.Realtime;
 using SIL.XForge.Services;
 using SIL.XForge.Utils;
 using MachineProject = SIL.Machine.WebApi.Models.Project;
+using Options = Microsoft.Extensions.Options.Options;
 
 namespace SIL.XForge.Scripture.Services
 {
@@ -697,12 +701,15 @@ namespace SIL.XForge.Scripture.Services
                 });
                 var translateMetrics = new MemoryRepository<TranslateMetrics>();
                 FileSystemService = Substitute.For<IFileSystemService>();
+                var options = Options.Create(new LocalizationOptions { ResourcesPath = "Resources"});
+                var factory = new ResourceManagerStringLocalizerFactory(options, NullLoggerFactory.Instance);
+                Localizer = new StringLocalizer<SharedResource>(factory);
                 SecurityService = Substitute.For<ISecurityService>();
                 SecurityService.GenerateKey().Returns("1234abc");
 
                 Service = new SFProjectService(RealtimeService, siteOptions, audioService, EmailService, ProjectSecrets,
                     SecurityService, FileSystemService, EngineService, SyncService, ParatextService, userSecrets,
-                    translateMetrics);
+                    translateMetrics, Localizer);
             }
 
             public SFProjectService Service { get; }
@@ -714,6 +721,7 @@ namespace SIL.XForge.Scripture.Services
             public IEmailService EmailService { get; }
             public ISecurityService SecurityService { get; }
             public IParatextService ParatextService { get; }
+            public IStringLocalizer<SharedResource> Localizer { get; }
 
             public SFProject GetProject(string id)
             {


### PR DESCRIPTION
* Add support to localize strings used in controllers
  and services
* Internationalize SFProjectService.cs
* Add unit test to prove that all
  the Keys appear in the english .resx file.

Note: I will follow this up with more i18n work if this PR is approved

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/397)
<!-- Reviewable:end -->
