### PR TITLE
SF-921 send language options to Auth0

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -8,22 +8,12 @@ import { Canon } from 'realtime-server/lib/scriptureforge/scripture-utils/canon'
 import { VerseRef } from 'realtime-server/lib/scriptureforge/scripture-utils/verse-ref';
 import { of, zip } from 'rxjs';
 import { map } from 'rxjs/operators';
-import locales from '../../../locales.json';
 import enChecking from '../assets/i18n/checking_en.json';
 import enNonChecking from '../assets/i18n/non_checking_en.json';
 import { environment } from '../environments/environment';
 import { AuthService } from './auth.service';
-import { ASP_CULTURE_COOKIE_NAME, aspCultureCookieValue, getAspCultureCookieLanguage } from './utils';
-
-interface Locale {
-  localName: string;
-  englishName: string;
-  canonicalTag: string;
-  direction: 'ltr' | 'rtl';
-  tags: string[];
-  production: boolean;
-  helps?: string;
-}
+import { Locale } from './models/i18n-locale';
+import { ASP_CULTURE_COOKIE_NAME, aspCultureCookieValue, getAspCultureCookieLanguage, getI18nLocales } from './utils';
 
 type DateFormat = Intl.DateTimeFormatOptions | ((date: Date) => string);
 
@@ -61,14 +51,7 @@ function pad(number: number) {
   providedIn: 'root'
 })
 export class I18nService {
-  static readonly locales: Locale[] = locales.map(locale => {
-    return {
-      ...locale,
-      canonicalTag: locale.tags[0],
-      production: !!locale.production,
-      direction: locale['direction'] || 'ltr'
-    };
-  });
+  static readonly locales: Locale[] = getI18nLocales();
 
   static dateFormats: { [key: string]: DateFormat } = {
     en: { month: 'short' },

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/i18n-locale.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/i18n-locale.ts
@@ -1,0 +1,9 @@
+export interface Locale {
+  localName: string;
+  englishName: string;
+  canonicalTag: string;
+  direction: 'ltr' | 'rtl';
+  tags: string[];
+  production: boolean;
+  helps?: string;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -2,8 +2,10 @@ import { translate } from '@ngneat/transloco';
 import Bowser from 'bowser';
 import ObjectID from 'bson-objectid';
 import { VerseRef } from 'realtime-server/lib/scriptureforge/scripture-utils/verse-ref';
+import locales from '../../../locales.json';
 import { version } from '../../../version.json';
 import { environment } from '../environments/environment';
+import { Locale } from './models/i18n-locale';
 
 export function nameof<T>(name: Extract<keyof T, string>): string {
   return name;
@@ -95,6 +97,17 @@ export function getAspCultureCookieLanguage(cookie: string): string {
     }
   });
   return uic! || c! || 'en';
+}
+
+export function getI18nLocales(): Locale[] {
+  return locales.map(locale => {
+    return {
+      ...locale,
+      canonicalTag: locale.tags[0],
+      production: !!locale.production,
+      direction: locale['direction'] || 'ltr'
+    };
+  });
 }
 
 export function browserLinks() {


### PR DESCRIPTION
* gives us one source of truth in `locales.json`
* move locales to utils to prevent circular dependency between auth and i18n services

Review in conjunction with PR https://github.com/sillsdev/auth0-configs/pull/55.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/673)
<!-- Reviewable:end -->
