### PR TITLE
Add migration tool to clone projects using Paratext Data dll

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -53,6 +53,20 @@
       }
     },
     {
+      "name": "Migration PtdaSyncAll",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build-migrator-ptdaSyncAll",
+      "program": "${workspaceRoot}/src/Migrations/PtdaSyncAll/bin/Debug/netcoreapp3.1/PtdaSyncAll.dll",
+      "cwd": "${workspaceRoot}/src/Migrations/PtdaSyncAll",
+      "stopAtEntry": false,
+      "console": "integratedTerminal",
+      "args": ["--start-ng-serve=listen"],
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    {
       "name": "Migrations PTDDCloneAll",
       "type": "coreclr",
       "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -53,15 +53,14 @@
       }
     },
     {
-      "name": "Migration PtdaSyncAll",
+      "name": "Migrations PTDDCloneAll",
       "type": "coreclr",
       "request": "launch",
-      "preLaunchTask": "build-migrator-ptdaSyncAll",
-      "program": "${workspaceRoot}/src/Migrations/PtdaSyncAll/bin/Debug/netcoreapp3.1/PtdaSyncAll.dll",
-      "cwd": "${workspaceRoot}/src/Migrations/PtdaSyncAll",
+      "preLaunchTask": "build-migrator-PTDDCloneAll",
+      "program": "${workspaceRoot}/src/Migrations/PTDDCloneAll/bin/Debug/netcoreapp3.1/PTDDCloneAll.dll",
+      "cwd": "${workspaceRoot}/src/Migrations/PTDDCloneAll",
       "stopAtEntry": false,
       "console": "integratedTerminal",
-      "args": ["--start-ng-serve=listen"],
       "env": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,6 +21,17 @@
       "problemMatcher": "$msCompile"
     },
     {
+      "label": "build-migrator-ptdaSyncAll",
+      "command": "dotnet",
+      "args": ["build", "/property:GenerateFullPaths=true"],
+      "type": "shell",
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceRoot}/src/Migrations/PtdaSyncAll"
+      },
+      "problemMatcher": "$msCompile"
+    },
+    {
       "label": "build-migrator-PTDDCloneAll",
       "command": "dotnet",
       "args": ["build", "/property:GenerateFullPaths=true"],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,13 +21,13 @@
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "build-migrator-ptdaSyncAll",
+      "label": "build-migrator-PTDDCloneAll",
       "command": "dotnet",
       "args": ["build", "/property:GenerateFullPaths=true"],
       "type": "shell",
       "group": "build",
       "options": {
-        "cwd": "${workspaceRoot}/src/Migrations/PtdaSyncAll"
+        "cwd": "${workspaceRoot}/src/Migrations/PTDDCloneAll"
       },
       "problemMatcher": "$msCompile"
     },

--- a/src/Migrations/PTDDCloneAll/PTDDCloneAll.csproj
+++ b/src/Migrations/PTDDCloneAll/PTDDCloneAll.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\SIL.XForge.Scripture\SIL.XForge.Scripture.csproj" />
+    <ProjectReference Include="..\..\SIL.XForge\SIL.XForge.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
+  </PropertyGroup>
+
+</Project>

--- a/src/Migrations/PTDDCloneAll/PTDDCloneAll.csproj
+++ b/src/Migrations/PTDDCloneAll/PTDDCloneAll.csproj
@@ -8,7 +8,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
 </Project>

--- a/src/Migrations/PTDDCloneAll/Program.cs
+++ b/src/Migrations/PTDDCloneAll/Program.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Autofac;
+using Autofac.Extensions.DependencyInjection;
+using SIL.XForge;
+using SIL.XForge.DataAccess;
+using SIL.XForge.Models;
+using SIL.XForge.Configuration;
+using SIL.XForge.Realtime;
+using SIL.XForge.Realtime.Json0;
+using SIL.XForge.Scripture;
+using SIL.XForge.Scripture.Models;
+using SIL.XForge.Scripture.Services;
+
+
+namespace PTDDCloneAll
+{
+    public class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            string mode = Environment.GetEnvironmentVariable("PTDDCLONEALL_MODE") ?? "inspect";
+            bool doClone = mode == "clone";
+            Console.WriteLine($"PTDDCloneAll starting. Will clone: {doClone}");
+            string sfAppDir = Environment.GetEnvironmentVariable("SF_APP_DIR") ?? "../../SIL.XForge.Scripture";
+            Directory.SetCurrentDirectory(sfAppDir);
+            IWebHostBuilder builder = CreateWebHostBuilder(args);
+            IWebHost webHost = builder.Build();
+            await webHost.StartAsync();
+            await CloneSFProjects(webHost, doClone);
+            await webHost.StopAsync();
+            Console.WriteLine("Clone all projects: Completed");
+        }
+
+        /// <summary>
+        /// Iterates through all SF projects on the server and identifies one administrator user on the project.
+        /// Using the administrator user's secrets, perform a send/receive with the Paratext server. Effectively,
+        /// this clones the project to the Scripture Forge server.
+        /// Text documents for Scripture texts are deleted and recreated from the up-to-date Paratext project data after
+        /// cloning. This will overwrite any un-synchronized data on SF.
+        /// </summary>
+        public static async Task CloneSFProjects(IWebHost webHost, bool doClone)
+        {
+            IRealtimeService realtimeService = webHost.Services.GetService<IRealtimeService>();
+            IQueryable<SFProject> allSFProjects = realtimeService.QuerySnapshots<SFProject>();
+            ParatextSyncRunner syncRunner = webHost.Services.GetService<ParatextSyncRunner>();
+            IOptions<SiteOptions> siteOptions = webHost.Services.GetService<IOptions<SiteOptions>>();
+            string syncDir = Path.Combine(siteOptions.Value.SiteDir, "sync");
+            string syncDirOld = Path.Combine(siteOptions.Value.SiteDir, "sync_old");
+
+            if (doClone)
+            {
+                if (!Directory.Exists(syncDirOld))
+                    Directory.CreateDirectory(syncDirOld);
+            }
+
+            IConnection connection = await realtimeService.ConnectAsync();
+            List<string> projectCloneResults = new List<string>();
+            // Get the paratext project ID and admin user for all SF Projects
+            foreach (SFProject proj in allSFProjects)
+            {
+                string migrationStatus = "Failed to find project administrator.";
+                foreach (string userId in proj.UserRoles.Keys)
+                {
+                    if (proj.UserRoles.TryGetValue(userId, out string role) && role == SFProjectRole.Administrator)
+                    {
+                        migrationStatus = $"Project administrator identified: {userId}";
+                        if (!doClone)
+                            break;
+                        try
+                        {
+                            // Delete the TextDocs in the SF project
+                            var projectDoc = await connection.FetchAsync<SFProject>(proj.Id);
+                            foreach (TextInfo text in projectDoc.Data.Texts)
+                            {
+                                if (text.HasSource)
+                                    await DeleteAllTextDocsForBookAsync(connection, proj.Id, text, TextType.Source);
+                                await DeleteAllTextDocsForBookAsync(connection, proj.Id, text, TextType.Target);
+                            }
+                            await projectDoc.SubmitJson0OpAsync(op =>
+                            {
+                                op.Set(pd => pd.Texts, new List<TextInfo>());
+                                // Increment the queued count such as in SyncService
+                                op.Inc(pd => pd.Sync.QueuedCount);
+                            });
+                            // Clone the paratext project and update the SF database with the project data
+                            await CloneAndSyncSFToParatext(syncRunner, proj.Id, userId);
+                            string projectDir = Path.Combine(syncDir, proj.Id);
+                            string projectDirOld = Path.Combine(syncDirOld, proj.Id);
+                            Directory.Move(projectDir, projectDirOld);
+                            migrationStatus = "Succeeded";
+                        }
+                        catch (Exception e)
+                        {
+                            string partialCloneDir = Path.Combine(syncDir, proj.ParatextId);
+                            if (Directory.Exists(partialCloneDir))
+                                Directory.Delete(partialCloneDir);
+                            migrationStatus = $"Error: {e.Message}";
+                        }
+                        break;
+                    }
+                }
+                projectCloneResults.Add($"{proj.Name} - {migrationStatus}");
+            }
+            Console.WriteLine("MIGRATION RESULTS:");
+            foreach (string result in projectCloneResults)
+            {
+                Console.WriteLine(result);
+            }
+        }
+
+        public static async Task CloneAndSyncSFToParatext(ParatextSyncRunner syncRunner, string projectId, string userId)
+        {
+            await syncRunner.RunAsync(projectId, userId, false);
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args)
+        {
+            IWebHostBuilder builder = WebHost.CreateDefaultBuilder(args);
+
+            // Secrets to connect to PT web API are associated with the SIL.XForge.Scripture assembly
+            Assembly sfAssembly = Assembly.GetAssembly(typeof(ParatextService));
+
+            IConfigurationRoot configuration = new ConfigurationBuilder()
+                .AddUserSecrets(sfAssembly)
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .Build();
+
+            return builder
+                .ConfigureAppConfiguration((context, config) =>
+                    {
+                        IWebHostEnvironment env = context.HostingEnvironment;
+                        if (env.IsDevelopment() || env.IsEnvironment("Testing"))
+                            config.AddJsonFile("appsettings.user.json", true);
+                        else
+                            config.AddJsonFile("secrets.json", true, true);
+                        if (env.IsEnvironment("Testing"))
+                        {
+                            var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
+                            if (appAssembly != null)
+                                config.AddUserSecrets(appAssembly, true);
+                        }
+                    })
+                .UseConfiguration(configuration)
+                .UseStartup<Startup>();
+        }
+
+        /// <summary>
+        /// Deletes all text docs from the database for a book.
+        /// </summary>
+        public static async Task DeleteAllTextDocsForBookAsync(IConnection connection, string sfProjectId, TextInfo text, TextType textType)
+        {
+            var tasks = new List<Task>();
+            foreach (Chapter chapter in text.Chapters)
+                tasks.Add(DeleteTextDocAsync(connection, sfProjectId, text, chapter.Number, textType));
+            await Task.WhenAll(tasks);
+        }
+
+        public static IDocument<TextData> GetTextDoc(IConnection connection, string sfProjectId, TextInfo text, int chapter, TextType textType)
+        {
+            return connection.Get<TextData>(TextData.GetTextDocId(sfProjectId, text.BookNum, chapter, textType));
+        }
+
+        public static async Task DeleteTextDocAsync(IConnection connection, string sfProjectId, TextInfo text, int chapter, TextType textType)
+        {
+            IDocument<TextData> textDoc = GetTextDoc(connection, sfProjectId, text, chapter, textType);
+            await textDoc.FetchAsync();
+            if (textDoc.IsLoaded)
+                await textDoc.DeleteAsync();
+        }
+    }
+}

--- a/src/Migrations/PTDDCloneAll/Program.cs
+++ b/src/Migrations/PTDDCloneAll/Program.cs
@@ -103,7 +103,7 @@ namespace PTDDCloneAll
                                 op.Inc(pd => pd.Sync.QueuedCount);
                             });
                             // Clone the paratext project and update the SF database with the project data
-                            await CloneAndSyncSFToParatext(webHost, proj, userId, syncDir);
+                            await CloneAndSyncFromParatext(webHost, proj, userId, syncDir);
                             string projectDir = Path.Combine(syncDir, proj.Id);
                             string projectDirOld = Path.Combine(syncDirOld, proj.Id);
                             Directory.Move(projectDir, projectDirOld);
@@ -120,10 +120,10 @@ namespace PTDDCloneAll
         }
 
         /// <summary>
-        /// Clone Paratext project data into the SF projects sync folder. Then synchronize the data in the SF DB
-        /// to the data in the Paratext project.
+        /// Clone Paratext project data into the SF projects sync folder. Then synchronize existing books
+        /// and notes in project.
         /// </summary>
-        public static async Task CloneAndSyncSFToParatext(IWebHost webHost, SFProject proj, string userId, string syncDir)
+        public static async Task CloneAndSyncFromParatext(IWebHost webHost, SFProject proj, string userId, string syncDir)
         {
             try
             {

--- a/src/Migrations/PTDDCloneAll/Program.cs
+++ b/src/Migrations/PTDDCloneAll/Program.cs
@@ -68,10 +68,11 @@ namespace PTDDCloneAll
 
             IConnection connection = await realtimeService.ConnectAsync();
             List<string> projectCloneResults = new List<string>();
+            string migrationStatus;
             // Get the paratext project ID and admin user for all SF Projects
             foreach (SFProject proj in allSFProjects)
             {
-                string migrationStatus = "Failed to find project administrator.";
+                migrationStatus = "Failed to find project administrator.";
                 foreach (string userId in proj.UserRoles.Keys)
                 {
                     if (proj.UserRoles.TryGetValue(userId, out string role) && role == SFProjectRole.Administrator)
@@ -158,7 +159,7 @@ namespace PTDDCloneAll
         }
 
         /// <summary>
-        /// Deletes all text docs from the database for a book.
+        /// Deletes all text docs from the database for a book. Copied and modified from ParatextSyncRunner.cs
         /// </summary>
         public static async Task DeleteAllTextDocsForBookAsync(IConnection connection, string sfProjectId, TextInfo text, TextType textType)
         {
@@ -168,11 +169,13 @@ namespace PTDDCloneAll
             await Task.WhenAll(tasks);
         }
 
+        // Copied and modified from ParatextSyncRunner.cs
         public static IDocument<TextData> GetTextDoc(IConnection connection, string sfProjectId, TextInfo text, int chapter, TextType textType)
         {
             return connection.Get<TextData>(TextData.GetTextDocId(sfProjectId, text.BookNum, chapter, textType));
         }
 
+        // Copied and modified from ParatextSyncRunner.cs
         public static async Task DeleteTextDocAsync(IConnection connection, string sfProjectId, TextInfo text, int chapter, TextType textType)
         {
             IDocument<TextData> textDoc = GetTextDoc(connection, sfProjectId, text, chapter, textType);

--- a/src/Migrations/PTDDCloneAll/Program.cs
+++ b/src/Migrations/PTDDCloneAll/Program.cs
@@ -58,7 +58,7 @@ namespace PTDDCloneAll
         /// Iterates through all SF projects on the server and identifies one administrator user on the project.
         /// Using the administrator user's secrets, perform a send/receive with the Paratext server. Effectively,
         /// this clones the project to the Scripture Forge server.
-        /// Text documents for Scripture texts are deleted and recreated from the up-to-date Paratext project data after
+        /// Text documents in the SF DB for Scripture texts are deleted and recreated from the up-to-date Paratext project data after
         /// cloning. This will overwrite any un-synchronized data on SF.
         /// </summary>
         public static async Task CloneSFProjects(IWebHost webHost, bool doClone)
@@ -112,13 +112,17 @@ namespace PTDDCloneAll
                         catch (Exception e)
                         {
                             Log($"Unable to clone {proj.Name} ({proj.Id}) as user: {userId}{Environment.NewLine}" +
-                                $"Error was: {e.Message}");
+                                $"Error was: {e}");
                         }
                     }
                 }
             }
         }
 
+        /// <summary>
+        /// Clone Paratext project data into the SF projects sync folder. Then synchronize the data in the SF DB
+        /// to the data in the Paratext project.
+        /// </summary>
         public static async Task CloneAndSyncSFToParatext(IWebHost webHost, SFProject proj, string userId, string syncDir)
         {
             try

--- a/src/Migrations/PTDDCloneAll/Startup.cs
+++ b/src/Migrations/PTDDCloneAll/Startup.cs
@@ -17,6 +17,9 @@ using SIL.XForge.Scripture.Services;
 
 namespace PTDDCloneAll
 {
+    /// <summary>
+    /// Configurations and services needed to bootstrap the PTDDCloneAll app.
+    /// This was copied and modified from `SIL.XForge.Scripture/Startup.cs`.
     public class Startup
     {
         public Startup(IConfiguration configuration, IWebHostEnvironment env, ILoggerFactory loggerFactory)

--- a/src/Migrations/PTDDCloneAll/Startup.cs
+++ b/src/Migrations/PTDDCloneAll/Startup.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Autofac;
+using Autofac.Extensions.DependencyInjection;
+using SIL.XForge;
+using SIL.XForge.Configuration;
+using SIL.XForge.Scripture;
+using SIL.XForge.Scripture.Services;
+
+namespace PTDDCloneAll
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration, IWebHostEnvironment env, ILoggerFactory loggerFactory)
+        {
+            Configuration = configuration;
+            Environment = env;
+            LoggerFactory = loggerFactory;
+        }
+
+        public IConfiguration Configuration { get; }
+        public IWebHostEnvironment Environment { get; }
+        public ILoggerFactory LoggerFactory { get; }
+        public IContainer ApplicationContainer { get; private set; }
+
+        private bool IsDevelopment => Environment.IsDevelopment() || Environment.IsEnvironment("Testing");
+
+        public IServiceProvider ConfigureServices(IServiceCollection services)
+        {
+            var containerBuilder = new ContainerBuilder();
+
+            services.AddExceptionReporting(Configuration);
+            services.AddConfiguration(Configuration);
+            services.AddSFRealtimeServer(LoggerFactory, Configuration, IsDevelopment);
+            services.AddSFServices();
+            services.AddSFDataAccess(Configuration);
+            services.Configure<RequestLocalizationOptions>(
+                opts =>
+                {
+                    var supportedCultures = new List<CultureInfo>();
+                    foreach (var culture in SharedResource.Cultures)
+                    {
+                        supportedCultures.Add(new CultureInfo(culture.Key));
+                    }
+
+                    opts.DefaultRequestCulture = new RequestCulture("en");
+                    // Formatting numbers, dates, etc.
+                    opts.SupportedCultures = supportedCultures;
+                    // UI strings that we localized.
+                    opts.SupportedUICultures = supportedCultures;
+                });
+            services.AddLocalization(options => options.ResourcesPath = "Resources");
+            services.AddSFMachine(Configuration);
+            services.AddTransient<ParatextSyncRunner>();
+
+            containerBuilder.Populate(services);
+            ApplicationContainer = containerBuilder.Build();
+            return new AutofacServiceProvider(ApplicationContainer);
+        }
+
+        public void Configure(IApplicationBuilder app, IHostApplicationLifetime appLifetime,
+            IExceptionHandler exceptionHandler)
+        {
+            Console.WriteLine("Configuring app");
+            app.UseRealtimeServer();
+            app.UseSFDataAccess();
+            app.UseSFServices();
+            app.UseMachine();
+            appLifetime.ApplicationStopped.Register(() => ApplicationContainer.Dispose());
+        }
+    }
+}

--- a/src/Migrations/PTDDCloneAll/build-production
+++ b/src/Migrations/PTDDCloneAll/build-production
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Build for running on another computer.
+#
+# Usage: ./build-production
+#
+# To run product on another computer, where PTDDCLONEALL_MODE can be set to "clone" to do a clone, or omitted to just inspect:
+# tar xf ptdd-clone-all-*.tar.xz
+# PTDDCLONEALL_MODE="clone" SF_APP_DIR="/path/to/sf/app" ptdd-clone-all-*/PTDDCloneAll |& tee /tmp/ptdd.log
+
+set -ue -o pipefail
+
+outputProductName="ptdd-clone-all-$(date '+%Y%m%d%H%M%S')"
+outputDir="bin/${outputProductName}"
+dotnet publish -o "${outputDir}"
+package="$(mktemp -d)/${outputProductName}.tar.xz"
+cd "${outputDir}/.."
+tar cfJ "${package}" ${outputProductName}

--- a/src/Migrations/PTDDCloneAll/build-production
+++ b/src/Migrations/PTDDCloneAll/build-production
@@ -3,15 +3,20 @@
 #
 # Usage: ./build-production
 #
-# To run product on another computer, where PTDDCLONEALL_MODE can be set to "clone" to do a clone, or omitted to just inspect:
-# tar xf ptdd-clone-all-*.tar.xz
-# PTDDCLONEALL_MODE="clone" SF_APP_DIR="/path/to/sf/app" ptdd-clone-all-*/PTDDCloneAll |& tee /tmp/ptdd.log
+# To run product on another computer:
+# Set ASPNETCORE_ENVIRONMENT to "Development" on a workstation, "Staging" on QA, or omit it for Live.
+# Set PTDDCLONEALL_MODE to "clone" to do the clone, or omit to just imspect
+# Extract program:
+#   tar xf ptdd-clone-all-*.tar.xz
+# Run:
+#   ASPNETCORE_ENVIRONMENT="Development" PTDDCLONEALL_MODE="clone" SF_APP_DIR="/path/to/sf/app" \
+#     ptdd-clone-all-*/PTDDCloneAll |& tee /tmp/ptdd.log
 
 set -ue -o pipefail
 
 outputProductName="ptdd-clone-all-$(date '+%Y%m%d%H%M%S')"
 outputDir="bin/${outputProductName}"
-dotnet publish -o "${outputDir}"
+dotnet publish --runtime "linux-x64" -o "${outputDir}"
 package="$(mktemp -d)/${outputProductName}.tar.xz"
 cd "${outputDir}/.."
 tar cfJ "${package}" ${outputProductName}

--- a/src/Migrations/PTDDCloneAll/build-production
+++ b/src/Migrations/PTDDCloneAll/build-production
@@ -5,7 +5,7 @@
 #
 # To run product on another computer:
 # Set ASPNETCORE_ENVIRONMENT to "Development" on a workstation, "Staging" on QA, or omit it for Live.
-# Set PTDDCLONEALL_MODE to "clone" to do the clone, or omit to just imspect
+# Set PTDDCLONEALL_MODE to "clone" to do the clone, or omit to just inspect
 # Extract program:
 #   tar xf ptdd-clone-all-*.tar.xz
 # Run:
@@ -20,3 +20,4 @@ dotnet publish --runtime "linux-x64" -o "${outputDir}"
 package="$(mktemp -d)/${outputProductName}.tar.xz"
 cd "${outputDir}/.."
 tar cfJ "${package}" ${outputProductName}
+echo "Product: ${package}"

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -402,7 +402,8 @@ namespace SIL.XForge.Scripture.Services
 
         private void SetupMercurial()
         {
-            string customHgPath = _paratextOptions.Value.HgExe;
+            // We do not yet know where hg will be installed on the server, so allow defining it in an env variable
+            string customHgPath = Environment.GetEnvironmentVariable("HG_PATH") ?? _paratextOptions.Value.HgExe;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 customHgPath = Path.GetExtension(customHgPath) != ".exe" ? customHgPath + ".exe" : customHgPath;
             if (!File.Exists(customHgPath))


### PR DESCRIPTION
Add the migration tool to the Migrations folder. This tool can be packaged and run on the QA or live server to clone the Paratext project data for all projects on the Scripture Forge server into the sync folder.
This is the final step in the two part migration process to use the Paratext Data dlls to synchronize SF projects with Paratext.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/757)
<!-- Reviewable:end -->
