### PR TITLE
Fix locale cookie expiration date

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -144,7 +144,9 @@ export class I18nService {
     if (locale != null) {
       this.currentLocale = locale;
       this.transloco.setActiveLang(locale.canonicalTag);
-      this.cookieService.set(ASP_CULTURE_COOKIE_NAME, aspCultureCookieValue(locale.canonicalTag));
+      const date = new Date();
+      date.setFullYear(date.getFullYear() + 1);
+      this.cookieService.set(ASP_CULTURE_COOKIE_NAME, aspCultureCookieValue(locale.canonicalTag), date, '/');
       // TODO save to Auth0
     } else {
       console.warn(`Failed attempt to set locale to unsupported locale ${tag}`);


### PR DESCRIPTION
- Set expiration to one year, consistent with what happens on the home
page, rather than letting it default to session
- Set the cookie's path to '/'. Previously there appeared to be an issue
where it was set to the current url, leading to multiple conflicting
cookies. After deleting those cookies it wasn't reproducable again.
However, there's no cost to specifying the path to prevent the
possiblity of issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/476)
<!-- Reviewable:end -->
