### PR TITLE
Capitalize RPC method names for consistency

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -42,7 +42,7 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
   }
 
   async onlineCreate(settings: SFProjectCreateSettings): Promise<string> {
-    return (await this.onlineInvoke<string>('create', { settings }))!;
+    return (await this.onlineInvoke<string>('Create', { settings }))!;
   }
 
   getUserConfig(id: string, userId: string): Promise<SFProjectUserConfigDoc> {
@@ -61,7 +61,7 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
   }
 
   onlineAddTranslateMetrics(id: string, metrics: TranslateMetrics): Promise<void> {
-    return this.onlineInvoke('addTranslateMetrics', { projectId: id, metrics });
+    return this.onlineInvoke('AddTranslateMetrics', { projectId: id, metrics });
   }
 
   getText(textId: TextDocId | string): Promise<TextDoc> {
@@ -92,34 +92,34 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
   }
 
   onlineSync(id: string): Promise<void> {
-    return this.onlineInvoke('sync', { projectId: id });
+    return this.onlineInvoke('Sync', { projectId: id });
   }
 
   onlineUpdateSettings(id: string, settings: SFProjectSettings): Promise<void> {
-    return this.onlineInvoke('updateSettings', { projectId: id, settings });
+    return this.onlineInvoke('UpdateSettings', { projectId: id, settings });
   }
 
   async onlineIsAlreadyInvited(id: string, email: string): Promise<boolean> {
-    return (await this.onlineInvoke<boolean>('isAlreadyInvited', { projectId: id, email }))!;
+    return (await this.onlineInvoke<boolean>('IsAlreadyInvited', { projectId: id, email }))!;
   }
 
   /** Get list of email addresses that have outstanding invitations on project.
    * Caller must be an admin on the project. */
   async onlineInvitedUsers(projectId: string): Promise<string[]> {
-    return (await this.onlineInvoke<string[]>('invitedUsers', { projectId }))!;
+    return (await this.onlineInvoke<string[]>('InvitedUsers', { projectId }))!;
   }
 
   /** Get added into project, with optionally specified shareKey code. */
   onlineCheckLinkSharing(id: string, shareKey?: string): Promise<void> {
-    return this.onlineInvoke('checkLinkSharing', { projectId: id, shareKey });
+    return this.onlineInvoke('CheckLinkSharing', { projectId: id, shareKey });
   }
 
   onlineInvite(id: string, email: string): Promise<string | undefined> {
-    return this.onlineInvoke('invite', { projectId: id, email });
+    return this.onlineInvoke('Invite', { projectId: id, email });
   }
 
   async onlineUninviteUser(projectId: string, emailToUninvite: string): Promise<string> {
-    return (await this.onlineInvoke<string>('uninviteUser', { projectId, emailToUninvite }))!;
+    return (await this.onlineInvoke<string>('UninviteUser', { projectId, emailToUninvite }))!;
   }
 
   async trainSelectedSegment(projectUserConfig: SFProjectUserConfig): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -137,7 +137,7 @@ export class AuthService {
 
   async updateInterfaceLanguage(language: string): Promise<void> {
     if (await this.isLoggedIn) {
-      await this.commandService.onlineInvoke(USERS_URL, 'updateInterfaceLanguage', { language });
+      await this.commandService.onlineInvoke(USERS_URL, 'UpdateInterfaceLanguage', { language });
     }
   }
 
@@ -192,10 +192,10 @@ export class AuthService {
     }
     this.scheduleRenewal();
     if (secondaryId != null) {
-      await this.commandService.onlineInvoke(USERS_URL, 'linkParatextAccount', { authId: secondaryId });
+      await this.commandService.onlineInvoke(USERS_URL, 'LinkParatextAccount', { authId: secondaryId });
     } else if (!environment.production) {
       try {
-        await this.commandService.onlineInvoke(USERS_URL, 'pullAuthUserProfile');
+        await this.commandService.onlineInvoke(USERS_URL, 'PullAuthUserProfile');
       } catch (err) {
         console.error(err);
         return false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.ts
@@ -44,7 +44,7 @@ export class CommandError extends Error {
 /**
  * This service is used to invoke JSON-RPC commands.
  *
- * @example commandService.onlineInvoke(url, 'method', { param1: 'value1', param2: 'value2' });
+ * @example commandService.onlineInvoke(url, 'Method', { param1: 'value1', param2: 'value2' });
  */
 @Injectable({
   providedIn: 'root'

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/project.service.ts
@@ -71,19 +71,19 @@ export abstract class ProjectService<
   }
 
   onlineAddCurrentUser(id: string, projectRole?: string): Promise<void> {
-    return this.onlineInvoke('addUser', { projectId: id, projectRole });
+    return this.onlineInvoke('AddUser', { projectId: id, projectRole });
   }
 
   onlineRemoveUser(id: string, userId: string): Promise<void> {
-    return this.onlineInvoke('removeUser', { projectId: id, projectUserId: userId });
+    return this.onlineInvoke('RemoveUser', { projectId: id, projectUserId: userId });
   }
 
   onlineUpdateCurrentUserRole(id: string, projectRole: string): Promise<void> {
-    return this.onlineInvoke('updateRole', { projectId: id, projectRole });
+    return this.onlineInvoke('UpdateRole', { projectId: id, projectRole });
   }
 
   onlineDelete(id: string): Promise<void> {
-    return this.onlineInvoke('delete', { projectId: id });
+    return this.onlineInvoke('Delete', { projectId: id });
   }
 
   async onlineUploadAudio(id: string, dataId: string, file: File): Promise<string> {
@@ -102,7 +102,7 @@ export abstract class ProjectService<
   }
 
   onlineDeleteAudio(id: string, dataId: string, ownerId: string): Promise<void> {
-    return this.onlineInvoke('deleteAudio', { projectId: id, ownerId, dataId });
+    return this.onlineInvoke('DeleteAudio', { projectId: id, ownerId, dataId });
   }
 
   protected onlineInvoke<T>(method: string, params?: any): Promise<T | undefined> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
@@ -60,7 +60,7 @@ export class UserService {
   }
 
   async onlineDelete(id: string): Promise<void> {
-    await this.onlineInvoke('delete', { userId: id });
+    await this.onlineInvoke('Delete', { userId: id });
   }
 
   onlineQuery(


### PR DESCRIPTION
RPC method names should be case insensitive, but due to a bug in JsonRpc.Router it's currently case sensitive for some method names and some locales. A fix has been submitted at https://github.com/edjCase/JsonRpc/pull/80, but it's likely to take some time  to have the fix merged. In the mean time, there's no real reason for the front end to have different capitalization than the back end.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/719)
<!-- Reviewable:end -->
