### PR TITLE
SF-892 - Empty question added without any text if audio permission is blocked in the browser

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.ts
@@ -78,7 +78,6 @@ export class CheckingAudioRecorderComponent implements OnInit, OnDestroy {
     this.navigator.mediaDevices
       .getUserMedia(mediaConstraints)
       .then(this.successCallback.bind(this), this.errorCallback.bind(this));
-    this.status.emit({ status: 'recording' });
   }
 
   async stopRecording() {
@@ -119,5 +118,6 @@ export class CheckingAudioRecorderComponent implements OnInit, OnDestroy {
     this.stream = stream;
     this.recordRTC = RecordRTC(stream, options);
     this.recordRTC.startRecording();
+    this.status.emit({ status: 'recording' });
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -313,6 +313,18 @@ describe('QuestionDialogComponent', () => {
     expect(env.component.questionText.errors!.required).not.toBeNull();
   }));
 
+  it('should not save with no text and audio permission is denied', fakeAsync(() => {
+    const env = new TestEnvironment();
+    flush();
+    env.inputValue(env.questionInput, '');
+    expect(env.component.questionText.valid).toBe(false);
+    expect(env.component.questionText.errors!.required).not.toBeNull();
+    // Test that audio permission was blocked and validation is still invalid
+    env.setAudioStatus('denied');
+    expect(env.component.questionText.valid).toBe(false);
+    expect(env.component.questionText.errors!.required).not.toBeNull();
+  }));
+
   it('display quill editor', fakeAsync(() => {
     const env = new TestEnvironment();
     flush();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -219,7 +219,7 @@ export class QuestionDialogComponent extends SubscriptionDisposable implements O
     this.audio = audio;
     if (audio.status === 'uploaded' || audio.status === 'processed' || audio.status === 'recording') {
       this.questionText.clearValidators();
-    } else if (audio.status === 'reset') {
+    } else if (audio.status === 'reset' || audio.status === 'denied') {
       this.questionText.setValidators([Validators.required, XFValidators.someNonWhitespace]);
     }
     this.questionText.updateValueAndValidity();


### PR DESCRIPTION
- Moved audio recorder `recording` event to only emit after successfully getting rights to use the microphone
- Reset question dialog  validation if `denied` access to the microphone

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/623)
<!-- Reviewable:end -->
