### PR TITLE
SF-701b Handle missing ops better

### DIFF
--- a/src/SIL.XForge.Scripture/Services/SFScriptureText.cs
+++ b/src/SIL.XForge.Scripture/Services/SFScriptureText.cs
@@ -11,7 +11,8 @@ namespace SIL.XForge.Scripture.Services
     /// <summary>Set of Scripture text segments.</summary>
     public class SFScriptureText : IText
     {
-        /// <remarks>Builds segments from texts and references. Will use ops in doc that have an insert and a segment attribute providing reference information.
+        /// <remarks>Builds segments from texts and references.
+        /// Will use ops in doc that have an insert and a segment attribute providing reference information.
         /// For example,
         /// { "insert": "In the beginning ...",
         ///   "attributes": { "segment": "verse_1_1" } }
@@ -20,9 +21,11 @@ namespace SIL.XForge.Scripture.Services
             BsonDocument doc)
         {
             if (doc == null)
-            {
                 throw new ArgumentNullException(nameof(doc));
-            }
+            doc.TryGetValue("ops", out BsonValue ops);
+            if (ops as BsonArray == null)
+                throw new ArgumentException("Doc is missing ops, perhaps the doc was deleted.", nameof(doc));
+
             Id = $"{projectId}_{book}_{chapter}";
             Segments = GetSegments(wordTokenizer, doc).OrderBy(s => s.SegmentRef).ToArray();
         }

--- a/test/SIL.XForge.Scripture.Tests/Services/SFScriptureTextTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFScriptureTextTests.cs
@@ -164,5 +164,23 @@ namespace SIL.XForge.Scripture.Services
             // SUT
             Assert.Throws<ArgumentNullException>(() => new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc));
         }
+
+        [Test]
+        public void Create_MissingOps_Crash()
+        {
+            var doc = new BsonDocument
+            {
+                {"_id", "abc123:MAT:1:target"},
+                // Missing ops
+            };
+            var bookNumber = 40;
+            var chapterNumber = 1;
+            var projectId = "myProject";
+            Assert.That(doc.Contains("ops"), Is.False, "Setup");
+            var tokenizer = new LatinWordTokenizer();
+
+            // SUT
+            Assert.Throws<ArgumentException>(() => new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc));
+        }
     }
 }


### PR DESCRIPTION
* add critical test back in to safeguard future changes

Note I was happy to ship the last PR for this since the change had been sitting for so long after all of Mark's hard work, and we value shipping code. However, I was not happy that I had to remove a test to do it and not just any test, the critical one for this issue. Even though the last fix just moved the check for missing ops back up into the parent call in `SFTextCorpusFactory`, I couldn't just move the test to the parent because that would require serious refactoring to make it testable (we'd probably need to get it to use a Delta doc instead of a BSON doc). The test is back now. This fix adds the check for missing ops into the constructor of the child (`SFScriptureText`) and throws so it can still be tested. This has the advantage of letting us know if the parent check gets removed and safeguards against it being called elsewhere without the check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/620)
<!-- Reviewable:end -->
