### PR TITLE
SF-689 Compress answer tabs on med and lg viewports

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -39,10 +39,10 @@
         <mdc-tab-bar #answerTabs fixed>
           <mdc-tab-scroller>
             <mdc-tab icon="title" label="Answer"></mdc-tab>
-            <mdc-tab icon="library_music" label="Record/Upload" fxHide.xs></mdc-tab>
-            <mdc-tab icon="library_music" label="Record" fxShow.xs fxHide></mdc-tab>
-            <mdc-tab icon="text_rotation_none" label="Select Text" fxHide.xs></mdc-tab>
-            <mdc-tab icon="text_rotation_none" label="Select" fxShow.xs fxHide></mdc-tab>
+            <mdc-tab icon="library_music" label="Record/Upload" fxShow.sm fxShow.xl fxHide></mdc-tab>
+            <mdc-tab icon="library_music" label="Record" fxHide.sm fxHide.xl></mdc-tab>
+            <mdc-tab icon="text_rotation_none" label="Select Text" fxShow.sm fxShow.xl fxHide></mdc-tab>
+            <mdc-tab icon="text_rotation_none" label="Select" fxHide.sm fxHide.xl></mdc-tab>
           </mdc-tab-scroller>
         </mdc-tab-bar>
         <div [fxShow]="answerTabs.activeTabIndex === 0" class="answer-tab answer-text">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
@@ -96,16 +96,16 @@
     mdc-tab {
       padding: 0 16px;
     }
-    @include media-breakpoint-down(xs) {
-      mdc-tab {
-        padding: 0 10px;
-      }
-      mdc-tab:first-child {
-        padding-left: 0;
-      }
-      mdc-tab:last-child {
-        padding-right: 0;
-      }
+  }
+  @include media-breakpoint-down(xs) {
+    mdc-tab {
+      padding: 0 10px;
+    }
+    mdc-tab:first-child {
+      padding-left: 0;
+    }
+    mdc-tab:last-child {
+      padding-right: 0;
     }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
@@ -92,15 +92,20 @@
     display: flex;
     justify-content: flex-end;
   }
-  @include media-breakpoint-down(xs) {
+  @include media-breakpoint-down(lg) {
     mdc-tab {
-      padding: 0 10px;
+      padding: 0 16px;
     }
-    mdc-tab:first-child {
-      padding-left: 0;
-    }
-    mdc-tab:last-child {
-      padding-right: 0;
+    @include media-breakpoint-down(xs) {
+      mdc-tab {
+        padding: 0 10px;
+      }
+      mdc-tab:first-child {
+        padding-left: 0;
+      }
+      mdc-tab:last-child {
+        padding-right: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
The horizontal overflow for the answer tabs wasn't working when the viewport was med or larger (for reason I couldn't discover.) This change compresses the answer tabs so they don't overflow out of the page.
![Answer_Tabs_Before](https://user-images.githubusercontent.com/17931130/68904321-eb731580-06fa-11ea-9e86-bad46fe9c73c.PNG)
![Answer_Tabs_After](https://user-images.githubusercontent.com/17931130/68904330-ee6e0600-06fa-11ea-9648-feaf002e7d05.PNG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/422)
<!-- Reviewable:end -->
