### PR TITLE
Connect: Expect progress bar not to be null

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
@@ -254,7 +254,7 @@ describe('ConnectProjectComponent', () => {
     tick();
 
     expect(env.component.state).toEqual('connecting');
-    expect(env.progressBar).toBeDefined();
+    expect(env.progressBar).not.toBeNull();
     expect(env.component.connectPending).toEqual(true);
 
     env.emitSyncProgress(0);
@@ -286,7 +286,7 @@ describe('ConnectProjectComponent', () => {
     tick();
 
     expect(env.component.state).toEqual('connecting');
-    expect(env.progressBar).toBeDefined();
+    expect(env.progressBar).not.toBeNull();
     expect(env.component.connectPending).toEqual(true);
 
     env.emitSyncProgress(0);


### PR DESCRIPTION
- `toBeDefined()` will always be true. Using `not.toBeNull()` will
test what we want.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/823)
<!-- Reviewable:end -->
