### PR TITLE
Internationalize checking-questions component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.html
@@ -14,7 +14,7 @@
       <mdc-icon *ngIf="questionDoc.data?.audioUrl">headset</mdc-icon>
       <span class="question-text" *ngIf="questionDoc.data?.text">{{ questionDoc.data.text }}</span>
     </div>
-    <a class="view-answers" mdcListItemMeta title="View Answers">
+    <a class="view-answers" mdcListItemMeta title="{{ 'checking.view_questions' | transloco }}">
       <i mdcIcon>forum</i> <span>{{ getUnreadAnswers(questionDoc) }}</span>
     </a>
   </mdc-list-item>


### PR DESCRIPTION
Just a small bit of text that got missed. I opted to re-use the string from the checking component, since it's identical and used in approximately the same context. Also, since there's only one string, and the prefix isn't the same as the component name, I just used the pipe instead of the structural directive.

Put another way, I didn't want to write `<ng-container *transloco="let t; read: 'checking'">` in a file named `checking-questions.component.html`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/533)
<!-- Reviewable:end -->
