### PR TITLE
SF-745 Change text selection dialog error message

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
@@ -50,7 +50,7 @@ describe('TextChooserDialogComponent', () => {
     env.selection = '';
     expect(env.errorMessage).toBeNull();
     env.click(env.saveButton);
-    expect(env.errorMessage.textContent).toEqual('Select text to attach to your answer.');
+    expect(env.errorMessage.textContent).toEqual('Select verses to attach to your answer.');
     env.closeDialog();
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -269,6 +269,6 @@
     "cancel": "Cancel",
     "save": "Save",
     "select_scripture": "Select scripture to attach to your answer",
-    "select_text_error_message": "Select text to attach to your answer."
+    "select_text_error_message": "Select verses to attach to your answer."
   }
 }


### PR DESCRIPTION
Selecting text that is not in verses (e.g. text in the introduction) is not supported. If a user selected it and clicked "save", the error message was "Select text to attach to your answer." That message may not be the most useful in that case, so it has been changed to "Select verses to attach to your answer" to be slightly clearer.

Once this is merged the updated translation file should be sent to Crowdin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/505)
<!-- Reviewable:end -->
