### PR TITLE
SF-780 Fix internationalization of project link invalid dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
@@ -49,7 +49,9 @@ export class ProjectComponent extends DataLoadingComponent implements OnInit {
               (err.code === CommandErrorCode.Forbidden || err.code === CommandErrorCode.NotFound)
             ) {
               await this.projectService.localDelete(projectId);
-              await this.noticeService.showMessageDialog(this.transloco.translate('project.project_link_is_invalid'));
+              await this.noticeService.showMessageDialog(() =>
+                this.transloco.translate('project.project_link_is_invalid')
+              );
               this.router.navigateByUrl('/projects', { replaceUrl: true });
               return;
             } else {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/message-dialog/message-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/message-dialog/message-dialog.component.ts
@@ -2,7 +2,7 @@ import { MDC_DIALOG_DATA } from '@angular-mdc/web/dialog';
 import { Component, Inject } from '@angular/core';
 
 export interface MessageDialogData {
-  message: string;
+  message: () => string;
 }
 
 @Component({
@@ -13,6 +13,6 @@ export class MessageDialogComponent {
   constructor(@Inject(MDC_DIALOG_DATA) private readonly data: MessageDialogData) {}
 
   get message(): string {
-    return this.data.message;
+    return this.data.message();
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/notice.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/notice.service.ts
@@ -44,7 +44,7 @@ export class NoticeService {
     return this.showSnackBar(message, ['snackbar-error']);
   }
 
-  showMessageDialog(message: string): Promise<void> {
+  showMessageDialog(message: () => string): Promise<void> {
     const dialogRef = this.dialog.open<MessageDialogComponent, MessageDialogData>(MessageDialogComponent, {
       data: { message }
     }) as MdcDialogRef<MessageDialogComponent, any>;


### PR DESCRIPTION
The problem is caused by the language not always being set yet when the dialog was opened. This resulted in odd, partially-translated dialogs such as this:

![](https://user-images.githubusercontent.com/6140710/73784394-616ba380-4763-11ea-841d-75f68f4ba384.png)

The reason for this is that the message is calculated before the dialog is opened, whereas the dismiss button is translated using Transloco's structural directive. Remarkably, it appears that the message dialog is used in only this one place. There were two main ways to go about fixing this that I considered:
- Fix the race condition. This would most likely be done by creating some promise that resolves after the language has been set, and then awaiting it. This wouldn't necessarily be very straightforward, since the language is only set from Auth0 upon login, and after that is retrieved from a cookie, so the logic would differ based on which scenario is in play. It probably wouldn't be super complicated though, and would likely be a property on the I18nService.
- Make the message dynamic by passing a function to the message dialog, rather than a string. While this feels odd, it makes the message dynamic, like nearly every other string in our views. Any other messages we show in the future will likewise be able to take advantage of this and not be bothered by ensuring the language has already been set before opening the dialog.

That said, feel free to object to this solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/541)
<!-- Reviewable:end -->
