### PR TITLE
Stop autofocusing in scripture chooser dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -199,7 +199,8 @@ export class QuestionDialogComponent extends SubscriptionDisposable implements O
     }
 
     const dialogConfig: MdcDialogConfig<ScriptureChooserDialogData> = {
-      data: { input: currentVerseSelection, booksAndChaptersToShow: this.data.textsByBookId, rangeStart }
+      data: { input: currentVerseSelection, booksAndChaptersToShow: this.data.textsByBookId, rangeStart },
+      autoFocus: false
     };
 
     const dialogRef = this.dialog.open(ScriptureChooserDialogComponent, dialogConfig) as MdcDialogRef<


### PR DESCRIPTION
Before | After
-------|------
![](https://user-images.githubusercontent.com/6140710/81117473-25c4af00-8ef5-11ea-803d-65c4558065e1.png) | ![](https://user-images.githubusercontent.com/6140710/81117464-20fffb00-8ef5-11ea-93a0-9d4290937801.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/637)
<!-- Reviewable:end -->
