### PR TITLE
SF-637 Fix redo in translate app

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
@@ -34,10 +34,8 @@ export class CheckingTextComponent extends SubscriptionDisposable {
   }
 
   @Input() set activeVerse(verseRef: VerseRef | undefined) {
-    // Removed the highlight on the old active verse
-    this.highlightActiveVerse(false);
     this._activeVerse = verseRef;
-    this.highlightActiveVerse(true);
+    this.highlightActiveVerse();
     this.scrollToActiveVerse();
   }
 
@@ -79,7 +77,7 @@ export class CheckingTextComponent extends SubscriptionDisposable {
   onLoaded(): void {
     this._editorLoaded = true;
     this.toggleQuestionVerses(true);
-    this.highlightActiveVerse(true);
+    this.highlightActiveVerse();
     this.scrollToActiveVerse();
   }
 
@@ -110,21 +108,19 @@ export class CheckingTextComponent extends SubscriptionDisposable {
     this.toggleQuestionSegments(questionCounts, segments, value);
   }
 
-  private highlightActiveVerse(toggle: boolean): void {
-    if (!this.isEditorLoaded || this._activeVerse == null) {
+  private highlightActiveVerse(): void {
+    if (!this.isEditorLoaded) {
       return;
     }
 
-    for (const segment of this.getVerseSegments(this._activeVerse)) {
-      const range = this.textComponent.getSegmentRange(segment);
-      if (range == null) {
-        continue;
-      }
-      this.textComponent.toggleHighlight(toggle, range);
-    }
+    const refs = this.getVerseSegments(this._activeVerse);
+    this.textComponent.highlight(refs);
   }
 
-  private getVerseSegments(verseRef: VerseRef): string[] {
+  private getVerseSegments(verseRef?: VerseRef): string[] {
+    if (verseRef == null) {
+      return [];
+    }
     const segments: string[] = [];
     let segment = '';
     for (const verseInRange of verseRef.allVerses()) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -2,7 +2,6 @@ import cloneDeep from 'lodash/cloneDeep';
 import Quill, { DeltaOperation, DeltaStatic, RangeStatic, Sources, StringMap } from 'quill';
 import { Subscription } from 'rxjs';
 import { Delta, TextDoc } from '../../core/models/text-doc';
-import { Segment } from './segment';
 
 const PARA_STYLES: Set<string> = new Set<string>([
   // Paragraphs
@@ -95,7 +94,6 @@ export class TextViewModel {
   private remoteChangesSub?: Subscription;
   private onCreateSub?: Subscription;
   private textDoc?: TextDoc;
-  private canSubmitApiChange: boolean = false;
 
   constructor() {}
 
@@ -161,7 +159,7 @@ export class TextViewModel {
       return;
     }
 
-    if ((this.canSubmitApiChange || source === 'user') && editor.isEnabled()) {
+    if (source === 'user' && editor.isEnabled()) {
       const modelDelta = this.viewToData(delta);
       if (modelDelta.ops != null && modelDelta.ops.length > 0) {
         this.textDoc.submit(modelDelta, this.editor);
@@ -171,34 +169,100 @@ export class TextViewModel {
     const updateDelta = this.updateSegments(editor);
     if (updateDelta.ops != null && updateDelta.ops.length > 0) {
       // defer the update, since it might cause the segment ranges to be out-of-sync with the view model
-      Promise.resolve().then(() => {
-        // use "api" source, so that this delta will not get added to the undo stack
-        // set "canSubmitApiChange" flag, so that this delta will still get submitted to the real-time doc
-        this.canSubmitApiChange = true;
-        try {
-          editor.updateContents(updateDelta);
-        } finally {
-          this.canSubmitApiChange = false;
+      Promise.resolve().then(() => editor.updateContents(updateDelta, source));
+    }
+  }
+
+  /**
+   * Not all browsers appear to be consistent with how child elements determine the value of dir="auto" i.e. paragraphs
+   * with child segments both having dir="auto" set.
+   * To get around this we apply dir="auto" to both paragraphs (when available) and segments. We then query
+   * each paragraph/segment and then specifically set the paragraph to what the direction of the first segment that
+   * contains text i.e. is not blank. For chapters we use the same direction value as the paragraph that follows it.
+   */
+  setDirection(): void {
+    const editor = this.checkEditor();
+
+    // set direction on individual segments
+    let delta = new Delta();
+    for (const [segmentId, range] of this.segments) {
+      let dir = 'auto';
+      const segment = editor.root.querySelector(`usx-segment[data-segment="${segmentId}"]`);
+      if (segment != null && segment.querySelectorAll('usx-blank').length === 0) {
+        dir = window.getComputedStyle(segment).direction || 'auto';
+      }
+
+      delta = delta.compose(new Delta().retain(range.index).retain(range.length, { 'direction-segment': dir }));
+    }
+    editor.updateContents(delta, 'silent');
+
+    // Loop through the paragraphs to see what direction it should be set to based off the first valid segment
+    delta = new Delta();
+    const paragraphs = editor.root.querySelectorAll('usx-para,p');
+    for (const paragraph of Array.from(paragraphs)) {
+      let dir = 'auto';
+      const segments = paragraph.querySelectorAll('usx-segment');
+      // Locate the first segment that isn't blank to see what direction the paragraph should be set to
+      const firstNonBlankSegment = Array.from(segments).find(segment => !segment.querySelector('usx-blank'));
+      if (firstNonBlankSegment != null) {
+        dir = window.getComputedStyle(firstNonBlankSegment).direction || 'auto';
+      }
+
+      const paraBlot = Quill.find(paragraph);
+      const index = editor.getIndex(paraBlot) + paraBlot.length() - 1;
+      delta = delta.compose(new Delta().retain(index).retain(1, { 'direction-block': dir }));
+    }
+    editor.updateContents(delta, 'silent');
+
+    // Chapters need its direction set from the paragraph that follows
+    delta = new Delta();
+    const chapters = editor.root.querySelectorAll('usx-chapter');
+    for (const chapter of Array.from(chapters)) {
+      const sibling = chapter.nextElementSibling;
+      if (sibling !== null) {
+        const dir = window.getComputedStyle(sibling).direction || 'auto';
+        const chapterEmbed = Quill.find(chapter);
+        const index = editor.getIndex(chapterEmbed);
+        delta = delta.compose(new Delta().retain(index).retain(1, { 'direction-block': dir }));
+      }
+    }
+    editor.updateContents(delta, 'silent');
+  }
+
+  highlight(segmentRefs: string[]): void {
+    const refs = new Set(segmentRefs);
+    const editor = this.checkEditor();
+    const delta = editor.getContents();
+    const clearDelta = new Delta();
+    if (delta.ops != null) {
+      let highlightPara = false;
+      for (const op of delta.ops) {
+        const len = typeof op.insert === 'string' ? op.insert.length : 1;
+        const attrs = op.attributes;
+        let newAttrs: StringMap | undefined;
+        if (attrs != null && attrs['segment'] != null) {
+          if (refs.has(attrs['segment'])) {
+            // highlight segment
+            newAttrs = { 'highlight-segment': true };
+            highlightPara = true;
+          } else if (attrs['highlight-segment'] != null) {
+            // clear highlight
+            newAttrs = { 'highlight-segment': false };
+          }
+        } else if (op.insert === '\n' || (op.attributes != null && op.attributes.para != null)) {
+          if (highlightPara) {
+            // highlight para
+            newAttrs = { 'highlight-para': true };
+            highlightPara = false;
+          } else if (attrs != null && attrs['highlight-para'] != null) {
+            // clear highlight
+            newAttrs = { 'highlight-para': false };
+          }
         }
-      });
+        clearDelta.retain(len, newAttrs);
+      }
     }
-  }
-
-  isHighlighted(segment: Segment): boolean {
-    const editor = this.checkEditor();
-    const formats = editor.getFormat(segment.range);
-    return formats['highlight-segment'] != null;
-  }
-
-  toggleHighlight(range: RangeStatic, value: boolean): void {
-    const editor = this.checkEditor();
-    if (range.length > 0) {
-      // this changes the underlying HTML, which can mess up some Quill events, so defer this call
-      Promise.resolve().then(() => {
-        editor.formatText(range.index, range.length, 'highlight-segment', value, 'silent');
-        editor.formatLine(range.index, range.length, 'highlight-para', value, 'silent');
-      });
-    }
+    editor.updateContents(clearDelta, 'silent');
   }
 
   hasSegmentRange(ref: string): boolean {
@@ -269,12 +333,18 @@ export class TextViewModel {
     if (delta.ops != null) {
       for (const op of delta.ops) {
         const modelOp: DeltaOperation = cloneDeep(op);
-        removeAttribute(modelOp, 'highlight-segment');
-        removeAttribute(modelOp, 'highlight-para');
-        removeAttribute(modelOp, 'para-contents');
-        removeAttribute(modelOp, 'question-segment');
-        removeAttribute(modelOp, 'question-count');
-        removeAttribute(modelOp, 'initial');
+        for (const attr of [
+          'highlight-segment',
+          'highlight-para',
+          'para-contents',
+          'question-segment',
+          'question-count',
+          'initial',
+          'direction-segment',
+          'direction-block'
+        ]) {
+          removeAttribute(modelOp, attr);
+        }
         (modelDelta as any).push(modelOp);
       }
     }
@@ -366,7 +436,6 @@ export class TextViewModel {
           } else if (paraSegments.length === 0) {
             paraSegments.push(new SegmentInfo('', curIndex));
           }
-          fixDelta = this.fixVerse(op, curIndex, fixDelta, fixOffset);
           setAttribute(op, attrs, 'para-contents', true);
           curIndex += len;
           curSegment = new SegmentInfo('verse_' + chapter + '_' + op.insert.verse.number, curIndex);
@@ -406,7 +475,7 @@ export class TextViewModel {
       // insert blank
       const delta = new Delta();
       delta.retain(segment.index + fixOffset);
-      const attrs: any = { segment: segment.ref, 'para-contents': true };
+      const attrs: any = { segment: segment.ref, 'para-contents': true, 'direction-segment': 'auto' };
       if (segment.isInitial) {
         attrs.initial = true;
       }
@@ -417,7 +486,7 @@ export class TextViewModel {
       // delete blank
       const delta = new Delta()
         .retain(segment.index + fixOffset)
-        .retain(segment.length - 1, { segment: segment.ref, 'para-contents': true })
+        .retain(segment.length - 1, { segment: segment.ref, 'para-contents': true, 'direction-segment': 'auto' })
         .delete(1);
       fixDelta = fixDelta.compose(delta);
       fixOffset--;
@@ -441,17 +510,6 @@ export class TextViewModel {
       fixDelta = fixDelta.compose(delta);
     }
     return [fixDelta, fixOffset];
-  }
-
-  private fixVerse(verseOp: DeltaOperation, curIndex: number, fixDelta: DeltaStatic, fixOffset: number): DeltaStatic {
-    // remove "highlight-segment" format, which can sometimes get placed on a verse number after an edit or undo
-    if (verseOp.attributes != null && verseOp.attributes['highlight-segment'] != null) {
-      const delta = new Delta();
-      delta.retain(curIndex + fixOffset);
-      delta.retain(1, { 'highlight-segment': false });
-      fixDelta = fixDelta.compose(delta);
-    }
-    return fixDelta;
   }
 
   private checkEditor(): Quill {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -182,8 +182,10 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
   set highlightSegment(value: boolean) {
     if (this._highlightSegment !== value) {
       this._highlightSegment = value;
-      if (this._segment != null) {
-        this.toggleHighlight(value);
+      if (value) {
+        this.highlight();
+      } else {
+        this.clearHighlight();
       }
     }
   }
@@ -348,20 +350,24 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
     this.update();
   }
 
-  toggleHighlight(value: boolean, range?: RangeStatic): void {
+  clearHighlight(): void {
+    this.highlight([]);
+  }
+
+  highlight(segmentRefs?: string[]): void {
     if (this._id == null) {
       return;
     }
-    if (range == null && this._segment != null) {
-      range = this._segment.range;
+    if (segmentRefs == null && this._segment != null) {
+      segmentRefs = [this._segment.ref];
     }
-    if (range == null) {
-      return;
+    if (segmentRefs != null) {
+      // this changes the underlying HTML, which can mess up some Quill events, so defer this call
+      Promise.resolve().then(() => this.viewModel.highlight(segmentRefs!));
     }
-    this.viewModel.toggleHighlight(range, value);
 
     if (!this.isReadOnly && this._id.textType === 'target' && this.highlightMarker != null) {
-      if (value) {
+      if (segmentRefs != null && segmentRefs.length > 0) {
         this.highlightMarker.style.visibility = '';
       } else {
         this.highlightMarker.style.visibility = 'hidden';
@@ -392,7 +398,6 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
 
     this.loaded.emit();
     this.applyEditorStyles();
-    // Get the computed direction the browser decided to use for quill for the current text
     this.setDirection();
   }
 
@@ -442,75 +447,14 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
     }
   }
 
-  /**
-   * Not all browsers appear to be consistent with how child elements determine the value of dir="auto" i.e. paragraphs
-   * with child segments both having dir="auto" set.
-   * To get around this we apply dir="auto" to both paragraphs (when available) and segments. We then query
-   * each paragraph/segment and then specifically set the paragraph to what the direction of the first segment that
-   * contains text i.e. is not blank. For chapters we use the same direction value as the paragraph that follows it.
-   */
   private setDirection() {
     // As the browser is automatically applying ltr/rtl we need to ask it which one it is using
-    // This value can then be used for other purposes i.e. CSS styles
+    // This value can then be used for other purposes e.g. CSS styles
     if (this.editor !== undefined) {
-      this.direction = window.getComputedStyle(this.quill.nativeElement).direction;
-      // Set the browser calculated direction on the segments so we can action elsewhere i.e. CSS
-      let segments: NodeListOf<Element> = this.quill.nativeElement.querySelectorAll('usx-segment');
-      for (const segment of Array.from(segments)) {
-        let dir = window.getComputedStyle(segment).direction;
-        if (dir === null) {
-          continue;
-        }
-        const segmentRef = segment.getAttribute('data-segment');
-        if (segmentRef === null) {
-          continue;
-        }
-        const range = this.viewModel.getSegmentRange(segmentRef);
-        if (range === undefined) {
-          continue;
-        }
-        const blanks = segment.querySelectorAll('usx-blank');
-        // Set the direction back to auto for blank segments so the browser can work it out when something is added
-        // or pasted in through the Translate app
-        if (blanks.length > 0) {
-          dir = 'auto';
-        }
-        segment.setAttribute('dir', dir);
-      }
-      // Loop through the paragraphs to see what direction it should be set to based off the first valid segment
-      const paragraphs: NodeListOf<Element> = this.quill.nativeElement.querySelectorAll('usx-para,.ql-editor > p');
-      for (const paragraph of Array.from(paragraphs)) {
-        let paraDir = 'auto';
-        // Locate the first segment that isn't blank to see what direction the paragraph should be set to
-        segments = paragraph.querySelectorAll('usx-segment');
-        for (const segment of Array.from(segments)) {
-          const dir = window.getComputedStyle(segment).direction;
-          if (dir === null) {
-            continue;
-          }
-          const blanks = segment.querySelectorAll('usx-blank');
-          // Only use the segment direction if this isn't a blank segment
-          if (blanks.length === 0) {
-            paraDir = dir;
-            break;
-          }
-        }
-        // Set the paragraph dir
-        paragraph.setAttribute('dir', paraDir);
-      }
-      // Chapters need its direction set from the paragraph that follows
-      const chapters: NodeListOf<Element> = this.quill.nativeElement.querySelectorAll('usx-chapter');
-      for (const chapter of Array.from(chapters)) {
-        const sibling = chapter.nextElementSibling;
-        if (sibling === null) {
-          continue;
-        }
-        const dir = window.getComputedStyle(sibling).direction;
-        if (dir === null) {
-          continue;
-        }
-        chapter.setAttribute('dir', dir);
-      }
+      const quillElement = this.quill.nativeElement as HTMLElement;
+      // set direction on the editor
+      this.direction = window.getComputedStyle(quillElement).direction;
+      this.viewModel.setDirection();
     }
   }
 
@@ -543,11 +487,9 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
       if (!this.tryChangeSegment(segmentRef, checksum, focus) && this._segment != null) {
         // the selection has not changed to a different segment, so update existing segment
         this.updateSegment();
-        if (this._highlightSegment && this._id != null) {
+        if (this._highlightSegment) {
           // ensure that the currently selected segment is highlighted
-          if (!this.viewModel.isHighlighted(this._segment)) {
-            this.viewModel.toggleHighlight(this._segment.range, true);
-          }
+          this.highlight();
         }
       }
       this.setHighlightMarkerPosition();
@@ -577,7 +519,7 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
 
     if (!this.viewModel.hasSegmentRange(segmentRef)) {
       if (this._segment != null && this.highlightSegment) {
-        this.toggleHighlight(false);
+        this.clearHighlight();
       }
       this._segment = undefined;
       this.segmentRefChange.emit();
@@ -600,9 +542,6 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
       }
     }
 
-    if (this._segment != null && this.highlightSegment) {
-      this.toggleHighlight(false);
-    }
     this._segment = new Segment(this._id.bookNum, this._id.chapterNum, segmentRef);
     if (checksum != null) {
       this._segment.initialChecksum = checksum;
@@ -610,7 +549,7 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
     this.updateSegment();
     this.segmentRefChange.emit(this.segmentRef);
     if (this.highlightSegment) {
-      this.toggleHighlight(true);
+      this.highlight();
     }
     return true;
   }


### PR DESCRIPTION
- refactor setting direction using Delta formats
- include auto formatting in undo stack
- ensure that verse embeds do not get inserted inside of segments
- remove spurious segment highlighting on undo/redo
- refactor segment highlighting
- ignore embeds when determining selection location after undo/redo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/634)
<!-- Reviewable:end -->
