### PR TITLE
Added checks for RTL on both source and target

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -33,7 +33,7 @@
             [highlightSegment]="target.hasFocus"
             (loaded)="onTextLoaded('source')"
             (updated)="onSourceUpdated($event.delta != null)"
-            [isRightToLeft]="isRightToLeft"
+            [isRightToLeft]="isSourceRightToLeft"
           ></app-text>
         </div>
       </div>
@@ -50,7 +50,7 @@
             (loaded)="onTextLoaded('target')"
             [highlightSegment]="target.hasFocus"
             [markInvalid]="true"
-            [isRightToLeft]="isRightToLeft"
+            [isRightToLeft]="isTargetRightToLeft"
           ></app-text>
           <app-suggestions
             [mdcElevation]="2"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -195,7 +195,14 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     return this.isValid && this.hasEditRight;
   }
 
-  get isRightToLeft(): boolean {
+  get isSourceRightToLeft(): boolean {
+    if (this.projectDoc?.data?.translateConfig?.source?.isRightToLeft != null) {
+      return this.projectDoc.data.translateConfig?.source?.isRightToLeft;
+    }
+    return false;
+  }
+
+  get isTargetRightToLeft(): boolean {
     if (this.projectDoc?.data?.isRightToLeft != null) {
       return this.projectDoc.data.isRightToLeft;
     }


### PR DESCRIPTION
When viewing both `source` and `target` in the translate app the `source` was having Quill set to the RTL of the `target` project. This change now checks `isRightToLeft` from the `TranslateSource`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/853)
<!-- Reviewable:end -->
