### PR TITLE
SF-743 Omit nonexistent chapter docs from FetchTextDocsAsync

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -327,6 +327,15 @@ namespace SIL.XForge.Scripture.Services
                 tasks.Add(textDoc.FetchAsync());
             }
             await Task.WhenAll(tasks);
+
+            // Omit items that are not actually in the database.
+            foreach (KeyValuePair<int, IDocument<Models.TextData>> item in textDocs.ToList())
+            {
+                if (!item.Value.IsLoaded)
+                {
+                    textDocs.Remove(item.Key);
+                }
+            }
             return textDocs;
         }
 


### PR DESCRIPTION
* Passing on a set of chapter docs that contains items that are not
actually in the SF DB causes problems later when SyncBookUsxAsync()
might try to delete docs from the DB, or when diffing the doc's null
Data.
* Add tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/544)
<!-- Reviewable:end -->
