### PR TITLE
PWA Manifest

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/icons/sf.svg
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/icons/sf.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1024pt" height="1024pt" viewBox="0 0 1024 1024" version="1.1">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1024" height="1024" viewBox="0 0 1024 1024" version="1.1">
 <defs>
 <linearGradient id="linear0" gradientUnits="userSpaceOnUse" x1="120.78" y1="774.21" x2="464.98" y2="485.4" gradientTransform="matrix(2,0,0,2,-22,-702.2)">
 <stop offset="0" style="stop-color:rgb(100%,100%,100%);stop-opacity:0.6;"/>

--- a/src/SIL.XForge.Scripture/ClientApp/src/manifest.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/manifest.json
@@ -45,7 +45,8 @@
     {
       "src": "assets/icons/sf-512x512.png",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "assets/icons/sf.svg",


### PR DESCRIPTION
- Updated sf.svg to correctly report dimensions as 1024x1024
- Updated manifest.json to state which icon can be used as `maskable`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/783)
<!-- Reviewable:end -->
