### PR TITLE
SF-1012 Fix padding of icons in navigation panel

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -32,7 +32,7 @@
         fill: $purpleLight;
       }
     }
-    mdc-icon {
+    mdc-icon:first-child {
       color: $purpleMedium;
       fill: $purpleMedium;
       transition: color 0.15s;


### PR DESCRIPTION
This was broken in 6aed2d79acb503b601eea9d583dff0f7f3a9d5be and caused Azerbaijani text to be cut off due to space constraints.

Before | After
-------|------
![](https://user-images.githubusercontent.com/6140710/88197225-29242880-cc10-11ea-8c51-03448bc5c611.png) | ![](https://user-images.githubusercontent.com/6140710/88197231-2aedec00-cc10-11ea-97f2-85c24ceb7617.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/733)
<!-- Reviewable:end -->
