### PR TITLE
vagrant: Add sfdev using Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,35 +110,37 @@ We use [Prettier](https://prettier.io/) with a pre-commit hook.
 
 We use [Angular Flex-Layout](https://github.com/angular/flex-layout) with [Angular MDC](https://trimox.github.io/angular-mdc-web) including the [Material Design Icons](https://google.github.io/material-design-icons/).
 
-### Recommended Development Environment
+### Development Environment
 
-Our recommended development environment for web development is Ubuntu 16.04.
-
-- [Vagrant GUI Setup](#vagrant-gui-setup). A Vagrant box with xForge already installed is downloaded and set up on your machine. This is the easiest and cleanest to setup.
-- [Local Linux Development Setup](#local-linux-development-setup). Everything is installed directly on your machine, which needs to be running Ubuntu 16.04. This is the fastest method because development is not done in a virtual machine.
+- [Vagrant GUI Setup](#vagrant-gui-setup). A Vagrant box with xForge already installed is downloaded and set up on your
+  machine. This is the easiest and cleanest to setup.
+- [Local Linux Development Setup](#local-linux-development-setup). Everything is installed directly on your machine,
+  which needs to be running Ubuntu 16.04. This is the fastest method because development is not done in a virtual machine.
 - [Manual Setup](#manual-setup) This setup is specifically written for **Windows** but the steps could be used for any OS.
 
-#### Vagrant GUI Setup
+#### Vagrant Development Machine
 
-Install [VirtualBox](https://www.virtualbox.org/), [Vagrant](https://www.vagrantup.com/), and [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git). To do this in Linux, run
+Install [VirtualBox](https://www.virtualbox.org/), [Vagrant](https://www.vagrantup.com/), and
+[git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git). To do this in Linux, run
 
     sudo apt install vagrant virtualbox virtualbox-guest-additions-iso git
 
-Setup git. At least name and email is needed in `.gitconfig`. You can do this from a terminal by running
+Setup git. At least name and email is needed in `.gitconfig`. You can do this from a terminal in your host machine by running
 
     git config --global user.name "My Name"
     git config --global user.email "me@example.com"
 
 Hardware-assisted virtualization (VT-x or AMD-V) needs to be enabled in your BIOS.
 
-Create a directory to manage the development machine, such as `xforge`. Checkout the xforge git repository to access (and later receive updates to) the vagrant development machine configuration file:
+Clone the xforge git repository to access (and later receive updates to) the vagrant development machine configuration file:
 
     git clone https://github.com/sillsdev/web-xforge
-    cd web-xforge/deploy/vagrant_xenial_gui
+    cd web-xforge/deploy/sfdev
 
-Run `vagrant up`. This will download, initialize, and run the development machine. The machine is about 5GB, so expect the download to take a while.
+Run `vagrant up`. This will download, initialize, and run the development machine. The machine is about 5GB, so expect
+the download to take a while.
 
-In the guest development machine, do the following additional steps. If a dialog about grub appears during upgrade, use TAB, ENTER, and SPACE to specify to use `sda` or to not worry about it, depending on which dialog you get.
+In the guest development machine, do the following additional steps.
 
 ```shell
 sudo apt update

--- a/deploy/sfdev/Vagrantfile
+++ b/deploy/sfdev/Vagrantfile
@@ -1,0 +1,74 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "sfdev"
+  config.vm.box_url = "http://linux.lsdev.sil.org/vagrant/sfdev/sfdev.json"
+  config.vm.hostname = "sfdev"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.gui = true
+    vb.cpus = 4
+    # At least 3000 MB of RAM is needed to run tests. Using an initial value here of 6000 MB in case the machine is
+    # opened on a computer with 8 GB RAM. Most of the time, 14000 MB RAM is enough for development, using Code,
+    # Chromium, running tests, etc. at the same time. Set the RAM value in a SFDEV_RAM environment variable by running
+    # a command such as
+    #   tee -a ~/.pam_environment <<< 'SFDEV_RAM="14000"'
+    # and then logging back into your computer. Or temporarily set the value here.
+    vb.memory = ENV['SFDEV_RAM'] || "6000"
+    # Enable 3D acceleration and enough video RAM for larger displays.
+    vb.customize ["modifyvm", :id, "--accelerate3d", "on"]
+    vb.customize ["modifyvm", :id, "--vram", "128"]
+  end
+
+  config.vm.provision "shell", privileged: false, inline: <<~SHELL
+    set -eux -o pipefail
+
+    function tryharderto() { i=0; until "$@"; do ((++i > 3)) && false; echo >&2 Retrying $i; sleep 2m; done }
+
+    # Canary
+    tee ~/Desktop/warning-not-provisioned.txt <<END
+    The presence of this file means that the vagrant virtual machine did not
+    finish provisioning correctly.
+    The best way to get to a working machine state is to backup any data that
+    you want to keep from this virtual machine, and then destroy and re-create
+    this vagrant virtual machine by running these commands from your host:
+        vagrant destroy
+        vagrant up
+    END
+
+    GIT_USER="#{`git config --get user.name`.strip}"
+    GIT_EMAIL="#{`git config --get user.email`.strip}"
+    [[ -z $GIT_USER ]] || git config --global user.name "${GIT_USER}"
+    [[ -z $GIT_EMAIL ]] || git config --global user.email "${GIT_EMAIL}"
+
+    cd ~/src/web-xforge
+    # Clear away some modified files. But not the whole tree in case a
+    # user runs this against their data.
+    git checkout -- src/SIL.XForge.Scripture/ClientApp/package{,-lock}.json || true
+    git pull --ff-only --recurse-submodules
+
+    cd ~/src/web-xforge/deploy
+    tryharderto ansible-playbook playbook_bionic.yml --limit localhost
+
+    sudo n lts
+
+    cd ~/src/web-xforge/
+    dotnet clean
+    # Remove orphaned? dotnet process.
+    sleep 10s
+    pkill dotnet
+    rm -rf /tmp/NuGetScratch/lock
+
+    cd ~/src/web-xforge/src/SIL.XForge.Scripture/ClientApp
+    npm i
+    cd ~/src/web-xforge/src/RealtimeServer
+    npm i
+    cd ~/src/web-xforge/src/SIL.XForge.Scripture
+    dotnet build
+
+    # Remove canary
+    rm ~/Desktop/warning-not-provisioned.txt
+    echo Provisioning finished successfully.
+  SHELL
+end

--- a/deploy/sfdev/base/instructions.md
+++ b/deploy/sfdev/base/instructions.md
@@ -1,0 +1,109 @@
+# Scripture Forge development base box creation instructions
+
+## Install
+
+* Use virtualbox manager to create a new VM with a temporary name (like `sfdev-base`).
+* Give 6 GB RAM and 200 GB dynamic storage. Actual RAM available will depend on a
+  Vagrantfile setting later on. Give 2 processors.
+* Boot Ubuntu .iso. Install Ubuntu. Don't install unneeded "third-party software".
+* Use computer name `sfdev`, username `vagrant` and password `vagrant`. Choose Log in
+  automatically.
+
+## Setup machine
+
+* Launch Software Updater and apply updates. If that gives any trouble, can fall back to:
+  boot to recovery mode, enable networking, and run `apt update && apt upgrade -y`.
+
+* Install guest additions.
+
+  * On your host machine, run
+
+    sudo apt install virtualbox-guest-additions-iso
+
+  * In the guest machine, run
+
+    sudo apt update && sudo apt install -y linux-headers-$(uname -r) build-essential \
+      dkms virtualbox-guest-utils virtualbox-guest-dkms
+
+    In the guest machine window, choose Devices > Insert Guest Additions CD image. In the
+    guest, a VBOXADDITIONS window appears; click Run. A terminal window will appear,
+    asking if you want to replace versions of additions. Enter yes. It will say something
+    went wrong. Right-click the CD icon on the panel or desktop and Eject the VirtualBox
+    Additions disc.
+
+  * In the guest machine window, choose Devices > Shared clipboard > Bidirectional.
+
+  * Reboot.
+
+* Set resolution to a big enough but conservative initial value of 1600x900, that will fit
+  inside someone's 1080p desktop.
+
+* Taking a virtual machine snapshot here makes for a good place to come back to when making
+  new versions of this virtual machine.
+
+* Run `provision` script on guest. Possibly by copying and pasting its contents into a new
+  file on guest and running it with `bash provision`.
+
+* Log out to use newly installed and activated Gnome extensions.
+
+* Launch VSCode. Open ~/src/web-xforge folder. Install workspace-recommended extensions.
+
+* Launch Settings. Don't use a bunch of RAM for error reports:
+  Privacy - Diagnostics - Send error reports to Canonical - Never.
+
+* Set desktop background.
+
+* Arrange desktop icons, since may be in disarray from resizing the desktop or moving panel.
+  Make a couple rows of icons, with the second row containing Chromium, Code, Byobu, Gitk,
+  Git Cola.
+
+* Clean up byobu status bar (F1).
+
+* Optionally edit basebox version file at `~/machine-info.txt`. "Installed from" can state
+  the installation media used to create the machine.
+
+## Finalize
+
+* Do the following to free up disk space, delete the guest's ssh host keys so they will be
+  re-generated uniquely by users, and zero-out deleted files so they don't take up space
+  shipping with the product. A `cat: write error: No space left on device` is expected and
+  not a problem.
+
+  sudo apt-get update && sudo apt-get -y autoremove && sudo apt-get -y clean \
+    && sudo rm -v /etc/ssh/ssh_host_* \
+    && cat /dev/zero > ~/zeros; sync; ls -lh ~/zeros; rm -v ~/zeros
+
+* Power off.
+
+## Generate and publish product
+
+* Export VM .box file. This may take 20+ minutes. The `--base` argument is the name of the
+  base machine in virtualbox manager. Replace the VERSION string in the below before
+  running.
+
+  export BOX="sfdev"
+  export VERSION="1.0.0"
+  date && time vagrant package --base ${BOX}-base --output ${BOX}-${VERSION}.box \
+    && ls -lh ${BOX}-${VERSION}.box && sha256sum ${BOX}-${VERSION}.box
+
+* Update the box .json file, including the sha.
+
+* Test base box. Enable vb.gui in Vagrantfile. Give it more RAM.
+
+  mkdir test && cd test && vagrant init ../${BOX}-${VERSION}.box && vim Vagrantfile
+  vagrant up
+
+* Clean up box test machine. In the `test` directory, run the following. Then delete the
+  `test` directory. The `vagrant box remove` command removes the internally stored copy of
+  the base box (to free disk space); it's not removing the '../foo' _file_, but internally
+  stored data with the designation of '../foo'.
+
+  vagrant destroy && vagrant box remove "../${BOX}-${VERSION}.box"
+
+## Notes
+
+* Changes to guest settings can be seen by observing differences in output from
+```
+gsettings list-recursively
+dconf dump /
+```

--- a/deploy/sfdev/base/provision
+++ b/deploy/sfdev/base/provision
@@ -105,13 +105,13 @@ gsettings set org.gnome.desktop.interface gtk-theme 'Yaru-dark'
 # Gedit: Menu - Preferences - Fonts & Colours - Solarized Dark
 gsettings set org.gnome.gedit.preferences.editor scheme 'solarized-dark'
 # Terminal: Menu - Preferences - Profiles > Unnamed - Colours.
-# Under Text and Background Color, clear "Use colors from system theme"; Built-in schemes: Solarized dark.
-# Under Palette, Build-in schemes: Solarized.
+# Under Text and Background Color, clear "Use colors from system theme"; Built-in schemes: Tango dark.
+# Under Palette, Build-in schemes: Tango.
 dconf write /org/gnome/terminal/legacy/profiles:/:b1dcc9dd-5262-4d8d-a863-c897e6d979b9/use-theme-colors false
-dconf write /org/gnome/terminal/legacy/profiles:/:b1dcc9dd-5262-4d8d-a863-c897e6d979b9/background-color "'rgb(0,43,54)'"
-dconf write /org/gnome/terminal/legacy/profiles:/:b1dcc9dd-5262-4d8d-a863-c897e6d979b9/foreground-color "'rgb(131,148,150)'"
+dconf write /org/gnome/terminal/legacy/profiles:/:b1dcc9dd-5262-4d8d-a863-c897e6d979b9/background-color "'rgb(46,52,54)'"
+dconf write /org/gnome/terminal/legacy/profiles:/:b1dcc9dd-5262-4d8d-a863-c897e6d979b9/foreground-color "'rgb(211,215,207)'"
 dconf write /org/gnome/terminal/legacy/profiles:/:b1dcc9dd-5262-4d8d-a863-c897e6d979b9/palette \
-  "['rgb(7,54,66)', 'rgb(220,50,47)', 'rgb(133,153,0)', 'rgb(181,137,0)', 'rgb(38,139,210)', 'rgb(211,54,130)', 'rgb(42,161,152)', 'rgb(238,232,213)', 'rgb(0,43,54)', 'rgb(203,75,22)', 'rgb(88,110,117)', 'rgb(101,123,131)', 'rgb(131,148,150)', 'rgb(108,113,196)', 'rgb(147,161,161)', 'rgb(253,246,227)']"
+  "['rgb(46,52,54)', 'rgb(204,0,0)', 'rgb(78,154,6)', 'rgb(196,160,0)', 'rgb(52,101,164)', 'rgb(117,80,123)', 'rgb(6,152,154)', 'rgb(211,215,207)', 'rgb(85,87,83)', 'rgb(239,41,41)', 'rgb(138,226,52)', 'rgb(252,233,79)', 'rgb(114,159,207)', 'rgb(173,127,168)', 'rgb(52,226,226)', 'rgb(238,238,236)']"
 
 # Tweaks - Extensions
 gsettings set org.gnome.shell enabled-extensions \
@@ -176,6 +176,8 @@ tryharderto sudo apt-get install code
 # Let VS Code watch lots of files.
 sudo tee -a /etc/sysctl.conf >/dev/null <<< 'fs.inotify.max_user_watches=524288'
 sudo sysctl -p
+# mono-devel for OmniSharp
+tryharderto sudo apt-get install -y mono-devel
 
 # Paratext
 (wget -O- https://packages.sil.org/keys/pso-keyring-2016.gpg \
@@ -193,8 +195,96 @@ git config --global color.ui true
 git config --global rerere.enabled true
 git config --global gui.editor gedit
 git config --global rebase.autosquash true
-# Set the textwidth on the git cola commit tool to help auto wrap commit messages
+# Git Cola settings. Set textwidth to help auto wrap commit messages.
 git config --global cola.textwidth 70
+git config --global cola.tabwidth 2
+git config --global cola.linebreak true
+git config --global cola.theme flat-dark-blue
+git config --global cola.icontheme dark
+# Arrange diff, commit, status, actions, branches, and console areas.
+mkdir -p "${HOME}/.config/git-cola"
+tee "${HOME}/.config/git-cola/settings" >/dev/null << END
+{
+    "gui_state": {
+        "mainview": {
+            "geometry": "AdnQywADAAAAAAA9AAAABwAABNsAAANKAAAAPQAAACwAAATbAAADSgAAAAAAAAAABkAAAAA9AAAALAAABNsAAANK",
+            "width": 1200,
+            "height": 800,
+            "x": 50,
+            "y": 10,
+            "lock_layout": false,
+            "windowstate": "AAAA/wAAAAL9AAAAAQAAAAIAAASfAAADB/wBAAAAA/sAAAAIAEQAaQBmAGYBAAAAAAAAAqoAAAB1AP////wAAAKtAAAB8gAAARUA/////AIAAAAE+wAAAAwAQwBvAG0AbQBpAHQBAAAAGAAAALsAAABFAP////sAAAAMAFMAdABhAHQAdQBzAQAAANYAAAEKAAAARQD////7AAAADgBBAGMAdABpAG8AbgBzAQAAAeMAAABFAAAARQD////8AAACKwAAAPQAAABFAP////wBAAAAAvsAAAAQAEIAcgBhAG4AYwBoAGUAcwEAAAKtAAAA7AAAAKIA////+wAAAA4AQwBvAG4AcwBvAGwAZQEAAAOcAAABAwAAAHAA/////AAAAqYAAAH5AAAAAAD////6/////wEAAAAD+wAAABQAUwB1AGIAbQBvAGQAdQBsAGUAcwAAAAAA/////wAAALgA////+wAAABIARgBhAHYAbwByAGkAdABlAHMAAAAAAP////8AAAC2AP////sAAAAMAFIAZQBjAGUAbgB0AAAAAAD/////AAAAkgD///8AAASfAAAAAAAAAAQAAAAEAAAACAAAAAj8AAAAAA=="
+        }
+    }
+}
+END
+# gitk solarized dark colour scheme
+mkdir -p "${HOME}/.config/git"
+tee "${HOME}/.config/git/gitk" >/dev/null << END
+set mainfont {sans 9}
+set textfont {monospace 9}
+set uifont {sans 9 bold}
+set tabstop 8
+set findmergefiles 0
+set maxgraphpct 50
+set maxwidth 16
+set cmitmode patch
+set wrapcomment none
+set autoselect 1
+set autosellen 40
+set showneartags 1
+set maxrefs 20
+set visiblerefs {"master"}
+set hideremotes 0
+set showlocalchanges 1
+set datetimeformat {%Y-%m-%d %H:%M:%S}
+set limitdiffs 1
+set uicolor #657b83
+set want_ttk 1
+set bgcolor #002b36
+set fgcolor #839496
+set uifgcolor #839496
+set uifgdisabledcolor #586e75
+set colors {"#6c71c4" "#268bd2" "#2aa198" "#859900" "#b58900" "#cb4b16" "#dc322f" "#d33682"}
+set diffcolors {"#dc322f" "#859900" "#268bd2"}
+set mergecolors {"#dc322f" "#268bd2" "#859900" "#6c71c4" brown "#009090" #d33682 "#808000" "#009000" "#ff0080" "#2aa198" "#b07070" "#70b0f0" "#70f0b0" "#f0b070" "#ff70b0"}
+set markbgcolor #073642
+set diffcontext 3
+set selectbgcolor #586e75
+set foundbgcolor #b58900
+set currentsearchhitbgcolor #cb4b16
+set extdifftool meld
+set perfile_attrs 0
+set headbgcolor #2aa198
+set headfgcolor #002b36
+set headoutlinecolor #839496
+set remotebgcolor #6c71c4
+set tagbgcolor #d33682
+set tagfgcolor #002b36
+set tagoutlinecolor #002b36
+set reflinecolor #839496
+set filesepbgcolor #073642
+set filesepfgcolor #839496
+set linehoverbgcolor #073642
+set linehoverfgcolor #839496
+set linehoveroutlinecolor #839496
+set mainheadcirclecolor #fdf6e3
+set workingfilescirclecolor #dc322f
+set indexcirclecolor #859900
+set circlecolors {white #268bd2 gray #268bd2 #268bd2}
+set linkfgcolor #268bd2
+set circleoutlinecolor #073642
+set web_browser xdg-open
+set geometry(main) 1227x739+53+11
+set geometry(state) normal
+set geometry(topwidth) 1227
+set geometry(topheight) 425
+set geometry(pwsash0) "684 1"
+set geometry(pwsash1) "1046 1"
+set geometry(botwidth) 773
+set geometry(botheight) 309
+set permviews {}
+END
 
 # Launchers
 
@@ -284,6 +374,9 @@ export NG_CLI_ANALYTICS=false
 cd ~/src/web-xforge/src/SIL.XForge.Scripture/ClientApp && npm i
 cd ~/src/web-xforge/src/RealtimeServer && npm i
 cd ~/src/web-xforge && dotnet build
+
+# Use system hg.
+tee -a ~/.pam_environment <<< 'HG_PATH=/usr/bin/hg'
 
 # Create readme `~/Desktop/machine-instructions.txt`.
 sudo tee ~/Desktop/machine-instructions.txt >/dev/null <<END

--- a/deploy/sfdev/base/provision
+++ b/deploy/sfdev/base/provision
@@ -1,0 +1,308 @@
+#!/bin/bash
+# Vagrant sfdev provision script, to be run in guest when creating basebox
+set -ueo pipefail
+
+# Helper method to avoid failing from a network hiccup during provision
+function tryharderto() { i=0; until "$@"; do ((++i > 3)) && false
+  echo >&2 Retrying ${i}; sleep 2m; done }
+
+## Vagrant Ubuntu setup
+
+# Set mirror to generic
+sudo perl -pi -e 's#/...archive.ubuntu.com#/archive.ubuntu.com#g' /etc/apt/sources.list
+
+# Apply all available updates
+tryharderto sudo apt-get update
+# Download separately to break up the commands and reduce the chance of being
+# asked for sudo password again.
+tryharderto sudo apt-get -dy upgrade
+tryharderto sudo apt-get -y upgrade
+tryharderto sudo apt-get -y dist-upgrade
+
+# Swap shouldn't be necessary and may cause unnecessary churn when backing up the guest
+# image. Disable and delete the swapfile.
+sudo swapoff -a && sudo perl -ni -e 'print unless /swapfile/' /etc/fstab \
+  && sudo rm -fv /swapfile
+
+# Don't prompt for OS upgrade to newer release
+sudo perl -pi -e 's/Prompt=lts/Prompt=never/' /etc/update-manager/release-upgrades
+
+# Passwordless sudo
+sudo tee /etc/sudoers.d/passwordless >/dev/null <<< 'vagrant ALL=(ALL) NOPASSWD: ALL'
+
+sudo tee /etc/sudoers.d/stars >/dev/null <<END
+# Show stars when typing sudo password.
+Defaults pwfeedback
+END
+sudo chmod 0400 /etc/sudoers.d/stars
+
+# Make vagrant accessible via ssh
+sudo apt-get install -y openssh-server
+
+# Install initial vagrant login key.
+mkdir -p ~/.ssh && chmod 0700 ~/.ssh
+wget https://raw.githubusercontent.com/hashicorp/vagrant/master/keys/vagrant.pub \
+  -O ~/.ssh/authorized_keys
+chmod 0600 ~/.ssh/authorized_keys
+
+# Prepare for ssh host keys to be re-generated uniquely by users
+sudo tee /root/regenerate-ssh-host-keys >/dev/null << END
+#!/bin/bash
+# Regenerate ssh host keys if not present
+test -f /etc/ssh/ssh_host_rsa_key || dpkg-reconfigure openssh-server
+END
+sudo chmod +x /root/regenerate-ssh-host-keys
+sudo tee /etc/systemd/system/regenerate-ssh-host-keys.service >/dev/null << END
+[Unit]
+Description=regenerate-ssh-host-keys
+
+[Service]
+ExecStart=/root/regenerate-ssh-host-keys
+
+[Install]
+WantedBy=multi-user.target
+END
+sudo systemctl enable regenerate-ssh-host-keys
+
+# Don't blank or lock VM screen
+gsettings set org.gnome.desktop.session idle-delay 0
+gsettings set org.gnome.desktop.screensaver lock-enabled false
+
+# Don't let deja-dup hassle user about backing up from within guest
+sudo apt-get remove -y deja-dup
+
+# Adjust bash prompt for colour, $ on next line, and exit code display
+perl -pi -e '/#force/ and s/^#//' ~/.bashrc
+perl -pi -e '/PS1/ and s/\\\$ /\\n\\\$ /' ~/.bashrc
+perl -pi -e '/PS1/ and s/@/\$?/' ~/.bashrc
+
+# Don't report developer or tester usage to analytics
+tee -a ~/.pam_environment <<< 'FEEDBACK=false'
+tee -a ~/.pam_environment <<< 'WESAY_TRACK_AS_DEVELOPER=1'
+
+# Record some base box version info, to help with diagnosis
+tee ~/machine-info.txt >/dev/null << END
+Vagrant base box information
+Name: sfdev
+Version:
+Creation date: $(date -I)
+Installed from:
+Notes:
+END
+
+## Configure task bar
+
+tryharderto sudo apt-get install -y \
+  gnome-shell-extension-dash-to-panel \
+  gnome-shell-extension-system-monitor \
+  gnome-shell-extension-arc-menu \
+  gnome-shell-extensions
+
+# Settings - Notifications - Do Not Disturb. Can be turned back on if important.
+gsettings set org.gnome.desktop.notifications show-banners false
+# Settings - Appearance - Window theme - Dark
+gsettings set org.gnome.desktop.interface gtk-theme 'Yaru-dark'
+# Gedit: Menu - Preferences - Fonts & Colours - Solarized Dark
+gsettings set org.gnome.gedit.preferences.editor scheme 'solarized-dark'
+# Terminal: Menu - Preferences - Profiles > Unnamed - Colours.
+# Under Text and Background Color, clear "Use colors from system theme"; Built-in schemes: Solarized dark.
+# Under Palette, Build-in schemes: Solarized.
+dconf write /org/gnome/terminal/legacy/profiles:/:b1dcc9dd-5262-4d8d-a863-c897e6d979b9/use-theme-colors false
+dconf write /org/gnome/terminal/legacy/profiles:/:b1dcc9dd-5262-4d8d-a863-c897e6d979b9/background-color "'rgb(0,43,54)'"
+dconf write /org/gnome/terminal/legacy/profiles:/:b1dcc9dd-5262-4d8d-a863-c897e6d979b9/foreground-color "'rgb(131,148,150)'"
+dconf write /org/gnome/terminal/legacy/profiles:/:b1dcc9dd-5262-4d8d-a863-c897e6d979b9/palette \
+  "['rgb(7,54,66)', 'rgb(220,50,47)', 'rgb(133,153,0)', 'rgb(181,137,0)', 'rgb(38,139,210)', 'rgb(211,54,130)', 'rgb(42,161,152)', 'rgb(238,232,213)', 'rgb(0,43,54)', 'rgb(203,75,22)', 'rgb(88,110,117)', 'rgb(101,123,131)', 'rgb(131,148,150)', 'rgb(108,113,196)', 'rgb(147,161,161)', 'rgb(253,246,227)']"
+
+# Tweaks - Extensions
+gsettings set org.gnome.shell enabled-extensions \
+  "['arc-menu@linxgem33.com', 'dash-to-panel@jderose9.github.com', 'system-monitor@paradoxxx.zero.gmail.com']"
+# Dash to panel: Position - Clock location - Right of system indicators
+gsettings set org.gnome.shell.extensions.dash-to-panel location-clock 'STATUSRIGHT'
+# Dash to panel: Behavior - Show Applications icon - Off
+gsettings set org.gnome.shell.extensions.dash-to-panel show-show-apps-button false
+# Arc menu: General - Arc Menu Default View - Categories List
+dconf write /org/gnome/shell/extensions/arc-menu/enable-pinned-apps false
+# Arc menu: Appearance - Override Arc Menu Theme - On
+dconf write /org/gnome/shell/extensions/arc-menu/enable-custom-arc-menu true
+# Arc menu: Appearance - Arc Menu Icon Settings - Arc Menu Icon: Start Box
+dconf write /org/gnome/shell/extensions/arc-menu/menu-button-icon "'Start_Box'"
+# Arc menu: Appearance - Arc Menu Icon Settings - 24 px
+dconf write /org/gnome/shell/extensions/arc-menu/custom-menu-button-icon-size 24.0
+# System-monitor: Display Icon: Off. Cpu, Memory, Net - Graph Width: 10, Refresh Time: 10000, Show Text: Off
+dconf write /org/gnome/shell/extensions/system-monitor/icon-display false
+dconf write /org/gnome/shell/extensions/system-monitor/cpu-graph-width 10
+dconf write /org/gnome/shell/extensions/system-monitor/cpu-refresh-time 10000
+dconf write /org/gnome/shell/extensions/system-monitor/cpu-show-text false
+dconf write /org/gnome/shell/extensions/system-monitor/memory-graph-width 10
+dconf write /org/gnome/shell/extensions/system-monitor/memory-refresh-time 10000
+dconf write /org/gnome/shell/extensions/system-monitor/memory-show-text false
+dconf write /org/gnome/shell/extensions/system-monitor/net-graph-width 10
+dconf write /org/gnome/shell/extensions/system-monitor/net-refresh-time 10000
+dconf write /org/gnome/shell/extensions/system-monitor/net-show-text false
+
+## Configure desktop for SF development
+
+# Tools
+
+tryharderto sudo apt-get install -y \
+  ack \
+  tig \
+  vim \
+  wget \
+  glances \
+  inotify-tools \
+  python-pyinotify \
+  synaptic \
+  chromium-browser \
+  dconf-cli \
+  git-gui \
+  git-cola \
+  terminator \
+  byobu \
+  meld \
+  kdiff3-qt
+
+# GitKraken
+sudo snap install --classic gitkraken
+
+# Visual Studio Code https://code.visualstudio.com/docs/setup/linux
+tryharderto sudo apt-get install -y curl
+cd
+curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
+sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main" > /etc/apt/sources.list.d/vscode.list'
+tryharderto sudo apt-get update
+tryharderto sudo apt-get install code
+# Let VS Code watch lots of files.
+sudo tee -a /etc/sysctl.conf >/dev/null <<< 'fs.inotify.max_user_watches=524288'
+sudo sysctl -p
+
+# Paratext
+(wget -O- https://packages.sil.org/keys/pso-keyring-2016.gpg \
+  | sudo tee /etc/apt/trusted.gpg.d/pso-keyring-2016.gpg) &> /dev/null
+(. /etc/os-release && sudo tee /etc/apt/sources.list.d/packages-sil-org.list>/dev/null \
+  <<< "deb http://packages.sil.org/$ID $VERSION_CODENAME main")
+sudo apt-get update
+tryharderto sudo apt-get install -y paratext-9.0
+
+# Git and GUI git tools settings
+git config --global diff.tool meld
+git config --global merge.conflictstyle diff3
+git config --global merge.tool kdiff3
+git config --global color.ui true
+git config --global rerere.enabled true
+git config --global gui.editor gedit
+git config --global rebase.autosquash true
+# Set the textwidth on the git cola commit tool to help auto wrap commit messages
+git config --global cola.textwidth 70
+
+# Launchers
+
+TOOLSDIR=${HOME}/Desktop/development-tools
+mkdir -p "${TOOLSDIR}"
+cp -aL /usr/share/applications/{terminator,code,byobu,chromium-browser,paratext9}.desktop \
+  /snap/gitkraken/current/meta/gui/gitkraken.desktop "${TOOLSDIR}"
+chmod +x "${TOOLSDIR}"/*.desktop
+
+# Fix icon
+perl -pi -e '/Icon/ and s#.*#Icon=/snap/gitkraken/current/usr/share/gitkraken/gitkraken.png#' \
+  "${TOOLSDIR}"/gitkraken.desktop
+
+OUTPUTFILE="${TOOLSDIR}/sf-git-cola.desktop"
+tee "${OUTPUTFILE}" >/dev/null << ENDOFOUTPUTFILE
+#!/usr/bin/env xdg-open
+
+[Desktop Entry]
+Version=1.0
+Type=Application
+Terminal=false
+Exec=bash -c 'cd \${HOME}/src/web-xforge && git cola'
+Name=SF Git Cola Commit Tool
+Icon=/usr/share/git-cola/icons/git-cola.svg
+ENDOFOUTPUTFILE
+chmod +x "${OUTPUTFILE}"
+
+OUTPUTFILE="${TOOLSDIR}/sf-gitk.desktop"
+tee "${OUTPUTFILE}" >/dev/null << ENDOFOUTPUTFILE
+#!/usr/bin/env xdg-open
+
+[Desktop Entry]
+Version=1.0
+Type=Application
+Terminal=false
+Exec=bash -c 'cd \${HOME}/src/web-xforge && gitk --branches'
+Name=SF Git History Viewer
+Icon=/usr/share/git-gui/lib/git-gui.ico
+ENDOFOUTPUTFILE
+chmod +x "${OUTPUTFILE}"
+
+# Trust the launchers. Seems to only work on desktop in Ubuntu 20.04.
+mv "${TOOLSDIR}"/*.desktop ~/Desktop/
+rmdir "${TOOLSDIR}"
+cd ~/Desktop
+for launcher in *.desktop; do
+  gio set "${launcher}" metadata::trusted true
+done
+
+# Set panel icons
+gsettings set org.gnome.shell favorite-apps \
+  "['firefox.desktop', 'org.gnome.Nautilus.desktop', 'chromium_chromium.desktop', 'code.desktop']"
+
+## SF repo and dev dependencies setup
+
+tryharderto sudo apt-get -y install ansible git
+
+mkdir -p ~/src
+cd ~/src
+if [ ! -d "web-xforge" ]; then
+  git clone --recurse-submodules https://github.com/sillsdev/web-xforge.git
+else
+  cd web-xforge
+  git pull --ff-only --recurse-submodules
+fi
+
+# mongodb-org isn't released for focal yet. Just install the bionic mongodb for now.
+perl -pi -e '/base_distribution_release/ and s/bionic/focal/' ~/src/web-xforge/deploy/dependencies.yml
+perl -pi -e '/repo.mongo/ and s/{{base_distribution_release}}/bionic/' ~/src/web-xforge/deploy/dependencies.yml
+# The first update_cache is causing trouble. Change it from 'yes' to 'no' for now. '0777'
+# isn't about file permissions; it's part of triggering multi-line substitution. The regex
+# finds the 'update_cache: yes' line that follows a line ending in 'mongodb-org'
+perl -0777 -pi -e 's/(mongodb-org.*?)update_cache: yes/$1update_cache: no/s' ~/src/web-xforge/deploy/dependencies.yml
+
+cd ~/src/web-xforge/deploy/
+ansible-playbook playbook_bionic.yml --limit localhost
+
+# Undo temporary changes
+git checkout -- ~/src/web-xforge/deploy/dependencies.yml
+
+# Install node LTS to upgrade to node 12 and npm 6.14.
+sudo n lts
+
+# Prevent npm @angular/cli from stopping to ask if we want to feed their analytics
+export NG_CLI_ANALYTICS=false
+# Download dependencies so VSCode doesn't show errors on start, like missing jest
+cd ~/src/web-xforge/src/SIL.XForge.Scripture/ClientApp && npm i
+cd ~/src/web-xforge/src/RealtimeServer && npm i
+cd ~/src/web-xforge && dotnet build
+
+# Create readme `~/Desktop/machine-instructions.txt`.
+sudo tee ~/Desktop/machine-instructions.txt >/dev/null <<END
+Scripture Forge Development Machine
+
+If possible, your git user and email were set from your host machine. If not, run
+
+  git config --global user.name "My Name"
+  git config --global user.email "me@example.com"
+
+See the xForge Project Workflow gdoc for setting developer secrets,
+Paratext account setup, enabling multiple monitors in VirtualBox, etc.
+
+You may find it helpful to increase the amount of RAM your virtual machine
+is given, by increasing 'vb.memory' in 'Vagrantfile', then running
+'vagrant halt && vagrant up' from your host.
+
+SF is cloned in ~/src/web-xforge .
+Launchers for development tools are on the desktop.
+END
+
+echo "$0: $(date -Is): Script finished successfully."

--- a/deploy/sfdev/base/sfdev.json
+++ b/deploy/sfdev/base/sfdev.json
@@ -1,0 +1,30 @@
+{
+  "description": "Scripture Forge Development Machine",
+  "name": "sfdev",
+  "versions": [
+    {
+      "version": "0.0.1",
+      "status": "active",
+      "providers": [
+        {
+          "checksum": "a87b09cd35645c1b88a904d6354b1f9ec8b5a148334d3bc81b4be03733164dca",
+          "checksum_type": "sha256",
+          "name": "virtualbox",
+          "url": "http://linux.lsdev.sil.org/vagrant/sfdev/sfdev-0.0.1.box"
+        }
+      ]
+    },
+    {
+      "version": "1.0.0",
+      "status": "active",
+      "providers": [
+        {
+          "checksum": "8376a4c30d3e82f5009a7a9a305baad715a027c2e8ac1b99fbab8fa907de9fd1",
+          "checksum_type": "sha256",
+          "name": "virtualbox",
+          "url": "http://linux.lsdev.sil.org/vagrant/sfdev/sfdev-1.0.0.box"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The current development and testing vagrant machine uses Ubuntu 16.04. This PR introduces a development & testing vagrant machine using Ubuntu 20.04. It also breaks away from the prior base box creation process, and uses cleaner naming.