### PR TITLE
Stop shrinking header when scrolling down

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -2,7 +2,7 @@
   <mdc-linear-progress [secondary]="true" *ngIf="isAppLoading != null" [open]="isAppLoading" fxFlex="none">
   </mdc-linear-progress>
   <header [class.overlay-drawer]="isDrawerPermanent">
-    <mdc-top-app-bar [short]="media.isActive(['lg', 'xl'])" fixed #topAppBar [scrollTarget]="appContent">
+    <mdc-top-app-bar fixed #topAppBar [scrollTarget]="appContent">
       <mdc-top-app-bar-row>
         <mdc-top-app-bar-section align="start">
           <a *ngIf="!isDrawerPermanent && isProjectSelected" (click)="toggleDrawer()">
@@ -134,7 +134,7 @@
     (closed)="drawerCollapsed()"
   >
     <mdc-drawer-header>
-      <div [class.mdc-top-app-bar--short-fixed-adjust]="isDrawerPermanent"></div>
+      <div [class.mdc-top-app-bar-adjust]="isDrawerPermanent"></div>
       <mdc-select *ngIf="projectDocs != null" class="project-select" (valueChange)="projectChanged($event.value)">
         <mdc-menu>
           <mdc-list>
@@ -276,7 +276,7 @@
       </mdc-list>
     </mdc-drawer-content>
   </mdc-drawer>
-  <div #appContent class="app-content mdc-top-app-bar--short-fixed-adjust">
+  <div #appContent class="app-content mdc-top-app-bar-adjust">
     <div>
       <router-outlet></router-outlet>
       <p *ngIf="showCheckingDisabled" class="checking-unavailable">{{ t("scripture_checking_not_available") }}</p>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -1,6 +1,7 @@
 @import '~src/variables';
 @import '~bootstrap/scss/mixins/breakpoints';
 @import '~@angular-mdc/theme/scss/icon-button/mixins';
+@import '~@material/top-app-bar/_variables.scss';
 
 :host {
   display: flex;
@@ -71,6 +72,10 @@
     .mdc-top-app-bar__section {
       padding: 4px;
     }
+  }
+
+  .mdc-top-app-bar-adjust {
+    margin-top: $mdc-top-app-bar-mobile-row-height;
   }
 
   .app-content {


### PR DESCRIPTION
Perhaps I'm missing something, but I've never quite understood why we have the header shrink when scrolling down the page. I'm not sure I know of any other websites that do that, and I think it could be slightly confusing to users.

However, since I don't know why it was done this way in the first place, I am merely bringing this up as a proposal. Perhaps there is a valid reason; if so feel free to close.

Before | After
-------|------
![](https://user-images.githubusercontent.com/6140710/80401872-0ab9c580-888b-11ea-958f-3832154af03f.png) | ![](https://user-images.githubusercontent.com/6140710/80401865-0a212f00-888b-11ea-83ba-85f769bd9a1c.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/626)
<!-- Reviewable:end -->
