### PR TITLE
Specify if sync all should skip synchronizing books

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -66,7 +66,8 @@
         // "SYNC_SET": "sfProject2 sfProject3",
         // "SF_PROJECT_ADMINS": "sfProject1:sfUserA sfProject2:sfUserB",
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "PTDASYNCALL_MODE": "NOTsync"
+        "PTDASYNCALL_MODE": "NOTsync",
+        "SKIPSYNCBOOK": "NOTskip"
       }
     },
     {

--- a/src/Migrations/PtdaSyncAll/PtdaSyncRunner.cs
+++ b/src/Migrations/PtdaSyncAll/PtdaSyncRunner.cs
@@ -409,8 +409,19 @@ namespace PtdaSyncAll
                             + $"That diff is: \n{diff}");
                     }
 
-                    ptBookText = await _paratextService.UpdateBookTextAsync(_userSecret, paratextId, bookId,
-                        revision, newUsxDoc.Root.ToString());
+                    var skipUpdate = Environment.GetEnvironmentVariable("SKIPSYNCBOOK");
+                    if (skipUpdate == "skip")
+                    {
+                        // Diffs will be recorded in the logs so we can evaluate if any changes were significant
+                        // and need to be addressed post-migration
+                        Console.WriteLine($"Skip pushing edits from SF to Paratext for {bookId}");
+                        return null;
+                    }
+                    else
+                    {
+                        ptBookText = await _paratextService.UpdateBookTextAsync(_userSecret, paratextId, bookId,
+                            revision, newUsxDoc.Root.ToString());
+                    }
                 }
             }
             return ptBookText;

--- a/src/Migrations/PtdaSyncAll/PtdaSyncRunner.cs
+++ b/src/Migrations/PtdaSyncAll/PtdaSyncRunner.cs
@@ -414,7 +414,8 @@ namespace PtdaSyncAll
                     {
                         // Diffs will be recorded in the logs so we can evaluate if any changes were significant
                         // and need to be addressed post-migration
-                        Console.WriteLine($"Skip pushing edits from SF to Paratext for {bookId}");
+                        Console.WriteLine($"Skip pushing edits from SF to Paratext."
+                            + $"BookId: {bookId} ParatextId: {paratextId}");
                         return null;
                     }
                     else


### PR DESCRIPTION
There are 2 projects that cannot be migrated due to inadequate book permissions, and users have not responded to our email. This change will allow us to synchronize any questions and answers, but will skip over changes to books. We can then retrospectively evaluate if the text changes were significant. An initial look at the text changes on these two projects reveal that they are not considerable changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/813)
<!-- Reviewable:end -->
