### PR TITLE
Remove right and left padding on segments

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -13,10 +13,6 @@ quill-editor {
       text-align: start;
     }
   }
-  usx-segment {
-    margin-left: 0.2em;
-    margin-right: 0.2em;
-  }
 }
 
 .read-only-editor > .ql-container {


### PR DESCRIPTION
This fixes a bug when dragging and dropping text into segments

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/522)
<!-- Reviewable:end -->
