### PR TITLE
SF-952 Fix ending ellipsis in scripture selection dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
@@ -212,6 +212,19 @@ describe('TextChooserDialogComponent', () => {
     });
   }));
 
+  it("doesn't show ending ellipsis when entire verse is selected", fakeAsync(async () => {
+    const env = new TestEnvironment({ start: 4, end: TestEnvironment.segmentLen(10) - 1 }, 'verse_1_10', 'verse_1_10');
+    env.fireSelectionChange();
+    expect(env.selectedText).toEqual('verse ten (Matthew 1:10)');
+    env.click(env.saveButton);
+    expect(await env.resultPromise).toEqual({
+      verses: { bookNum: 40, chapterNum: 1, verseNum: 10, verse: '10' },
+      text: 'verse ten',
+      startClipped: false,
+      endClipped: false
+    });
+  }));
+
   it('shows the correct verse range when first or last segment has only white space selected', fakeAsync(async () => {
     const env = new TestEnvironment({ start: TestEnvironment.segmentLen(7) - 1, end: 1 }, 'verse_1_7', 'verse_1_9');
     env.fireSelectionChange();
@@ -545,6 +558,8 @@ class TestEnvironment {
     delta.insert(' target: chapter 1, verse 8. ', { segment: 'verse_1_8' });
     delta.insert({ verse: { number: '9', style: 'v' } });
     delta.insert({ blank: true }, { segment: 'verse_1_9' });
+    delta.insert({ verse: { number: '10', style: 'v' } });
+    delta.insert('verse ten', { segment: 'verse_1_10' });
     return delta;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
@@ -328,7 +328,7 @@ export class TextChooserDialogComponent extends SubscriptionDisposable {
     const startSegmentLeadingWhitespaceLength = startNodeText.length - startNodeText.trimLeft().length;
     const startSegmentClipped = startOffset + startTrimLength > startSegmentLeadingWhitespaceLength;
     const endSegmentLengthWithoutTrailingWhitespace = endNodeText.trimRight().length;
-    const endSegmentClipped = endOffset + endTrimLength < endSegmentLengthWithoutTrailingWhitespace;
+    const endSegmentClipped = endOffset - endTrimLength < endSegmentLengthWithoutTrailingWhitespace;
 
     // Even if the entirety of the first or last segment was selected, it's possible that segment isn't the only segment
     // for that verse. Assemble a list of segments that are in the same verse as the selection's first segment's verse.


### PR DESCRIPTION
Ellipsis shown when it should not be | Ellipsis not shown when it should be
-------------------------------------|-------------------------------------
Since the selection is expanded to include the entirety of partially selected words, the entire verse is selected in this example, despite the last letter of the last word not being included by the user. | All of the first word is selected (because the selection is expanded to include all of partially selected words), but the selection doesn't go to the end of the verse, so the ending ellipsis should be shown.
![](https://user-images.githubusercontent.com/6140710/82097402-d2aae300-96d0-11ea-818f-047060e59f27.png) | ![](https://user-images.githubusercontent.com/6140710/82097403-d3437980-96d0-11ea-9bf8-0e3662aadb2a.png)

This turned out turned out to be a simple error in calculating how much of the verse is included in the final selection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/654)
<!-- Reviewable:end -->
