### PR TITLE
SF-1088 Sync: Upgrade to ParatextData 9.2.3-alpha

### DIFF
--- a/src/SIL.XForge.Scripture/Models/SFParatextUser.cs
+++ b/src/SIL.XForge.Scripture/Models/SFParatextUser.cs
@@ -1,0 +1,13 @@
+using Paratext.Data.Users;
+
+namespace SIL.XForge.Scripture.Models
+{
+    /// <summary>
+    /// SF customization of ParatextUser
+    /// </summary>
+    public class SFParatextUser : ParatextUser
+    {
+        public SFParatextUser(string ptUsername) : base(ptUsername, true)
+        { }
+    }
+}

--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-    <PackageReference Include="ParatextData" Version="9.1.10-beta" />
+    <PackageReference Include="ParatextData" Version="9.2.3-alpha" />
     <PackageReference Include="SIL.Machine.WebApi" Version="$(MachineVersion)" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
   </ItemGroup>

--- a/src/SIL.XForge.Scripture/Services/InternetSharedRepositorySourceProvider.cs
+++ b/src/SIL.XForge.Scripture/Services/InternetSharedRepositorySourceProvider.cs
@@ -1,5 +1,7 @@
 using System;
+using Paratext.Data.Users;
 using SIL.XForge.Models;
+using SIL.XForge.Scripture.Models;
 
 namespace SIL.XForge.Scripture.Services
 {
@@ -24,11 +26,13 @@ namespace SIL.XForge.Scripture.Services
                 throw new ArgumentException();
             }
 
+            string ptUsername = _jwtTokenHelper.GetParatextUsername(userSecret);
+            var ptUser = new SFParatextUser(ptUsername);
             JwtRESTClient jwtClient = GenerateParatextRegistryJwtClient(userSecret, registryServerUri,
                 applicationProductVersion);
             IInternetSharedRepositorySource source =
                 new JwtInternetSharedRepositorySource(userSecret.ParatextTokens.AccessToken,
-                    jwtClient, sendReceiveServerUri);
+                    jwtClient, ptUser, sendReceiveServerUri);
             source.RefreshToken(userSecret.ParatextTokens.AccessToken);
             return source;
         }

--- a/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
@@ -15,8 +15,8 @@ namespace SIL.XForge.Scripture.Services
     {
         private readonly JwtRESTClient _registryClient;
 
-        public JwtInternetSharedRepositorySource(string accessToken, JwtRESTClient registryClient, string srServerUri)
-            : base(srServerUri)
+        public JwtInternetSharedRepositorySource(string accessToken, JwtRESTClient registryClient, ParatextUser authenticationPtUser, string srServerUri)
+            : base(authenticationPtUser, srServerUri)
         {
             _registryClient = registryClient;
             SetToken(accessToken);
@@ -84,6 +84,14 @@ namespace SIL.XForge.Scripture.Services
                 pushRepo.SendReceiveId, "registered", "yes", "userschanged", "no");
 
             MarkSharedChangeSetsPublic(repository);
+        }
+
+        /// <summary>
+        /// This looks like it would be important, but it doesn't seem to matter what it returns, to synchronize.
+        /// </summary>
+        public override string GetHgUri(SharedRepository sharedRepository)
+        {
+            return string.Empty;
         }
 
         /// <summary>

--- a/src/SIL.XForge.Scripture/Services/LazyScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/LazyScrTextCollection.cs
@@ -4,6 +4,7 @@ using Paratext.Data;
 using Paratext.Data.ProjectSettingsAccess;
 using SIL.XForge.Services;
 using SIL.XForge.Scripture.Models;
+using Paratext.Data.Users;
 
 namespace SIL.XForge.Scripture.Services
 {
@@ -30,10 +31,10 @@ namespace SIL.XForge.Scripture.Services
         /// <summary>
         /// Get a ScrText for a given user from the data for a paratext project with the target project ID and type.
         /// </summary>
-        /// <param name="username"> The username of the user retrieving the ScrText. </param>
+        /// <param name="ptUsername"> The username of the user retrieving the ScrText. </param>
         /// <param name="projectId"> The ID of the target project. </param>
         /// <param name="textType"> Target or Source. </param>
-        public ScrText FindById(string username, string projectId, Models.TextType textType)
+        public ScrText FindById(string ptUsername, string projectId, Models.TextType textType)
         {
             if (projectId == null)
                 return null;
@@ -48,7 +49,7 @@ namespace SIL.XForge.Scripture.Services
 
             string name = GetNameFromSettings(settingsFile);
             if (name != null)
-                return CreateScrText(username, new ProjectName()
+                return CreateScrText(ptUsername, new ProjectName()
                 {
                     ProjectPath = fullProjectPath,
                     ShortName = name
@@ -56,9 +57,10 @@ namespace SIL.XForge.Scripture.Services
             return null;
         }
 
-        protected virtual ScrText CreateScrText(string username, ProjectName projectName)
+        protected virtual ScrText CreateScrText(string ptUsername, ProjectName projectName)
         {
-            return new MultiUserScrText(SettingsDirectory, username, projectName);
+            var associatedUser = new SFParatextUser(ptUsername);
+            return new ScrText(projectName, associatedUser);
         }
 
         private string GetNameFromSettings(string settingsFilePath)

--- a/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
+++ b/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
@@ -7,6 +7,7 @@ using System.Xml;
 using System.Xml.Linq;
 using Paratext.Data;
 using Paratext.Data.ProjectComments;
+using Paratext.Data.Users;
 using SIL.Xml;
 
 namespace SIL.XForge.Scripture.Services
@@ -36,15 +37,16 @@ namespace SIL.XForge.Scripture.Services
         /// Parses the XML into a nested list of Comments - each inner list is the data for a thread.
         /// </summary>
         /// <param name="noteXml"></param>
+        /// <param name="ptUser">ParatextUser to use when creating any new Comments.</param>
         /// <returns>Nested list of comments</returns>
         /// <remarks>This code assumes that the XML passes the validation of the notes XML schema.</remarks>
-        public static List<List<Comment>> ParseNotes(string noteXml)
+        public static List<List<Comment>> ParseNotes(string noteXml, ParatextUser ptUser)
         {
             List<List<Comment>> result = new List<List<Comment>>();
             XDocument doc = XDocument.Parse(noteXml);
             foreach (var threadElem in doc.Root.Elements("thread"))
             {
-                result.Add(ParseThread(threadElem));
+                result.Add(ParseThread(threadElem, ptUser));
             }
             return result;
         }
@@ -143,7 +145,7 @@ namespace SIL.XForge.Scripture.Services
         #endregion
 
         #region Private helper methods for parsing
-        private static List<Comment> ParseThread(XElement threadElem)
+        private static List<Comment> ParseThread(XElement threadElem, ParatextUser ptUser)
         {
             List<Comment> result = new List<Comment>();
             Comment comment = null;
@@ -151,7 +153,7 @@ namespace SIL.XForge.Scripture.Services
             {
                 if (comment == null)
                 {
-                    comment = new Comment();
+                    comment = new Comment(ptUser);
                     XAttribute threadId = threadElem.Attribute("id");
                     if (threadId != null)
                         comment.Thread = threadId.Value;

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -139,7 +139,6 @@ namespace SIL.XForge.Scripture.Services
             SetupMercurial();
             WritingSystemRepository.Initialize();
             ScrTextCollection.Initialize(SyncDir);
-            RegistryServer.Initialize(_applicationProductVersion);
             InstallStyles();
             // Allow use of custom versification systems
             Versification.Table.Implementation = new ParatextVersificationTable();
@@ -295,7 +294,7 @@ namespace SIL.XForge.Scripture.Services
             doc.LoadXml(usx);
             UsxFragmenter.FindFragments(scrText.ScrStylesheet(bookNum), doc.CreateNavigator(),
                 XPathExpression.Compile("*[false()]"), out string usfm);
-            usfm = UsfmToken.NormalizeUsfm(scrText.ScrStylesheet(bookNum), usfm, false, scrText.RightToLeft);
+            usfm = UsfmToken.NormalizeUsfm(scrText.ScrStylesheet(bookNum), usfm, false, scrText.RightToLeft, scrText);
             scrText.PutText(bookNum, 0, false, usfm, null);
             _logger.LogInformation("{0} updated {1} in {2}.", userSecret.Id,
                 Canon.BookNumberToEnglishName(bookNum), scrText.Name);
@@ -327,7 +326,8 @@ namespace SIL.XForge.Scripture.Services
             if (scrText == null)
                 throw new DataNotFoundException("Can't get access to cloned project.");
             CommentManager manager = CommentManager.Get(scrText);
-            var notes = NotesFormatter.ParseNotes(notesText);
+            var ptUser = new SFParatextUser(username);
+            var notes = NotesFormatter.ParseNotes(notesText, ptUser);
 
             // Algorithm sourced from Paratext DataAccessServer
             foreach (var thread in notes)

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -266,6 +266,9 @@ namespace SIL.XForge.Scripture.Services
                 _paratextService.PutBookText(_userSecret, paratextId, text.BookNum, newUsxDoc.Root.ToString());
         }
 
+        /// <summary>
+        /// Send answer-notes to Paratext. Don't send questions that have no answers.
+        /// </summary>
         private async Task UpdateParatextNotesAsync(TextInfo text, IReadOnlyList<IDocument<Question>> questionDocs)
         {
             if (!CheckingEnabled)

--- a/test/SIL.XForge.Scripture.Tests/Services/MockLazyScrTextCollection.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockLazyScrTextCollection.cs
@@ -1,12 +1,15 @@
 using Paratext.Data;
+using Paratext.Data.Users;
+using SIL.XForge.Scripture.Models;
 
 namespace SIL.XForge.Scripture.Services
 {
     public class MockLazyScrTextCollection : LazyScrTextCollection
     {
-        protected override ScrText CreateScrText(string username, ProjectName projectName)
+        protected override ScrText CreateScrText(string ptUsername, ProjectName projectName)
         {
-            return new MockScrText(projectName);
+            var associatedPtUser = new SFParatextUser(ptUsername);
+            return new MockScrText(associatedPtUser, projectName);
         }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MockScrText.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockScrText.cs
@@ -7,6 +7,7 @@ using NSubstitute;
 using Paratext.Data.Languages;
 using PtxUtils;
 using SIL.WritingSystems;
+using Paratext.Data.Users;
 
 namespace SIL.XForge.Scripture.Services
 {
@@ -15,9 +16,9 @@ namespace SIL.XForge.Scripture.Services
     /// </summary>
     public class MockScrText : ScrText
     {
-        public MockScrText(ProjectName pn)
+        public MockScrText(ParatextUser associatedPtUser, ProjectName projectName) : base(associatedPtUser)
         {
-            projectName = pn;
+            this.projectName = projectName;
             Settings = new MockProjectSettings(this);
             _language = new MockScrLanguage(this);
         }


### PR DESCRIPTION
- Stop using now-removed MultiUserScrText.
- Satisfy new ParatextUser argument to ScrText ctor.
- Subclass ParatextUser as SFParatextUser, to have a 'valid' user.
- RegistryServer.Initialize() now wants a ParatextUser. We aren't
  using it anyway. Stop trying to initializing it until we need it.
- Satisfy call to GetHgUri() without crashing because of a null
  RegistrationCode.

---

So far so good in testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/831)
<!-- Reviewable:end -->
