### PR TITLE
Fix clickability of help menu list items

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -49,21 +49,17 @@
             <mdc-menu #helpMenu [anchorCorner]="'bottomStart'" [anchorElement]="helpMenuAnchor">
               <mdc-list-group>
                 <mdc-list>
-                  <mdc-list-item>
-                    <a target="_blank" [href]="helpsPage">{{ t("help") }}</a>
-                  </mdc-list-item>
-                  <mdc-list-item name="issues">
-                    <a target="_blank" [href]="issueMailTo">
-                      <mdc-list-item-text>
-                        {{ t("report_issue") }}
-                        <div>
-                          <small>{{ t("report_issue_email", { email: issueEmail }) }}</small>
-                        </div>
-                      </mdc-list-item-text>
-                    </a>
-                  </mdc-list-item>
+                  <a mdc-list-item target="_blank" [href]="helpsPage">{{ t("help") }}</a>
+                  <a mdc-list-item target="_blank" [href]="issueMailTo">
+                    <mdc-list-item-text
+                      >{{ t("report_issue") }}
+                      <mdc-list-item-secondary
+                        >{{ t("report_issue_email", { email: issueEmail }) }}
+                      </mdc-list-item-secondary>
+                    </mdc-list-item-text>
+                  </a>
                   <mdc-list-divider></mdc-list-divider>
-                  <div class="mdc-list-group__subheader">{{ t("product_version", { version: version }) }}</div>
+                  <div mdcListGroupSubheader class="version">{{ t("product_version", { version: version }) }}</div>
                 </mdc-list>
               </mdc-list-group>
             </mdc-menu>
@@ -87,11 +83,8 @@
                 <div class="mdc-list-group__subheader">
                   {{ t("logged_in_as") }}
                   <div fxLayout="row" fxLayoutAlign="start center">
-                    <span fxFlex>&nbsp;</span>
-                    <button id="edit-name-btn" mdcIconButton type="button" (click)="editName()">
-                      <mdc-icon>edit</mdc-icon>
-                    </button>
                     <strong class="user-menu-name">{{ currentUser?.displayName }}</strong>
+                    <button id="edit-name-btn" mdcIconButton icon="edit" type="button" (click)="editName()"></button>
                   </div>
                 </div>
                 <div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -83,9 +83,13 @@
     mdc-top-app-bar-section {
       mdc-menu {
         min-width: 200px;
+        text-align: left; // Needed for some menu items in Chrome but not Firefox
         a {
           width: 100%;
           color: var(--mdc-theme-text-primary-on-background);
+        }
+        .version {
+          color: var(--mdc-theme-text-secondary-on-background);
         }
       }
     }


### PR DESCRIPTION
A couple list items in the help menu were not fully clickable (some regions of the list item just closed the menu when clicked). Here's a visualization of the element structure created using Pesticide CSS:

Before | After
-------|------
![](https://user-images.githubusercontent.com/6140710/96624552-e6d7b980-12da-11eb-869b-46ae97cb0aef.png) | ![](https://user-images.githubusercontent.com/6140710/96625782-a11bf080-12dc-11eb-8b42-0ba65f083923.png)

I've made two changes:
1. The entire region of each of the top two list items is now clickable.
2. I changed `<div class="mdc-list-group__subheader">` to `<div mdcListGroupSubheader>` because it seemed more consistent with the way we use Angular MDC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/846)
<!-- Reviewable:end -->
