### PR TITLE
SF-610 Improve rtl support in Quill editor

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -13,6 +13,10 @@ quill-editor {
       text-align: start;
     }
   }
+  usx-segment {
+    margin-left: 0.2em;
+    margin-right: 0.2em;
+  }
 }
 
 .read-only-editor > .ql-container {
@@ -77,7 +81,8 @@ quill-editor {
   }
 }
 
-.ltr .question-segment[data-question-count] {
+.ltr .ql-editor > p .question-segment[data-question-count],
+usx-para[dir='ltr'] .question-segment[data-question-count] {
   margin-left: 1.75em;
   &:before {
     left: -2.25em;
@@ -86,7 +91,8 @@ quill-editor {
     left: -1.5em;
   }
 }
-.rtl .question-segment[data-question-count] {
+.rtl .ql-editor > .question-segment[data-question-count],
+usx-para[dir='rtl'] .question-segment[data-question-count] {
   margin-right: 1.75em;
   &:before {
     right: -2.25em;
@@ -114,17 +120,10 @@ quill-editor {
         display: inline;
         box-sizing: border-box;
 
-        box-decoration-break: clone;
-        -webkit-box-decoration-break: clone;
+        box-decoration-break: slice;
 
         color: rgba(0, 0, 0, 0.8);
         background-color: white;
-
-        usx-verse > span > span {
-          padding-top: 0.35em;
-          background-color: #f5f3ef;
-          border-radius: 8px;
-        }
       }
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -168,126 +168,122 @@ usx-para {
     text-align: center;
   }
 }
-.ltr {
-  usx-para {
-    &[data-style='li'],
-    &[data-style='li1'] {
-      margin-left: 10%;
-      text-indent: -7.5%;
-    }
+usx-para[dir='ltr'] {
+  &[data-style='li'],
+  &[data-style='li1'] {
+    margin-left: 10%;
+    text-indent: -7.5%;
+  }
 
-    &[data-style='li2'] {
-      margin-left: 15%;
-      text-indent: -7.5%;
-    }
+  &[data-style='li2'] {
+    margin-left: 15%;
+    text-indent: -7.5%;
+  }
 
-    &[data-style='li3'] {
-      margin-left: 20%;
-      text-indent: -7.5%;
-    }
+  &[data-style='li3'] {
+    margin-left: 20%;
+    text-indent: -7.5%;
+  }
 
-    &[data-style='li4'] {
-      margin-left: 25%;
-      text-indent: -7.5%;
-    }
+  &[data-style='li4'] {
+    margin-left: 25%;
+    text-indent: -7.5%;
+  }
 
-    &[data-style='q'],
-    &[data-style='q1'] {
-      margin-left: 25%;
-      text-indent: -20%;
-    }
+  &[data-style='q'],
+  &[data-style='q1'] {
+    margin-left: 25%;
+    text-indent: -20%;
+  }
 
-    &[data-style='q2'] {
-      margin-left: 25%;
-      text-indent: -15%;
-    }
+  &[data-style='q2'] {
+    margin-left: 25%;
+    text-indent: -15%;
+  }
 
-    &[data-style='q3'] {
-      margin-left: 25%;
-      text-indent: -10%;
-    }
+  &[data-style='q3'] {
+    margin-left: 25%;
+    text-indent: -10%;
+  }
 
-    &[data-style='q4'] {
-      margin-left: 25%;
-      text-indent: -5%;
-    }
+  &[data-style='q4'] {
+    margin-left: 25%;
+    text-indent: -5%;
+  }
 
-    &[data-style='qm'],
-    &[data-style='qm1'] {
-      margin-left: 20%;
-      text-indent: -15%;
-    }
+  &[data-style='qm'],
+  &[data-style='qm1'] {
+    margin-left: 20%;
+    text-indent: -15%;
+  }
 
-    &[data-style='qm2'] {
-      margin-left: 20%;
-      text-indent: -10%;
-    }
+  &[data-style='qm2'] {
+    margin-left: 20%;
+    text-indent: -10%;
+  }
 
-    &[data-style='qm3'] {
-      margin-left: 20%;
-      text-indent: -5%;
-    }
+  &[data-style='qm3'] {
+    margin-left: 20%;
+    text-indent: -5%;
   }
 }
-.rtl {
-  usx-para {
-    &[data-style='li'],
-    &[data-style='li1'] {
-      margin-right: 10%;
-      text-indent: -7.5%;
-    }
+usx-para[dir='rtl'] {
+  &[data-style='li'],
+  &[data-style='li1'] {
+    margin-right: 10%;
+    text-indent: -7.5%;
+  }
 
-    &[data-style='li2'] {
-      margin-right: 15%;
-      text-indent: -7.5%;
-    }
+  &[data-style='li2'] {
+    margin-right: 15%;
+    text-indent: -7.5%;
+  }
 
-    &[data-style='li3'] {
-      margin-right: 20%;
-      text-indent: -7.5%;
-    }
+  &[data-style='li3'] {
+    margin-right: 20%;
+    text-indent: -7.5%;
+  }
 
-    &[data-style='li4'] {
-      margin-right: 25%;
-      text-indent: -7.5%;
-    }
+  &[data-style='li4'] {
+    margin-right: 25%;
+    text-indent: -7.5%;
+  }
 
-    &[data-style='q'],
-    &[data-style='q1'] {
-      margin-right: 25%;
-      text-indent: -20%;
-    }
+  &[data-style='q'],
+  &[data-style='q1'] {
+    margin-right: 25%;
+    text-indent: -20%;
+  }
 
-    &[data-style='q2'] {
-      margin-right: 25%;
-      text-indent: -15%;
-    }
+  &[data-style='q2'] {
+    margin-right: 25%;
+    text-indent: -15%;
+  }
 
-    &[data-style='q3'] {
-      margin-right: 25%;
-      text-indent: -10%;
-    }
+  &[data-style='q3'] {
+    margin-right: 25%;
+    text-indent: -10%;
+  }
 
-    &[data-style='q4'] {
-      margin-right: 25%;
-      text-indent: -5%;
-    }
+  &[data-style='q4'] {
+    margin-right: 25%;
+    text-indent: -5%;
+  }
 
-    &[data-style='qm'],
-    &[data-style='qm1'] {
-      margin-right: 20%;
-      text-indent: -15%;
-    }
+  &[data-style='qm'],
+  &[data-style='qm1'] {
+    margin-right: 20%;
+    text-indent: -15%;
+  }
 
-    &[data-style='qm2'] {
-      margin-right: 20%;
-      text-indent: -10%;
-    }
+  &[data-style='qm2'] {
+    margin-right: 20%;
+    text-indent: -10%;
+  }
 
-    &[data-style='qm3'] {
-      margin-right: 20%;
-      text-indent: -5%;
-    }
+  &[data-style='qm3'] {
+    margin-right: 20%;
+    text-indent: -5%;
   }
 }
 
@@ -312,10 +308,14 @@ usx-verse {
     // superscript
     top: -0.5em;
     position: relative;
+    display: inline-block;
     font-size: 75%;
-    line-height: 0;
-    vertical-align: baseline;
-    padding-right: 0.12em;
+    line-height: 1;
+    padding: 0.3em 0.4em;
+    background-color: #f5f3ef;
+    border-radius: 8px;
+    white-space: nowrap;
+    margin: 0 0.2em 0 0.3em;
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1125,6 +1125,25 @@ describe('CheckingComponent', () => {
       expect(segment.hasAttribute('data-question-count')).toBe(true);
       expect(segment.getAttribute('data-question-count')).toBe('13');
     }));
+
+    it('sets text and paragraph direction ', fakeAsync(() => {
+      const env = new TestEnvironment(ADMIN_USER);
+      // the dir property is needed on the Quill editor because chapters don't always have paragraphs
+      expect(env.quillEditorElement.getAttribute('dir')).toEqual('auto');
+      // ensure multiple paragraphs were found, otherwise the test is meaningless
+      expect(env.paragraphs.length).toBeGreaterThan(1);
+      for (const index in env.paragraphs) {
+        if (env.paragraphs.hasOwnProperty(index)) {
+          const paragraph = env.paragraphs[index];
+          // Ensure the correct direction has been applied to each paragraph
+          let expected = 'ltr';
+          if (index === '3') {
+            expected = 'rtl';
+          }
+          expect(paragraph.getAttribute('dir')).toEqual(expected);
+        }
+      }
+    }));
   });
 });
 
@@ -1334,6 +1353,10 @@ class TestEnvironment {
 
   get quillEditorElement(): HTMLElement {
     return document.getElementsByTagName('quill-editor')[0] as HTMLElement;
+  }
+
+  get paragraphs(): HTMLElement[] {
+    return this.fixture.debugElement.nativeElement.querySelectorAll('usx-para');
   }
 
   get recordButton(): DebugElement {
@@ -1909,6 +1932,9 @@ class TestEnvironment {
     delta.insert({ blank: true }, { segment: `verse_${chapter}_4/p_1` });
     delta.insert({ verse: { number: '5', style: 'v' } });
     delta.insert(`target: chapter ${chapter}, `, { segment: `verse_${chapter}_5` });
+    delta.insert('\n', { para: { style: 'p' } });
+    delta.insert({ verse: { number: '6', style: 'v' } });
+    delta.insert(`ישע`, { segment: `verse_${chapter}_6` });
     delta.insert('\n', { para: { style: 'p' } });
     return delta;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -104,7 +104,7 @@ export function registerScripture(): void {
       node.appendChild(document.createTextNode(ZWSP));
       const containerSpan = document.createElement('span');
       const verseSpan = document.createElement('span');
-      verseSpan.innerText = NBSP + value.number + NBSP;
+      verseSpan.innerText = value.number;
       containerSpan.appendChild(verseSpan);
       node.appendChild(containerSpan);
       setUsxValue(node, value);
@@ -311,6 +311,7 @@ export function registerScripture(): void {
     static create(value: Para): Node {
       const node = super.create(value) as HTMLElement;
       node.setAttribute(customAttributeName('style'), value.style);
+      node.setAttribute('dir', 'auto');
       setUsxValue(node, value);
       return node;
     }
@@ -365,6 +366,7 @@ export function registerScripture(): void {
     static create(value: string): Node {
       const node = super.create(value) as HTMLElement;
       node.setAttribute(customAttributeName('segment'), value);
+      node.setAttribute('dir', 'auto');
       return node;
     }
 


### PR DESCRIPTION
Set `dir="auto"` on each paragraph, rather than just the editor as a whole.

![](https://user-images.githubusercontent.com/6140710/71845198-cadd9100-3095-11ea-9931-f845e9e2e0db.png)

This isn't a perfect solution (it doesn't support bi-directional text within a paragraph), but it should greatly improve the situation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/494)
<!-- Reviewable:end -->
