### PR TITLE
SF-864b USX save and read whitespace

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -281,7 +281,6 @@ namespace SIL.XForge.Scripture.Services
             {
                 bookTextElem = await LoadXmlFileAsync(fileName);
 
-
                 var oldUsxDoc = new XDocument(bookTextElem.Element("usx"));
                 XDocument newUsxDoc = _deltaUsxMapper.ToUsx(oldUsxDoc, text.Chapters.OrderBy(c => c.Number)
                     .Select(c => new ChapterDelta(c.Number, c.LastVerse, c.IsValid, dbChapterDocs[c.Number].Data)));
@@ -612,7 +611,7 @@ namespace SIL.XForge.Scripture.Services
         {
             using (Stream stream = _fileSystemService.OpenFile(fileName, FileMode.Open))
             {
-                return await XElement.LoadAsync(stream, LoadOptions.None, CancellationToken.None);
+                return await XElement.LoadAsync(stream, LoadOptions.PreserveWhitespace, CancellationToken.None);
             }
         }
 
@@ -620,7 +619,7 @@ namespace SIL.XForge.Scripture.Services
         {
             using (Stream stream = _fileSystemService.CreateFile(fileName))
             {
-                await bookTextElem.SaveAsync(stream, SaveOptions.None, CancellationToken.None);
+                await bookTextElem.SaveAsync(stream, SaveOptions.DisableFormatting, CancellationToken.None);
             }
         }
 


### PR DESCRIPTION
* Make sure when writing and reading USX files that the removed non-data whitespace is preserved
* So that on Sync (as well as Clone) only data whitespace is compared for changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/600)
<!-- Reviewable:end -->
