### PR TITLE
SF-891 Provide helpful error dialog when login via auth provider fails

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -225,6 +225,10 @@
     "to_report_issue_email": "To report an issue, email {{ issueEmailLink }}.",
     "unsupported_browser": "You are using an unsupported browser, which may be the reason for this error. We recommend upgrading to the latest {{ chromeLink }} or {{ firefoxLink }}."
   },
+  "error_messages": {
+    "error_occurred_login": "An error occurred during login.",
+    "try_again": "Try Again"
+  },
   "exception_handling_service": {
     "network_request_failed": "A network request failed. Some functionality may be unavailable.",
     "unknown_error": "Unknown error"

--- a/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
@@ -67,13 +67,6 @@ as-split.is-disabled > .as-split-gutter .as-split-gutter-icon {
   padding-top: 5px !important;
 }
 
-.snackbar-above-footer {
-  bottom: 63px;
-  @include media-breakpoint-only(xs) {
-    bottom: 45px;
-  }
-}
-
 .snackbar-error .mdc-snackbar__surface {
   background-color: var(--mdc-theme-error);
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/message-dialog/message-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/message-dialog/message-dialog.component.html
@@ -1,12 +1,10 @@
-<ng-container *transloco="let t; read: 'message_dialog'">
-  <mdc-dialog>
-    <mdc-dialog-container>
-      <mdc-dialog-surface>
-        <mdc-dialog-title>{{ message }}</mdc-dialog-title>
-        <mdc-dialog-actions>
-          <button mdcDialogButton type="button" mdcDialogAction="close">{{ t("dismiss") }}</button>
-        </mdc-dialog-actions>
-      </mdc-dialog-surface>
-    </mdc-dialog-container>
-  </mdc-dialog>
-</ng-container>
+<mdc-dialog>
+  <mdc-dialog-container>
+    <mdc-dialog-surface>
+      <mdc-dialog-title>{{ message }}</mdc-dialog-title>
+      <mdc-dialog-actions>
+        <button mdcDialogButton type="button" mdcDialogAction="close">{{ closeButtonText }}</button>
+      </mdc-dialog-actions>
+    </mdc-dialog-surface>
+  </mdc-dialog-container>
+</mdc-dialog>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/message-dialog/message-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/message-dialog/message-dialog.component.ts
@@ -1,8 +1,10 @@
 import { MDC_DIALOG_DATA } from '@angular-mdc/web/dialog';
 import { Component, Inject } from '@angular/core';
+import { translate } from '@ngneat/transloco';
 
 export interface MessageDialogData {
   message: () => string;
+  closeButtonText?: () => string;
 }
 
 @Component({
@@ -14,5 +16,9 @@ export class MessageDialogComponent {
 
   get message(): string {
     return this.data.message();
+  }
+
+  get closeButtonText(): string {
+    return this.data.closeButtonText ? this.data.closeButtonText() : translate('message_dialog.dismiss');
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/notice.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/notice.service.ts
@@ -1,7 +1,6 @@
 import { MdcDialog, MdcDialogRef } from '@angular-mdc/web/dialog';
 import { MdcSnackbar, MdcSnackbarConfig } from '@angular-mdc/web/snackbar';
 import { Injectable } from '@angular/core';
-import { AuthService } from './auth.service';
 import { MessageDialogComponent, MessageDialogData } from './message-dialog/message-dialog.component';
 
 /** Manages and provides access to notices shown to user on the web site. */
@@ -12,11 +11,7 @@ export class NoticeService {
   private _isAppLoading: boolean = false;
   private loadingCount: number = 0;
 
-  constructor(
-    private readonly snackbar: MdcSnackbar,
-    private readonly authService: AuthService,
-    private readonly dialog: MdcDialog
-  ) {}
+  constructor(private readonly snackbar: MdcSnackbar, private readonly dialog: MdcDialog) {}
 
   get isAppLoading(): boolean {
     return this._isAppLoading;
@@ -44,9 +39,9 @@ export class NoticeService {
     return this.showSnackBar(message, ['snackbar-error']);
   }
 
-  showMessageDialog(message: () => string): Promise<void> {
+  showMessageDialog(message: () => string, closeButtonText?: () => string): Promise<void> {
     const dialogRef = this.dialog.open<MessageDialogComponent, MessageDialogData>(MessageDialogComponent, {
-      data: { message }
+      data: { message, closeButtonText }
     }) as MdcDialogRef<MessageDialogComponent, any>;
 
     return dialogRef.afterClosed().toPromise();
@@ -54,9 +49,6 @@ export class NoticeService {
 
   private async showSnackBar(message: string, classes: string[] = []): Promise<void> {
     let config: MdcSnackbarConfig<any> | undefined;
-    if (!(await this.authService.isLoggedIn)) {
-      classes.push('snackbar-above-footer');
-    }
     config = { classes: classes.join(' ') };
     this.snackbar.open(message, undefined, config);
   }


### PR DESCRIPTION
When using Facebook as an auth provider, the user has the option of canceling. Unfortunately Auth0 then sends the user back to our app, rather than back to the login screen. 

Here the user can click "Not now":
![](https://user-images.githubusercontent.com/6140710/80538667-1f25bd00-8974-11ea-871d-cc533c5ae246.png)

Here the user can click "Cancel":
![](https://user-images.githubusercontent.com/6140710/80538304-82631f80-8973-11ea-904b-ebaf6cac0d7c.png)

Error dialog:
Before | After
-------|------
![](https://user-images.githubusercontent.com/6140710/80539408-75473000-8975-11ea-9ae1-3049ced6fa92.png) | ![](https://user-images.githubusercontent.com/6140710/80538170-3fa14780-8973-11ea-8336-70f3d6c35e71.png)

Note that all login errors are handled this way (Assuming it's an error that is sent back to the app, rather than e.g. a incorrect password, which would be handled on the Auth0 login page).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/628)
<!-- Reviewable:end -->
