### PR TITLE
 SF-928 - Checkers can add a comment offline and have it synced when online

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/memory-realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/memory-realtime-remote-store.ts
@@ -125,6 +125,10 @@ export class MemoryRealtimeDocAdapter implements RealtimeDocAdapter {
     return Promise.resolve();
   }
 
+  updatePendingOps(ops: any[]): void {
+    this.pendingOps.push(...ops);
+  }
+
   destroy(): Promise<void> {
     return Promise.resolve();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime-remote-store.ts
@@ -40,6 +40,7 @@ export interface RealtimeDocAdapter {
   submitOp(op: any, source?: any): Promise<void>;
   exists(): Promise<boolean>;
   delete(): Promise<void>;
+  updatePendingOps(ops: any[]): void;
 
   destroy(): Promise<void>;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
@@ -231,6 +231,11 @@ export class SharedbRealtimeDocAdapter implements RealtimeDocAdapter {
     });
   }
 
+  updatePendingOps(ops: any[]): void {
+    this.doc.pendingOps.push(...ops.map(component => ({ op: component, type: this.doc.type, callbacks: [] })));
+    this.doc.flush();
+  }
+
   destroy(): Promise<void> {
     return new Promise((resolve, reject) => {
       this.doc.destroy(err => {


### PR DESCRIPTION
This PR actually resolves a couple of race bugs when content is added offline and the page is reloaded/ navigated away/closed down and opened up again. These fixes will relate to all real time documents and it is something Damien has specifically helped with.

I have found one instance where a duplication can occur and that is with the use of live reload. With live reload enabled, and a comment is added offline (shut down the backend), when the backend is enabled (without manually refreshing the front end) the app may initially try to add the operation depending on the timing of the reconnecting websocket. If this process can start just before live reload refreshes the page then the offline data doesn't have a chance to update and it is then processed again after the refresh. This is just a dev scenario that "may" happen from time to time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/655)
<!-- Reviewable:end -->
