### PR TITLE
Fix text selection dialog layout on mobile

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.scss
@@ -13,6 +13,7 @@
 
 app-text {
   display: block;
+  overflow-y: scroll;
   max-height: calc(100vh - 25rem);
   min-height: 300px;
 }
@@ -24,10 +25,6 @@ app-text {
 .error-message {
   color: var(--mdc-theme-error);
   font-size: 0.85em;
-}
-
-::ng-deep quill-editor {
-  overflow-y: scroll;
 }
 
 ::ng-deep app-text quill-editor > .ql-container > .ql-editor {


### PR DESCRIPTION
Before | After
-------|------
![Screen Shot 2019-11-11 at 15 04 18-fullpage](https://user-images.githubusercontent.com/6140710/68617175-afd71200-0494-11ea-9206-a77f033d68a8.png) | ![Screen Shot 2019-11-11 at 15 05 04-fullpage](https://user-images.githubusercontent.com/6140710/68617184-b6fe2000-0494-11ea-9f06-c3c1e720ab4b.png)

Note: The excessive scroll bars only exist in responsive design mode on desktop. On Firefox mobile they do not show up.

This accidentally slipped through in #396. I'm not sure exactly how, but I know it wasn't originally broken, so my guess is that it happened in a rebase. I did see this issue pop up after a rebase and fixed it, but I didn't check the responsive design mode, where my fix apparently did not apply.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/408)
<!-- Reviewable:end -->
