### PR TITLE
Internationalize browser unsupported dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -265,6 +265,11 @@
     "connect_project": "Connect project",
     "not_connected_to_any_projects": "Looks like you aren't connected to any projects yet."
   },
+  "supported_browsers_dialog": {
+    "dismiss": "Dismiss",
+    "browser_unsupported": "This browser is unsupported",
+    "upgrade_chrome_firefox": "Some of the features of this website may not work correctly with your browser. We recommend upgrading to the latest {{ chromeLink }} or {{ firefoxLink }}."
+  },
   "text_chooser_dialog": {
     "cancel": "Cancel",
     "save": "Save",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.html
@@ -6,10 +6,7 @@
         <mdc-dialog-content>
           <p>{{ data.message }}</p>
           <p [innerHTML]="t('to_report_issue_email', { issueEmailLink: issueEmailLink })"></p>
-          <p
-            *ngIf="browserUnsupported"
-            [innerHTML]="t('unsupported_browser', { chromeLink: chromeLink, firefoxLink: firefoxLink })"
-          ></p>
+          <p *ngIf="browserUnsupported" [innerHTML]="t('unsupported_browser', browserLinks)"></p>
           <a (click)="this.showDetails = !this.showDetails" [fxShow]="data.stack">{{
             showDetails ? t("hide_details") : t("show_details")
           }}</a>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.spec.ts
@@ -45,13 +45,6 @@ describe('ErrorComponent', () => {
     expect(env.showDetails.style.display).toBe('none');
     expect(env.stackTrace.style.display).toBe('none');
   }));
-
-  it('should correctly generate links', fakeAsync(() => {
-    const errorComponent = new ErrorComponent(null as any, null as any);
-    expect(errorComponent.getLinkHTML('example', 'https://example.com')).toEqual(
-      `<a href="https://example.com" target="_blank">example</a>`
-    );
-  }));
 });
 
 @Directive({

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.ts
@@ -1,7 +1,6 @@
 import { MDC_DIALOG_DATA, MdcDialogRef } from '@angular-mdc/web/dialog';
 import { Component, Inject } from '@angular/core';
-import { translate } from '@ngneat/transloco';
-import { issuesEmailTemplate, supportedBrowser } from 'xforge-common/utils';
+import { browserLinks, getLinkHTML, issuesEmailTemplate, supportedBrowser } from 'xforge-common/utils';
 import { environment } from '../../environments/environment';
 
 export interface ErrorAlert {
@@ -21,22 +20,10 @@ export class ErrorComponent {
   constructor(public dialogRef: MdcDialogRef<ErrorComponent>, @Inject(MDC_DIALOG_DATA) public data: ErrorAlert) {}
 
   get issueEmailLink() {
-    return this.getLinkHTML(environment.issueEmail, issuesEmailTemplate(this.data.eventId));
+    return getLinkHTML(environment.issueEmail, issuesEmailTemplate(this.data.eventId));
   }
 
-  get chromeLink() {
-    return this.getLinkHTML(translate('error.chrome'), 'https://www.google.com/chrome/');
-  }
-
-  get firefoxLink() {
-    return this.getLinkHTML(translate('error.firefox'), 'https://firefox.com');
-  }
-
-  getLinkHTML(text: string, href: string) {
-    const a = document.createElement('a');
-    a.href = href;
-    a.setAttribute('target', '_blank');
-    a.textContent = text;
-    return a.outerHTML;
+  get browserLinks() {
+    return browserLinks();
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/supported-browsers-dialog/supported-browsers-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/supported-browsers-dialog/supported-browsers-dialog.component.html
@@ -1,17 +1,13 @@
-<mdc-dialog>
-  <mdc-dialog-container>
-    <mdc-dialog-surface>
-      <mdc-dialog-title>This browser is unsupported</mdc-dialog-title>
-      <mdc-dialog-content>
-        <p>
-          Some of the features of this website may not work correctly with your browser. We recommend upgrading to the
-          latest <a target="_blank" href="https://www.google.com/chrome/">Chrome</a> or
-          <a target="_blank" href="https://www.mozilla.org">Firefox.</a>
-        </p>
-      </mdc-dialog-content>
-      <mdc-dialog-actions>
-        <button mdcDialogButton type="button" mdcDialogAction="close">Dismiss</button>
-      </mdc-dialog-actions>
-    </mdc-dialog-surface>
-  </mdc-dialog-container>
-</mdc-dialog>
+<ng-container *transloco="let t; read: 'supported_browsers_dialog'">
+  <mdc-dialog>
+    <mdc-dialog-container>
+      <mdc-dialog-surface>
+        <mdc-dialog-title>{{ t("browser_unsupported") }}</mdc-dialog-title>
+        <mdc-dialog-content> <p [innerHTML]="t('upgrade_chrome_firefox', browserLinks)"></p> </mdc-dialog-content>
+        <mdc-dialog-actions>
+          <button mdcDialogButton type="button" mdcDialogAction="close">{{ t("dismiss") }}</button>
+        </mdc-dialog-actions>
+      </mdc-dialog-surface>
+    </mdc-dialog-container>
+  </mdc-dialog>
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/supported-browsers-dialog/supported-browsers-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/supported-browsers-dialog/supported-browsers-dialog.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { browserLinks } from 'xforge-common/utils';
 
 @Component({
   selector: 'app-supported-browsers-dialog',
@@ -6,4 +7,8 @@ import { Component } from '@angular/core';
 })
 export class SupportedBrowsersDialogComponent {
   constructor() {}
+
+  get browserLinks() {
+    return browserLinks();
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.spec.ts
@@ -1,4 +1,4 @@
-import { getAspCultureCookieLanguage } from './utils';
+import { getAspCultureCookieLanguage, getLinkHTML } from './utils';
 
 describe('Utils', () => {
   it('should parse ASP Culture cookie', () => {
@@ -16,5 +16,11 @@ describe('Utils', () => {
 
     language = getAspCultureCookieLanguage('');
     expect(language).toEqual('en');
+  });
+
+  it('should correctly generate links', () => {
+    expect(getLinkHTML('example', 'https://example.com')).toEqual(
+      `<a href="https://example.com" target="_blank">example</a>`
+    );
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -1,3 +1,4 @@
+import { translate } from '@ngneat/transloco';
 import Bowser from 'bowser';
 import ObjectID from 'bson-objectid';
 import { VerseRef } from 'realtime-server/lib/scriptureforge/scripture-utils/verse-ref';
@@ -124,4 +125,19 @@ export function getAspCultureCookieLanguage(cookie: string): string {
     }
   });
   return uic! || c! || 'en';
+}
+
+export function browserLinks() {
+  return {
+    chromeLink: getLinkHTML(translate('error.chrome'), 'https://www.google.com/chrome/'),
+    firefoxLink: getLinkHTML(translate('error.firefox'), 'https://firefox.com')
+  };
+}
+
+export function getLinkHTML(text: string, href: string) {
+  const a = document.createElement('a');
+  a.href = href;
+  a.setAttribute('target', '_blank');
+  a.textContent = text;
+  return a.outerHTML;
 }


### PR DESCRIPTION
The translation strings from the error component for "Chrome" and "Firefox" are now used in both the error component and the unsupported browser component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/532)
<!-- Reviewable:end -->
