### PR TITLE
Fix mismatched size of add question button in checking app

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -88,6 +88,9 @@
           }
           &.action-icons {
             justify-content: flex-end;
+            .mdc-icon-button {
+              @include mdc-icon-button-size(24px, 24px, 8px);
+            }
           }
         }
       }


### PR DESCRIPTION
This is a totally trivial thing, but I keep noticing that the add question button is larger on hover than the buttons beside it. This is because we have CSS specifically specifying a smaller size for those buttons, in `share.component.scss` and `font-size.component.scss`.

Before | After
-------|------
![](https://user-images.githubusercontent.com/6140710/75205714-817afb00-5742-11ea-9e59-eb4534bb4dee.png) | ![](https://user-images.githubusercontent.com/6140710/75205744-90fa4400-5742-11ea-935f-ab737408af0a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/570)
<!-- Reviewable:end -->
