### PR TITLE
SF-1107 Access answer audio through cache

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -66,7 +66,7 @@
           </div>
           <div [fxShow]="answerTabs.activeTabIndex === 1" class="answer-tab answer-record-upload">
             <app-checking-audio-combined
-              [source]="activeAnswer?.audioUrl"
+              [source]="answerUrls[activeAnswer?.dataId]"
               (update)="processAudio($event)"
             ></app-checking-audio-combined>
           </div>
@@ -138,7 +138,8 @@
                 }}</span>
                 <span class="answer-scripture-verse">{{ scriptureTextVerseRef(answer.verseRef) }}</span>
               </div>
-              <app-checking-audio-player *ngIf="answer.audioUrl" [source]="answer.audioUrl"></app-checking-audio-player>
+              <app-checking-audio-player *ngIf="answer.audioUrl" [source]="answerUrls[answer.dataId]">
+              </app-checking-audio-player>
               <div class="answer-footer">
                 <div class="actions">
                   <button

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -11,8 +11,9 @@
       >
         <div class="question">
           <div class="question-text">{{ questionDoc?.data?.text }}</div>
-          <div *ngIf="questionUrl" class="question-audio">
-            <app-checking-audio-player [source]="questionUrl"></app-checking-audio-player>
+          <div *ngIf="questionDoc?.data?.audioUrl" class="question-audio">
+            <app-checking-audio-player [source]="getFileSource(questionDoc?.data?.audioUrl)">
+            </app-checking-audio-player>
           </div>
           <div class="question-footer" *ngIf="isProjectAdmin">
             <div class="actions">
@@ -66,7 +67,7 @@
           </div>
           <div [fxShow]="answerTabs.activeTabIndex === 1" class="answer-tab answer-record-upload">
             <app-checking-audio-combined
-              [source]="answerUrls[activeAnswer?.dataId]"
+              [source]="getFileSource(activeAnswer?.audioUrl)"
               (update)="processAudio($event)"
             ></app-checking-audio-combined>
           </div>
@@ -138,7 +139,7 @@
                 }}</span>
                 <span class="answer-scripture-verse">{{ scriptureTextVerseRef(answer.verseRef) }}</span>
               </div>
-              <app-checking-audio-player *ngIf="answer.audioUrl" [source]="answerUrls[answer.dataId]">
+              <app-checking-audio-player *ngIf="answer.audioUrl" [source]="getFileSource(answer.audioUrl)">
               </app-checking-audio-player>
               <div class="answer-footer">
                 <div class="actions">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -323,10 +323,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
   }
 
   getFileSource(url: string | undefined): string | undefined {
-    if (url == null || url === '') {
-      return undefined;
-    }
-    if (this.fileSources.has(url)) {
+    if (url != null && url !== '' && this.fileSources.has(url)) {
       return this.fileSources.get(url);
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.html
@@ -12,7 +12,7 @@
       <mdc-icon>volume_off</mdc-icon>
       <span class="audio-unavailable-message">{{ t("audio_unavailable") }}</span>
       <a
-        *ngIf="!errorOnLoad; else loadError"
+        *ngIf="!localUrlError; else loadError"
         #audioUnavailableTooltip="matTooltip"
         (click)="audioUnavailableTooltip.show()"
         matTooltip="{{ t('audio_cannot_be_played') }}"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.spec.ts
@@ -91,7 +91,7 @@ describe('CheckingAudioPlayerComponent', () => {
   });
 
   it('show error tooltip if error loading audio', async () => {
-    const template = `<app-checking-audio-player #player1 source="unsupported.audio"></app-checking-audio-player>`;
+    const template = `<app-checking-audio-player #player1 source="blob://unsupported"></app-checking-audio-player>`;
     const env = new TestEnvironment(template, false);
     await env.waitForPlayer(1000);
     expect(env.audioNotAvailableMessage).not.toBeNull();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.ts
@@ -19,7 +19,7 @@ export class CheckingAudioPlayerComponent extends SubscriptionDisposable impleme
   @ViewChild(MdcSlider) slider?: MdcSlider;
 
   seek: number = 0;
-  errorOnLoad: boolean = false;
+  localUrlError: boolean = false;
 
   private _currentTime: number = 0;
   private _duration: number = 0;
@@ -33,7 +33,7 @@ export class CheckingAudioPlayerComponent extends SubscriptionDisposable impleme
     this.audio.addEventListener('loadedmetadata', () => {
       this.updateDuration();
       this.audioDataLoaded = true;
-      this.errorOnLoad = false;
+      this.localUrlError = false;
     });
 
     this.audio.addEventListener('timeupdate', () => {
@@ -49,7 +49,7 @@ export class CheckingAudioPlayerComponent extends SubscriptionDisposable impleme
     });
 
     this.audio.addEventListener('error', () => {
-      this.errorOnLoad = true;
+      this.localUrlError = isLocalBlobUrl(this.audio.src) ? true : false;
     });
 
     this.subscribe(this.pwaService.onlineStatus, isOnline => {
@@ -101,7 +101,7 @@ export class CheckingAudioPlayerComponent extends SubscriptionDisposable impleme
       this.enabled = false;
     }
     this.audioDataLoaded = false;
-    this.errorOnLoad = false;
+    this.localUrlError = false;
   }
 
   /**
@@ -109,7 +109,7 @@ export class CheckingAudioPlayerComponent extends SubscriptionDisposable impleme
    * loaded already (and therefore cached in memory).
    */
   get isAudioAvailable(): boolean {
-    return (isLocalBlobUrl(this.audio.src) || this.pwaService.isOnline || this.audioDataLoaded) && !this.errorOnLoad;
+    return (isLocalBlobUrl(this.audio.src) || this.pwaService.isOnline || this.audioDataLoaded) && !this.localUrlError;
   }
 
   private get checkIsPlaying(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -360,16 +360,16 @@ describe('CheckingComponent', () => {
       env.waitForSliderUpdate();
       expect(env.audioPlayerOnQuestion).toBeNull();
       verify(mockedFileService.findOrUpdateCache(FileType.Audio, QuestionDoc.COLLECTION, questionId, undefined)).times(
-        6
+        5
       );
     }));
 
     it('uploads audio then updates audio url', fakeAsync(() => {
       const env = new TestEnvironment(ADMIN_USER, 'JHN', false);
       env.selectQuestion(14);
-      expect(env.component.answersPanel?.questionUrl).toBeUndefined();
       const questionId = 'q14Id';
       const questionDoc = cloneDeep(env.getQuestionDoc(questionId));
+      expect(env.component.answersPanel?.getFileSource(questionDoc.data?.audioUrl)).toBeUndefined();
       questionDoc.submitJson0Op(op => {
         op.set<string>(qd => qd.audioUrl!, 'anAudioFile.mp3');
       });
@@ -381,7 +381,7 @@ describe('CheckingComponent', () => {
       env.fileSyncComplete.next();
       tick();
       env.fixture.detectChanges();
-      expect(env.component.answersPanel?.questionUrl).toBeDefined();
+      expect(env.component.answersPanel?.getFileSource(questionDoc.data?.audioUrl)).toBeDefined();
       verify(mockedFileService.findOrUpdateCache(FileType.Audio, 'questions', questionId, 'anAudioFile.mp3')).once();
     }));
 
@@ -794,7 +794,7 @@ describe('CheckingComponent', () => {
       expect(env.component.answersPanel?.answers.length).toEqual(1);
       const newAnswer = env.component.answersPanel!.answers[0];
       expect(newAnswer.audioUrl).toEqual('blob://audio');
-      expect(env.component.answersPanel?.answerUrls[newAnswer.dataId]).toBeDefined();
+      expect(env.component.answersPanel?.getFileSource(newAnswer.audioUrl)).toBeDefined();
       verify(mockedFileService.findOrUpdateCache(FileType.Audio, 'questions', anything(), 'blob://audio'));
     }));
 


### PR DESCRIPTION
* The answers component loads audio content through the cache
* Audio cache gets updated anytime local audio is uploaded
* When browser or add-to-homescreen is re-opened it will play cached answers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/848)
<!-- Reviewable:end -->
