### PR TITLE
SF-831 Fix overflow of community checking label in Azerbaijani

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -33,6 +33,9 @@
         color: $purpleMedium;
         transition: color 0.15s;
       }
+      .mdc-list-item__graphic {
+        margin-right: 24px;
+      }
     }
   }
 


### PR DESCRIPTION
Shortening the translation was first ruled out as a possibility before increasing the area.

Reducing the icon's right margin from 32px to 30px would be sufficient on my machine, but it's possible with a slightly different font, layout engine, or scrollbar width, the text could take up a little more space, so I reduced it to 24px for good measure.

For what it's worth, I've only ever reproduced this as an administrator with lots of books in Chromium. Without a lot of books the scrollbar doesn't appear, and in Firefox on my machine, the scroll bar isn't wide enough to cause the issue.

Before | After
-------|------
![localhost_5000_projects_5e3302ee5497624e44d16a6a_checking_ALL (1)](https://user-images.githubusercontent.com/6140710/79495904-4d5de100-7ff3-11ea-8c74-d11d1a6b0976.png) | ![localhost_5000_projects_5e3302ee5497624e44d16a6a_checking_JON](https://user-images.githubusercontent.com/6140710/79496993-fa852900-7ff4-11ea-83cc-aef363bd838e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/617)
<!-- Reviewable:end -->
