### PR TITLE
Enable en-GB for production and remove locale code from menu

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -30,7 +30,6 @@
                 >
                   <!-- `langMenu.open = false` is workaround for menu not closing when click is on a span element -->
                   <span [class.locale-disabled]="!locale.production">{{ locale.localName }}</span>
-                  <span class="locale-code" (click)="langMenu.open = false">{{ locale.canonicalTag }}</span>
                 </mdc-list-item>
               </mdc-list>
             </mdc-menu>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -95,17 +95,8 @@ a {
   @include mdc-icon-button-size(32px, 32px, 8px);
 }
 
-.locale-menu mdc-list-item {
-  justify-content: space-between;
-}
-
 .locale-disabled::after {
   content: ' *';
-}
-
-.locale-code {
-  font-size: 0.9em;
-  font-family: monospace;
 }
 
 .active-locale {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -66,7 +66,7 @@ export class I18nService {
       direction: 'ltr',
       tags: ['en-GB'],
       dateFormat: { month: 'short', hour12: true },
-      production: false
+      production: true
     },
     {
       localName: 'Español',


### PR DESCRIPTION
How it looks now:

Development | Production (including QA)
------------|--------------------------
![Screen Shot 2019-12-20 at 16 28 35](https://user-images.githubusercontent.com/6140710/71294204-cac75c80-2345-11ea-873d-98e832e184c2.png) | ![Screen Shot 2019-12-20 at 16 23 29](https://user-images.githubusercontent.com/6140710/71294161-a3708f80-2345-11ea-9019-01680aa15741.png)

The locale codes may be useful for developers, but they're more likely to confuse users. The `en-GB` locale is production ready since the only thing it affects is date format. It makes for an easy way to test our locale selection and persistence system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/482)
<!-- Reviewable:end -->
