### PR TITLE
Migrator: Make PtdaSyncAll sync all 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -63,7 +63,8 @@
       "console": "integratedTerminal",
       "args": ["--start-ng-serve=listen"],
       "env": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "PTDASYNCALL_MODE": "NOTsync"
       }
     },
     {

--- a/src/Migrations/PtdaSyncAll/Startup.cs
+++ b/src/Migrations/PtdaSyncAll/Startup.cs
@@ -13,6 +13,7 @@ using Autofac.Extensions.DependencyInjection;
 using SIL.XForge;
 using SIL.XForge.Configuration;
 using SIL.XForge.Scripture;
+using SIL.XForge.Scripture.Services;
 
 namespace PtdaSyncAll
 {
@@ -49,6 +50,11 @@ namespace PtdaSyncAll
             services.AddSFServices();
 
             services.AddSFDataAccess(Configuration);
+
+            services.AddLocalization(options => options.ResourcesPath = "Resources");
+
+            services.AddSFMachine(Configuration);
+            services.AddTransient<ParatextSyncRunner>();
 
             services.Configure<RequestLocalizationOptions>(
                 opts =>

--- a/src/Migrations/PtdaSyncAll/build-production
+++ b/src/Migrations/PtdaSyncAll/build-production
@@ -6,10 +6,14 @@
 #
 # Usage: ./build-production
 #
-# To run product on another computer (with ASPNETCORE_ENVIRONMENT set to Development on a workstation, Staging for QA,
-# or omitted for Live):
-# tar xf ptda-sync-all-*.tar.xz
-# ASPNETCORE_ENVIRONMENT=Development SF_APP_DIR="/path/to/sf/app" ptda-sync-all-*/PtdaSyncAll |& tee /tmp/ptda.log
+# To run product on another computer:
+# Set ASPNETCORE_ENVIRONMENT to Development on a workstation, Staging for QA, or omit it for Live.
+# Set PTDASYNCALL_MODE to "sync" to do a sync, or anything else or omit to just inspect.
+# Extract program:
+#   tar xf ptda-sync-all-*.tar.xz
+# Run:
+#   ASPNETCORE_ENVIRONMENT=Development PTDASYNCALL_MODE="sync" SF_APP_DIR="/path/to/sf/app" \
+#     ptda-sync-all-*/PtdaSyncAll |& tee /tmp/ptda.log
 
 set -ue -o pipefail
 


### PR DESCRIPTION
Program.cs
- Add call to RunAsync(). Using existing inspection method since it
has a useful structure for doing this, and in context of reporting on
what we are doing.
- Allow running in inspect mode or sync mode, depending on environment
variable.
- Give helpful message if program fails because SF is running.
- Add more information to error messages that can happen while
processing.
- Add fancy Log() method with time. It will be interesting to see how
long the program takes to run.

Startup.cs
- Add needed services.
- Using `AddTransient` since each usage of ParatextSyncRunner should
be a new instance. We don't want to use a singleton with data mixed in
from other sync runs.

build-production
- Add inspect vs sync mode setting instructions and to usage command.

launch.json
- Add mode environment variable. The `NOTsync` value will result in
running in inspect mode, and is easy to remove the `NOT` part to run
in sync mode during development.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/739)
<!-- Reviewable:end -->
