### PR TITLE
SF-1055 - An error occurred during login

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -337,12 +337,8 @@ export class AuthService {
             resolve(null);
           } else if (retryUponTimeout && err.code === 'timeout') {
             this.checkSession(false)
-              .then(retryAuthResult => {
-                resolve(retryAuthResult);
-              })
-              .catch(retryError => {
-                reject(retryError);
-              });
+              .then(resolve)
+              .catch(reject);
           } else {
             reject(err);
           }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -329,14 +329,14 @@ export class AuthService {
     });
   }
 
-  private checkSession(retryTimeout: boolean = false): Promise<auth0.Auth0DecodedHash | null> {
+  private checkSession(retryUponTimeout: boolean = true): Promise<auth0.Auth0DecodedHash | null> {
     return new Promise<auth0.Auth0DecodedHash | null>((resolve, reject) => {
-      this.auth0.checkSession({ state: JSON.stringify({}) }, async (err, authResult) => {
+      this.auth0.checkSession({ state: JSON.stringify({}) }, (err, authResult) => {
         if (err != null) {
           if (err.code === 'login_required') {
             resolve(null);
-          } else if (!retryTimeout && err.code === 'timeout') {
-            this.checkSession(true)
+          } else if (retryUponTimeout && err.code === 'timeout') {
+            this.checkSession(false)
               .then(retryAuthResult => {
                 resolve(retryAuthResult);
               })


### PR DESCRIPTION
- Retry `checkSession` for `auth0` when a timeout occurs

This issue relates to a timeout from `auth0` but I'm not entirely sure what and when this occurs. The only way I was able to consistently cause a timeout was to edit my hosts file and direct `sil-appbuilder.auth0.com` to my `localhost`. 

The timeout happens after 1 minute of running `checkSession()` in `auth.service.ts` which then runs `checkSession()` from `auth0`.

What I've currently done is a simple retry. This could be easily changed to retry multiple times but I think if it is failing multiple times then perhaps there is a larger issue going on.

I also think we don't need to check with `auth0` everytime the app loads. When we first authenticate `auth0` gives us the relevant tokens and states when it will expire. If we know the expiry date, and are storing the tokens, then there really is no need to keep asking if we have permission. I'd see this as a separate task. I know Nathaniel has also raised questions about looking at our whole login process so this could perhaps form part of that review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/801)
<!-- Reviewable:end -->
