### PR TITLE
Include event ID in error dialog under details

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -219,6 +219,7 @@
   "error": {
     "chrome": "Chrome",
     "close": "Close",
+    "error_id": "Error ID: {{ errorId }}",
     "error_occurred": "An error has occurred",
     "firefox": "Firefox",
     "hide_details": "Hide details",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.html
@@ -10,6 +10,7 @@
           <a (click)="this.showDetails = !this.showDetails" [fxShow]="data.stack">{{
             showDetails ? t("hide_details") : t("show_details")
           }}</a>
+          <p [fxShow]="showDetails">{{ t("error_id", { errorId: data.eventId }) }}</p>
           <pre [fxShow]="showDetails">{{ data.stack }}</pre>
         </mdc-dialog-content>
         <mdc-dialog-actions>


### PR DESCRIPTION
This should help us cross reference errors the testers report with events in Bugsnag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/729)
<!-- Reviewable:end -->
