### PR TITLE
SF-955 - Editing in a RTL text is inconsistent

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -80,23 +80,20 @@ quill-editor {
   }
 }
 
-usx-para,
-p {
-  &[dir='ltr'],
-  &[dir='auto'] {
-    .question-segment[data-question-count] {
-      margin-left: 1.75em;
-      &:before {
-        left: -2.25em;
-      }
-      &:after {
-        left: -1.5em;
-      }
+quill-editor.ltr {
+  .question-segment[data-question-count] {
+    margin-left: 1.75em;
+
+    &:before {
+      left: -2.25em;
+    }
+
+    &:after {
+      left: -1.5em;
     }
   }
 }
-usx-para[dir='rtl'],
-p[dir='rtl'] {
+quill-editor.rtl {
   .question-segment[data-question-count] {
     margin-right: 1.75em;
     &:before {
@@ -154,7 +151,7 @@ p[dir='rtl'] {
 
 // workaround for Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1569107
 // using "box-decoration-break: clone" or blur radius in a "box-shadow" with RTL text can cause weird behavior
-.template-editor.contains-rtl-text[data-browser-engine='gecko'] > .ql-container > .ql-editor {
+.template-editor.rtl[data-browser-engine='gecko'] > .ql-container > .ql-editor {
   usx-para,
   p {
     > usx-para-contents {

--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -120,6 +120,14 @@ usx-para {
     margin-left: 25%;
   }
 
+  &[data-style='is'] {
+    font-weight: bold;
+    text-align: center;
+    font-size: 1.16em;
+    margin-top: 2pt;
+    margin-bottom: 2pt;
+  }
+
   &[data-style='s'],
   &[data-style='s1'] {
     font-weight: bold;
@@ -168,122 +176,143 @@ usx-para {
     text-align: center;
   }
 }
-usx-para[dir='ltr'] {
-  &[data-style='li'],
-  &[data-style='li1'] {
-    margin-left: 10%;
-    text-indent: -7.5%;
-  }
+quill-editor.ltr {
+  usx-para {
+    &[data-style='li'],
+    &[data-style='li1'] {
+      margin-left: 10%;
+      text-indent: -7.5%;
+    }
 
-  &[data-style='li2'] {
-    margin-left: 15%;
-    text-indent: -7.5%;
-  }
+    &[data-style='li2'] {
+      margin-left: 15%;
+      text-indent: -7.5%;
+    }
 
-  &[data-style='li3'] {
-    margin-left: 20%;
-    text-indent: -7.5%;
-  }
+    &[data-style='li3'] {
+      margin-left: 20%;
+      text-indent: -7.5%;
+    }
 
-  &[data-style='li4'] {
-    margin-left: 25%;
-    text-indent: -7.5%;
-  }
+    &[data-style='li4'] {
+      margin-left: 25%;
+      text-indent: -7.5%;
+    }
 
-  &[data-style='q'],
-  &[data-style='q1'] {
-    margin-left: 25%;
-    text-indent: -20%;
-  }
+    &[data-style='q'],
+    &[data-style='q1'] {
+      margin-left: 25%;
+      text-indent: -20%;
+    }
 
-  &[data-style='q2'] {
-    margin-left: 25%;
-    text-indent: -15%;
-  }
+    &[data-style='q2'] {
+      margin-left: 25%;
+      text-indent: -15%;
+    }
 
-  &[data-style='q3'] {
-    margin-left: 25%;
-    text-indent: -10%;
-  }
+    &[data-style='q3'] {
+      margin-left: 25%;
+      text-indent: -10%;
+    }
 
-  &[data-style='q4'] {
-    margin-left: 25%;
-    text-indent: -5%;
-  }
+    &[data-style='q4'] {
+      margin-left: 25%;
+      text-indent: -5%;
+    }
 
-  &[data-style='qm'],
-  &[data-style='qm1'] {
-    margin-left: 20%;
-    text-indent: -15%;
-  }
+    &[data-style='qm'],
+    &[data-style='qm1'] {
+      margin-left: 20%;
+      text-indent: -15%;
+    }
 
-  &[data-style='qm2'] {
-    margin-left: 20%;
-    text-indent: -10%;
-  }
+    &[data-style='qm2'] {
+      margin-left: 20%;
+      text-indent: -10%;
+    }
 
-  &[data-style='qm3'] {
-    margin-left: 20%;
-    text-indent: -5%;
+    &[data-style='qm3'] {
+      margin-left: 20%;
+      text-indent: -5%;
+    }
   }
 }
-usx-para[dir='rtl'] {
-  &[data-style='li'],
-  &[data-style='li1'] {
-    margin-right: 10%;
-    text-indent: -7.5%;
-  }
+quill-editor.rtl {
+  usx-para {
+    &[data-style='io'],
+    &[data-style='io1'] {
+      margin-right: 10%;
+    }
 
-  &[data-style='li2'] {
-    margin-right: 15%;
-    text-indent: -7.5%;
-  }
+    &[data-style='io2'] {
+      margin-right-left: 15%;
+    }
 
-  &[data-style='li3'] {
-    margin-right: 20%;
-    text-indent: -7.5%;
-  }
+    &[data-style='io3'] {
+      margin-right: 20%;
+    }
 
-  &[data-style='li4'] {
-    margin-right: 25%;
-    text-indent: -7.5%;
-  }
+    &[data-style='io4'] {
+      margin-right: 25%;
+    }
 
-  &[data-style='q'],
-  &[data-style='q1'] {
-    margin-right: 25%;
-    text-indent: -20%;
-  }
+    &[data-style='li'],
+    &[data-style='li1'] {
+      margin-right: 10%;
+      text-indent: -7.5%;
+    }
 
-  &[data-style='q2'] {
-    margin-right: 25%;
-    text-indent: -15%;
-  }
+    &[data-style='li2'] {
+      margin-right: 15%;
+      text-indent: -7.5%;
+    }
 
-  &[data-style='q3'] {
-    margin-right: 25%;
-    text-indent: -10%;
-  }
+    &[data-style='li3'] {
+      margin-right: 20%;
+      text-indent: -7.5%;
+    }
 
-  &[data-style='q4'] {
-    margin-right: 25%;
-    text-indent: -5%;
-  }
+    &[data-style='li4'] {
+      margin-right: 25%;
+      text-indent: -7.5%;
+    }
 
-  &[data-style='qm'],
-  &[data-style='qm1'] {
-    margin-right: 20%;
-    text-indent: -15%;
-  }
+    &[data-style='q'],
+    &[data-style='q1'] {
+      margin-right: 25%;
+      text-indent: -20%;
+    }
 
-  &[data-style='qm2'] {
-    margin-right: 20%;
-    text-indent: -10%;
-  }
+    &[data-style='q2'] {
+      margin-right: 25%;
+      text-indent: -15%;
+    }
 
-  &[data-style='qm3'] {
-    margin-right: 20%;
-    text-indent: -5%;
+    &[data-style='q3'] {
+      margin-right: 25%;
+      text-indent: -10%;
+    }
+
+    &[data-style='q4'] {
+      margin-right: 25%;
+      text-indent: -5%;
+    }
+
+    &[data-style='qm'],
+    &[data-style='qm1'] {
+      margin-right: 20%;
+      text-indent: -15%;
+    }
+
+    &[data-style='qm2'] {
+      margin-right: 20%;
+      text-indent: -10%;
+    }
+
+    &[data-style='qm3'] {
+      margin-right: 20%;
+      text-indent: -5%;
+    }
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.html
@@ -4,4 +4,5 @@
   [id]="id"
   [placeholder]="placeholder"
   (loaded)="onLoaded()"
+  [isRightToLeft]="isRightToLeft"
 ></app-text>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
@@ -17,12 +17,12 @@ import { TextComponent } from '../../../shared/text/text.component';
 export class CheckingTextComponent extends SubscriptionDisposable {
   @ViewChild(TextComponent, { static: true }) textComponent!: TextComponent;
   @Output() questionVerseSelected = new EventEmitter<VerseRef>();
+  @Input() isRightToLeft: boolean = false;
 
   private clickSubs: Subscription[] = [];
   private _activeVerse?: VerseRef;
   private _editorLoaded = false;
   private _id?: TextDocId;
-  private _isRightToLeft: boolean = false;
   private _questionVerses?: VerseRef[];
   private _placeholder?: string;
 
@@ -59,14 +59,6 @@ export class CheckingTextComponent extends SubscriptionDisposable {
 
   get id(): TextDocId | undefined {
     return this._id;
-  }
-
-  @Input() set isRightToLeft(value: boolean) {
-    this._isRightToLeft = value;
-  }
-
-  get isRightToLeft(): boolean {
-    return this._isRightToLeft;
   }
 
   @Input() set questionVerses(verseRefs: VerseRef[] | undefined) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
@@ -22,6 +22,7 @@ export class CheckingTextComponent extends SubscriptionDisposable {
   private _activeVerse?: VerseRef;
   private _editorLoaded = false;
   private _id?: TextDocId;
+  private _isRightToLeft: boolean = false;
   private _questionVerses?: VerseRef[];
   private _placeholder?: string;
 
@@ -58,6 +59,14 @@ export class CheckingTextComponent extends SubscriptionDisposable {
 
   get id(): TextDocId | undefined {
     return this._id;
+  }
+
+  @Input() set isRightToLeft(value: boolean) {
+    this._isRightToLeft = value;
+  }
+
+  get isRightToLeft(): boolean {
+    return this._isRightToLeft;
   }
 
   @Input() set questionVerses(verseRefs: VerseRef[] | undefined) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -108,6 +108,7 @@
                       [activeVerse]="activeQuestionVerseRef"
                       [questionVerses]="questionVerseRefs"
                       (questionVerseSelected)="verseRefClicked($event)"
+                      [isRightToLeft]="isRightToLeft"
                     ></app-checking-text>
                   </div>
                 </as-split-area>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1375,25 +1375,6 @@ describe('CheckingComponent', () => {
       expect(segment.classList.contains('question-segment')).toBe(true);
       expect(segment.classList.contains('highlight-segment')).toBe(true);
     }));
-
-    it('sets text and paragraph direction ', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
-      // the dir property is needed on the Quill editor because chapters don't always have paragraphs
-      expect(env.quillEditorElement.getAttribute('dir')).toEqual('auto');
-      // ensure multiple paragraphs were found, otherwise the test is meaningless
-      expect(env.paragraphs.length).toBeGreaterThan(1);
-      for (const index in env.paragraphs) {
-        if (env.paragraphs.hasOwnProperty(index)) {
-          const paragraph = env.paragraphs[index];
-          // Ensure the correct direction has been applied to each paragraph
-          let expected = 'ltr';
-          if (index === '3') {
-            expected = 'rtl';
-          }
-          expect(paragraph.getAttribute('dir')).toEqual(expected);
-        }
-      }
-    }));
   });
 });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -195,8 +195,8 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
   }
 
   get isRightToLeft(): boolean {
-    if (this.projectDoc?.data && this.projectDoc.data?.isRightToLeft) {
-      return this.projectDoc.data?.isRightToLeft;
+    if (this.projectDoc?.data && this.projectDoc.data?.isRightToLeft != null) {
+      return this.projectDoc.data.isRightToLeft;
     }
     return false;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -194,6 +194,13 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
     );
   }
 
+  get isRightToLeft(): boolean {
+    if (this.projectDoc?.data && this.projectDoc.data?.isRightToLeft) {
+      return this.projectDoc.data?.isRightToLeft;
+    }
+    return false;
+  }
+
   get questionDocs(): Readonly<QuestionDoc[]> {
     return this.questionsQuery != null ? this.questionsQuery.docs.filter(qd => !qd.data!.isArchived) : [];
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -195,7 +195,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
   }
 
   get isRightToLeft(): boolean {
-    if (this.projectDoc?.data && this.projectDoc.data?.isRightToLeft != null) {
+    if (this.projectDoc?.data?.isRightToLeft != null) {
       return this.projectDoc.data.isRightToLeft;
     }
     return false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -431,29 +431,15 @@ export function registerScripture(): string[] {
       return node.getAttribute(customAttributeName('segment'))!;
     }
 
-    constructor(domNode: HTMLElement) {
-      super(domNode);
-      domNode.setAttribute('dir', 'auto');
-    }
-
     format(name: string, value: any): void {
       if (name === SegmentInline.blotName && value != null) {
         this.domNode.setAttribute(customAttributeName('segment'), value);
-      } else if (name === 'direction-segment') {
-        this.domNode.setAttribute('dir', value);
       } else {
         super.format(name, value);
       }
     }
-
-    formats(): { [index: string]: any } {
-      const fmts = super.formats();
-      fmts['direction-segment'] = this.domNode.getAttribute('dir') || '';
-      return fmts;
-    }
   }
   formats.push(SegmentInline);
-  formats.push('direction-segment');
 
   (Inline as any).order.push('segment');
   (Inline as any).order.push('para-contents');
@@ -537,11 +523,6 @@ export function registerScripture(): string[] {
     scope: Parchment.Scope.INLINE
   });
   formats.push(InvalidInlineClass);
-
-  const BlockDirectionAttribute = new QuillParchment.Attributor.Attribute('direction-block', 'dir', {
-    scope: Parchment.Scope.BLOCK
-  });
-  formats.push(BlockDirectionAttribute);
 
   class DisableHtmlClipboard extends QuillClipboard {
     onPaste(e: ClipboardEvent): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
@@ -14,10 +14,9 @@
     'template-editor': !readOnlyEnabled,
     ltr: isLtr,
     rtl: isRtl,
-    'mark-invalid': markInvalid,
-    'contains-rtl-text': containsRtlText
+    'mark-invalid': markInvalid
   }"
-  dir="auto"
+  [dir]="isRtl ? 'rtl' : 'ltr'"
   [lang]="lang"
   [attr.data-browser-engine]="browserEngine"
 >

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -119,7 +119,17 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
         'move next, segment end, right arrow': {
           key: 'right',
           handler: () => {
-            if (this.isSelectionAtSegmentEnd) {
+            if (this.isLtr && this.isSelectionAtSegmentEnd) {
+              this.moveNextSegment(false);
+              return false;
+            }
+            return true;
+          }
+        },
+        'move next, segment end, left arrow': {
+          key: 'left',
+          handler: () => {
+            if (this.isRtl && this.isSelectionAtSegmentEnd) {
               this.moveNextSegment(false);
               return false;
             }
@@ -142,6 +152,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     }
   };
   private _id?: TextDocId;
+  private _isRightToLeft: boolean = false;
   private _modules: any = this.DEFAULT_MODULES;
   private _editor?: Quill;
   private viewModel = new TextViewModel();
@@ -197,6 +208,10 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       }
       this.setLangFromText();
     }
+  }
+
+  @Input() set isRightToLeft(value: boolean) {
+    this._isRightToLeft = value;
   }
 
   get modules(): any {
@@ -269,11 +284,11 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   }
 
   get isLtr(): boolean {
-    return this.direction === 'ltr';
+    return !this._isRightToLeft;
   }
 
   get isRtl(): boolean {
-    return this.direction === 'rtl';
+    return this._isRightToLeft;
   }
 
   get isSelectionAtSegmentEnd(): boolean {
@@ -380,10 +395,6 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     // skip updating when only formatting changes occurred
     if (delta.ops != null && delta.ops.some(op => op.insert != null || op.delete != null)) {
       this.update(delta);
-      // Update direction logic for the text
-      Promise.resolve().then(() => {
-        this.setDirection();
-      });
     }
   }
 
@@ -443,7 +454,6 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
 
     this.loaded.emit();
     this.applyEditorStyles();
-    this.setDirection();
   }
 
   private isBackspaceAllowed(range: RangeStatic): boolean {
@@ -489,17 +499,6 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     const prevRef = this.viewModel.getPrevSegmentRef(this._segment.ref);
     if (prevRef != null) {
       this.setSegment(prevRef, undefined, true, end);
-    }
-  }
-
-  private setDirection() {
-    // As the browser is automatically applying ltr/rtl we need to ask it which one it is using
-    // This value can then be used for other purposes e.g. CSS styles
-    if (this.editor !== undefined) {
-      const quillElement = this.quill.nativeElement as HTMLElement;
-      // set direction on the editor
-      this.direction = window.getComputedStyle(quillElement).direction;
-      this.containsRtlText = this.viewModel.setDirection();
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -69,13 +69,11 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   @Output() segmentRefChange = new EventEmitter<string>();
   @Output() loaded = new EventEmitter(true);
   lang: string = '';
-  containsRtlText: boolean = false;
   // only use USX formats and not default Quill formats
   readonly allowedFormats: string[] = USX_FORMATS;
   // allow for different CSS based on the browser engine
   readonly browserEngine: string = getBrowserEngine();
 
-  private direction: string | null = null;
   private _editorStyles: any = { fontSize: '1rem' };
   private readonly DEFAULT_MODULES: any = {
     toolbar: false,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -33,6 +33,7 @@
             [highlightSegment]="target.hasFocus"
             (loaded)="onTextLoaded('source')"
             (updated)="onSourceUpdated($event.delta != null)"
+            [isRightToLeft]="isRightToLeft"
           ></app-text>
         </div>
       </div>
@@ -49,6 +50,7 @@
             (loaded)="onTextLoaded('target')"
             [highlightSegment]="target.hasFocus"
             [markInvalid]="true"
+            [isRightToLeft]="isRightToLeft"
           ></app-text>
           <app-suggestions
             [mdcElevation]="2"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -700,7 +700,7 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('ensure direction is RTL when project is to to RTL', fakeAsync(() => {
+    it('ensure direction is RTL when project is to set to RTL', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setupProject({ isRightToLeft: true });
       env.wait();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -700,46 +700,11 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('set chapter, paragraph, and segment direction when new text is added and deleted', fakeAsync(() => {
+    it('ensure direction is RTL when project is to to RTL', fakeAsync(() => {
       const env = new TestEnvironment();
-      env.setProjectUserConfig({ selectedBookNum: 40, selectedChapterNum: 1, selectedSegment: 'verse_1_1' });
+      env.setupProject({ isRightToLeft: true });
       env.wait();
-
-      // Chapter and paragraph set to language of the first segment
-      expect(env.getChapterDirection(0)).toBe('ltr');
-      expect(env.getParagraphDirection(0)).toBe('ltr');
-      expect(env.getSegmentDirection('verse_1_1')).toBe('ltr');
-
-      // Set segment to blank so dir="auto"
-      // - chapter and paragraph will remain as ltr as the next valid segment has ltr text
-      // - verse 1 & 2 are blank which makes verse 3 the next valid segment to check the direction on
-      env.targetEditor.setSelection(3, 27, 'user');
-      env.deleteCharacters();
-      expect(env.component.target!.segmentText).toBe('');
-      expect(env.getSegmentDirection('verse_1_1')).toBe('auto');
-      expect(env.getSegmentDirection('verse_1_2')).toBe('auto');
-      expect(env.getSegmentDirection('verse_1_3')).toBe('ltr');
-      expect(env.getChapterDirection(0)).toBe('ltr');
-      expect(env.getParagraphDirection(0)).toBe('ltr');
-
-      // Set segment to LTR text so dir="ltr"
-      // - chapter and paragraph remains as ltr but takes it from the first verse segment
-      const index = env.typeCharacters('ltr');
-      expect(env.component.target!.segmentText).toBe('ltr');
-      expect(env.getSegmentDirection('verse_1_1')).toBe('ltr');
-      expect(env.getChapterDirection(0)).toBe('ltr');
-      expect(env.getParagraphDirection(0)).toBe('ltr');
-      env.targetEditor.setSelection(index - 3, 3, 'user');
-      env.deleteCharacters();
-
-      // Set segment to RTL text so dir="rtl"
-      // - chapter and paragraph switches to rtl as well
-      env.typeCharacters('ישע');
-      expect(env.component.target!.segmentText).toBe('ישע');
-      expect(env.getSegmentDirection('verse_1_1')).toBe('rtl');
-      expect(env.getChapterDirection(0)).toBe('rtl');
-      expect(env.getParagraphDirection(0)).toBe('rtl');
-
+      expect(env.component.target!.isRtl).toBe(true);
       env.dispose();
     }));
 
@@ -755,7 +720,6 @@ describe('EditorComponent', () => {
       expect(contents.ops![5].attributes).toEqual({
         'para-contents': true,
         segment: 'verse_1_2',
-        'direction-segment': 'ltr',
         'highlight-segment': true
       });
       expect(contents.ops![6].insert).toEqual({ verse: { number: '3', style: 'v' } });
@@ -768,7 +732,6 @@ describe('EditorComponent', () => {
       expect(contents.ops![5].attributes).toEqual({
         'para-contents': true,
         segment: 'verse_1_2',
-        'direction-segment': 'auto',
         'highlight-segment': true
       });
       // check to make sure that data after the affected segment hasn't gotten corrupted
@@ -784,7 +747,6 @@ describe('EditorComponent', () => {
       expect(contents.ops![5].attributes).toEqual({
         'para-contents': true,
         segment: 'verse_1_2',
-        'direction-segment': 'ltr',
         'highlight-segment': true
       });
       expect(contents.ops![6].insert).toEqual({ verse: { number: '3', style: 'v' } });
@@ -797,7 +759,7 @@ describe('EditorComponent', () => {
   describe('Translation Suggestions disabled', () => {
     it('start with no previous selection', fakeAsync(() => {
       const env = new TestEnvironment();
-      env.setupProject(false);
+      env.setupProject({ translateConfig: { translationSuggestionsEnabled: false } });
       env.setProjectUserConfig();
       env.updateParams({ projectId: 'project01', bookId: 'LUK' });
       env.wait();
@@ -814,7 +776,7 @@ describe('EditorComponent', () => {
 
     it('start with previously selected segment', fakeAsync(() => {
       const env = new TestEnvironment();
-      env.setupProject(false);
+      env.setupProject({ translateConfig: { translationSuggestionsEnabled: false } });
       env.setProjectUserConfig({ selectedBookNum: 42, selectedChapterNum: 2, selectedSegment: 'verse_2_1' });
       env.updateParams({ projectId: 'project01', bookId: 'LUK' });
       env.wait();
@@ -832,7 +794,7 @@ describe('EditorComponent', () => {
 
     it('user cannot edit', fakeAsync(() => {
       const env = new TestEnvironment();
-      env.setupProject(false);
+      env.setupProject({ translateConfig: { translationSuggestionsEnabled: false } });
       env.setCurrentUser('user02');
       env.setProjectUserConfig();
       env.updateParams({ projectId: 'project01', bookId: 'LUK' });
@@ -851,7 +813,7 @@ describe('EditorComponent', () => {
 
     it('chapter is invalid', fakeAsync(() => {
       const env = new TestEnvironment();
-      env.setupProject(false);
+      env.setupProject({ translateConfig: { translationSuggestionsEnabled: false } });
       env.setProjectUserConfig();
       env.updateParams({ projectId: 'project01', bookId: 'MRK' });
       env.wait();
@@ -952,6 +914,57 @@ class TestEnvironment {
   private readonly params$: BehaviorSubject<Params>;
   private trainingProgress$ = new Subject<ProgressStatus>();
 
+  private testProject: SFProject = {
+    name: 'project 01',
+    paratextId: 'target01',
+    shortName: 'TRG',
+    isRightToLeft: false,
+    userRoles: { user01: SFProjectRole.ParatextTranslator, user02: SFProjectRole.ParatextConsultant },
+    writingSystem: { tag: 'qaa' },
+    translateConfig: {
+      translationSuggestionsEnabled: true,
+      source: {
+        paratextId: 'source01',
+        name: 'source',
+        shortName: 'SRC',
+        writingSystem: {
+          tag: 'qaa'
+        }
+      }
+    },
+    checkingConfig: {
+      checkingEnabled: false,
+      usersSeeEachOthersResponses: true,
+      shareEnabled: true,
+      shareLevel: CheckingShareLevel.Specific
+    },
+    sync: { queuedCount: 0 },
+    texts: [
+      {
+        bookNum: 40,
+        chapters: [
+          { number: 1, lastVerse: 3, isValid: true },
+          { number: 2, lastVerse: 3, isValid: true }
+        ],
+        hasSource: true
+      },
+      { bookNum: 41, chapters: [{ number: 1, lastVerse: 3, isValid: false }], hasSource: true },
+      {
+        bookNum: 42,
+        chapters: [
+          { number: 1, lastVerse: 3, isValid: true },
+          { number: 2, lastVerse: 3, isValid: true }
+        ],
+        hasSource: false
+      },
+      {
+        bookNum: 43,
+        chapters: [{ number: 1, lastVerse: 0, isValid: true }],
+        hasSource: false
+      }
+    ]
+  };
+
   constructor() {
     this.params$ = new BehaviorSubject<Params>({ projectId: 'project01', bookId: 'MAT' });
     this.addTextDoc(new TextDocId('project01', 40, 1, 'source'));
@@ -1038,58 +1051,17 @@ class TestEnvironment {
     when(mockedUserService.currentUserId).thenReturn(userId);
   }
 
-  setupProject(translationSuggestionsEnabled: boolean = true): void {
+  setupProject(data: Partial<SFProject> = {}): void {
+    const projectData = cloneDeep(this.testProject);
+    if (data.translateConfig?.translationSuggestionsEnabled != null) {
+      projectData.translateConfig.translationSuggestionsEnabled = data.translateConfig.translationSuggestionsEnabled;
+    }
+    if (data.isRightToLeft != null) {
+      projectData.isRightToLeft = data.isRightToLeft;
+    }
     this.realtimeService.addSnapshot<SFProject>(SFProjectDoc.COLLECTION, {
       id: 'project01',
-      data: {
-        name: 'project 01',
-        paratextId: 'target01',
-        shortName: 'TRG',
-        userRoles: { user01: SFProjectRole.ParatextTranslator, user02: SFProjectRole.ParatextConsultant },
-        writingSystem: { tag: 'qaa' },
-        translateConfig: {
-          translationSuggestionsEnabled,
-          source: {
-            paratextId: 'source01',
-            name: 'source',
-            shortName: 'SRC',
-            writingSystem: {
-              tag: 'qaa'
-            }
-          }
-        },
-        checkingConfig: {
-          checkingEnabled: false,
-          usersSeeEachOthersResponses: true,
-          shareEnabled: true,
-          shareLevel: CheckingShareLevel.Specific
-        },
-        sync: { queuedCount: 0 },
-        texts: [
-          {
-            bookNum: 40,
-            chapters: [
-              { number: 1, lastVerse: 3, isValid: true },
-              { number: 2, lastVerse: 3, isValid: true }
-            ],
-            hasSource: true
-          },
-          { bookNum: 41, chapters: [{ number: 1, lastVerse: 3, isValid: false }], hasSource: true },
-          {
-            bookNum: 42,
-            chapters: [
-              { number: 1, lastVerse: 3, isValid: true },
-              { number: 2, lastVerse: 3, isValid: true }
-            ],
-            hasSource: false
-          },
-          {
-            bookNum: 43,
-            chapters: [{ number: 1, lastVerse: 0, isValid: true }],
-            hasSource: false
-          }
-        ]
-      }
+      data: projectData
     });
   }
 
@@ -1109,10 +1081,6 @@ class TestEnvironment {
     );
   }
 
-  getChapterDirection(index: number): string | null {
-    return this.getChapterElement(index)!.getAttribute('dir');
-  }
-
   getChapterElement(index: number): Element | null {
     const chapters = this.targetEditor.container.querySelectorAll('usx-chapter');
     if (chapters.hasOwnProperty(index) !== undefined) {
@@ -1121,20 +1089,12 @@ class TestEnvironment {
     return null;
   }
 
-  getParagraphDirection(index: number): string | null {
-    return this.getParagraphElement(index)!.getAttribute('dir');
-  }
-
   getParagraphElement(index: number): Element | null {
     const paragraphs = this.targetEditor.container.querySelectorAll('usx-para');
     if (paragraphs.hasOwnProperty(index) !== undefined) {
       return paragraphs[index];
     }
     return null;
-  }
-
-  getSegmentDirection(segmentRef: string): string | null {
-    return this.getSegmentElement(segmentRef)!.getAttribute('dir');
   }
 
   getSegmentElement(segmentRef: string): HTMLElement | null {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -196,8 +196,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   get isRightToLeft(): boolean {
-    if (this.projectDoc?.data && this.projectDoc.data?.isRightToLeft) {
-      return this.projectDoc.data?.isRightToLeft;
+    if (this.projectDoc?.data && this.projectDoc.data?.isRightToLeft != null) {
+      return this.projectDoc.data.isRightToLeft;
     }
     return false;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -196,7 +196,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   get isRightToLeft(): boolean {
-    if (this.projectDoc?.data && this.projectDoc.data?.isRightToLeft != null) {
+    if (this.projectDoc?.data?.isRightToLeft != null) {
       return this.projectDoc.data.isRightToLeft;
     }
     return false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -195,6 +195,13 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     return this.isValid && this.hasEditRight;
   }
 
+  get isRightToLeft(): boolean {
+    if (this.projectDoc?.data && this.projectDoc.data?.isRightToLeft) {
+      return this.projectDoc.data?.isRightToLeft;
+    }
+    return false;
+  }
+
   get isValid(): boolean {
     if (this.text == null) {
       return true;


### PR DESCRIPTION
- Removed previous logic that set RTL/LTR based on text contained in a paragraph
- Enforce direction based on project `isRightToLeft` setting from Paratext
- Improved USX formatting for RTL

Issues identified to be addressed were:

1. Arrow keys do not work at the end of a segment.
2. Unable to select the first position in a segment.
3. In a LTR segment, typing at the beginning of the segment adds to the end.
4. Unable to navigate to a blank segment.
5. In a LTR segment, unable to select the end of the segment.
6. Selection marker should appear on right side when document is RTL.

This PR does not look heavily at bidirectional text within segments but focuses on RTL scripts working correctly. Segments can contain LTR scripts but Chrome decides to handle things differently where it will jump the cursor to the left side of the script and work backwards whereas Firefox does the opposite. If the LTR script is at the start/end of a segment this can be a little disorignating when trying to click at the right position. We decided that those who use Chrome in RTL would likely be used to how it operates and those who use Firefox would equally be used to how it operates. 

Testing was completed on a real Arabic project and compared with how it rendered in Paratext.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/840)
<!-- Reviewable:end -->
