### PR TITLE
Sync: Allow projects to have their synchronization disabled

### DIFF
--- a/src/RealtimeServer/common/models/project.ts
+++ b/src/RealtimeServer/common/models/project.ts
@@ -1,4 +1,6 @@
 export interface Project {
   name: string;
   userRoles: { [userRef: string]: string };
+  /** Whether the project has its capability to synchronize project data turned off. */
+  syncDisabled?: boolean;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
@@ -2,6 +2,7 @@
   <div fxLayout="column" class="base-container">
     <h2 id="title">{{ t("synchronize_project", { projectName: projectName }) }}</h2>
     <span *ngIf="!isAppOnline" class="offline-text"> {{ t("connect_network_to_synchronize") }} </span>
+    <span *ngIf="syncDisabled" id="syncDisabled-message" class="syncDisabled-text">{{ t("sync_is_disabled") }}</span>
     <mdc-card outlined class="sync-card">
       <div fxLayout="column" class="card-content">
         <button
@@ -22,7 +23,7 @@
             primary
             type="button"
             (click)="syncProject()"
-            [disabled]="isLoading || !isAppOnline"
+            [disabled]="isLoading || !isAppOnline || syncDisabled"
             id="btn-sync"
           >
             <mdc-icon>sync</mdc-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
@@ -50,3 +50,8 @@ h2 {
   padding-bottom: 1rem;
   text-align: center;
 }
+
+.syncDisabled-text {
+  padding-bottom: 1rem;
+  text-align: center;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
@@ -124,6 +124,20 @@ describe('SyncComponent', () => {
     expect(env.component.syncActive).toBe(true);
     expect(env.progressBar).toBeDefined();
   }));
+
+  it('should explain and disable button when syncDisabled', fakeAsync(() => {
+    const env = new TestEnvironment(true, false, true, true);
+    expect(env.logInButton).toBeNull();
+    expect(env.syncButton.nativeElement.disabled).toBe(true);
+    expect(env.lastSyncDate.textContent).toContain('Last synced on');
+    expect(env.syncDisabledMessage).not.toBeNull();
+  }));
+
+  it('should not explain or disable button when not syncDisabled', fakeAsync(() => {
+    const env = new TestEnvironment(true, false, true, false);
+    expect(env.syncButton.nativeElement.disabled).toBe(false);
+    expect(env.syncDisabledMessage).toBeNull();
+  }));
 });
 
 class TestEnvironment {
@@ -134,7 +148,12 @@ class TestEnvironment {
   private isLoading: boolean = false;
   private isOnline: BehaviorSubject<boolean>;
 
-  constructor(isParatextAccountConnected: boolean = false, isInProgress: boolean = false, isOnline: boolean = true) {
+  constructor(
+    isParatextAccountConnected: boolean = false,
+    isInProgress: boolean = false,
+    isOnline: boolean = true,
+    isSyncDisabled: boolean = false
+  ) {
     when(mockedActivatedRoute.params).thenReturn(of({ projectId: 'testProject01' }));
     const ptUsername = isParatextAccountConnected ? 'Paratext User01' : '';
     when(mockedParatextService.getParatextUsername()).thenReturn(of(ptUsername));
@@ -171,6 +190,7 @@ class TestEnvironment {
           lastSyncSuccessful: true,
           dateLastSuccessfulSync: date.toJSON()
         },
+        syncDisabled: isSyncDisabled,
         texts: [],
         userRoles: {}
       }
@@ -208,6 +228,10 @@ class TestEnvironment {
 
   get syncMessage(): HTMLElement {
     return this.fixture.nativeElement.querySelector('#sync-message');
+  }
+
+  get syncDisabledMessage(): HTMLElement {
+    return this.fixture.nativeElement.querySelector('#syncDisabled-message');
   }
 
   get offlineMessage(): HTMLElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
@@ -20,6 +20,7 @@ export class SyncComponent extends DataLoadingComponent implements OnInit, OnDes
   syncActive: boolean = false;
   isAppOnline: boolean = false;
   showParatextLogin = false;
+  syncDisabled: boolean = false;
 
   private projectDoc?: SFProjectDoc;
   private paratextUsername?: string;
@@ -137,6 +138,10 @@ export class SyncComponent extends DataLoadingComponent implements OnInit, OnDes
   private checkSyncStatus(): void {
     if (this.projectDoc == null || this.projectDoc.data == null) {
       return;
+    }
+
+    if (this.projectDoc.data.syncDisabled != null) {
+      this.syncDisabled = this.projectDoc.data.syncDisabled;
     }
 
     if (this.projectDoc.data.sync.queuedCount > 0) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -162,7 +162,8 @@
     "successfully_synchronized_with_paratext": "Successfully synchronized {{ projectName }} with Paratext.",
     "synchronize": "Synchronize",
     "synchronize_project": "Synchronize {{ projectName }} with Paratext",
-    "your_project_is_being_synchronized": "Your project is being synchronized..."
+    "your_project_is_being_synchronized": "Your project is being synchronized...",
+    "sync_is_disabled": "Synchronization for this project needed to be disabled, so it is not available at this time. Please contact scriptureforgeissues@sil.org to discuss what needs done so project synchronization can be enabled again."
   },
   "text": {
     "book_does_not_exist": "This book does not exist.",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/project.service.ts
@@ -87,6 +87,10 @@ export abstract class ProjectService<
     return this.onlineInvoke('delete', { projectId: id });
   }
 
+  async onlineSetSyncDisabled(projectId: string, isDisabled: boolean): Promise<void> {
+    this.onlineInvoke<void>('setSyncDisabled', { projectId, isDisabled });
+  }
+
   protected onlineInvoke<T>(method: string, params?: any): Promise<T | undefined> {
     return this.commandService.onlineInvoke<T>(PROJECTS_URL, method, params);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.html
@@ -46,8 +46,17 @@
           </mat-form-field>
         </td>
       </ng-container>
+      <ng-container matColumnDef="syncDisabled">
+        <td mat-cell *matCellDef="let row">
+          <mdc-checkbox
+            [checked]="row.syncDisabled"
+            (change)="onUpdateSyncDisabled(row, $event.checked)"
+          ></mdc-checkbox>
+          Sync Disabled
+        </td>
+      </ng-container>
 
-      <tr mat-row *matRowDef="let row; columns: ['name', 'tasks', 'role']"></tr>
+      <tr mat-row *matRowDef="let row; columns: ['name', 'tasks', 'role', 'syncDisabled']"></tr>
     </table>
 
     <mat-paginator

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.spec.ts
@@ -1,5 +1,6 @@
+import { MdcCheckbox } from '@angular-mdc/web';
 import { DebugElement, getDebugNode } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -121,6 +122,38 @@ describe('SaProjectsComponent', () => {
     verify(mockedProjectService.onlineRemoveUser('project01', 'user01')).once();
   }));
 
+  it('should show if sync disabled', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.setupProjectData();
+    env.fixture.detectChanges();
+    tick();
+    env.fixture.detectChanges();
+    tick();
+
+    const projectRowWithSyncNotDisabled: number = 0;
+    const projectRowWithSyncDisabled: number = 1;
+    expect(env.isSyncDisabled(projectRowWithSyncNotDisabled)).toBe(false);
+    expect(env.isSyncDisabled(projectRowWithSyncDisabled)).toBe(true);
+    verify(mockedProjectService.onlineSetSyncDisabled(anything(), anything())).never();
+  }));
+
+  it('should process change for sync disabled', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.setupProjectData();
+    env.fixture.detectChanges();
+    tick();
+    env.fixture.detectChanges();
+    tick();
+
+    const projectInRow: number = 0;
+    expect(env.isSyncDisabled(projectInRow)).toBe(false);
+    // SUT
+    env.clickButton(env.syncDisabledControl(projectInRow));
+    expect(env.isSyncDisabled(projectInRow)).toBe(true);
+
+    verify(mockedProjectService.onlineSetSyncDisabled('project01', true)).once();
+  }));
+
   it('should filter projects', fakeAsync(() => {
     const env = new TestEnvironment();
     env.setupProjectData();
@@ -158,6 +191,8 @@ class TestEnvironment {
   readonly component: SaProjectsComponent;
   readonly fixture: ComponentFixture<SaProjectsComponent>;
 
+  private readonly roleColumn = 2;
+  private readonly syncDisabledColumn = 3;
   private readonly realtimeService: TestRealtimeService = TestBed.get<TestRealtimeService>(TestRealtimeService);
 
   constructor() {
@@ -226,7 +261,18 @@ class TestEnvironment {
   }
 
   roleSelect(row: number): DebugElement {
-    return this.cell(row, 2).query(By.css('mat-select'));
+    return this.cell(row, this.roleColumn).query(By.css('mat-select'));
+  }
+
+  isSyncDisabled(row: number): boolean {
+    return (this.cell(row, this.syncDisabledColumn).query(By.css('mdc-checkbox')).componentInstance as MdcCheckbox)
+      .checked;
+  }
+
+  syncDisabledControl(row: number): DebugElement {
+    return this.cell(row, this.syncDisabledColumn)
+      .query(By.css('mdc-checkbox'))
+      .query(By.css('input'));
   }
 
   changeSelectValue(select: DebugElement, option: number): void {
@@ -268,7 +314,8 @@ class TestEnvironment {
         id: 'project02',
         data: {
           name: 'Project 02',
-          userRoles: {}
+          userRoles: {},
+          syncDisabled: true
         }
       },
       {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.ts
@@ -30,6 +30,13 @@ class Row {
   get tasks(): string {
     return this.projectDoc.taskNames.join(', ');
   }
+
+  get syncDisabled(): boolean {
+    if (this.projectDoc.data == null || this.projectDoc.data.syncDisabled == null) {
+      return false;
+    }
+    return this.projectDoc.data.syncDisabled;
+  }
 }
 
 @Component({
@@ -104,6 +111,10 @@ export class SaProjectsComponent extends DataLoadingComponent implements OnInit 
     }
     row.projectRole = projectRole;
     row.isUpdatingRole = false;
+  }
+
+  async onUpdateSyncDisabled(row: Row, newValue: boolean): Promise<void> {
+    return this.projectService.onlineSetSyncDisabled(row.id, newValue);
   }
 
   private generateRows(): void {

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -277,5 +277,22 @@ namespace SIL.XForge.Scripture.Controllers
                 return InvalidParamsError(fe.Message);
             }
         }
+
+        public async Task<IRpcMethodResult> SetSyncDisabled(string projectId, bool isDisabled)
+        {
+            try
+            {
+                await _projectService.SetSyncDisabledAsync(UserId, SystemRole, projectId, isDisabled);
+                return Ok();
+            }
+            catch (ForbiddenException)
+            {
+                return ForbiddenError();
+            }
+            catch (DataNotFoundException dnfe)
+            {
+                return NotFoundError(dnfe.Message);
+            }
+        }
     }
 }

--- a/src/SIL.XForge/Models/Project.cs
+++ b/src/SIL.XForge/Models/Project.cs
@@ -6,5 +6,6 @@ namespace SIL.XForge.Models
     {
         public string Name { get; set; }
         public Dictionary<string, string> UserRoles { get; set; } = new Dictionary<string, string>();
+        public bool SyncDisabled { get; set; }
     }
 }

--- a/src/SIL.XForge/Services/IProjectService.cs
+++ b/src/SIL.XForge/Services/IProjectService.cs
@@ -12,5 +12,6 @@ namespace SIL.XForge.Services
         Task<Uri> SaveAudioAsync(string curUserId, string projectId, string dataId, string extension,
             Stream inputStream);
         Task DeleteAudioAsync(string curUserId, string projectId, string ownerId, string dataId);
+        Task SetSyncDisabledAsync(string curUserId, string systemRole, string projectId, bool isDisabled);
     }
 }

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -139,6 +139,18 @@ namespace SIL.XForge.Services
                 FileSystemService.DeleteFile(filePath);
         }
 
+        public async Task SetSyncDisabledAsync(string curUserId, string systemRole, string projectId, bool isDisabled)
+        {
+            if (systemRole != SystemRole.SystemAdmin)
+                throw new ForbiddenException();
+
+            using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
+            {
+                IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
+                await projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.SyncDisabled, isDisabled));
+            }
+        }
+
         protected virtual async Task AddUserToProjectAsync(IConnection conn, IDocument<TModel> projectDoc,
             IDocument<User> userDoc, string projectRole, bool removeShareKeys = true)
         {

--- a/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using NSubstitute;
+using NUnit.Framework;
+using SIL.XForge.DataAccess;
+using SIL.XForge.Realtime;
+using SIL.XForge.Scripture.Models;
+using SIL.XForge.Scripture.Realtime;
+using Hangfire;
+using SIL.XForge.Services;
+
+namespace SIL.XForge.Scripture.Services
+{
+    [TestFixture]
+    public class SyncServiceTests
+    {
+        private static readonly string Project01 = "project01";
+        private static readonly string Project02 = "project02";
+
+        [Test]
+        public void SyncAsync_Enqueues()
+        {
+            var env = new TestEnvironment();
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).SyncDisabled, Is.False);
+            // SUT
+            Assert.DoesNotThrowAsync(() => env.Service.SyncAsync("userid", Project01, false));
+        }
+
+        [Test]
+        public void SyncAsync_NotIfSyncDisabled()
+        {
+            var env = new TestEnvironment();
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).SyncDisabled, Is.True, "setup");
+            Assert.ThrowsAsync<ForbiddenException>(() => env.Service.SyncAsync("userid", Project02, false));
+        }
+
+        private class TestEnvironment
+        {
+            public TestEnvironment()
+            {
+                BackgroundJobClient = Substitute.For<IBackgroundJobClient>();
+                RealtimeService = new SFMemoryRealtimeService();
+
+                RealtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(
+                    new[]
+                    {
+                        new SFProject
+                        {
+                            Id = Project01,
+                            Name = "project01",
+                            ShortName = "P01",
+                            CheckingConfig = new CheckingConfig
+                            {
+                                ShareEnabled = false
+                            },
+                            UserRoles = new Dictionary<string, string>
+                            {
+                            },
+                        },
+                        new SFProject
+                        {
+                            Id = Project02,
+                            Name = "project02",
+                            ShortName = "P02",
+                            CheckingConfig = new CheckingConfig
+                            {
+                                ShareEnabled = false
+                            },
+                            UserRoles = new Dictionary<string, string>
+                            {
+                            },
+                            SyncDisabled = true
+                        },
+                }));
+
+                Service = new SyncService(BackgroundJobClient, RealtimeService);
+            }
+
+            public SyncService Service { get; }
+            public IBackgroundJobClient BackgroundJobClient { get; }
+            public SFMemoryRealtimeService RealtimeService { get; }
+        }
+    }
+}


### PR DESCRIPTION
So, I don't really need to expose a backend API method of `GetSyncDisabled`, do I. But then, do I need `SetSyncDisabled`? I'm a bit foggy in remembering how this is supposed to work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/804)
<!-- Reviewable:end -->
