### PR TITLE
Setup: Add WritingSystemRepository, enhance

### DIFF
--- a/deploy/dependencies.yml
+++ b/deploy/dependencies.yml
@@ -110,6 +110,7 @@
         - "/var/lib/scriptureforge/audio"
         - "/var/lib/xforge"
         - "/var/lib/xforge/avatars"
+        - "{{lookup('env','HOME')}}/.local/share/SIL/WritingSystemRepository/3"
 
     - name: add localhost to dnsmasq
       lineinfile:

--- a/deploy/dependencies.yml
+++ b/deploy/dependencies.yml
@@ -63,8 +63,14 @@
         state: latest
         global: yes
 
-    - name: change node version
-      shell: "n {{node_version}}"
+    - name: check current node version
+      shell: node --version || echo error
+      register: node_version_installed
+      changed_when: False
+
+    - name: set node version
+      command: "n {{node_version}}"
+      when: "node_version_installed.stdout != 'v' + node_version"
 
     # Install mercurial 4.7+ from system or pip
     - name: install pip mercurial dependencies


### PR DESCRIPTION
While testing SF-1047 (server Ansible for ParatextData) on a dev machine by adding some Ansible into our existing dev machine Ansible files, the WritingSystemRepository directory was found to be something our dev machine ansible wasn't covering already. This PR adds that in. 
And also a cleanup while working in that area.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/849)
<!-- Reviewable:end -->
