### PR TITLE
Fix mistaken logging of test exceptions when running tests

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
@@ -31,7 +31,7 @@ class MockConsole {
   error(val: any) {
     if (
       !['', 'Test error', 'Original error'].includes(val.message) &&
-      !(val.message != null && val.message.startsWith('Unknown error: '))
+      !(val.message != null && val.message.startsWith('Unknown error'))
     ) {
       console.error(val);
     }


### PR DESCRIPTION
In "Fix Bugsnag 'unsupported object' error (#557)" I changed the tests in a way that resulted in unnecessary excessive logging that makes it harder to understand the output, especially when there are actual errors.

Before this commit:
```
$ ng test
13% building 25/26 modules 1 active ..._modules/postcss-loader/src/index.js??embedded!/home/nate/src/web-xforge/src/SIL.XForge.Scripture/ClientApp/node_modules/sass-loader/lib/loader.js??ref--15-3!/home/nate/src/web-xforge/src/SIL.XForge.Scripture/ClientApp/src/styles.scss24 02 2020 16:16:26.312:WARN [karma]: No captured browser, open http://localhost:9876/
24 02 2020 16:16:26.330:INFO [karma-server]: Karma v4.2.0 server started at http://0.0.0.0:9876/
24 02 2020 16:16:26.330:INFO [launcher]: Launching browsers xForgeChrome with concurrency unlimited
24 02 2020 16:16:26.334:INFO [launcher]: Starting browser Chrome
24 02 2020 16:16:58.783:WARN [karma]: No captured browser, open http://localhost:9876/
24 02 2020 16:16:58.970:INFO [Chromium 80.0.3987 (Ubuntu 0.0.0)]: Connected on socket r12NyJXeeDqQDaW_AAAA with id 53664043
ERROR: Error: Unknown error (with circular references): [object Object]
Error: Unknown error (with circular references): [object Object]
    at ExceptionHandlingService.<anonymous> (http://localhost:9876/_karma_webpack_/main.js:35357:41)
    at step (http://localhost:9876/_karma_webpack_/main.js:35288:23)
    at Object.next (http://localhost:9876/_karma_webpack_/main.js:35269:53)
    at http://localhost:9876/_karma_webpack_/main.js:35263:71
    at new ZoneAwarePromise (http://localhost:9876/_karma_webpack_/polyfills.js:6421:29)
    at ./src/xforge-common/exception-handling-service.ts.__awaiter (http://localhost:9876/_karma_webpack_/main.js:35259:12)
    at ExceptionHandlingService../src/xforge-common/exception-handling-service.ts.ExceptionHandlingService.handleError (http://localhost:9876/_karma_webpack_/main.js:35318:16)
    at http://localhost:9876/_karma_webpack_/main.js:35117:54
    at step (http://localhost:9876/_karma_webpack_/main.js:34996:23)
    at Object.next (http://localhost:9876/_karma_webpack_/main.js:34977:53)
Chromium 80.0.3987 (Ubuntu 0.0.0): Executed 344 of 409 SUCCESS (0 secs / 1 min 2.907 secs)
ERROR: Error: Unknown error (with circular references): [object Object]
Error: Unknown error (with circular references): [object Object]
    at ExceptionHandlingService.<anonymous> (http://localhost:9876/_karma_webpack_/main.js:35357:41)
    at step (http://localhost:9876/_karma_webpack_/main.js:35288:23)
    at Object.next (http://localhost:9876/_karma_webpack_/main.js:35269:53)
    at http://localhost:9876/_karma_webpack_/main.js:35263:71
    at new ZoneAwarePromise (http://localhost:9876/_karma_webpack_/polyfills.js:6421:29)
    at ./src/xforge-common/exception-handling-service.ts.__awaiter (http://localhost:9876/_karma_webpack_/main.js:35259:12)
    at ExceptionHandlingService../src/xforge-common/exception-handling-service.ts.ExceptionHandlingService.handleError (http://localhost:9876/_karma_webpack_/main.js:35318:16)
    at http://localhost:9876/_karma_webpack_/main.js:35117:54
    at step (http://localhost:9876/_karma_webpack_/main.js:34996:23)
Chromium 80.0.3987 (Ubuntu 0.0.0): Executed 409 of 409 SUCCESS (1 min 26.988 secs / 1 min 7.789 secs)
TOTAL: 409 SUCCESS
TOTAL: 409 SUCCESS
```
After:
```
$ ng test
13% building 25/26 modules 1 active ..._modules/postcss-loader/src/index.js??embedded!/home/nate/src/web-xforge/src/SIL.XForge.Scripture/ClientApp/node_modules/sass-loader/lib/loader.js??ref--15-3!/home/nate/src/web-xforge/src/SIL.XForge.Scripture/ClientApp/src/styles.scss24 02 2020 16:13:46.210:WARN [karma]: No captured browser, open http://localhost:9876/
24 02 2020 16:13:46.225:INFO [karma-server]: Karma v4.2.0 server started at http://0.0.0.0:9876/
24 02 2020 16:13:46.226:INFO [launcher]: Launching browsers xForgeChrome with concurrency unlimited
22% building 107/108 modules 1 active ...odules/postcss-loader/src/index.js??embedded!/home/nate/src/web-xforge/src/SIL.XForge.Scripture/ClientApp/node_modules/sass-loader/lib/loader.js??ref--15-3!/home/nate/src/web-xforge/src/SIL.XForge.Scripture/ClientApp/src/styles.scss24 02 2020 16:13:46.418:INFO [launcher]: Starting browser Chrome
24 02 2020 16:14:17.810:WARN [karma]: No captured browser, open http://localhost:9876/
24 02 2020 16:14:17.984:INFO [Chromium 80.0.3987 (Ubuntu 0.0.0)]: Connected on socket LpGRVZR3n-JaXUR-AAAA with id 83091375
Chromium 80.0.3987 (Ubuntu 0.0.0): Executed 409 of 409 SUCCESS (1 min 27.202 secs / 1 min 7.918 secs)
TOTAL: 409 SUCCESS
TOTAL: 409 SUCCESS
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/565)
<!-- Reviewable:end -->
