### PR TITLE
Expand error logging in CallApiAsync

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -257,9 +257,7 @@ namespace SIL.XForge.Scripture.Services
                 }
                 else
                 {
-                    string error = await response.Content.ReadAsStringAsync();
-                    throw new HttpRequestException(
-                        $"HTTP Request error, Code: {response.StatusCode}, Content: {error}");
+                    throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response));
                 }
             }
 


### PR DESCRIPTION
The previous hotfix did not affect CallApiAsync, which is what needed more logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/742)
<!-- Reviewable:end -->
