### PR TITLE
SF-1024 Stop service worker from handling server endpoints

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/ngsw-config.json
+++ b/src/SIL.XForge.Scripture/ClientApp/ngsw-config.json
@@ -34,6 +34,10 @@
   "navigationUrls": [
     "/**",
     "!/",
+    "!/terms",
+    "!/privacy",
+    "!/learn-more",
+    "!/language-api",
     "!/connect/**",
     "!/identity-api/**",
     "!/json-api/**",


### PR DESCRIPTION
Navigating to
- `/terms`
- `/privacy`
- `/learn-more`
- `/language-api` (triggered by switching language on home page)
was being handled by the service worker, leading to a not found page.

There may be other paths, but I'm not sure what they are.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/752)
<!-- Reviewable:end -->
