### PR TITLE
Install mercurial 4.7+ from pip or system

### DIFF
--- a/deploy/dependencies.yml
+++ b/deploy/dependencies.yml
@@ -44,7 +44,6 @@
           - "mongodb-org"
           - nodejs
           - npm
-          - python-pip
         update_cache: yes
       tags: ["packages"]
 
@@ -67,10 +66,23 @@
     - name: change node version
       shell: "n {{node_version}}"
 
-    - name: install custom mercurial
+    # Install mercurial 4.7+ from system or pip
+    - name: install pip mercurial dependencies
+      apt:
+        name:
+          - python-pip
+          - python2.7
+      when: ansible_distribution_major_version|int < 20
+    - name: install pip mercurial
       pip:
         name: mercurial
         version: 4.8.2
+      when: ansible_distribution_major_version|int < 20
+    - name: install system package mercurial
+      apt:
+        name:
+          - mercurial
+      when: ansible_distribution_major_version|int >= 20
 
     - name: update the mongo config file
       lineinfile:


### PR DESCRIPTION
- Ubuntu 20.04 had trouble installing mercurial from pip. Depending on
the version, it either didn't install, or later there were errors in
SF about changedChapter.py.
- Continue installing mercurial 4.8.2 in Ubuntu 16.04 and 18.04, but
install the mercurial system package in Ubuntu 20.04+.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/790)
<!-- Reviewable:end -->
