### PR TITLE
SF-701 Handle missing ops or doc in SFTextCorpusFactory

### DIFF
--- a/src/SIL.XForge.Scripture/Services/SFScriptureText.cs
+++ b/src/SIL.XForge.Scripture/Services/SFScriptureText.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -7,11 +8,21 @@ using SIL.Machine.Tokenization;
 
 namespace SIL.XForge.Scripture.Services
 {
+    /// <summary>Set of Scripture text segments.</summary>
     public class SFScriptureText : IText
     {
+        /// <remarks>Builds segments from texts and references. Will use ops in doc that have an insert and a segment attribute providing reference information.
+        /// For example,
+        /// { "insert": "In the beginning ...",
+        ///   "attributes": { "segment": "verse_1_1" } }
+        /// </remarks>
         public SFScriptureText(ITokenizer<string, int> wordTokenizer, string projectId, int book, int chapter,
             BsonDocument doc)
         {
+            if (doc == null)
+            {
+                throw new ArgumentNullException(nameof(doc));
+            }
             Id = $"{projectId}_{book}_{chapter}";
             Segments = GetSegments(wordTokenizer, doc).OrderBy(s => s.SegmentRef).ToArray();
         }
@@ -24,8 +35,12 @@ namespace SIL.XForge.Scripture.Services
         {
             string prevRef = null;
             var sb = new StringBuilder();
-            var ops = (BsonArray)doc["ops"];
-            foreach (BsonDocument op in ops.Cast<BsonDocument>())
+            doc.TryGetValue("ops", out BsonValue ops);
+            if (ops as BsonArray == null)
+            {
+                yield break;
+            }
+            foreach (BsonDocument op in ((BsonArray)ops).Cast<BsonDocument>())
             {
                 // skip embeds
                 if (!op.TryGetValue("insert", out BsonValue value) || value.BsonType != BsonType.String)

--- a/src/SIL.XForge.Scripture/Services/SFScriptureText.cs
+++ b/src/SIL.XForge.Scripture/Services/SFScriptureText.cs
@@ -35,12 +35,8 @@ namespace SIL.XForge.Scripture.Services
         {
             string prevRef = null;
             var sb = new StringBuilder();
-            doc.TryGetValue("ops", out BsonValue ops);
-            if (ops as BsonArray == null)
-            {
-                yield break;
-            }
-            foreach (BsonDocument op in ((BsonArray)ops).Cast<BsonDocument>())
+            var ops = (BsonArray)doc["ops"];
+            foreach (BsonDocument op in ops.Cast<BsonDocument>())
             {
                 // skip embeds
                 if (!op.TryGetValue("insert", out BsonValue value) || value.BsonType != BsonType.String)

--- a/src/SIL.XForge.Scripture/Services/SFTextCorpusFactory.cs
+++ b/src/SIL.XForge.Scripture/Services/SFTextCorpusFactory.cs
@@ -68,7 +68,7 @@ namespace SIL.XForge.Scripture.Services
                         string id = TextData.GetTextDocId(projectId, text.BookNum, chapter.Number, textType);
                         FilterDefinition<BsonDocument> filter = Builders<BsonDocument>.Filter.Eq("_id", id);
                         BsonDocument doc = await textDataColl.Find(filter).FirstOrDefaultAsync();
-                        if (doc != null)
+                        if (doc != null && doc.TryGetValue("ops", out BsonValue ops) && ops as BsonArray != null)
                             texts.Add(new SFScriptureText(wordTokenizer, projectId, text.BookNum, chapter.Number, doc));
                     }
                 }

--- a/test/SIL.XForge.Scripture.Tests/Services/SFScriptureTextTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFScriptureTextTests.cs
@@ -153,28 +153,6 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public void Create_MissingOps_EmptySegments()
-        {
-            var doc = new BsonDocument
-            {
-                {"_id", "abc123:MAT:1:target"},
-                // Missing ops
-            };
-            var numberSegments = 0;
-            var bookNumber = 40;
-            var chapterNumber = 1;
-            var projectId = "myProject";
-            Assert.That(doc.Contains("ops"), Is.False, "Setup");
-            var tokenizer = new LatinWordTokenizer();
-
-            // SUT
-            var text = new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc);
-
-            Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
-            Assert.That(text.Segments.Count(), Is.EqualTo(numberSegments));
-        }
-
-        [Test]
         public void Create_NullDoc_Crash()
         {
             BsonDocument doc = null;

--- a/test/SIL.XForge.Scripture.Tests/Services/SFScriptureTextTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFScriptureTextTests.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Linq;
+using MongoDB.Bson;
+using NUnit.Framework;
+using SIL.Machine.Tokenization;
+
+namespace SIL.XForge.Scripture.Services
+{
+    [TestFixture]
+    public class SFScriptureTextTests
+    {
+        [Test]
+        public void Create_HasDocOps_HasSegments()
+        {
+            // Make a BsonDocument that looks like data
+            // from SF DB - xforge - texts.
+            var doc = new BsonDocument
+            {
+                {"_id", "abc123:MAT:1:target"},
+                {"ops", new BsonArray
+                    {
+                        new BsonDocument
+                        {
+                            {"insert", new BsonDocument
+                                {
+                                    {"chapter", new BsonDocument
+                                        {
+                                            {"number","1"},
+                                            {"style","c"}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        new BsonDocument
+                        {
+                            {"insert", new BsonDocument
+                                {
+                                    {"verse", new BsonDocument
+                                        {
+                                            {"number","1"},
+                                            {"style","v"}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        new BsonDocument
+                        {
+                            {"insert", "First verse text here"},
+                            {"attributes", new BsonDocument
+                                {
+                                    {"segment", "verse_1_1"}
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+            var numberOps = 3;
+            var numberSegments = 1;
+            var bookNumber = 40;
+            var chapterNumber = 1;
+            var projectId = "myProject";
+            Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
+            var tokenizer = new LatinWordTokenizer();
+
+            // SUT
+            var text = new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc);
+
+            Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
+            Assert.That(text.Segments.Count(), Is.EqualTo(numberSegments));
+        }
+
+        [Test]
+        public void Create_NoSegments_EmptySegments()
+        {
+            var doc = new BsonDocument
+            {
+                {"_id", "abc123:MAT:1:target"},
+                {"ops", new BsonArray
+                    {
+                        new BsonDocument
+                        {
+                            {"insert", new BsonDocument
+                                {
+                                    {"chapter", new BsonDocument
+                                        {
+                                            {"number","1"},
+                                            {"style","c"}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        new BsonDocument
+                        {
+                            {"insert", new BsonDocument
+                                {
+                                    {"verse", new BsonDocument
+                                        {
+                                            {"number","1"},
+                                            {"style","v"}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        // No verse text inserts with a segment reference.
+                    }
+                }
+            };
+            var numberOps = 2;
+            var numberSegments = 0;
+            var bookNumber = 40;
+            var chapterNumber = 1;
+            var projectId = "myProject";
+            Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
+            var tokenizer = new LatinWordTokenizer();
+
+            // SUT
+            var text = new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc);
+
+            Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
+            Assert.That(text.Segments.Count(), Is.EqualTo(numberSegments));
+        }
+
+        [Test]
+        public void Create_EmptyOps_EmptySegments()
+        {
+            var doc = new BsonDocument
+            {
+                {"_id", "abc123:MAT:1:target"},
+                {"ops", new BsonArray
+                    {
+                        // Empty ops array
+                    }
+                }
+            };
+            var numberOps = 0;
+            var numberSegments = 0;
+            var bookNumber = 40;
+            var chapterNumber = 1;
+            var projectId = "myProject";
+            Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
+            var tokenizer = new LatinWordTokenizer();
+
+            // SUT
+            var text = new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc);
+
+            Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
+            Assert.That(text.Segments.Count(), Is.EqualTo(numberSegments));
+        }
+
+        [Test]
+        public void Create_MissingOps_EmptySegments()
+        {
+            var doc = new BsonDocument
+            {
+                {"_id", "abc123:MAT:1:target"},
+                // Missing ops
+            };
+            var numberSegments = 0;
+            var bookNumber = 40;
+            var chapterNumber = 1;
+            var projectId = "myProject";
+            Assert.That(doc.Contains("ops"), Is.False, "Setup");
+            var tokenizer = new LatinWordTokenizer();
+
+            // SUT
+            var text = new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc);
+
+            Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
+            Assert.That(text.Segments.Count(), Is.EqualTo(numberSegments));
+        }
+
+        [Test]
+        public void Create_NullDoc_Crash()
+        {
+            BsonDocument doc = null;
+            var bookNumber = 40;
+            var chapterNumber = 1;
+            var projectId = "myProject";
+            var tokenizer = new LatinWordTokenizer();
+
+            // SUT
+            Assert.Throws<ArgumentNullException>(() => new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc));
+        }
+    }
+}


### PR DESCRIPTION
* Treat missing doc ops as an empty ops.
* This fixes SF-701 where a `KeyNotFoundException: Element 'ops' not found.` exception can occur when syncing, if the SF DB has chapter texts with no ops.
* Add SFScriptureText tests, comments

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/612)
<!-- Reviewable:end -->
