### PR TITLE
SF-893: Disable default Quill formatting

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
@@ -4,6 +4,7 @@
   [placeholder]="placeholder"
   [readOnly]="readOnlyEnabled"
   [strict]="false"
+  [formats]="allowedFormats"
   [modules]="modules"
   (onEditorCreated)="onEditorCreated($event)"
   (onContentChanged)="onContentChanged($event.delta, $event.source)"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -33,7 +33,7 @@ function onNativeSelectionChanged(): void {
   }
 }
 
-registerScripture();
+const USX_FORMATS = registerScripture();
 window.document.addEventListener('selectionchange', onNativeSelectionChanged);
 
 export interface TextUpdatedEvent {
@@ -57,6 +57,8 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
   @Output() segmentRefChange = new EventEmitter<string>();
   @Output() loaded = new EventEmitter(true);
   lang: string = '';
+  // only use USX formats and not default Quill formats
+  readonly allowedFormats: string[] = USX_FORMATS;
 
   private direction: string | null = null;
   private _editorStyles: any = { fontSize: '1rem' };
@@ -64,6 +66,10 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
     toolbar: false,
     keyboard: {
       bindings: {
+        // disable default tab keyboard shortcuts in Quill
+        tab: null,
+        'remove tab': null,
+
         'disable backspace': {
           key: 'backspace',
           altKey: null,


### PR DESCRIPTION
- whitelist USX formats
- re-enable default Quill keyboard behavior

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/653)
<!-- Reviewable:end -->
