### PR TITLE
Do ParatextData SendReceive as particular PT user

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -196,9 +196,17 @@ namespace SIL.XForge.Scripture.Services
             // TODO report results
             List<SendReceiveResult> results = Enumerable.Empty<SendReceiveResult>().ToList();
             bool success = false;
-            bool noErrors = SharingLogicWrapper.HandleErrors(() => success = SharingLogicWrapper
-                .ShareChanges(sharedPtProjectsToSr, source.AsInternetSharedRepositorySource(),
-                out results, sharedPtProjectsToSr));
+            bool noErrors = false;
+            noErrors = SharingLogicWrapper.HandleErrors(() =>
+            {
+                RegistrationInfo.PerformAsUser(username, () =>
+                {
+                    success = SharingLogicWrapper
+                     .ShareChanges(sharedPtProjectsToSr, source.AsInternetSharedRepositorySource(),
+                     out results, sharedPtProjectsToSr);
+
+                });
+            });
             if (!noErrors || !success)
                 throw new InvalidOperationException(
                     "Failed: Errors occurred while performing the sync with the Paratext Server.");


### PR DESCRIPTION
`ParatextData SharingLogic.Share1Project()` checks the project
`Permissions.GetUser()` and returns early if the result is null.
This gets over to `RegistrationInfo.UserName`, where various
strategies may let us cause `UserName` to return the PT username of
the SF user at hand, such as by using `RegistrationInfo.Implementation
= new ...;`

`RegistrationInfo.PerformAsUser(username, action)` lets us temporarily
override the username and run action, which is simple and easy to
implement.

But this may present a race condition when used by multiple users?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/676)
<!-- Reviewable:end -->
