### PR TITLE
SF-617 Include buffered answers in total answer heading count

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -95,7 +95,10 @@
     </div>
     <div class="answers-container">
       <ng-container *ngIf="!answerFormVisible && answers.length > 0 && (currentUserTotalAnswers > 0 || !canAddAnswer)">
-        <h3 id="totalAnswersMessage">{{ totalAnswersHeading }}</h3>
+        <h3 id="totalAnswersMessage">
+          <div *ngIf="shouldReportAnswerCountInHeading; else noAnswerCountReport">{{ totalAnswers }} Answers</div>
+          <ng-template #noAnswerCountReport><div>Your Answer</div></ng-template>
+        </h3>
         <div class="answer" *ngFor="let answer of answers" [ngClass]="{ 'answer-unread': !hasUserReadAnswer(answer) }">
           <div *ngIf="canSeeOtherUserResponses" class="like">
             <button
@@ -156,7 +159,7 @@
   </div>
   <div class="answers-component-footer" *ngIf="remoteAnswersCount > 0">
     <button mdc-button id="show-unread-answers-button" (click)="showRemoteAnswers()">
-      show {{ remoteAnswersCount }} more unread answers
+      Show {{ remoteAnswersCount }} more unread answers
     </button>
   </div>
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
@@ -203,3 +203,9 @@
   display: inline-block;
   font-style: italic;
 }
+
+.answers-component-footer {
+  button {
+    display: block;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -191,12 +191,12 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     return this._questionDoc;
   }
 
-  get totalAnswersHeading(): string {
-    if (this.canSeeOtherUserResponses || !this.canAddAnswer) {
-      return this.answers.length + ' Answers';
-    } else {
-      return 'Your Answer';
-    }
+  get shouldReportAnswerCountInHeading(): boolean {
+    return this.canSeeOtherUserResponses || !this.canAddAnswer;
+  }
+
+  get totalAnswers(): number {
+    return this.allAnswers.length;
   }
 
   private get projectRole(): SFProjectRole {


### PR DESCRIPTION
* Splitting up the h3 conditionally, and adding spans, to make testing
the DOM simple.
* Adding similar assertions for 'Show unreads' banner answer count
from DOM.
* Styling .answers-component-footer button was needed to maintain
spacing in the 'Show more' button around the unshown answer count.

==

See animation where answers header includes the count of buffered/unshown answers.

![incudeInHeader](https://user-images.githubusercontent.com/7265309/69063765-48601b80-09da-11ea-939f-e8a825c7ce8d.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/429)
<!-- Reviewable:end -->

Update: Testing the change to use "ngIf else" shows that it correctly works with respect to "See other's answers and comments" and still shows the correct count in the header when it shows a count.