### PR TITLE
SF-978 - Cache audio on answers when played

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1310,6 +1310,15 @@ describe('CheckingComponent', () => {
       verify(questionDoc!.updateAnswerFileCache()).twice();
       expect().nothing();
     }));
+
+    it('update answer audio cache on remote removal of an answer', fakeAsync(() => {
+      const env = new TestEnvironment(ADMIN_USER);
+      const questionDoc = spy(env.getQuestionDoc('q6Id'));
+      env.selectQuestion(6);
+      env.simulateRemoteDeleteAnswer('q6Id', 0);
+      verify(questionDoc!.updateAnswerFileCache()).twice();
+      expect().nothing();
+    }));
   });
 
   describe('Text', () => {
@@ -1939,6 +1948,12 @@ class TestEnvironment {
       }
     }, false);
     tick(this.questionReadTimer);
+    this.fixture.detectChanges();
+  }
+
+  simulateRemoteDeleteAnswer(questionId: string, answerIndex: number): void {
+    const questionDoc = this.getQuestionDoc(questionId);
+    questionDoc.submitJson0Op(op => op.remove(q => q.answers, answerIndex), false);
     this.fixture.detectChanges();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -350,16 +350,14 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
         if (this.questionsRemoteChangesSub != null) {
           this.questionsRemoteChangesSub.unsubscribe();
         }
-        this.questionsRemoteChangesSub = this.subscribe(
-          merge(this.questionsQuery.remoteDocChanges$, this.questionsQuery.ready$),
-          () => {
-            if (this.pwaService.isOnline) {
-              for (const qd of this.questionsQuery!.docs) {
-                qd.updateFileCache();
-              }
+        this.questionsRemoteChangesSub = this.subscribe(this.questionsQuery.remoteDocChanges$, (qd: QuestionDoc) => {
+          if (this.pwaService.isOnline) {
+            qd.updateFileCache();
+            if (qd === this.questionsPanel!.activeQuestionDoc) {
+              qd.updateAnswerFileCache();
             }
           }
-        );
+        });
         if (this.questionsSub != null) {
           this.questionsSub.unsubscribe();
         }
@@ -628,6 +626,9 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
     this.calculateScriptureSliderPosition(true);
     this.refreshSummary();
     this.collapseDrawer();
+    if (this.pwaService.isOnline) {
+      questionDoc.updateAnswerFileCache();
+    }
   }
 
   async questionDialog(): Promise<void> {
@@ -819,6 +820,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
     } else {
       activeQuestionDoc.submitJson0Op(op => op.insert(q => q.answers, 0, answers[0]));
     }
+    activeQuestionDoc.updateAnswerFileCache();
     this.questionsPanel.updateElementsRead(activeQuestionDoc);
     this.refreshSummary();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/question-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/question-doc.ts
@@ -72,7 +72,7 @@ export class QuestionDoc extends ProjectDataDoc<Question> {
       if (offlineData != null) {
         for (const answer of offlineData.data.answers) {
           const file = await this.realtimeService.fileService!.get(FileType.Audio, answer.dataId);
-          if (file != null && this.data!.answers.find(a => a === answer) == null) {
+          if (file != null && this.data!.answers.find(a => a.dataId === answer.dataId) == null) {
             await this.realtimeService.fileService!.findOrUpdateCache(FileType.Audio, this.collection, answer.dataId);
           }
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
@@ -90,6 +90,14 @@ export class FileService extends SubscriptionDisposable {
     });
   }
 
+  async get(dataCollection: string, dataId: string): Promise<FileOfflineData | undefined> {
+    return await this.offlineStore.get<FileOfflineData>(dataCollection, dataId);
+  }
+
+  async getAll(dataCollection: string): Promise<FileOfflineData[]> {
+    return await this.offlineStore.getAll<FileOfflineData>(dataCollection);
+  }
+
   /**
    * Uploads a file to the file server, or if offline, stores the file in IndexedDB and uploads next time there is a
    * valid connection.


### PR DESCRIPTION
- Added `updateAnswerFileCache` to the question doc so it can be called when required
- Cache answer audio on question activation
- Cache answer audio on remote changes to a question currently being viewed
- Cache answer audio when saving an answer
- Moved update file cache subscription to now take place when a realtime doc updates offline data
- Changed realtime doc for `updateOfflineData` to `protected` so that it can be expanded in child classes
- Updated realtime query to emit the specific document that has remotely changed
- Added `get` and `getAll` to file service
- Updated checking tests to reset `mockedFileService` for each test so that `verify` is valid per test rather than over all tests
- Created tests for ensuring answer audio is cached

There was a point on the Jira task when a `user is unlikely to revisit the answer`. This can be covered in a future task that will introduce a settings page around what gets cached for offline use and what should be deleted and when.

### Acceptance tests
- _Checker_ adds an answer with audio and the audio is cached
- _Checker_ removes audio from answer and the audio is removed from cache
- _Checker_ deletes an answer with audio and the audio is removed from cache
- _Checker_ adds an answer with audio. _Admin_ does not view the question containing the answer so no audio is cached for the answer
- _Checker_ adds an answer with audio. _Admin_ views the question containing the answer and the audio is cached
- _Checker_ adds an answer with audio. _Admin_ views the question containing the answer and the audio is cached. _Checker_ removes audio from answer and audio is removed from cache for both the _Checker_ and the _Admin_
- _Checker_ adds an answer with audio. _Admin_ views the question containing the answer and the audio is cached. _Checker_ deletes their answer and audio is removed from cache for both the _Checker_ and the _Admin_
- _Checker_ adds an answer with audio. _Admin_ views the question containing the answer and the audio is cached. _Admin_ deletes the checkers answer and audio is removed from cache for both the _Checker_ and the _Admin_

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/800)
<!-- Reviewable:end -->
