### PR TITLE
SF-719 Add logging to ParatextService to debug RefreshAccessTokenAsync

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -210,6 +210,12 @@ namespace SIL.XForge.Scripture.Services
                 new JProperty("refresh_token", userSecret.ParatextTokens.RefreshToken));
             request.Content = new StringContent(requestObj.ToString(), Encoding.UTF8, "application/json");
             HttpResponseMessage response = await _registryClient.SendAsync(request);
+            if ((int)response.StatusCode >= 400)
+            {
+                Console.WriteLine($"ParatextService.RefreshAccessTokenAsync received {(int)response.StatusCode} HTTP response");
+                Console.WriteLine("Response content:");
+                Console.WriteLine(await response.Content.ReadAsStringAsync());
+            }
             response.EnsureSuccessStatusCode();
 
             string responseJson = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
This code (actually a slightly different version) is already on qa and was used to diagnose the 401 error we were receiving from the Paratext registry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/477)
<!-- Reviewable:end -->
