### PR TITLE
LT-1062 Don't cache repo sources

### DIFF
--- a/src/SIL.XForge.Scripture/Services/IInternetSharedRepositorySourceProvider.cs
+++ b/src/SIL.XForge.Scripture/Services/IInternetSharedRepositorySourceProvider.cs
@@ -1,0 +1,10 @@
+using SIL.XForge.Models;
+
+namespace SIL.XForge.Scripture.Services
+{
+    public interface IInternetSharedRepositorySourceProvider
+    {
+        IInternetSharedRepositorySource GetSource(UserSecret userSecret, string sendReceiveServerUri,
+            string registryServerUri, string applicationProductVersion);
+    }
+}

--- a/src/SIL.XForge.Scripture/Services/InternetSharedRepositorySourceProvider.cs
+++ b/src/SIL.XForge.Scripture/Services/InternetSharedRepositorySourceProvider.cs
@@ -1,0 +1,49 @@
+using System;
+using SIL.XForge.Models;
+
+namespace SIL.XForge.Scripture.Services
+{
+    /// <summary>
+    /// Provides objects implementing IInternetSharedRepositorySource.
+    /// </summary>
+    public class InternetSharedRepositorySourceProvider : IInternetSharedRepositorySourceProvider
+    {
+        private readonly IJwtTokenHelper _jwtTokenHelper;
+
+        public InternetSharedRepositorySourceProvider(IJwtTokenHelper jwtTokenHelper)
+        {
+            _jwtTokenHelper = jwtTokenHelper;
+        }
+
+        public IInternetSharedRepositorySource GetSource(UserSecret userSecret, string sendReceiveServerUri,
+            string registryServerUri, string applicationProductVersion)
+        {
+            if (userSecret == null || sendReceiveServerUri == null || registryServerUri == null
+                || applicationProductVersion == null)
+            {
+                throw new ArgumentNullException();
+            }
+
+            JwtRESTClient jwtClient = GenerateParatextRegistryJwtClient(userSecret, registryServerUri,
+                applicationProductVersion);
+            IInternetSharedRepositorySource source =
+                new JwtInternetSharedRepositorySource(userSecret.ParatextTokens.AccessToken,
+                    jwtClient, sendReceiveServerUri);
+            source.RefreshToken(userSecret.ParatextTokens.AccessToken);
+            return source;
+        }
+
+        /// <summary>
+        /// Initialize the Registry Server with a Jwt REST Client. Must be called for each unique user.
+        /// </summary>
+        private JwtRESTClient GenerateParatextRegistryJwtClient(UserSecret userSecret,
+            string registryServerUri, string applicationProductVersion)
+        {
+            string jwtToken = _jwtTokenHelper.GetJwtTokenFromUserSecret(userSecret);
+
+            string api = registryServerUri + "/api8/";
+            return new JwtRESTClient(api, applicationProductVersion, jwtToken);
+        }
+
+    }
+}

--- a/src/SIL.XForge.Scripture/Services/InternetSharedRepositorySourceProvider.cs
+++ b/src/SIL.XForge.Scripture/Services/InternetSharedRepositorySourceProvider.cs
@@ -44,6 +44,5 @@ namespace SIL.XForge.Scripture.Services
             string api = registryServerUri + "/api8/";
             return new JwtRESTClient(api, applicationProductVersion, jwtToken);
         }
-
     }
 }

--- a/src/SIL.XForge.Scripture/Services/InternetSharedRepositorySourceProvider.cs
+++ b/src/SIL.XForge.Scripture/Services/InternetSharedRepositorySourceProvider.cs
@@ -18,10 +18,10 @@ namespace SIL.XForge.Scripture.Services
         public IInternetSharedRepositorySource GetSource(UserSecret userSecret, string sendReceiveServerUri,
             string registryServerUri, string applicationProductVersion)
         {
-            if (userSecret == null || sendReceiveServerUri == null || registryServerUri == null
-                || applicationProductVersion == null)
+            if (userSecret == null || string.IsNullOrEmpty(sendReceiveServerUri)
+                || string.IsNullOrEmpty(registryServerUri) || string.IsNullOrEmpty(applicationProductVersion))
             {
-                throw new ArgumentNullException();
+                throw new ArgumentException();
             }
 
             JwtRESTClient jwtClient = GenerateParatextRegistryJwtClient(userSecret, registryServerUri,
@@ -34,7 +34,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         /// <summary>
-        /// Initialize the Registry Server with a Jwt REST Client. Must be called for each unique user.
+        /// Initialize the Registry Server with a Jwt REST Client.
         /// </summary>
         private JwtRESTClient GenerateParatextRegistryJwtClient(UserSecret userSecret,
             string registryServerUri, string applicationProductVersion)

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -119,9 +119,6 @@ namespace SIL.XForge.Scripture.Services
         internal IScrTextCollection ScrTextCollection { get; set; }
         internal ISharingLogicWrapper SharingLogicWrapper { get; set; }
         internal IHgWrapper HgWrapper { get; set; }
-        /// <summary> Set of SF user IDs and corresponding sources for remote PT projects. </summary>
-        internal Dictionary<string, IInternetSharedRepositorySource> InternetSharedRepositorySources { get; set; }
-            = new Dictionary<string, IInternetSharedRepositorySource>();
 
         /// <summary> Prepare access to Paratext.Data library, authenticate, and prepare Mercurial. </summary>
         public void Init()
@@ -538,22 +535,14 @@ namespace SIL.XForge.Scripture.Services
         }
 
         /// <summary>
-        /// Get cached or setup new access to a source for PT project repositories, based on user secret.
+        /// Get access to a source for PT project repositories, based on user secret.
         ///</summary>
         private async Task<IInternetSharedRepositorySource> GetInternetSharedRepositorySource(UserSecret userSecret)
         {
             if (userSecret == null) throw new ArgumentNullException();
-            IInternetSharedRepositorySource source;
             await RefreshAccessTokenAsync(userSecret);
-
-            if (!InternetSharedRepositorySources.ContainsKey(userSecret.Id))
-            {
-                source = _internetSharedRepositorySourceProvider.GetSource(userSecret,
-                    _sendReceiveServerUri, _registryServerUri, _applicationProductVersion);
-                InternetSharedRepositorySources[userSecret.Id] = source;
-            }
-            source = InternetSharedRepositorySources[userSecret.Id];
-            source.RefreshToken(userSecret.ParatextTokens.AccessToken);
+            IInternetSharedRepositorySource source = _internetSharedRepositorySourceProvider.GetSource(userSecret,
+                _sendReceiveServerUri, _registryServerUri, _applicationProductVersion);
             return source;
         }
 

--- a/src/SIL.XForge.Scripture/Services/SFServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/SFServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<IGuidService, GuidService>();
             services.AddSingleton<ISFProjectService, SFProjectService>();
             services.AddSingleton<IJwtTokenHelper, JwtTokenHelper>();
+            services.AddSingleton<IInternetSharedRepositorySourceProvider, InternetSharedRepositorySourceProvider>();
             return services;
         }
     }

--- a/test/SIL.XForge.Scripture.Tests/SIL.XForge.Scripture.Tests.csproj
+++ b/test/SIL.XForge.Scripture.Tests/SIL.XForge.Scripture.Tests.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\SIL.XForge.Scripture\SIL.XForge.Scripture.csproj" />
+    <ProjectReference Include="..\SIL.XForge.Tests\SIL.XForge.Tests.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
@@ -15,11 +15,17 @@ namespace SIL.XForge.Scripture.Services
         public void GetSource_BadArguments()
         {
             var env = new TestEnvironment();
-            Assert.Throws<ArgumentNullException>(() => env.Provider.GetSource(null, null, null, null));
-            Assert.Throws<ArgumentNullException>(() => env.Provider.GetSource(null, "abc", "abc", "abc"));
-            Assert.Throws<ArgumentNullException>(() => env.Provider.GetSource(new UserSecret(), null, "abc", "abc"));
-            Assert.Throws<ArgumentNullException>(() => env.Provider.GetSource(new UserSecret(), "abc", null, "abc"));
-            Assert.Throws<ArgumentNullException>(() => env.Provider.GetSource(new UserSecret(), "abc", "abc", null));
+            Assert.Throws<ArgumentException>(() => env.Provider.GetSource(null, null, null, null));
+            Assert.Throws<ArgumentException>(() => env.Provider.GetSource(null, "abc", "abc", "abc"));
+            Assert.Throws<ArgumentException>(() => env.Provider.GetSource(new UserSecret(), null, "abc", "abc"));
+            Assert.Throws<ArgumentException>(() => env.Provider.GetSource(new UserSecret(), "abc", null, "abc"));
+            Assert.Throws<ArgumentException>(() => env.Provider.GetSource(new UserSecret(), "abc", "abc", null));
+            Assert.Throws<ArgumentException>(() =>
+                env.Provider.GetSource(new UserSecret(), string.Empty, "abc", "abc"));
+            Assert.Throws<ArgumentException>(() =>
+                env.Provider.GetSource(new UserSecret(), "abc", string.Empty, "abc"));
+            Assert.Throws<ArgumentException>(() =>
+                env.Provider.GetSource(new UserSecret(), "abc", "abc", string.Empty));
         }
 
         [Test]

--- a/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Threading.Tasks;
 using NSubstitute;
 using NUnit.Framework;
+using Paratext.Data;
 using PtxUtils;
 using SIL.XForge.Models;
 using SIL.XForge.Services;
@@ -37,7 +37,6 @@ namespace SIL.XForge.Scripture.Services
             };
             IInternetSharedRepositorySource source = env.Provider.GetSource(userSecret, "srServer", "regServer", "1");
             Assert.That(source, Is.Not.Null);
-
         }
 
         private class TestEnvironment
@@ -50,6 +49,7 @@ namespace SIL.XForge.Scripture.Services
                 MockJwtTokenHelper = Substitute.For<IJwtTokenHelper>();
                 MockJwtTokenHelper.GetJwtTokenFromUserSecret(Arg.Any<UserSecret>()).Returns("token_1234");
                 RegistryU.Implementation = new DotNetCoreRegistry();
+                InternetAccess.RawStatus = InternetUse.Enabled;
                 Provider = new InternetSharedRepositorySourceProvider(MockJwtTokenHelper);
             }
         }

--- a/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading.Tasks;
+using NSubstitute;
+using NUnit.Framework;
+using PtxUtils;
+using SIL.XForge.Models;
+using SIL.XForge.Services;
+
+namespace SIL.XForge.Scripture.Services
+{
+    [TestFixture]
+    public class InternetSharedRepositorySourceProviderTests
+    {
+        [Test]
+        public void GetSource_BadArguments()
+        {
+            var env = new TestEnvironment();
+            Assert.Throws<ArgumentNullException>(() => env.Provider.GetSource(null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => env.Provider.GetSource(null, "abc", "abc", "abc"));
+            Assert.Throws<ArgumentNullException>(() => env.Provider.GetSource(new UserSecret(), null, "abc", "abc"));
+            Assert.Throws<ArgumentNullException>(() => env.Provider.GetSource(new UserSecret(), "abc", null, "abc"));
+            Assert.Throws<ArgumentNullException>(() => env.Provider.GetSource(new UserSecret(), "abc", "abc", null));
+        }
+
+        [Test]
+        public void GetSource()
+        {
+            var env = new TestEnvironment();
+            var userSecret = new UserSecret
+            {
+                Id = "user01",
+                ParatextTokens = new Tokens
+                {
+                    AccessToken = TokenHelper.CreateNewAccessToken(),
+                    RefreshToken = "refresh_token01"
+                }
+            };
+            IInternetSharedRepositorySource source = env.Provider.GetSource(userSecret, "srServer", "regServer", "1");
+            Assert.That(source, Is.Not.Null);
+
+        }
+
+        private class TestEnvironment
+        {
+            public IJwtTokenHelper MockJwtTokenHelper;
+            public InternetSharedRepositorySourceProvider Provider;
+
+            public TestEnvironment()
+            {
+                MockJwtTokenHelper = Substitute.For<IJwtTokenHelper>();
+                MockJwtTokenHelper.GetJwtTokenFromUserSecret(Arg.Any<UserSecret>()).Returns("token_1234");
+                RegistryU.Implementation = new DotNetCoreRegistry();
+                Provider = new InternetSharedRepositorySourceProvider(MockJwtTokenHelper);
+            }
+        }
+    }
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -491,6 +491,7 @@ namespace SIL.XForge.Scripture.Services
             public IHgWrapper MockHgWrapper;
             public ILogger<ParatextService> MockLogger;
             public IJwtTokenHelper MockJwtTokenHelper;
+            public IInternetSharedRepositorySourceProvider MockInternetSharedRepositorySourceProvider;
             public ParatextService Service;
 
             public TestEnvironment()
@@ -506,11 +507,13 @@ namespace SIL.XForge.Scripture.Services
                 MockSharingLogicWrapper = Substitute.For<ISharingLogicWrapper>();
                 MockHgWrapper = Substitute.For<IHgWrapper>();
                 MockJwtTokenHelper = Substitute.For<IJwtTokenHelper>();
+                MockInternetSharedRepositorySourceProvider = Substitute.For<IInternetSharedRepositorySourceProvider>();
 
                 RealtimeService = new SFMemoryRealtimeService();
 
                 Service = new ParatextService(MockWebHostEnvironment, MockParatextOptions, MockRepository,
-                    RealtimeService, MockExceptionHandler, MockSiteOptions, MockFileSystemService, MockLogger, MockJwtTokenHelper);
+                    RealtimeService, MockExceptionHandler, MockSiteOptions, MockFileSystemService,
+                    MockLogger, MockJwtTokenHelper, MockInternetSharedRepositorySourceProvider);
                 Service.ScrTextCollection = MockScrTextCollection;
                 Service.SharingLogicWrapper = MockSharingLogicWrapper;
                 Service.HgWrapper = MockHgWrapper;
@@ -518,8 +521,13 @@ namespace SIL.XForge.Scripture.Services
 
                 MockJwtTokenHelper.GetParatextUsername(Arg.Any<UserSecret>()).Returns(User01);
                 MockJwtTokenHelper.GetJwtTokenFromUserSecret(Arg.Any<UserSecret>()).Returns("token_1234");
-                MockJwtTokenHelper.RefreshAccessTokenAsync(Arg.Any<ParatextOptions>(), Arg.Any<Tokens>(), Arg.Any<HttpClient>())
-                    .Returns(Task.FromResult(new Tokens { AccessToken = "token_1234", RefreshToken = "refresh_token_1234" }));
+                MockJwtTokenHelper.RefreshAccessTokenAsync(Arg.Any<ParatextOptions>(), Arg.Any<Tokens>(),
+                    Arg.Any<HttpClient>())
+                    .Returns(Task.FromResult(new Tokens
+                    {
+                        AccessToken = "token_1234",
+                        RefreshToken = "refresh_token_1234"
+                    }));
                 MockFileSystemService.DirectoryExists(SyncDir).Returns(true);
                 RegistryU.Implementation = new DotNetCoreRegistry();
                 ScrTextCollection.Implementation = new SFScrTextCollection();

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -186,7 +186,8 @@ namespace SIL.XForge.Scripture.Services
                         .ContainsKey(testCase.sfUserId), Is.EqualTo(testCase.sfUserIsOnSfProject),
                         "not set up - whether user is on existing sf project or not");
                 }
-                Assert.That(env.Service.InternetSharedRepositorySources[testCase.sfUserId].GetRepositories()
+                Assert.That(env.MockInternetSharedRepositorySourceProvider.GetSource(testCase.userSecret,
+                    string.Empty, string.Empty, string.Empty).GetRepositories()
                     .FirstOrDefault(sharedRepository => sharedRepository.SendReceiveId == testCase.paratextProjectId)
                     .SourceUsers.GetRole(testCase.ptUsername) == UserRoles.Administrator,
                     Is.EqualTo(testCase.ptUserIsAdminOnPtProject),
@@ -581,7 +582,8 @@ namespace SIL.XForge.Scripture.Services
                 ProjectMetadata projMeta3 = GetMetadata("paratext_" + Project03, "Full Name " + Project03);
                 mockSource.GetRepositories().Returns(new List<SharedRepository> { repo1, repo3, repo2 });
                 mockSource.GetProjectsMetaData().Returns(new[] { projMeta1, projMeta2, projMeta3 });
-                Service.InternetSharedRepositorySources[userSecret.Id] = mockSource;
+                MockInternetSharedRepositorySourceProvider.GetSource(userSecret, Arg.Any<string>(),
+                    Arg.Any<string>(), Arg.Any<string>()).Returns(mockSource);
                 return mockSource;
             }
 

--- a/test/SIL.XForge.Tests/Services/TokenHelper.cs
+++ b/test/SIL.XForge.Tests/Services/TokenHelper.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using IdentityModel;
+using Microsoft.IdentityModel.Tokens;
+
+namespace SIL.XForge.Services
+{
+    /// <summary>
+    /// Helper for unit tests using access tokens
+    /// </summary>
+    public class TokenHelper
+    {
+        public static string CreateAccessToken(DateTime issuedAt)
+        {
+            var token = new JwtSecurityToken("ptreg_rsa", "pt-api",
+                new[]
+                {
+                    new Claim(JwtClaimTypes.Subject, "paratext01"),
+                    new Claim(JwtClaimTypes.IssuedAt, EpochTime.GetIntDate(issuedAt).ToString())
+                },
+                expires: issuedAt + TimeSpan.FromMinutes(5));
+            var handler = new JwtSecurityTokenHandler();
+            return handler.WriteToken(token);
+        }
+
+        public static string CreateNewAccessToken()
+        {
+            return CreateAccessToken(DateTime.Now);
+        }
+    }
+}

--- a/test/SIL.XForge.Tests/Services/UserServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/UserServiceTests.cs
@@ -125,7 +125,7 @@ namespace SIL.XForge.Services
                         Id = "user01",
                         ParatextTokens = new Tokens
                         {
-                            AccessToken = CreateAccessToken(IssuedAt),
+                            AccessToken = TokenHelper.CreateAccessToken(IssuedAt),
                             RefreshToken = "refresh_token"
                         }
                     }
@@ -192,21 +192,8 @@ namespace SIL.XForge.Services
                         new JObject(
                             new JProperty("connection", "paratext"),
                             new JProperty("user_id", "paratext|paratext01"),
-                            new JProperty("access_token", CreateAccessToken(issuedAt)),
+                            new JProperty("access_token", TokenHelper.CreateAccessToken(issuedAt)),
                             new JProperty("refresh_token", "new_refresh_token")))));
-            }
-
-            private string CreateAccessToken(DateTime issuedAt)
-            {
-                var token = new JwtSecurityToken("ptreg_rsa", "pt-api",
-                    new[]
-                    {
-                        new Claim(JwtClaimTypes.Subject, "paratext01"),
-                        new Claim(JwtClaimTypes.IssuedAt, EpochTime.GetIntDate(issuedAt).ToString())
-                    },
-                    expires: issuedAt + TimeSpan.FromMinutes(5));
-                var handler = new JwtSecurityTokenHandler();
-                return handler.WriteToken(token);
             }
         }
     }


### PR DESCRIPTION
Stopping the caching was easy. The unit tests were using the cache to set Sources and assert about them. This PR moves Source creation into a service that can be mocked. This allows the tests to remain mostly unmodified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/795)
<!-- Reviewable:end -->
