### PR TITLE
SF-938 - Ensure user config is saved offline and synced online

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
@@ -146,6 +146,7 @@ export abstract class RealtimeDoc<T = any, Ops = any> {
     this.updateOfflineDataSub.unsubscribe();
     this.onDeleteSub.unsubscribe();
     await this.adapter.destroy();
+    this.subscribedState = false;
   }
 
   protected prepareDataForStore(data: T): any {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
@@ -24,6 +24,7 @@ export abstract class RealtimeDoc<T = any, Ops = any> {
   private subscribePromise?: Promise<void>;
   private localDelete$ = new Subject<void>();
   private _delete$: Observable<void>;
+  private subscribedState: boolean = false;
   private subscribeQueryCount: number = 0;
   private loadOfflineDataPromise?: Promise<void>;
 
@@ -44,11 +45,11 @@ export abstract class RealtimeDoc<T = any, Ops = any> {
   }
 
   get isLoaded(): boolean {
-    return this.adapter.type != null;
+    return this.adapter.type != null && this.subscribedState;
   }
 
   get subscribed(): boolean {
-    return this.adapter.subscribed || this.subscribeQueryCount > 0;
+    return this.subscribedState || this.subscribeQueryCount > 0;
   }
 
   get collection(): string {
@@ -215,6 +216,7 @@ export abstract class RealtimeDoc<T = any, Ops = any> {
       this.checkExists();
     } else {
       await promise;
+      this.subscribedState = this.adapter.subscribed;
     }
   }
 


### PR DESCRIPTION
- Added subscribed state to RealtimeDoc
- Changed `isLoaded()` to also check if the doc has been subscribed to - this covers instances where a snapshot was ingested and not subscribed to yet

The issue encountered in this is sharedb docs are automatically unsubscribed as soon the connection state changes. As user docs are never subscribed to via a realtime query it meant the offline data would never be updated. This PR creates a new subscribed state so we can track if the document was subscribed to at some point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/669)
<!-- Reviewable:end -->
