### PR TITLE
SF-1096 Fix DebugElement toBeDefined to not.toBeNull

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -228,7 +228,6 @@
           <mdc-list-item
             [appRouterLink]="['/projects', selectedProjectId, 'sync']"
             [class.list-item-disabled]="!isAppOnline"
-            id="sync-item"
             (selectionChange)="itemSelected()"
           >
             <mdc-icon mdcListItemGraphic>sync</mdc-icon>
@@ -237,7 +236,6 @@
           <mdc-list-item
             [appRouterLink]="['/projects', selectedProjectId, 'settings']"
             [class.list-item-disabled]="!isAppOnline"
-            id="settings-item"
             (selectionChange)="itemSelected()"
           >
             <mdc-icon mdcListItemGraphic>settings</mdc-icon>
@@ -246,7 +244,6 @@
           <mdc-list-item
             [appRouterLink]="['/projects', selectedProjectId, 'users']"
             [class.list-item-disabled]="!isAppOnline"
-            id="users-item"
             (selectionChange)="itemSelected()"
           >
             <mdc-icon mdcListItemGraphic>people</mdc-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.spec.ts
@@ -69,7 +69,7 @@ describe('CheckingAudioPlayerComponent', () => {
     const env = new TestEnvironment(template, false);
     await env.waitForPlayer(1000);
     expect(env.component.player1.hasSource).toBe(true);
-    expect(env.audioNotAvailableMessage).toBeDefined();
+    expect(env.audioNotAvailableMessage).not.toBeNull();
   });
 
   it('it can play blobs even when offline', async () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -487,7 +487,7 @@ describe('CheckingComponent', () => {
   describe('Answers', () => {
     it('answer panel is initiated and shows the first question', fakeAsync(() => {
       const env = new TestEnvironment(CHECKER_USER);
-      expect(env.answerPanel).toBeDefined();
+      expect(env.answerPanel).not.toBeNull();
     }));
 
     it('can answer a question', fakeAsync(() => {
@@ -552,11 +552,11 @@ describe('CheckingComponent', () => {
       env.selectQuestion(2);
       env.clickButton(env.addAnswerButton);
       env.waitForSliderUpdate();
-      expect(env.yourAnswerField).toBeDefined();
+      expect(env.yourAnswerField).not.toBeNull();
       env.clickButton(env.cancelAnswerButton);
       env.waitForSliderUpdate();
       expect(env.yourAnswerField).toBeNull();
-      expect(env.addAnswerButton).toBeDefined();
+      expect(env.addAnswerButton).not.toBeNull();
     }));
 
     it('does not save the answer when storage quota exceeded', fakeAsync(() => {
@@ -601,7 +601,7 @@ describe('CheckingComponent', () => {
       env.clickButton(env.addAnswerButton);
       env.waitForSliderUpdate();
       env.clickButton(env.audioTab);
-      expect(env.recordButton).toBeDefined();
+      expect(env.recordButton).not.toBeNull();
     }));
 
     it('check answering validation', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.spec.ts
@@ -42,7 +42,7 @@ describe('ScriptureChooserDialog', () => {
     expect(env.dialogText).not.toContain('Matthew');
     expect(env.dialogText).toContain(env.backIconName);
     expect(env.dialogText).toContain('chapter');
-    expect(env.chapter3).toBeDefined('missing chapter 3 button');
+    expect(env.chapter3).not.toBeNull('missing chapter 3 button');
   }));
 
   it('clicking chapter goes to verse chooser, shows back button', fakeAsync(() => {
@@ -55,7 +55,7 @@ describe('ScriptureChooserDialog', () => {
     expect(env.dialogText).not.toContain('Matthew');
     expect(env.dialogText).not.toContain('chapter');
     expect(env.dialogText).toContain(env.backIconName);
-    expect(env.verse21).toBeDefined('missing verse 21 button');
+    expect(env.verse21).not.toBeNull('missing verse 21 button');
   }));
 
   it('clicking verse closes and reports selection', fakeAsync(() => {
@@ -88,7 +88,7 @@ describe('ScriptureChooserDialog', () => {
     env.click(env.backoutButton);
     expect(env.dialogText).toContain(env.backIconName);
     expect(env.dialogText).toContain('chapter');
-    expect(env.chapter3).toBeDefined('missing chapter 3 button');
+    expect(env.chapter3).not.toBeNull('missing chapter 3 button');
   }));
 
   it('book not highlighted, if no (undefined) incoming reference', fakeAsync(() => {
@@ -502,27 +502,27 @@ describe('ScriptureChooserDialog', () => {
       return this.overlayContainerElement.textContent;
     }
 
-    get bookEphesians(): DebugElement | undefined {
+    get bookEphesians(): DebugElement {
       return this.buttonWithText('EPHESIANS');
     }
 
-    get bookRomans(): DebugElement | undefined {
+    get bookRomans(): DebugElement {
       return this.buttonWithText('ROMANS');
     }
 
-    get chapter3(): DebugElement | undefined {
+    get chapter3(): DebugElement {
       return this.buttonWithText('3');
     }
 
-    get chapter11(): DebugElement | undefined {
+    get chapter11(): DebugElement {
       return this.buttonWithText('11');
     }
 
-    get verse21(): DebugElement | undefined {
+    get verse21(): DebugElement {
       return this.buttonWithText('21');
     }
 
-    get verse33(): DebugElement | undefined {
+    get verse33(): DebugElement {
       return this.buttonWithText('33');
     }
 
@@ -538,13 +538,13 @@ describe('ScriptureChooserDialog', () => {
       return this.fixture.debugElement.query(By.css('.mdc-button--unelevated'));
     }
 
-    click(element: DebugElement | undefined): void {
+    click(element: DebugElement): void {
       element!.nativeElement.click();
       this.fixture.detectChanges();
       flush();
     }
 
-    buttonWithText(text: string): DebugElement | undefined {
+    buttonWithText(text: string): DebugElement {
       return this.fixture.debugElement
         .queryAll(By.css('button'))
         .find(button => button.nativeElement.innerText === text)!;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
@@ -87,7 +87,7 @@ describe('SyncComponent', () => {
     env.clickElement(env.syncButton);
     verify(mockedProjectService.onlineSync('testProject01')).once();
     expect(env.component.syncActive).toBe(true);
-    expect(env.progressBar).toBeDefined();
+    expect(env.progressBar).not.toBeNull();
     expect(env.component.isProgressDeterminate).toBe(false);
     expect(env.syncMessage.textContent).toContain('Your project is being synchronized');
     expect(env.logInButton).toBeNull();
@@ -110,7 +110,7 @@ describe('SyncComponent', () => {
     env.clickElement(env.syncButton);
     verify(mockedProjectService.onlineSync('testProject01')).once();
     expect(env.component.syncActive).toBe(true);
-    expect(env.progressBar).toBeDefined();
+    expect(env.progressBar).not.toBeNull();
     // Simulate sync in progress
     env.emitSyncProgress(0);
     // Simulate sync error
@@ -122,7 +122,7 @@ describe('SyncComponent', () => {
   it('should show progress if in-progress when loaded', fakeAsync(() => {
     const env = new TestEnvironment(true, true);
     expect(env.component.syncActive).toBe(true);
-    expect(env.progressBar).toBeDefined();
+    expect(env.progressBar).not.toBeNull();
   }));
 
   it('should explain and disable button when syncDisabled', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -550,14 +550,14 @@ describe('EditorComponent', () => {
 
       resetCalls(env.mockedRemoteTranslationEngine);
       env.updateTrainingProgress(0.1);
-      expect(env.trainingProgress).toBeDefined();
+      expect(env.trainingProgress).not.toBeNull();
       expect(env.component.showTrainingProgress).toBe(true);
-      expect(env.trainingProgressSpinner).toBeDefined();
+      expect(env.trainingProgressSpinner).not.toBeNull();
       env.updateTrainingProgress(1);
-      expect(env.trainingCompleteIcon).toBeDefined();
+      expect(env.trainingCompleteIcon).not.toBeNull();
       expect(env.trainingProgressSpinner).toBeNull();
       env.completeTrainingProgress();
-      expect(env.trainingProgress).toBeDefined();
+      expect(env.trainingProgress).not.toBeNull();
       expect(env.component.showTrainingProgress).toBe(true);
       tick(5000);
       env.wait();
@@ -565,9 +565,9 @@ describe('EditorComponent', () => {
       expect(env.trainingProgress).toBeNull();
       expect(env.component.showTrainingProgress).toBe(false);
       env.updateTrainingProgress(0.1);
-      expect(env.trainingProgress).toBeDefined();
+      expect(env.trainingProgress).not.toBeNull();
       expect(env.component.showTrainingProgress).toBe(true);
-      expect(env.trainingProgressSpinner).toBeDefined();
+      expect(env.trainingProgressSpinner).not.toBeNull();
 
       env.dispose();
     }));
@@ -583,9 +583,9 @@ describe('EditorComponent', () => {
 
       resetCalls(env.mockedRemoteTranslationEngine);
       env.updateTrainingProgress(0.1);
-      expect(env.trainingProgress).toBeDefined();
+      expect(env.trainingProgress).not.toBeNull();
       expect(env.component.showTrainingProgress).toBe(true);
-      expect(env.trainingProgressSpinner).toBeDefined();
+      expect(env.trainingProgressSpinner).not.toBeNull();
       env.clickTrainingProgressCloseButton();
       expect(env.trainingProgress).toBeNull();
       expect(env.component.showTrainingProgress).toBe(false);
@@ -596,9 +596,9 @@ describe('EditorComponent', () => {
       verify(env.mockedRemoteTranslationEngine.translateInteractively(anything())).once();
 
       env.updateTrainingProgress(0.1);
-      expect(env.trainingProgress).toBeDefined();
+      expect(env.trainingProgress).not.toBeNull();
       expect(env.component.showTrainingProgress).toBe(true);
-      expect(env.trainingProgressSpinner).toBeDefined();
+      expect(env.trainingProgressSpinner).not.toBeNull();
 
       env.dispose();
     }));
@@ -614,18 +614,18 @@ describe('EditorComponent', () => {
 
       resetCalls(env.mockedRemoteTranslationEngine);
       env.updateTrainingProgress(0.1);
-      expect(env.trainingProgress).toBeDefined();
+      expect(env.trainingProgress).not.toBeNull();
       expect(env.component.showTrainingProgress).toBe(true);
-      expect(env.trainingProgressSpinner).toBeDefined();
+      expect(env.trainingProgressSpinner).not.toBeNull();
       env.throwTrainingProgressError();
       expect(env.trainingProgress).toBeNull();
       expect(env.component.showTrainingProgress).toBe(false);
 
       tick(30000);
       env.updateTrainingProgress(0.1);
-      expect(env.trainingProgress).toBeDefined();
+      expect(env.trainingProgress).not.toBeNull();
       expect(env.component.showTrainingProgress).toBe(true);
-      expect(env.trainingProgressSpinner).toBeDefined();
+      expect(env.trainingProgressSpinner).not.toBeNull();
 
       env.dispose();
     }));


### PR DESCRIPTION
- DebugElement query() appears to be returning type
  `DebugElement | null`, and so checking if the return is
  .toBeDefined() will always be true. So instead, check whether the
  return is or isn't null.
- scripture-chooser-dialog.component.spec.ts: Methods were defined
  as returning type `DebugElement | undefined`, which is probably not
  true. Change that to the also incorrect(?), but matching the .d.ts
  declarations, type `DebugElement`.
- app.component.spec.ts: A test here was using .toBeDefined, and
  when that was changed, it revealed that the test wasn't really
  working.
  - Add more setup to test.
  - mdc-list-item elements don't seem to keep an id, and so we
    can't check for them by looking for an element with such an id. So
    look for items in the menu list that have matching text, to check
    for presence or absence of a list item.
  - Setting `component.isProjectAdmin$ = of(true or false)` didn't
    seem to be working, so keep the same observable and send out
    .next() values on it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/839)
<!-- Reviewable:end -->
