### PR TITLE
SF-923 Question count misaligned when segment blank

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -78,15 +78,18 @@ quill-editor {
   }
 }
 
-usx-para[dir='ltr'],
-p[dir='ltr'] {
-  .question-segment[data-question-count] {
-    margin-left: 1.75em;
-    &:before {
-      left: -2.25em;
-    }
-    &:after {
-      left: -1.5em;
+usx-para,
+p {
+  &[dir='ltr'],
+  &[dir='auto'] {
+    .question-segment[data-question-count] {
+      margin-left: 1.75em;
+      &:before {
+        left: -2.25em;
+      }
+      &:after {
+        left: -1.5em;
+      }
     }
   }
 }


### PR DESCRIPTION
Before | After
-------|------
![](https://user-images.githubusercontent.com/6140710/80393000-e0add680-887d-11ea-9ee7-1a25b0774971.png) | ![](https://user-images.githubusercontent.com/6140710/80392997-df7ca980-887d-11ea-828a-a5f6cb51c95c.png)

The problem was that when there is no text, the paragraph has dir set to auto and doesn't properly align the question count icon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/625)
<!-- Reviewable:end -->
