### PR TITLE
SF-802 Fix layout of text doc question icons on rtl texts

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -77,24 +77,28 @@ quill-editor {
   }
 }
 
-.ltr .ql-editor > p .question-segment[data-question-count],
-usx-para[dir='ltr'] .question-segment[data-question-count] {
-  margin-left: 1.75em;
-  &:before {
-    left: -2.25em;
-  }
-  &:after {
-    left: -1.5em;
+usx-para[dir='ltr'],
+p[dir='ltr'] {
+  .question-segment[data-question-count] {
+    margin-left: 1.75em;
+    &:before {
+      left: -2.25em;
+    }
+    &:after {
+      left: -1.5em;
+    }
   }
 }
-.rtl .ql-editor > .question-segment[data-question-count],
-usx-para[dir='rtl'] .question-segment[data-question-count] {
-  margin-right: 1.75em;
-  &:before {
-    right: -2.25em;
-  }
-  &:after {
-    right: -1.5em;
+usx-para[dir='rtl'],
+p[dir='rtl'] {
+  .question-segment[data-question-count] {
+    margin-right: 1.75em;
+    &:before {
+      right: -2.25em;
+    }
+    &:after {
+      right: -1.5em;
+    }
   }
 }
 


### PR DESCRIPTION
This solution seems to work, but I am not at all certain that it is correct. I basically did two things:

1. I changed `.ltr .ql-editor > p .question-segment[data-question-count]` to `.ltr .ql-editor > .question-segment[data-question-count]`. I *think* the previous selector was just wrong. It wasn't consistent with the rtl selector. @nigel-wells Perhaps you could take a look at this selector?
2. Changed the part of the selector that selects `usx-para[dir='ltr']` to select that *and* `p[dir='ltr']` (likewise for the rtl selector). That's because sometimes we set `dir` on `usx-para` and sometimes we set it on `p`. I don't really understand why/when we use one or the other. Perhaps @nigel-wells or @ddaspit can provide insight on that as well.

&nbsp; | Chrome | Firefox
-------|--------|--------
Before | ![localhost_5000_projects_5e1ccff3c6fa161e98137753_checking_ALL](https://user-images.githubusercontent.com/6140710/75061627-19f94d00-54af-11ea-84d2-0a81989d4f38.png) | ![Screen Shot 2020-02-21 at 13 28 15](https://user-images.githubusercontent.com/6140710/75061712-4319dd80-54af-11ea-9374-8756c2c4e93d.png)
After  | ![localhost_5000_projects_5e1ccff3c6fa161e98137753_checking_ALL (1)](https://user-images.githubusercontent.com/6140710/75061665-2e3d4a00-54af-11ea-98d4-940769b128fb.png) | ![Screen Shot 2020-02-21 at 13 31 22](https://user-images.githubusercontent.com/6140710/75061758-5e84e880-54af-11ea-880a-e878876557e1.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/562)
<!-- Reviewable:end -->
