### PR TITLE
Remove unneeded definite assignment assertions and class properties

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -58,7 +58,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   private currentUserDoc?: UserDoc;
   private _projectSelect?: MdcSelect;
   private projectDeletedDialogRef: any;
-  private _topAppBar!: MdcTopAppBar;
+  private _topAppBar?: MdcTopAppBar;
   private selectedProjectDoc?: SFProjectDoc;
   private selectedProjectDeleteSub?: Subscription;
   private removedFromProjectSub?: Subscription;
@@ -73,7 +73,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     noticeService: NoticeService,
     public media: MediaObserver,
     private readonly projectService: SFProjectService,
-    private readonly pwaService: PwaService,
+    pwaService: PwaService,
     private readonly route: ActivatedRoute,
     private readonly adminAuthGuard: SFAdminAuthGuard,
     private readonly dialog: MdcDialog,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/offline/offline.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/offline/offline.component.ts
@@ -9,7 +9,7 @@ import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
   styleUrls: ['./offline.component.scss']
 })
 export class OfflineComponent extends SubscriptionDisposable {
-  constructor(private readonly router: Router, private readonly pwaService: PwaService) {
+  constructor(private readonly router: Router, pwaService: PwaService) {
     super();
     this.subscribe(pwaService.onlineStatus, status => {
       if (status) {


### PR DESCRIPTION
- Definite assignment assertion modifiers are sometimes necessary, but should be avoided when not needed. In this case a couple uses were not necessary.
- In a couple instances constructors incorrectly declared parameters as properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/638)
<!-- Reviewable:end -->
