### PR TITLE
SF-972 Log out all tabs when one tab logs out

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -71,8 +71,9 @@ export class AuthService {
   ) {
     // listen for changes to the auth state
     // this indicates that a user has logged in/out on a different tab/window
+    // when localStorage is cleared event.key is null
     this.localSettings.remoteChanges$
-      .pipe(filter(event => event.key === USER_ID_SETTING))
+      .pipe(filter(event => event.key === USER_ID_SETTING || event.key === null))
       .subscribe(() => this.locationService.go('/'));
 
     this.tryLogInPromise = this.tryLogIn();

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/local-settings.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/local-settings.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { fromEvent, Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { filter, map } from 'rxjs/operators';
 import { parseJSON } from './utils';
 
 export interface LocalSettingChangeEvent {
@@ -16,13 +16,15 @@ export class LocalSettingsService {
   readonly remoteChanges$: Observable<LocalSettingChangeEvent>;
 
   constructor() {
-    this.remoteChanges$ = fromEvent<StorageEvent>(window, 'storage').pipe(
-      map(evt => ({
-        key: evt.key,
-        oldValue: evt.oldValue != null ? parseJSON(evt.oldValue) : undefined,
-        newValue: evt.newValue != null ? parseJSON(evt.newValue) : undefined
-      }))
-    );
+    this.remoteChanges$ = fromEvent<StorageEvent>(window, 'storage')
+      .pipe(filter(evt => evt.storageArea === localStorage))
+      .pipe(
+        map(evt => ({
+          key: evt.key,
+          oldValue: evt.oldValue != null ? parseJSON(evt.oldValue) : undefined,
+          newValue: evt.newValue != null ? parseJSON(evt.newValue) : undefined
+        }))
+      );
   }
 
   get<T>(key: string): T | undefined {


### PR DESCRIPTION
Currently when one tab logs out, the others do nothing. That's because our code is looking for a change to the user_id stored in localStorage, but when we log out, localStorage is cleared all at once, and the event that is fired has the key set to null, rather than user_id.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/692)
<!-- Reviewable:end -->
