### PR TITLE
Add checkmark to selected locale

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -29,6 +29,7 @@
                   (click)="langMenu.open = false; i18n.setLocale(locale.canonicalTag)"
                 >
                   <!-- `langMenu.open = false` is workaround for menu not closing when click is on a span element -->
+                  <mdc-icon>check</mdc-icon>
                   <span [class.locale-disabled]="!locale.production">{{ locale.localName }}</span>
                 </mdc-list-item>
               </mdc-list>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -117,6 +117,15 @@ a {
   font-weight: bold;
 }
 
+.locale-menu {
+  mdc-list-item:not(.active-locale) mdc-icon {
+    visibility: hidden;
+  }
+  mdc-icon {
+    margin-right: 0.5em;
+  }
+}
+
 .locale-menu .mdc-list-item {
   white-space: nowrap;
   font-family: language_picker;


### PR DESCRIPTION
- Presently it's not obvious which locale is selected, since the bold isn't very bold.
- Angular MDC has a way of showing checkmarks for the selected item in a group, but it doesn't appear to integrate with our locale selection.

![](https://user-images.githubusercontent.com/6140710/79284688-677bb000-7e89-11ea-88f8-0dea41cb59c9.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/614)
<!-- Reviewable:end -->
