### PR TITLE
SF-720 Mark remotely added answers as read when shown

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -181,7 +181,7 @@
       </div>
     </div>
     <div class="answers-component-footer" *ngIf="remoteAnswersCount > 0 && !answerFormVisible && shouldSeeAnswersList">
-      <button mdc-button id="show-unread-answers-button" (click)="showRemoteAnswers()">
+      <button mdc-button id="show-unread-answers-button" (click)="showRemoteAnswers(true)">
         {{ t("show_more_unread", { count: remoteAnswersCount }) }}
       </button>
     </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -33,7 +33,7 @@ import { CheckingTextComponent } from '../checking-text/checking-text.component'
 import { CommentAction } from './checking-comments/checking-comments.component';
 
 export interface AnswerAction {
-  action: 'delete' | 'save' | 'show-form' | 'hide-form' | 'like' | 'recorder';
+  action: 'delete' | 'save' | 'show-form' | 'hide-form' | 'like' | 'recorder' | 'show-unread';
   answer?: Answer;
   text?: string;
   verseRef?: VerseRefData;
@@ -430,12 +430,15 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     });
   }
 
-  showRemoteAnswers() {
+  showRemoteAnswers(showUnreadClicked?: boolean) {
     if (this.questionDoc == null || this.questionDoc.data == null) {
       return;
     }
     this.answersToShow = this.questionDoc.data.answers.map(answer => answer.dataId);
     this.justEditedAnswer = false;
+    if (showUnreadClicked) {
+      this.action.emit({ action: 'show-unread' });
+    }
   }
 
   private canLikeAnswer(answer: Answer): LikeAnswerResponse {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -225,6 +225,9 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
   }
 
   activateQuestion(questionDoc: QuestionDoc): void {
+    if (this.activeQuestionDoc != null && this.activeQuestionDoc.id === questionDoc.id) {
+      return;
+    }
     this.activeQuestionDoc = questionDoc;
     this.changed.emit(questionDoc);
     this.activeQuestionDoc$.next(questionDoc);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -681,6 +681,7 @@ describe('CheckingComponent', () => {
       // The new answer does not show up yet.
       expect(env.answers.length).toEqual(2);
       expect(env.component.answersPanel!.answers.length).toEqual(2);
+      expect(env.component.answersPanel!.projectUserConfigDoc!.data!.answerRefsRead.length).toEqual(3);
       expect(env.totalAnswersMessageCount).toEqual(3);
 
       // But a show-unread-answers control appears.
@@ -689,10 +690,11 @@ describe('CheckingComponent', () => {
 
       // Clicking makes the answer appear and the control go away.
       env.clickButton(env.showUnreadAnswersButton);
-      flush();
+      tick(env.questionReadTimer);
       expect(env.answers.length).toEqual(3);
       expect(env.component.answersPanel!.answers.length).toEqual(3);
       expect(env.showUnreadAnswersButton).toBeNull();
+      expect(env.component.answersPanel!.projectUserConfigDoc!.data!.answerRefsRead.length).toEqual(4);
       expect(env.totalAnswersMessageCount).toEqual(3);
     }));
 
@@ -718,9 +720,12 @@ describe('CheckingComponent', () => {
       expect(env.showUnreadAnswersButton).not.toBeNull();
       expect(env.unreadAnswersBannerCount).toEqual(1);
 
+      // clicking on the unread answer badge does not show the question
+      expect(env.getUnread(env.selectQuestion(6))).toEqual(1);
+
       // Clicking makes the answer appear and the control go away.
       env.clickButton(env.showUnreadAnswersButton);
-      flush();
+      tick(env.questionReadTimer);
       expect(env.answers.length).toEqual(2);
       expect(env.component.answersPanel!.answers.length).toEqual(2);
       expect(env.showUnreadAnswersButton).toBeNull();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -720,7 +720,7 @@ describe('CheckingComponent', () => {
       expect(env.showUnreadAnswersButton).not.toBeNull();
       expect(env.unreadAnswersBannerCount).toEqual(1);
 
-      // clicking on the unread answer badge does not show the question
+      // clicking on the unread answer badge does not show the unread answer
       expect(env.getUnread(env.selectQuestion(6))).toEqual(1);
 
       // Clicking makes the answer appear and the control go away.

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -720,8 +720,9 @@ describe('CheckingComponent', () => {
       expect(env.showUnreadAnswersButton).not.toBeNull();
       expect(env.unreadAnswersBannerCount).toEqual(1);
 
-      // clicking on the unread answer badge does not show the unread answer
+      // clicking on the unread answer badge and waiting 2s does not show the unread answer
       expect(env.getUnread(env.selectQuestion(6))).toEqual(1);
+      expect(env.showUnreadAnswersButton).not.toBeNull();
 
       // Clicking makes the answer appear and the control go away.
       env.clickButton(env.showUnreadAnswersButton);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -187,7 +187,8 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
   }
 
   get questionDocs(): Readonly<QuestionDoc[]> {
-    return this.questionsQuery != null ? this.questionsQuery.docs : [];
+    // Wait until the question query is ready before showing any question
+    return this.questionsQuery != null && this.questionsQuery.ready ? this.questionsQuery.docs : [];
   }
 
   get textsByBookId(): TextsByBookId {
@@ -429,6 +430,10 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
         if (answerAction.answer != null) {
           this.likeAnswer(answerAction.answer);
         }
+        break;
+      case 'show-unread':
+        // Emit the question doc so that answers and comments get marked as read
+        this.questionsPanel.activeQuestionDoc$.next(this.questionsPanel.activeQuestionDoc);
         break;
       case 'show-form':
         this.resetAnswerPanelHeightOnFormHide = true;


### PR DESCRIPTION
* Answers were not being marked as read when a user clicked on
* show unread answers
* Also do not mark the answer read if the user clicks the answer badge
* Also wait to show questions until question query is ready

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/490)
<!-- Reviewable:end -->
