### PR TITLE
Hide non-production locales on qa

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -17,7 +17,7 @@
         </mdc-top-app-bar-section>
         <mdc-top-app-bar-section align="end" *ngIf="currentUser != null">
           <!-- not in MVP <mdc-icon mdcTopAppBarActionItem title="Notifications">notifications</mdc-icon> -->
-          <div mdcMenuSurfaceAnchor #langMenuAnchor>
+          <div mdcMenuSurfaceAnchor #langMenuAnchor *ngIf="i18n.locales.length >= 2">
             <mdc-icon mdcTopAppBarActionItem title="Language" (click)="langMenu.open = !langMenu.open">
               translate
             </mdc-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -7,7 +7,7 @@ import { of, zip } from 'rxjs';
 import { map } from 'rxjs/operators';
 import enChecking from '../assets/i18n/checking_en.json';
 import enNonChecking from '../assets/i18n/non_checking_en.json';
-import { environment } from '../environments/environment.pwa-test';
+import { environment } from '../environments/environment';
 
 export type LocaleCode = 'en' | 'zh_CN';
 


### PR DESCRIPTION
- Hide locales on qa if they would be hidden on live
- Only show the language picker if there are two or more locales

Contrary to what I had thought, the non-production locales would not have been shown on live had we deployed the current master to live. I mis-read the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/445)
<!-- Reviewable:end -->
