### PR TITLE
Allow silent cloning mode for clone all migration tool

### DIFF
--- a/src/Migrations/PTDDCloneAll/PTDDSyncRunner.cs
+++ b/src/Migrations/PTDDCloneAll/PTDDSyncRunner.cs
@@ -90,7 +90,19 @@ namespace PTDDCloneAll
             {
                 if (!await InitAsync(projectId, userId))
                 {
-                    await CompleteSync(false);
+                    if (silent)
+                    {
+                        await _projectDoc.SubmitJson0OpAsync(op =>
+                        {
+                            op.Inc(pd => pd.Sync.QueuedCount, -1);
+                            op.Unset(pd => pd.Sync.PercentCompleted);
+                        });
+                    }
+                    else
+                    {
+                        await CompleteSync(false);
+                    }
+                    CloseConnection();
                     return;
                 }
 

--- a/src/Migrations/PTDDCloneAll/Program.cs
+++ b/src/Migrations/PTDDCloneAll/Program.cs
@@ -138,7 +138,13 @@ namespace PTDDCloneAll
             string syncDir, bool silent)
         {
             Log($"Cloning {proj.Name} ({proj.Id}) as SF user {userId}");
-            string partialCloneDir = Path.Combine(syncDir, proj.ParatextId);
+            string existingCloneDir = Path.Combine(syncDir, proj.ParatextId);
+            // If the project directory already exists, no need to sync the project
+            if (Directory.Exists(existingCloneDir))
+            {
+                Log("The project has already been cloned. Skipping...");
+                return;
+            }
             try
             {
                 PTDDSyncRunner syncRunner = webHost.Services.GetService<PTDDSyncRunner>();
@@ -147,14 +153,14 @@ namespace PTDDCloneAll
                 if (silent)
                 {
                     Log($"Deleting cloned repository for {proj.Name}");
-                    Directory.Delete(partialCloneDir, true);
+                    Directory.Delete(existingCloneDir, true);
                 }
             }
             catch (Exception e)
             {
                 Log($"There was a problem cloning the project.{Environment.NewLine}Exception is: {e}");
-                if (Directory.Exists(partialCloneDir))
-                    Directory.Delete(partialCloneDir, true);
+                if (Directory.Exists(existingCloneDir))
+                    Directory.Delete(existingCloneDir, true);
                 throw;
             }
         }

--- a/src/Migrations/PTDDCloneAll/Program.cs
+++ b/src/Migrations/PTDDCloneAll/Program.cs
@@ -32,12 +32,13 @@ namespace PTDDCloneAll
     {
         const string CLONE = "clone";
         const string CLONE_AND_MOVE_OLD = "cloneandmoveold";
+        const string CLONE_SILENT = "clonesilent";
         const string INSPECT = "inspect";
 
         public static async Task Main(string[] args)
         {
             string modeEnv = Environment.GetEnvironmentVariable("PTDDCLONEALL_MODE");
-            string mode = modeEnv == CLONE || modeEnv == CLONE_AND_MOVE_OLD ? modeEnv : INSPECT;
+            string mode = modeEnv == CLONE || modeEnv == CLONE_AND_MOVE_OLD || modeEnv == CLONE_SILENT ? modeEnv : INSPECT;
             Log($"PTDDCloneAll starting. Migration mode: {mode}");
             string sfAppDir = Environment.GetEnvironmentVariable("SF_APP_DIR") ?? "../../SIL.XForge.Scripture";
             Directory.SetCurrentDirectory(sfAppDir);
@@ -73,7 +74,7 @@ namespace PTDDCloneAll
             IParatextService paratextService = webHost.Services.GetService<IParatextService>();
             IRepository<UserSecret> userSecretRepo = webHost.Services.GetService<IRepository<UserSecret>>();
             string syncDir = Path.Combine(siteOptions.Value.SiteDir, "sync");
-            bool doClone = mode == CLONE || mode == CLONE_AND_MOVE_OLD;
+            bool doClone = mode == CLONE || mode == CLONE_AND_MOVE_OLD || mode == CLONE_SILENT;
 
             string syncDirOld = Path.Combine(siteOptions.Value.SiteDir, "sync_old");
             if (mode == CLONE_AND_MOVE_OLD)
@@ -105,8 +106,9 @@ namespace PTDDCloneAll
                                 // Increment the queued count such as in SyncService
                                 op.Inc(pd => pd.Sync.QueuedCount);
                             });
+                            bool silent = mode == CLONE_SILENT;
                             // Clone the paratext project and update the SF database with the project data
-                            await CloneAndSyncFromParatext(webHost, proj, userId, syncDir);
+                            await CloneAndSyncFromParatext(webHost, proj, userId, syncDir, silent);
 
                             if (mode == CLONE_AND_MOVE_OLD)
                             {
@@ -132,21 +134,27 @@ namespace PTDDCloneAll
         /// Clone Paratext project data into the SF projects sync folder. Then synchronize existing books
         /// and notes in project.
         /// </summary>
-        public static async Task CloneAndSyncFromParatext(IWebHost webHost, SFProject proj, string userId, string syncDir)
+        public static async Task CloneAndSyncFromParatext(IWebHost webHost, SFProject proj, string userId,
+            string syncDir, bool silent)
         {
+            Log($"Cloning {proj.Name} ({proj.Id}) as SF user {userId}");
+            string partialCloneDir = Path.Combine(syncDir, proj.ParatextId);
             try
             {
-                Log($"Cloning {proj.Name} ({proj.Id}) as SF user {userId}");
                 PTDDSyncRunner syncRunner = webHost.Services.GetService<PTDDSyncRunner>();
-                await syncRunner.RunAsync(proj.Id, userId, false);
+                await syncRunner.RunAsync(proj.Id, userId, false, silent);
                 Log($"{proj.Name} - Succeeded");
+                if (silent)
+                {
+                    Log($"Deleting cloned repository for {proj.Name}");
+                    Directory.Delete(partialCloneDir, true);
+                }
             }
             catch (Exception e)
             {
                 Log($"There was a problem cloning the project.{Environment.NewLine}Exception is: {e}");
-                string partialCloneDir = Path.Combine(syncDir, proj.ParatextId);
                 if (Directory.Exists(partialCloneDir))
-                    Directory.Delete(partialCloneDir);
+                    Directory.Delete(partialCloneDir, true);
                 throw;
             }
         }


### PR DESCRIPTION
This allows us to run a silent clone of the projects, and then deletes the cloned repositories without persisting anything to the SF mongo database.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/796)
<!-- Reviewable:end -->
