### PR TITLE
Set shared project Permissions to custom with PT username

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -194,12 +194,14 @@ namespace SIL.XForge.Scripture.Services
             string username = GetParatextUsername(userSecret);
             // Specifically set the ScrText property of the SharedProject to indicate the project is available locally
             targetSharedProj.ScrText = ScrTextCollection.FindById(username, ptTargetId, Models.TextType.Target);
+            targetSharedProj.Permissions = targetSharedProj.ScrText.Permissions;
             List<SharedProject> sharedPtProjectsToSr = new List<SharedProject> { targetSharedProj };
             if (sourcePtProject != null)
             {
                 SharedProject sourceSharedProj = SharingLogicWrapper.CreateSharedProject(ptSourceId,
                     sourcePtProject.ShortName, source.AsInternetSharedRepositorySource(), repositories);
                 sourceSharedProj.ScrText = ScrTextCollection.FindById(username, ptTargetId, Models.TextType.Source);
+                sourceSharedProj.Permissions = sourceSharedProj.ScrText.Permissions;
                 sharedPtProjectsToSr.Add(sourceSharedProj);
             }
 


### PR DESCRIPTION
The problem before this fix: `ParatextService SendReceiveAsync()` gets
to Paratext `SharingLogic Share1Project()` where it calls
`sharedProject.Permissions.GetUser()`. If the result is null,
`Share1Project` returns early and changes are never locally committed
to the hg repo or pushed.
`PermissionManager GetUser()` gets to `GetUserInternal()`, which gets
`string.Empty` from `RegistrationInfo.UserName` via
`GetDefaultUser()`. In the end we don't commit locally.

This fix: `MultiUserPermissionManager` overrides `GetDefaultUser()` to
return a desired PT username. `ParatextService SendReceiveAsync()`
now sets a shared project's .Permissions to such a custom
`MultiUserPermissionManager` so text changes are committed to the
local hg repo. It is just re-using the one in the SharedProject's
`ScrText.Permissions`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/699)
<!-- Reviewable:end -->
