### PR TITLE
Always show error id in error dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.html
@@ -7,11 +7,11 @@
           <p>{{ data.message }}</p>
           <p [innerHTML]="t('to_report_issue_email', { issueEmailLink: issueEmailLink })"></p>
           <p *ngIf="browserUnsupported" [innerHTML]="t('unsupported_browser', browserLinks)"></p>
-          <a (click)="this.showDetails = !this.showDetails" [fxShow]="data.stack">{{
+          <a (click)="this.showDetails = !this.showDetails">{{
             showDetails ? t("hide_details") : t("show_details")
           }}</a>
-          <p [fxShow]="showDetails">{{ t("error_id", { errorId: data.eventId }) }}</p>
-          <pre [fxShow]="showDetails">{{ data.stack }}</pre>
+          <p class="error-id" [fxShow]="showDetails">{{ t("error_id", { errorId: data.eventId }) }}</p>
+          <pre [fxShow]="showDetails && data.stack">{{ data.stack }}</pre>
         </mdc-dialog-content>
         <mdc-dialog-actions>
           <button mdcDialogButton type="button" mdcDialogAction="close">{{ t("close") }}</button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.spec.ts
@@ -22,28 +22,21 @@ describe('ErrorComponent', () => {
     expect(env.errorMessage.textContent).toBe('The error message');
     expect(env.showDetails.textContent).toBe('Show details');
     expect(env.stackTrace.style.display).toBe('none');
+    expect(env.errorId.style.display).toBe('none');
 
     env.showDetails.click();
     env.fixture.detectChanges();
     expect(env.showDetails.textContent).toBe('Hide details');
     expect(env.stackTrace.style.display).not.toBe('none');
     expect(env.stackTrace.textContent).toBe('The error stack');
+    expect(env.errorId.style.display).not.toBe('none');
+    expect(env.errorId.textContent).toBe('Error ID: 0');
 
     env.showDetails.click();
     env.fixture.detectChanges();
     expect(env.showDetails.textContent).toBe('Show details');
     expect(env.stackTrace.style.display).toBe('none');
-  }));
-
-  it('should only offer to show more when a stack trace is available', fakeAsync(() => {
-    const env = new TestEnvironment({
-      message: 'Testing without stack',
-      eventId: '1'
-    });
-
-    expect(env.errorMessage.textContent).toBe('Testing without stack');
-    expect(env.showDetails.style.display).toBe('none');
-    expect(env.stackTrace.style.display).toBe('none');
+    expect(env.errorId.style.display).toBe('none');
   }));
 });
 
@@ -104,6 +97,10 @@ class TestEnvironment {
 
   get stackTrace(): HTMLElement {
     return this.element.querySelector('pre') as HTMLElement;
+  }
+
+  get errorId(): HTMLElement {
+    return this.element.querySelector('.error-id') as HTMLElement;
   }
 
   get closeButton(): HTMLElement {


### PR DESCRIPTION
Previously the only thing under "show more" was the stack trace, so we didn't offer to show more when there was no stack trace. Now that the error id is also shown under "show more," we should no lnoger hide the button when there's no stack trace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/747)
<!-- Reviewable:end -->
