### PR TITLE
SF-792 Fix login language selection

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -231,11 +231,9 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       }
 
       this.currentUserDoc = await this.userService.getCurrentUser();
-      if (isNewlyLoggedIn) {
-        const languageTag = this.currentUserDoc.data!.interfaceLanguage;
-        if (languageTag != null) {
-          this.i18n.trySetLocale(languageTag);
-        }
+      const languageTag = this.currentUserDoc.data!.interfaceLanguage;
+      if (languageTag != null) {
+        this.i18n.trySetLocale(languageTag, false);
       }
 
       const projectDocs$ = this.currentUserDoc.remoteChanges$.pipe(

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -106,7 +106,7 @@ export class I18nService {
   ) {
     const language = this.cookieService.get(ASP_CULTURE_COOKIE_NAME);
     if (language != null) {
-      this.trySetLocale(getAspCultureCookieLanguage(language));
+      this.trySetLocale(getAspCultureCookieLanguage(language), false);
     }
   }
 
@@ -130,7 +130,7 @@ export class I18nService {
     this.trySetLocale(tag);
   }
 
-  trySetLocale(tag: string) {
+  trySetLocale(tag: string, doAuthUpdate: boolean = true) {
     const locale = I18nService.getLocale(tag);
     if (locale == null) {
       console.warn(`Failed attempt to set locale to unsupported locale ${tag}`);
@@ -142,7 +142,9 @@ export class I18nService {
     const date = new Date();
     date.setFullYear(date.getFullYear() + 1);
     this.cookieService.set(ASP_CULTURE_COOKIE_NAME, aspCultureCookieValue(locale.canonicalTag), date, '/');
-    this.authService.updateInterfaceLanguage(locale.canonicalTag);
+    if (doAuthUpdate) {
+      this.authService.updateInterfaceLanguage(locale.canonicalTag);
+    }
   }
 
   localizeBook(book: number | string) {


### PR DESCRIPTION
* Cookie language was clobbering Auth0 updates
* Flow: Cookie (homepage) > Auth0 user (Login) > user doc (frontend)
* This flow doesn't need `trySetLocale` to update userdoc or Auth0 user
* But frontend change of language should update all

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/556)
<!-- Reviewable:end -->
