### PR TITLE
SF-663 Fix missing questions on overview page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -99,7 +99,7 @@
     fxLayout="row"
     fxLayoutAlign="space-around"
     class="reviewer-panels"
-    *ngIf="allQuestionsCount === '-' || allQuestionsCount === '0'"
+    *ngIf="allQuestionsCount === '0'"
     id="no-questions-label"
   >
     <p>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -157,12 +157,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
         this.dataChangesSub.unsubscribe();
       }
       this.dataChangesSub = merge(this.projectDoc.remoteChanges$, this.questionsQuery.remoteChanges$).subscribe(() => {
-        this.loadingStarted();
-        try {
-          this.initTexts();
-        } finally {
-          this.loadingFinished();
-        }
+        this.initTextsWithLoadingIndicator();
       });
     });
   }
@@ -204,11 +199,11 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
     return count;
   }
 
-  questionCount(bookNum: number, chapterNumber: number, fromArchive = false): number {
+  questionCount(bookNumber: number, chapterNumber: number, fromArchive = false): number {
     if (this.projectDoc == null) {
       return 0;
     }
-    const id = new TextDocId(this.projectDoc.id, bookNum, chapterNumber);
+    const id = new TextDocId(this.projectDoc.id, bookNumber, chapterNumber);
     const questionDocs = this.getQuestionDocs(id, fromArchive);
     return questionDocs.length;
   }
@@ -318,6 +313,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
       projectId: this.projectDoc.id
     };
     await this.questionDialogService.questionDialog(data, questionDoc);
+    this.initTextsWithLoadingIndicator();
   }
 
   getBookName(text: TextInfo): string {
@@ -326,6 +322,15 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
 
   getBookId(text: TextInfo): string {
     return Canon.bookNumberToId(text.bookNum);
+  }
+
+  private initTextsWithLoadingIndicator() {
+    this.loadingStarted();
+    try {
+      this.initTexts();
+    } finally {
+      this.loadingFinished();
+    }
   }
 
   private initTexts(): void {


### PR DESCRIPTION
- This is the fourth time we've worked on this issue in one way or another, with the previous fix being c12d511720b9d31f24228d639c4bb4f59e257f7a
- Also a couple miscellaneous changes

Previously `initTexts` was only called when the route changed (switching projects) or `projectDoc.remoteChanges$` or `questionsQuery.remoteChanges$` provides us new data. It would appear `remoteChanges$` means just that; remote changes. That doesn't really explain why it happens so much more often when using a production build though, and doesn't always happen with non-production builds. I do think `initTexts` is idempotent though, so I'm not really worried about it causing problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/619)
<!-- Reviewable:end -->
