### PR TITLE
SF-738 Fix jerkyness when selecting text for an answer

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.scss
@@ -22,6 +22,11 @@ app-text {
   font-style: italic;
 }
 
+.selection-preview {
+  height: 6em;
+  overflow-y: scroll;
+}
+
 .error-message {
   color: var(--mdc-theme-error);
   font-size: 0.85em;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
@@ -343,7 +343,7 @@ class TestEnvironment {
       } as Selection;
     });
 
-    when(mockedDocument.addEventListener('selectionchange', anything())).thenCall(
+    when(mockedDocument.addEventListener('selectionchange', anything(), anything())).thenCall(
       (_event: string, callback: () => any) => {
         this.selectionChangeHandler = callback;
       }


### PR DESCRIPTION
- Debounce selection change event
- Set selection preview element to a constant height to prevent the text
that is being selected from moving as a result of the selection

(Note that debouncing the selection change event wasn't really necessary in order to fix this).

An alternative solution I considered was to wait until after the user is finished making a selection. However, there is no event for this, so the only way to detect it would be based on mouse and keyboard events, which wouldn't be a very reliable method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/500)
<!-- Reviewable:end -->
