### PR TITLE
SF-957 Disable training segment if suggestions is disabled

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -285,7 +285,9 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
     if (this.projectUserConfigDoc != null && this.projectUserConfigDoc.data != null) {
       const activeQuestionDoc = this.activeQuestionDoc;
       if (activeQuestionDoc != null && activeQuestionDoc.data != null) {
-        await this.projectService.trainSelectedSegment(this.projectUserConfigDoc.data);
+        if (this.project != null && this.project.translateConfig.translationSuggestionsEnabled) {
+          await this.projectService.trainSelectedSegment(this.projectUserConfigDoc.data);
+        }
         await this.projectUserConfigDoc.submitJson0Op(op => {
           op.set<string>(puc => puc.selectedTask!, 'checking');
           op.set(puc => puc.selectedQuestionRef!, activeQuestionDoc.id);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -439,11 +439,15 @@ describe('CheckingComponent', () => {
       const projectUserConfigDoc = env.component.projectUserConfigDoc!.data!;
       verify(mockedProjectService.trainSelectedSegment(anything())).once();
       expect(projectUserConfigDoc.selectedQuestionRef).toBe('project01:q5Id');
+      env.component.projectDoc!.submitJson0Op(op => {
+        op.set<boolean>(p => p.translateConfig.translationSuggestionsEnabled, false);
+      });
+      env.waitForSliderUpdate();
       env.selectQuestion(4);
       expect(projectUserConfigDoc.selectedTask).toBe('checking');
       expect(projectUserConfigDoc.selectedQuestionRef).toBe('project01:q4Id');
       expect(projectUserConfigDoc.selectedBookNum).toBe(43);
-      verify(mockedProjectService.trainSelectedSegment(anything())).twice();
+      verify(mockedProjectService.trainSelectedSegment(anything())).once();
     }));
 
     it('saves the last visited question in all question context', fakeAsync(() => {
@@ -1298,7 +1302,7 @@ class TestEnvironment {
       shareLevel: CheckingShareLevel.Anyone
     },
     translateConfig: {
-      translationSuggestionsEnabled: false
+      translationSuggestionsEnabled: true
     },
     texts: [
       {


### PR DESCRIPTION
The bug occurs when a project initially had a source project, and later the project has translation suggestions disabled. When the user navigates to the checking app, we tried to train the most recently edited segment, but since the translation engine was not operational, the translation engine request returned an HttpErrorResponse.
This doesn't happen on project that has never had a source because with no source text, the request is never made.
Another solution to consider is to remove all the source text docs if we disable translation suggestions, but I wasn't sure we wanted to do that.