### PR TITLE
SF-760: Fix data corruption on undo

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/typings.d.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/typings.d.ts
@@ -15,7 +15,7 @@ interface NodeModule {
 }
 
 declare module 'quill' {
-  export interface History {
+  export interface HistoryStatic {
     clear(): void;
     undo(): void;
     redo(): void;
@@ -27,7 +27,7 @@ declare module 'quill' {
     container: Element;
     scrollingContainer: Element;
     selection: Selection;
-    history: History;
+    history: HistoryStatic;
 
     isEnabled(): boolean;
     setSelection(index: number, source?: Sources): void;
@@ -82,6 +82,30 @@ declare module 'quill' {
     dangerouslyPasteHTML(index: any, html?: any, source?: any): void;
     onPaste(e: ClipboardEvent): void;
     convert(html?: string): DeltaStatic;
+  }
+
+  export interface HistoryDelta {
+    undo: DeltaStatic;
+    redo: DeltaStatic;
+  }
+
+  export interface HistoryStack {
+    undo: HistoryDelta[];
+    redo: HistoryDelta[];
+  }
+
+  export type HistoryStackType = Extract<keyof HistoryStack, string>;
+
+  export class History extends Module implements HistoryStatic {
+    lastRecorded: number;
+    ignoreChange: boolean;
+    stack: HistoryStack;
+
+    clear(): void;
+    undo(): void;
+    redo(): void;
+    cutoff(): void;
+    change(source: HistoryStackType, dest: HistoryStackType): void;
   }
 
   export class Picker {


### PR DESCRIPTION
- change source of segment update delta to "api", which causes the
history module to not add the change to the undo stack
- fix selection location after undo
- remove "higlight-segment" format from verse embeds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/539)
<!-- Reviewable:end -->
