### PR TITLE
SF-995 Set secure and sameSite attributes on locale cookie

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -124,7 +124,15 @@ export class I18nService {
     this.transloco.setActiveLang(locale.canonicalTag);
     const date = new Date();
     date.setFullYear(date.getFullYear() + 1);
-    this.cookieService.set(ASP_CULTURE_COOKIE_NAME, aspCultureCookieValue(locale.canonicalTag), date, '/');
+    this.cookieService.set(
+      ASP_CULTURE_COOKIE_NAME,
+      aspCultureCookieValue(locale.canonicalTag),
+      date,
+      '/',
+      undefined,
+      true,
+      'Strict'
+    );
     if (doAuthUpdate) {
       this.authService.updateInterfaceLanguage(locale.canonicalTag);
     }


### PR DESCRIPTION
In the console, Firefox has the following warning:
> Cookie “.AspNetCore.Culture” will be soon rejected because it has the “sameSite” attribute set to “none” or an invalid value, without the “secure” attribute. To know more about the “sameSite“ attribute, read https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite

Similar messages are displayed in Chromium.

For context, major browsers are rolling out a change to make the sameSite attribute default to "Lax" rather than "None". This makes the default more secure, but can break backwards compatibility for sites that relied on the default being "None".

Additionally, major browsers are going to start requiring that when sameSite is set to "None", the secure attribute is set to "true".

Right now some of our cookies are not setting either attribute.

I believe that the warning in the Firefox console is not in fact correct. Because the default is changing from "None" to "Lax", and we didn't specifically specify "None", it will in the future be set to "Lax", and the secure attribute will not be required. This is assuming both changes will happen at the same time (which I think is correct, but it's possible I'm mistaken).

Since browsers are changing the default value for sameSite, it's best practice to specify the value intended, rather than let the browser pick the default (especially since older browsers will continue with the old default). In fact, if I understand the documentation correctly, after the change, Firefox will warn of an incorrect use if we let a cookie specify "Lax" by default, rather than explicitly.

Both Chromium and Firefox have options that allow us to test this out.
- In Firefox, go to `about:config` and search for "samesite".
  - Set `network.cookie.sameSite.laxByDefault` to true.
  - Set `network.cookie.sameSite.noneRequiresSecure` to true.
  - No need to restart the browser, but you should clear cookies.
- In Chromium, go to `chrome://flags/` and search for "samesite".
  - Enable `#same-site-by-default-cookies`
  - Enable `#cookies-without-same-site-must-be-secure`
  - Click "Relaunch" at the bottom of the page.
  - Clear cookies.

---

There are other cookies that still have the same issue. Several Auth0 cookies and a _csrf cookie (not sure what it's set by) still have warnings. Unfortunately, they're not as easy to deal with, and would probably require changes upstream. I'll continue to look into them to make sure we won't have anything break as the changes roll out.

Tl;dr: This PR eliminates a couple cookie-related warnings from the console by being more specific about the security policy we want the browser to follow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/753)
<!-- Reviewable:end -->
