### PR TITLE
SF-942 - 401 error results in user being told they're offline

### DIFF
--- a/src/RealtimeServer/common/web-socket-stream-listener.ts
+++ b/src/RealtimeServer/common/web-socket-stream-listener.ts
@@ -73,7 +73,7 @@ export class WebSocketStreamListener {
     this.httpServer.close();
   }
 
-  private verifyToken(req: http.IncomingMessage, done: Function): void {
+  private verifyToken(req: http.IncomingMessage, done: (res: boolean, code?: number, message?: string) => void): void {
     const url = req.url;
     if (url != null && url.includes('?access_token=')) {
       // the url contains an access token

--- a/src/RealtimeServer/common/web-socket-stream-listener.ts
+++ b/src/RealtimeServer/common/web-socket-stream-listener.ts
@@ -42,13 +42,18 @@ export class WebSocketStreamListener {
   listen(backend: ShareDB): void {
     // Connect any incoming WebSocket connection to ShareDB
     const wss = new ws.Server({
-      server: this.httpServer,
-      verifyClient: (info, done) => this.verifyToken(info, done)
+      server: this.httpServer
     });
 
     wss.on('connection', (webSocket: WebSocket, req: http.IncomingMessage) => {
-      const stream = new WebSocketJSONStream(webSocket);
-      backend.listen(stream, req);
+      this.verifyToken(req, (res: boolean, code: number = 200, message?: string) => {
+        if (res) {
+          const stream = new WebSocketJSONStream(webSocket);
+          backend.listen(stream, req);
+        } else {
+          webSocket.close(4000 + code, message);
+        }
+      });
     });
   }
 
@@ -68,11 +73,8 @@ export class WebSocketStreamListener {
     this.httpServer.close();
   }
 
-  private verifyToken(
-    info: { origin: string; secure: boolean; req: http.IncomingMessage },
-    done: (res: boolean, code?: number, message?: string, headers?: http.OutgoingHttpHeaders) => void
-  ): void {
-    const url = info.req.url;
+  private verifyToken(req: http.IncomingMessage, done: Function): void {
+    const url = req.url;
     if (url != null && url.includes('?access_token=')) {
       // the url contains an access token
       const token = url.split('?access_token=')[1];
@@ -88,7 +90,7 @@ export class WebSocketStreamListener {
             // check that the access token was granted xForge API scope
             const scopeClaim = decoded['scope'];
             if (scopeClaim != null && scopeClaim.split(' ').includes(this.scope)) {
-              (info.req as any).user = decoded;
+              (req as any).user = decoded;
               done(true);
             } else {
               done(false, 401, 'A required scope has not been granted.');
@@ -96,7 +98,7 @@ export class WebSocketStreamListener {
           }
         }
       );
-    } else if (isLocalRequest(info.req)) {
+    } else if (isLocalRequest(req)) {
       // no access token, but the request is local, so it is allowed
       done(true);
     } else {


### PR DESCRIPTION
- Changed WebSockets to always establish a connection
- Moved verifyToken to take place on a successful connection and if this returns false the connection is immediately closed

The result of this means the Reconnecting WebSocket no longer triggers an error event which is what we use for connection issues and going "offline". Now the 401 response simply closes the WebSocket.

The underlaying issue is the browser does not pay attention to http headers so closing the socket instead allows us to pass additional information as to "why" it is closing.

WebSockets also appear to discourage the use of `verifyClient` which is what we were using: https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback so this feels like a good time to address this as well.

I have also noticed that sometimes `checkSession()` in `auth.service.ts` returns a timeout with auth0. This may only be relating to me taking my time stepping through code in the debugger but raising it here in case there is something else going on. The end result is the login process stalls for 30 seconds until the timeout occurs as we have an `await` for the promise to complete. After the timeout a dialog appears saying there was an issue logging in and to try again. Clicking the button refreshes the page and everything resolves itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/643)
<!-- Reviewable:end -->
