### PR TITLE
SF-743 Followup refactor, test, edit

### DIFF
--- a/src/SIL.XForge.Scripture/Models/Chapter.cs
+++ b/src/SIL.XForge.Scripture/Models/Chapter.cs
@@ -4,6 +4,9 @@ namespace SIL.XForge.Scripture.Models
     {
         public int Number { get; set; }
         public int LastVerse { get; set; }
+        /// <summary>Whether the chapter's USX conforms to the usx-sf SF USX
+        /// schema, which is a subset of the USX schema. If not, it will not
+        /// be editable in SF.</summary>
         public bool IsValid { get; set; }
     }
 }

--- a/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
@@ -41,6 +41,22 @@ namespace SIL.XForge.Scripture.Services
             public bool TopLevelVerses { get; set; }
         }
 
+        /// <summary>
+        /// Create list of ChapterDelta objects from USX.
+        ///
+        /// PT Data Access gives USX with chapters for each chapter that is
+        /// present in its project content. It will skip over chapters that are
+        /// not present in its project content. If there are no chapters present
+        /// in the project content, PT Data Access will return USX with no explicit
+        /// chapters.
+        ///
+        /// ToChapterDeltas will return a ChapterDelta for each chapter in
+        /// USX. If there are no explicit chapters in USX, return a single
+        /// ChapterDelta with a non-null Delta with an empty Ops list. This
+        /// is because every book has at least one chapter. The book
+        /// introduction is part of an implicit first chapter, even if there
+        /// are no explicit chapters.
+        /// </summary>
         public IEnumerable<ChapterDelta> ToChapterDeltas(XDocument usxDoc)
         {
             var invalidNodes = new HashSet<XNode>();

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -38,6 +38,10 @@ namespace SIL.XForge.Scripture.Services
     /// 1. The current notes are retrieved from the PT data access API.
     /// 2. A notes changelist XML is generated from the real-time question docs.
     /// 3. The notes changelist is sent to the PT data access API.
+    ///
+    /// Target and source refer to child and mother translation data. Not
+    /// to be confused with a target or source for where data is coming
+    /// from or going to when fetching or syncing.
     /// </summary>
     public class ParatextSyncRunner
     {
@@ -240,15 +244,37 @@ namespace SIL.XForge.Scripture.Services
         private async Task<List<Chapter>> SyncBookUsxAsync(TextInfo text, TextType textType, string paratextId,
             string fileName, bool isReadOnly, ISet<int> chaptersToInclude)
         {
-            SortedList<int, IDocument<Models.TextData>> textDocs = await FetchTextDocsAsync(text, textType);
+            SortedList<int, IDocument<Models.TextData>> dbChapterDocs = await FetchTextDocsAsync(text, textType);
 
             string bookId = Canon.BookNumberToId(text.BookNum);
-            // Merge mongo data to PT cloud.
+            string ptBookText = await FetchFromAndUpdateParatextAsync(text,
+                paratextId, fileName, isReadOnly, bookId, dbChapterDocs);
+            await UpdateProgress();
+
+            XElement bookTextElem = XElement.Parse(ptBookText);
+            var usxDoc = new XDocument(bookTextElem.Element("usx"));
+            Dictionary<int, ChapterDelta> incomingChapters = _deltaUsxMapper.ToChapterDeltas(usxDoc)
+                .ToDictionary(cd => cd.Number);
+
+            // Set SF DB to snapshot from Paratext.
+            List<Chapter> chapters = await ChangeDbToNewSnapshotAsync(text,
+                textType, chaptersToInclude, dbChapterDocs, incomingChapters);
+
+            // Save to disk
+            await SaveXmlFileAsync(bookTextElem, fileName);
+
+            await UpdateProgress();
+            return chapters;
+        }
+
+        private async Task<string> FetchFromAndUpdateParatextAsync(TextInfo text, string paratextId,
+            string fileName, bool isReadOnly, string bookId, SortedList<int, IDocument<Models.TextData>> dbChapterDocs)
+        {
             XElement bookTextElem;
-            string bookText;
+            string ptBookText;
             if (isReadOnly)
             {
-                bookText = await _paratextService.GetBookTextAsync(_userSecret, paratextId, bookId);
+                ptBookText = await _paratextService.GetBookTextAsync(_userSecret, paratextId, bookId);
             }
             else
             {
@@ -257,61 +283,64 @@ namespace SIL.XForge.Scripture.Services
 
                 var oldUsxDoc = new XDocument(bookTextElem.Element("usx"));
                 XDocument newUsxDoc = _deltaUsxMapper.ToUsx(oldUsxDoc, text.Chapters.OrderBy(c => c.Number)
-                    .Select(c => new ChapterDelta(c.Number, c.LastVerse, c.IsValid, textDocs[c.Number].Data)));
+                    .Select(c => new ChapterDelta(c.Number, c.LastVerse, c.IsValid, dbChapterDocs[c.Number].Data)));
 
                 var revision = (string)bookTextElem.Attribute("revision");
 
                 if (XNode.DeepEquals(oldUsxDoc, newUsxDoc))
                 {
-                    bookText = await _paratextService.GetBookTextAsync(_userSecret, paratextId, bookId);
+                    ptBookText = await _paratextService.GetBookTextAsync(_userSecret, paratextId, bookId);
                 }
                 else
                 {
-                    bookText = await _paratextService.UpdateBookTextAsync(_userSecret, paratextId, bookId,
+                    ptBookText = await _paratextService.UpdateBookTextAsync(_userSecret, paratextId, bookId,
                         revision, newUsxDoc.Root.ToString());
                 }
             }
-            await UpdateProgress();
+            return ptBookText;
+        }
 
-            bookTextElem = XElement.Parse(bookText);
+        internal async Task<List<Chapter>> ChangeDbToNewSnapshotAsync(
+            TextInfo text, TextType textType, ISet<int> chaptersToInclude,
+            SortedList<int, IDocument<TextData>> dbChapterDocs, Dictionary<int,
+            ChapterDelta> incomingChapters)
+        {
+            Debug.Assert(dbChapterDocs.All(chapter => chapter.Value.IsLoaded),
+                "Docs must be loaded from the DB.");
+            Debug.Assert(incomingChapters.All(incomingChapter => incomingChapter.Value.Delta != null),
+                "Incoming chapter deltas cannot be null. Maybe DeltaUsxMapper.ToChapterDeltas() has a bug?");
 
-            // Merge updated PT cloud data into mongo.
-            var usxDoc = new XDocument(bookTextElem.Element("usx"));
             var tasks = new List<Task>();
-            Dictionary<int, ChapterDelta> deltas = _deltaUsxMapper.ToChapterDeltas(usxDoc)
-                .ToDictionary(cd => cd.Number);
             var chapters = new List<Chapter>();
-            Debug.Assert(textDocs.All(chapter => chapter.Value.IsLoaded), "Docs must be loaded from the DB.");
-            Debug.Assert(deltas.All(incomingChapter => incomingChapter.Value.Delta != null), "Incoming chapter deltas cannot be null. Maybe DeltaUsxMapper.ToChapterDeltas() has a bug?");
-            foreach (KeyValuePair<int, ChapterDelta> kvp in deltas)
+            foreach (KeyValuePair<int, ChapterDelta> incomingChapter in incomingChapters)
             {
-                if (textDocs.TryGetValue(kvp.Key, out IDocument<Models.TextData> textDataDoc))
+                if (dbChapterDocs.TryGetValue(incomingChapter.Key, out IDocument<Models.TextData> dbChapterDoc))
                 {
-                    Delta diffDelta = textDataDoc.Data.Diff(kvp.Value.Delta);
+                    Delta diffDelta = dbChapterDoc.Data.Diff(incomingChapter.Value.Delta);
                     if (diffDelta.Ops.Count > 0)
-                        tasks.Add(textDataDoc.SubmitOpAsync(diffDelta));
-                    textDocs.Remove(kvp.Key);
+                    {
+                        tasks.Add(dbChapterDoc.SubmitOpAsync(diffDelta));
+                    }
+                    dbChapterDocs.Remove(incomingChapter.Key);
                 }
-                else if (chaptersToInclude == null || chaptersToInclude.Contains(kvp.Key))
+                else if (chaptersToInclude == null || chaptersToInclude.Contains(incomingChapter.Key))
                 {
-                    textDataDoc = GetTextDoc(text, kvp.Key, textType);
-                    tasks.Add(textDataDoc.CreateAsync(new Models.TextData(kvp.Value.Delta)));
+                    // Set database to content from Paratext.
+                    dbChapterDoc = GetTextDoc(text, incomingChapter.Key, textType);
+                    tasks.Add(dbChapterDoc.CreateAsync(new Models.TextData(incomingChapter.Value.Delta)));
                 }
                 chapters.Add(new Chapter
                 {
-                    Number = kvp.Key,
-                    LastVerse = kvp.Value.LastVerse,
-                    IsValid = kvp.Value.IsValid
+                    Number = incomingChapter.Key,
+                    LastVerse = incomingChapter.Value.LastVerse,
+                    IsValid = incomingChapter.Value.IsValid
                 });
             }
-            foreach (KeyValuePair<int, IDocument<Models.TextData>> kvp in textDocs)
-                tasks.Add(kvp.Value.DeleteAsync());
+            foreach (KeyValuePair<int, IDocument<Models.TextData>> dbChapterDoc in dbChapterDocs)
+            {
+                tasks.Add(dbChapterDoc.Value.DeleteAsync());
+            }
             await Task.WhenAll(tasks);
-
-            // Save to disk
-            await SaveXmlFileAsync(bookTextElem, fileName);
-
-            await UpdateProgress();
             return chapters;
         }
 

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -280,6 +281,8 @@ namespace SIL.XForge.Scripture.Services
             Dictionary<int, ChapterDelta> deltas = _deltaUsxMapper.ToChapterDeltas(usxDoc)
                 .ToDictionary(cd => cd.Number);
             var chapters = new List<Chapter>();
+            Debug.Assert(textDocs.All(chapter => chapter.Value.IsLoaded), "Docs must be loaded from the DB.");
+            Debug.Assert(deltas.All(incomingChapter => incomingChapter.Value.Delta != null), "Incoming chapter deltas cannot be null. Maybe DeltaUsxMapper.ToChapterDeltas() has a bug?");
             foreach (KeyValuePair<int, ChapterDelta> kvp in deltas)
             {
                 if (textDocs.TryGetValue(kvp.Key, out IDocument<Models.TextData> textDataDoc))

--- a/src/SIL.XForge/Realtime/MemoryDocument.cs
+++ b/src/SIL.XForge/Realtime/MemoryDocument.cs
@@ -43,6 +43,11 @@ namespace SIL.XForge.Realtime
 
         public async Task DeleteAsync()
         {
+            if (!_repo.Contains(Id))
+            {
+                throw new Microsoft.AspNetCore.NodeServices.HostingModels.NodeInvocationException(
+                    "Document does not exist", "Would be received in production.");
+            }
             await _repo.DeleteAsync(Id);
             Data = default(T);
             Version = -1;

--- a/src/SIL.XForge/Realtime/RichText/Delta.cs
+++ b/src/SIL.XForge/Realtime/RichText/Delta.cs
@@ -147,6 +147,11 @@ namespace SIL.XForge.Realtime.RichText
             if (this == other)
                 return new Delta();
 
+            if (other == null)
+            {
+                throw new ArgumentNullException(nameof(other));
+            }
+
             if (!TryConcatInserts(this, out string thisStr) || !TryConcatInserts(other, out string otherStr))
                 throw new InvalidOperationException("Both deltas must be documents.");
 

--- a/test/SIL.XForge.Tests/Realtime/RichText/DeltaTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/RichText/DeltaTests.cs
@@ -381,8 +381,25 @@ namespace SIL.XForge.Realtime.RichText
         {
             var a = Delta.New().Insert("AB");
             var b = Delta.New().Insert("A");
-            var expected = Delta.New().Retain(1).Delete(1);
+            var expected = Delta.New().Retain("A".Length).Delete("B".Length);
             Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+        }
+
+        [Test]
+        public void Diff_Empty()
+        {
+            var a = Delta.New().Insert("AB");
+            var b = Delta.New();
+            var expected = Delta.New().Delete("AB".Length);
+            Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+        }
+
+        [Test]
+        public void Diff_Null()
+        {
+            var a = Delta.New().Insert("AB");
+            Delta b = null;
+            Assert.That(() => a.Diff(b), Throws.ArgumentNullException);
         }
 
         [Test]


### PR DESCRIPTION
* Explicitly crash on Delta.Diff(null).
* SF-743 Assert state of data
  - There might be a problem where incoming chapter deltas have a null
    Delta from DeltaUsxMapper.ToChapterDeltas(). If so, crash early and
    with some explanation.
* Crash in MemoryDocument.DeleteAsync() to mimic production
  - To help unit tests identify problems.
* Refactor in ParatextSyncRunner
  - Break up SyncBookUsxAsync() into some smaller methods, to help
    understandability and testing.
  - Rename variables to make it more clear what data sources we are
    working with and what the variables are. (eg PT Data Access, SF
    database, chapters)
  - Add comments.
  - This is not intended to have any behavioural changes.
* SF-743 Add sync test
  - Add test for ChangeDbToNewSnapshotAsync() now that it exists after
    refactor.
  - This could probably be changed to just test against RunAsync().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/504)
<!-- Reviewable:end -->
