### PR TITLE
Mock versioning manager functionality in ParatextService tests

### DIFF
--- a/src/SIL.XForge.Scripture/Services/IParatextDataHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextDataHelper.cs
@@ -1,0 +1,10 @@
+using Paratext.Data;
+using Paratext.Data.Repository;
+
+namespace SIL.XForge.Scripture.Services
+{
+    public interface IParatextDataHelper
+    {
+        void CommitVersionedText(ScrText scrText, string comment);
+    }
+}

--- a/src/SIL.XForge.Scripture/Services/ParatextDataHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextDataHelper.cs
@@ -1,0 +1,15 @@
+using Paratext.Data;
+using Paratext.Data.Repository;
+
+namespace SIL.XForge.Scripture.Services
+{
+    /// <summary> Provides methods calls to Paratext Data. Can be mocked in tests. </summary>
+    public class ParatextDataHelper : IParatextDataHelper
+    {
+        public void CommitVersionedText(ScrText scrText, string comment)
+        {
+            VersionedText vText = VersioningManager.Get(scrText);
+            vText.Commit(comment, null, false);
+        }
+    }
+}

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -56,6 +56,7 @@ namespace SIL.XForge.Scripture.Services
         private readonly IExceptionHandler _exceptionHandler;
         private readonly ILogger _logger;
         private readonly IJwtTokenHelper _jwtTokenHelper;
+        private readonly IParatextDataHelper _paratextDataHelper;
         private string _applicationProductVersion = "SF";
         private string _registryServerUri = "https://registry.paratext.org";
         private string _sendReceiveServerUri = InternetAccess.uriProduction;
@@ -65,7 +66,7 @@ namespace SIL.XForge.Scripture.Services
         public ParatextService(IWebHostEnvironment env, IOptions<ParatextOptions> paratextOptions,
             IRepository<UserSecret> userSecretRepository, IRealtimeService realtimeService,
             IExceptionHandler exceptionHandler, IOptions<SiteOptions> siteOptions, IFileSystemService fileSystemService,
-            ILogger<ParatextService> logger, IJwtTokenHelper jwtTokenHelper,
+            ILogger<ParatextService> logger, IJwtTokenHelper jwtTokenHelper, IParatextDataHelper paratextDataHelper,
             IInternetSharedRepositorySourceProvider internetSharedRepositorySourceProvider)
         {
             _paratextOptions = paratextOptions;
@@ -76,6 +77,7 @@ namespace SIL.XForge.Scripture.Services
             _fileSystemService = fileSystemService;
             _logger = logger;
             _jwtTokenHelper = jwtTokenHelper;
+            _paratextDataHelper = paratextDataHelper;
             _internetSharedRepositorySourceProvider = internetSharedRepositorySourceProvider;
 
             _httpClientHandler = new HttpClientHandler();
@@ -361,9 +363,8 @@ namespace SIL.XForge.Scripture.Services
             {
                 foreach (string user in users)
                     manager.SaveUser(user, false);
-                VersionedText vText = VersioningManager.Get(scrText);
-                vText.Commit($"{nbrAddedComments} notes added and {nbrDeletedComments + nbrUpdatedComments} notes "
-                    + $"updated or deleted in synchronize", null, false, username);
+                _paratextDataHelper.CommitVersionedText(scrText, $"{nbrAddedComments} notes added and "
+                    + $"{nbrDeletedComments + nbrUpdatedComments} notes updated or deleted in synchronize");
                 _logger.LogInformation("{0} added {1} notes, updated {2} notes and deleted {3} notes", userSecret.Id,
                     nbrAddedComments, nbrUpdatedComments, nbrDeletedComments);
             }

--- a/src/SIL.XForge.Scripture/Services/SFServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/SFServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<IGuidService, GuidService>();
             services.AddSingleton<ISFProjectService, SFProjectService>();
             services.AddSingleton<IJwtTokenHelper, JwtTokenHelper>();
+            services.AddSingleton<IParatextDataHelper, ParatextDataHelper>();
             services.AddSingleton<IInternetSharedRepositorySourceProvider, InternetSharedRepositorySourceProvider>();
             return services;
         }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -499,6 +499,7 @@ namespace SIL.XForge.Scripture.Services
             public IHgWrapper MockHgWrapper;
             public MockLogger<ParatextService> MockLogger;
             public IJwtTokenHelper MockJwtTokenHelper;
+            public IParatextDataHelper MockParatextDataHelper;
             public IInternetSharedRepositorySourceProvider MockInternetSharedRepositorySourceProvider;
             public ParatextService Service;
 
@@ -515,13 +516,14 @@ namespace SIL.XForge.Scripture.Services
                 MockSharingLogicWrapper = Substitute.For<ISharingLogicWrapper>();
                 MockHgWrapper = Substitute.For<IHgWrapper>();
                 MockJwtTokenHelper = Substitute.For<IJwtTokenHelper>();
+                MockParatextDataHelper = Substitute.For<IParatextDataHelper>();
                 MockInternetSharedRepositorySourceProvider = Substitute.For<IInternetSharedRepositorySourceProvider>();
 
                 RealtimeService = new SFMemoryRealtimeService();
 
                 Service = new ParatextService(MockWebHostEnvironment, MockParatextOptions, MockRepository,
                     RealtimeService, MockExceptionHandler, MockSiteOptions, MockFileSystemService,
-                    MockLogger, MockJwtTokenHelper, MockInternetSharedRepositorySourceProvider);
+                    MockLogger, MockJwtTokenHelper, MockParatextDataHelper, MockInternetSharedRepositorySourceProvider);
                 Service.ScrTextCollection = MockScrTextCollection;
                 Service.SharingLogicWrapper = MockSharingLogicWrapper;
                 Service.HgWrapper = MockHgWrapper;


### PR DESCRIPTION
An exception was caught in test each time VersioningManager was used to get a new VersionedText. The tests continued and passed anyway. This change pulls the commit part out of PutNotes so it can be mocked in the tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/826)
<!-- Reviewable:end -->
