### PR TITLE
Remind users their browser is unsupported when an error occurs

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.html
@@ -7,13 +7,18 @@
         <p>
           To report an issue, email <a target="_blank" [href]="issueMailTo">{{ issueEmail }}</a>
         </p>
+        <p *ngIf="browserUnsupported">
+          You are using an unsupported browser, which may be the reason for this error. We recommend upgrading to the
+          latest <a target="_blank" href="https://www.google.com/chrome/">Chrome</a> or
+          <a target="_blank" href="https://www.mozilla.org">Firefox.</a>
+        </p>
         <a (click)="this.showDetails = !this.showDetails" [fxShow]="data.stack"
           >{{ showDetails ? "Hide" : "Show" }} details</a
         >
         <pre [fxShow]="showDetails">{{ data.stack }}</pre>
       </mdc-dialog-content>
       <mdc-dialog-actions>
-        <button default mdcDialogButton type="button" mdcDialogAction="close">Close</button>
+        <button mdcDialogButton type="button" mdcDialogAction="close">Close</button>
       </mdc-dialog-actions>
     </mdc-dialog-surface>
   </mdc-dialog-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.ts
@@ -1,6 +1,6 @@
 import { MDC_DIALOG_DATA, MdcDialogRef } from '@angular-mdc/web/dialog';
 import { Component, Inject } from '@angular/core';
-import { issuesEmailTemplate } from 'xforge-common/utils';
+import { issuesEmailTemplate, supportedBrowser } from 'xforge-common/utils';
 import { environment } from '../../environments/environment';
 
 export interface ErrorAlert {
@@ -16,6 +16,7 @@ export interface ErrorAlert {
 export class ErrorComponent {
   issueEmail = environment.issueEmail;
   showDetails: boolean = false;
+  browserUnsupported = !supportedBrowser();
 
   constructor(public dialogRef: MdcDialogRef<ErrorComponent>, @Inject(MDC_DIALOG_DATA) public data: ErrorAlert) {}
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
@@ -149,7 +149,10 @@ export class ExceptionHandlingService implements ErrorHandler {
     if (!this.dialogOpen && this.alertQueue.length) {
       ngZone.run(() => {
         this.dialogOpen = true;
-        const dialogRef = dialog.open(ErrorComponent, { data: this.alertQueue[this.alertQueue.length - 1] });
+        const dialogRef = dialog.open(ErrorComponent, {
+          autoFocus: false,
+          data: this.alertQueue[this.alertQueue.length - 1]
+        });
         dialogRef.afterClosed().subscribe(() => {
           this.alertQueue.pop();
           this.dialogOpen = false;


### PR DESCRIPTION
Currently users can choose to ignore the dialog that tells them their browser is unsupported. When an error occurs it's a good time to remind them it may be due to their unsupported browser.

![Screen Shot 2019-11-26 at 21 38 46](https://user-images.githubusercontent.com/6140710/69689298-89b99080-1096-11ea-930a-ebf339b4989e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/444)
<!-- Reviewable:end -->
