### PR TITLE
SF-944 Scroll question into view when switching questions

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -131,6 +131,7 @@
     *ngIf="isProjectSelected"
     [drawer]="isDrawerPermanent ? 'permanent' : 'modal'"
     [open]="isExpanded"
+    [autoFocus]="false"
     (closed)="drawerCollapsed()"
   >
     <mdc-drawer-header>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { MdcList, MdcListItem } from '@angular-mdc/web';
+import { Component, EventEmitter, Input, Output, ViewChild, ViewChildren } from '@angular/core';
 import sortBy from 'lodash/sortBy';
 import { Operation } from 'realtime-server/lib/common/models/project-rights';
 import { Answer } from 'realtime-server/lib/scriptureforge/models/answer';
@@ -31,6 +32,7 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
   _questionDocs: Readonly<QuestionDoc[]> = [];
   activeQuestionDoc?: QuestionDoc;
   activeQuestionDoc$ = new Subject<QuestionDoc>();
+  @ViewChild(MdcList, { static: true }) mdcList!: MdcList;
   private _activeQuestionVerseRef?: VerseRef;
 
   constructor(private readonly userService: UserService, private readonly projectService: SFProjectService) {
@@ -76,6 +78,25 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
       this.activeQuestionDoc = undefined;
     }
     this._questionDocs = questionDocs;
+  }
+
+  // When the list of questions is hidden it has display: none applied, which prevents scrolling to the active question
+  // The instant it becomes visible we scroll the active question into view
+  @Input() set visible(value: boolean) {
+    if (value) {
+      this.scrollToActiveQuestion();
+    }
+  }
+
+  // The list of questions is rendered before there are any questions to render, so to scroll to the active question
+  // on page load we have to watch as each element is added to the view
+  @ViewChildren(MdcListItem) set questionElements(listItem: MdcListItem) {
+    if (
+      listItem.elementRef != null &&
+      (listItem.elementRef.nativeElement as HTMLElement).classList.contains('.mdc-list-item--activated')
+    ) {
+      this.scrollToActiveQuestion();
+    }
   }
 
   private get canAddAnswer(): boolean {
@@ -243,6 +264,14 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
           this.activeQuestionDoc$.next(questionDoc);
         }
       });
+    }
+    setTimeout(() => this.scrollToActiveQuestion());
+  }
+
+  private scrollToActiveQuestion() {
+    const element = (this.mdcList.elementRef.nativeElement as HTMLElement).querySelector('.mdc-list-item--activated');
+    if (element != null) {
+      element.scrollIntoView({ block: 'nearest' });
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -5,6 +5,7 @@
         id="question-drawer"
         [drawer]="isDrawerPermanent ? 'permanent' : 'modal'"
         [open]="isExpanded"
+        [autoFocus]="false"
         (closed)="drawerCollapsed()"
       >
         <div class="d-flex flex-max" id="questions-panel">
@@ -20,6 +21,7 @@
                   #questionsPanel
                   (update)="questionUpdated($event)"
                   (changed)="questionChanged($event)"
+                  [visible]="isDrawerPermanent || isExpanded"
                   [questionDocs]="questionDocs"
                   [project]="projectDoc?.data"
                   [projectUserConfigDoc]="projectUserConfigDoc"


### PR DESCRIPTION
Also stop autofocusing first element in menu drawer and questions panel

Situations where we make sure to scroll the question into view:
- On page/view load
- Switching questions with the next/previous buttons
- Opening the question list (on mobile)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/650)
<!-- Reviewable:end -->
