### PR TITLE
SF-795 Fix text selection that starts outside any verses

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
@@ -49,6 +49,7 @@ export class TextChooserDialogComponent extends SubscriptionDisposable {
   private rawTextSelection = '';
   private selectedVerses?: VerseRefData;
   private selectionChanged = false;
+  private readonly verseSegmentSelector = 'usx-segment[data-segment^=verse_]';
 
   constructor(
     private readonly dialogRef: MdcDialogRef<TextChooserDialogComponent>,
@@ -385,11 +386,11 @@ export class TextChooserDialogComponent extends SubscriptionDisposable {
   }
 
   private getSegments(verse?: number) {
-    return this.segments().filter(el => (verse == null ? true : verse === this.getVerseFromElement(el)));
+    return this.verseSegments().filter(el => (verse == null ? true : verse === this.getVerseFromElement(el)));
   }
 
   private isInASegment(node: Node): boolean {
-    if (this.isSegment(node)) {
+    if (this.isVerseSegment(node)) {
       return true;
     } else if (node.parentNode != null) {
       return this.isInASegment(node.parentNode);
@@ -398,16 +399,14 @@ export class TextChooserDialogComponent extends SubscriptionDisposable {
     }
   }
 
-  private isSegment(node: Node) {
-    return node.nodeType === node.ELEMENT_NODE && (node as Element).tagName.toLowerCase() === 'usx-segment';
+  private isVerseSegment(node: Node) {
+    return node.nodeType === node.ELEMENT_NODE && (node as Element).matches(this.verseSegmentSelector);
   }
 
-  private segments(): Element[] {
+  private verseSegments(): Element[] {
     if (this.scriptureText == null) {
       return [];
     }
-    return Array.from(
-      (this.scriptureText.nativeElement as HTMLElement).querySelectorAll('usx-segment[data-segment^=verse_]')
-    );
+    return Array.from((this.scriptureText.nativeElement as HTMLElement).querySelectorAll(this.verseSegmentSelector));
   }
 }


### PR DESCRIPTION
The operative part is the change in `isVerseSegment` (previously named `isSegment`) from:
``` ts
return node.nodeType === node.ELEMENT_NODE && (node as Element).tagName.toLowerCase() === 'usx-segment'; 
```
to:
``` ts
return Array.from((this.scriptureText.nativeElement as HTMLElement).querySelectorAll(this.verseSegmentSelector)); 
```
where `this.verseSegmentSelector` is `'usx-segment[data-segment^=verse_]'`. The problem was an assumption that all usx-segments are inside verses, which is not necessarily the case. Instead we have to check that not only is it a usx-segment, but that it has a `data-segment` attribute that starts with `verse_`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/560)
<!-- Reviewable:end -->
