### PR TITLE
SF-963 Inform user when audio is unavailable

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-combined/checking-audio-combined.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-combined/checking-audio-combined.component.spec.ts
@@ -5,6 +5,7 @@ import { ngfModule } from 'angular-file';
 import { mock, when } from 'ts-mockito';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
+import { PwaService } from 'xforge-common/pwa.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule, getAudioBlob, TestTranslocoModule } from 'xforge-common/test-utils';
@@ -17,6 +18,7 @@ import { CheckingAudioCombinedComponent } from './checking-audio-combined.compon
 
 const mockedUserService = mock(UserService);
 const mockedNoticeService = mock(NoticeService);
+const mockedPwaService = mock(PwaService);
 
 describe('CheckingAudioCombinedComponent', () => {
   configureTestingModule(() => ({
@@ -29,7 +31,8 @@ describe('CheckingAudioCombinedComponent', () => {
     imports: [UICommonModule, ngfModule, TestTranslocoModule, TestRealtimeModule.forRoot(SF_TYPE_REGISTRY)],
     providers: [
       { provide: UserService, useMock: mockedUserService },
-      { provide: NoticeService, useMock: mockedNoticeService }
+      { provide: NoticeService, useMock: mockedNoticeService },
+      { provide: PwaService, useMock: mockedPwaService }
     ]
   }));
 
@@ -98,6 +101,7 @@ class TestEnvironment {
     when(mockedUserService.getCurrentUser()).thenCall(() =>
       this.realtimeService.subscribe(UserDoc.COLLECTION, 'user01')
     );
+    when(mockedPwaService.isOnline).thenReturn(true);
     this.fixture.detectChanges();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.html
@@ -1,7 +1,20 @@
-<div *ngIf="hasSource" class="player">
-  <button *ngIf="!isPlaying" mdc-icon-button icon="play_arrow" type="button" (click)="play()" class="play"></button>
-  <button *ngIf="isPlaying" mdc-icon-button icon="pause" type="button" (click)="pause()" class="pause"></button>
-  <div class="current-time">{{ currentTime | audioTime }}</div>
-  <mdc-slider class="slider" min="0" max="100" step="1" [value]="seek" (input)="seeking($event)"></mdc-slider>
-  <div class="duration">{{ duration | audioTime }}</div>
-</div>
+<ng-container *transloco="let t; read: 'checking_audio_player'">
+  <div *ngIf="hasSource" class="player">
+    <button *ngIf="!isPlaying" mdc-icon-button icon="play_arrow" type="button" (click)="play()" class="play"></button>
+    <button *ngIf="isPlaying" mdc-icon-button icon="pause" type="button" (click)="pause()" class="pause"></button>
+    <div class="current-time" [fxShow]="isAudioAvailable">{{ currentTime | audioTime }}</div>
+    <mdc-slider
+      [fxShow]="isAudioAvailable"
+      class="slider"
+      min="0"
+      max="100"
+      step="1"
+      [value]="seek"
+      (input)="seeking($event)"
+    ></mdc-slider>
+    <div *ngIf="!isAudioAvailable" class="audio-not-available">
+      <mdc-icon>warning</mdc-icon> {{ t("audio_cannot_be_played") }}
+    </div>
+    <div class="duration" [fxShow]="isAudioAvailable">{{ duration | audioTime }}</div>
+  </div>
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.scss
@@ -14,4 +14,12 @@
     flex: 1;
     width: 100%;
   }
+  .audio-not-available {
+    width: 100%;
+    text-align: center;
+    mdc-icon {
+      height: 1.25em;
+      vertical-align: middle;
+    }
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -180,6 +180,9 @@
     "upload_audio_file": "Upload Audio File",
     "upload": "Upload"
   },
+  "checking_audio_player": {
+    "audio_cannot_be_played": "This audio cannot be played while you are offline. Connect to the internet to play this audio."
+  },
   "checking_audio_recorder": {
     "mic_access_denied": "Access to your microphone was denied. Please enable the microphone from your browser.",
     "record": "Record",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
@@ -18,20 +18,21 @@ import { SubscriptionDisposable } from './subscription-disposable';
 import { TypeRegistry } from './type-registry';
 import { COMMAND_API_NAMESPACE, PROJECTS_URL } from './url-constants';
 
-// Urls containing this prefix are local blob not yet been uploaded to the server e.g. blob:https://scriptureforge...
-const LOCAL_BLOB_PREFIX = 'blob:';
-
 /**
  * Formats the name of a file stored on the server into a URL that a http client can use to request the data.
  */
 export function formatFileSource(fileType: FileType, source: string): string {
-  if (!source.startsWith(LOCAL_BLOB_PREFIX)) {
+  if (!isLocalBlobUrl(source)) {
     if (source.startsWith('/')) {
       source = source.substring(1);
     }
     source = `${environment.assets}${fileType}/${source}`;
   }
   return source;
+}
+
+export function isLocalBlobUrl(url: string): boolean {
+  return url.startsWith('blob:');
 }
 
 /**
@@ -156,7 +157,7 @@ export class FileService extends SubscriptionDisposable {
       return undefined;
     } else {
       // The cache needs to be updated if no file exists or the onlineUrl does not match a valid request url.
-      const notYetUploaded = url.startsWith(LOCAL_BLOB_PREFIX);
+      const notYetUploaded = isLocalBlobUrl(url);
       if (!this.pwaService.isOnline || notYetUploaded) {
         return fileData;
       }


### PR DESCRIPTION
Here's how it looks now:
![](https://user-images.githubusercontent.com/6140710/88120728-a0ff3e00-cb91-11ea-85c6-9f6501e35fb9.png)

This should be shown when the audio is not stored offline, and the user is offline, and the audio data wasn't already loaded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/732)
<!-- Reviewable:end -->
