### PR TITLE
SF-1002 Allow users to edit display name offline

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -89,7 +89,7 @@
                   {{ t("logged_in_as") }}
                   <div fxLayout="row" fxLayoutAlign="start center">
                     <span fxFlex>&nbsp;</span>
-                    <button *ngIf="isAppOnline" id="edit-name-btn" mdcIconButton type="button" (click)="editName()">
+                    <button id="edit-name-btn" mdcIconButton type="button" (click)="editName()">
                       <mdc-icon>edit</mdc-icon>
                     </button>
                     <strong class="user-menu-name">{{ currentUser?.displayName }}</strong>


### PR DESCRIPTION
- This is already possible when the user answers a question for the first time, since the user is prompted with a dialog.
- There isn't really any reason it needed to be disabled in the first place. I think maybe at the time I thought editing the name would require immediately saving it via an API call, but the user object is part of the realtime system. This is just reverting a change that never needed to be made in the first place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/803)
<!-- Reviewable:end -->
