### PR TITLE
SF-965 Update progress circle when answering a question

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -490,9 +490,12 @@ describe('CheckingComponent', () => {
     it('can answer a question', fakeAsync(() => {
       const env = new TestEnvironment(CHECKER_USER);
       env.selectQuestion(2);
+      // Checker user already has an answer on question 6 and 9
+      expect(env.component.summary.answered).toEqual(2);
       env.answerQuestion('Answer question 2');
       expect(env.answers.length).toEqual(1);
       expect(env.getAnswerText(0)).toBe('Answer question 2');
+      expect(env.component.summary.answered).toEqual(3);
     }));
 
     it('opens dialog if answering a question for the first time', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -815,6 +815,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
       activeQuestionDoc.submitJson0Op(op => op.insert(q => q.answers, 0, answers[0]));
     }
     this.questionsPanel.updateElementsRead(activeQuestionDoc);
+    this.refreshSummary();
   }
 
   private saveComment(answer: Answer, comment: Comment): void {


### PR DESCRIPTION
Previously the progress circle didn't update after a user answers a question. Now the progress circle updates immediately, reflecting the newly answered question.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/761)
<!-- Reviewable:end -->
