### PR TITLE
SF-943 Fix no methods matched request error

### DIFF
--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -78,7 +78,7 @@ namespace SIL.XForge.Scripture.Controllers
             }
         }
 
-        public async Task<IRpcMethodResult> AddUser(string projectId, string projectRole = null)
+        public async Task<IRpcMethodResult> AddUser(string projectId, string projectRole)
         {
             try
             {
@@ -93,6 +93,11 @@ namespace SIL.XForge.Scripture.Controllers
             {
                 return NotFoundError(dnfe.Message);
             }
+        }
+
+        public async Task<IRpcMethodResult> AddUser(string projectId)
+        {
+            return await this.AddUser(projectId, null);
         }
 
         public async Task<IRpcMethodResult> RemoveUser(string projectId, string projectUserId)
@@ -196,7 +201,7 @@ namespace SIL.XForge.Scripture.Controllers
             }
         }
 
-        public async Task<IRpcMethodResult> CheckLinkSharing(string projectId, string shareKey = null)
+        public async Task<IRpcMethodResult> CheckLinkSharing(string projectId, string shareKey)
         {
             try
             {
@@ -211,6 +216,11 @@ namespace SIL.XForge.Scripture.Controllers
             {
                 return NotFoundError(dnfe.Message);
             }
+        }
+
+        public async Task<IRpcMethodResult> CheckLinkSharing(string projectId)
+        {
+            return await CheckLinkSharing(projectId, null);
         }
 
         public async Task<IRpcMethodResult> AddTranslateMetrics(string projectId, TranslateMetrics metrics)


### PR DESCRIPTION
This was most likely broken in 2b1fc3c4f58853494aa6f3621e92870320eaa4a7 when JsonRpc.Router was upgraded to 4.0.4.

It appears JsonRpc.Router no longer supports default arguments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/642)
<!-- Reviewable:end -->
