### PR TITLE
Inject browser globals and mock them in tests

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.ts
@@ -1,5 +1,6 @@
-import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Inject, OnDestroy, OnInit, Output } from '@angular/core';
 import RecordRTC from 'recordrtc';
+import { NAVIGATOR } from 'xforge-common/browser-globals';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { UserService } from 'xforge-common/user.service';
@@ -23,7 +24,11 @@ export class CheckingAudioRecorderComponent implements OnInit, OnDestroy {
   private recordRTC?: RecordRTC;
   private user?: UserDoc;
 
-  constructor(private userService: UserService, private noticeService: NoticeService) {}
+  constructor(
+    private readonly userService: UserService,
+    private readonly noticeService: NoticeService,
+    @Inject(NAVIGATOR) private readonly navigator: Navigator
+  ) {}
 
   get hasAudioAttachment(): boolean {
     return this.audioUrl !== '';
@@ -69,7 +74,7 @@ export class CheckingAudioRecorderComponent implements OnInit, OnDestroy {
 
   startRecording() {
     const mediaConstraints: MediaStreamConstraints = { audio: true };
-    navigator.mediaDevices
+    this.navigator.mediaDevices
       .getUserMedia(mediaConstraints)
       .then(this.successCallback.bind(this), this.errorCallback.bind(this));
     this.status.emit({ status: 'recording' });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
@@ -3,6 +3,7 @@ import { Component, ElementRef, Inject, OnDestroy, Optional, ViewChild } from '@
 import { toVerseRef, VerseRefData } from 'realtime-server/lib/scriptureforge/models/verse-ref-data';
 import { Canon } from 'realtime-server/lib/scriptureforge/scripture-utils/canon';
 import { VerseRef } from 'realtime-server/lib/scriptureforge/scripture-utils/verse-ref';
+import { DOCUMENT } from 'xforge-common/browser-globals';
 import { TextDocId } from '../core/models/text-doc';
 import { TextsByBookId } from '../core/models/texts-by-book-id';
 import {
@@ -51,13 +52,14 @@ export class TextChooserDialogComponent implements OnDestroy {
   constructor(
     private readonly dialogRef: MdcDialogRef<TextChooserDialogComponent>,
     readonly dialog: MdcDialog,
+    @Inject(DOCUMENT) private readonly document: Document,
     @Optional() @Inject(MDC_DIALOG_DATA) private readonly data: TextChooserDialogData
   ) {
     // caniuse doesn't have complete data for the selection events api, but testing on BrowserStack shows the event is
     // fired at least as far back as iOS v7 on Safari 7.
     // Edge 42 with EdgeHTML 17 also fires the events.
     // Firefox and Chrome also support it. We can degrade gracefully by getting the selection when the dialog closes.
-    document.addEventListener('selectionchange', this.selectionChangeHandler);
+    this.document.addEventListener('selectionchange', this.selectionChangeHandler);
 
     this.bookNum = this.data.bookNum;
     this.chapterNum = this.data.chapterNum;
@@ -72,7 +74,7 @@ export class TextChooserDialogComponent implements OnDestroy {
   }
 
   updateSelection() {
-    const selection = document.getSelection();
+    const selection = this.document.getSelection();
     const rawSelection = (selection || '').toString();
     if (selection != null && rawSelection.trim() !== '' && rawSelection !== this.rawTextSelection) {
       // all non-empty verse elements in the selection
@@ -145,7 +147,7 @@ export class TextChooserDialogComponent implements OnDestroy {
   }
 
   ngOnDestroy() {
-    document.removeEventListener('selectionchange', this.selectionChangeHandler);
+    this.document.removeEventListener('selectionchange', this.selectionChangeHandler);
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -26,6 +26,7 @@ import {
 import * as RichText from 'rich-text';
 import { BehaviorSubject, defer, Subject } from 'rxjs';
 import { anything, deepEqual, instance, mock, resetCalls, verify, when } from 'ts-mockito';
+import { CONSOLE } from 'xforge-common/browser-globals';
 import { NoticeService } from 'xforge-common/notice.service';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
@@ -45,6 +46,18 @@ const mockedUserService = mock(UserService);
 const mockedNoticeService = mock(NoticeService);
 const mockedActivatedRoute = mock(ActivatedRoute);
 
+class MockConsole {
+  log(val: any) {
+    if (
+      typeof val !== 'string' ||
+      (!/(Translated|Trained) segment, length: \d+, time: \d+\.\d+ms/.test(val) &&
+        !/Segment \w+ of document \w+ was trained successfully\./.test(val))
+    ) {
+      console.log(val);
+    }
+  }
+}
+
 describe('EditorComponent', () => {
   configureTestingModule(() => ({
     declarations: [EditorComponent, SuggestionsComponent],
@@ -53,7 +66,8 @@ describe('EditorComponent', () => {
       { provide: SFProjectService, useMock: mockedSFProjectService },
       { provide: UserService, useMock: mockedUserService },
       { provide: NoticeService, useMock: mockedNoticeService },
-      { provide: ActivatedRoute, useMock: mockedActivatedRoute }
+      { provide: ActivatedRoute, useMock: mockedActivatedRoute },
+      { provide: CONSOLE, useValue: new MockConsole() }
     ]
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1,5 +1,5 @@
 import { MdcDialog } from '@angular-mdc/web/dialog';
-import { AfterViewInit, Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, Inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { MediaObserver } from '@angular/flex-layout';
 import { ActivatedRoute } from '@angular/router';
 import {
@@ -21,6 +21,7 @@ import { TextInfo } from 'realtime-server/lib/scriptureforge/models/text-info';
 import { Canon } from 'realtime-server/lib/scriptureforge/scripture-utils/canon';
 import { fromEvent, Subject, Subscription, timer } from 'rxjs';
 import { debounceTime, delayWhen, filter, repeat, retryWhen, tap } from 'rxjs/operators';
+import { CONSOLE, ConsoleInterface } from 'xforge-common/browser-globals';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { NoticeService } from 'xforge-common/notice.service';
 import { UserService } from 'xforge-common/user.service';
@@ -92,7 +93,8 @@ export class EditorComponent extends DataLoadingComponent implements OnInit, OnD
     noticeService: NoticeService,
     private readonly helpHeroService: HelpHeroService,
     private readonly dialog: MdcDialog,
-    private readonly mediaObserver: MediaObserver
+    private readonly mediaObserver: MediaObserver,
+    @Inject(CONSOLE) private readonly console: ConsoleInterface
   ) {
     super(noticeService);
     const wordTokenizer = new LatinWordTokenizer();
@@ -624,7 +626,7 @@ export class EditorComponent extends DataLoadingComponent implements OnInit, OnD
     if (sourceSegment === this.source.segmentText) {
       this.translationSession = translationSession;
       const finish = performance.now();
-      console.log(`Translated segment, length: ${words.length}, time: ${finish - start}ms`);
+      this.console.log(`Translated segment, length: ${words.length}, time: ${finish - start}ms`);
     }
   }
 
@@ -704,7 +706,7 @@ export class EditorComponent extends DataLoadingComponent implements OnInit, OnD
 
     await this.translationSession.approve(true);
     segment.acceptChanges();
-    console.log(
+    this.console.log(
       'Segment ' + segment.ref + ' of document ' + Canon.bookNumberToId(segment.bookNum) + ' was trained successfully.'
     );
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
@@ -15,7 +15,7 @@ import { NONE_ROLE, ProjectRoleInfo } from 'xforge-common/models/project-role-in
 import { UserProfileDoc } from 'xforge-common/models/user-profile-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
-import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { configureTestingModule, emptyHammerLoader, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
 import { SFProjectDoc } from '../../core/models/sf-project-doc';
@@ -40,7 +40,8 @@ describe('CollaboratorsComponent', () => {
       { provide: LocationService, useMock: mockedLocationService },
       { provide: NoticeService, useMock: mockedNoticeService },
       { provide: SFProjectService, useMock: mockedProjectService },
-      { provide: UserService, useMock: mockedUserService }
+      { provide: UserService, useMock: mockedUserService },
+      emptyHammerLoader
     ]
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/browser-globals.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/browser-globals.ts
@@ -1,0 +1,35 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * Alias for the Console interface defined in globals.d.ts and lib.dom.d.ts. Using Console as a constructor's parameter
+ * type results in `ReferenceError: Console is not defined` at run time. This is because a reference to Console is in
+ * the output, as part of the constructor's metadata, despite Console not being defined in the browser.
+ */
+export type ConsoleInterface = Console;
+
+/**
+ * InjectionToken for window.console
+ */
+export const CONSOLE = new InjectionToken<Console>('Console', {
+  providedIn: 'root',
+  factory: () => window.console
+});
+
+/**
+ * InjectionToken for window.document.
+ * Angular has its own DOCUMENT injection token, but if we use that token to mock the document in the tests, then
+ * Angular won't be able to access the document. By using a separate injection token we can mock the document in our
+ * code but Angular will still have the actual document.
+ */
+export const DOCUMENT = new InjectionToken<Document>('Document', {
+  providedIn: 'root',
+  factory: () => window.document
+});
+
+/**
+ * InjectionToken for window.navigator
+ */
+export const NAVIGATOR = new InjectionToken<Navigator>('Navigator', {
+  providedIn: 'root',
+  factory: () => window.navigator
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-reporting.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-reporting.service.ts
@@ -44,7 +44,7 @@ export class ErrorReportingService {
 
   private readonly bugsnagClient = ErrorReportingService.createBugsnagClient();
 
-  notify(error: any, opts?: any, cb?: (err: any, report: any) => void): void {
-    this.bugsnagClient.notify(error, opts, cb);
+  notify(error: any, opts?: any, callback?: (err: any, report: any) => void): void {
+    this.bugsnagClient.notify(error, opts, callback);
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.spec.ts
@@ -17,7 +17,7 @@ import { ProjectService } from '../project.service';
 import { Filters, QueryParameters } from '../query-parameters';
 import { RealtimeDocTypes } from '../realtime-doc-types';
 import { TestRealtimeService } from '../test-realtime.service';
-import { configureTestingModule } from '../test-utils';
+import { configureTestingModule, emptyHammerLoader } from '../test-utils';
 import { UICommonModule } from '../ui-common.module';
 import { UserService } from '../user.service';
 import { SaProjectsComponent } from './sa-projects.component';
@@ -33,7 +33,8 @@ describe('SaProjectsComponent', () => {
     providers: [
       { provide: NoticeService, useMock: mockedNoticeService },
       { provide: ProjectService, useMock: mockedProjectService },
-      { provide: UserService, useMock: mockedUserService }
+      { provide: UserService, useMock: mockedUserService },
+      emptyHammerLoader
     ]
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.spec.ts
@@ -23,7 +23,7 @@ import { ProjectService } from '../project.service';
 import { Filters, QueryParameters } from '../query-parameters';
 import { RealtimeDocTypes } from '../realtime-doc-types';
 import { TestRealtimeService } from '../test-realtime.service';
-import { configureTestingModule } from '../test-utils';
+import { configureTestingModule, emptyHammerLoader } from '../test-utils';
 import { UICommonModule } from '../ui-common.module';
 import { UserService } from '../user.service';
 import { SaDeleteDialogComponent } from './sa-delete-dialog.component';
@@ -42,7 +42,8 @@ describe('SaUsersComponent', () => {
       { provide: MdcDialog, useMock: mockedMdcDialog },
       { provide: NoticeService, useMock: mockedNoticeService },
       { provide: UserService, useMock: mockedUserService },
-      { provide: ProjectService, useMock: mockedProjectService }
+      { provide: ProjectService, useMock: mockedProjectService },
+      emptyHammerLoader
     ]
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-utils.ts
@@ -1,4 +1,5 @@
 import { TestBed, TestModuleMetadata } from '@angular/core/testing';
+import { HAMMER_LOADER } from '@angular/platform-browser';
 import { TranslocoTestingModule } from '@ngneat/transloco';
 import { configureTestSuite } from 'ng-bullet';
 import { instance, reset } from 'ts-mockito';
@@ -48,3 +49,9 @@ export const TestTranslocoModule = TranslocoTestingModule.withLangs(
     defaultLang: 'en'
   }
 );
+
+// used to prevent Angular from complaining that HammerJS isn't available
+export const emptyHammerLoader = {
+  provide: HAMMER_LOADER,
+  useValue: () => new Promise(() => {})
+};


### PR DESCRIPTION
A number of tests produce a significant amount of logging in the console, resulting in a noisy output. This is especially bad in the exception handling service, which logs errors complete with stack traces. I've mocked the console object to suppress messages that are expected.

There are also some places where the tests overwrite a global variable in order to mock it. This works, but is rather hackish. In the places I'm aware of that have this issue, the global value (e.g. document, console, navigator) is now injected so it can be mocked in the tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/433)
<!-- Reviewable:end -->
