### PR TITLE
Include method name in JsonRpc error message

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.ts
@@ -64,7 +64,8 @@ export class CommandService {
       .post<JsonRpcResponse<T>>(url, request, { headers: { 'Content-Type': 'application/json' } })
       .toPromise();
     if (response.error != null) {
-      throw new CommandError(response.error.code, response.error.message, response.error.data);
+      const message = `Error invoking ${method}: ${response.error.message}`;
+      throw new CommandError(response.error.code, message, response.error.data);
     }
     return response.result;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
@@ -55,7 +55,23 @@ describe('ExceptionHandlingService', () => {
 
   it('should not crash on anything', async () => {
     const env = new TestEnvironment();
-    const values = [undefined, null, NaN, Infinity, -1, 0, Symbol(), [] as any[], '', new Error()];
+    const values = [
+      undefined,
+      null,
+      NaN,
+      true,
+      false,
+      Infinity,
+      -1,
+      0,
+      Symbol(),
+      [],
+      '',
+      '\0',
+      new Error(),
+      () => {},
+      BigInt(3)
+    ];
     await Promise.all(values.map(value => env.service.handleError(value)));
     expect(env.errorReports.length).toBe(values.length);
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
@@ -51,6 +51,7 @@ export class ExceptionHandlingService implements ErrorHandler {
     }
 
     if (typeof error !== 'object' || error === null || Array.isArray(error)) {
+      // using String(value) rather than plain string concatenation, because concatenating a symbol throws an error
       error = new Error('Unknown error: ' + String(error));
     }
 


### PR DESCRIPTION
- Including the name of the method that failed in the error message should help when it comes to interpreting Bugsnag events and support requests from users. Previously messages such as "Exception occurred from target method execution" and "No methods matched request" have been unhelpfully ambiguous.
- Also made the tests for the exception handling service slightly more robust.

Note:
BigInt was included in the tests because I was trying to cover all primitive types, and it's a new primitive in ECMAScript 2020. It's not really that important; it was added for good measure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/726)
<!-- Reviewable:end -->
