### PR TITLE
Fix clickability of part of chapter select menu in translate app

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.scss
@@ -16,12 +16,11 @@
   @include mdc-select-container-fill-color(transparent);
   height: 40px;
   align-items: center;
-  padding-right: 1.25em;
 
   ::ng-deep .mdc-select__selected-text {
     border: none;
     min-width: 140px;
-    padding: 8px;
+    padding: 8px 2em 8px 8px;
     height: 40px;
   }
   ::ng-deep .mdc-select__dropdown-icon {


### PR DESCRIPTION
Previously the far right side of the chapter selection menu in the translate app was not clickable.

This was introduced in  #432 when fixing a related issue.

Before | After
-------|------
![](https://user-images.githubusercontent.com/6140710/72169975-16e24b80-339e-11ea-8a6d-9c118a8a76d5.png) | ![](https://user-images.githubusercontent.com/6140710/72172122-5f036d00-33a2-11ea-9972-56222b798ba0.png)


These screenshots are from Firefox's element picker. The purple area shows padding, which in this case corresponded to an unclickable region of the chapter selection menu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/507)
<!-- Reviewable:end -->
