### PR TITLE
SF-617 Release pending answers from buffer if user deletes own

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -240,6 +240,8 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
       action: 'delete',
       answer: answer
     });
+    // All answers should show next time any do.
+    this.showRemoteAnswers();
   }
 
   editAnswer(answer: Answer) {


### PR DESCRIPTION
* So that back at the 'Add answer' screen, there is not also a 'Show
unreads' banner.
* Add unit tests regarding the 'Show unreads' banner and
buffering remote answers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/420)
<!-- Reviewable:end -->
