### PR TITLE
SF-740 The project has been deleted

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -343,6 +343,17 @@ describe('AppComponent', () => {
       // Expect: Community Checking | Overview | John | Synchronize | Settings | Users
       expect(env.menuLength).toEqual(6);
     }));
+
+    it('ensure local storage is cleared when removed from project', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.navigate(['/projects', 'project01']);
+      env.init();
+
+      const projectId = 'project01';
+      expect(env.selectedProjectId).toEqual(projectId);
+      env.removesUserFromProject(projectId);
+      verify(mockedSFProjectService.localDelete(projectId)).once();
+    }));
   });
 });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -330,6 +330,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
           ) {
             // The user has been removed from the project
             this.showProjectDeletedDialog();
+            this.projectService.localDelete(this.selectedProjectDoc.id);
           }
           // See if we need to enable any books in the checking app
           if (this.isCheckingEnabled && !this.checkingVisible) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -4,7 +4,7 @@ import { LatinWordTokenizer, MAX_SEGMENT_LENGTH, RemoteTranslationEngine } from 
 import * as crc from 'crc-32';
 import { obj } from 'realtime-server/lib/common/utils/obj-path';
 import { getQuestionDocId, Question } from 'realtime-server/lib/scriptureforge/models/question';
-import { SFProject } from 'realtime-server/lib/scriptureforge/models/sf-project';
+import { SF_PROJECTS_COLLECTION, SFProject } from 'realtime-server/lib/scriptureforge/models/sf-project';
 import {
   getSFProjectUserConfigDocId,
   SFProjectUserConfig
@@ -51,6 +51,13 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
 
   createTranslationEngine(projectId: string): RemoteTranslationEngine {
     return new RemoteTranslationEngine(projectId, this.machineHttp);
+  }
+
+  /**
+   * Remove project from local storage which is useful when a project is no longer accessible by a user
+   */
+  localDelete(projectId: string): Promise<void> {
+    return this.realtimeService.offlineStore.delete(SF_PROJECTS_COLLECTION, projectId);
   }
 
   onlineAddTranslateMetrics(id: string, metrics: TranslateMetrics): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
@@ -169,6 +169,21 @@ describe('ProjectComponent', () => {
     verify(mockedRouter.navigateByUrl('/projects', anything())).once();
     expect().nothing();
   }));
+
+  it('ensure local storage is cleared when sharing a project fails', fakeAsync(() => {
+    const env = new TestEnvironment();
+    const projectId = 'project01';
+    when(mockedSFProjectService.onlineCheckLinkSharing(projectId, undefined)).thenReject(
+      new CommandError(CommandErrorCode.Forbidden, 'Forbidden')
+    );
+    env.setProjectData({ selectedTask: 'translate', selectedBooknum: 41 });
+    env.setLinkSharing(true);
+    env.fixture.detectChanges();
+    tick();
+
+    verify(mockedSFProjectService.localDelete(projectId)).once();
+    expect().nothing();
+  }));
 });
 
 class TestEnvironment {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
@@ -48,6 +48,7 @@ export class ProjectComponent extends DataLoadingComponent implements OnInit {
               err instanceof CommandError &&
               (err.code === CommandErrorCode.Forbidden || err.code === CommandErrorCode.NotFound)
             ) {
+              await this.projectService.localDelete(projectId);
               await this.noticeService.showMessageDialog(this.transloco.translate('project.project_link_is_invalid'));
               this.router.navigateByUrl('/projects', { replaceUrl: true });
               return;


### PR DESCRIPTION
- Created localDelete() in sf-project.service.ts to remove the project from indexdb
- If sharing fails then the local data of the project is removed
- If a user is removed from the project then the local data of the project is removed

The bug occurs when IndexDB has stored that sharing is disabled. When sharing is enabled again and the link shared 2 remote changes get triggered. The first tells IndexDB that sharing is now enabled. At this point the user roles on the project is yet to have its remote changes brought through so the app thinks they don't have permission. Straight after that the second remote change triggers which gives the user role permission to the project. By this point it is too late as the dialog is already appeared.

The solution I suggest is to ensure any local data in IndexDB is removed which means when the sharing URL is used again it will grab an online copy of the project rather than a local copy and therefore have all the remote changes in a single request.

I am assuming that if a user is removed from a project there is no need to remember anything about that project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/510)
<!-- Reviewable:end -->
