### PR TITLE
Fix styling of question count icon

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
@@ -11,6 +11,8 @@
   [ngClass]="{
     'read-only-editor': readOnlyEnabled,
     'template-editor': !readOnlyEnabled,
+    ltr: isLtr,
+    rtl: isRtl,
     'mark-invalid': markInvalid
   }"
   dir="auto"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -58,6 +58,7 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
   @Output() loaded = new EventEmitter(true);
   lang: string = '';
 
+  private direction: string | null = null;
   private _editorStyles: any = { fontSize: '1rem' };
   private readonly DEFAULT_MODULES: any = {
     toolbar: false,
@@ -220,6 +221,14 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
   set editorStyles(styles: object) {
     this._editorStyles = styles;
     this.applyEditorStyles();
+  }
+
+  get isLtr(): boolean {
+    return this.direction === 'ltr';
+  }
+
+  get isRtl(): boolean {
+    return this.direction === 'rtl';
   }
 
   get isSelectionAtSegmentEnd(): boolean {
@@ -435,6 +444,7 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
     // As the browser is automatically applying ltr/rtl we need to ask it which one it is using
     // This value can then be used for other purposes i.e. CSS styles
     if (this.editor !== undefined) {
+      this.direction = window.getComputedStyle(this.quill.nativeElement).direction;
       // Set the browser calculated direction on the segments so we can action elsewhere i.e. CSS
       let segments: NodeListOf<Element> = this.quill.nativeElement.querySelectorAll('usx-segment');
       for (const segment of Array.from(segments)) {


### PR DESCRIPTION
This was broken in #528 (8d72a6399084c5c7b5c8ade093885023d99730f1) with the removal of the `rtl` and `ltr` classes from the Quill editor element.

Here's how it looks when there is a question that's not in a `usx-para`.

![](https://user-images.githubusercontent.com/6140710/73211301-f6deb600-4119-11ea-9a1c-592908b72e6a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/530)
<!-- Reviewable:end -->
