### PR TITLE
Rename localization functions in i18n service to reduce ambiguity

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -431,7 +431,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   }
 
   getBookName(text: TextInfo): string {
-    return this.i18n.translateBook(text.bookNum);
+    return this.i18n.localizeBook(text.bookNum);
   }
 
   getBookId(text: TextInfo): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -321,7 +321,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
   }
 
   getBookName(text: TextInfo): string {
-    return this.i18n.translateBook(text.bookNum);
+    return this.i18n.localizeBook(text.bookNum);
   }
 
   getBookId(text: TextInfo): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -396,7 +396,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
       return '';
     }
     const verseRef = verse instanceof VerseRef ? verse : toVerseRef(verse);
-    return `(${this.i18n.translateReference(verseRef)})`;
+    return `(${this.i18n.localizeReference(verseRef)})`;
   }
 
   showAnswerForm() {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -147,7 +147,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
   }
 
   get bookName(): string {
-    return this.text == null ? '' : this.i18n.translateBook(this.text.bookNum);
+    return this.text == null ? '' : this.i18n.localizeBook(this.text.bookNum);
   }
 
   get chapter(): number | undefined {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.html
@@ -21,7 +21,7 @@
               [primary]="data.input?.book === book"
               (click)="onClickBook(book)"
             >
-              {{ i18n.translateBook(book) }}
+              {{ i18n.localizeBook(book) }}
             </button>
           </div>
           <button
@@ -30,7 +30,7 @@
             [primary]="data.input?.book === book"
             (click)="onClickBook(book)"
           >
-            {{ i18n.translateBook(book) }}
+            {{ i18n.localizeBook(book) }}
           </button>
         </mdc-dialog-content>
       </mdc-dialog-surface>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.ts
@@ -169,6 +169,6 @@ export class ScriptureChooserDialogComponent implements OnInit {
   }
 
   getBookName(text: TextInfo): string {
-    return this.i18n.translateBook(text.bookNum);
+    return this.i18n.localizeBook(text.bookNum);
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.spec.ts
@@ -66,8 +66,8 @@ class TestEnvironment {
   readonly component: ChapterNavComponent;
 
   constructor(start?: { book: number; chapter: number }) {
-    when(mockedI18nService.translateBook(1)).thenReturn('Book 1');
-    when(mockedI18nService.translateBook(2)).thenReturn('Book 2');
+    when(mockedI18nService.localizeBook(1)).thenReturn('Book 1');
+    when(mockedI18nService.localizeBook(2)).thenReturn('Book 2');
     this.fixture = TestBed.createComponent(ChapterNavHostComponent);
     this.fixture.detectChanges();
     this.hostComponent = this.fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.ts
@@ -16,7 +16,7 @@ export class ChapterNavComponent {
   constructor(private i18n: I18nService) {}
 
   get bookName(): string {
-    return this.bookNum == null ? '' : this.i18n.translateBook(this.bookNum);
+    return this.bookNum == null ? '' : this.i18n.localizeBook(this.bookNum);
   }
 
   get chapterString(): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
@@ -73,7 +73,7 @@ export class TextChooserDialogComponent extends SubscriptionDisposable {
   }
 
   get bookName(): string {
-    return this.i18n.translateBook(this.bookNum);
+    return this.i18n.localizeBook(this.bookNum);
   }
 
   updateSelection() {
@@ -128,7 +128,7 @@ export class TextChooserDialogComponent extends SubscriptionDisposable {
   }
 
   get referenceForDisplay() {
-    return this.selectedVerses ? `(${this.i18n.translateReference(toVerseRef(this.selectedVerses))})` : '';
+    return this.selectedVerses ? `(${this.i18n.localizeReference(toVerseRef(this.selectedVerses))})` : '';
   }
 
   submit() {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
@@ -139,7 +139,7 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
   }
 
   getBookName(text: TextInfo): string {
-    return this.i18n.translateBook(text.bookNum);
+    return this.i18n.localizeBook(text.bookNum);
   }
 
   getBookId(text: TextInfo): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -145,15 +145,15 @@ export class I18nService {
     this.authService.updateInterfaceLanguage(locale.canonicalTag);
   }
 
-  translateBook(book: number | string) {
+  localizeBook(book: number | string) {
     if (typeof book === 'number') {
       book = Canon.bookNumberToId(book);
     }
     return this.transloco.translate(`canon.book_names.${book}`);
   }
 
-  translateReference(verse: VerseRef) {
-    return `${this.translateBook(verse.bookNum)} ${verse.chapterNum}:${verse.verse}`;
+  localizeReference(verse: VerseRef) {
+    return `${this.localizeBook(verse.bookNum)} ${verse.chapterNum}:${verse.verse}`;
   }
 
   localizeRole(role: string) {


### PR DESCRIPTION
Before "SF-783 Localize user roles (#542)" was merged @irahopkinson pointed out that localization functions in the i18n service may be confusing if they start with "translate" instead of "localize", since we have a translate app, and it may appear to be related to the translate app, rather than localization.

This was done by a project-wide find-and-replace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/548)
<!-- Reviewable:end -->
