### PR TITLE
SF-828 - The question icon does not appear after creating a question in the book

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -38,10 +38,13 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
     // Only mark as read if it has been viewed for a set period of time and not an accidental click
     this.subscribe(this.activeQuestionDoc$.pipe(debounceTime(2000)), questionDoc => {
       this.updateElementsRead(questionDoc);
-      if (questionDoc != null && questionDoc.data != null) {
-        this.storeMostRecentQuestion(questionDoc.data.verseRef.bookNum);
-      }
     });
+  }
+
+  get activeQuestionBook(): number | undefined {
+    return this.activeQuestionDoc == null || this.activeQuestionDoc.data == null
+      ? undefined
+      : this.activeQuestionDoc.data.verseRef.bookNum;
   }
 
   get activeQuestionChapter(): number | undefined {
@@ -233,9 +236,13 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
       questionChanged = false;
     }
     this.activeQuestionDoc = questionDoc;
-    this.changed.emit(questionDoc);
-    if (questionChanged) {
-      this.activeQuestionDoc$.next(questionDoc);
+    if (questionDoc.data != null) {
+      this.storeMostRecentQuestion(questionDoc.data.verseRef.bookNum).then(() => {
+        this.changed.emit(questionDoc);
+        if (questionChanged) {
+          this.activeQuestionDoc$.next(questionDoc);
+        }
+      });
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -103,7 +103,7 @@
                       #textPanel
                       [id]="textDocId"
                       [fontSize]="scriptureFontSize"
-                      [activeVerse]="questionsPanel.activeQuestionVerseRef"
+                      [activeVerse]="activeQuestionVerseRef"
                       [questionVerses]="questionVerseRefs"
                       (questionVerseSelected)="verseRefClicked($event)"
                     ></app-checking-text>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -143,6 +143,12 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
     this.checkBookStatus();
   }
 
+  get activeQuestionVerseRef(): VerseRef | undefined {
+    if (this.questionsPanel != null && this.book === this.questionsPanel.activeQuestionBook) {
+      return this.questionsPanel.activeQuestionVerseRef;
+    }
+  }
+
   get bookName(): string {
     return this.text == null ? '' : this.i18n.localizeBook(this.text.bookNum);
   }
@@ -347,8 +353,9 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
         if (this.questionsSub != null) {
           this.questionsSub.unsubscribe();
         }
-        this.questionsSub = this.subscribe(merge(this.questionsQuery.ready$, this.questionsQuery.remoteChanges$), () =>
-          this.checkBookStatus()
+        this.questionsSub = this.subscribe(
+          merge(this.questionsQuery.ready$, this.questionsQuery.remoteChanges$, this.questionsQuery.localChanges$),
+          () => this.checkBookStatus()
         );
         const prevBook = this.book;
         this.book = bookNum;
@@ -673,6 +680,21 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
       }
     }
     this.questionVerseRefs = questionVerseRefs;
+    if (
+      !this.showAllBooks &&
+      this.book != null &&
+      this.questionsPanel != null &&
+      this.questionsPanel.activeQuestionBook != null &&
+      Canon.bookNumberToId(this.book) !== this.activatedRoute.snapshot.params['bookId']
+    ) {
+      this._book = undefined;
+      this.router.navigate([
+        '/projects',
+        this.projectDoc.id,
+        'checking',
+        Canon.bookNumberToId(this.questionsPanel.activeQuestionBook)
+      ]);
+    }
   }
 
   private getAnswerIndex(answer: Answer): number {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.ts
@@ -53,6 +53,10 @@ export class ScriptureChooserDialogComponent implements OnInit {
     return this.otBooks.length > 0;
   }
 
+  private get hasMultipleBooks(): boolean {
+    return this.otBooks.length + this.ntBooks.length > 1;
+  }
+
   ngOnInit() {
     const books = Object.keys(this.data.booksAndChaptersToShow);
     this.otBooks = books.filter(book => this.isOT(book));
@@ -72,6 +76,10 @@ export class ScriptureChooserDialogComponent implements OnInit {
           this.showRangeEndSelection();
         }
       }
+    }
+    // When there is only one book available then start at the chapters view
+    if (!this.hasMultipleBooks) {
+      this.onClickBook(Object.keys(this.data.booksAndChaptersToShow)[0]);
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-query.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-query.ts
@@ -14,6 +14,7 @@ export class RealtimeQuery<T extends RealtimeDoc = RealtimeDoc> {
   private unsubscribe$ = new Subject<void>();
   private _count: number = 0;
   private _unpagedCount: number = 0;
+  private readonly _localChanges$ = new Subject<void>();
   private readonly _remoteChanges$ = new Subject<void>();
   private readonly _ready$ = new Subject<void>();
 
@@ -42,6 +43,10 @@ export class RealtimeQuery<T extends RealtimeDoc = RealtimeDoc> {
 
   get unpagedCount(): number {
     return this._unpagedCount;
+  }
+
+  get localChanges$(): Observable<void> {
+    return this._localChanges$;
   }
 
   get remoteChanges$(): Observable<void> {
@@ -85,6 +90,7 @@ export class RealtimeQuery<T extends RealtimeDoc = RealtimeDoc> {
       return;
     }
     await this.localQuery();
+    this._localChanges$.next();
   }
 
   private async localQuery(): Promise<string[] | undefined> {


### PR DESCRIPTION
- Active question returns undefined now if the text displayed is a different book from the active question
- Showing questions for a specific book now only lets you add questions to that book and not other books on the project
- Scripture dialog will automatically switch to chapter view if only a single book is available
- Added `localChanges$` as an observable for when `remoteChanges$` is not available

The Jira task I believe relates to a connection issue with the backend which then doesn't let  `remoteChanges$` emit an event. As changes are are added locally it means part of the interface is updated immediately but the area relying on `remoteChanges$` to fire (segments and question icon being added to the text component) never gets triggered. I added a new `localChanges$` so that we can still trigger the appropriate event. This will be useful for PWA work as well. With the latest PWA work in `master` it does make testing this a little more difficult now as you are routed to the offline page when a connection to the backend is lost.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/622)
<!-- Reviewable:end -->
