### PR TITLE
SF-754 Fix split container y-axis scrolling on Firefox

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -39,6 +39,9 @@
       @include media-breakpoint-down(sm) {
         max-height: calc(100vh - 180px);
       }
+      > as-split {
+        height: auto; /* fix for SF-754 */
+      }
     }
     #scripture-panel {
       > .panel {


### PR DESCRIPTION
I was able to see this happen when my screen was 700 x 650 and the content of comments was more than the height of the page.
![Overflow_answer_height_100](https://user-images.githubusercontent.com/17931130/72760165-27ac7180-3b95-11ea-9eb7-bc859e94ff5d.PNG)

Specifying height=auto seemed to fix this issue.
![Overflow_answer_height_auto](https://user-images.githubusercontent.com/17931130/72760172-2aa76200-3b95-11ea-95a6-f0bc18d7c3b5.PNG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/519)
<!-- Reviewable:end -->
