### PR TITLE
Service Worker Registration

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
@@ -49,7 +49,10 @@ import { UsersModule } from './users/users.module';
     CoreModule,
     HttpClientModule,
     // not ready for production yet - 2018-11 IJH
-    ServiceWorkerModule.register('ngsw-worker.js', { enabled: environment.pwaTest }), // || environment.production }),
+    ServiceWorkerModule.register('ngsw-worker.js', {
+      enabled: environment.pwaTest, // || environment.production,
+      registrationStrategy: 'registerImmediately'
+    }),
     TranslateModule,
     CheckingModule,
     UsersModule,


### PR DESCRIPTION
- Changed the registration strategy for the service worker to `registerImmediately` to avoid conflicts with using the `ReconnectingWebsocket`

 Angular's service worker by default has a registration strategy to `registerWhenStable` which is described as :
```
Register as soon as the application stabilizes (no pending micro-/macro-tasks).
```
As we are using `ReconnectingWebSocket` it creates a macro task timer which means the app is never consider stable therefore the service worker won't register. There must have been just enough  time between the web socket connecting originally compared to where I then moved it to which introduced the issue. Thankfully we can simply change the registration strategy to `registerImmediately` which does what it says and registers it straight away without waiting for anything in the app that might hold things up.

I can confirm this also resolves the install, uninstall, install issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/667)
<!-- Reviewable:end -->
