### PR TITLE
SF-617 Show total answer count header if there are any answers

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -94,7 +94,7 @@
       </form>
     </div>
     <div class="answers-container">
-      <ng-container *ngIf="!answerFormVisible && answers.length > 0 && (currentUserTotalAnswers > 0 || !canAddAnswer)">
+      <ng-container *ngIf="shouldShowAnswers">
         <h3 id="totalAnswersMessage">
           <div *ngIf="shouldReportAnswerCountInHeading; else noAnswerCountReport">{{ totalAnswers }} Answers</div>
           <ng-template #noAnswerCountReport><div>Your Answer</div></ng-template>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -195,6 +195,10 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     return this.canSeeOtherUserResponses || !this.canAddAnswer;
   }
 
+  get shouldShowAnswers(): boolean {
+    return !this.answerFormVisible && this.totalAnswers > 0 && (this.currentUserTotalAnswers > 0 || !this.canAddAnswer);
+  }
+
   get totalAnswers(): number {
     return this.allAnswers.length;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -671,7 +671,7 @@ describe('CheckingComponent', () => {
       env.deleteAnswer('a6Id');
 
       // Total answers header goes away.
-      expect(env.totalAnswersMessageCount).toEqual(-1);
+      expect(env.totalAnswersMessageCount).toBeNull();
 
       // A remote answer is added
       env.simulateNewRemoteAnswer('remoteAnswerId123');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -657,6 +657,28 @@ describe('CheckingComponent', () => {
       expect(env.totalAnswersMessageCount).toEqual(2);
     }));
 
+    it('proj admin sees total answer count if >0 answers', fakeAsync(() => {
+      const env = new TestEnvironment(ADMIN_USER);
+      // Select a question with at least one answer, but with no answers
+      // authored by the project admin, in case that hinders this test.
+      env.selectQuestion(6);
+
+      expect(env.answers.length).toEqual(1, 'setup');
+      expect(env.component.answersPanel!.answers.length).toEqual(1, 'setup');
+      expect(env.showUnreadAnswersButton).toBeNull();
+      expect(env.totalAnswersMessageCount).toEqual(1);
+      // Delete only answer on question.
+      env.deleteAnswer('a6Id');
+
+      // Total answers header goes away.
+      expect(env.totalAnswersMessageCount).toEqual(-1);
+
+      // A remote answer is added
+      env.simulateNewRemoteAnswer('remoteAnswerId123');
+      // The total answers header comes back.
+      expect(env.totalAnswersMessageCount).toEqual(1);
+    }));
+
     it('new remote answers and banner dont show, if user has not yet answered the question', fakeAsync(() => {
       const env = new TestEnvironment(CHECKER_USER);
       env.selectQuestion(7);


### PR DESCRIPTION
* ..., including buffered answers.
* Otherwise, a project admin can be looking at a screen with no
answers, no answer header, and a banner saying 'Show 1 more unread
answers'. Now the project admin will also see a header saying '1
Answers'.

===

A key change here was changing from using `answers.length` to using `this.totalAnswers`.

See animation below, where the project admin on the right-hand screen sees a total answer count even if all answers are buffered.

![projectAdminSeesTotal](https://user-images.githubusercontent.com/7265309/69357379-37194800-0c42-11ea-9863-4a35008caf1a.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/434)
<!-- Reviewable:end -->
