### PR TITLE
SF-863 Fix split area height problem caused by audio component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-combined/checking-audio-combined.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-combined/checking-audio-combined.component.html
@@ -43,7 +43,7 @@
         icon="delete"
         class="remove-audio-file"
       ></button>
-      <app-checking-audio-player [source]="source"></app-checking-audio-player>
+      <app-checking-audio-player *ngIf="!!source" [source]="source"></app-checking-audio-player>
     </ng-container>
   </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.html
@@ -22,6 +22,6 @@
       icon="refresh"
       class="try-again"
     ></button>
-    <app-checking-audio-player [source]="audioUrl"></app-checking-audio-player>
+    <app-checking-audio-player *ngIf="!!audioUrl" [source]="audioUrl"></app-checking-audio-player>
   </div>
 </ng-container>


### PR DESCRIPTION
- Render audio component before audio data is loaded
- Fix resulting issue where currentTime and/or duration is NaN
- Fix issue (possibly resulting from this change) where duration and or
  currentTime is briefly enormous
- Fix slider layout issue where slider thumb was positioned incorrectly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/610)
<!-- Reviewable:end -->
