### PR TITLE
Train saved segment before updating last user location

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -14,6 +14,7 @@ import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { UserService } from 'xforge-common/user.service';
 import { QuestionDoc } from '../../../core/models/question-doc';
 import { SFProjectUserConfigDoc } from '../../../core/models/sf-project-user-config-doc';
+import { SFProjectService } from '../../../core/sf-project.service';
 import { CheckingUtils } from '../../checking.utils';
 
 @Component({
@@ -33,7 +34,7 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
   private _activeQuestionVerseRef?: VerseRef;
   private storeQuestion: boolean = true;
 
-  constructor(private userService: UserService) {
+  constructor(private readonly userService: UserService, private readonly projectService: SFProjectService) {
     super();
     // Only mark as read if it has been viewed for a set period of time and not an accidental click
     this.subscribe(this.activeQuestionDoc$.pipe(debounceTime(2000)), questionDoc => {
@@ -242,6 +243,7 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
     if (this.projectUserConfigDoc != null && this.projectUserConfigDoc.data != null) {
       const activeQuestionDoc = this.activeQuestionDoc;
       if (activeQuestionDoc != null && activeQuestionDoc.data != null) {
+        await this.projectService.trainSelectedSegment(this.projectUserConfigDoc.data);
         await this.projectUserConfigDoc.submitJson0Op(op => {
           op.set<string>(puc => puc.selectedTask!, 'checking');
           op.set(puc => puc.selectedQuestionRef!, activeQuestionDoc.id);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -341,6 +341,7 @@ describe('CheckingComponent', () => {
       expect(projectUserConfigDoc.selectedTask).toBe('checking');
       expect(projectUserConfigDoc.selectedQuestionRef).toBe('project01:q4Id');
       expect(projectUserConfigDoc.selectedBookNum).toBe(43);
+      verify(mockedProjectService.trainSelectedSegment(anything())).once();
     }));
 
     it('saves the last question answered in all question context', fakeAsync(() => {
@@ -351,6 +352,7 @@ describe('CheckingComponent', () => {
       expect(projectUserConfigDoc.selectedTask).toBe('checking');
       expect(projectUserConfigDoc.selectedQuestionRef).toBe('project01:q4Id');
       expect(projectUserConfigDoc.selectedBookNum).toBeUndefined();
+      verify(mockedProjectService.trainSelectedSegment(anything())).once();
     }));
 
     it('can cancel answering a question', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/text-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/text-doc.ts
@@ -42,9 +42,9 @@ export class TextDoc extends RealtimeDoc<TextData, TextData> {
       for (let i = 0; i < this.data.ops.length; i++) {
         const op = this.data.ops[i];
         const nextOp = i < this.data.ops.length - 1 ? this.data.ops[i + 1] : undefined;
-        if (op.attributes && op.attributes.segment) {
+        if (op.attributes != null && op.attributes.segment != null) {
           if (op.insert.blank != null) {
-            const segRef: string = op.attributes != null ? op.attributes.segment : '';
+            const segRef = op.attributes.segment;
             if (
               nextOp == null ||
               nextOp.insert == null ||
@@ -60,6 +60,27 @@ export class TextDoc extends RealtimeDoc<TextData, TextData> {
       }
     }
     return { translated, blank };
+  }
+
+  getSegmentText(ref: string): string {
+    if (this.data == null || this.data.ops == null) {
+      return '';
+    }
+
+    let text = '';
+    let inSegment = false;
+    for (const op of this.data.ops) {
+      if (op.attributes != null && op.attributes.segment === ref) {
+        if (op.insert != null && typeof op.insert === 'string') {
+          text += op.insert;
+          inSegment = true;
+        }
+      } else if (inSegment) {
+        break;
+      }
+    }
+
+    return text;
   }
 
   protected prepareDataForStore(data: TextData): any {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/segment.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/segment.ts
@@ -9,7 +9,7 @@ export class Segment {
   private _checksum?: number;
   private initialTextLen: number = -1;
 
-  constructor(public readonly bookNum: number, public readonly ref: string) {}
+  constructor(public readonly bookNum: number, public readonly chapter: number, public readonly ref: string) {}
 
   get text(): string {
     return this._text;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -135,7 +135,6 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
   set id(value: TextDocId | undefined) {
     if (!isEqual(this._id, value)) {
       this._id = value;
-      this._segment = undefined;
       this.initialSegmentRef = undefined;
       this.initialSegmentChecksum = undefined;
       this.initialSegmentFocus = undefined;
@@ -481,11 +480,14 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
     focus: boolean = false,
     end: boolean = true
   ): boolean {
-    if (
-      this._id == null ||
-      this._editor == null ||
-      (this._segment != null && this._id.bookNum === this._segment.bookNum && segmentRef === this._segment.ref)
-    ) {
+    if (this._id == null || this._editor == null) {
+      return false;
+    }
+
+    if (this._segment != null && this._id.bookNum === this._segment.bookNum && segmentRef === this._segment.ref) {
+      if (focus) {
+        this._editor.focus();
+      }
       // the selection has not changed to a different segment
       return false;
     }
@@ -518,7 +520,7 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
     if (this._segment != null && this.highlightSegment) {
       this.toggleHighlight(false);
     }
-    this._segment = new Segment(this._id.bookNum, segmentRef);
+    this._segment = new Segment(this._id.bookNum, this._id.chapterNum, segmentRef);
     if (checksum != null) {
       this._segment.initialChecksum = checksum;
     }


### PR DESCRIPTION
- add trainSelectedSegment() to SFProjectService
- preserve current segment when switching books or chapters
- ensure that the correct source segment is selected when focus returned
to selected target segment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/423)
<!-- Reviewable:end -->
