### PR TITLE
Fix en-GB and az date formats

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -51,8 +51,10 @@ describe('I18nService', () => {
     const service = new I18nService(instance(mockedTranslocoService), instance(mockedCookieService));
     expect(service.formatDate(date)).toEqual('Nov 25, 1991, 5:28 PM');
     service.setLocale('en-GB');
-    expect(service.formatDate(date)).toEqual('25 Nov 1991, 17:28');
+    expect(service.formatDate(date)).toEqual('25 Nov 1991, 5:28 pm');
     service.setLocale('zh-CN');
     expect(service.formatDate(date)).toEqual('1991/11/25 下午5:28');
+    service.setLocale('az');
+    expect(service.formatDate(date)).toEqual('25.11.1991 17:28');
   });
 });


### PR DESCRIPTION
- The az format was not working in Chrome
- Change en-GB format from 24 hour format to 12 hour format

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/472)
<!-- Reviewable:end -->
