### PR TITLE
SF-817b Activate question when clicking currently active question

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -225,13 +225,18 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
   }
 
   activateQuestion(questionDoc: QuestionDoc): void {
+    // The reason for the convoluted questionChanged logic is because the change needs to be emitted even if it's the
+    // same question, but calling activeQuestionDoc$.next when the question is unchanged causes complicated test errors
     this._activeQuestionVerseRef = questionDoc.data == null ? undefined : toVerseRef(questionDoc.data.verseRef);
+    let questionChanged = true;
     if (this.activeQuestionDoc != null && this.activeQuestionDoc.id === questionDoc.id) {
-      return;
+      questionChanged = false;
     }
     this.activeQuestionDoc = questionDoc;
     this.changed.emit(questionDoc);
-    this.activeQuestionDoc$.next(questionDoc);
+    if (questionChanged) {
+      this.activeQuestionDoc$.next(questionDoc);
+    }
   }
 
   private changeQuestion(newDifferential: number): void {


### PR DESCRIPTION
- Causes split area to adjust when clicking currently active question
- Closes question list when tapping current question on mobile (previously tapping the active question on mobile had no effect, and the question list remained open)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/573)
<!-- Reviewable:end -->
