### PR TITLE
SF-883 Show dialog on sync fail

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
@@ -98,11 +98,7 @@ describe('SyncComponent', () => {
     // Simulate sync error
     env.emitSyncComplete(false);
     expect(env.component.syncActive).toBe(false);
-    verify(
-      mockedNoticeService.show(
-        'Something went wrong while synchronizing the Sync Test Project with Paratext. Please try again.'
-      )
-    ).once();
+    verify(mockedNoticeService.showMessageDialog(anything())).once();
   }));
 
   it('should show progress if in-progress when loaded', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
@@ -134,7 +134,7 @@ export class SyncComponent extends DataLoadingComponent implements OnInit, OnDes
           translate('sync.successfully_synchronized_with_paratext', { projectName: this.projectName })
         );
       } else {
-        this.noticeService.show(
+        this.noticeService.showMessageDialog(() =>
           translate('sync.something_went_wrong_synchronizing_this_project', { projectName: this.projectName })
         );
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -153,7 +153,7 @@
     "last_synced_time_stamp": "Last synced on {{ timeStamp }}",
     "log_in_to_paratext": "Log in to Paratext",
     "never_been_synced": "Never been synced",
-    "something_went_wrong_synchronizing_this_project": "Something went wrong while synchronizing the {{ projectName }} with Paratext. Please try again.",
+    "something_went_wrong_synchronizing_this_project": "Something went wrong while synchronizing {{ projectName }} with Paratext. Please try again.",
     "successfully_synchronized_with_paratext": "Successfully synchronized {{ projectName }} with Paratext.",
     "synchronize": "Synchronize",
     "synchronize_project": "Synchronize {{ projectName }} with Paratext",


### PR DESCRIPTION
Also update failure text to be consistent with success text

![Screen Shot 2020-03-30 at 22 06 38](https://user-images.githubusercontent.com/6140710/77979493-cb6f7780-72d2-11ea-9a1d-f6c46e60e33e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/605)
<!-- Reviewable:end -->
