### PR TITLE
SF-939 Disable suggestions in translate app when offline

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -619,7 +619,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   private async translateSegment(): Promise<void> {
     this.translationSession = undefined;
-    if (this.translationEngine == null || this.source == null) {
+    if (this.translationEngine == null || this.source == null || !this.pwaService.isOnline) {
       return;
     }
     const sourceSegment = this.source.segmentText;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
@@ -4,17 +4,19 @@
       <mdc-dialog-surface>
         <mdc-dialog-title>{{ t("translation_suggestions_settings") }}</mdc-dialog-title>
         <mdc-dialog-content class="content-padding" fxLayout="column" fxLayoutGap="25px">
+          <div class="offline-text" *ngIf="!pwaService.isOnline">{{ t("settings_not_available_offline") }}</div>
           <mdc-form-field>
             <mdc-switch
               id="suggestions-enabled-switch"
               *ngIf="open"
               [(ngModel)]="translationSuggestionsUserEnabled"
+              [disabled]="!pwaService.isOnline"
             ></mdc-switch>
             <label class="switch-label">{{ t("translation_suggestions") }}</label>
           </mdc-form-field>
           <mdc-select
             id="num-suggestions-select"
-            [disabled]="!translationSuggestionsUserEnabled"
+            [disabled]="settingsEnabled"
             [(ngModel)]="numSuggestions"
             placeholder="{{ t('number_of_suggestions') }}"
           >
@@ -28,7 +30,7 @@
             </div>
             <mdc-slider
               #confidenceThresholdSlider
-              [disabled]="!translationSuggestionsUserEnabled"
+              [disabled]="settingsEnabled"
               [min]="0"
               [max]="100"
               [(ngModel)]="confidenceThreshold"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
@@ -1,3 +1,5 @@
+@import '~src/styles';
+
 .slider-labels {
   margin-top: 15px;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.ts
@@ -3,6 +3,7 @@ import { MdcSlider } from '@angular-mdc/web/slider';
 import { Component, Inject, ViewChild } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { debounceTime, map, skip } from 'rxjs/operators';
+import { PwaService } from 'xforge-common/pwa.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { SFProjectUserConfigDoc } from '../../core/models/sf-project-user-config-doc';
 
@@ -25,7 +26,8 @@ export class SuggestionsSettingsDialogComponent extends SubscriptionDisposable {
 
   constructor(
     dialogRef: MdcDialogRef<SuggestionsSettingsDialogComponent>,
-    @Inject(MDC_DIALOG_DATA) data: SuggestionsSettingsDialogData
+    @Inject(MDC_DIALOG_DATA) data: SuggestionsSettingsDialogData,
+    readonly pwaService: PwaService
   ) {
     super();
     this.projectUserConfigDoc = data.projectUserConfigDoc;
@@ -35,7 +37,7 @@ export class SuggestionsSettingsDialogComponent extends SubscriptionDisposable {
         this.confidenceThresholdSlider.layout();
         this.confidenceThresholdSlider.disabled = false; // cannot set value when slider is disabled
         this.confidenceThresholdSlider.setValue(this.projectUserConfigDoc.data!.confidenceThreshold * 100);
-        this.confidenceThresholdSlider.disabled = !this.translationSuggestionsUserEnabled;
+        this.confidenceThresholdSlider.disabled = this.settingsEnabled;
       }
       this.open = true;
     });
@@ -53,6 +55,10 @@ export class SuggestionsSettingsDialogComponent extends SubscriptionDisposable {
       ),
       threshold => this.projectUserConfigDoc.submitJson0Op(op => op.set(puc => puc.confidenceThreshold, threshold))
     );
+  }
+
+  get settingsEnabled(): boolean {
+    return !this.translationSuggestionsUserEnabled || !this.pwaService.isOnline;
   }
 
   get translationSuggestionsUserEnabled(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -148,6 +148,7 @@
     "close": "Close",
     "more": "More",
     "number_of_suggestions": "Number of suggestions",
+    "settings_not_available_offline": "These settings are not available while you are offline.",
     "suggestion_confidence": "Suggestion confidence",
     "translation_suggestions": "Translation suggestions",
     "translation_suggestions_settings": "Translation suggestions settings"


### PR DESCRIPTION
With regards to training segments, it appears that naturally does not occur when offline. It seems to only try to train a segment when a suggestion is used, though the actual logic is difficult to decipher. In any case, I haven't been able to cause any errors when offline, other than the usual console errors caused by the websocket being unable to connect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/668)
<!-- Reviewable:end -->
