### PR TITLE
Move locale cookie logic to i18n service

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -26,13 +26,13 @@
                 <mdc-list-item
                   *ngFor="let locale of i18n.locales"
                   [class.locale-disabled]="!locale.production"
-                  [class.active-locale]="locale.localeCode === i18n.localeCode"
-                  (click)="setLocale(locale.localeCode)"
+                  [class.active-locale]="locale.canonicalTag === i18n.localeCode"
+                  (click)="i18n.setLocale(locale.canonicalTag)"
                 >
                   {{ locale.localName }}
                   <!-- click handler is workaround for menu not closing when click is on the span element -->
                   <span class="locale-code" (click)="langMenu.open = false">{{
-                    locale.localeCode
+                    locale.canonicalTag
                   }}</span></mdc-list-item
                 >
               </mdc-list>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -15,20 +15,14 @@ import { combineLatest, from, Observable, Subscription } from 'rxjs';
 import { distinctUntilChanged, filter, map, startWith, switchMap, tap } from 'rxjs/operators';
 import { AuthService } from 'xforge-common/auth.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
-import { I18nService, LocaleCode } from 'xforge-common/i18n.service';
+import { I18nService } from 'xforge-common/i18n.service';
 import { LocationService } from 'xforge-common/location.service';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { SupportedBrowsersDialogComponent } from 'xforge-common/supported-browsers-dialog/supported-browsers-dialog.component';
 import { UserService } from 'xforge-common/user.service';
-import {
-  ASP_CULTURE_COOKIE_NAME,
-  aspCultureCookieValue,
-  getAspCultureCookieLanguage,
-  issuesEmailTemplate,
-  supportedBrowser
-} from 'xforge-common/utils';
+import { issuesEmailTemplate, supportedBrowser } from 'xforge-common/utils';
 import { version } from '../../../version.json';
 import { environment } from '../environments/environment';
 import { HelpHeroService } from './core/help-hero.service';
@@ -235,16 +229,9 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
 
       this.currentUserDoc = await this.userService.getCurrentUser();
       if (isNewlyLoggedIn) {
-        const interfaceLanguage = this.currentUserDoc.data!.interfaceLanguage || 'en';
-        const locale = I18nService.findLocale(interfaceLanguage);
-        if (locale != null) {
-          this.setLocale(locale.localeCode);
-        }
-      } else {
-        const interfaceLanguage = getAspCultureCookieLanguage(this.cookieService.get(ASP_CULTURE_COOKIE_NAME));
-        const locale = I18nService.findLocale(interfaceLanguage);
-        if (locale != null) {
-          this.i18n.setLocale(locale.localeCode);
+        const languageTag = this.currentUserDoc.data!.interfaceLanguage;
+        if (languageTag != null) {
+          this.i18n.trySetLocale(languageTag);
         }
       }
 
@@ -404,11 +391,6 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
 
   async goHome(): Promise<void> {
     (await this.isLoggedIn) ? this.router.navigateByUrl('/projects') : this.locationService.go('/');
-  }
-
-  setLocale(localeCode: LocaleCode): void {
-    this.cookieService.set(ASP_CULTURE_COOKIE_NAME, aspCultureCookieValue(I18nService.getTag(localeCode)));
-    this.i18n.setLocale(localeCode);
   }
 
   projectChanged(value: string): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -5,6 +5,7 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
 import { ngfModule } from 'angular-file';
+import { CookieService } from 'ngx-cookie-service';
 import { SystemRole } from 'realtime-server/lib/common/models/system-role';
 import { User } from 'realtime-server/lib/common/models/user';
 import { CheckingShareLevel } from 'realtime-server/lib/scriptureforge/models/checking-config';
@@ -43,6 +44,7 @@ const mockedProjectService = mock(SFProjectService);
 const mockedUserService = mock(UserService);
 const mockedAuthService = mock(AuthService);
 const mockedQuestionDialogService = mock(QuestionDialogService);
+const mockedCookieService = mock(CookieService);
 
 describe('CheckingOverviewComponent', () => {
   configureTestingModule(() => ({
@@ -54,7 +56,8 @@ describe('CheckingOverviewComponent', () => {
       { provide: SFProjectService, useMock: mockedProjectService },
       { provide: UserService, useMock: mockedUserService },
       { provide: AuthService, useMock: mockedAuthService },
-      { provide: QuestionDialogService, useMock: mockedQuestionDialogService }
+      { provide: QuestionDialogService, useMock: mockedQuestionDialogService },
+      { provide: CookieService, useMock: mockedCookieService }
     ]
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-owner/checking-owner.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-owner/checking-owner.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { By } from '@angular/platform-browser';
 import { TranslocoService } from '@ngneat/transloco';
 import { AvatarService } from 'ngx-avatar';
+import { CookieService } from 'ngx-cookie-service';
 import { UserProfile } from 'realtime-server/lib/common/models/user';
 import { instance, mock, when } from 'ts-mockito';
 import { AvatarTestingModule } from 'xforge-common/avatar/avatar-testing.module';
@@ -74,6 +75,7 @@ class TestEnvironment {
   readonly mockedUserService = mock(UserService);
   readonly mockedAvatarService = mock(AvatarService);
   readonly mockedTransloco = mock(TranslocoService);
+  readonly mockedCookieService = mock(CookieService);
 
   private readonly realtimeService = new TestRealtimeService(SF_REALTIME_DOC_TYPES);
 
@@ -94,7 +96,8 @@ class TestEnvironment {
       providers: [
         { provide: UserService, useFactory: () => instance(this.mockedUserService) },
         { provide: AvatarService, useFactory: () => instance(this.mockedAvatarService) },
-        { provide: TranslocoService, useFactory: () => instance(this.mockedTransloco) }
+        { provide: TranslocoService, useFactory: () => instance(this.mockedTransloco) },
+        { provide: CookieService, useFactory: () => instance(this.mockedCookieService) }
       ]
     });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -8,6 +8,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { ngfModule } from 'angular-file';
 import { AngularSplitModule } from 'angular-split';
 import clone from 'lodash/clone';
+import { CookieService } from 'ngx-cookie-service';
 import { SystemRole } from 'realtime-server/lib/common/models/system-role';
 import { User } from 'realtime-server/lib/common/models/user';
 import { CheckingShareLevel } from 'realtime-server/lib/scriptureforge/models/checking-config';
@@ -64,6 +65,7 @@ const mockedActivatedRoute = mock(ActivatedRoute);
 const mockedMdcDialog = mock(MdcDialog);
 const mockedTextChooserDialogComponent = mock(TextChooserDialogComponent);
 const mockedQuestionDialogService = mock(QuestionDialogService);
+const mockedCookieService = mock(CookieService);
 
 function createUser(id: string, role: string, nameConfirmed: boolean = true): UserInfo {
   return {
@@ -121,7 +123,8 @@ describe('CheckingComponent', () => {
       { provide: NoticeService, useMock: mockedNoticeService },
       { provide: MdcDialog, useMock: mockedMdcDialog },
       { provide: TextChooserDialogComponent, useMock: mockedTextChooserDialogComponent },
-      { provide: QuestionDialogService, useMock: mockedQuestionDialogService }
+      { provide: QuestionDialogService, useMock: mockedQuestionDialogService },
+      { provide: CookieService, useMock: mockedCookieService }
     ]
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -5,6 +5,7 @@ import { HttpClient } from '@angular/common/http';
 import { Component, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { CookieService } from 'ngx-cookie-service';
 import { Question } from 'realtime-server/lib/scriptureforge/models/question';
 import { getTextDocId } from 'realtime-server/lib/scriptureforge/models/text-data';
 import { fromVerseRef } from 'realtime-server/lib/scriptureforge/models/verse-ref-data';
@@ -32,6 +33,7 @@ const mockedNoticeService = mock(NoticeService);
 const mockedProjectService = mock(SFProjectService);
 const mockedUserService = mock(UserService);
 const mockedHttpClient = mock(HttpClient);
+const mockedCookieService = mock(CookieService);
 
 describe('QuestionDialogComponent', () => {
   configureTestingModule(() => ({
@@ -41,7 +43,8 @@ describe('QuestionDialogComponent', () => {
       { provide: UserService, useMock: mockedUserService },
       { provide: NoticeService, useMock: mockedNoticeService },
       { provide: SFProjectService, useMock: mockedProjectService },
-      { provide: HttpClient, useMock: mockedHttpClient }
+      { provide: HttpClient, useMock: mockedHttpClient },
+      { provide: CookieService, useMock: mockedCookieService }
     ]
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
@@ -1,5 +1,6 @@
 import { MdcDialog, MdcDialogRef } from '@angular-mdc/web/dialog';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { CookieService } from 'ngx-cookie-service';
 import { User } from 'realtime-server/lib/common/models/user';
 import { Observable } from 'rxjs';
 import { anything, mock, when } from 'ts-mockito';
@@ -16,6 +17,7 @@ const mockedMdcDialog = mock(MdcDialog);
 const mockedUserService = mock(UserService);
 const mockedErrorReportingService = mock(ErrorReportingService);
 const mockedNoticeService = mock(NoticeService);
+const mockedCookieService = mock(CookieService);
 
 // suppress any expected logging so it won't be shown in the test results
 class MockConsole {
@@ -42,7 +44,8 @@ describe('ExceptionHandlingService', () => {
       { provide: UserService, useMock: mockedUserService },
       { provide: ErrorReportingService, useMock: mockedErrorReportingService },
       { provide: NoticeService, useMock: mockedNoticeService },
-      { provide: CONSOLE, useValue: new MockConsole() }
+      { provide: CONSOLE, useValue: new MockConsole() },
+      { provide: CookieService, useMock: mockedCookieService }
     ],
     imports: [TestTranslocoModule]
   }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -1,26 +1,28 @@
 import { TranslocoService } from '@ngneat/transloco';
+import { CookieService } from 'ngx-cookie-service';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import { I18nService } from './i18n.service';
 
 const mockedTranslocoService = mock(TranslocoService);
+const mockedCookieService = mock(CookieService);
 
 describe('I18nService', () => {
   it('should be able to get a locale', () => {
     expect(I18nService.getLocale('en')).toBeDefined();
-    expect(I18nService.getLocale('en').localeCode).toEqual('en');
+    expect(I18nService.getLocale('en')!.canonicalTag).toEqual('en');
   });
 
   it('should set locale', () => {
-    const service = new I18nService(instance(mockedTranslocoService));
+    const service = new I18nService(instance(mockedTranslocoService), instance(mockedCookieService));
     expect(service).toBeTruthy();
-    service.setLocale('zh_CN');
-    verify(mockedTranslocoService.setActiveLang('zh_CN')).called();
-    expect(service.localeCode).toEqual('zh_CN');
+    service.setLocale('zh-CN');
+    verify(mockedTranslocoService.setActiveLang('zh-CN')).called();
+    expect(service.localeCode).toEqual('zh-CN');
   });
 
   it('should wrap text with HTML tags', () => {
     when(mockedTranslocoService.translate<string>(anything(), anything())).thenReturn('translated key');
-    const service = new I18nService(instance(mockedTranslocoService));
+    const service = new I18nService(instance(mockedTranslocoService), instance(mockedCookieService));
     expect(
       service.translateAndInsertTags('namespace.key', {
         value: 2,
@@ -46,11 +48,11 @@ describe('I18nService', () => {
 
   it('should localize dates', () => {
     const date = new Date('November 25, 1991 17:28');
-    const service = new I18nService(instance(mockedTranslocoService));
+    const service = new I18nService(instance(mockedTranslocoService), instance(mockedCookieService));
     expect(service.formatDate(date)).toEqual('Nov 25, 1991, 5:28 PM');
-    service.setLocale('en_GB');
+    service.setLocale('en-GB');
     expect(service.formatDate(date)).toEqual('25 Nov 1991, 17:28');
-    service.setLocale('zh_CN');
+    service.setLocale('zh-CN');
     expect(service.formatDate(date)).toEqual('1991/11/25 下午5:28');
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -3,18 +3,18 @@ import { Injectable } from '@angular/core';
 import { TranslocoConfig, TranslocoService } from '@ngneat/transloco';
 import { Translation, TranslocoLoader } from '@ngneat/transloco';
 import merge from 'lodash/merge';
+import { CookieService } from 'ngx-cookie-service';
 import { of, zip } from 'rxjs';
 import { map } from 'rxjs/operators';
 import enChecking from '../assets/i18n/checking_en.json';
 import enNonChecking from '../assets/i18n/non_checking_en.json';
 import { environment } from '../environments/environment';
-
-export type LocaleCode = 'en' | 'en_GB' | 'az' | 'id' | 'zh_CN';
+import { ASP_CULTURE_COOKIE_NAME, aspCultureCookieValue, getAspCultureCookieLanguage } from './utils';
 
 interface Locale {
   localName: string;
   englishName: string;
-  localeCode: LocaleCode;
+  canonicalTag: string;
   direction: 'ltr' | 'rtl';
   tags: string[];
   production: boolean;
@@ -32,6 +32,7 @@ export class TranslationLoader implements TranslocoLoader {
       // statically load English so there will always be keys to fall back to
       return of(en);
     } else {
+      code = code.replace(/-/g, '_');
       return zip(
         this.http.get<Translation>(`/assets/i18n/checking_${code}.json`),
         this.http.get<Translation>(`/assets/i18n/non_checking_${code}.json`)
@@ -48,7 +49,6 @@ export class I18nService {
     {
       localName: 'English (US)',
       englishName: 'English (US)',
-      localeCode: 'en',
       direction: 'ltr',
       tags: ['en', 'en-US'],
       dateFormatOptions: { month: 'short', year: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric' },
@@ -57,7 +57,6 @@ export class I18nService {
     {
       localName: 'English (UK)',
       englishName: 'English (UK)',
-      localeCode: 'en_GB',
       direction: 'ltr',
       tags: ['en-GB'],
       dateFormatOptions: { month: 'short', year: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric' },
@@ -66,7 +65,6 @@ export class I18nService {
     {
       localName: 'Azərbaycanca',
       englishName: 'Azerbaijani',
-      localeCode: 'az',
       direction: 'ltr',
       tags: ['az', 'az-AZ'],
       production: false
@@ -74,7 +72,6 @@ export class I18nService {
     {
       localName: 'Bahasa Indonesia',
       englishName: 'Indonesian',
-      localeCode: 'id',
       direction: 'ltr',
       tags: ['id', 'id-ID'],
       production: false
@@ -82,55 +79,69 @@ export class I18nService {
     {
       localName: '简体中文',
       englishName: 'Chinese (Simplified)',
-      localeCode: 'zh_CN',
       direction: 'ltr',
-      tags: ['zh', 'zh-CN'],
+      tags: ['zh-CN', 'zh'],
       production: false
     }
-  ];
+  ].map(locale => {
+    (locale as Locale).canonicalTag = locale.tags[0];
+    return locale as Locale;
+  });
 
-  static readonly defaultLocale = I18nService.getLocale('en');
+  static readonly defaultLocale = I18nService.getLocale('en')!;
   static readonly availableLocales = I18nService.locales.filter(locale => locale.production || !environment.production);
 
   static readonly translocoConfig: TranslocoConfig = {
-    availableLangs: I18nService.availableLocales.map(locale => locale.localeCode),
+    availableLangs: I18nService.availableLocales.map(locale => locale.canonicalTag),
     reRenderOnLangChange: true,
-    fallbackLang: 'en',
-    defaultLang: I18nService.defaultLocale.localeCode,
+    fallbackLang: I18nService.defaultLocale.canonicalTag,
+    defaultLang: I18nService.defaultLocale.canonicalTag,
     missingHandler: {
       useFallbackTranslation: true
     }
   };
 
-  static getLocale(code: LocaleCode): Locale {
-    return this.locales.find(locale => locale.localeCode === code)!;
-  }
-
-  static findLocale(tag: string): Locale | undefined {
+  static getLocale(tag: string): Locale | undefined {
     return this.locales.find(locale =>
       locale.tags.some(canonicalTag => canonicalTag.toLowerCase() === tag.toLowerCase())
     );
   }
 
-  static getTag(code: LocaleCode): string {
-    return code.replace('_', '-');
-  }
-
   private currentLocale: Locale = I18nService.defaultLocale;
 
-  constructor(private readonly transloco: TranslocoService) {}
+  constructor(private readonly transloco: TranslocoService, private readonly cookieService: CookieService) {
+    const language = this.cookieService.get(ASP_CULTURE_COOKIE_NAME);
+    if (language != null) {
+      this.trySetLocale(getAspCultureCookieLanguage(language));
+    }
+  }
 
   get localeCode() {
-    return this.currentLocale.localeCode;
+    return this.currentLocale.canonicalTag;
   }
 
   get locales() {
     return I18nService.availableLocales;
   }
 
-  setLocale(code: LocaleCode) {
-    this.currentLocale = I18nService.getLocale(code);
-    this.transloco.setActiveLang(this.currentLocale.localeCode);
+  setLocale(tag: string) {
+    const locale = I18nService.getLocale(tag);
+    if (locale == null) {
+      throw new Error(`Cannot set locale to non-existent locale ${tag}`);
+    }
+    this.trySetLocale(tag);
+  }
+
+  trySetLocale(tag: string) {
+    const locale = I18nService.getLocale(tag);
+    if (locale != null) {
+      this.currentLocale = locale;
+      this.transloco.setActiveLang(locale.canonicalTag);
+      this.cookieService.set(ASP_CULTURE_COOKIE_NAME, aspCultureCookieValue(locale.canonicalTag));
+      // TODO save to Auth0
+    } else {
+      console.warn(`Failed attempt to set locale to unsupported locale ${tag}`);
+    }
   }
 
   translateAndInsertTags(key: string, params: object = {}) {
@@ -148,7 +159,7 @@ export class I18nService {
   formatDate(date: Date) {
     // fall back to en in the event the language code isn't valid
     return date.toLocaleString(
-      [I18nService.getTag(this.localeCode), I18nService.getTag(I18nService.defaultLocale.localeCode)],
+      [this.localeCode, I18nService.defaultLocale.canonicalTag],
       // Browser default is all numeric, but includes seconds. So this fallback is same as default, but without seconds.
       this.currentLocale.dateFormatOptions || {
         month: 'numeric',


### PR DESCRIPTION
- Move locale cookie logic to i18n service
- Also gets rid of `localeCode` property in favor of `canonicalTag`, which corresponds to the first element of the `tags` array.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/470)
<!-- Reviewable:end -->
