### PR TITLE
Fix lgtm alert for unnecessary null check

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/scroll-into-view.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/scroll-into-view.ts
@@ -33,7 +33,6 @@ export class ScrollIntoViewDirective implements AfterViewInit {
     if (parent == null) {
       return null;
     } else if (
-      parent != null &&
       parent.scrollHeight > parent.clientHeight &&
       ['scroll', 'auto'].includes(window.getComputedStyle(parent).overflowY as string)
     ) {


### PR DESCRIPTION
See where lgtm introduced the alert: https://lgtm.com/projects/g/sillsdev/web-xforge/rev/ea4b3bb2f963730342268d36aa78ec048ea1b0c6

This was introduced in #581, where lgtm found the new alert, but it appears the bot never commented on the PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/598)
<!-- Reviewable:end -->
