### PR TITLE
SF-827 Stop subscribing to updates to text doc in checking app

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.html
@@ -1,1 +1,7 @@
-<app-text [isReadOnly]="true" [id]="id" [placeholder]="placeholder" (loaded)="onLoaded()"></app-text>
+<app-text
+  [isReadOnly]="true"
+  [subscribeToUpdates]="false"
+  [id]="id"
+  [placeholder]="placeholder"
+  (loaded)="onLoaded()"
+></app-text>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -115,7 +115,7 @@ export class TextViewModel {
     return textData.ops == null || textData.ops.length === 0;
   }
 
-  bind(textDoc: TextDoc): void {
+  bind(textDoc: TextDoc, subscribeToUpdates: boolean): void {
     const editor = this.checkEditor();
     if (this.textDoc != null) {
       this.unbind();
@@ -124,7 +124,9 @@ export class TextViewModel {
     this.textDoc = textDoc;
     editor.setContents(this.textDoc.data as DeltaStatic);
     editor.history.clear();
-    this.remoteChangesSub = this.textDoc.remoteChanges$.subscribe(ops => editor.updateContents(ops as DeltaStatic));
+    if (subscribeToUpdates) {
+      this.remoteChangesSub = this.textDoc.remoteChanges$.subscribe(ops => editor.updateContents(ops as DeltaStatic));
+    }
     this.onCreateSub = this.textDoc.create$.subscribe(() => {
       if (textDoc.data != null) {
         editor.setContents(textDoc.data as DeltaStatic);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -52,6 +52,7 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
   @Input() isReadOnly: boolean = true;
   @Input() markInvalid: boolean = false;
   @Input() multiSegmentSelection = false;
+  @Input() subscribeToUpdates = true;
   @Output() updated = new EventEmitter<TextUpdatedEvent>(true);
   @Output() segmentRefChange = new EventEmitter<string>();
   @Output() loaded = new EventEmitter(true);
@@ -386,7 +387,7 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
     }
     this.placeholder = translate('text.loading');
     const textDoc = await this.projectService.getText(this._id);
-    this.viewModel.bind(textDoc);
+    this.viewModel.bind(textDoc, this.subscribeToUpdates);
     this.updatePlaceholderText();
 
     this.loaded.emit();


### PR DESCRIPTION
Edits to the text doc caused some issues:

![](https://user-images.githubusercontent.com/6140710/76638081-3de60680-6522-11ea-912a-3aa697e9d931.png)

To fix this, I stopped it from subscribing to updates, as specified in the functional spec.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/584)
<!-- Reviewable:end -->
