### PR TITLE
Sync: Do not write PT username to server logs

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -288,7 +288,7 @@ namespace SIL.XForge.Scripture.Services
                 XPathExpression.Compile("*[false()]"), out string usfm);
             usfm = UsfmToken.NormalizeUsfm(scrText.ScrStylesheet(bookNum), usfm, false, scrText.RightToLeft);
             scrText.PutText(bookNum, 0, false, usfm, null);
-            _logger.LogInformation("{0} updated {1} in {2}.", GetParatextUsername(userSecret),
+            _logger.LogInformation("{0} updated {1} in {2}.", userSecret.Id,
                 Canon.BookNumberToEnglishName(bookNum), scrText.Name);
         }
 
@@ -355,10 +355,10 @@ namespace SIL.XForge.Scripture.Services
                 foreach (string user in users)
                     manager.SaveUser(user, false);
                 VersionedText vText = VersioningManager.Get(scrText);
-                vText.Commit($"{nbrAddedComments} notes added and {nbrDeletedComments + nbrUpdatedComments} notes updated or deleted in synchronize",
-                     null, false, username);
-                _logger.LogInformation("{0} added {1} notes, updated {2} notes and deleted {3} notes",
-                    username, nbrAddedComments, nbrUpdatedComments, nbrDeletedComments);
+                vText.Commit($"{nbrAddedComments} notes added and {nbrDeletedComments + nbrUpdatedComments} notes "
+                    + $"updated or deleted in synchronize", null, false, username);
+                _logger.LogInformation("{0} added {1} notes, updated {2} notes and deleted {3} notes", userSecret.Id,
+                    nbrAddedComments, nbrUpdatedComments, nbrDeletedComments);
             }
             catch (Exception e)
             {

--- a/src/SIL.XForge/Models/UserSecret.cs
+++ b/src/SIL.XForge/Models/UserSecret.cs
@@ -6,6 +6,10 @@ namespace SIL.XForge.Models
     /// </summary>
     public class UserSecret : IIdentifiable
     {
+        /// <summary>
+        /// SF user ID of the user that these secrets pertain to. (This is not a different set of IDs for
+        /// specifically user secrets.)
+        /// </summary>
         public string Id { get; set; }
 
         public Tokens ParatextTokens { get; set; }

--- a/test/SIL.XForge.Scripture.Tests/Services/MockLogger.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockLogger.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace SIL.XForge.Scripture.Services
+{
+    /// <summary>
+    /// Mock for ILogger since it's difficult to mock with NSubstitute.
+    /// </summary>
+    public class MockLogger<T> : ILogger<T>
+    {
+        /// <summary>
+        /// Stores logged messages.
+        /// </summary>
+        public readonly List<string> Messages = new List<string>();
+
+        public MockLogger()
+        {
+
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
+            Func<TState, Exception, string> formatter)
+        {
+            Messages.Add(((object)state).ToString());
+        }
+    }
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -280,6 +280,9 @@ namespace SIL.XForge.Scripture.Services
             env.Service.PutBookText(userSecret, ptProjectId, ruthBookNum, newDocUsx.Root.ToString());
             env.ProjectScrText.FileManager.Received(1)
                 .WriteFileCreatingBackup(Arg.Any<string>(), Arg.Any<Action<string>>());
+
+            // PT username is not written to server logs
+            Assert.That(env.MockLogger.Messages.Any((string message) => message.Contains(env.Username01)), Is.False);
         }
 
         [Test]
@@ -333,6 +336,9 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(thread.Comments.Count, Is.EqualTo(1));
             comment = thread.Comments.First();
             Assert.That(comment.Deleted, Is.True, "Comment should be marked deleted");
+
+            // PT username is not written to server logs
+            Assert.That(env.MockLogger.Messages.Any((string message) => message.Contains(env.Username01)), Is.False);
         }
 
         [Test]
@@ -491,7 +497,7 @@ namespace SIL.XForge.Scripture.Services
             public IScrTextCollection MockScrTextCollection;
             public ISharingLogicWrapper MockSharingLogicWrapper;
             public IHgWrapper MockHgWrapper;
-            public ILogger<ParatextService> MockLogger;
+            public MockLogger<ParatextService> MockLogger;
             public IJwtTokenHelper MockJwtTokenHelper;
             public IInternetSharedRepositorySourceProvider MockInternetSharedRepositorySourceProvider;
             public ParatextService Service;
@@ -504,7 +510,7 @@ namespace SIL.XForge.Scripture.Services
                 MockExceptionHandler = Substitute.For<IExceptionHandler>();
                 MockSiteOptions = Substitute.For<IOptions<SiteOptions>>();
                 MockFileSystemService = Substitute.For<IFileSystemService>();
-                MockLogger = Substitute.For<ILogger<ParatextService>>();
+                MockLogger = new MockLogger<ParatextService>();
                 MockScrTextCollection = Substitute.For<IScrTextCollection>();
                 MockSharingLogicWrapper = Substitute.For<ISharingLogicWrapper>();
                 MockHgWrapper = Substitute.For<IHgWrapper>();


### PR DESCRIPTION
- Note that the PutNotes test change may look nice, but that test
isn't working right now anyway :-/. See SF-1089.
- Introduces class MockLogger<T>, since using NSubstitute with ILogger
is tricky.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/818)
<!-- Reviewable:end -->
