### PR TITLE
SF-1080 - Quill box does not display in the Project after login to SF

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -33,13 +33,13 @@ export function supportedBrowser(): boolean {
     chromium: '>=58',
     edge: '>=76',
     firefox: '>=51',
-    safari: '>=10.1',
+    safari: '>=11.1',
 
     mobile: {
       chrome: '>=78',
       firefox: '>=68',
       opera: '>=46',
-      safari: '>=10.3',
+      safari: '>=11.3',
       'android browser': '>=76',
       'samsung internet': '>=7.2'
     }


### PR DESCRIPTION
 - Increased minimum browser support of Safari to 11.1 desktop and 11.3 on mobile

After investigation and looking at browser version usage it was decided to simply not support Safari 10.x any longer.

Note that I've had some issues with testing on BrowserStack with `localhost` so it might need to wait until it reaches QA to test the dialog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/837)
<!-- Reviewable:end -->
