### PR TITLE
Fix lgtm alerts and non-relative imports

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.ts
@@ -4,10 +4,10 @@ import { Operation } from 'realtime-server/lib/common/models/project-rights';
 import { Question } from 'realtime-server/lib/scriptureforge/models/question';
 import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/scriptureforge/models/sf-project-rights';
 import { fromVerseRef } from 'realtime-server/lib/scriptureforge/models/verse-ref-data';
-import { QuestionDoc } from 'src/app/core/models/question-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { UserService } from 'xforge-common/user.service';
 import { objectId } from 'xforge-common/utils';
+import { QuestionDoc } from '../../core/models/question-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { QuestionDialogComponent, QuestionDialogData, QuestionDialogResult } from './question-dialog.component';
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnDestroy, Output, ViewEncapsulation } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
 import isEqual from 'lodash/isEqual';
 import merge from 'lodash/merge';
 import Quill, { DeltaStatic, RangeStatic, Sources } from 'quill';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.ts
@@ -1,7 +1,7 @@
 import { MDC_DIALOG_DATA, MdcDialogRef } from '@angular-mdc/web/dialog';
 import { Component, Inject } from '@angular/core';
-import { environment } from 'src/environments/environment';
 import { issuesEmailTemplate } from 'xforge-common/utils';
+import { environment } from '../../environments/environment';
 
 export interface ErrorAlert {
   message: string;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -1,8 +1,8 @@
 import Bowser from 'bowser';
 import { ObjectId } from 'bson';
 import { VerseRef } from 'realtime-server/lib/scriptureforge/scripture-utils/verse-ref';
-import { environment } from 'src/environments/environment';
 import { version } from '../../../version.json';
+import { environment } from '../environments/environment';
 
 export function nameof<T>(name: Extract<keyof T, string>): string {
   return name;

--- a/src/SIL.XForge/Configuration/AudioOptions.cs
+++ b/src/SIL.XForge/Configuration/AudioOptions.cs
@@ -1,6 +1,6 @@
 namespace SIL.XForge.Configuration
 {
-    /// <sumary>
+    /// <summary>
     /// This class defines the audio configuration.
     /// </summary>
     public class AudioOptions


### PR DESCRIPTION
- Fixes two lgtm alerts (unused imports)
- Makes imports that start with `src/` relative (`../`). I'm not sure this is important, but we've been standardizing on it. If it is important, I have a very simple lgtm query that can catch this. I just don't know if it's actually important or not.
- Also fixes spelling in order to fix a C# doc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/410)
<!-- Reviewable:end -->
