### PR TITLE
SF-777 Fix duplicate question on checking overview

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -115,9 +115,8 @@ describe('CheckingOverviewComponent', () => {
         dateModified: dateNow.toJSON()
       };
 
-      const questionDocId = getQuestionDocId('project01', newQuestion.dataId);
-      when(mockedQuestionDialogService.questionDialog(anything(), anything())).thenReturn(
-        env.realtimeService.create<QuestionDoc>(QuestionDoc.COLLECTION, questionDocId, newQuestion)
+      when(mockedQuestionDialogService.questionDialog(anything(), anything())).thenCall(() =>
+        env.addQuestion(newQuestion)
       );
 
       env.waitForQuestions();
@@ -131,7 +130,7 @@ describe('CheckingOverviewComponent', () => {
 
       env.clickElement(env.addQuestionButton);
       verify(mockedQuestionDialogService.questionDialog(anything(), undefined)).once();
-      env.fixture.detectChanges();
+      env.waitForQuestions();
       expect(env.textRows.length).toEqual(5); // Matthew, Luke, Luke 1, Question 1, Question 2
       expect(env.questionEditButtons.length).toEqual(2);
     }));
@@ -151,9 +150,8 @@ describe('CheckingOverviewComponent', () => {
         dateModified: dateNow.toJSON()
       };
 
-      const docId = getQuestionDocId('project01', newQuestion.dataId);
-      when(mockedQuestionDialogService.questionDialog(anything(), undefined)).thenReturn(
-        env.realtimeService.create<QuestionDoc>(QuestionDoc.COLLECTION, docId, newQuestion)
+      when(mockedQuestionDialogService.questionDialog(anything(), undefined)).thenCall(() =>
+        env.addQuestion(newQuestion)
       );
       env.waitForQuestions();
       expect(env.textRows.length).toEqual(0);
@@ -161,6 +159,10 @@ describe('CheckingOverviewComponent', () => {
       verify(mockedQuestionDialogService.questionDialog(anything(), undefined)).once();
       env.waitForQuestions();
       expect(env.textRows.length).toEqual(1);
+      env.simulateRowClick(1);
+      const id = new TextDocId('project01', 42, 1);
+      env.simulateRowClick(2, id);
+      expect(env.textRows.length).toEqual(3);
     }));
   });
 
@@ -729,6 +731,7 @@ class TestEnvironment {
   }
 
   waitForQuestions(): void {
+    this.realtimeService.updateAllSubscribeQueries();
     this.fixture.detectChanges();
     tick();
     this.fixture.detectChanges();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -317,11 +317,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
       textsByBookId: this.textsByBookId,
       projectId: this.projectDoc.id
     };
-    const resultQuestionDoc = await this.questionDialogService.questionDialog(data, questionDoc);
-    if (resultQuestionDoc != null && questionDoc == null) {
-      // Only add question to the view if a new question was created, not when a question is edited
-      this.addQuestionDoc(resultQuestionDoc);
-    }
+    await this.questionDialogService.questionDialog(data, questionDoc);
   }
 
   getBookName(text: TextInfo): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -175,7 +175,7 @@ describe('CheckingComponent', () => {
       expect().nothing();
     }));
 
-    it('hides add question button for reviewer', fakeAsync(() => {
+    it('hides add question button for community checker', fakeAsync(() => {
       const env = new TestEnvironment(CHECKER_USER);
       expect(env.addQuestionButton).toBeNull();
     }));


### PR DESCRIPTION
This was broken in 293b9219411e9dbc29e77a1c01b4fa40e9d2732b:
SF-752: Await local query updates when a doc is updated #516

This was due to a clash with an earlier fix that didn't get to the root of the problem:
09f000ef4866f07b3c4075c137a312e120fba15a
SF-663 Show newly added questions without full refresh #430

---

In terms of reviewing this, I suggest looking at #430 (the first fix) and #516 (the second fix, which conflicted with the first).

To fix the tests I had to change from using `env.realtimeService.create` to `env.addQuestion`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/535)
<!-- Reviewable:end -->
