### PR TITLE
SF-813a Fix line break after verse number

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -308,10 +308,8 @@ usx-verse {
     // superscript
     top: -0.5em;
     position: relative;
-    display: inline-block;
     font-size: 75%;
-    line-height: 1;
-    padding: 0.3em 0.4em;
+    padding: 0.2em 0.4em;
     background-color: #f5f3ef;
     border-radius: 8px;
     white-space: nowrap;


### PR DESCRIPTION
Notice that in the first column verse number 2 and 4 are at the end of the line, rather than sticking with the first word of the verse and wrapping to the next line.

Before | After
-------|------
![](https://user-images.githubusercontent.com/6140710/75203922-7d98aa00-573d-11ea-8a2d-7219fe932415.png) | ![](https://user-images.githubusercontent.com/6140710/75203933-81c4c780-573d-11ea-9566-eb21f79ef3fb.png)

There are some minor differences in appearance, but I don't think it's very significant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/568)
<!-- Reviewable:end -->
