### PR TITLE
SF-617 Don't show show-more  banner to users if can not see others ans

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -105,7 +105,7 @@
       <div class="answers-container">
         <ng-container *ngIf="shouldShowAnswers">
           <h3 id="totalAnswersMessage">
-            <div *ngIf="shouldReportAnswerCountInHeading; else noAnswerCountReport">
+            <div *ngIf="shouldSeeAnswersList; else noAnswerCountReport">
               {{ t("answers", { count: totalAnswers }) }}
             </div>
             <ng-template #noAnswerCountReport
@@ -174,7 +174,7 @@
         </ng-container>
       </div>
     </div>
-    <div class="answers-component-footer" *ngIf="remoteAnswersCount > 0 && !answerFormVisible">
+    <div class="answers-component-footer" *ngIf="remoteAnswersCount > 0 && !answerFormVisible && shouldSeeAnswersList">
       <button mdc-button id="show-unread-answers-button" (click)="showRemoteAnswers()">
         {{ t("show_more_unread", { count: remoteAnswersCount }) }}
       </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -133,7 +133,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
       return [];
     }
 
-    if (this.canSeeOtherUserResponses || !this.canAddAnswer) {
+    if (this.shouldSeeAnswersList) {
       return this._questionDoc.data.answers.filter(
         answer => answer.ownerRef === this.userService.currentUserId || this.answersToShow.includes(answer.dataId)
       );
@@ -192,7 +192,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     return this._questionDoc;
   }
 
-  get shouldReportAnswerCountInHeading(): boolean {
+  get shouldSeeAnswersList(): boolean {
     return this.canSeeOtherUserResponses || !this.canAddAnswer;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -798,6 +798,37 @@ describe('CheckingComponent', () => {
       expect(env.unreadAnswersBannerCount).toEqual(1);
     }));
 
+    it('show-remote-answer banner not shown to user if see-others-answers is disabled', fakeAsync(() => {
+      const env = new TestEnvironment(CHECKER_USER);
+      env.setSeeOtherUserResponses(false);
+      expect(env.component.projectDoc!.data!.checkingConfig.usersSeeEachOthersResponses).toBe(false, 'setup');
+      env.selectQuestion(7);
+      // User answers a question
+      env.answerQuestion('New answer from current user');
+      expect(env.totalAnswersMessageText).toEqual('Your answer', 'setup');
+
+      // A remote answer is added.
+      env.simulateNewRemoteAnswer();
+      expect(env.totalAnswersMessageText).toEqual('Your answer');
+      // Banner is not shown
+      expect(env.showUnreadAnswersButton).toBeNull();
+    }));
+
+    it('show-remote-answer banner still shown to proj admin if see-others-answers is disabled', fakeAsync(() => {
+      const env = new TestEnvironment(ADMIN_USER);
+      env.setSeeOtherUserResponses(false);
+      expect(env.component.projectDoc!.data!.checkingConfig.usersSeeEachOthersResponses).toBe(false, 'setup');
+      // Select a question with no answers authored by the project admin, in case that hinders this test.
+      env.selectQuestion(6);
+      expect(env.totalAnswersMessageCount).toEqual(1, 'setup');
+
+      // A remote answer is added.
+      env.simulateNewRemoteAnswer();
+      expect(env.totalAnswersMessageCount).toEqual(2);
+      // Banner is shown
+      expect(env.showUnreadAnswersButton).not.toBeNull();
+    }));
+
     describe('Comments', () => {
       it('can comment on an answer', fakeAsync(() => {
         const env = new TestEnvironment(CHECKER_USER);
@@ -1208,6 +1239,14 @@ class TestEnvironment {
 
   get showUnreadAnswersButton(): DebugElement {
     return this.fixture.debugElement.query(By.css('#show-unread-answers-button'));
+  }
+
+  get totalAnswersMessageText(): string | null {
+    const element = document.querySelector('#totalAnswersMessage');
+    if (element == null) {
+      return null;
+    }
+    return element.textContent;
   }
 
   get totalAnswersMessageCount(): number | null {


### PR DESCRIPTION
* If the project disallows users seeing each other's answers, don't
show a show-more-answers banner to users.
* But show it to project admins still since they can see all the
answers.
* 'Your answer' should continue to show to users if they have an
answer on a not-see-others-answers project.

===

See 1:20 animation showing the behaviour of the dont-show-others-answers setting on whether the show-more-unreads banner displays for checkers and admins (the admin is on the right), whether checkers see 'Your answer' or 'n Answers' in the answer list header, and that an admin sees 'n Answers'.

![notseeother-1m20](https://user-images.githubusercontent.com/7265309/69449685-af523d00-0d18-11ea-92e8-ce02938b9abe.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/436)
<!-- Reviewable:end -->
