### PR TITLE
SF-924b Do not use VersionedTexts from cache to share changes on s/r

### DIFF
--- a/src/SIL.XForge.Scripture/Services/SubstituteDictionaryCache.cs
+++ b/src/SIL.XForge.Scripture/Services/SubstituteDictionaryCache.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace SIL.XForge.Scripture.Services
+{
+    public static class SubstituteDictionaryCache
+    {
+        /// <summary> Gets a dictionary cache that never returns its contents. </summary>
+        public static Dictionary<TKey, TVal> ValuesNeverFoundCache<TKey, TVal>()
+        {
+            return new Dictionary<TKey, TVal>(new SubstituteComparer<TKey>());
+        }
+    }
+
+    class SubstituteComparer<T> : IEqualityComparer<T>
+    {
+        // Always return false
+        public bool Equals(T key1, T key2)
+        {
+            return false;
+        }
+
+        // Needed to implement interface
+        public int GetHashCode(T key)
+        {
+            return 54321;
+        }
+    }
+}


### PR DESCRIPTION
The better fix would be to change Paratext code to disable the versionedText cache. I am totally ok if this is not an acceptable solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/640)
<!-- Reviewable:end -->
