### PR TITLE
Throw error if PTDDSyncRunner runs unsuccessfully

### DIFF
--- a/src/Migrations/PTDDCloneAll/PTDDSyncRunner.cs
+++ b/src/Migrations/PTDDCloneAll/PTDDSyncRunner.cs
@@ -221,15 +221,14 @@ namespace PTDDCloneAll
                 }
 
                 await CompleteSync(true);
+                CloseConnection();
             }
             catch (Exception e)
             {
                 _logger.LogError(e, "Error occurred while executing Paratext sync for project '{Project}'", projectId);
                 await CompleteSync(false);
-            }
-            finally
-            {
                 CloseConnection();
+                throw;
             }
         }
 

--- a/src/Migrations/PTDDCloneAll/Program.cs
+++ b/src/Migrations/PTDDCloneAll/Program.cs
@@ -70,6 +70,8 @@ namespace PTDDCloneAll
             IRealtimeService realtimeService = webHost.Services.GetService<IRealtimeService>();
             IQueryable<SFProject> allSFProjects = realtimeService.QuerySnapshots<SFProject>();
             IOptions<SiteOptions> siteOptions = webHost.Services.GetService<IOptions<SiteOptions>>();
+            IParatextService paratextService = webHost.Services.GetService<IParatextService>();
+            IRepository<UserSecret> userSecretRepo = webHost.Services.GetService<IRepository<UserSecret>>();
             string syncDir = Path.Combine(siteOptions.Value.SiteDir, "sync");
             bool doClone = mode == CLONE || mode == CLONE_AND_MOVE_OLD;
 
@@ -90,7 +92,9 @@ namespace PTDDCloneAll
                     if (proj.UserRoles.TryGetValue(userId, out string role) && role == SFProjectRole.Administrator)
                     {
                         foundAdmin = true;
-                        Log($"Project administrator identified on {proj.Name}: {userId}");
+                        UserSecret userSecret = userSecretRepo.Query().FirstOrDefault((UserSecret us) => us.Id == userId);
+                        string ptUsername = paratextService.GetParatextUsername(userSecret);
+                        Log($"Project administrator identified on {proj.Name}: {ptUsername} ({userId})");
                         if (!doClone)
                             break;
                         try


### PR DESCRIPTION
*Also report Paratext username of user used to clone projects.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/786)
<!-- Reviewable:end -->
