### PR TITLE
SF-941 - Disable offline route on QA/Production

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject, fromEvent, merge, Observable, of } from 'rxjs';
 import { mapTo } from 'rxjs/operators';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
+import { environment } from '../environments/environment';
 
 @Injectable({
   providedIn: 'root'
@@ -31,7 +32,12 @@ export class PwaService extends SubscriptionDisposable {
       // The app is "online" if the browser/network thinks it's online AND
       // we have a valid web socket connection OR
       //    the web socket hasn't yet had a chance to connect i.e. (null) when the app first loads
-      this.appOnlineStatus.next(this.windowOnLineStatus.getValue() && this.webSocketStatus.getValue() !== false);
+      if (environment.production) {
+        // For the time being we don't want to simulate going online/offline on production so always return online
+        this.appOnlineStatus.next(true);
+      } else {
+        this.appOnlineStatus.next(this.windowOnLineStatus.getValue() && this.webSocketStatus.getValue() !== false);
+      }
     });
   }
 


### PR DESCRIPTION
- Always return true for checking online/offline status in pwa.service.ts for production

This will be removed when we are ready for the PWA to be made available in production

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/633)
<!-- Reviewable:end -->
