### PR TITLE
SF-624 Delay marking remotely added comments as read

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -10,7 +10,6 @@ import { SFProject } from 'realtime-server/lib/scriptureforge/models/sf-project'
 import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/scriptureforge/models/sf-project-rights';
 import { SFProjectRole } from 'realtime-server/lib/scriptureforge/models/sf-project-role';
 import { fromVerseRef, toVerseRef, VerseRefData } from 'realtime-server/lib/scriptureforge/models/verse-ref-data';
-import { Canon } from 'realtime-server/lib/scriptureforge/scripture-utils/canon';
 import { VerseRef } from 'realtime-server/lib/scriptureforge/scripture-utils/verse-ref';
 import { Subscription } from 'rxjs';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -220,20 +219,6 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
       return SFProjectRole.None;
     }
     return this.project.userRoles[this.userService.currentUserId] as SFProjectRole;
-  }
-
-  /** Fetch a TextsByBookId that only contains the book and chapter that pertains to the question. */
-  private get currentBookAndChapter(): TextsByBookId {
-    const textsByBook: TextsByBookId = {};
-    if (this.textsByBookId != null && this._questionDoc != null && this._questionDoc.data != null) {
-      const bookNum: number = this._questionDoc.data.verseRef.bookNum;
-      const bookId = Canon.bookNumberToId(bookNum);
-      const currentText = this.textsByBookId[bookId];
-      const questionChapterNumber = this._questionDoc.data.verseRef.chapterNum;
-      textsByBook[bookId] = cloneDeep(currentText);
-      textsByBook[bookId].chapters = currentText.chapters.filter(chapter => chapter.number === questionChapterNumber);
-    }
-    return textsByBook;
   }
 
   ngOnInit(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.ts
@@ -8,6 +8,7 @@ import { Comment } from 'realtime-server/lib/scriptureforge/models/comment';
 import { SFProject } from 'realtime-server/lib/scriptureforge/models/sf-project';
 import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/scriptureforge/models/sf-project-rights';
 import { SFProjectRole } from 'realtime-server/lib/scriptureforge/models/sf-project-role';
+import { debounceTime } from 'rxjs/operators';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { UserService } from 'xforge-common/user.service';
 import { QuestionDoc } from '../../../../core/models/question-doc';
@@ -138,7 +139,9 @@ export class CheckingCommentsComponent extends SubscriptionDisposable implements
       this.initUserCommentRefsRead = cloneDeep(this.projectUserConfigDoc.data.commentRefsRead);
     }
     if (this.questionDoc != null) {
-      this.subscribe(this.questionDoc.remoteChanges$, () => {
+      // Give the user two seconds before marking the comment as read. This also prevents SF-624 - prematurely
+      // marking a remotely added comment as read
+      this.subscribe(this.questionDoc.remoteChanges$.pipe(debounceTime(2000)), () => {
         if (this.projectUserConfigDoc == null || this.projectUserConfigDoc.data == null || this.answer == null) {
           return;
         }


### PR DESCRIPTION
* The subscription to remote changes in a question doc appears to queue up values,
* and emits them once subscribed to, one at a time. This would mark a third comment read,
* and then the fourth comment would appear and hide both, leaving the third read even though the
* user could not have been quick enough to read it.
* Also remove unused property.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/461)
<!-- Reviewable:end -->
