### PR TITLE
Fix disposing of subscriptions in checking component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -373,6 +373,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
   }
 
   ngOnDestroy(): void {
+    super.ngOnDestroy();
     if (this.questionsQuery != null) {
       this.questionsQuery.dispose();
     }


### PR DESCRIPTION
The CheckingComponent class extends DataLoadingComponent, which in turn extends SubscriptionDisposable. SubscriptionDisposable disposes subscriptions when ngOnDestroy is called. The DataLoadingComponent calls `super.ngOnDestroy()` within ngOnDestroy. I think without this change, DataLoadingComponent and SubscriptionDisposable do not have their respective implementations of ngOnDestroy called.

I searched our project for `ngOnDestroy`, and in each instance where we implement it, it either calls `super.ngOnDestroy()`, or it's in a class that directly implements `OnDestroy`, rather than extending a class that implements it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/566)
<!-- Reviewable:end -->
