### PR TITLE
SF-1022 Update question verseRefs in scripture panel when edited remo…

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -7,7 +7,7 @@ import { Comment } from 'realtime-server/lib/scriptureforge/models/comment';
 import { SFProject } from 'realtime-server/lib/scriptureforge/models/sf-project';
 import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/scriptureforge/models/sf-project-rights';
 import { SFProjectRole } from 'realtime-server/lib/scriptureforge/models/sf-project-role';
-import { Subject, Subscription } from 'rxjs';
+import { Subject } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { UserService } from 'xforge-common/user.service';
@@ -31,7 +31,6 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
   activeQuestionDoc?: QuestionDoc;
   activeQuestionDoc$ = new Subject<QuestionDoc>();
   @ViewChild(MdcList, { static: true }) mdcList!: MdcList;
-  private questionDocSubscription?: Subscription;
 
   constructor(private readonly userService: UserService, private readonly projectService: SFProjectService) {
     super();
@@ -255,9 +254,6 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
         this.changed.emit(questionDoc);
         if (questionChanged) {
           this.activeQuestionDoc$.next(questionDoc);
-          if (this.questionDocSubscription != null) {
-            this.questionDocSubscription.unsubscribe();
-          }
         }
       });
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -7,8 +7,6 @@ import { Comment } from 'realtime-server/lib/scriptureforge/models/comment';
 import { SFProject } from 'realtime-server/lib/scriptureforge/models/sf-project';
 import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/scriptureforge/models/sf-project-rights';
 import { SFProjectRole } from 'realtime-server/lib/scriptureforge/models/sf-project-role';
-import { toVerseRef } from 'realtime-server/lib/scriptureforge/models/verse-ref-data';
-import { VerseRef } from 'realtime-server/lib/scriptureforge/scripture-utils/verse-ref';
 import { Subject, Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
@@ -33,7 +31,6 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
   activeQuestionDoc?: QuestionDoc;
   activeQuestionDoc$ = new Subject<QuestionDoc>();
   @ViewChild(MdcList, { static: true }) mdcList!: MdcList;
-  private _activeQuestionVerseRef?: VerseRef;
   private questionDocSubscription?: Subscription;
 
   constructor(private readonly userService: UserService, private readonly projectService: SFProjectService) {
@@ -62,10 +59,6 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
     }
     const activeQuestionDocId = this.activeQuestionDoc.id;
     return this.questionDocs.findIndex(question => question.id === activeQuestionDocId);
-  }
-
-  get activeQuestionVerseRef(): VerseRef | undefined {
-    return this._activeQuestionVerseRef;
   }
 
   get questionDocs(): Readonly<QuestionDoc[]> {
@@ -252,7 +245,6 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
   activateQuestion(questionDoc: QuestionDoc): void {
     // The reason for the convoluted questionChanged logic is because the change needs to be emitted even if it's the
     // same question, but calling activeQuestionDoc$.next when the question is unchanged causes complicated test errors
-    this._activeQuestionVerseRef = questionDoc.data == null ? undefined : toVerseRef(questionDoc.data.verseRef);
     let questionChanged = true;
     if (this.activeQuestionDoc != null && this.activeQuestionDoc.id === questionDoc.id) {
       questionChanged = false;
@@ -266,11 +258,6 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
           if (this.questionDocSubscription != null) {
             this.questionDocSubscription.unsubscribe();
           }
-          this.questionDocSubscription = questionDoc.remoteChanges$.subscribe(
-            () =>
-              (this._activeQuestionVerseRef =
-                questionDoc.data == null ? undefined : toVerseRef(questionDoc.data.verseRef))
-          );
         }
       });
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1354,6 +1354,28 @@ describe('CheckingComponent', () => {
       expect(segment.getAttribute('data-question-count')).toBe('13');
     }));
 
+    it('updates question highlight when verse ref changes', fakeAsync(() => {
+      const env = new TestEnvironment(CHECKER_USER);
+      env.selectQuestion(4);
+      expect(env.getVerse(1, 3)).not.toBeNull();
+      let segment = env.getVerse(1, 3);
+      expect(segment.classList.contains('question-segment')).toBe(true);
+      expect(segment.classList.contains('highlight-segment')).toBe(true);
+      expect(fromVerseRef(env.component.activeQuestionVerseRef!).verseNum).toEqual(3);
+      env.component.questionsPanel!.activeQuestionDoc!.submitJson0Op(op => {
+        op.set(qd => qd.verseRef, fromVerseRef(VerseRef.parse('JHN 1:5')));
+      }, false);
+      env.waitForSliderUpdate();
+      tick();
+      segment = env.getVerse(1, 3);
+      expect(segment.classList.contains('question-segment')).toBe(false);
+      expect(segment.classList.contains('highlight-segment')).toBe(false);
+      expect(fromVerseRef(env.component.activeQuestionVerseRef!).verseNum).toEqual(5);
+      segment = env.getVerse(1, 5);
+      expect(segment.classList.contains('question-segment')).toBe(true);
+      expect(segment.classList.contains('highlight-segment')).toBe(true);
+    }));
+
     it('sets text and paragraph direction ', fakeAsync(() => {
       const env = new TestEnvironment(ADMIN_USER);
       // the dir property is needed on the Quill editor because chapters don't always have paragraphs

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -79,7 +79,6 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
     answered: 0
   };
   questionVerseRefs: VerseRef[] = [];
-  _activeQuestionVerseRef?: VerseRef;
   answersPanelContainerElement?: ElementRef;
   projectDoc?: SFProjectDoc;
   projectUserConfigDoc?: SFProjectUserConfigDoc;
@@ -89,6 +88,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
   private _isDrawerPermanent: boolean = true;
   private _chapter?: number;
   private questionsQuery?: RealtimeQuery<QuestionDoc>;
+  private _activeQuestionVerseRef?: VerseRef;
   private questionsSub?: Subscription;
   private projectDeleteSub?: Subscription;
   private projectRemoteChangesSub?: Subscription;
@@ -353,7 +353,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
         this.questionsRemoteChangesSub = this.subscribe(this.questionsQuery.remoteDocChanges$, (qd: QuestionDoc) => {
           const isActiveQuestionDoc = qd.id === this.questionsPanel!.activeQuestionDoc?.id;
           if (isActiveQuestionDoc) {
-            this._activeQuestionVerseRef = qd.data == null ? undefined : toVerseRef(qd.data.verseRef);
+            this.updateActiveQuestionVerseRef(qd);
           }
           if (this.pwaService.isOnline) {
             qd.updateFileCache();
@@ -630,9 +630,9 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
       return;
     }
 
-    this.book = questionDoc.data == null ? undefined : questionDoc.data.verseRef.bookNum;
+    this.book = questionDoc.data?.verseRef.bookNum;
     this.chapter = this.questionsPanel.activeQuestionChapter;
-    this._activeQuestionVerseRef = questionDoc.data == null ? undefined : toVerseRef(questionDoc.data.verseRef);
+    this.updateActiveQuestionVerseRef(questionDoc);
     this.calculateScriptureSliderPosition(true);
     this.refreshSummary();
     this.collapseDrawer();
@@ -895,6 +895,10 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
         })
       );
     }
+  }
+
+  private updateActiveQuestionVerseRef(questionDoc: QuestionDoc): void {
+    this._activeQuestionVerseRef = questionDoc.data == null ? undefined : toVerseRef(questionDoc.data.verseRef);
   }
 
   private calculateScriptureSliderPosition(maximizeAnswerPanel: boolean = false): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -364,7 +364,12 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
         const prevBook = this.book;
         this.book = bookNum;
         this.questionsSub = this.subscribe(
-          merge(this.questionsQuery.ready$, this.questionsQuery.remoteChanges$, this.questionsQuery.localChanges$),
+          merge(
+            this.questionsQuery.ready$,
+            this.questionsQuery.remoteChanges$,
+            this.questionsQuery.localChanges$,
+            this.questionsQuery.remoteDocChanges$
+          ),
           () => this.updateQuestionRefsOrRedirect()
         );
         this.userDoc = await this.userService.getCurrentUser();


### PR DESCRIPTION
…tely
* Subscribe to changes to a questionDoc to know have the most up to date verse ref.
* Update question refs data on any question doc has changed

Previously the question icon and highlight do not update in real time on a checker user if an admin edits a question's verse ref. This change keeps the checking questions component's knowledge of the activeQuestionVerseRef up to date.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/814)
<!-- Reviewable:end -->
