### PR TITLE
Make add question button on checking overview page more prominent

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -3,7 +3,7 @@
     <mdc-icon fxFlex="32px">library_books</mdc-icon>
     <h2 fxFlex>{{ t("texts_with_questions") }}</h2>
     <div fxFlexAlign="center" *ngIf="isProjectAdmin; else overallProgressChart">
-      <button *ngIf="!isLoading" mdc-button type="button" (click)="questionDialog()" id="add-question-button">
+      <button *ngIf="!isLoading" mdc-button primary type="button" (click)="questionDialog()" id="add-question-button">
         <mdc-icon>post_add</mdc-icon> <span fxHide.xs>{{ t("add_question") }}</span>
       </button>
     </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
@@ -1,13 +1,13 @@
 @import '~src/variables';
 @import '~bootstrap/scss/mixins/breakpoints';
 
-#add-question-button mdc-icon {
-  // Bigger icon if shown without label on smaller devices
+#add-question-button {
   @include media-breakpoint-only(xs) {
+    min-width: 48px;
+  }
+  mdc-icon {
     font-size: 24px;
-    // Vertically align it better with the 'Texts and Questions' icon.
-    padding-bottom: 10px;
-    box-sizing: initial;
+    height: 24px;
   }
 }
 


### PR DESCRIPTION
We've discussed making the add question button on the checking overview page more prominent but haven't come to any conclusions yet if I recall correctly. This is my suggested incremental improvement.

Desktop | Mobile
--------|-------
![](https://user-images.githubusercontent.com/6140710/82396731-abc81600-9a1c-11ea-9bbf-6bdfa3dee06c.png) | ![](https://user-images.githubusercontent.com/6140710/82396792-d2864c80-9a1c-11ea-8a5f-cd4e20074083.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/660)
<!-- Reviewable:end -->
