### PR TITLE
SF-932b Hide Paratext login while offline

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
@@ -17,7 +17,7 @@
       ></mdc-linear-progress>
     </mdc-card>
     <form *ngSwitchDefault [formGroup]="connectProjectForm" (ngSubmit)="submit()">
-      <ng-container *ngIf="projects?.length > 0; else noProjectMsg">
+      <ng-container *ngIf="projects?.length > 0 || state === 'offline'; else noProjectMsg">
         <p *ngIf="hasNonAdministratorProject && !showSettings && isAppOnline" id="connect-non-admin-msg">
           {{ t("only_paratext_admins_can_start") }}
         </p>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
@@ -48,14 +48,17 @@ describe('ConnectProjectComponent', () => {
     ]
   }));
 
-  it('should display login button when PT projects is null', () => {
+  it('should display login button when PT projects is null', fakeAsync(() => {
     const env = new TestEnvironment();
     when(mockedParatextService.getProjects()).thenReturn(of(undefined));
     env.fixture.detectChanges();
 
     expect(env.component.state).toEqual('login');
     expect(env.loginButton).not.toBeNull();
-  });
+    expect(env.loginButton.nativeElement.disabled).toBe(false);
+    env.onlineStatus = false;
+    expect(env.loginButton).toBeNull();
+  }));
 
   it('should display form when PT projects is empty', fakeAsync(() => {
     const env = new TestEnvironment();
@@ -178,8 +181,9 @@ describe('ConnectProjectComponent', () => {
     const env = new TestEnvironment(false);
     env.setupDefaultProjectData();
     env.fixture.detectChanges();
-    expect(env.component.state).toEqual('loading');
+    expect(env.component.state).toEqual('offline');
     expect(env.offlineMessage).not.toBeNull();
+    expect(env.noProjectsMessage).toBeNull();
     expect(env.component.connectProjectForm.disabled).toBe(true);
     expect(env.submitButton.nativeElement.disabled).toBe(true);
 
@@ -193,6 +197,7 @@ describe('ConnectProjectComponent', () => {
 
     env.onlineStatus = false;
     expect(env.nonAdminMessage).toBeNull();
+    expect(env.component.state).toEqual('offline');
   }));
 
   it('submit if user selects a source project then disables translation suggestions', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
@@ -5,7 +5,7 @@
     <mdc-card outlined class="sync-card">
       <div fxLayout="column" class="card-content">
         <button
-          *ngIf="!isLoggedIntoParatext && !isLoading && isAppOnline"
+          *ngIf="showParatextLogin && isAppOnline"
           class="action-button"
           mdc-button
           type="button"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
@@ -49,6 +49,9 @@ describe('SyncComponent', () => {
     expect(env.logInButton.nativeElement.textContent).toContain('Log in to Paratext');
     expect(env.syncButton).toBeNull();
     expect(env.lastSyncDate).toBeNull();
+    expect(env.logInButton.nativeElement.disabled).toBe(false);
+    env.onlineStatus = false;
+    expect(env.logInButton).toBeNull();
   }));
 
   it('should redirect the user to log in to paratext', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
@@ -19,6 +19,7 @@ import { SFProjectService } from '../core/sf-project.service';
 export class SyncComponent extends DataLoadingComponent implements OnInit, OnDestroy {
   syncActive: boolean = false;
   isAppOnline: boolean = false;
+  showParatextLogin = false;
 
   private projectDoc?: SFProjectDoc;
   private paratextUsername?: string;
@@ -85,6 +86,8 @@ export class SyncComponent extends DataLoadingComponent implements OnInit, OnDes
           if (username != null) {
             this.paratextUsername = username;
           }
+          // Explicit to prevent flashing the login button during page load
+          this.showParatextLogin = !this.isLoggedIntoParatext;
         });
       }
     });


### PR DESCRIPTION
* explicitly hide the Paratext login on the sync component until
* the user is online and can make a request to the paratext server