### PR TITLE
Update ansible: node 10.9, connection settings for PTDataDll, etc

### DIFF
--- a/deploy/dependencies.yml
+++ b/deploy/dependencies.yml
@@ -10,7 +10,7 @@
       - "vars/{{ansible_os_family}}.yml"
       - "vars/os_defaults.yml"
   vars:
-    node_version: 8.11.4
+    node_version: 10.16.3
     mongodb_version: 4.0
     repo_path: "{{playbook_dir}}/.."
   pre_tasks:
@@ -146,7 +146,14 @@
         create: yes
 
     - name: Install/update reportgenerator
+      become: no
       shell: dotnet tool install -g dotnet-reportgenerator-globaltool || dotnet tool update -g dotnet-reportgenerator-globaltool
+
+    - name: Set initial PT connection settings
+      become: no
+      copy:
+        src: InternetSettings.xml
+        dest: ~/.local/share/Paratext91/
 
   handlers:
     - name: restart mongod

--- a/deploy/files/InternetSettings.xml
+++ b/deploy/files/InternetSettings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<InternetSettingsMemento>
+  <SelectedServer>Development</SelectedServer>
+  <PermittedInternetUse>Enabled</PermittedInternetUse>
+  <ProxyPort>0</ProxyPort>
+</InternetSettingsMemento>


### PR DESCRIPTION
* Node 10.9 was needed on develop branch to run the frontend.
* PTDataDll needs some settings specified to know how to use the
Internet.
* reportgenerator should be installed for the current user, not for
root.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/646)
<!-- Reviewable:end -->
