### PR TITLE
Clone target and source as subfolders in the main sync project

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Although this setup is specifically written for **Windows**, the steps could be 
 5. Install [Node v12](https://nodejs.org/en/download/)
 6. Install [FFmpeg v4](https://ffmpeg.org/download.html) executable into the `C:\usr\bin\` directory.
 7. Install a developer editor, [VS Code](https://code.visualstudio.com/download) is recommended (the repo includes VS Code settings)
-8. Install [Mercurial v4.7](https://www.mercurial-scm.org/) (python 2) and copy contents into the `C:\usr\local\bin\ directory`.
+8. Install [Mercurial v4.8](https://www.mercurial-scm.org/) (python 2) and copy contents into the `C:\usr\local\bin\ directory`.
 9. Create folders owned by you. Check in the Ansible `deploy/dependencies.yml` for the valid list of folders. As of writing they were:
 
 - `/var/lib/scriptureforge/sync/`

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ To report an issue with the **Scripture Forge** application, email "scripturefor
 The rest of this document discusses the development of the underlying software.
 
 ## Contents <!-- omit in toc -->
+
 <!-- The table of contents is automatically updated by VSCode extension
 "yzhang.markdown-all-in-one" when saving. -->
 
@@ -191,20 +192,21 @@ Although this setup is specifically written for **Windows**, the steps could be 
    `git clone --recurse-submodules https://github.com/sillsdev/web-xforge`.
 
 3. Install [MongoDB v4](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows/) as a service
-4. Install [.Net Core SDK-2.1](https://dotnet.microsoft.com/download/dotnet-core/2.1)
-5. Install [Node v10](https://nodejs.org/en/download/)
+4. Install [.Net Core SDK-3.1](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+5. Install [Node v12](https://nodejs.org/en/download/)
 6. Install [FFmpeg v4](https://ffmpeg.org/download.html) executable into the `C:\usr\bin\` directory.
 7. Install a developer editor, [VS Code](https://code.visualstudio.com/download) is recommended (the repo includes VS Code settings)
-8. Create folders owned by you. Check in the Ansible `deploy/dependencies.yml` for the valid list of folders. As of writing they were:
+8. Install [Mercurial v4.7](https://www.mercurial-scm.org/) (python 2) and copy contents into the `C:\usr\local\bin\ directory`.
+9. Create folders owned by you. Check in the Ansible `deploy/dependencies.yml` for the valid list of folders. As of writing they were:
 
-   - `/var/lib/scriptureforge/sync/`
-   - `/var/lib/scriptureforge/audio/`
-   - `/var/lib/xforge/avatars/`
+- `/var/lib/scriptureforge/sync/`
+- `/var/lib/scriptureforge/audio/`
+- `/var/lib/xforge/avatars/`
 
-   On Windows, just put these off your root drive, e.g. `C:\var\lib\...`
+On Windows, just put these off your root drive, e.g. `C:\var\lib\...`
 
-9. Add developer secrets. Ask another developer how to get these.
-10. In `src/SIL.XForge.Scripture/`, run `dotnet run`. Browse to `http://localhost:5000`.
+10. Add developer secrets. Ask another developer how to get these.
+11. In `src/SIL.XForge.Scripture/`, run `dotnet run`. Browse to `http://localhost:5000`.
 
 ### Development Process
 

--- a/deploy/dependencies.yml
+++ b/deploy/dependencies.yml
@@ -70,7 +70,7 @@
     - name: install custom mercurial
       pip:
         name: mercurial
-        version: 5.3.1
+        version: 4.8.2
 
     - name: update the mongo config file
       lineinfile:

--- a/src/SIL.XForge.Scripture/Models/TextInfo.cs
+++ b/src/SIL.XForge.Scripture/Models/TextInfo.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace SIL.XForge.Scripture.Models
 {
@@ -6,6 +7,26 @@ namespace SIL.XForge.Scripture.Models
     {
         Target,
         Source
+    }
+
+    public class TextTypeUtils
+    {
+        public static string DirectoryName(TextType textType)
+        {
+            string textTypeDir;
+            switch (textType)
+            {
+                case TextType.Target:
+                    textTypeDir = "target";
+                    break;
+                case TextType.Source:
+                    textTypeDir = "source";
+                    break;
+                default:
+                    throw new InvalidEnumArgumentException(nameof(textType), (int)textType, typeof(TextType));
+            }
+            return textTypeDir;
+        }
     }
 
     public class TextInfo

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -16,13 +16,13 @@ namespace SIL.XForge.Scripture.Services
         Task<Attempt<string>> TryGetProjectRoleAsync(UserSecret userSecret, string paratextId);
         Task<IReadOnlyDictionary<string, string>> GetProjectRolesAsync(UserSecret userSecret, string projectId);
 
-        IReadOnlyList<int> GetBookList(UserSecret userSecret, string ptProjectId);
-        string GetBookText(UserSecret userSecret, string ptProjectId, int bookNum);
+        IReadOnlyList<int> GetBookList(UserSecret userSecret, string ptProjectId, TextType textType);
+        string GetBookText(UserSecret userSecret, string ptProjectId, int bookNum, TextType textType);
         void PutBookText(UserSecret userSecret, string ptProjectId, int bookNum, string usx);
         string GetNotes(UserSecret userSecret, string ptProjectId, int bookNum);
         void PutNotes(UserSecret userSecret, string ptProjectId, string notesText);
 
-        Task SendReceiveAsync(UserSecret userSecret, IEnumerable<string> ptProjectIds,
+        Task SendReceiveAsync(UserSecret userSecret, string ptTargetId, string ptSourceId,
             IProgress<ProgressState> progress = null);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/IScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/IScrTextCollection.cs
@@ -1,5 +1,4 @@
 using Paratext.Data;
-using SIL.XForge.Scripture;
 
 namespace SIL.XForge.Scripture.Services
 {

--- a/src/SIL.XForge.Scripture/Services/IScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/IScrTextCollection.cs
@@ -1,10 +1,11 @@
 using Paratext.Data;
+using SIL.XForge.Scripture;
 
 namespace SIL.XForge.Scripture.Services
 {
     public interface IScrTextCollection
     {
         void Initialize(string settingsDir = null);
-        ScrText FindById(string username, string projectId);
+        ScrText FindById(string username, string projectId, Models.TextType textType);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -114,14 +114,13 @@ namespace SIL.XForge.Scripture.Services
                 }
 
                 // perform Paratext send/receive
-                var paratextIds = new List<string> { targetParatextId };
-                if (sourceParatextId != null)
-                    paratextIds.Add(sourceParatextId);
-                await _paratextService.SendReceiveAsync(_userSecret, paratextIds, UseNewProgress());
+                await _paratextService.SendReceiveAsync(_userSecret, targetParatextId, sourceParatextId,
+                    UseNewProgress());
 
-                var targetBooks = new HashSet<int>(_paratextService.GetBookList(_userSecret, targetParatextId));
+                var targetBooks = new HashSet<int>(_paratextService.GetBookList(_userSecret, targetParatextId,
+                    TextType.Target));
                 var sourceBooks = new HashSet<int>(TranslationSuggestionsEnabled
-                    ? _paratextService.GetBookList(_userSecret, sourceParatextId)
+                    ? _paratextService.GetBookList(_userSecret, targetParatextId, TextType.Source)
                     : Enumerable.Empty<int>());
                 sourceBooks.IntersectWith(targetBooks);
 
@@ -181,7 +180,7 @@ namespace SIL.XForge.Scripture.Services
                             sourceTextDocs = new SortedList<int, IDocument<TextData>>();
                         }
                         var chaptersToInclude = new HashSet<int>(newChapters.Select(c => c.Number));
-                        await UpdateTextDocsAsync(text, TextType.Source, sourceParatextId, sourceTextDocs,
+                        await UpdateTextDocsAsync(text, TextType.Source, targetParatextId, sourceTextDocs,
                             chaptersToInclude);
                     }
 
@@ -256,7 +255,7 @@ namespace SIL.XForge.Scripture.Services
 
         private void UpdateParatextBook(TextInfo text, string paratextId, SortedList<int, IDocument<TextData>> textDocs)
         {
-            string bookText = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
+            string bookText = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum, TextType.Target);
             var oldUsxDoc = XDocument.Parse(bookText);
             XDocument newUsxDoc = _deltaUsxMapper.ToUsx(oldUsxDoc, text.Chapters.OrderBy(c => c.Number)
                 .Select(c => new ChapterDelta(c.Number, c.LastVerse, c.IsValid, textDocs[c.Number].Data)));
@@ -287,7 +286,7 @@ namespace SIL.XForge.Scripture.Services
         private async Task<List<Chapter>> UpdateTextDocsAsync(TextInfo text, TextType textType, string paratextId,
             SortedList<int, IDocument<TextData>> textDocs, ISet<int> chaptersToInclude = null)
         {
-            string bookText = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
+            string bookText = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum, textType);
             var usxDoc = XDocument.Parse(bookText);
             var tasks = new List<Task>();
             Dictionary<int, ChapterDelta> deltas = _deltaUsxMapper.ToChapterDeltas(usxDoc)

--- a/src/SIL.XForge/Services/FileSystemService.cs
+++ b/src/SIL.XForge/Services/FileSystemService.cs
@@ -20,6 +20,11 @@ namespace SIL.XForge.Services
             return File.Open(path, mode);
         }
 
+        public string FileReadText(string path)
+        {
+            return File.ReadAllText(path);
+        }
+
         public void DeleteFile(string path)
         {
             File.Delete(path);

--- a/src/SIL.XForge/Services/IFileSystemService.cs
+++ b/src/SIL.XForge/Services/IFileSystemService.cs
@@ -8,6 +8,7 @@ namespace SIL.XForge.Services
         Stream CreateFile(string path);
         bool FileExists(string path);
         Stream OpenFile(string path, FileMode mode);
+        string FileReadText(string path);
         void DeleteFile(string path);
         void CreateDirectory(string path);
         bool DirectoryExists(string path);

--- a/test/SIL.XForge.Scripture.Tests/Services/LazyScrTextCollectionTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/LazyScrTextCollectionTests.cs
@@ -42,7 +42,7 @@ namespace SIL.XForge.Scripture.Services
             string projectTextName = "Proj01";
             string path = Path.Combine(_testDirectory, projectId, "target");
             string content = $"<ScriptureText><Name>{projectTextName}</Name><guid>{projectId}</guid></ScriptureText>";
-            _fileSystemService.OpenFile(Arg.Any<string>(), FileMode.Open).Returns(GetStream(content));
+            _fileSystemService.FileReadText(Arg.Any<string>()).Returns(content);
             _fileSystemService.FileExists(Arg.Any<string>()).Returns(true);
 
             ScrText scrText = _lazyScrTextCollection.FindById(username, projectId, Models.TextType.Target);
@@ -62,8 +62,7 @@ namespace SIL.XForge.Scripture.Services
             string path = Path.Combine(_testDirectory, targetProjectId, "source");
             string content =
                 $"<ScriptureText><Name>{sourceTextName}</Name><guid>{sourceProjectId}</guid></ScriptureText>";
-
-            _fileSystemService.OpenFile(Arg.Any<string>(), FileMode.Open).Returns(GetStream(content));
+            _fileSystemService.FileReadText(Arg.Any<string>()).Returns(content);
             _fileSystemService.FileExists(Arg.Any<string>()).Returns(true);
 
             ScrText scrText = _lazyScrTextCollection.FindById(username, targetProjectId, Models.TextType.Source);
@@ -71,16 +70,6 @@ namespace SIL.XForge.Scripture.Services
             Assert.AreEqual(sourceTextName, scrText.Name);
             Assert.AreEqual(path, scrText.Directory);
             _fileSystemService.Received(1).FileExists(Path.Combine(path, ProjectSettings.fileName));
-        }
-
-        private static Stream GetStream(string content)
-        {
-            var stream = new MemoryStream();
-            var writer = new StreamWriter(stream);
-            writer.Write(content);
-            writer.Flush();
-            stream.Position = 0;
-            return stream;
         }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/LazyScrTextCollectionTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/LazyScrTextCollectionTests.cs
@@ -31,25 +31,46 @@ namespace SIL.XForge.Scripture.Services
         public void FindById_DoesNotExist_ReturnsNull()
         {
             string username = "User";
-            Assert.IsNull(_lazyScrTextCollection.FindById(username, "projectDoesNotExist"));
+            Assert.IsNull(_lazyScrTextCollection.FindById(username, "projectDoesNotExist", Models.TextType.Target));
         }
 
         [Test]
-        public void FindById_SingleProjectExists_ReturnsProject()
+        public void FindById_TargetProjectExists_ReturnsProject()
         {
             string projectId = "Project01";
             string username = "User";
             string projectTextName = "Proj01";
-            string path = Path.Combine(_testDirectory, projectId);
+            string path = Path.Combine(_testDirectory, projectId, "target");
             string content = $"<ScriptureText><Name>{projectTextName}</Name><guid>{projectId}</guid></ScriptureText>";
             _fileSystemService.OpenFile(Arg.Any<string>(), FileMode.Open).Returns(GetStream(content));
-            _fileSystemService.EnumerateDirectories(Arg.Any<string>()).Returns(new[] { path });
             _fileSystemService.FileExists(Arg.Any<string>()).Returns(true);
 
-            ScrText scrText = _lazyScrTextCollection.FindById(username, projectId);
+            ScrText scrText = _lazyScrTextCollection.FindById(username, projectId, Models.TextType.Target);
             Assert.NotNull(scrText);
             Assert.AreEqual(projectTextName, scrText.Name);
             Assert.AreEqual(path, scrText.Directory);
+            _fileSystemService.Received(1).FileExists(Path.Combine(path, ProjectSettings.fileName));
+        }
+
+        [Test]
+        public void FindById_SourceProjectExists_ReturnsProject()
+        {
+            string targetProjectId = "target01";
+            string sourceProjectId = "source01";
+            string username = "User";
+            string sourceTextName = "Src01";
+            string path = Path.Combine(_testDirectory, targetProjectId, "source");
+            string content =
+                $"<ScriptureText><Name>{sourceTextName}</Name><guid>{sourceProjectId}</guid></ScriptureText>";
+
+            _fileSystemService.OpenFile(Arg.Any<string>(), FileMode.Open).Returns(GetStream(content));
+            _fileSystemService.FileExists(Arg.Any<string>()).Returns(true);
+
+            ScrText scrText = _lazyScrTextCollection.FindById(username, targetProjectId, Models.TextType.Source);
+            Assert.NotNull(scrText);
+            Assert.AreEqual(sourceTextName, scrText.Name);
+            Assert.AreEqual(path, scrText.Directory);
+            _fileSystemService.Received(1).FileExists(Path.Combine(path, ProjectSettings.fileName));
         }
 
         private static Stream GetStream(string content)

--- a/test/SIL.XForge.Scripture.Tests/Services/MockScrText.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockScrText.cs
@@ -15,8 +15,6 @@ namespace SIL.XForge.Scripture.Services
     /// </summary>
     public class MockScrText : ScrText
     {
-
-
         public MockScrText(ProjectName pn)
         {
             projectName = pn;
@@ -49,7 +47,6 @@ namespace SIL.XForge.Scripture.Services
             return _fileManager;
         }
 
-        public ProjectSettings _settings;
         public override ProjectSettings Settings => _settings;
         public override ScrStylesheet DefaultStylesheet => new MockScrStylesheet("./usfm.sty");
         public override string Directory => projectName.ProjectPath;
@@ -57,6 +54,7 @@ namespace SIL.XForge.Scripture.Services
         public override ScrLanguage Language => _language;
         public ProjectFileManager _fileManager;
         private ScrLanguage _language;
+        private ProjectSettings _settings;
     }
 
     /// <summary>

--- a/test/SIL.XForge.Scripture.Tests/Services/MockScrText.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockScrText.cs
@@ -18,7 +18,7 @@ namespace SIL.XForge.Scripture.Services
         public MockScrText(ProjectName pn)
         {
             projectName = pn;
-            _settings = new MockProjectSettings(this);
+            Settings = new MockProjectSettings(this);
             _language = new MockScrLanguage(this);
         }
 
@@ -47,14 +47,13 @@ namespace SIL.XForge.Scripture.Services
             return _fileManager;
         }
 
-        public override ProjectSettings Settings => _settings;
+        public override ProjectSettings Settings { get; }
         public override ScrStylesheet DefaultStylesheet => new MockScrStylesheet("./usfm.sty");
         public override string Directory => projectName.ProjectPath;
         public override string Name => projectName.ShortName;
         public override ScrLanguage Language => _language;
         public ProjectFileManager _fileManager;
         private ScrLanguage _language;
-        private ProjectSettings _settings;
     }
 
     /// <summary>


### PR DESCRIPTION
In our production code, target and source Paratext projects were located in separate subfolders of a project in the sync folder. This change reintroduces that functionality so that projects that share the same source will have a unique clone of that source paratext project.

* require the text type when accessing paratext project data
* add test for failing pt send/receive
* specify custom mercurial required in README

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/627)
<!-- Reviewable:end -->
