### PR TITLE
Use minimal implementation of ScrTextCollection to initialize Paratext Data

### DIFF
--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="ParatextData" Version="9.1.9-beta" />
+    <PackageReference Include="ParatextData" Version="9.1.10-beta" />
     <PackageReference Include="SIL.Machine.WebApi" Version="$(MachineVersion)" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
   </ItemGroup>

--- a/src/SIL.XForge.Scripture/Services/LazyScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/LazyScrTextCollection.cs
@@ -22,6 +22,9 @@ namespace SIL.XForge.Scripture.Services
         public void Initialize(string projectsPath)
         {
             SettingsDirectory = projectsPath;
+            // Initialize so that Paratext.Data can find settings files
+            ScrTextCollection.Implementation = new SFScrTextCollection();
+            ScrTextCollection.Initialize(projectsPath);
         }
 
         /// <summary>

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -144,6 +144,8 @@ namespace SIL.XForge.Scripture.Services
             ScrTextCollection.Initialize(SyncDir);
             RegistryServer.Initialize(_applicationProductVersion);
             InstallStyles();
+            // Allow use of custom versification systems
+            Versification.Table.Implementation = new ParatextVersificationTable();
         }
 
         /// <summary>

--- a/src/SIL.XForge.Scripture/Services/SfScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/SfScrTextCollection.cs
@@ -1,4 +1,6 @@
+using System;
 using Paratext.Data;
+using SIL.WritingSystems;
 
 namespace SIL.XForge.Scripture.Services
 {
@@ -7,13 +9,55 @@ namespace SIL.XForge.Scripture.Services
     /// additional side effects of using the full ScrTextCollection that we may not be ready for yet or not want when
     /// using ParatextData from Scripture Forge.
     /// </summary>
-    public class SfScrTextCollection : ScrTextCollection
+    public class SFScrTextCollection : ScrTextCollection
     {
-        protected override string SettingsDirectoryInternal { get; set; }
+        protected override string DictionariesDirectoryInternal => null;
+
+        protected override string ResourcesDirectoryInternal => null;
 
         protected override void InitializeInternal(string settingsDir, bool allowMigration)
         {
-            SettingsDirectoryInternal = settingsDir;
+            if (SettingsDirectoryInternal != null && (SettingsDirectoryInternal == settingsDir || settingsDir == null))
+                return;
+
+            // Get settings directory
+            if (settingsDir != null)
+                SettingsDirectoryInternal = settingsDir;
+        }
+
+        protected override void RefreshScrTextsInternal(bool allowMigration)
+        {
+            throw new NotImplementedException("This method should not be used in SF context.");
+        }
+
+        protected override string SelectSettingsFolder()
+        {
+            throw new NotImplementedException("This method should not be used in SF context.");
+        }
+
+        protected override void DeleteDirToRecycleBin(string dir)
+        {
+            throw new NotImplementedException("This method should not be used in SF context.");
+        }
+
+        protected override WritingSystemDefinition CreateWsDef(string languageId, bool allowSldr)
+        {
+            return null;
+        }
+
+        protected override UnsupportedReason MigrateProjectIfNeeded(ScrText scrText)
+        {
+            throw new NotImplementedException("This method should not be used in SF context.");
+        }
+
+        protected override ScrText CreateResourceProject(ProjectName name)
+        {
+            throw new NotImplementedException("This method should not be used in SF context.");
+        }
+
+        protected override ScrText MarbleResourceLookup(string name)
+        {
+            throw new NotImplementedException("This method should not be used in SF context.");
         }
     }
 }

--- a/src/SIL.XForge.Scripture/Services/SfScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/SfScrTextCollection.cs
@@ -1,0 +1,19 @@
+using Paratext.Data;
+
+namespace SIL.XForge.Scripture.Services
+{
+    /// <summary>
+    /// Subclass of ParatextData ScrTextCollection that allows us to specify things like SettingsDirectory, but without
+    /// additional side effects of using the full ScrTextCollection that we may not be ready for yet or not want when
+    /// using ParatextData from Scripture Forge.
+    /// </summary>
+    public class SfScrTextCollection : ScrTextCollection
+    {
+        protected override string SettingsDirectoryInternal { get; set; }
+
+        protected override void InitializeInternal(string settingsDir, bool allowMigration)
+        {
+            SettingsDirectoryInternal = settingsDir;
+        }
+    }
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -522,6 +522,7 @@ namespace SIL.XForge.Scripture.Services
                     .Returns(Task.FromResult(new Tokens { AccessToken = "token_1234", RefreshToken = "refresh_token_1234" }));
                 MockFileSystemService.DirectoryExists(SyncDir).Returns(true);
                 RegistryU.Implementation = new DotNetCoreRegistry();
+                ScrTextCollection.Implementation = new SFScrTextCollection();
                 AddProjectRepository();
             }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/SfScrTextCollectionTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SfScrTextCollectionTests.cs
@@ -1,0 +1,28 @@
+using NUnit.Framework;
+
+namespace SIL.XForge.Scripture.Services
+{
+    [TestFixture]
+    public class SfScrTextCollectionTests
+    {
+        [Test]
+        public void SetsSettingsDirectory()
+        {
+            var env = new TestEnvironment();
+            Reflection.ReflectionHelper.CallMethod(env.Subject, "InitializeInternal", "/srv/scriptureforge/projects",
+                false);
+            string dir = Reflection.ReflectionHelper.GetProperty(env.Subject, "SettingsDirectoryInternal") as string;
+            Assert.That(dir, Is.EqualTo("/srv/scriptureforge/projects"));
+        }
+
+        private class TestEnvironment
+        {
+            public SfScrTextCollection Subject;
+
+            public TestEnvironment()
+            {
+                Subject = new SfScrTextCollection();
+            }
+        }
+    }
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/SfScrTextCollectionTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SfScrTextCollectionTests.cs
@@ -1,28 +1,18 @@
 using NUnit.Framework;
+using Paratext.Data;
 
 namespace SIL.XForge.Scripture.Services
 {
     [TestFixture]
-    public class SfScrTextCollectionTests
+    public class SFScrTextCollectionTests
     {
         [Test]
         public void SetsSettingsDirectory()
         {
-            var env = new TestEnvironment();
-            Reflection.ReflectionHelper.CallMethod(env.Subject, "InitializeInternal", "/srv/scriptureforge/projects",
-                false);
-            string dir = Reflection.ReflectionHelper.GetProperty(env.Subject, "SettingsDirectoryInternal") as string;
+            ScrTextCollection.Implementation = new SFScrTextCollection();
+            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+            string dir = ScrTextCollection.SettingsDirectory;
             Assert.That(dir, Is.EqualTo("/srv/scriptureforge/projects"));
-        }
-
-        private class TestEnvironment
-        {
-            public SfScrTextCollection Subject;
-
-            public TestEnvironment()
-            {
-                Subject = new SfScrTextCollection();
-            }
         }
     }
 }


### PR DESCRIPTION
Up to this point our code has made use of Paratext Data without initializing Paratext Data. But this was causing problems if we needed to use ScrTextCollection.SettingsDirectory since it has not been initialized to a path. After discussing with the Paratext developers, we decided that it is essential for Paratext Data to have access to ScrTextCollection.SettingsDirectory. This provides a minimal implementation of ScrTextCollection, so Paratext Data has this requirement satisfied.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/784)
<!-- Reviewable:end -->
