### PR TITLE
SF-964b Do not save questions and answers if audio could not be saved

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -43,6 +43,7 @@ export interface AnswerAction {
   selectionStartClipped?: boolean;
   selectionEndClipped?: boolean;
   audio?: AudioAttachment;
+  savedCallback?: () => void;
 }
 
 enum LikeAnswerResponse {
@@ -441,8 +442,6 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
       await this.userService.editDisplayName(true);
     }
     this.emitAnswerToSave();
-    this.hideAnswerForm();
-    this.justEditedAnswer = true;
   }
 
   /** If a given answer should have attention drawn to it in the UI. */
@@ -518,7 +517,11 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
       scriptureText: this.selectedText || undefined,
       selectionStartClipped: this.selectionStartClipped,
       selectionEndClipped: this.selectionEndClipped,
-      verseRef: this.verseRef == null ? undefined : fromVerseRef(this.verseRef)
+      verseRef: this.verseRef == null ? undefined : fromVerseRef(this.verseRef),
+      savedCallback: () => {
+        this.hideAnswerForm();
+        this.justEditedAnswer = true;
+      }
     });
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -573,6 +573,9 @@ describe('CheckingComponent', () => {
       ).thenResolve(undefined);
 
       env.selectQuestion(1);
+      env.clickButton(env.addAnswerButton);
+      env.waitForSliderUpdate();
+      expect(env.saveAnswerButton).not.toBeNull();
       const answerAction: AnswerAction = {
         action: 'save',
         text: 'answer 01',
@@ -587,6 +590,7 @@ describe('CheckingComponent', () => {
       env.waitForSliderUpdate();
       const questionDoc = env.component.questionsPanel!.activeQuestionDoc!;
       expect(questionDoc.data!.answers.length).toEqual(0);
+      expect(env.saveAnswerButton).not.toBeNull();
     }));
 
     it('can change answering tabs', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -557,7 +557,7 @@ describe('CheckingComponent', () => {
       expect(env.addAnswerButton).toBeDefined();
     }));
 
-    it('discards audio content if storage quota exceeded', fakeAsync(() => {
+    it('does not save the answer when storage quota exceeded', fakeAsync(() => {
       const env = new TestEnvironment(CHECKER_USER);
       when(
         mockedFileService.uploadFile(
@@ -586,8 +586,7 @@ describe('CheckingComponent', () => {
       env.component.answerAction(answerAction);
       env.waitForSliderUpdate();
       const questionDoc = env.component.questionsPanel!.activeQuestionDoc!;
-      expect(questionDoc.data!.answers.length).toEqual(1);
-      expect(questionDoc.data!.answers[0].audioUrl).toBeUndefined();
+      expect(questionDoc.data!.answers.length).toEqual(0);
     }));
 
     it('can change answering tabs', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -453,6 +453,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
         answer.selectionStartClipped = answerAction.selectionStartClipped;
         answer.selectionEndClipped = answerAction.selectionEndClipped;
         answer.dateModified = dateNow;
+        let shouldSaveAnswer = true;
         if (answerAction.audio != null) {
           if (answerAction.audio.fileName != null && answerAction.audio.blob != null) {
             if (this.questionsPanel.activeQuestionDoc != null) {
@@ -463,16 +464,18 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
                 answerAction.audio.blob,
                 answerAction.audio.fileName
               );
-              // TODO: If storage is full we should prevent saving the answer rather than discarding it
-              if (urlResult != null) {
-                answer.audioUrl = urlResult;
+              if (urlResult == null) {
+                shouldSaveAnswer = false;
               }
+              answer.audioUrl = urlResult;
             }
           } else if (answerAction.audio.status === 'reset') {
             answer.audioUrl = undefined;
           }
         }
-        this.saveAnswer(answer);
+        if (shouldSaveAnswer) {
+          this.saveAnswer(answer);
+        }
         break;
       case 'delete':
         if (answerAction.answer != null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -453,7 +453,6 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
         answer.selectionStartClipped = answerAction.selectionStartClipped;
         answer.selectionEndClipped = answerAction.selectionEndClipped;
         answer.dateModified = dateNow;
-        let shouldSaveAnswer = true;
         if (answerAction.audio != null) {
           if (answerAction.audio.fileName != null && answerAction.audio.blob != null) {
             if (this.questionsPanel.activeQuestionDoc != null) {
@@ -465,7 +464,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
                 answerAction.audio.fileName
               );
               if (urlResult == null) {
-                shouldSaveAnswer = false;
+                break;
               }
               answer.audioUrl = urlResult;
             }
@@ -473,8 +472,9 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
             answer.audioUrl = undefined;
           }
         }
-        if (shouldSaveAnswer) {
-          this.saveAnswer(answer);
+        this.saveAnswer(answer);
+        if (answerAction.savedCallback != null) {
+          answerAction.savedCallback();
         }
         break;
       case 'delete':

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.ts
@@ -33,6 +33,8 @@ export class QuestionDialogService {
       QuestionDialogComponent,
       QuestionDialogResult | 'close'
     >;
+    // ENHANCE: Put the audio upload logic into QuestionDialogComponent so we can detect if the upload
+    // fails and notify the user without discarding the question.
     const result: QuestionDialogResult | 'close' | undefined = await dialogRef.afterClosed().toPromise();
     if (result == null || result === 'close') {
       return questionDoc;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.ts
@@ -53,10 +53,11 @@ export class QuestionDialogService {
         result.audio.blob,
         result.audio.fileName
       );
-      // TODO: If storage is full we should prevent saving the answer rather than discarding it
-      if (urlResult != null) {
-        audioUrl = urlResult;
+      if (urlResult == null) {
+        // Discard the question if an error occurred while uploading or storing the audio
+        return undefined;
       }
+      audioUrl = urlResult;
     } else if (result.audio.status === 'reset') {
       audioUrl = undefined;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -90,7 +90,12 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
     return this.realtimeService.subscribeQuery(QuestionDoc.COLLECTION, queryParams);
   }
 
-  async createQuestion(id: string, question: Question, audioFileName?: string, audioBlob?: Blob): Promise<QuestionDoc> {
+  async createQuestion(
+    id: string,
+    question: Question,
+    audioFileName?: string,
+    audioBlob?: Blob
+  ): Promise<QuestionDoc | undefined> {
     const docId = getQuestionDocId(id, question.dataId);
     if (audioFileName != null && audioBlob != null) {
       const audioUrl = await this.fileService.uploadFile(
@@ -103,9 +108,12 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
         audioFileName,
         true
       );
+      if (audioUrl == null) {
+        return;
+      }
       question.audioUrl = audioUrl;
     }
-    return this.realtimeService.create(QuestionDoc.COLLECTION, docId, question);
+    return this.realtimeService.create<QuestionDoc>(QuestionDoc.COLLECTION, docId, question);
   }
 
   onlineSync(id: string): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -241,7 +241,7 @@
     "unknown_error": "Unknown error"
   },
   "file_service": {
-    "exceeded_storage_quota": "Failed to upload a file because your device is out of storage space. Please free up space to continue working without disruptions.",
+    "exceeded_storage_quota": "Failed to upload a file because your device is out of storage space. Your changes have been discarded. Please free up space to continue working without disruptions.",
     "i_understand": "I understand",
     "storage_space_is_limited": "The storage space on this device is limited. It is recommended to have a minimum of 500 MB of free space to ensure all feature are available. Please free up storage space."
   },

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -241,7 +241,7 @@
     "unknown_error": "Unknown error"
   },
   "file_service": {
-    "exceeded_storage_quota": "Failed to upload a file because your device is out of storage space. Your changes have been discarded. Please free up space to continue working without disruptions.",
+    "exceeded_storage_quota": "Failed to save your changes because your device is out of storage space. Please free up space to continue working without disruptions.",
     "i_understand": "I understand",
     "storage_space_is_limited": "The storage space on this device is limited. It is recommended to have a minimum of 500 MB of free space to ensure all feature are available. Please free up storage space."
   },


### PR DESCRIPTION
If the storage quota has been reached and uploading or storing an audio file fails, discard the question or answer if it is being created, or discard changes if being edited. Then show a dialog to free up space.
![Storage_Quota_Data_Discarded](https://user-images.githubusercontent.com/17931130/89815462-165f8e00-db02-11ea-8efb-7dff221127a9.PNG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/763)
<!-- Reviewable:end -->
