### PR TITLE
hotfix: handle when syncUser is missing

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
@@ -212,14 +212,10 @@ namespace SIL.XForge.Scripture.Services
             bool isParatextUser = paratextUsername != null;
 
             SyncUser syncUser;
-            if (syncUserRef != null)
+            // check if comment has already been synced before
+            if (syncUserRef == null || !_idToSyncUser.TryGetValue(syncUserRef, out syncUser))
             {
-                // comment has already been synced before so lookup the PT username
-                syncUser = _idToSyncUser[syncUserRef];
-            }
-            else
-            {
-                // the comment has never been synced before
+                // the comment has never been synced before (or syncUser is missing)
                 // if the owner is not a PT user, then use the current user's PT username
                 if (paratextUsername == null)
                     paratextUsername = _currentParatextUsername;


### PR DESCRIPTION
* handle the case when a syncUser is missing, possibly due to a crashed sync (NewSyncUsers are only updated at the end of a successful sync)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/687)
<!-- Reviewable:end -->
