### PR TITLE
Disable closing of question dialog when clicking outside dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.ts
@@ -25,7 +25,7 @@ export class QuestionDialogService {
 
   /** Opens a question dialog that can be used to add a new question or edit an existing question. */
   async questionDialog(config: QuestionDialogData, questionDoc?: QuestionDoc): Promise<QuestionDoc | undefined> {
-    const dialogConfig: MdcDialogConfig = { data: config };
+    const dialogConfig: MdcDialogConfig = { data: config, clickOutsideToClose: false };
     const dialogRef = this.dialog.open(QuestionDialogComponent, dialogConfig) as MdcDialogRef<
       QuestionDialogComponent,
       QuestionDialogResult | 'close'


### PR DESCRIPTION
Currently it's very easy to accidentally close the question dialog by clicking outside the dialog. This could easily lead to losing some work, especially if a question isn't super short and/or has audio attached. It's still possible to close the dialog by clicking the cancel button at the bottom of the dialog, which is a lot less likely to happen by accident.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/576)
<!-- Reviewable:end -->
