### PR TITLE
Allow setting a custom realtime port while running migration tool

### DIFF
--- a/src/Migrations/PTDDCloneAll/Program.cs
+++ b/src/Migrations/PTDDCloneAll/Program.cs
@@ -179,6 +179,7 @@ namespace PTDDCloneAll
                             if (appAssembly != null)
                                 config.AddUserSecrets(appAssembly, true);
                         }
+                        config.AddEnvironmentVariables();
                     })
                 .UseConfiguration(configuration)
                 .UseStartup<Startup>();

--- a/src/Migrations/PTDDCloneAll/Startup.cs
+++ b/src/Migrations/PTDDCloneAll/Startup.cs
@@ -73,6 +73,9 @@ namespace PTDDCloneAll
             IExceptionHandler exceptionHandler)
         {
             Console.WriteLine("Configuring app");
+            // Set a custom realtime port using the Realtime__Port environment variable
+            string realtimePort = Configuration["Realtime:Port"];
+            Console.WriteLine($"Realtime:Port : {realtimePort}");
             app.UseRealtimeServer();
             app.UseSFDataAccess();
             app.UseSFServices();

--- a/src/SIL.XForge.Scripture/appsettings.Staging.json
+++ b/src/SIL.XForge.Scripture/appsettings.Staging.json
@@ -14,8 +14,5 @@
     "ManagementAudience": "https://dev-sillsdev.auth0.com/api/v2/",
     "FrontendClientId": "4eHLjo40mAEGFU6zUxdYjnpnC1K1Ydnj",
     "BackendClientId": "0je4EE9NauROSGjrR1SCryL74TpF2CVC"
-  },
-  "Paratext": {
-    "HgExe": "/usr/bin/hg"
   }
 }


### PR DESCRIPTION
When the migration tool is run, it opens a connection to the realtime server on port 5003 which client browsers are listening on. This allows us to run the migration tool without clients connecting to the server during the process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/775)
<!-- Reviewable:end -->
