### PR TITLE
SF-931 Indicate routes that are not available offline

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -95,17 +95,17 @@
                     <strong class="user-menu-name">{{ currentUser?.displayName }}</strong>
                   </div>
                 </div>
-                <div [hidden]="!isAppOnline">
+                <div>
                   <mdc-list-divider></mdc-list-divider>
                   <mdc-list>
-                    <mdc-list-item *ngIf="isSystemAdmin" routerLink="/system-administration">
+                    <mdc-list-item *ngIf="isSystemAdmin" routerLink="/system-administration" [disabled]="!isAppOnline">
                       {{ t("system_administration") }}
                     </mdc-list-item>
                     <mdc-list-item routerLink="/projects">{{ t("project_home") }}</mdc-list-item>
-                    <mdc-list-item *ngIf="canChangePassword" (click)="changePassword()">
+                    <mdc-list-item *ngIf="canChangePassword" (click)="changePassword()" [disabled]="!isAppOnline">
                       {{ t("change_password") }}
                     </mdc-list-item>
-                    <mdc-list-item name="logout" (click)="logOut()">{{ t("log_out") }}</mdc-list-item>
+                    <mdc-list-item name="logout" (click)="logOut()"> {{ t("log_out") }} </mdc-list-item>
                   </mdc-list>
                 </div>
                 <mdc-list-divider></mdc-list-divider>
@@ -143,7 +143,7 @@
               projectDoc.data?.name
             }}</mdc-list-item>
             <mdc-list-divider></mdc-list-divider>
-            <mdc-list-item value="*connect-project*">
+            <mdc-list-item value="*connect-project*" [class.list-item-disabled]="!isAppOnline">
               <mdc-icon mdcListItemGraphic>add</mdc-icon>
               {{ t("connect_project") }}
             </mdc-list-item>
@@ -243,6 +243,7 @@
           <mdc-list-item
             [routerLink]="['/projects', selectedProjectId, 'sync']"
             [activated]="rlaSync.isActive"
+            [class.list-item-disabled]="!isAppOnline"
             routerLinkActive
             #rlaSync="routerLinkActive"
             id="sync-item"
@@ -254,6 +255,7 @@
           <mdc-list-item
             [routerLink]="['/projects', selectedProjectId, 'settings']"
             [activated]="rlaSettings.isActive"
+            [class.list-item-disabled]="!isAppOnline"
             routerLinkActive
             #rlaSettings="routerLinkActive"
             id="settings-item"
@@ -265,6 +267,7 @@
           <mdc-list-item
             [routerLink]="['/projects', selectedProjectId, 'users']"
             [activated]="rlaUsers.isActive"
+            [class.list-item-disabled]="!isAppOnline"
             routerLinkActive
             #rlaUsers="routerLinkActive"
             id="users-item"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -21,22 +21,22 @@
         width: 100%;
       }
     }
+  }
 
-    .mdc-list-item {
-      cursor: pointer;
-      &:hover,
-      &.mdc-list-item--activated {
-        mdc-icon {
-          color: $purpleLight;
-        }
-      }
+  .mdc-list-item {
+    cursor: pointer;
+    &:hover,
+    &.mdc-list-item--activated {
       mdc-icon {
-        color: $purpleMedium;
-        transition: color 0.15s;
+        color: $purpleLight;
       }
-      .mdc-list-item__graphic {
-        margin-right: 24px;
-      }
+    }
+    mdc-icon {
+      color: $purpleMedium;
+      transition: color 0.15s;
+    }
+    .mdc-list-item__graphic {
+      margin-right: 24px;
     }
   }
 
@@ -143,5 +143,15 @@ a {
   padding-bottom: 8px;
   mdc-icon {
     margin-right: 10px;
+  }
+}
+
+:host,
+.mdc-menu {
+  .mdc-list-item.list-item-disabled {
+    &,
+    mdc-icon {
+      color: var(--mdc-theme-text-disabled-on-background);
+    }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -378,16 +378,18 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   changePassword(): void {
     if (this.currentUser == null) {
       return;
+    } else if (!this.isAppOnline) {
+      this.noticeService.show(translate('app.action_not_available_offline'));
+    } else {
+      this.authService
+        .changePassword(this.currentUser.email)
+        .then(() => {
+          this.noticeService.show(translate('app.password_reset_email_sent'));
+        })
+        .catch(() => {
+          this.noticeService.show(translate('app.cannot_change_password'));
+        });
     }
-
-    this.authService
-      .changePassword(this.currentUser.email)
-      .then(() => {
-        this.noticeService.show(translate('app.password_reset_email_sent'));
-      })
-      .catch(() => {
-        this.noticeService.show(translate('app.cannot_change_password'));
-      });
   }
 
   async editName(): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -1,5 +1,6 @@
 {
   "app": {
+    "action_not_available_offline": "This action isn't available while you are offline.",
     "all_questions": "All Questions",
     "cannot_change_password": "Can't change password at this time. Try again later or report an issue in the Help menu.",
     "change_password": "Change password",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.ts
@@ -13,7 +13,7 @@ export class AvatarComponent {
   @Input() user?: UserProfile;
   @Input() showOnlineStatus: boolean = false;
 
-  constructor(private readonly pwaService: PwaService) {}
+  constructor(readonly pwaService: PwaService) {}
 
   get avatarUrl(): string {
     return this.user != null ? this.user.avatarUrl : '';


### PR DESCRIPTION
Online | Offline
-------|--------
![](https://user-images.githubusercontent.com/6140710/82269207-ebb8cb80-993e-11ea-8a74-a7af759f3630.png) | ![](https://user-images.githubusercontent.com/6140710/82269205-ea879e80-993e-11ea-8943-a4943975cc64.png)

A few concerns here:
- In the top app bar we hide the language switching menu, and items in the menu on the right. That's inconsistent with the way we're merely marking items in the sidebar as unavailable offline.
- I'm not sure the positioning of the cloud is very good, or even the right solution.

I also marked pwaService as public in `avatar.component.ts`, since it is used in the template. Previously a warning was shown in the template regarding accessing a private menu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/657)
<!-- Reviewable:end -->
