### PR TITLE
SF-675 Draw attention to own answer if just added/edited

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -116,7 +116,7 @@
           <div
             class="answer"
             *ngFor="let answer of answers"
-            [ngClass]="{ 'answer-unread': !hasUserReadAnswer(answer) }"
+            [ngClass]="{ attention: shouldDrawAttentionToAnswer(answer) }"
           >
             <div *ngIf="canSeeOtherUserResponses" class="like">
               <button

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
@@ -122,14 +122,14 @@
     padding: 10px 0;
     border-top: 1px solid $borderColor;
 
-    &.answer-unread {
-      animation-name: answer-unread;
+    &.attention {
+      animation-name: attention;
       animation-duration: 10s;
       animation-fill-mode: forwards;
 
-      @keyframes answer-unread {
+      @keyframes attention {
         from {
-          background: $answerUnread;
+          background: $attention;
         }
         to {
           background: #fff;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-global-vars.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-global-vars.scss
@@ -2,6 +2,6 @@
 
 $questionUnread: $sf_grey;
 $questionAnswered: $mdc-theme-secondary;
-$answerUnread: lighten($mdc-theme-secondary, 20%);
-$commentUnread: $answerUnread;
+$attention: lighten($mdc-theme-secondary, 20%);
+$commentUnread: $attention;
 $borderColor: rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
- If user adds an answer, or edits an answer, draw attention to what
they just added/changed, rather than to other answers.
- If user starts to edit their answer, but cancels, don't draw
attention to their unchanged answer.
- Continue drawing attention to unread answers, but only if the user
had not just added/changed an answer.
- Reusing 'answer-unread' style as 'attention'.

--

See animation demonstrating what is highlighted.

![sf-675b](https://user-images.githubusercontent.com/7265309/70088457-87de5880-15d3-11ea-9650-33b99546f53f.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/451)
<!-- Reviewable:end -->
