### PR TITLE
Add lgtm query for js imports relative to project root

### DIFF
--- a/.lgtm/javascript-queries/import-relative-to-project-root.ql
+++ b/.lgtm/javascript-queries/import-relative-to-project-root.ql
@@ -1,0 +1,15 @@
+/**
+ * @name JavaScript import relative to project root
+ * @description For consistency, imports should be relative to the current file, rather than the project root.
+ * @kind problem
+ * @problem.severity recommendation
+ * @precision high
+ * @id js/import-relative-to-project-root
+ * @tags maintainability
+ */
+
+import javascript
+
+from ImportDeclaration id
+where id.getImportedPath().getComponent(0) = "src"
+select id.getImportedPath(), "JavaScript import relative to project root, rather than current file"


### PR DESCRIPTION
Finds imports that start with `src/`.

This has been tested. To see the kinds of alerts it would produce, see https://lgtm.com/projects/g/Nateowami/web-xforge-test/rev/pr-3ed316089d950f77aeb60176c42872419ef2ad96

I'm pretty sure this won't take effect immediately upon being merged, but after a day or two.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/414)
<!-- Reviewable:end -->
