### PR TITLE
SF-811 Create 404 page in Angular app

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app-routing.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app-routing.module.ts
@@ -6,6 +6,7 @@ import { SystemAdministrationComponent } from 'xforge-common/system-administrati
 import { ConnectProjectComponent } from './connect-project/connect-project.component';
 import { ProjectComponent } from './project/project.component';
 import { SettingsComponent } from './settings/settings.component';
+import { PageNotFoundComponent } from './shared/page-not-found/page-not-found.component';
 import { SFAdminAuthGuard } from './shared/project-router.guard';
 import { StartComponent } from './start/start.component';
 import { SyncComponent } from './sync/sync.component';
@@ -16,7 +17,8 @@ const routes: Routes = [
   { path: 'projects/:projectId/sync', component: SyncComponent, canActivate: [SFAdminAuthGuard] },
   { path: 'projects/:projectId', component: ProjectComponent, canActivate: [AuthGuard] },
   { path: 'projects', component: StartComponent, canActivate: [AuthGuard] },
-  { path: 'system-administration', component: SystemAdministrationComponent, canActivate: [SystemAdminAuthGuard] }
+  { path: 'system-administration', component: SystemAdministrationComponent, canActivate: [SystemAdminAuthGuard] },
+  { path: '**', component: PageNotFoundComponent }
 ];
 
 @NgModule({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
@@ -44,7 +44,6 @@ import { UsersModule } from './users/users.module';
     EditNameDialogComponent
   ],
   imports: [
-    AppRoutingModule,
     BrowserModule.withServerTransition({ appId: 'ng-cli-universal' }),
     BrowserAnimationsModule,
     CoreModule,
@@ -56,7 +55,8 @@ import { UsersModule } from './users/users.module';
     UsersModule,
     UICommonModule,
     XForgeCommonModule,
-    TranslocoModule
+    TranslocoModule,
+    AppRoutingModule
   ],
   providers: [CookieService, DatePipe, { provide: ErrorHandler, useClass: ExceptionHandlingService }],
   entryComponents: [

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { ngfModule } from 'angular-file';
 import { CookieService } from 'ngx-cookie-service';
 import { SystemRole } from 'realtime-server/lib/common/models/system-role';
@@ -48,7 +49,7 @@ const mockedCookieService = mock(CookieService);
 
 describe('CheckingOverviewComponent', () => {
   configureTestingModule(() => ({
-    imports: [DialogTestModule],
+    imports: [DialogTestModule, RouterTestingModule],
     providers: [
       { provide: ActivatedRoute, useMock: mockedActivatedRoute },
       { provide: MdcDialog, useMock: mockedMdcDialog },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-routing.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-routing.module.ts
@@ -11,7 +11,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forChild(routes)],
   exports: [RouterModule]
 })
 export class CheckingRoutingModule {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking.module.ts
@@ -53,7 +53,7 @@ import { QuestionDialogComponent } from './question-dialog/question-dialog.compo
     SharedModule,
     UICommonModule,
     XForgeCommonModule,
-    AngularSplitModule.forRoot(),
+    AngularSplitModule.forChild(),
     ngfModule,
     TranslocoModule
   ],

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/page-not-found/page-not-found.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/page-not-found/page-not-found.component.html
@@ -1,0 +1,4 @@
+<ng-container *transloco="let t; read: 'app'">
+  <h2><mdc-icon>error_outline</mdc-icon>{{ t("page_not_found") }}</h2>
+  <a routerLink="/projects">{{ t("project_home") }}</a>
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/page-not-found/page-not-found.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/page-not-found/page-not-found.component.scss
@@ -1,0 +1,9 @@
+:host {
+  text-align: center;
+}
+
+mdc-icon {
+  line-height: 1.2em;
+  vertical-align: top;
+  padding-right: 0.25em;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/page-not-found/page-not-found.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/page-not-found/page-not-found.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-page-not-found',
+  templateUrl: './page-not-found.component.html',
+  styleUrls: ['./page-not-found.component.scss']
+})
+export class PageNotFoundComponent {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-routing.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-routing.module.ts
@@ -10,7 +10,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forChild(routes)],
   exports: [RouterModule]
 })
 export class TranslateRoutingModule {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/users-routing.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/users-routing.module.ts
@@ -8,7 +8,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forChild(routes)],
   exports: [RouterModule]
 })
 export class UsersRoutingModule {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -10,6 +10,7 @@
     "log_out": "Log out",
     "logged_in_as": "Logged in as",
     "overview": "Overview",
+    "page_not_found": "Page not found",
     "password_reset_email_sent": "We've just sent you an email to reset your password.",
     "product_version": "Product version: v{{ version }}",
     "project_home": "Project home",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/xforge-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/xforge-common.module.ts
@@ -5,6 +5,7 @@ import { RouterModule } from '@angular/router';
 import { TRANSLOCO_CONFIG, TRANSLOCO_LOADER, TranslocoModule } from '@ngneat/transloco';
 import { ngfModule } from 'angular-file';
 import { AvatarModule } from 'ngx-avatar';
+import { PageNotFoundComponent } from '../app/shared/page-not-found/page-not-found.component';
 import { AuthHttpInterceptor } from './auth-http-interceptor';
 import { AvatarComponent } from './avatar/avatar.component';
 import { I18nService, TranslationLoader } from './i18n.service';
@@ -27,6 +28,7 @@ const componentExports = [
   SaDeleteDialogComponent,
   SaUsersComponent,
   SystemAdministrationComponent,
+  PageNotFoundComponent,
   WriteStatusComponent
 ];
 


### PR DESCRIPTION
- Moved import of AppRoutingModule to after import of other routing modules, as suggested by Angular docs (https://angular.io/guide/router#module-import-order-matters):
> "Each routing module augments the route configuration in the order of import. If you list AppRoutingModule first, the wildcard route will be registered before the hero routes. The wildcard route-which matches every URL-will intercept the attempt to navigate to a hero route."

- Changed a number of instances of forRoot to forChild, in the non-root modules, as instructed by Angular docs (https://angular.io/guide/router#hero-feature-routing-requirements):
> "Only call RouterModule.forRoot() in the root AppRoutingModule (or the AppModule if that's where you register top level application routes). In any other module, you must call the RouterModule.forChild method to register additional routes."

The component itself is extremely simple:

![Screen Shot 2020-02-18 at 14 36 45](https://user-images.githubusercontent.com/6140710/74774698-32c0f300-5262-11ea-8264-6174631e9b22.png)
Suggestions for improving it are welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/559)
<!-- Reviewable:end -->
