### PR TITLE
SF-1020 Shorten audio unavailable offline message

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.html
@@ -1,20 +1,23 @@
 <ng-container *transloco="let t; read: 'checking_audio_player'">
-  <div *ngIf="hasSource" class="player">
-    <button *ngIf="!isPlaying" mdc-icon-button icon="play_arrow" type="button" (click)="play()" class="play"></button>
-    <button *ngIf="isPlaying" mdc-icon-button icon="pause" type="button" (click)="pause()" class="pause"></button>
-    <div class="current-time" [fxShow]="isAudioAvailable">{{ currentTime | audioTime }}</div>
-    <mdc-slider
-      [fxShow]="isAudioAvailable"
-      class="slider"
-      min="0"
-      max="100"
-      step="1"
-      [value]="seek"
-      (input)="seeking($event)"
-    ></mdc-slider>
-    <div *ngIf="!isAudioAvailable" class="audio-not-available">
-      <mdc-icon>warning</mdc-icon> {{ t("audio_cannot_be_played") }}
+  <div class="audio-area">
+    <div *ngIf="hasSource && isAudioAvailable" class="player">
+      <button *ngIf="!isPlaying" mdc-icon-button icon="play_arrow" type="button" (click)="play()" class="play"></button>
+      <button *ngIf="isPlaying" mdc-icon-button icon="pause" type="button" (click)="pause()" class="pause"></button>
+      <div class="current-time">{{ currentTime | audioTime }}</div>
+      <mdc-slider class="slider" min="0" max="100" step="1" [value]="seek" (input)="seeking($event)"></mdc-slider>
+
+      <div class="duration">{{ duration | audioTime }}</div>
     </div>
-    <div class="duration" [fxShow]="isAudioAvailable">{{ duration | audioTime }}</div>
+    <div *ngIf="!isAudioAvailable" class="audio-not-available">
+      <mdc-icon>volume_off</mdc-icon>
+      <span class="audio-unavailable-message">{{ t("audio_unavailable") }}</span>
+      <a
+        #audioUnavailableTooltip="matTooltip"
+        (click)="audioUnavailableTooltip.show()"
+        matTooltip="{{ t('audio_cannot_be_played') }}"
+      >
+        <mdc-icon>help</mdc-icon>
+      </a>
+    </div>
   </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.scss
@@ -1,25 +1,47 @@
 @import '../checking-global-vars';
 
-.player {
-  display: flex;
-  align-items: center;
+.audio-area {
   padding: 4px;
   border-radius: 4px;
   border: 1px solid $borderColor;
-  .duration,
-  .current-time {
-    padding: 0 10px;
+
+  .player {
+    display: flex;
+    align-items: center;
+
+    .duration,
+    .current-time {
+      padding: 0 10px;
+    }
+    .slider {
+      flex: 1;
+      width: 100%;
+    }
   }
-  .slider {
-    flex: 1;
-    width: 100%;
-  }
+
   .audio-not-available {
-    width: 100%;
-    text-align: center;
+    display: flex;
+    align-items: center;
+
+    // Same font size and padding as mdc-button to match Play button
     mdc-icon {
-      font-size: 1em;
-      vertical-align: top;
+      font-size: 24px;
+      padding: 12px;
+    }
+
+    .audio-unavailable-message {
+      // Same left padding as .player.current-time
+      padding-left: 10px;
+    }
+
+    a {
+      color: $blueMedium;
+      cursor: pointer;
+
+      mdc-icon {
+        font-size: 1.3em;
+        padding: 6px;
+      }
     }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -181,7 +181,8 @@
     "upload": "Upload"
   },
   "checking_audio_player": {
-    "audio_cannot_be_played": "This audio cannot be played while you are offline. Connect to the internet to play this audio."
+    "audio_unavailable": "Audio unavailable.",
+    "audio_cannot_be_played": "This audio cannot be played while you are offline because it has not been downloaded. Connect to the Internet to play."
   },
   "checking_audio_recorder": {
     "mic_access_denied": "Access to your microphone was denied. Please enable the microphone from your browser.",

--- a/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
@@ -96,3 +96,7 @@ button.mdc-icon-button {
     color: $greenLight !important;
   }
 }
+
+.mat-tooltip {
+  font-size: 1em;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -29,6 +29,7 @@ import { MatPaginatorIntl, MatPaginatorModule } from '@angular/material/paginato
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSelectModule } from '@angular/material/select';
 import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslocoService } from '@ngneat/transloco';
 import { AutofocusDirective } from './autofocus.directive';
 import { BlurOnClickDirective } from './blur-on-click.directive';
@@ -47,6 +48,7 @@ const modules = [
   MatProgressSpinnerModule,
   MatSelectModule,
   MatTableModule,
+  MatTooltipModule,
   MdcButtonModule,
   MdcCardModule,
   MdcCheckboxModule,


### PR DESCRIPTION
* Shortening the initial message displayed. Additional description is
  shown when pointing to or clicking a question mark 'help' icon.
* Changed 'warning' icon to 'volume_off'. This doesn't seem like a
  'warning' situation. 'volume_off' visually shows that there is audio
  but it's not playing.
* html, scss
   - Moved `isAudioAvailable` items into their own div, rather than
     check for `isAudioAvailable` on each element.
   - The play button is now hidden if audio is not available.
   - Introduced CSS class `audio-area` to apply similar styling to the
     audio-unavailable message as to the player controls area (such as
     the border around it).
* styles.scss
   - The tooltip default font size is a bit small on desktops but was
     ok on mobile. Introduced `.mat-tooltip` style here, rather than
     in the component scss, to get the setting to apply.
   - More ideas are at https://stackoverflow.com/q/44587532 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/748)
<!-- Reviewable:end -->
