### PR TITLE
SF-663 Fix answer tab overflow

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -39,10 +39,8 @@
         <mdc-tab-bar #answerTabs fixed>
           <mdc-tab-scroller>
             <mdc-tab icon="title" label="Answer"></mdc-tab>
-            <mdc-tab icon="library_music" label="Record/Upload" fxHide.xs></mdc-tab>
-            <mdc-tab icon="library_music" label="Record" fxShow.xs fxHide></mdc-tab>
-            <mdc-tab icon="text_rotation_none" label="Select Text" fxHide.xs></mdc-tab>
-            <mdc-tab icon="text_rotation_none" label="Select" fxShow.xs fxHide></mdc-tab>
+            <mdc-tab icon="library_music" label="{{ media.isActive('xs') ? 'Record' : 'Record/Upload' }}"></mdc-tab>
+            <mdc-tab icon="text_rotation_none" label="{{ media.isActive('xs') ? 'Select' : 'Select Text' }}"></mdc-tab>
           </mdc-tab-scroller>
         </mdc-tab-bar>
         <div [fxShow]="answerTabs.activeTabIndex === 0" class="answer-tab answer-text">
@@ -57,17 +55,14 @@
             ></mdc-text-field>
           </mdc-form-field>
         </div>
-        <div
-          [fxShow]="answerTabs.activeTabIndex === 1 || answerTabs.activeTabIndex === 2"
-          class="answer-tab answer-record-upload"
-        >
+        <div [fxShow]="answerTabs.activeTabIndex === 1" class="answer-tab answer-record-upload">
           <app-checking-audio-combined
             [source]="activeAnswer?.audioUrl"
             (update)="processAudio($event)"
           ></app-checking-audio-combined>
         </div>
         <div
-          [fxHide]="!(answerTabs.activeTabIndex === 3 || answerTabs.activeTabIndex === 4)"
+          [fxHide]="answerTabs.activeTabIndex !== 2"
           class="answer-tab answer-select-text"
           [class.text-selected]="selectedText"
         >

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
@@ -92,15 +92,9 @@
     display: flex;
     justify-content: flex-end;
   }
-  @include media-breakpoint-down(xs) {
+  @include media-breakpoint-down(lg) {
     mdc-tab {
       padding: 0 10px;
-    }
-    mdc-tab:first-child {
-      padding-left: 0;
-    }
-    mdc-tab:last-child {
-      padding-right: 0;
     }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -1,5 +1,6 @@
 import { MdcDialog } from '@angular-mdc/web/dialog';
 import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
+import { MediaObserver } from '@angular/flex-layout';
 import { AbstractControl, FormControl, FormGroup, Validators } from '@angular/forms';
 import cloneDeep from 'lodash/cloneDeep';
 import { Operation } from 'realtime-server/lib/common/models/project-rights';
@@ -115,7 +116,8 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     private readonly userService: UserService,
     private readonly dialog: MdcDialog,
     private readonly noticeService: NoticeService,
-    private readonly questionDialogService: QuestionDialogService
+    private readonly questionDialogService: QuestionDialogService,
+    public media: MediaObserver
   ) {
     super();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -26,7 +26,9 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-    width: 100%;
+    flex-grow: 1;
+    // setting min width prevents the element from overflowing the flex parent
+    min-width: 0;
     .chapter-select {
       cursor: pointer;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1099,7 +1099,7 @@ class TestEnvironment {
   }
 
   get audioTab(): DebugElement {
-    return this.fixture.debugElement.query(By.css('#answer-form mdc-tab[label="Record/Upload"]'));
+    return this.fixture.debugElement.query(By.css('#answer-form mdc-tab:nth-child(2)'));
   }
 
   get removeAudioButton(): DebugElement {
@@ -1128,7 +1128,7 @@ class TestEnvironment {
   }
 
   get selectTextTab(): DebugElement {
-    return this.fixture.debugElement.query(By.css('#answer-form mdc-tab[label="Select Text"]'));
+    return this.fixture.debugElement.query(By.css('#answer-form mdc-tab:nth-child(3)'));
   }
 
   get selectVersesButton(): DebugElement {


### PR DESCRIPTION
There turned out to be two problems here:
1. The main component (`#text-panel`), being a child in a flex layout, automatically has a `min-width` of `auto` (content size). This allowed its content to overflow the parent.
2. Some of the tabs were hidden, and this appears to mess up the automatic scrolling functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/431)
<!-- Reviewable:end -->
