### PR TITLE
SF-963b Fix audio not available message on mobile viewport

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.scss
@@ -18,8 +18,8 @@
     width: 100%;
     text-align: center;
     mdc-icon {
-      height: 1.25em;
-      vertical-align: middle;
+      font-size: 1em;
+      vertical-align: top;
     }
   }
 }


### PR DESCRIPTION
&nbsp; | Before | After
-------|--------|------
Small screen | ![](https://user-images.githubusercontent.com/6140710/88328630-bf327e80-ccf6-11ea-8db9-f7a4f328e2d6.png) | ![](https://user-images.githubusercontent.com/6140710/88328635-bfcb1500-ccf6-11ea-9744-3c9a52d6b371.png)
Large screen | ![](https://user-images.githubusercontent.com/6140710/88328738-dffad400-ccf6-11ea-86e0-c4c19bdc0eba.png) | ![](https://user-images.githubusercontent.com/6140710/88328740-e0936a80-ccf6-11ea-95fc-9d542a60934e.png)

Suggestings for abbreviating the text without obfuscating the message are welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/738)
<!-- Reviewable:end -->
