### PR TITLE
Assign comment to project admin user if checker not on PT project

### DIFF
--- a/src/SIL.XForge.Scripture/Services/IParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextNotesMapper.cs
@@ -11,7 +11,8 @@ namespace SIL.XForge.Scripture.Services
     {
         List<SyncUser> NewSyncUsers { get; }
 
-        void Init(UserSecret currentUserSecret, SFProjectSecret projectSecret);
+        Task InitAsync(UserSecret currentUserSecret, SFProjectSecret projectSecret, List<User> ptUsers,
+            string paratextProjectId);
         Task<XElement> GetNotesChangelistAsync(XElement oldNotesElem, IEnumerable<IDocument<Question>> questionsDocs);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
@@ -31,6 +31,7 @@ namespace SIL.XForge.Scripture.Services
         private UserSecret _currentUserSecret;
         private string _currentParatextUsername;
         private SFProjectSecret _projectSecret;
+        private List<string> _ptProjectUsers;
 
         public ParatextNotesMapper(IRepository<UserSecret> userSecrets, IParatextService paratextService)
         {
@@ -40,7 +41,8 @@ namespace SIL.XForge.Scripture.Services
 
         public List<SyncUser> NewSyncUsers { get; } = new List<SyncUser>();
 
-        public void Init(UserSecret currentUserSecret, SFProjectSecret projectSecret)
+        public async Task InitAsync(UserSecret currentUserSecret, SFProjectSecret projectSecret, List<User> ptUsers,
+            string paratextProjectId)
         {
             _currentUserSecret = currentUserSecret;
             _currentParatextUsername = _paratextService.GetParatextUsername(currentUserSecret);
@@ -51,6 +53,14 @@ namespace SIL.XForge.Scripture.Services
             {
                 _idToSyncUser[syncUser.Id] = syncUser;
                 _usernameToSyncUser[syncUser.ParatextUsername] = syncUser;
+            }
+            _ptProjectUsers = new List<string>();
+            var roles = await _paratextService.GetProjectRolesAsync(currentUserSecret, paratextProjectId);
+            foreach (User user in ptUsers)
+            {
+                // Populate the list with all Paratext users belonging to the project
+                if (roles.TryGetValue(user.ParatextId, out string role))
+                    _ptProjectUsers.Add(user.Id);
             }
         }
 
@@ -142,13 +152,13 @@ namespace SIL.XForge.Scripture.Services
         private async Task<string> AddCommentIfChangedAsync(Dictionary<string, XElement> oldCommentElems,
             XElement threadElem, Comment comment, IReadOnlyList<object> prefixContent = null)
         {
-            (string syncUserId, string user, bool isParatextUser) = await GetSyncUserAsync(comment.SyncUserRef,
+            (string syncUserId, string user, bool isParatextUserOnProject) = await GetSyncUserAsync(comment.SyncUserRef,
                 comment.OwnerRef);
 
             var commentElem = new XElement("comment");
             commentElem.Add(new XAttribute("user", user));
-            // if the user isn't a PT user, then set external user id
-            if (!isParatextUser)
+            // if the user is not a Paratext user on the project, then set external user id
+            if (!isParatextUserOnProject)
                 commentElem.Add(new XAttribute("extUser", comment.OwnerRef));
             commentElem.Add(new XAttribute("date", comment.DateCreated.ToString("o").Replace("Z", "+00:00")));
             var contentElem = new XElement("content");
@@ -196,27 +206,34 @@ namespace SIL.XForge.Scripture.Services
         /// <summary>
         /// Gets the Paratext user for a comment from the specified sync user id and owner id.
         /// </summary>
-        private async Task<(string SyncUserId, string ParatextUsername, bool IsParatextUser)> GetSyncUserAsync(
+        private async Task<(string SyncUserId, string ParatextUsername, bool isParatextUserOnProject)> GetSyncUserAsync(
             string syncUserRef, string ownerRef)
         {
             // if the owner is a PT user, then get the PT username
             if (!_userIdToUsername.TryGetValue(ownerRef, out string paratextUsername))
             {
-                Attempt<UserSecret> attempt = await _userSecrets.TryGetAsync(ownerRef);
-                if (attempt.TryResult(out UserSecret userSecret))
-                    paratextUsername = _paratextService.GetParatextUsername(userSecret);
-                // cache the results
-                _userIdToUsername[ownerRef] = paratextUsername;
+                if (_ptProjectUsers.Any(pu => pu == ownerRef))
+                {
+                    Attempt<UserSecret> attempt = await _userSecrets.TryGetAsync(ownerRef);
+                    if (attempt.TryResult(out UserSecret userSecret))
+                        paratextUsername = _paratextService.GetParatextUsername(userSecret);
+                    // cache the results
+                    _userIdToUsername[ownerRef] = paratextUsername;
+                }
+                else
+                {
+                    paratextUsername = null;
+                }
             }
 
-            bool isParatextUser = paratextUsername != null;
+            bool isParatextUserOnProject = paratextUsername != null;
 
             SyncUser syncUser;
             // check if comment has already been synced before
             if (syncUserRef == null || !_idToSyncUser.TryGetValue(syncUserRef, out syncUser))
             {
                 // the comment has never been synced before (or syncUser is missing)
-                // if the owner is not a PT user, then use the current user's PT username
+                // if the owner is not a PT user on the project, then use the current user's PT username
                 if (paratextUsername == null)
                     paratextUsername = _currentParatextUsername;
                 if (!_usernameToSyncUser.TryGetValue(paratextUsername, out syncUser))
@@ -233,7 +250,7 @@ namespace SIL.XForge.Scripture.Services
                     NewSyncUsers.Add(syncUser);
                 }
             }
-            return (syncUser.Id, syncUser.ParatextUsername, isParatextUser);
+            return (syncUser.Id, syncUser.ParatextUsername, isParatextUserOnProject);
         }
 
         private bool IsCommentNewOrChanged(Dictionary<string, XElement> oldCommentElems, string key,

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -214,7 +214,10 @@ namespace SIL.XForge.Scripture.Services
             if (!(await _userSecrets.TryGetAsync(userId)).TryResult(out _userSecret))
                 return false;
 
-            _notesMapper.Init(_userSecret, _projectSecret);
+            List<User> paratextUsers = await _realtimeService.QuerySnapshots<User>()
+                .Where(u => _projectDoc.Data.UserRoles.Keys.Contains(u.Id) && u.ParatextId != null)
+                .ToListAsync();
+            await _notesMapper.InitAsync(_userSecret, _projectSecret, paratextUsers, _projectDoc.Data.ParatextId);
 
             await _projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.Sync.PercentCompleted, 0));
 

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
@@ -110,6 +110,11 @@ namespace SIL.XForge.Scripture.Services
                 XElement notesElem = await env.Mapper.GetNotesChangelistAsync(XElement.Parse(oldNotesText),
                     await env.GetQuestionDocsAsync(conn));
 
+                // User 3 is a PT user but does not have a role on this particular PT project, according to the PT
+                // Registry. So we will attribute their comment to user 1, who does have a role on this project
+                // according to the PT registry. Otherwise we would get errors when uploading a note attributed to user
+                // 3's PT username since they do not have appropriate access to write a note. Also, NewSyncUsers will
+                // not contain user 3.
                 const string expectedNotesText = @"
                     <notes version=""1.1"">
                         <thread id=""ANSWER_answer01"">
@@ -327,7 +332,8 @@ namespace SIL.XForge.Scripture.Services
 
             public async Task InitMapperAsync(bool includeSyncUsers, bool twoPtUsersOnProject)
             {
-                await Mapper.InitAsync(UserSecrets.Get("user01"), ProjectSecret(includeSyncUsers), ParatextUsersOnProject(twoPtUsersOnProject), "paratextId");
+                await Mapper.InitAsync(UserSecrets.Get("user01"), ProjectSecret(includeSyncUsers),
+                    ParatextUsersOnProject(twoPtUsersOnProject), "paratextId");
             }
 
             public void AddData(string answerSyncUserId1, string answerSyncUserId2, string commentSyncUserId1,

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
@@ -20,7 +20,8 @@ namespace SIL.XForge.Scripture.Services
         public async Task GetNotesChangelistAsync_AddNotes()
         {
             var env = new TestEnvironment();
-            env.InitMapper(false);
+            env.SetParatextProjectRoles(true);
+            await env.InitMapperAsync(false, true);
             env.AddData(null, null, null, null);
 
             using (IConnection conn = await env.RealtimeService.ConnectAsync())
@@ -85,10 +86,80 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
+        public async Task GetNotesChangelistAsync_ParatextUserNotOnProject_AddNotes()
+        {
+            var env = new TestEnvironment();
+            env.SetParatextProjectRoles(false);
+            await env.InitMapperAsync(false, true);
+            env.AddData(null, null, null, null);
+
+            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            {
+                const string oldNotesText = @"
+                    <notes version=""1.1"">
+                        <thread id=""ANSWER_answer03"">
+                            <selection verseRef=""MAT 1:2"" startPos=""0"" selectedText="""" />
+                            <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-03T08:00:00.0000000+00:00"">
+                                <content>
+                                    <p><span style=""bold"">Test question?</span></p>
+                                    <p>Test answer 3.</p>
+                                </content>
+                            </comment>
+                        </thread>
+                    </notes>";
+                XElement notesElem = await env.Mapper.GetNotesChangelistAsync(XElement.Parse(oldNotesText),
+                    await env.GetQuestionDocsAsync(conn));
+
+                const string expectedNotesText = @"
+                    <notes version=""1.1"">
+                        <thread id=""ANSWER_answer01"">
+                            <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
+                            <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-01T08:00:00.0000000+00:00"">
+                                <content>
+                                    <p><span style=""bold"">Test question?</span></p>
+                                    <p>Test answer 1.</p>
+                                </content>
+                            </comment>
+                            <comment user=""PT User 1"" extUser=""user03"" date=""2019-01-01T09:00:00.0000000+00:00"">
+                                <content>Test comment 1.</content>
+                            </comment>
+                        </thread>
+                        <thread id=""ANSWER_answer02"">
+                            <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
+                            <comment user=""PT User 1"" extUser=""user04"" date=""2019-01-02T08:00:00.0000000+00:00"">
+                                <content>
+                                    <p><span style=""bold"">Test question?</span></p>
+                                    <p><span style=""italic"">This is some scripture. (MAT 1:2-3)</span></p>
+                                    <p>Test answer 2.</p>
+                                </content>
+                            </comment>
+                            <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-02T09:00:00.0000000+00:00"">
+                                <content>Test comment 2.</content>
+                            </comment>
+                        </thread>
+                        <thread id=""ANSWER_answer03"">
+                            <selection verseRef=""MAT 1:2"" startPos=""0"" selectedText="""" />
+                            <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-03T08:00:00.0000000+00:00"" deleted=""true"">
+                                <content>
+                                    <p><span style=""bold"">Test question?</span></p>
+                                    <p>Test answer 3.</p>
+                                </content>
+                            </comment>
+                        </thread>
+                    </notes>";
+                Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
+
+                Assert.That(env.Mapper.NewSyncUsers.Select(su => su.ParatextUsername),
+                    Is.EquivalentTo(new[] { "PT User 1" }));
+            }
+        }
+
+        [Test]
         public async Task GetNotesChangelistAsync_UpdateNotes()
         {
             var env = new TestEnvironment();
-            env.InitMapper(true);
+            env.SetParatextProjectRoles(true);
+            await env.InitMapperAsync(true, true);
             env.AddData("syncuser01", "syncuser03", null, "syncuser03");
 
             using (IConnection conn = await env.RealtimeService.ConnectAsync())
@@ -152,7 +223,8 @@ namespace SIL.XForge.Scripture.Services
         public async Task GetNotesChangelistAsync_DeleteNotes()
         {
             var env = new TestEnvironment();
-            env.InitMapper(true);
+            env.SetParatextProjectRoles(true);
+            await env.InitMapperAsync(true, true);
             env.AddData("syncuser01", "syncuser03", "syncuser03", "syncuser03");
 
             using (IConnection conn = await env.RealtimeService.ConnectAsync())
@@ -242,19 +314,20 @@ namespace SIL.XForge.Scripture.Services
 
                 RealtimeService = new SFMemoryRealtimeService();
 
-                var paratextService = Substitute.For<IParatextService>();
-                paratextService.GetParatextUsername(Arg.Is<UserSecret>(u => u.Id == "user01")).Returns("PT User 1");
-                paratextService.GetParatextUsername(Arg.Is<UserSecret>(u => u.Id == "user03")).Returns("PT User 3");
-                Mapper = new ParatextNotesMapper(UserSecrets, paratextService);
+                ParatextService = Substitute.For<IParatextService>();
+                ParatextService.GetParatextUsername(Arg.Is<UserSecret>(u => u.Id == "user01")).Returns("PT User 1");
+                ParatextService.GetParatextUsername(Arg.Is<UserSecret>(u => u.Id == "user03")).Returns("PT User 3");
+                Mapper = new ParatextNotesMapper(UserSecrets, ParatextService);
             }
 
             public ParatextNotesMapper Mapper { get; }
             public MemoryRepository<UserSecret> UserSecrets { get; }
             public SFMemoryRealtimeService RealtimeService { get; }
+            public IParatextService ParatextService { get; }
 
-            public void InitMapper(bool includeSyncUsers)
+            public async Task InitMapperAsync(bool includeSyncUsers, bool twoPtUsersOnProject)
             {
-                Mapper.Init(UserSecrets.Get("user01"), ProjectSecret(includeSyncUsers));
+                await Mapper.InitAsync(UserSecrets.Get("user01"), ProjectSecret(includeSyncUsers), ParatextUsersOnProject(twoPtUsersOnProject), "paratextId");
             }
 
             public void AddData(string answerSyncUserId1, string answerSyncUserId2, string commentSyncUserId1,
@@ -321,6 +394,15 @@ namespace SIL.XForge.Scripture.Services
                 return new[] { questionDoc };
             }
 
+            public void SetParatextProjectRoles(bool twoPtUserOnProject)
+            {
+                Dictionary<string, string> ptUserRoles = new Dictionary<string, string>();
+                ptUserRoles["ptuser01"] = "pt_administrator";
+                if (twoPtUserOnProject)
+                    ptUserRoles["ptuser03"] = "pt_translator";
+                ParatextService.GetProjectRolesAsync(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(ptUserRoles);
+            }
+
             private static SFProjectSecret ProjectSecret(bool includeSyncUsers)
             {
                 var syncUsers = new List<SyncUser>();
@@ -335,6 +417,17 @@ namespace SIL.XForge.Scripture.Services
                     Id = "project01",
                     SyncUsers = syncUsers.ToList()
                 };
+            }
+
+            private static List<User> ParatextUsersOnProject(bool twoPtUsersOnProject)
+            {
+                var ptUsers = new List<User>
+                {
+                    new User { Id = "user01", ParatextId = "ptuser01" }
+                };
+                if (twoPtUsersOnProject)
+                    ptUsers.Add(new User { Id = "user03", ParatextId = "ptuser03" });
+                return ptUsers;
             }
         }
     }


### PR DESCRIPTION
If a Paratext user not belonging to a Paratext project works on the community checking app, the ParatextNotesMapper would assign comments to the Paratext user. Then the comment would get rejected when trying to send and receive because the user was not on the Paratext project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/688)
<!-- Reviewable:end -->
