### PR TITLE
SF-685 Fix exception selecting text with non-Roman script

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
@@ -147,6 +147,24 @@ describe('TextChooserDialogComponent', () => {
     env.closeDialog();
   }));
 
+  it('can handle Arabic', fakeAsync(async () => {
+    const env = new TestEnvironment(
+      TestEnvironment.defaultDialogData,
+      [
+        {
+          startOffset: 2,
+          endOffset: 38 // 26 Unicode code points, but 38 JavaScript chars
+        }
+      ],
+      'verse_1_6',
+      'verse_1_6',
+      'changed'
+    );
+    env.fireSelectionChange();
+    expect(env.selectedText).toEqual('وَقَعَتِ الأحْداثُ التّالِيَةُ فَي أيّامِ (MAT 1:6)');
+    env.closeDialog();
+  }));
+
   it('indicates when not all segments of the end verse were selected', fakeAsync(async () => {
     const env = new TestEnvironment(
       TestEnvironment.defaultDialogData,
@@ -427,6 +445,8 @@ class TestEnvironment {
     delta.insert({ verse: { number: '5', style: 'v' } });
     delta.insert(`target: chapter 1, `, { segment: 'verse_1_5' });
     delta.insert('\n', { para: { style: 'p' } });
+    delta.insert({ verse: { number: '6', style: 'v' } });
+    delta.insert(`وَقَعَتِ الأحْداثُ التّالِيَةُ فَي أيّامِ أحَشْوِيرُوشَ.`, { segment: 'verse_1_6' });
     this.realtimeService.addSnapshot(TextDoc.COLLECTION, {
       id: getTextDocId(TestEnvironment.PROJECT01, bookNum, 1, 'target'),
       type: RichText.type.name,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
@@ -182,13 +182,16 @@ export class TextChooserDialogComponent implements OnDestroy {
 
     let startTrimLength = startText.length - startText.trimLeft().length;
     if (startTrimLength === 0 && startText !== '') {
+      // [\s\S] matches ANY character including \n, unlike .
+      // \u200B is zero width space
       // Find the last word boundary that isn't the end of the string. This works because * is greedy.
       startTrimLength =
-        /[\s\S]*\b(?=[\s\S])/.exec(startNodeText.substring(0, startOffset + 1))![0].length - startOffset;
+        /[\s\S]*(?:\u200B|\b|\s|^)(?=[\s\S])/.exec(startNodeText.substring(0, startOffset + 1))![0].length -
+        startOffset;
     }
     let endTrimLength = endText.length - endText.trimRight().length;
     if (endTrimLength === 0 && endText !== '') {
-      endTrimLength = -Math.max(0, endNodeText.substring(endOffset - 1).search(/[\s\S]\b/));
+      endTrimLength = -Math.max(0, endNodeText.substring(endOffset - 1).search(/[\s\S](?:\u200B|\b|\s|$)/));
     }
 
     let result = [startNodeText, centralSelection, segments.length === 1 ? '' : endNodeText].filter(s => s).join(' ');


### PR DESCRIPTION
Previously the logic for finding the nearest word boundary was to search for word boundaries with `\b` in a regex. Unfortunately, this doesn't work for non-Roman scripts.

Instead we are now searching for white space, zero-width space, or word boundary. I've added a test for Arabic that fails before making this change and now passes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/438)
<!-- Reviewable:end -->
