### PR TITLE
Remove unused npm dependencies

### DIFF
--- a/src/RealtimeServer/package-lock.json
+++ b/src/RealtimeServer/package-lock.json
@@ -553,12 +553,6 @@
         "@types/node": "*"
       }
     },
-    "@types/lodash": {
-      "version": "4.14.136",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.136.tgz",
-      "integrity": "sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==",
-      "dev": true
-    },
     "@types/mime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",

--- a/src/RealtimeServer/package.json
+++ b/src/RealtimeServer/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "express": "^4.17.1",
     "jwks-rsa": "^1.6.0",
-    "lodash": ">=4.17.14",
     "mongodb": "^2.2.36",
     "ot-json0": "^1.1.0",
     "rich-text": "^3.1.0",
@@ -32,7 +31,6 @@
     "@types/jest": "^24.0.18",
     "@types/jest-expect-message": "^1.0.0",
     "@types/jsonwebtoken": "^8.3.3",
-    "@types/lodash": "^4.14.136",
     "@types/mongodb": "^2.2.25",
     "@types/ws": "^6.0.2",
     "jest": "^24.9.0",

--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -268,9 +268,9 @@
       }
     },
     "@angular-devkit/core": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-8.3.2.tgz",
-      "integrity": "sha512-jFrBGPJBhy4D4foH9YHDrlbqGmb+ZivTKtHnR4yV241VUd3W53+KABrvPyHeS5xk/aHTRsm76rx6l+UREEEUkw==",
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-8.3.18.tgz",
+      "integrity": "sha512-SPlQmBlrcaKZeE9srvuFElcen9iOled4lkD3M4cGwe56u6YoJ71oTAtmGiw9nofTtW0PghGVq8WdDQG5BRqX8Q==",
       "requires": {
         "ajv": "6.10.2",
         "fast-json-stable-stringify": "2.0.0",
@@ -301,11 +301,11 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-8.3.2.tgz",
-      "integrity": "sha512-WwiHtDeW7+Gw5pukdjyuwQ+Ino7AFnoKUqqYrsTwPnNky+p8JVT4tY6jTxwenOLOVsLSDz5oVn9jk5u70HLX4Q==",
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-8.3.18.tgz",
+      "integrity": "sha512-J9sf/6cSUx2kdXppo/69uZ1gBeM5fcXfnP7MCJCVnsk09QCD9Kr+Xeh8h4WEmLtne7XzI9dcCttHQ5WDNuRulA==",
       "requires": {
-        "@angular-devkit/core": "8.3.2",
+        "@angular-devkit/core": "8.3.18",
         "rxjs": "6.4.0"
       },
       "dependencies": {
@@ -662,24 +662,14 @@
         "tslib": "^1.9.0"
       }
     },
-    "@angular/platform-server": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-8.2.4.tgz",
-      "integrity": "sha512-SpvpGDEcJ748okD3ExbhQUVoOBm9QKGCeynuRg4aEusXKJ3TZ9/IiJLMjyc87YeRC6+4YU4zymT3JaaTxD8C2g==",
-      "requires": {
-        "domino": "^2.1.2",
-        "tslib": "^1.9.0",
-        "xhr2": "^0.1.4"
-      }
-    },
     "@angular/pwa": {
-      "version": "0.803.2",
-      "resolved": "https://registry.npmjs.org/@angular/pwa/-/pwa-0.803.2.tgz",
-      "integrity": "sha512-XMshG8cesILlIfIZzD4XgyWJtkLuJxBUiIgQ2thajY7ImR6nXg/gOs7UvpwgnkBfWfSUbxQVR0idqBVz3JWsdQ==",
+      "version": "0.803.18",
+      "resolved": "https://registry.npmjs.org/@angular/pwa/-/pwa-0.803.18.tgz",
+      "integrity": "sha512-KF40VDrjrl6iktU/7UBEAIOyEDmXm1sANdzLjynKwETpUExnoZ8k942KMChagVBtWJY8BrXo0EdWw1Kx6/4UmQ==",
       "requires": {
-        "@angular-devkit/core": "8.3.2",
-        "@angular-devkit/schematics": "8.3.2",
-        "@schematics/angular": "8.3.2",
+        "@angular-devkit/core": "8.3.18",
+        "@angular-devkit/schematics": "8.3.18",
+        "@schematics/angular": "8.3.18",
         "parse5-html-rewriting-stream": "5.1.0"
       }
     },
@@ -2585,12 +2575,12 @@
       }
     },
     "@schematics/angular": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-8.3.2.tgz",
-      "integrity": "sha512-kDT5lhr488NpqS4OKn8B9VUwl5AUNqRkLLqWgNHvxQcV1OtLhVJVw4ih1vhrH7wlUd39EwnRqtBX+53cg2PDmA==",
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-8.3.18.tgz",
+      "integrity": "sha512-3cQYcmzsWD/MnqauoSozIu1R7DJvty13BH6+XIorEfguWqOwOwgNIWLMsa0iIcy0+TV3vWFI0KZpCKup2u/I1Q==",
       "requires": {
-        "@angular-devkit/core": "8.3.2",
-        "@angular-devkit/schematics": "8.3.2"
+        "@angular-devkit/core": "8.3.18",
+        "@angular-devkit/schematics": "8.3.18"
       }
     },
     "@schematics/update": {
@@ -2691,12 +2681,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-      "dev": true
-    },
-    "@types/file-saver": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.1.tgz",
-      "integrity": "sha512-g1QUuhYVVAamfCifK7oB7G3aIl4BbOyzDOqVyUfEr4tfBKrXfeH+M+Tg7HKCXSrbzxYdhyCP7z9WbKo0R2hBCw==",
       "dev": true
     },
     "@types/glob": {
@@ -2814,12 +2798,6 @@
       "version": "3.0.30",
       "resolved": "https://registry.npmjs.org/@types/xregexp/-/xregexp-3.0.30.tgz",
       "integrity": "sha512-u1dpabg81Rd660bYebOqMXO0+E63H1hxunPAWGebNb7TpxqZYe9YaVLgkkj6ZnzLs3yLumtVB956o8u8OZdhXw==",
-      "dev": true
-    },
-    "@types/zxcvbn": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@types/zxcvbn/-/zxcvbn-4.4.0.tgz",
-      "integrity": "sha512-GQLOT+SN20a+AI51y3fAimhyTF4Y0RG+YP3gf91OibIZ7CJmPFgoZi+ZR5a+vRbS01LbQosITWum4ATmJ1Z6Pg==",
       "dev": true
     },
     "@webassemblyjs/ast": {
@@ -5217,11 +5195,6 @@
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
     },
-    "domino": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/domino/-/domino-2.1.3.tgz",
-      "integrity": "sha512-EwjTbUv1Q/RLQOdn9k7ClHutrQcWGsfXaRQNOnM/KgK4xDBoLFEcIRFuBSxAx13Vfa63X029gXYrNFrSy+DOSg=="
-    },
     "duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -5847,11 +5820,6 @@
           }
         }
       }
-    },
-    "file-saver": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.2.tgz",
-      "integrity": "sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw=="
     },
     "fileset": {
       "version": "2.0.3",
@@ -13688,11 +13656,18 @@
       }
     },
     "parse5-sax-parser": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/parse5-sax-parser/-/parse5-sax-parser-5.1.0.tgz",
-      "integrity": "sha512-VEhdEDhBkoSILPmsZ96SoIIUow3hZbtgQsqXw7r8DxxnqsCIO0fwkT9mWgBcf9SPjVUh92liuEprHrrYzXBPWQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5-sax-parser/-/parse5-sax-parser-5.1.1.tgz",
+      "integrity": "sha512-9HIh6zd7bF1NJe95LPCUC311CekdOi55R+HWXNCsGY6053DWaMijVKOv1oPvdvPTvFicifZyimBVJ6/qvG039Q==",
       "requires": {
-        "parse5": "^5.1.0"
+        "parse5": "^5.1.1"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+          "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
+        }
       }
     },
     "parseqs": {
@@ -14433,7 +14408,6 @@
       "requires": {
         "express": "^4.17.1",
         "jwks-rsa": "^1.6.0",
-        "lodash": ">=4.17.14",
         "mongodb": "^2.2.36",
         "ot-json0": "^1.1.0",
         "rich-text": "^3.1.0",
@@ -18272,11 +18246,6 @@
         "ultron": "~1.1.0"
       }
     },
-    "xhr2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
-      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8="
-    },
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
@@ -18425,11 +18394,6 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.9.1.tgz",
       "integrity": "sha512-GkPiJL8jifSrKReKaTZ5jkhrMEgXbXYC+IPo1iquBjayRa0q86w3Dipjn8b415jpitMExe9lV8iTsv8tk3DGag=="
-    },
-    "zxcvbn": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz",
-      "integrity": "sha1-KOwXzwl0PtyrBW3dixsGJizHPDA="
     }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -28,7 +28,6 @@
     "@angular/material": "^8.1.4",
     "@angular/platform-browser": "^8.2.4",
     "@angular/platform-browser-dynamic": "^8.2.4",
-    "@angular/platform-server": "^8.2.4",
     "@angular/pwa": "^0.803.2",
     "@angular/router": "^8.2.4",
     "@angular/service-worker": "^8.2.4",
@@ -45,7 +44,6 @@
     "core-js": "^2.6.5",
     "crc-32": "^1.2.0",
     "date-fns": "^1.30.1",
-    "file-saver": "^2.0.2",
     "hammerjs": "^2.0.8",
     "helphero": "^1.3.0",
     "jwt-decode": "^2.2.0",
@@ -64,8 +62,7 @@
     "sharedb": "^1.0.0-beta.22",
     "uuid": "^3.3.2",
     "xregexp": "^4.2.4",
-    "zone.js": "^0.9.1",
-    "zxcvbn": "^4.4.2"
+    "zone.js": "^0.9.1"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.803.2",
@@ -75,7 +72,6 @@
     "@angular/language-service": "^8.2.4",
     "@types/auth0-js": "^9.10.2",
     "@types/bson": "^1.0.11",
-    "@types/file-saver": "^2.0.1",
     "@types/jasmine": "~3.3.12",
     "@types/jasminewd2": "~2.0.6",
     "@types/jwt-decode": "^2.2.1",
@@ -84,7 +80,6 @@
     "@types/quill": "^1.3.10",
     "@types/uuid": "^3.4.5",
     "@types/xregexp": "^3.0.29",
-    "@types/zxcvbn": "^4.4.0",
     "codelyzer": "^5.1.0",
     "husky": "^2.2.0",
     "jasmine-core": "^3.4.0",


### PR DESCRIPTION
Removed:
- `@angular/platform-server`
- `file-saver`
- `zxcvbn`
And the associated types:
- `@types/file-saver`
- `@types/zxcvbn`
And from RealtimeServer:
- `lodash`
- `@types/lodash`

Both `core-js` and `@angular/pwa` appear to be currently unused, but I left them because I thought we are likely to use them in the future.

Perhaps some of these packages need to remain, however, I couldn't find that they are actually used. Everything builds fine (including a production build), the tests pass, and the app seems to work fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/409)
<!-- Reviewable:end -->
