### PR TITLE
SF-861 Remote disable community checking shows message dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1,6 +1,6 @@
 import { MdcDialog, MdcDialogRef } from '@angular-mdc/web/dialog';
 import { Location } from '@angular/common';
-import { DebugElement } from '@angular/core';
+import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -100,7 +100,10 @@ const OBSERVER_USER: UserInfo = createUser('04', SFProjectRole.ParatextObserver)
 
 class MockComponent {}
 
-const ROUTES: Route[] = [{ path: 'projects/:projectId/checking/:bookId', component: MockComponent }];
+const ROUTES: Route[] = [
+  { path: 'projects/:projectId/checking/:bookId', component: MockComponent },
+  { path: 'projects/:projectId', component: MockComponent }
+];
 
 describe('CheckingComponent', () => {
   configureTestingModule(() => ({
@@ -193,6 +196,20 @@ describe('CheckingComponent', () => {
       env.waitForSliderUpdate();
       expect(env.component.projectDoc).toBeUndefined();
       expect(env.component.questionDocs.length).toEqual(0);
+      env.waitForSliderUpdate();
+    }));
+
+    it('responds to remote community checking disabled', fakeAsync(() => {
+      const env = new TestEnvironment(CHECKER_USER);
+      env.selectQuestion(1);
+      when(mockedNoticeService.showMessageDialog(anything())).thenResolve();
+      env.component.projectDoc!.submitJson0Op(
+        op => op.set<boolean>(p => p.checkingConfig.checkingEnabled, false),
+        false
+      );
+      env.waitForSliderUpdate();
+      expect(env.component.projectDoc).toBeUndefined();
+      verify(mockedNoticeService.showMessageDialog(anything())).once();
       env.waitForSliderUpdate();
     }));
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1,6 +1,6 @@
 import { MdcDialog, MdcDialogRef } from '@angular-mdc/web/dialog';
 import { Location } from '@angular/common';
-import { Component, DebugElement } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -202,14 +202,18 @@ describe('CheckingComponent', () => {
     it('responds to remote community checking disabled', fakeAsync(() => {
       const env = new TestEnvironment(CHECKER_USER);
       env.selectQuestion(1);
-      when(mockedNoticeService.showMessageDialog(anything())).thenResolve();
+      const projectUserConfig = env.component.projectUserConfigDoc!.data!;
+      expect(projectUserConfig.selectedTask).toEqual('checking');
+      expect(projectUserConfig.selectedQuestionRef).not.toBeNull();
       env.component.projectDoc!.submitJson0Op(
         op => op.set<boolean>(p => p.checkingConfig.checkingEnabled, false),
         false
       );
       env.waitForSliderUpdate();
+      expect(projectUserConfig.selectedTask).toBeUndefined();
+      expect(projectUserConfig.selectedQuestionRef).toBeUndefined();
       expect(env.component.projectDoc).toBeUndefined();
-      verify(mockedNoticeService.showMessageDialog(anything())).once();
+      verify(mockedNoticeService.show(anything())).once();
       env.waitForSliderUpdate();
     }));
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -213,7 +213,6 @@ describe('CheckingComponent', () => {
       expect(projectUserConfig.selectedTask).toBeUndefined();
       expect(projectUserConfig.selectedQuestionRef).toBeUndefined();
       expect(env.component.projectDoc).toBeUndefined();
-      verify(mockedNoticeService.show(anything())).once();
       env.waitForSliderUpdate();
     }));
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -390,8 +390,8 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
             this.onRemovedFromProject();
             if (navigateToTranslate) {
               this.router.navigate(['/projects', projectId, 'translate', bookId], { replaceUrl: true });
+              this.noticeService.show(translate('app.scripture_checking_not_available'));
             } else {
-              this.noticeService.show(translate('checking.community_checking_disabled'));
               this.router.navigate(['/projects', projectId], { replaceUrl: true });
             }
           }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -148,7 +148,6 @@
     }
   },
   "checking": {
-    "community_checking_disabled": "Community checking has been disabled for this project.",
     "me": "Me",
     "next": "Next",
     "previous": "Previous",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -148,6 +148,7 @@
     }
   },
   "checking": {
+    "community_checking_disabled": "Community checking has been disabled for this project.",
     "me": "Me",
     "next": "Next",
     "previous": "Previous",


### PR DESCRIPTION
When a project admin disables the checking app, other users on the checking app were affected.
Previously, the app becomes unresponsive and the users get notified at the bottom.
![Before_checking_disabled](https://user-images.githubusercontent.com/17931130/80645805-e136a080-8a28-11ea-8a34-545adfef109e.PNG)

Now users get notified with a message dialog, and the app navigates away from the checking app.
![After_checking_disabled](https://user-images.githubusercontent.com/17931130/80645898-04615000-8a29-11ea-8de9-e816cde3bcd1.PNG)

I chose to use a dialog over a snackbar message since it may happen when a user has stepped away from the computer, and would miss the snackbar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/629)
<!-- Reviewable:end -->
