### PR TITLE
Sync: Install usfm_mod stylesheet

### DIFF
--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -52,6 +52,9 @@
     <None Update="usfm.sty">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="usfm_mod.sty">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="changedChapter.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -422,14 +422,14 @@ namespace SIL.XForge.Scripture.Services
         /// <summary> Copy resource files from the Assembly Directory into the sync directory. </summary>
         private void InstallStyles()
         {
-            string usfmStyFile = Path.Combine(SyncDir, "usfm.sty");
-            if (!File.Exists(usfmStyFile))
+            string[] resources = new[] { "usfm.sty", "revisionStyle.sty", "revisionTemplate.tem", "usfm_mod.sty" };
+            foreach (string resource in resources)
             {
-                string[] resources = new[] { "usfm.sty", "revisionStyle.sty", "revisionTemplate.tem" };
-                foreach (string resource in resources)
+                string target = Path.Combine(SyncDir, resource);
+                string source = Path.Combine(AssemblyDirectory, resource);
+                if (!File.Exists(target))
                 {
-                    string target = Path.Combine(SyncDir, resource);
-                    string source = Path.Combine(AssemblyDirectory, resource);
+                    _logger.LogInformation($"Installing missing {target}");
                     File.Copy(source, target, true);
                 }
             }

--- a/src/SIL.XForge.Scripture/usfm_mod.sty
+++ b/src/SIL.XForge.Scripture/usfm_mod.sty
@@ -1,0 +1,74 @@
+# Version=2.500
+# ********************************************************************
+# * usfm_mod.sty is the default stylesheet for Paratext 7 Bible      *
+# *   modules. This stylesheet gets appended to the usfm.sty         *
+# *   stylesheet or the frtbak.sty stylesheet.                       *
+# ********************************************************************
+# Last Updated: Januaray 24, 2014 Tim Steenwyk
+
+# Bible Module style definitions
+
+\Marker err
+\Endmarker err*
+\Name OBSOLETE err...err* - Module Error
+\Description An error in a module file
+\OccursUnder id c vrs inc ref rep mod
+\TextProperties nonpublishable nonvernacular
+\TextType Other
+\StyleType Character
+\FontSize 12
+\Color 00000255
+
+\Marker inc
+\Name Module Include Options
+\Description Options for including stuff in modules
+\Rank 4
+\TextProperties paragraph nonpublishable nonvernacular
+\TextType Other
+\FontSize 12
+\StyleType Paragraph
+
+\Marker vrs
+\Name Module Versification 
+\Description Specifies the versification used in a module
+\Rank 4
+\TextProperties paragraph nonpublishable nonvernacular
+\TextType Other
+\FontSize 12
+\StyleType Paragraph
+
+\Marker ref
+\Name Module Verse Reference
+\Description Included verse references in modules
+\Rank 4
+\TextProperties paragraph nonpublishable nonvernacular
+\TextType Other
+\FontSize 12
+\StyleType Paragraph
+
+\Marker refnp
+\Name Module Verse Reference No Paragraphs
+\Description Included verse references in modules with no paragraph markers
+\Rank 4
+\TextProperties paragraph nonpublishable nonvernacular
+\TextType Other
+\FontSize 12
+\StyleType Paragraph
+
+\Marker rep
+\Name Module Text Replacement
+\Description Replaces text included in modules
+\Rank 4
+\TextProperties paragraph nonpublishable nonvernacular
+\TextType Other
+\FontSize 12
+\StyleType Paragraph
+
+\Marker mod
+\Name Module Import
+\Description Includes another module in modules
+\Rank 4
+\TextProperties paragraph nonpublishable nonvernacular
+\TextType Other
+\FontSize 12
+\StyleType Paragraph


### PR DESCRIPTION
- usfm_mod.sty was looked for when cloning a project with some front
and back matter.
- Including usfm_sb.sty so it's there when/if needed.

ParatextData was asking for usfm_mod.sty. I can't help but want to supply it. See email for context and explanations. I'm expecting that this PR will be argued against, but it's here if wanted. 

Using or not using the usfm_mod.sty sytlesheet didn't seem to have an impact on the files in the cloned project directory. And a brief look at some of the extra project books in SF did not quickly spot any visible differences.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/780)
<!-- Reviewable:end -->
