### PR TITLE
SF-673 Gracefully handle failed onlineInviteUsers() at collaborators

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.ts
@@ -189,15 +189,20 @@ export class CollaboratorsComponent extends DataLoadingComponent implements OnIn
           )
       );
     }
-    const invitees: Row[] = (await this.projectService.onlineInvitedUsers(this.projectId)).map(invitee => {
-      return {
-        id: '',
-        user: { email: invitee },
-        roleName: '',
-        isInvitee: true
-      } as Row;
-    });
     await Promise.all(tasks);
-    this._userRows = userRows.concat(invitees);
+
+    try {
+      const invitees: Row[] = (await this.projectService.onlineInvitedUsers(this.projectId)).map(invitee => {
+        return {
+          id: '',
+          user: { email: invitee },
+          roleName: '',
+          isInvitee: true
+        } as Row;
+      });
+      this._userRows = userRows.concat(invitees);
+    } catch {
+      this.noticeService.show('There was a problem loading the list of invited users.');
+    }
   }
 }


### PR DESCRIPTION
* If the current admin had their access removed while on the users
page (collaborators component), the behaviour was that they would see
a permission error from calling onlineInvitedUsers(), then told that
the project is no longer accessible, and sent to another page.
* Now if it happens, a snackbar message shows saying there was a
problem loading the list of invited users, they are told that the
project is no longer accessible, and sent to /projects.
* The order of when Promise.all(tasks) is called was changed slightly
to not unnecessarily include it in the try.
* The error is thrown from command.service.ts onlineInvoke().

---

See animation where the admin on the removes the admin on the right from the project.

![sf-673-fix](https://user-images.githubusercontent.com/7265309/70280436-a54b2800-1775-11ea-988f-70b37bc49d0e.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/458)
<!-- Reviewable:end -->
