### PR TITLE
SF-1104 Increase width of project selection list

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
@@ -59,7 +59,6 @@
 
     #project-select {
       width: 100%;
-      margin-right: 32px;
     }
 
     #no-projects-msg {
@@ -114,11 +113,22 @@
   max-width: calc(100% - 44px);
 }
 
+mdc-menu {
+  // Make the MDC Menu List extend to the width of the MDC Select that it drops down from, minus some space to still
+  // show the drop down arrow.
+  width: calc(100% - 40px);
+}
+
 mdc-select {
   margin-bottom: 4px;
   ::ng-deep .mdc-select__anchor {
     width: 100%;
   }
+}
+
+mdc-list-item {
+  height: unset;
+  min-height: 48px;
 }
 
 mdc-linear-progress ::ng-deep {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
@@ -108,3 +108,8 @@
     min-width: 150px;
   }
 }
+
+mdc-list-item {
+  height: unset;
+  min-height: 48px;
+}


### PR DESCRIPTION
- The contents of the list can start to disappear from view if wrapped
  over several lines in the vertical space given to each list item.
  This can happen if the project name is long, or if we append
  "(already connected)".
- Increase the width of the two project lists to decrease the chance
  of some of the menu item being obscured by wrapping. It only starts
  to be a problem if it wraps over more than 2 lines.
- The #projects-menu min-width uses min() to help choose between
  values suitable for different size viewports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/843)
<!-- Reviewable:end -->
