### PR TITLE
Base static page Bugsnag config on config file

### DIFF
--- a/src/SIL.XForge.Scripture/Pages/Index.cshtml.cs
+++ b/src/SIL.XForge.Scripture/Pages/Index.cshtml.cs
@@ -1,9 +1,12 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 using SIL.XForge.Configuration;
 using SIL.XForge.Services;
 
@@ -32,23 +35,35 @@ namespace SIL.XForge.Scripture.Pages
         private readonly IOptions<AuthOptions> _authOptions;
         private readonly IOptions<SiteOptions> _siteOptions;
         private readonly IEmailService _emailService;
+        private readonly IConfiguration _configuration;
 
         public IndexModel(IHostingEnvironment env, IOptions<AuthOptions> authOptions, IOptions<SiteOptions> siteOptions,
-            IEmailService emailService)
+            IEmailService emailService, IConfiguration configuration)
         {
             _env = env;
             _authOptions = authOptions;
             _siteOptions = siteOptions;
             _emailService = emailService;
+            _configuration = configuration;
         }
 
         public void OnGet()
         {
+            ViewData["ProductVersion"] = System.Diagnostics.FileVersionInfo.GetVersionInfo(@System.Reflection.Assembly.GetEntryAssembly().Location).ProductVersion;
+
+            var bugsnagConfig = new Dictionary<string, object>
+                {
+                    { "apiKey", _configuration.GetValue<string>("Bugsnag:ApiKey") },
+                    { "appVersion", ViewData["ProductVersion"] },
+                    { "notifyReleaseStages", _configuration.GetSection("Bugsnag:NotifyReleaseStages").Get<string[]>() },
+                    { "releaseStage", _configuration.GetValue<string>("Bugsnag:ReleaseStage") }
+                };
+            ViewData["BugsnagConfig"] = JsonConvert.SerializeObject(bugsnagConfig, Formatting.Indented);
+
             ViewData["Domain"] = _authOptions.Value.Domain;
             ViewData["ClientId"] = _authOptions.Value.FrontendClientId;
             ViewData["Audience"] = _authOptions.Value.Audience;
             ViewData["Scope"] = _authOptions.Value.Scope;
-            ViewData["ReleaseStage"] = _env.IsProduction() ? "live" : (_env.IsStaging() ? "qa" : "dev");
         }
 
         public async Task<IActionResult> OnPostAsync()

--- a/src/SIL.XForge.Scripture/Pages/Shared/_Layout.cshtml
+++ b/src/SIL.XForge.Scripture/Pages/Shared/_Layout.cshtml
@@ -53,7 +53,7 @@
                     <div id="profile">
                         <ul class="app">
                             <li class="copyright">&copy; @DateTime.Now.Year <a target="_blank" href="http://www.sil.org">SIL International</a></li>
-                            <li class="version">@System.Diagnostics.FileVersionInfo.GetVersionInfo(@System.Reflection.Assembly.GetEntryAssembly().Location).ProductVersion</li>
+                            <li class="version">@ViewData["ProductVersion"]</li>
                         </ul>
                         <ul class="links">
                             <li><a href="~/terms">@SharedLocalizer[SharedResource.Keys.Terms]</a></li>
@@ -70,12 +70,7 @@
     </footer>
     <script src="https://d2wy8f7a9ursnm.cloudfront.net/v6/bugsnag.min.js"></script>
     <script>
-        window.bugsnagClient = bugsnag({
-            apiKey: 'b72a46a8924a3cd161d4c5534287923c',
-            appVersion: '@System.Diagnostics.FileVersionInfo.GetVersionInfo(@System.Reflection.Assembly.GetEntryAssembly().Location).ProductVersion',
-            notifyReleaseStages: ['live', 'qa'],
-            releaseStage: '@ViewData["ReleaseStage"]'
-        });
+        window.bugsnagClient = bugsnag(@Html.Raw(@ViewData["BugsnagConfig"]));
     </script>
     <script src="~/lib/material-design-lite/js/material.min.js"></script>
     <script src="https://cdn.auth0.com/js/auth0/9.10/auth0.min.js"></script>


### PR DESCRIPTION
Our Bugsnag config has gotten a little redundant. This PR fetches the Bugsnag config from the config file, rather than placing it in the view file directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/554)
<!-- Reviewable:end -->
