### PR TITLE
SF-930 - Improve load time for PWA (latest)

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -100,7 +100,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       // Check authentication when coming back online
       // This is also run on first load when the websocket connects for the first time
       if (this.isAppOnline && !this.isAppLoading) {
-        this.authService.attemptOnlineLogin();
+        this.authService.checkOnlineAuth();
       }
     });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -76,7 +76,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     noticeService: NoticeService,
     public media: MediaObserver,
     private readonly projectService: SFProjectService,
-    pwaService: PwaService,
+    private readonly pwaService: PwaService,
     private readonly route: ActivatedRoute,
     private readonly adminAuthGuard: SFAdminAuthGuard,
     private readonly dialog: MdcDialog,
@@ -96,6 +96,11 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       if (status !== this.isAppOnline) {
         this.isAppOnline = status;
         this.checkDeviceStorage();
+        // Check authentication when coming back online
+        // This is also run on first load when the websocket connects for the first time
+        if (this.isAppOnline && !this.isAppLoading) {
+          this.authService.attemptOnlineLogin();
+        }
       }
     });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -96,11 +96,11 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       if (status !== this.isAppOnline) {
         this.isAppOnline = status;
         this.checkDeviceStorage();
-        // Check authentication when coming back online
-        // This is also run on first load when the websocket connects for the first time
-        if (this.isAppOnline && !this.isAppLoading) {
-          this.authService.attemptOnlineLogin();
-        }
+      }
+      // Check authentication when coming back online
+      // This is also run on first load when the websocket connects for the first time
+      if (this.isAppOnline && !this.isAppLoading) {
+        this.authService.attemptOnlineLogin();
       }
     });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -248,7 +248,6 @@ export class AuthService {
         return false;
       }
     }
-    console.log('navigate', state.returnUrl, this.locationService.hash);
     if (state.returnUrl != null) {
       this.router.navigateByUrl(state.returnUrl, { replaceUrl: true });
     } else if (this.locationService.hash !== '') {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.ts
@@ -45,7 +45,9 @@ export class PwaService extends SubscriptionDisposable {
   }
 
   set webSocketResponse(status: boolean) {
-    this.webSocketStatus.next(status);
+    if (status !== this.webSocketStatus.getValue()) {
+      this.webSocketStatus.next(status);
+    }
   }
 
   async checkOnline(): Promise<boolean> {


### PR DESCRIPTION
Decided to split #765 so that the lazy loading of the system administrator module can be included after the upgrade to Angular 9.

This PR covers:
- Always login with offline authentication if available
- Check ping and auth0 when the app is confirmed as being online
- Only set the web socket status if it has actually changed to avoid multiple events being submitted

Improving load time is really an ongoing task rather than a once off task so I see this PR as a first step.

The main impact this PR aids with is actually after the initial load in to memory (when you get past the `Loading...` message) and the app being usable. The app will now always initially load up using offline authentication if available and then check after the fact with auth0 if it is still valid. It also checks again when coming back online if a user was offline at some stage.

Other thoughts:

- Review all our packages to see if any can be combined or simply removed
- Potentially look at creating an independant app shell component which can be rendered as our `index.html` page rather than the current `Loading...` screen. It will essentially be the same thing but it gives a greater impression that the app has loaded even though it technically hasn't yet
- Consider lazy loading: connect project, project settings, project sync, project users
- Consider lazy loading checking and translate app - I briefly investigated this and it does significantly reduce the bundle. We would need to weigh up if it is worth the extra request involved to pull in the new bundle files created though. I suspect it won't be an issue as the service worker will look to cache everything anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/767)
<!-- Reviewable:end -->
