### PR TITLE
SF-813: Only use box-decoration-break: slice on Firefox

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -124,7 +124,7 @@ p[dir='rtl'] {
         display: inline;
         box-sizing: border-box;
 
-        box-decoration-break: slice;
+        box-decoration-break: clone;
 
         color: rgba(0, 0, 0, 0.8);
         background-color: white;
@@ -147,6 +147,21 @@ p[dir='rtl'] {
     position: absolute;
     top: 0px;
     left: 6px;
+  }
+}
+
+// workaround for Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1569107
+// using "box-decoration-break: clone" or blur radius in a "box-shadow" with RTL text can cause weird behavior
+.template-editor.contains-rtl-text[data-browser-engine='gecko'] > .ql-container > .ql-editor {
+  usx-para,
+  p {
+    > usx-para-contents {
+      box-decoration-break: slice;
+    }
+  }
+
+  .highlight-para > usx-para-contents {
+    box-shadow: 1px 1px 0px 1px #ede6de;
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -304,6 +304,7 @@ usx-chapter {
 
 usx-verse {
   user-select: none;
+  unicode-bidi: embed;
   > span > span > span {
     // superscript
     top: -0.5em;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -103,8 +103,8 @@ export function registerScripture(): string[] {
 
     static create(value: Verse): Node {
       const node = super.create(value) as HTMLElement;
-      // add a ZWSP before the verse number, so that it allows breaking
-      node.appendChild(document.createTextNode(ZWSP));
+      // add a wbr element before the verse number, so that it allows breaking
+      node.appendChild(document.createElement('wbr'));
       const containerSpan = document.createElement('span');
       const verseSpan = document.createElement('span');
       verseSpan.innerText = value.number;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -180,9 +180,10 @@ export class TextViewModel {
    * each paragraph/segment and then specifically set the paragraph to what the direction of the first segment that
    * contains text i.e. is not blank. For chapters we use the same direction value as the paragraph that follows it.
    */
-  setDirection(): void {
+  setDirection(): boolean {
     const editor = this.checkEditor();
 
+    let containsRtlText = false;
     // set direction on individual segments
     let delta = new Delta();
     for (const [segmentId, range] of this.segments) {
@@ -193,6 +194,10 @@ export class TextViewModel {
       }
 
       delta = delta.compose(new Delta().retain(range.index).retain(range.length, { 'direction-segment': dir }));
+
+      if (dir === 'rtl') {
+        containsRtlText = true;
+      }
     }
     editor.updateContents(delta, 'silent');
 
@@ -227,6 +232,7 @@ export class TextViewModel {
       }
     }
     editor.updateContents(delta, 'silent');
+    return containsRtlText;
   }
 
   highlight(segmentRefs: string[]): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
@@ -14,9 +14,11 @@
     'template-editor': !readOnlyEnabled,
     ltr: isLtr,
     rtl: isRtl,
-    'mark-invalid': markInvalid
+    'mark-invalid': markInvalid,
+    'contains-rtl-text': containsRtlText
   }"
   dir="auto"
   [lang]="lang"
+  [attr.data-browser-engine]="browserEngine"
 >
 </quill-editor>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -5,6 +5,7 @@ import merge from 'lodash/merge';
 import Quill, { DeltaStatic, RangeStatic, Sources } from 'quill';
 import { fromEvent } from 'rxjs';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
+import { getBrowserEngine } from 'xforge-common/utils';
 import { TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { registerScripture } from './quill-scripture';
@@ -57,8 +58,11 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
   @Output() segmentRefChange = new EventEmitter<string>();
   @Output() loaded = new EventEmitter(true);
   lang: string = '';
+  containsRtlText: boolean = false;
   // only use USX formats and not default Quill formats
   readonly allowedFormats: string[] = USX_FORMATS;
+  // allow for different CSS based on the browser engine
+  readonly browserEngine: string = getBrowserEngine();
 
   private direction: string | null = null;
   private _editorStyles: any = { fontSize: '1rem' };
@@ -69,6 +73,10 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
         // disable default tab keyboard shortcuts in Quill
         tab: null,
         'remove tab': null,
+        'embed left': null,
+        'embed left shift': null,
+        'embed right': null,
+        'embed right shift': null,
 
         'disable backspace': {
           key: 'backspace',
@@ -460,7 +468,7 @@ export class TextComponent extends SubscriptionDisposable implements OnDestroy {
       const quillElement = this.quill.nativeElement as HTMLElement;
       // set direction on the editor
       this.direction = window.getComputedStyle(quillElement).direction;
-      this.viewModel.setDirection();
+      this.containsRtlText = this.viewModel.setDirection();
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -7,6 +7,8 @@ import { version } from '../../../version.json';
 import { environment } from '../environments/environment';
 import { Locale } from './models/i18n-locale';
 
+const BROWSER = Bowser.getParser(window.navigator.userAgent);
+
 export function nameof<T>(name: Extract<keyof T, string>): string {
   return name;
 }
@@ -25,10 +27,8 @@ export function promiseTimeout<T>(promise: Promise<T>, timeout: number) {
 }
 
 export function supportedBrowser(): boolean {
-  const bowser = Bowser.getParser(window.navigator.userAgent);
-
   // See https://caniuse.com/#feat=indexeddb2 for browsers supporting IndexedDB 2.0
-  const isSupportedBrowser = bowser.satisfies({
+  const isSupportedBrowser = BROWSER.satisfies({
     chrome: '>=58',
     chromium: '>=58',
     edge: '>=76',
@@ -45,6 +45,11 @@ export function supportedBrowser(): boolean {
     }
   });
   return isSupportedBrowser ? true : false;
+}
+
+export function getBrowserEngine(): string {
+  const engine = BROWSER.getEngine().name;
+  return engine == null ? '' : engine.toLowerCase();
 }
 
 export function issuesEmailTemplate(errorId?: string): string {


### PR DESCRIPTION
- only apply box-decoration-break: slice on Firefox
- see Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1569107
- adjust box-shadow for selected paragraph so it looks better on Firefox
- added in `wbr` element for breaking the verse with the following segment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/661)
<!-- Reviewable:end -->
