### PR TITLE
I18n for Firefox private browsing and out of space errors

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -236,6 +236,7 @@
     "try_again": "Try Again"
   },
   "exception_handling_service": {
+    "firefox_private_browsing_or_no_space": "Something went wrong. Please check that you are not using Firefox in the unsupported private browsing mode and that your device has the recommended 500 MB of free space.",
     "network_request_failed": "A network request failed. Some functionality may be unavailable.",
     "out_of_space": "An error occurred because your device is out of storage space.",
     "unknown_error": "Unknown error"

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
@@ -98,7 +98,7 @@ export class ExceptionHandlingService implements ErrorHandler {
       message.includes('A mutation operation was attempted on a database that did not allow mutations.') &&
       window.navigator.userAgent.includes('Gecko/')
     ) {
-      message = 'Firefox private browsing mode is not supported because IndexedDB is not available.';
+      message = translate('exception_handling_service.firefox_private_browsing_or_no_space');
     }
 
     // try/finally blocks are to prevent an exception from preventing reporting or logging of an error


### PR DESCRIPTION
When a device using Firefox is full, IndexedDB becomes unreliable. It used to show a message dialog about private browsing mode which was not the case. I've made the message to cover both cases where a user is incorrectly using private browsing in FF, or if their device is out of space.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/820)
<!-- Reviewable:end -->
