### PR TITLE
SF-924b Disable caching of VersionedText for send/receive with Paratext

### DIFF
--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="ParatextData" Version="9.1.4-beta" />
+    <PackageReference Include="ParatextData" Version="9.1.5-beta" />
     <PackageReference Include="SIL.Machine.WebApi" Version="$(MachineVersion)" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0" />
   </ItemGroup>

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -123,6 +123,8 @@ namespace SIL.XForge.Scripture.Services
             SyncDir = Path.Combine(_siteOptions.Value.SiteDir, "sync");
             if (!_fileSystemService.DirectoryExists(SyncDir))
                 _fileSystemService.CreateDirectory(SyncDir);
+            // Disable caching VersionedText instances since multiple repos may exist on SF server with the same GUID
+            Environment.SetEnvironmentVariable("PTD_CACHE_VERSIONED_TEXT", "DISABLED");
             RegistryU.Implementation = new DotNetCoreRegistry();
             Alert.Implementation = new DotNetCoreAlert(_logger);
             ParatextDataSettings.Initialize(new PersistedParatextDataSettings());


### PR DESCRIPTION
Send and receive with Paratext would not work correctly if there are multiple clones of the same project on the SF server. We allow multiple clones because a Paratext project and be a target project of a SF project and a source project for one or more SF projects. This allows Paratext Data to correctly identify the correct local repo to use to perform a send/receive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/648)
<!-- Reviewable:end -->
