### PR TITLE
SF-974 Stop redirecting first tab when opening a second SF tab

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -166,9 +166,9 @@ export class AuthService {
         // In online mode do the normal checks with auth0
         let authResult = await this.parseHash();
         if (!(await this.handleOnlineAuth(authResult))) {
-          this.clearState();
           authResult = await this.checkSession();
           if (!(await this.handleOnlineAuth(authResult))) {
+            this.clearState();
             return { loggedIn: false, newlyLoggedIn: false };
           }
         } else {


### PR DESCRIPTION
The problem was that in the past, if the access token wasn't in the URL, we would clear auth data out of local storage before attempting to verify that the user is authenticated. This caused the other tab to think the user had been logged out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/693)
<!-- Reviewable:end -->
