### PR TITLE
SF-991 Close menus when they lose focus to navigation item

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/route.directive.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/route.directive.ts
@@ -35,7 +35,6 @@ export class RouterDirective {
   @HostListener('click', ['$event'])
   onClick(event: MouseEvent) {
     event.preventDefault();
-    event.stopPropagation();
     if (event.ctrlKey || event.metaKey) {
       this.window.open(this.url, '_blank', 'noopener');
     } else {
@@ -48,7 +47,6 @@ export class RouterDirective {
     // if it's the middle mouse button (but not an a tag, because preventDefault doesn't stop it from opening a new tab)
     if (event.which === 2 && !this.isLink) {
       event.preventDefault();
-      event.stopPropagation();
       this.window.open(this.url, '_blank', 'noopener');
     }
   }


### PR DESCRIPTION
Stopping event propagation was unnecessary and prevented menus from closing

This was broken in e7296f9460a169a6957853afc695d23a7f235c8e

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/706)
<!-- Reviewable:end -->
