### PR TITLE
Allow custom realtime port while using sync all migration tool

### DIFF
--- a/src/Migrations/PtdaSyncAll/Program.cs
+++ b/src/Migrations/PtdaSyncAll/Program.cs
@@ -319,6 +319,7 @@ namespace PtdaSyncAll
                             if (appAssembly != null)
                                 config.AddUserSecrets(appAssembly, true);
                         }
+                        config.AddEnvironmentVariables();
                     })
                 .UseConfiguration(configuration)
                 .UseStartup<Startup>();

--- a/src/Migrations/PtdaSyncAll/Startup.cs
+++ b/src/Migrations/PtdaSyncAll/Startup.cs
@@ -80,6 +80,9 @@ namespace PtdaSyncAll
         public void Configure(IApplicationBuilder app, IHostApplicationLifetime appLifetime,
             IExceptionHandler exceptionHandler)
         {
+            // Set a custom realtime port using the Realtime__Port environment variable
+            string realtimePort = Configuration["Realtime:Port"];
+            Console.WriteLine($"Realtime:Port : {realtimePort}");
             app.UseRealtimeServer();
             app.UseSFDataAccess();
             appLifetime.ApplicationStopped.Register(() => ApplicationContainer.Dispose());


### PR DESCRIPTION
This will allow us to use an environment variable Realtime__Port to set a custom realtime port during the migration process so that client browsers will not connect to the server during the migration process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/776)
<!-- Reviewable:end -->
