### PR TITLE
Specify hg path in settings files

### DIFF
--- a/src/SIL.XForge.Scripture/appsettings.Development.json
+++ b/src/SIL.XForge.Scripture/appsettings.Development.json
@@ -20,5 +20,8 @@
   },
   "DataAccess": {
     "ConnectionString": "mongodb://localhost:27017"
+  },
+  "Paratext": {
+    "HgExe": "/usr/local/bin/hg"
   }
 }

--- a/src/SIL.XForge.Scripture/appsettings.Staging.json
+++ b/src/SIL.XForge.Scripture/appsettings.Staging.json
@@ -14,5 +14,8 @@
     "ManagementAudience": "https://dev-sillsdev.auth0.com/api/v2/",
     "FrontendClientId": "4eHLjo40mAEGFU6zUxdYjnpnC1K1Ydnj",
     "BackendClientId": "0je4EE9NauROSGjrR1SCryL74TpF2CVC"
+  },
+  "Paratext": {
+    "HgExe": "/usr/bin/hg"
   }
 }

--- a/src/SIL.XForge.Scripture/appsettings.Testing.json
+++ b/src/SIL.XForge.Scripture/appsettings.Testing.json
@@ -24,5 +24,8 @@
     "ManagementAudience": "https://sil-appbuilder.auth0.com/api/v2/",
     "FrontendClientId": "aoAGb9Yx1H5WIsvCW6JJCteJhSa37ftH",
     "BackendClientId": "D7bF2gHmMVAaC67a1GF6f0DdQdRpqQwA"
+  },
+  "Paratext": {
+    "HgExe": "/usr/local/bin/hg"
   }
 }

--- a/src/SIL.XForge.Scripture/appsettings.json
+++ b/src/SIL.XForge.Scripture/appsettings.json
@@ -46,6 +46,6 @@
     "FfmpegPath": "/usr/bin/ffmpeg"
   },
   "Paratext": {
-    "HgExe": "/usr/local/bin/hg"
+    "HgExe": "/usr/bin/hg"
   }
 }


### PR DESCRIPTION
The hg path on QA and Live has been set to /usr/bin/hg. In the vagrant dev machines, ansible installs hg to /usr/local/bin/hg.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/773)
<!-- Reviewable:end -->
