### PR TITLE
Move list of locales to separate JSON file

### DIFF
--- a/src/SIL.XForge.Scripture/SharedResource.cs
+++ b/src/SIL.XForge.Scripture/SharedResource.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using SIL.XForge.Models;
+using System.IO;
+using Newtonsoft.Json;
 
 namespace SIL.XForge.Scripture
 {
@@ -35,62 +37,18 @@ namespace SIL.XForge.Scripture
         /// <summary>
         /// Map of culture identifier (language tag) to interface language object (local name displayed in the chooser)
         /// </summary>
-        public static Dictionary<string, InterfaceLanguage> Cultures = new Dictionary<string, InterfaceLanguage>
+        public static Dictionary<string, InterfaceLanguage> Cultures = SharedResource.getCultures();
+
+        static Dictionary<string, InterfaceLanguage> getCultures()
         {
-            { "en", new InterfaceLanguage
-                {
-                    LocalName = "English (US)",
-                    EnglishName = "English (US)",
-                    CanonicalTag = "en",
-                    Tags = new string[]{ "en", "en-US" },
-                    Production = true
-                }
-            },
-            { "en-GB", new InterfaceLanguage
-                {
-                    LocalName = "English (UK)",
-                    EnglishName = "English (UK)",
-                    CanonicalTag = "en-GB",
-                    Tags = new string[]{ "en-GB" },
-                    Production = true
-                }
-            },
-            { "es", new InterfaceLanguage
-                {
-                    LocalName = "Español",
-                    EnglishName = "Spanish",
-                    CanonicalTag = "es",
-                    Tags = new string[]{ "es", "es-ES" },
-                    Production = false
-                }
-            },
-            { "zh-CN", new InterfaceLanguage
-                {
-                    LocalName = "简体中文",
-                    EnglishName = "Chinese (Simplified)",
-                    Direction = "ltr",
-                    Tags = new string[]{ "zh-CN", "zh" },
-                    Production = false
-                }
-            },
-            { "id", new InterfaceLanguage
-                {
-                    LocalName = "Bahasa Indonesia",
-                    EnglishName = "Indonesian",
-                    CanonicalTag = "id",
-                    Tags = new string[]{ "id", "id-ID" },
-                    Production = false
-                }
-            },
-            { "az", new InterfaceLanguage
-                {
-                    LocalName = "Azərbaycanca",
-                    EnglishName = "Azerbaijani",
-                    CanonicalTag = "az",
-                    Tags = new string[]{ "az", "az-AZ" },
-                    Production = false
-                }
+            // TODO consider making file path relative to current file rather than CWD
+            var cultureData = JsonConvert.DeserializeObject<List<InterfaceLanguage>>(File.ReadAllText("locales.json"));
+            var cultures = new Dictionary<string, InterfaceLanguage> { };
+            foreach (var culture in cultureData)
+            {
+                cultures.Add(culture.CanonicalTag, culture);
             }
-        };
+            return cultures;
+        }
     }
 }

--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -85,9 +85,8 @@ namespace SIL.XForge.Scripture
             services.Configure<RequestLocalizationOptions>(
                 opts =>
                 {
-                    // Add new cultures here as they are localized
                     var supportedCultures = new List<CultureInfo>();
-                    foreach(var culture in SharedResource.Cultures)
+                    foreach (var culture in SharedResource.Cultures)
                     {
                         supportedCultures.Add(new CultureInfo(culture.Key));
                     }
@@ -104,7 +103,8 @@ namespace SIL.XForge.Scripture
             services.AddMvc()
                 .SetCompatibilityVersion(CompatibilityVersion.Version_2_1)
                 .AddViewLocalization()
-                .AddDataAnnotationsLocalization(options => {
+                .AddDataAnnotationsLocalization(options =>
+                {
                     options.DataAnnotationLocalizerProvider = (type, factory) =>
                         factory.Create(typeof(SharedResource));
                 });

--- a/src/SIL.XForge.Scripture/locales.json
+++ b/src/SIL.XForge.Scripture/locales.json
@@ -1,0 +1,34 @@
+[
+  {
+    "localName": "English (US)",
+    "englishName": "English (US)",
+    "tags": ["en", "en-US"],
+    "production": true
+  },
+  {
+    "localName": "English (UK)",
+    "englishName": "English (UK)",
+    "tags": ["en-GB"],
+    "production": true
+  },
+  {
+    "localName": "简体中文",
+    "englishName": "Chinese (Simplified)",
+    "tags": ["zh-CN", "zh"]
+  },
+  {
+    "localName": "Español",
+    "englishName": "Spanish",
+    "tags": ["es", "es-ES"]
+  },
+  {
+    "localName": "Bahasa Indonesia",
+    "englishName": "Indonesian",
+    "tags": ["id", "id-ID"]
+  },
+  {
+    "localName": "Azərbaycanca",
+    "englishName": "Azerbaijani",
+    "tags": ["az", "az-AZ"]
+  }
+]

--- a/src/SIL.XForge/Models/InterfaceLanguage.cs
+++ b/src/SIL.XForge/Models/InterfaceLanguage.cs
@@ -4,9 +4,12 @@ namespace SIL.XForge.Models
     {
         public string LocalName { get; set; }
         public string EnglishName { get; set; }
-        public string CanonicalTag { get; set; }
+        public string CanonicalTag
+        {
+            get { return this.Tags[0]; }
+        }
         public string Direction { get; set; } = LanguageDirection.LTR;
         public string[] Tags { get; set; }
-        public bool Production { get; set; }
+        public bool Production { get; set; } = false;
     }
 }


### PR DESCRIPTION
Back end and front end now both read locales from the same place

Note: This PR also enables en-GB as a production-ready locale. Among other things #482 does that, but the file where it's specified is moved in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/487)
<!-- Reviewable:end -->
