### PR TITLE
SF-990 Redirect to translate app if checking app is disabled

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
@@ -107,6 +107,16 @@ describe('ProjectComponent', () => {
     expect().nothing();
   }));
 
+  it('if checking is disabled, navigate to translate app, even if last location was in checking app', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.setProjectData({ selectedTask: 'checking', selectedBooknum: 41, hasTexts: true, checkingEnabled: false });
+    env.fixture.detectChanges();
+    tick();
+
+    verify(mockedRouter.navigate(deepEqual(['./', 'translate', 'MAT']), anything())).once();
+    expect().nothing();
+  }));
+
   it('do not navigate when project does not exist', fakeAsync(() => {
     const env = new TestEnvironment();
     env.fixture.detectChanges();
@@ -218,7 +228,13 @@ class TestEnvironment {
   }
 
   setProjectData(
-    args: { hasTexts?: boolean; selectedTask?: string; selectedBooknum?: number; role?: SFProjectRole } = {}
+    args: {
+      hasTexts?: boolean;
+      selectedTask?: string;
+      selectedBooknum?: number;
+      role?: SFProjectRole;
+      checkingEnabled?: boolean;
+    } = {}
   ): void {
     this.realtimeService.addSnapshot<SFProjectUserConfig>(SFProjectUserConfigDoc.COLLECTION, {
       id: getSFProjectUserConfigDocId('project01', 'user01'),
@@ -251,7 +267,7 @@ class TestEnvironment {
           translationSuggestionsEnabled: false
         },
         checkingConfig: {
-          checkingEnabled: true,
+          checkingEnabled: args.checkingEnabled == null ? true : args.checkingEnabled,
           usersSeeEachOthersResponses: true,
           shareEnabled: true,
           shareLevel: CheckingShareLevel.Specific


### PR DESCRIPTION
Previously, if a user had last visited the checking app, and then checking was disabled, clicking on the Scripture Forge icon or clicking on "Project home" in the menu sent the user to a mostly blank page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/707)
<!-- Reviewable:end -->
