### PR TITLE
Use asterisk to show non-production locales in menu

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -25,16 +25,13 @@
               <mdc-list>
                 <mdc-list-item
                   *ngFor="let locale of i18n.locales"
-                  [class.locale-disabled]="!locale.production"
                   [class.active-locale]="locale.canonicalTag === i18n.localeCode"
-                  (click)="i18n.setLocale(locale.canonicalTag)"
+                  (click)="langMenu.open = false; i18n.setLocale(locale.canonicalTag)"
                 >
-                  {{ locale.localName }}
-                  <!-- click handler is workaround for menu not closing when click is on the span element -->
-                  <span class="locale-code" (click)="langMenu.open = false">{{
-                    locale.canonicalTag
-                  }}</span></mdc-list-item
-                >
+                  <!-- `langMenu.open = false` is workaround for menu not closing when click is on a span element -->
+                  <span [class.locale-disabled]="!locale.production">{{ locale.localName }}</span>
+                  <span class="locale-code" (click)="langMenu.open = false">{{ locale.canonicalTag }}</span>
+                </mdc-list-item>
               </mdc-list>
             </mdc-menu>
           </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -99,9 +99,8 @@ a {
   justify-content: space-between;
 }
 
-.locale-disabled {
-  text-decoration: line-through;
-  color: gray;
+.locale-disabled::after {
+  content: ' *';
 }
 
 .locale-code {


### PR DESCRIPTION
A recent PR added the concept of non-production-ready locales to the back end. Here's how the selector on the main page now looks:
![Screenshot from 2019-12-19 13-51-23](https://user-images.githubusercontent.com/6140710/71200961-11925500-2267-11ea-8e18-e4c779786d93.png)
Asterisks indicate the locales that will not be shown on qa or live. For consistency, this PR changes how locales are listed in the Angular app:

Before | After
-------|------
![Screen Shot 2019-12-19 at 12 57 36](https://user-images.githubusercontent.com/6140710/71201030-34bd0480-2267-11ea-9cfb-c8922cea8822.png) | ![Screen Shot 2019-12-19 at 13 56 41](https://user-images.githubusercontent.com/6140710/71201134-68982a00-2267-11ea-90d7-0209f9257565.png)

As you can see, I removed the lighter color and strikethrough. I think consistency in how we indicate this will be less confusing for developers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/479)
<!-- Reviewable:end -->
