### PR TITLE
SF-708 Add ellipses to selected text when needed

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/answer.ts
+++ b/src/RealtimeServer/scriptureforge/models/answer.ts
@@ -5,6 +5,8 @@ import { VerseRefData } from './verse-ref-data';
 export interface Answer extends Comment {
   verseRef?: VerseRefData;
   scriptureText?: string;
+  selectionStartClipped?: boolean;
+  selectionEndClipped?: boolean;
   audioUrl?: string;
   likes: Like[];
   comments: Comment[];

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -77,7 +77,8 @@
             [class.text-selected]="selectedText"
           >
             <p [fxHide]="!selectedText" [fxHide.lt-xl]="!canShowScriptureInput" class="scripture-text">
-              {{ selectedText }} <span class="answer-scripture-verse">{{ scriptureTextVerseRef(verseRef) }}</span>
+              {{ (selectionStartClipped ? "…" : "") + (selectedText || "") + (selectionEndClipped ? "…" : "") }}
+              <span class="answer-scripture-verse">{{ scriptureTextVerseRef(verseRef) }}</span>
             </p>
             <p [fxHide]="!!selectedText" class="scripture-text-blank">{{ t("no_scripture_selected") }}</p>
             <div class="buttons-wrapper">
@@ -131,7 +132,11 @@
             <div class="answer-detail">
               <div *ngIf="answer.text" class="answer-text">{{ answer.text }}</div>
               <div *ngIf="answer.scriptureText" class="answer-scripture">
-                <span class="answer-scripture-text">{{ answer.scriptureText }}</span>
+                <span class="answer-scripture-text">{{
+                  (answer.selectionStartClipped ? "…" : "") +
+                    (answer.scriptureText || "") +
+                    (answer.selectionEndClipped ? "…" : "")
+                }}</span>
                 <span class="answer-scripture-verse">{{ scriptureTextVerseRef(answer.verseRef) }}</span>
               </div>
               <app-checking-audio-player *ngIf="answer.audioUrl" [source]="answer.audioUrl"></app-checking-audio-player>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -37,6 +37,8 @@ export interface AnswerAction {
   text?: string;
   verseRef?: VerseRefData;
   scriptureText?: string;
+  selectionStartClipped?: boolean;
+  selectionEndClipped?: boolean;
   audio?: AudioAttachment;
 }
 
@@ -106,6 +108,8 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
   /** IDs of answers to show to user (so, excluding unshown incoming answers). */
   answersToShow: string[] = [];
   selectedText?: string;
+  selectionStartClipped?: boolean;
+  selectionEndClipped?: boolean;
   verseRef?: VerseRef;
 
   private _questionDoc?: QuestionDoc;
@@ -228,6 +232,8 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
   clearSelection() {
     this.selectedText = '';
     this.verseRef = undefined;
+    this.selectionStartClipped = undefined;
+    this.selectionEndClipped = undefined;
   }
 
   archiveQuestion(): void {
@@ -259,6 +265,8 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     }
     this.selectedText = this.activeAnswer.scriptureText;
     this.justEditedAnswer = false;
+    this.selectionStartClipped = this.activeAnswer.selectionStartClipped;
+    this.selectionEndClipped = this.activeAnswer.selectionEndClipped;
     this.showAnswerForm();
   }
 
@@ -299,6 +307,8 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
         const selection = result as TextSelection;
         this.verseRef = toVerseRef(selection.verses);
         this.selectedText = selection.text;
+        this.selectionStartClipped = selection.startClipped;
+        this.selectionEndClipped = selection.endClipped;
       }
     });
   }
@@ -456,6 +466,8 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
       answer: this.activeAnswer,
       audio: this.audio,
       scriptureText: this.selectedText || undefined,
+      selectionStartClipped: this.selectionStartClipped,
+      selectionEndClipped: this.selectionEndClipped,
       verseRef: this.verseRef == null ? undefined : fromVerseRef(this.verseRef)
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -606,9 +606,9 @@ describe('CheckingComponent', () => {
       expect(env.scriptureText).toBeFalsy();
       // Add scripture
       env.clickButton(env.selectVersesButton);
-      expect(env.scriptureText).toBe('The selected text (JHN 2:2-5)');
+      expect(env.scriptureText).toBe('…The selected text (JHN 2:2-5)');
       env.clickButton(env.saveAnswerButton);
-      expect(env.getAnswerScriptureText(0)).toBe('The selected text(JHN 2:2-5)');
+      expect(env.getAnswerScriptureText(0)).toBe('…The selected text(JHN 2:2-5)');
     }));
 
     it('can remove scripture from an answer', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -400,6 +400,8 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
         answer.text = answerAction.text;
         answer.scriptureText = answerAction.scriptureText;
         answer.verseRef = answerAction.verseRef;
+        answer.selectionStartClipped = answerAction.selectionStartClipped;
+        answer.selectionEndClipped = answerAction.selectionEndClipped;
         answer.dateModified = dateNow;
         if (answerAction.audio != null) {
           if (answerAction.audio.fileName != null && answerAction.audio.blob != null) {
@@ -681,6 +683,8 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
           .set(q => q.answers[answerIndex].text, newAnswer.text)
           .set(q => q.answers[answerIndex].scriptureText, newAnswer.scriptureText)
           .set(q => q.answers[answerIndex].verseRef, newAnswer.verseRef)
+          .set(q => q.answers[answerIndex].selectionStartClipped, newAnswer.selectionStartClipped)
+          .set(q => q.answers[answerIndex].selectionEndClipped, newAnswer.selectionEndClipped)
           .set(q => q.answers[answerIndex].audioUrl, newAnswer.audioUrl)
           .set(q => q.answers[answerIndex].dateModified, newAnswer.dateModified)
       );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.html
@@ -11,7 +11,8 @@
           </div>
           <app-text #scriptureText [id]="textDocId" multiSegmentSelection="true"></app-text>
           <p class="selection-preview">
-            {{ selectedText }} <span class="selection-reference">{{ referenceForDisplay }}</span>
+            {{ (startClipped ? "…" : "") + (selectedText || "") + (endClipped ? "…" : "") }}
+            <span class="selection-reference">{{ referenceForDisplay }}</span>
           </p>
           <span class="error-message" *ngIf="showError">{{ t("select_text_error_message") }}</span>
         </mdc-dialog-content>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
@@ -56,7 +56,7 @@ describe('TextChooserDialogComponent', () => {
     const env = new TestEnvironment({ start: 1, end: 10 }, 'verse_1_2/p_1', 'verse_1_3');
     expect(env.selectedText).toEqual('');
     env.fireSelectionChange();
-    expect(env.selectedText).toEqual('target: chapter (MAT 1:3)');
+    expect(env.selectedText).toEqual('target: chapter… (MAT 1:3)');
     env.closeDialog();
   }));
 
@@ -123,7 +123,7 @@ describe('TextChooserDialogComponent', () => {
   it('expands the selection to whole words', fakeAsync(async () => {
     const env = new TestEnvironment({ start: 13, end: 1 }, 'verse_1_4', 'verse_1_5');
     env.fireSelectionChange();
-    expect(env.selectedText).toEqual('chapter 1, verse 4. rest of verse 4 target (MAT 1:4-5)');
+    expect(env.selectedText).toEqual('…chapter 1, verse 4. rest of verse 4 target… (MAT 1:4-5)');
     env.closeDialog();
   }));
 
@@ -131,14 +131,14 @@ describe('TextChooserDialogComponent', () => {
     // 26 Unicode code points, but 38 JavaScript chars
     const env = new TestEnvironment({ start: 2, end: 38 }, 'verse_1_6', 'verse_1_6');
     env.fireSelectionChange();
-    expect(env.selectedText).toEqual('وَقَعَتِ الأحْداثُ التّالِيَةُ فَي أيّامِ (MAT 1:6)');
+    expect(env.selectedText).toEqual('وَقَعَتِ الأحْداثُ التّالِيَةُ فَي أيّامِ… (MAT 1:6)');
     env.closeDialog();
   }));
 
   it('indicates when not all segments of the end verse were selected', fakeAsync(async () => {
     const env = new TestEnvironment({ start: 3, end: TestEnvironment.segmentLen(4) }, 'verse_1_3', 'verse_1_4');
     env.fireSelectionChange();
-    expect(env.selectedText).toEqual('target: chapter 1, verse 3. target: chapter 1, verse 4. (MAT 1:3-4)');
+    expect(env.selectedText).toEqual('target: chapter 1, verse 3. target: chapter 1, verse 4.… (MAT 1:3-4)');
     env.click(env.saveButton);
     expect(await env.resultPromise).toEqual({
       verses: { bookNum: 40, chapterNum: 1, verseNum: 3, verse: '3-4' },
@@ -151,7 +151,7 @@ describe('TextChooserDialogComponent', () => {
   it('indicates when not all segments of the start verse were selected', fakeAsync(async () => {
     const env = new TestEnvironment({ start: 0, end: TestEnvironment.segmentLen(5) }, 'verse_1_4/p_1', 'verse_1_5');
     env.fireSelectionChange();
-    expect(env.selectedText).toEqual('rest of verse 4 target: chapter 1, (MAT 1:4-5)');
+    expect(env.selectedText).toEqual('…rest of verse 4 target: chapter 1, (MAT 1:4-5)');
     env.click(env.saveButton);
     expect(await env.resultPromise).toEqual({
       verses: { bookNum: 40, chapterNum: 1, verseNum: 4, verse: '4-5' },
@@ -164,7 +164,7 @@ describe('TextChooserDialogComponent', () => {
   it('indicates when the segments were only partially selected', fakeAsync(async () => {
     const env = new TestEnvironment({ start: 6, end: TestEnvironment.segmentLen(5) - 2 }, 'verse_1_4', 'verse_1_5');
     env.fireSelectionChange();
-    expect(env.selectedText).toEqual(': chapter 1, verse 4. rest of verse 4 target: chapter 1 (MAT 1:4-5)');
+    expect(env.selectedText).toEqual('…: chapter 1, verse 4. rest of verse 4 target: chapter 1… (MAT 1:4-5)');
     env.click(env.saveButton);
     expect(await env.resultPromise).toEqual({
       verses: { bookNum: 40, chapterNum: 1, verseNum: 4, verse: '4-5' },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
@@ -195,8 +195,7 @@ export class TextChooserDialogComponent implements OnDestroy {
       .substring(startOffset + startTrimLength, result.length - endNodeText.length + endOffset - endTrimLength)
       .trim();
 
-    const startStartSegmentClipped =
-      startOffset + startTrimLength > startNodeText.length - startNodeText.trimLeft().length;
+    const startSegmentClipped = startOffset + startTrimLength > startNodeText.length - startNodeText.trimLeft().length;
     const endSegmentClipped = endOffset + endTrimLength < endNodeText.trimRight().length;
 
     const firstVerseSegments = Array.from(this.getSegments(this.getVerseFromElement(segments[0]))).filter(
@@ -207,9 +206,10 @@ export class TextChooserDialogComponent implements OnDestroy {
     ).filter(el => (el.textContent || '').trim() !== '');
 
     const startClipped =
-      startStartSegmentClipped || (firstVerseSegments.length !== 0 && !firstVerseSegments[0].contains(segments[0]));
+      (startSegmentClipped && startText.trim() !== '') ||
+      (firstVerseSegments.length !== 0 && !firstVerseSegments[0].contains(segments[0]));
     const endClipped =
-      endSegmentClipped ||
+      (endSegmentClipped && endText.trim() !== '') ||
       (lastVerseSegments.length !== 0 &&
         !lastVerseSegments[lastVerseSegments.length - 1].contains(segments[segments.length - 1]));
 


### PR DESCRIPTION
When only part of a verse is selected ellipses are now shown when needed. They should be shown everywhere the selected text will be shown. Here's what it looks like in the initial text selection dialog.
![Screen Shot 2019-12-05 at 21 53 49](https://user-images.githubusercontent.com/6140710/70291635-bc0b7200-17a9-11ea-9b5b-1cb7d27465ef.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/459)
<!-- Reviewable:end -->
