### PR TITLE
SF-776 Add exception reporting to Node backend

### DIFF
--- a/src/RealtimeServer/common/exception-reporter.ts
+++ b/src/RealtimeServer/common/exception-reporter.ts
@@ -1,0 +1,20 @@
+import bugsnag from '@bugsnag/js';
+
+export class ExceptionReporter {
+  private readonly bugsnagClient: any;
+
+  constructor(bugsnagApiKey: string, releaseStage: string, version: string) {
+    this.bugsnagClient = bugsnag({
+      apiKey: bugsnagApiKey,
+      appVersion: version,
+      appType: 'node',
+      notifyReleaseStages: ['live', 'qa'],
+      releaseStage: releaseStage,
+      autoNotify: false
+    });
+  }
+
+  report(error: any) {
+    this.bugsnagClient.notify(error);
+  }
+}

--- a/src/RealtimeServer/package-lock.json
+++ b/src/RealtimeServer/package-lock.json
@@ -206,6 +206,32 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@bugsnag/browser": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-6.5.2.tgz",
+      "integrity": "sha512-XFKKorJc92ivLnlHHhLiPvkP03tZ5y7n0Z2xO6lOU7t+jWF5YapgwqQAda/TWvyYO38B/baWdnOpWMB3QmjhkA=="
+    },
+    "@bugsnag/js": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-6.5.2.tgz",
+      "integrity": "sha512-4ibw624fM5+Y/WSuo3T/MsJVtslsPV8X0MxFuRxdvpKVUXX216d8hN8E/bG4hr7aipqQOGhBYDqSzeL2wgmh0Q==",
+      "requires": {
+        "@bugsnag/browser": "^6.5.2",
+        "@bugsnag/node": "^6.5.2"
+      }
+    },
+    "@bugsnag/node": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-6.5.2.tgz",
+      "integrity": "sha512-KQ1twKoOttMCYsHv7OXUVsommVcrk6RGQ5YoZGlTbREhccbzsvjbiXPKiY31Qc7OXKvaJwSXhnOKrQTpRleFUg==",
+      "requires": {
+        "byline": "^5.0.0",
+        "error-stack-parser": "^2.0.2",
+        "iserror": "^0.0.2",
+        "pump": "^3.0.0",
+        "stack-generator": "^2.0.3"
+      }
+    },
     "@cnakazawa/watch": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
@@ -1043,6 +1069,11 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
+    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -1461,7 +1492,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -1473,6 +1503,14 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "requires": {
+        "stackframe": "^1.1.1"
       }
     },
     "es-abstract": {
@@ -2865,6 +2903,11 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
+    "iserror": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
+      "integrity": "sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4120,7 +4163,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -4356,7 +4398,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -5047,11 +5088,24 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "stack-generator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
+      "integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
+      "requires": {
+        "stackframe": "^1.1.1"
+      }
+    },
     "stack-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
       "dev": true
+    },
+    "stackframe": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.1.1.tgz",
+      "integrity": "sha512-0PlYhdKh6AfFxRyK/v+6/k+/mMfyiEBbTM5L94D0ZytQnJ166wuwoTYLHFWGbs2dpA8Rgq763KGWmN1EQEYHRQ=="
     },
     "static-extend": {
       "version": "0.1.2",
@@ -5646,8 +5700,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "2.4.1",

--- a/src/RealtimeServer/package.json
+++ b/src/RealtimeServer/package.json
@@ -15,6 +15,7 @@
   "types": "lib/common/index.d.ts",
   "private": true,
   "dependencies": {
+    "@bugsnag/js": "^6.5.2",
     "express": "^4.17.1",
     "jwks-rsa": "^1.6.0",
     "mongodb": "^3.3.5",

--- a/src/RealtimeServer/typings/sharedb/index.d.ts
+++ b/src/RealtimeServer/typings/sharedb/index.d.ts
@@ -24,6 +24,9 @@ declare class ShareDB {
     register: (type: { name?: string; uri?: string; [key: string]: any }) => void;
     map: { [key: string]: any };
   };
+  static logger: {
+    setMethods: (override: { info?: Function; warn?: Function; error?: Function }) => void;
+  };
   constructor(options?: {
     db?: any;
     pubsub?: ShareDB.PubSub;

--- a/src/SIL.XForge/Realtime/RealtimeService.cs
+++ b/src/SIL.XForge/Realtime/RealtimeService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Configuration;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using SIL.ObjectModel;
@@ -23,10 +24,11 @@ namespace SIL.XForge.Realtime
         private readonly IOptions<AuthOptions> _authOptions;
         private readonly IMongoDatabase _database;
         private readonly Dictionary<Type, DocConfig> _docConfigs;
+        private readonly IConfiguration _configuration;
 
         public RealtimeService(RealtimeServer server, IOptions<SiteOptions> siteOptions,
             IOptions<DataAccessOptions> dataAccessOptions, IOptions<RealtimeOptions> realtimeOptions,
-            IOptions<AuthOptions> authOptions, IMongoClient mongoClient)
+            IOptions<AuthOptions> authOptions, IMongoClient mongoClient, IConfiguration configuration)
         {
             Server = server;
             _siteOptions = siteOptions;
@@ -34,6 +36,7 @@ namespace SIL.XForge.Realtime
             _realtimeOptions = realtimeOptions;
             _authOptions = authOptions;
             _database = mongoClient.GetDatabase(_dataAccessOptions.Value.MongoDatabaseName);
+            _configuration = configuration;
 
             RealtimeOptions options = _realtimeOptions.Value;
             _docConfigs = new Dictionary<Type, DocConfig>();
@@ -139,7 +142,10 @@ namespace SIL.XForge.Realtime
                 Port = _realtimeOptions.Value.Port,
                 Authority = $"https://{_authOptions.Value.Domain}/",
                 Audience = _authOptions.Value.Audience,
-                Scope = _authOptions.Value.Scope
+                Scope = _authOptions.Value.Scope,
+                BugsnagApiKey = this._configuration.GetValue<string>("Bugsnag:ApiKey"),
+                ReleaseStage = this._configuration.GetValue<string>("Bugsnag:ReleaseStage"),
+                Version = System.Diagnostics.FileVersionInfo.GetVersionInfo(@System.Reflection.Assembly.GetEntryAssembly().Location).ProductVersion
             };
         }
     }


### PR DESCRIPTION
This catches errors from three sources and reports them to Bugsnag:
- The ShareDB server
- The Express server that serves static files
- The Node HTTP server that passes HTTP connections on to ShareDB and Express (if I'm understanding our code correctly)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/597)
<!-- Reviewable:end -->
