### PR TITLE
SF-816b Second attempt to fix layout of answers count

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -26,10 +26,10 @@
               keyboard_arrow_{{ itemVisible[getBookId(text)] ? "down" : "right" }}
             </mdc-icon>
             <span fxFlex>{{ getBookName(text) }}</span>
-            <span fxFlex="100px" fxShow fxHide.xs fxLayoutAlign="end center">
+            <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
               {{ questionCountLabel(bookQuestionCount(text)) }}
             </span>
-            <span fxFlex="100px" fxShow fxHide.xs fxLayoutAlign="end center">
+            <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
               {{ answerCountLabel(bookAnswerCount(text)) }}
             </span>
             <span fxFlex="64px" fxShow fxHide.xs fxLayoutAlign="end center">&nbsp;</span>
@@ -51,10 +51,10 @@
                   keyboard_arrow_{{ itemVisible[getTextDocId(text.bookNum, chapter.number)] ? "down" : "right" }}
                 </mdc-icon>
                 <span fxFlex>{{ getBookName(text) + " " + chapter?.number }}</span>
-                <span fxFlex="80px" fxShow fxHide.xs fxLayoutAlign="end center">
+                <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
                   {{ questionCountLabel(questionCount(text.bookNum, chapter.number)) }}
                 </span>
-                <span fxFlex="80px" fxShow fxHide.xs fxLayoutAlign="end center">
+                <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
                   {{ answerCountLabel(chapterAnswerCount(text.bookNum, chapter.number)) }}
                 </span>
                 <span fxFlex="64px" fxShow fxHide.xs fxLayoutAlign="end center">&nbsp;</span>
@@ -72,7 +72,7 @@
                   <span fxFlex class="no-overflow-ellipsis">
                     <span *ngIf="questionDoc.data?.text">{{ questionDoc.data?.text }}</span>
                   </span>
-                  <span fxFlex="80px" fxShow fxHide.xs fxLayoutAlign="end center">
+                  <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
                     {{ answerCountLabel(questionDoc.data?.answers.length) }}
                   </span>
                   <span fxFlex="64px" fxLayoutAlign="end center">


### PR DESCRIPTION
It turns out my previous fix (#578) was incomplete. I failed to account for expanding the tree. I also didn't leave it with quite enough padding.

Here's how it looks now with fairly large numbers:

![](https://user-images.githubusercontent.com/6140710/76113313-eb509b80-5fb1-11ea-913f-20ae1c5a805e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/579)
<!-- Reviewable:end -->
