### PR TITLE
SF-927 - Checkers can answer a question offline and have it synced when online

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -10,7 +10,7 @@ import { AuthType, getAuthType, User } from 'realtime-server/lib/common/models/u
 import { SFProjectRole } from 'realtime-server/lib/scriptureforge/models/sf-project-role';
 import { TextInfo } from 'realtime-server/lib/scriptureforge/models/text-info';
 import { Canon } from 'realtime-server/lib/scriptureforge/scripture-utils/canon';
-import { combineLatest, from, Observable, Subscription } from 'rxjs';
+import { combineLatest, from, merge, Observable, Subscription } from 'rxjs';
 import { distinctUntilChanged, filter, map, startWith, switchMap, tap } from 'rxjs/operators';
 import { AuthService } from 'xforge-common/auth.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
@@ -467,6 +467,18 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       );
     }
     await Promise.all(promises);
+    this.questionCountQueries.forEach((query: RealtimeQuery, bookNum: number) => {
+      this.subscribe(merge(query.remoteChanges$, query.localChanges$, query.ready$), () => {
+        if (this.selectedProjectDoc == null) {
+          return;
+        }
+        if (query.count > 0) {
+          this.selectedProjectDoc.loadTextDocs(bookNum);
+        } else {
+          this.selectedProjectDoc.unLoadTextDocs(bookNum);
+        }
+      });
+    });
   }
 
   private disposeQuestionQueries(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -474,8 +474,6 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
         }
         if (query.count > 0) {
           this.selectedProjectDoc.loadTextDocs(bookNum);
-        } else {
-          this.selectedProjectDoc.unLoadTextDocs(bookNum);
         }
       });
     });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -193,8 +193,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
   }
 
   get questionDocs(): Readonly<QuestionDoc[]> {
-    // Wait until the question query is ready before showing any question
-    return this.questionsQuery != null && this.questionsQuery.ready ? this.questionsQuery.docs : [];
+    return this.questionsQuery != null ? this.questionsQuery.docs : [];
   }
 
   get textsByBookId(): TextsByBookId {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-doc.ts
@@ -35,9 +35,18 @@ export class SFProjectDoc extends ProjectDoc<SFProject> {
 
   async unLoadTextDocs(bookNum?: number): Promise<void> {
     for (const textDocId of this.getTextDocs(bookNum)) {
-      const doc = this.realtimeService.get(TEXTS_COLLECTION, textDocId.toString());
-      await doc.dispose();
+      if (this.realtimeService.isSet(TEXTS_COLLECTION, textDocId.toString())) {
+        const doc = this.realtimeService.get(TEXTS_COLLECTION, textDocId.toString());
+        await doc.dispose();
+      }
     }
+  }
+
+  protected async onDelete(): Promise<void> {
+    await super.onDelete();
+    await this.deleteProjectDocs(SFProjectUserConfigDoc.COLLECTION);
+    await this.deleteProjectDocs(TextDoc.COLLECTION);
+    await this.deleteProjectDocs(QuestionDoc.COLLECTION);
   }
 
   private getTextDocs(bookNum?: number): TextDocId[] {
@@ -52,13 +61,6 @@ export class SFProjectDoc extends ProjectDoc<SFProject> {
       }
     }
     return texts;
-  }
-
-  protected async onDelete(): Promise<void> {
-    await super.onDelete();
-    await this.deleteProjectDocs(SFProjectUserConfigDoc.COLLECTION);
-    await this.deleteProjectDocs(TextDoc.COLLECTION);
-    await this.deleteProjectDocs(QuestionDoc.COLLECTION);
   }
 
   private async deleteProjectDocs(collection: string): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
@@ -147,6 +147,7 @@ export abstract class RealtimeDoc<T = any, Ops = any> {
     this.onDeleteSub.unsubscribe();
     await this.adapter.destroy();
     this.subscribedState = false;
+    await this.realtimeService.onLocalDocDispose(this);
   }
 
   protected prepareDataForStore(data: T): any {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
@@ -31,7 +31,12 @@ export abstract class RealtimeDoc<T = any, Ops = any> {
   constructor(protected readonly realtimeService: RealtimeService, public readonly adapter: RealtimeDocAdapter) {
     this._delete$ = merge(this.localDelete$, this.adapter.delete$);
     this.updateOfflineDataSub = merge(this.adapter.remoteChanges$, this.adapter.idle$, this.adapter.create$).subscribe(
-      () => this.updateOfflineData()
+      async () => {
+        if (this.subscribePromise != null) {
+          await this.subscribePromise;
+        }
+        this.updateOfflineData();
+      }
     );
     this.onDeleteSub = this.adapter.delete$.subscribe(() => this.onDelete());
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.ts
@@ -46,6 +46,10 @@ export class RealtimeService {
     return new RealtimeQuery<T>(this, this.remoteStore.createQueryAdapter(collection, parameters));
   }
 
+  isSet<T extends RealtimeDoc>(collection: string, id: string): boolean {
+    return this.docs.get(getDocKey(collection, id)) != null;
+  }
+
   /**
    * Gets the real-time doc with the specified id and subscribes to remote changes.
    *
@@ -139,10 +143,9 @@ export class RealtimeService {
   }
 
   async onLocalDocDispose(doc: RealtimeDoc): Promise<void> {
-    const key = getDocKey(doc.collection, doc.id);
-    if (this.docs.get(key) != null) {
+    if (this.isSet(doc.collection, doc.id)) {
       await this.offlineStore.delete(doc.collection, doc.id);
-      this.docs.delete(key);
+      this.docs.delete(getDocKey(doc.collection, doc.id));
     }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.ts
@@ -137,4 +137,12 @@ export class RealtimeService {
       await Promise.all(promises);
     }
   }
+
+  async onLocalDocDispose(doc: RealtimeDoc): Promise<void> {
+    const key = getDocKey(doc.collection, doc.id);
+    if (this.docs.get(key) != null) {
+      await this.offlineStore.delete(doc.collection, doc.id);
+      this.docs.delete(key);
+    }
+  }
 }


### PR DESCRIPTION
- Removed reliance on `questionQuery` being `ready` before questions docs are returned
- Add methods to load and unload text docs per project required for the checking app
- Disposing of a realtime doc will now remove its offline storage and remove it from the available collection

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/677)
<!-- Reviewable:end -->
