### PR TITLE
SF-743 Add sync tests

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -191,11 +191,11 @@ namespace SIL.XForge.Scripture.Services
             }
             finally
             {
-                _conn?.Dispose();
+                CloseConnection();
             }
         }
 
-        private async Task<bool> InitAsync(string projectId, string userId)
+        internal async Task<bool> InitAsync(string projectId, string userId)
         {
             _conn = await _realtimeService.ConnectAsync();
             _projectDoc = await _conn.FetchAsync<SFProject>(projectId);
@@ -215,6 +215,11 @@ namespace SIL.XForge.Scripture.Services
             if (!_fileSystemService.DirectoryExists(WorkingDir))
                 _fileSystemService.CreateDirectory(WorkingDir);
             return true;
+        }
+
+        internal void CloseConnection()
+        {
+            _conn?.Dispose();
         }
 
         private async Task<List<Chapter>> SyncOrCloneBookUsxAsync(TextInfo text, TextType textType, string paratextId,
@@ -310,7 +315,7 @@ namespace SIL.XForge.Scripture.Services
         /// <summary>
         /// Fetches all text docs from the database for a book.
         /// </summary>
-        private async Task<SortedList<int, IDocument<Models.TextData>>> FetchTextDocsAsync(TextInfo text,
+        internal async Task<SortedList<int, IDocument<Models.TextData>>> FetchTextDocsAsync(TextInfo text,
             TextType textType)
         {
             var textDocs = new SortedList<int, IDocument<Models.TextData>>();


### PR DESCRIPTION
* Add tests for existing functionality.
* Extend test environment to help test situations with missing
  chapters text docs.
  - Change from specifying chapter counts to specifying the
    highest chapter. So a book with chapters 1 and 3 would only
    have two chapters, but a highest-chapter of 3. This assists with
    specifying books with missing chapters.
  - Make special provision for including Source books in Paratext
    even if they have no chapters, as long as the Target also has
    no chapters, to help construct situations of chapterless books.
  - Change AddPTBook() to better mimic situations of Paratext missing
    chapters.
* Expose `FetchTextDocsAsync()`, `InitAsync()` and `CloseConnection()`
  to tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/543)
<!-- Reviewable:end -->
