### PR TITLE
SF-920 - List of languages in mobile view

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -22,7 +22,13 @@
               <mdc-icon mdcTopAppBarActionItem title="{{ t('language') }}" (click)="langMenu.open = !langMenu.open">
                 translate
               </mdc-icon>
-              <mdc-menu #langMenu [anchorCorner]="'bottomStart'" [anchorElement]="langMenuAnchor" class="locale-menu">
+              <mdc-menu
+                #langMenu
+                [anchorCorner]="'bottomStart'"
+                [anchorElement]="langMenuAnchor"
+                [anchorMargin]="{ right: media.isActive('xs') ? -88 : 0 }"
+                class="locale-menu"
+              >
                 <mdc-list>
                   <mdc-list-item
                     *ngFor="let locale of i18n.locales"


### PR DESCRIPTION
- Set `anchorMargin` for language menu on extra small screens

The margin 88 refers to keeping it flush with the content on the right edge of the screen

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/624)
<!-- Reviewable:end -->
