### PR TITLE
SF-950 Do not highlight question on first sync

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -96,8 +96,9 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
       }
       // If any answers have been edited, identify which ones and highlight it
       for (const op of ops) {
-        // 'oi' is an insert i.e. when replacing the dateModified on an answer
-        if (op['oi'] != null && op.p[0] === 'answers') {
+        // 'oi' is an insert e.g. when replacing the dateModified on an answer
+        // We're only interested when text is edited
+        if (op['oi'] != null && op.p[0] === 'answers' && op.p[2] === 'text') {
           const answer = this.allAnswers[op.p[1]];
           if (this.answersHighlightStatus.has(answer.dataId)) {
             this.answersHighlightStatus.set(answer.dataId, false);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -554,6 +554,18 @@ describe('CheckingComponent', () => {
       expect(env.getAnswerText(otherAnswerIndex)).toBe('Question 9 edited answer');
     }));
 
+    it('does not highlight upon sync', fakeAsync(() => {
+      const env = new TestEnvironment(CHECKER_USER);
+      env.selectQuestion(9);
+      const answerIndex = 1;
+      expect(env.getAnswer(answerIndex).classes['attention']).toBe(false);
+      expect(env.getAnswerText(answerIndex)).toBe('Answer 1 on question');
+
+      env.simulateSync(answerIndex);
+      expect(env.getAnswer(answerIndex).classes['attention']).toBe(false);
+      expect(env.getAnswerText(answerIndex)).toBe('Answer 1 on question');
+    }));
+
     it('still shows answers as read after canceling an edit', fakeAsync(() => {
       const env = new TestEnvironment(CHECKER_USER);
       env.selectQuestion(7);
@@ -1737,6 +1749,15 @@ class TestEnvironment {
     questionDoc.submitJson0Op(op => {
       op.set(q => q.answers[index].text!, text);
       op.set(q => q.answers[index].dateModified, new Date().toJSON());
+    }, false);
+    tick(this.questionReadTimer);
+    this.fixture.detectChanges();
+  }
+
+  simulateSync(index: number): void {
+    const questionDoc = this.component.questionsPanel!.activeQuestionDoc!;
+    questionDoc.submitJson0Op(op => {
+      op.set(q => (q.answers[index] as any).syncUserRef, objectId());
     }, false);
     tick(this.questionReadTimer);
     this.fixture.detectChanges();


### PR DESCRIPTION
The first time a project is synced after a question is added, the property syncUserRef is added to the question. Previously this caused the question to be marked as newly edited.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/659)
<!-- Reviewable:end -->
