### PR TITLE
SF-813 - Lines are not wrapping correctly in texts

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -123,9 +123,6 @@ p[dir='rtl'] {
         border-radius: 4px;
         display: inline;
         box-sizing: border-box;
-
-        box-decoration-break: slice;
-
         color: rgba(0, 0, 0, 0.8);
         background-color: white;
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -304,7 +304,6 @@ usx-chapter {
 
 usx-verse {
   user-select: none;
-  display: inline-block;
   > span > span > span {
     // superscript
     top: -0.5em;
@@ -315,12 +314,13 @@ usx-verse {
     border-radius: 8px;
     white-space: nowrap;
     margin: 0 0.2em 0 0.3em;
+    display: inline-block;
   }
 }
 
 usx-segment {
   box-decoration-break: clone;
-  padding: 0 0.3em;
+  padding: 0 0.5em;
 }
 
 usx-note {

--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -316,6 +316,12 @@ usx-verse {
     margin: 0 0.2em 0 0.3em;
     display: inline-block;
   }
+  &.wrap {
+    &:before {
+      content: '';
+      display: block;
+    }
+  }
 }
 
 usx-segment {

--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -304,6 +304,7 @@ usx-chapter {
 
 usx-verse {
   user-select: none;
+  display: inline-block;
   > span > span > span {
     // superscript
     top: -0.5em;
@@ -315,6 +316,11 @@ usx-verse {
     white-space: nowrap;
     margin: 0 0.2em 0 0.3em;
   }
+}
+
+usx-segment {
+  box-decoration-break: clone;
+  padding: 0 0.3em;
 }
 
 usx-note {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -559,6 +559,11 @@ export function registerScripture(): string[] {
   });
   formats.push(BlockDirectionAttribute);
 
+  const VerseWrapClass = new ClassAttributor('verse-wrap', 'verse-wrap', {
+    scope: Parchment.Scope.INLINE
+  });
+  formats.push(VerseWrapClass);
+
   class DisableHtmlClipboard extends QuillClipboard {
     onPaste(e: ClipboardEvent): void {
       if (e.defaultPrevented || !this.quill.isEnabled() || e.clipboardData == null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -328,6 +328,26 @@ export class TextViewModel {
     return undefined;
   }
 
+  wrapVerses(): void {
+    const editor = this.checkEditor();
+    let delta = new Delta();
+    const verses = editor.root.querySelectorAll('usx-verse');
+    for (const verse of Array.from(verses)) {
+      const segment = verse.nextElementSibling;
+      if (segment !== null) {
+        const verseEmbed = Quill.find(verse);
+        const verseIndex = editor.getIndex(verseEmbed);
+        const verseBounds = editor.getBounds(editor.getIndex(verseEmbed), 1);
+        const segmentEmbed = Quill.find(segment);
+        const segmentBounds = editor.getBounds(editor.getIndex(segmentEmbed), 1);
+        // Improve logic of "5". The difference is the verse has a negative top applied
+        const forceVerseWrap = segmentBounds.top - verseBounds.top > 5;
+        delta = delta.compose(new Delta().retain(verseIndex).retain(1, { 'verse-wrap': forceVerseWrap }));
+      }
+    }
+    editor.updateContents(delta, 'silent');
+  }
+
   private viewToData(delta: DeltaStatic): DeltaStatic {
     const modelDelta = new Delta();
     if (delta.ops != null) {
@@ -341,7 +361,8 @@ export class TextViewModel {
           'question-count',
           'initial',
           'direction-segment',
-          'direction-block'
+          'direction-block',
+          'verse-wrap'
         ]) {
           removeAttribute(modelOp, attr);
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -461,6 +461,8 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
       // set direction on the editor
       this.direction = window.getComputedStyle(quillElement).direction;
       this.viewModel.setDirection();
+      // Only placed here to prove the concept - needs to trigger on editor change and window resize
+      this.viewModel.wrapVerses();
     }
   }
 


### PR DESCRIPTION
- Moved box-decoration-break from `usx-para-contents` to `usx-segment` and change to `clone`
- Add additional padding to `usx-segment` to display nicely when it wraps
- Changed `usx-verse` to be `display: inline-block` to ensure verses aren't forcing a line break when text is being added

I realise the change to `usx-verse` may seem like a regression as I believe the previous iteration was to ensure verses stayed on the same line as the contents of that verse - this change will stop that. In order to actually achieve that we will either need to encompass the verse and contents in in their own element or add the verse number as a `data` attribute on the `usx-segment` and then make use of `:before` or `:after` depending on which one is NOT currently used for the question icon. I suspect we may need to use `:before` or `:after` as modifying the HTML will affect what goes back to paratext won't it?

@Nateowami I've not been able to test this on Linux Firefox to see if these changes reintroduce the issues we solved before which is why this is a draft PR. Do you mind testing it out for me?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/644)
<!-- Reviewable:end -->
