### PR TITLE
Fix showing of snackbar when a network error occurs

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
@@ -73,6 +73,10 @@ as-split.is-disabled > .as-split-gutter .as-split-gutter-icon {
   }
 }
 
+.snackbar-error .mdc-snackbar__surface {
+  background-color: var(--mdc-theme-error);
+}
+
 .mdc-select__selected-text {
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/notice.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/notice.service.ts
@@ -37,11 +37,11 @@ export class NoticeService {
   }
 
   async show(message: string): Promise<void> {
-    let config: MdcSnackbarConfig<any> | undefined;
-    if (!(await this.authService.isLoggedIn)) {
-      config = { classes: 'snackbar-above-footer' };
-    }
-    this.snackbar.open(message, undefined, config);
+    return this.showSnackBar(message);
+  }
+
+  async showError(message: string): Promise<void> {
+    return this.showSnackBar(message, ['snackbar-error']);
   }
 
   showMessageDialog(message: string): Promise<void> {
@@ -50,5 +50,14 @@ export class NoticeService {
     }) as MdcDialogRef<MessageDialogComponent, any>;
 
     return dialogRef.afterClosed().toPromise();
+  }
+
+  private async showSnackBar(message: string, classes: string[] = []): Promise<void> {
+    let config: MdcSnackbarConfig<any> | undefined;
+    if (!(await this.authService.isLoggedIn)) {
+      classes.push('snackbar-above-footer');
+    }
+    config = { classes: classes.join(' ') };
+    this.snackbar.open(message, undefined, config);
   }
 }


### PR DESCRIPTION
The snackbar wasn't being shown when the network error came from a promise rejection (which is how all or almost all network errors reach the exception handler).

How it looks now:
![](https://user-images.githubusercontent.com/6140710/73089129-98100700-3ea3-11ea-8272-264f9ad391e5.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/527)
<!-- Reviewable:end -->
