### PR TITLE
SF-617 Buffer answers if can't add answer

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -82,13 +82,12 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
       this.questionChangeSubscription!.unsubscribe();
     }
     this.questionChangeSubscription = this.subscribe(questionDoc.remoteChanges$, () => {
-      // If any answers are added by someone else before this user answers the question
-      // to reveal answers, include those new answers in what will be shown when we first
-      // show the answers.
-      if (this.currentUserTotalAnswers > 0) {
-        return;
+      // If the user hasn't added an answer yet and is able to, then
+      // don't hold back any incoming answers from appearing right away
+      // as soon as the user adds their answer.
+      if (this.currentUserTotalAnswers === 0 && this.canAddAnswer) {
+        this.showRemoteAnswers();
       }
-      this.showRemoteAnswers();
     });
   }
   @Input() checkingTextComponent?: CheckingTextComponent;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -620,6 +620,34 @@ describe('CheckingComponent', () => {
       expect(env.showUnreadAnswersButton).toBeNull();
     }));
 
+    it('new remote answers from other users are not displayed to proj admin until requested', fakeAsync(() => {
+      const env = new TestEnvironment(ADMIN_USER);
+      // Select a question with at least one answer, but with no answers
+      // authored by the project admin since that was hindering this test.
+      env.selectQuestion(6);
+
+      expect(env.answers.length).toEqual(1, 'setup');
+      expect(env.component.answersPanel!.answers.length).toEqual(1, 'setup');
+      expect(env.showUnreadAnswersButton).toBeNull();
+
+      env.simulateNewRemoteAnswer();
+
+      // New remote answer is buffered rather than shown immediately.
+      expect(env.answers.length).toEqual(1);
+      expect(env.component.answersPanel!.answers.length).toEqual(1);
+
+      // show-unread-answers banner appears.
+      expect(env.showUnreadAnswersButton).not.toBeNull();
+      expect(env.showUnreadAnswersButton.nativeElement.innerText).toContain(' 1 ', 'should have shown unread count');
+
+      // Clicking makes the answer appear and the control go away.
+      env.clickButton(env.showUnreadAnswersButton);
+      flush();
+      expect(env.answers.length).toEqual(2);
+      expect(env.component.answersPanel!.answers.length).toEqual(2);
+      expect(env.showUnreadAnswersButton).toBeNull();
+    }));
+
     it('new remote answers and banner dont show, if user has not yet answered the question', fakeAsync(() => {
       const env = new TestEnvironment(CHECKER_USER);
       env.selectQuestion(7);


### PR DESCRIPTION
* The project admin was seeing new answers right away without them
being held back with a show-more banner. This is because a project
admin isn't shown the 'Add answer' screen even if
currentUserTotalAnswers === 0. They are just shown the screen with a
list of answers.
* Check if the current user is even able to add an answer when
deciding whether to buffer. If they can't then buffer.
* Then it successfully buffers for a project admin.


===

See attached 1-minute animation where incoming answers are buffered for a project admin (on the right) even tho the project admin owns no answers. This is demo'd with only a couple answers, but will no doubt more clearly be useful when there are 20 answers.

![projAdminBuffer](https://user-images.githubusercontent.com/7265309/68952253-cd4df980-077c-11ea-9cce-b4d6ae74955d.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/426)
<!-- Reviewable:end -->
