### PR TITLE
Show error message if a file could not be saved

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -242,7 +242,7 @@
     "unknown_error": "Unknown error"
   },
   "file_service": {
-    "exceeded_storage_quota": "Failed to save your changes because your device is out of storage space. Please free up space to continue working without disruptions.",
+    "failed_to_save": "Failed to save your changes. Error Message: {{ message }}. Please check that you have the recommended 500 MB of free space on your device.",
     "i_understand": "I understand",
     "storage_space_is_limited": "The storage space on this device is limited. It is recommended to have a minimum of 500 MB of free space to ensure all feature are available. Please free up storage space."
   },

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -242,7 +242,7 @@
     "unknown_error": "Unknown error"
   },
   "file_service": {
-    "failed_to_save": "Failed to save your changes. Error Message: {{ message }}. Please check that you have the recommended 500 MB of free space on your device.",
+    "failed_to_save": "Failed to save your changes. Please check that you have the recommended 500 MB of free space on your device.",
     "i_understand": "I understand",
     "storage_space_is_limited": "The storage space on this device is limited. It is recommended to have a minimum of 500 MB of free space to ensure all feature are available. Please free up storage space."
   },

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
@@ -65,7 +65,7 @@ export class ExceptionHandlingService implements ErrorHandler {
       return;
     }
 
-    if (error instanceof DOMException && error.name === 'QuotaExceededError') {
+    if (error instanceof DOMException && (error.name === 'QuotaExceededError' || error.name === 'DataError')) {
       ngZone.run(() => noticeService.showError(translate('exception_handling_service.out_of_space')));
       return;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
@@ -256,12 +256,12 @@ export class FileService extends SubscriptionDisposable {
    * Detects if the error is caused by exceeding the browser's storage quota, and prompt the user to free up space.
    */
   private async onCachingError(error: any): Promise<void> {
-    if (!(error instanceof DOMException) || error.name !== 'QuotaExceededError') {
+    if (!(error instanceof DOMException)) {
       return Promise.reject(error);
     }
-    // Prompt the user to free up storage space
+    // Prompt the user to check storage space
     await this.noticeService.showMessageDialog(
-      () => this.transloco.translate('file_service.exceeded_storage_quota'),
+      () => this.transloco.translate('file_service.failed_to_save', { message: error.message }),
       () => this.transloco.translate('file_service.i_understand')
     );
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
@@ -261,7 +261,7 @@ export class FileService extends SubscriptionDisposable {
     }
     // Prompt the user to check storage space
     await this.noticeService.showMessageDialog(
-      () => this.transloco.translate('file_service.failed_to_save', { message: error.message }),
+      () => this.transloco.translate('file_service.failed_to_save'),
       () => this.transloco.translate('file_service.i_understand')
     );
   }


### PR DESCRIPTION
When a user's device is full, IndexedDB could abort a transaction with either a QuotaExceededError or a DataError. If this happens while uploading a file, we catch that an notify the user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/824)
<!-- Reviewable:end -->
