### PR TITLE
SF-939b Fix translate suggestions dialog when going offline

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
@@ -5,18 +5,17 @@
         <mdc-dialog-title>{{ t("translation_suggestions_settings") }}</mdc-dialog-title>
         <mdc-dialog-content class="content-padding" fxLayout="column" fxLayoutGap="25px">
           <div class="offline-text" *ngIf="!pwaService.isOnline">{{ t("settings_not_available_offline") }}</div>
-          <mdc-form-field>
+          <mdc-form-field [formGroup]="suggestionsSwitchFormGroup">
             <mdc-switch
               id="suggestions-enabled-switch"
               *ngIf="open"
-              [(ngModel)]="translationSuggestionsUserEnabled"
-              [disabled]="!pwaService.isOnline"
+              formControlName="suggestionsEnabledSwitch"
             ></mdc-switch>
             <label class="switch-label">{{ t("translation_suggestions") }}</label>
           </mdc-form-field>
           <mdc-select
             id="num-suggestions-select"
-            [disabled]="settingsEnabled"
+            [disabled]="settingsDisabled"
             [(ngModel)]="numSuggestions"
             placeholder="{{ t('number_of_suggestions') }}"
           >
@@ -30,7 +29,7 @@
             </div>
             <mdc-slider
               #confidenceThresholdSlider
-              [disabled]="settingsEnabled"
+              [disabled]="settingsDisabled"
               [min]="0"
               [max]="100"
               [(ngModel)]="confidenceThreshold"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
@@ -88,6 +88,15 @@ describe('SuggestionsSettingsDialogComponent', () => {
     expect(env.confidenceThresholdSlider.disabled).toBe(true);
     expect(env.numSuggestionsSelect.disabled).toBe(true);
   }));
+
+  it('the suggestions toggle is switched on when the dialog opens while offline', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.isOnline = false;
+    env.openDialog();
+
+    expect(env.suggestionsEnabledSwitch.disabled).toBe(true);
+    expect(env.suggestionsEnabledSwitch.checked).toBe(true);
+  }));
 });
 
 @Directive({
@@ -138,6 +147,7 @@ class TestEnvironment {
     this.overlayContainerElement = TestBed.get(OverlayContainer).getContainerElement();
 
     when(mockedPwaService.isOnline).thenCall(() => this.onlineStatus.getValue());
+    when(mockedPwaService.onlineStatus).thenReturn(this.onlineStatus.asObservable());
   }
 
   get confidenceThresholdSlider(): MdcSlider {


### PR DESCRIPTION
Previously, when opening the dialog while offline, the toggle switch remained off even when it should be on, due to being disabled.

Before | After
-------|------
![](https://user-images.githubusercontent.com/6140710/83933836-1cd82f00-a77a-11ea-92b1-25ef6bc0d8fb.png) | ![](https://user-images.githubusercontent.com/6140710/83933886-89ebc480-a77a-11ea-9d7e-42d1eae5aa2e.png)


Also fixed the issue with the slider:

![](https://user-images.githubusercontent.com/6140710/83933837-1d70c580-a77a-11ea-9de4-e74905925c31.png)

(This problem occurs when we go offline, the message is shown, causing the dialog to become wider, and messing up the layout of the slider).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/682)
<!-- Reviewable:end -->
