### PR TITLE
SF-1016 - The error appears when returning to online mode after adding some answers in offline mode

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.ts
@@ -60,13 +60,14 @@ export class CommandService {
       params,
       id: uuidv1()
     };
-    const response = await this.http
-      .post<JsonRpcResponse<T>>(url, request, { headers: { 'Content-Type': 'application/json' } })
-      .toPromise();
-    if (response.error != null) {
-      const message = `Error invoking ${method}: ${response.error.message}`;
-      throw new CommandError(response.error.code, message, response.error.data);
+    try {
+      const response = await this.http
+        .post<JsonRpcResponse<T>>(url, request, { headers: { 'Content-Type': 'application/json' } })
+        .toPromise();
+      return response.result;
+    } catch (error) {
+      const message = `Error invoking ${method}: ${error.message}`;
+      throw new CommandError(error.code, message, error.data);
     }
-    return response.result;
   }
 }


### PR DESCRIPTION
- When `online` try and upload files and, failing that, resort to offline handling
- When `online` try and delete files and, failing that, resort to offline handling
- Added `try catch` around `JsonRpc` requests as these never caused errors when they should have. This provides additional information to Bugsnag as well in terms of what method failed

This PR resolves the 504 dialog (and sometimes network connection snackbar) when attempting to use `onlineInvoke` requests when not entirely online. Please note that the console will still display errors which is normal for offline mode.

This PR also resolves audio files - being left orphaned on the server when the attempted file creation/deletion failed.

It is also worth noting that I've only applied the `try catch` logic around the `onlineInvoke` requests for audio files - there may be other scenarios that need to be addressed as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/760)
<!-- Reviewable:end -->
