### PR TITLE
SF-624 Hide unread answers icon from non-admin users

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -102,7 +102,7 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
   }
 
   getUnreadAnswers(questionDoc: QuestionDoc): number {
-    if (this.canAddAnswer && (this.project == null || !this.project.checkingConfig.usersSeeEachOthersResponses)) {
+    if (this.canAddAnswer || this.project == null || !this.project.checkingConfig.usersSeeEachOthersResponses) {
       return 0;
     }
     let unread = 0;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -103,6 +103,7 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
 
   getUnreadAnswers(questionDoc: QuestionDoc): number {
     if (this.canAddAnswer || this.project == null || !this.project.checkingConfig.usersSeeEachOthersResponses) {
+      // Non-admin users will not see unread answers badge because it may be distracting
       return 0;
     }
     let unread = 0;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -270,10 +270,10 @@ describe('CheckingComponent', () => {
     }));
 
     it('unread questions badge is only visible when the setting is ON to see other answers', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
-      expect(env.getUnread(env.questions[6])).toEqual(4);
+      const env = new TestEnvironment(ADMIN_USER);
+      expect(env.getUnread(env.questions[5])).toEqual(1);
       env.setSeeOtherUserResponses(false);
-      expect(env.getUnread(env.questions[6])).toEqual(0);
+      expect(env.getUnread(env.questions[5])).toEqual(0);
     }));
 
     it('responds to remote question added', fakeAsync(() => {
@@ -563,12 +563,11 @@ describe('CheckingComponent', () => {
 
     it('do not show answers until current user has submitted an answer', fakeAsync(() => {
       const env = new TestEnvironment(CHECKER_USER);
+      expect(env.getUnread(env.questions[6])).toEqual(0);
       env.selectQuestion(7);
       expect(env.answers.length).toBe(0);
-      expect(env.getUnread(env.questions[6])).toEqual(4);
       env.answerQuestion('Answer from checker');
       expect(env.answers.length).toBe(2);
-      expect(env.getUnread(env.questions[6])).toEqual(0);
     }));
 
     it('checker can only see their answers when the setting is OFF to see other answers', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -269,11 +269,19 @@ describe('CheckingComponent', () => {
       expect().nothing();
     }));
 
-    it('unread questions badge is only visible when the setting is ON to see other answers', fakeAsync(() => {
+    it('unread answers badge is only visible when the setting is ON to see other answers', fakeAsync(() => {
       const env = new TestEnvironment(ADMIN_USER);
       expect(env.getUnread(env.questions[5])).toEqual(1);
       env.setSeeOtherUserResponses(false);
       expect(env.getUnread(env.questions[5])).toEqual(0);
+    }));
+
+    it('unread answers badge always hidden from community checkers', fakeAsync(() => {
+      const env = new TestEnvironment(CHECKER_USER);
+      // One unread answer and three comments are hidden
+      expect(env.getUnread(env.questions[6])).toEqual(0);
+      env.setSeeOtherUserResponses(false);
+      expect(env.getUnread(env.questions[6])).toEqual(0);
     }));
 
     it('responds to remote question added', fakeAsync(() => {


### PR DESCRIPTION
* show unread icon to admins when see others answer is on

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/455)
<!-- Reviewable:end -->
