### PR TITLE
Set MockScrText.Settings.Guid

### DIFF
--- a/test/SIL.XForge.Scripture.Tests/Services/MockScrText.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockScrText.cs
@@ -20,12 +20,18 @@ namespace SIL.XForge.Scripture.Services
         {
             this.projectName = projectName;
             Settings = new MockProjectSettings(this);
+            // ScrText sets its cachedGuid from the settings Guid. Here we are doing it the other way around.
+            // Some tests may need both MockScrText.Guid and MockScrText.Settings.Guid to be set.
             _language = new MockScrLanguage(this);
         }
 
         public string CachedGuid
         {
-            set { cachedGuid = value; }
+            set
+            {
+                cachedGuid = value;
+                Settings.Guid = value;
+            }
         }
 
         public Dictionary<string, string> Data = new Dictionary<string, string>();


### PR DESCRIPTION
- ParatextServiceTests.cs PutNotes test fails when VersionedText.cs
  VersionedText(ScrText) checks if ScrText Settings.Guid is empty, and
  if so calculates a new guid for it. It tries to write the info to a
  file but has trouble and crashes.
- I haven't fully compared the context of our MockScrText construction
  and how ScrText objects get constructed. But I do see that setting
  ScrText.Settings results in setting ScrText.CachedGuid to the value
  of Settings.Guid.
- Set ScrText.Settings.Guid when we set up a MockScrText with a known
  Guid so we don't crash in VersionedText.cs VersionedText(ScrText).


To clarify, this code was written to prevent the test from crashing rather than testing. It won't necessarily make the test pass.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/827)
<!-- Reviewable:end -->
