### PR TITLE
SF-862 Fix layout of checking answers error message

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -93,7 +93,7 @@
               <button type="button" (click)="selectScripture()" mdc-button primary>{{ t("select_verses") }}</button>
             </div>
           </div>
-          <div *ngIf="answerFormSubmitAttempted && answerText.invalid" class="form-helper-text">
+          <div class="form-helper-text" [ngClass]="{ visible: answerFormSubmitAttempted && answerText.invalid }">
             {{ t("answer_required_before_saving") }}
           </div>
           <div class="form-actions">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
@@ -85,8 +85,12 @@
     color: var(--mdc-theme-error);
     font-size: 0.75em;
     padding-left: 15px;
+    margin-bottom: 0.5em;
     font-weight: 400;
     letter-spacing: 0.03333333em;
+    &:not(.visible) {
+      visibility: hidden;
+    }
   }
   .form-actions {
     display: flex;


### PR DESCRIPTION
Before | After
-------|------
![](https://user-images.githubusercontent.com/6140710/81132606-0a6d9a00-8f1d-11ea-9b82-f24d3d229c44.png) | ![](https://user-images.githubusercontent.com/6140710/81132607-0b063080-8f1d-11ea-8c89-c2aa1dc75ad0.png)
![](https://user-images.githubusercontent.com/6140710/81132907-ff673980-8f1d-11ea-843c-be2a4c668970.png) | ![](https://user-images.githubusercontent.com/6140710/81132906-fecea300-8f1d-11ea-83ac-2439775edcde.png)


This prevents a layout change when the error message is shown, which would throw off the split-area height when the error message is shown, causing the save and cancel buttons to be partially hidden.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/639)
<!-- Reviewable:end -->
