### PR TITLE
SF-1028 Load audio data after user comes back online

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-combined/checking-audio-combined.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-combined/checking-audio-combined.component.spec.ts
@@ -2,6 +2,7 @@ import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ngfModule } from 'angular-file';
+import { of } from 'rxjs';
 import { mock, when } from 'ts-mockito';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -102,6 +103,7 @@ class TestEnvironment {
       this.realtimeService.subscribe(UserDoc.COLLECTION, 'user01')
     );
     when(mockedPwaService.isOnline).thenReturn(true);
+    when(mockedPwaService.onlineStatus).thenReturn(of(true));
     this.fixture.detectChanges();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.spec.ts
@@ -1,6 +1,7 @@
 import { Component, DebugElement, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
 import { PwaService } from 'xforge-common/pwa.service';
 import { TestTranslocoModule } from 'xforge-common/test-utils';
@@ -109,6 +110,7 @@ class TestEnvironment {
       imports: [UICommonModule, TestTranslocoModule]
     });
     when(this.mockedPwaService.isOnline).thenCall(() => isOnline);
+    when(this.mockedPwaService.onlineStatus).thenReturn(of(isOnline));
 
     TestBed.overrideComponent(HostComponent, { set: { template: template } });
     this.fixture = TestBed.createComponent(HostComponent);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.spec.ts
@@ -1,10 +1,12 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { of } from 'rxjs';
 import { anything, mock, verify, when } from 'ts-mockito';
 import { NAVIGATOR } from 'xforge-common/browser-globals';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
+import { PwaService } from 'xforge-common/pwa.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
@@ -17,6 +19,7 @@ import { CheckingAudioRecorderComponent } from './checking-audio-recorder.compon
 const mockedUserService = mock(UserService);
 const mockedNoticeService = mock(NoticeService);
 const mockedNavigator = mock(Navigator);
+const mockedPwaService = mock(PwaService);
 
 describe('CheckingAudioRecorderComponent', () => {
   configureTestingModule(() => ({
@@ -25,7 +28,8 @@ describe('CheckingAudioRecorderComponent', () => {
     providers: [
       { provide: UserService, useMock: mockedUserService },
       { provide: NoticeService, useMock: mockedNoticeService },
-      { provide: NAVIGATOR, useMock: mockedNavigator }
+      { provide: NAVIGATOR, useMock: mockedNavigator },
+      { provide: PwaService, useMock: mockedPwaService }
     ]
   }));
 
@@ -95,6 +99,8 @@ class TestEnvironment {
         return this.rejectUserMedia ? Promise.reject() : navigator.mediaDevices.getUserMedia(mediaConstraints);
       }
     } as MediaDevices);
+    when(mockedPwaService.isOnline).thenReturn(true);
+    when(mockedPwaService.onlineStatus).thenReturn(of(true));
     this.fixture.detectChanges();
   }
 


### PR DESCRIPTION
The reason I haven't added a test is because in order to trigger the issue, there has to be an error loading the audio. And while we can mock the PwaService to tell the component it is offline, we don't have a way to actually go offline in the tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/758)
<!-- Reviewable:end -->
