### PR TITLE
Improve key generation in SecurityService

### DIFF
--- a/src/SIL.XForge/Services/SecurityService.cs
+++ b/src/SIL.XForge/Services/SecurityService.cs
@@ -1,28 +1,20 @@
 using System.Security.Cryptography;
-using System.Text;
+using Microsoft.AspNetCore.WebUtilities;
 
 namespace SIL.XForge.Services
 {
     /// <summary>Security related utilities</summary>
     public class SecurityService : ISecurityService
     {
-        /// <summary>Return a random 16-character base-36 string.</summary>
+        /// <summary>Return a random 16-character base-64 string that is safe to use in URLs.</summary>
         public string GenerateKey()
         {
-            char[] chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890".ToCharArray();
-            byte[] data = new byte[1];
-            using (var crypto = new RNGCryptoServiceProvider())
+            byte[] data = new byte[12];  // 12 bytes of data become 16 bytes of base-64 text
+            using (var crypto = RandomNumberGenerator.Create())
             {
-                crypto.GetNonZeroBytes(data);
-                data = new byte[16];
-                crypto.GetNonZeroBytes(data);
+                crypto.GetBytes(data);
             }
-            var key = new StringBuilder(16);
-            foreach (byte b in data)
-            {
-                key.Append(chars[b % (chars.Length)]);
-            }
-            return key.ToString();
+            return WebEncoders.Base64UrlEncode(data);
         }
     }
 }

--- a/src/SIL.XForge/Services/SecurityService.cs
+++ b/src/SIL.XForge/Services/SecurityService.cs
@@ -9,11 +9,8 @@ namespace SIL.XForge.Services
         /// <summary>Return a random 16-character base-64 string that is safe to use in URLs.</summary>
         public string GenerateKey()
         {
-            byte[] data = new byte[12];  // 12 bytes of data become 16 bytes of base-64 text
-            using (var crypto = RandomNumberGenerator.Create())
-            {
-                crypto.GetBytes(data);
-            }
+            System.Span<byte> data = stackalloc byte[12];  // 12 bytes of data become 16 bytes of base-64 text
+            RandomNumberGenerator.Fill(data);
             return WebEncoders.Base64UrlEncode(data);
         }
     }


### PR DESCRIPTION
Original implementation had several issues:

- Why throw away a byte of random data at the start? We could use 16 bytes of random data, not 17. Since it's coming from RNGCryptoServiceProvider, it's drawing on a presumably-limited entropy pool such as /dev/random on Linux, so if this gets called too often there might be slowdowns as the entropy pool waits to gather enough entropy to return the requested bytes.
- Why limit oneself to non-zero bytes here? GetBytes() would produce 256 possible values (8 true bits of entropy per byte) as opposed to GetNonZeroBytes's 255 values (only 7.9944 bits of entropy per byte).
- Why limit oneself to 62 possible characters instead of 64? Yes, these IDs are going to be used in URLs from time to time so Base64 is unsafe as it would produce strings containing + and /, but that's what Base64UrlEncode is for (the base64url alphabet uses - instead of + for 62 and _ instead of / for 63, so it's URL-safe) and that method is built into ASP.Net Core. Also, if we're base64 encoding to produce a 16-byte string, then we can just get 12 bytes of data from the RNGCryptoServiceProvider, which will produce exactly 16 bytes of base64url-encoded text, saving us 4 (or 5 once we get rid of the uselessly-consumed single byte) bytes of entropy from the server's entropy pool.
- https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.randomnumbergenerator?view=netcore-3.1 says "To create a random number generator, call the Create() method. This is preferred over calling the constructor of the derived class RNGCryptoServiceProvider, which is not available on all platforms." So I've done that.

The second commit in this PR further improves on the first commit by using features introduced in C# 7.2 and .NET Core 2.1: the `Span<T>` class and the `stackalloc` keyword are used to allocate the 12 bytes on the stack rather than the heap, avoiding creating an object that the garbage collector is just going to throw away. This also allows us to use the static `RandomNumberGenerator.Fill()` method, which avoids us creating another object that will just create more GC pressure (and require calling a `Dispose()` method, which might involve some expensive operations under the hood). By using the static method, we allow the .NET code to worry about instantiating and disposing of the RNG instance, which it can presumably do better than we can (e.g., by keeping a singleton instance around for the lifetime of the server process). If we need to be able to build the project on C# compilers older than C# 7.2, or run it on runtimes older than .NET Core 2.1, then we can reject the second commit and just use the first commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/737)
<!-- Reviewable:end -->
