### PR TITLE
SF-1012b Fix highlighting of icons in navigation panel

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -32,10 +32,12 @@
         fill: $purpleLight;
       }
     }
-    mdc-icon:first-child {
+    mdc-icon {
       color: $purpleMedium;
       fill: $purpleMedium;
       transition: color 0.15s;
+    }
+    mdc-icon:first-child {
       margin-right: 24px;
       &.ngx-mdc-icon {
         width: 24px;


### PR DESCRIPTION
This was broken in ba0b7dc50240f3d5ab02656f5f7824481d4be3e2.

#722 (original) | #733 (first fix) | fix/sf-1012b (this PR)
----------------|------------------|-----------------------
![](https://user-images.githubusercontent.com/6140710/88246714-4f29e700-cc69-11ea-9968-01148a1790b8.png) | ![](https://user-images.githubusercontent.com/6140710/88246716-505b1400-cc69-11ea-8372-7f9ca6a16602.png) | ![](https://user-images.githubusercontent.com/6140710/88246748-708ad300-cc69-11ea-8e05-ec87d52eaeaa.png)

@irahopkinson I'd appreciate it if you'd double-check my work locally, given my apparent inability to notice UI changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/736)
<!-- Reviewable:end -->
