### PR TITLE
SF-1072 Connect: Do not connect PT project twice

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.ts
@@ -15,6 +15,7 @@ export class ParatextService {
     this.authService.linkParatext(returnUrl);
   }
 
+  /** Get projects the user has access to. */
   getProjects(): Observable<ParatextProject[] | undefined> {
     return this.http
       .get<ParatextProject[]>('paratext-api/projects', { headers: this.getHeaders() })

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -56,6 +56,7 @@
     "no_connectable_projects": "Looks like there are no connectable projects for you.{{ newLine }}Please go to Paratext to register a project to connect to.",
     "only_paratext_admins_can_start": "** You must be the Paratext Administrator of a project to start it here. Ask your Administrator to connect to your project then you can also connect to it here after that.",
     "paratext_project": "Paratext Project",
+    "problem_already_connected": "The project is already connected. Maybe another project administrator connected the project at the same time. Please try again. If it continues to be a problem, please report the issue so we can get it fixed.",
     "translation_suggestions": "Translation Suggestions",
     "translations_will_be_suggested_as_you_edit": "Translations for words and phrases will be suggested as you edit Scripture. It is recommended that your project is setup as a {{ boldStart }}Daughter Translation{{ boldEnd }} in Paratext.",
     "you_can_change_later": "You can change these later.",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.ts
@@ -64,6 +64,9 @@ export class CommandService {
       const response = await this.http
         .post<JsonRpcResponse<T>>(url, request, { headers: { 'Content-Type': 'application/json' } })
         .toPromise();
+      if (response.error != null) {
+        throw response.error;
+      }
       return response.result;
     } catch (error) {
       const message = `Error invoking ${method}: ${error.message}`;

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -42,6 +42,10 @@ namespace SIL.XForge.Scripture.Controllers
             {
                 return NotFoundError(dnfe.Message);
             }
+            catch (InvalidOperationException e)
+            {
+                return InvalidParamsError(e.Message);
+            }
         }
 
         public async Task<IRpcMethodResult> Delete(string projectId)


### PR DESCRIPTION
- Disallow in backend.
- I didn't find a great preexisting exception to use and used
  ArgumentOutOfRangeException.
- Report problem in front-end for the exceptional circumstance.
- command-service.ts would receive a response back from
  this.http.post() that was not a thrown error but a response with an
  error. Throwing that makes it be treated similarly.
- connect-project.component.ts:
  - Catch errors from projectService.onlineCreate(). If the error
    looks like the already-connected problem, inform the user to just
    retry, or report if it keeps happening, and re-query the paratext
    projects.
  - Pass the error to errorHandler.handleError() to re-use its email
    reporting capability, and to log this situation to bugsnag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/822)
<!-- Reviewable:end -->
