### PR TITLE
SF-1123 Set isRightToLeft on every instance of TextComponent

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -325,7 +325,8 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
     const data: QuestionDialogData = {
       questionDoc,
       textsByBookId: this.textsByBookId,
-      projectId: this.projectDoc.id
+      projectId: this.projectDoc.id,
+      isRightToLeft: this.projectDoc.data?.isRightToLeft
     };
     await this.questionDialogService.questionDialog(data);
     this.initTextsWithLoadingIndicator();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -313,7 +313,8 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     const data: QuestionDialogData = {
       questionDoc: this._questionDoc,
       textsByBookId: this.textsByBookId!,
-      projectId: projectId
+      projectId: projectId,
+      isRightToLeft: this.project?.isRightToLeft
     };
     const dialogResponseDoc: QuestionDoc | undefined = await this.questionDialogService.questionDialog(data);
     if (dialogResponseDoc?.data != null) {
@@ -335,6 +336,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
       chapterNum: (this.verseRef && this.verseRef.chapterNum) || verseRef.chapterNum,
       textsByBookId: this.textsByBookId!,
       projectId: this.projectId!,
+      isRightToLeft: this.project?.isRightToLeft,
       selectedText: this.selectedText || '',
       selectedVerses: this.verseRef
     };

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.spec.ts
@@ -84,6 +84,15 @@ describe('CheckingTextComponent', () => {
     expect(env.segmentHasQuestion(1, 4)).toBe(true);
     expect(env.isSegmentHighlighted(1, 4)).toBe(true);
   }));
+
+  it('can set text direction explicitly', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.wait();
+    expect(env.fixture.nativeElement.querySelector('quill-editor[class="read-only-editor ltr"')).not.toBeNull();
+    env.component.isRightToLeft = true;
+    env.wait();
+    expect(env.fixture.nativeElement.querySelector('quill-editor[class="read-only-editor rtl"')).not.toBeNull();
+  }));
 });
 
 class TestEnvironment {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -657,7 +657,8 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
       questionDoc: undefined,
       textsByBookId: this.textsByBookId,
       projectId: this.projectDoc.id,
-      defaultVerse: new VerseRef(this.book, this.chapter, 1)
+      defaultVerse: new VerseRef(this.book, this.chapter, 1),
+      isRightToLeft: this.projectDoc.data?.isRightToLeft
     };
     const newQuestion = await this.questionDialogService.questionDialog(data);
     if (newQuestion != null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
@@ -54,6 +54,7 @@
                 [id]="textDocId"
                 placeholder="{{ t('enter_a_reference_to_load_text') }}"
                 [activeVerse]="selection"
+                [isRightToLeft]="isTextRightToLeft"
               ></app-checking-text>
             </div>
             <mdc-form-field>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -164,11 +164,12 @@ describe('QuestionDialogComponent', () => {
     }
   }));
 
-  it('should set default verse if provided', fakeAsync(() => {
+  it('should set default verse and text direction when provided', fakeAsync(() => {
     const verseRef: VerseRef = VerseRef.parse('LUK 1:1');
-    const env = new TestEnvironment(undefined, verseRef);
+    const env = new TestEnvironment(undefined, verseRef, true);
     flush();
     expect(env.component.scriptureStart.value).toBe('LUK 1:1');
+    expect(env.component.isTextRightToLeft).toBe(true);
   }));
 
   it('should validate matching book and chapter', fakeAsync(() => {
@@ -544,7 +545,7 @@ class TestEnvironment {
 
   private readonly realtimeService: TestRealtimeService = TestBed.get<TestRealtimeService>(TestRealtimeService);
 
-  constructor(question?: Question, defaultVerseRef?: VerseRef) {
+  constructor(question?: Question, defaultVerseRef?: VerseRef, isRtl: boolean = false) {
     this.fixture = TestBed.createComponent(ChildViewContainerComponent);
     const viewContainerRef = this.fixture.componentInstance.childViewContainer;
     let questionDoc: QuestionDoc | undefined;
@@ -573,7 +574,8 @@ class TestEnvironment {
           JHN: { bookNum: 43, hasSource: false, chapters: [{ number: 1, lastVerse: 0, isValid: true }] }
         },
         projectId: 'project01',
-        defaultVerse: defaultVerseRef
+        defaultVerse: defaultVerseRef,
+        isRightToLeft: isRtl
       },
       viewContainerRef
     };

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -26,6 +26,7 @@ export interface QuestionDialogData {
   textsByBookId: TextsByBookId;
   projectId: string;
   defaultVerse?: VerseRef;
+  isRightToLeft?: boolean;
 }
 
 export interface QuestionDialogResult {
@@ -107,6 +108,10 @@ export class QuestionDialogComponent extends SubscriptionDisposable implements O
       end = translate('question_dialog.must_be_same_book_and_chapter');
     }
     return { startError: start, endError: end };
+  }
+
+  get isTextRightToLeft(): boolean {
+    return this.data.isRightToLeft == null ? false : this.data.isRightToLeft;
   }
 
   ngOnInit(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
@@ -16,7 +16,7 @@
     rtl: isRtl,
     'mark-invalid': markInvalid
   }"
-  [dir]="isRtl ? 'rtl' : 'ltr'"
+  [dir]="textDirection"
   [lang]="lang"
   [attr.data-browser-engine]="browserEngine"
 >

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -60,15 +60,29 @@ describe('TextComponent', () => {
     env.onlineStatus = true;
     expect(env.component.placeholder).toEqual('text.loading');
   }));
+
+  it('does not apply right to left for placeholder message', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.fixture.detectChanges();
+    env.hostComponent.isTextRightToLeft = true;
+    env.fixture.detectChanges();
+    expect(env.component.placeholder).toEqual('initial placeholder text');
+    expect(env.component.isRtl).toBe(false);
+    expect(env.fixture.nativeElement.querySelector('quill-editor[dir="auto"]')).not.toBeNull();
+  }));
 });
 
 class MockQuill extends Quill {}
 
-@Component({ selector: 'app-host', template: `<app-text [placeholder]="initialPlaceHolder" [id]="id"></app-text>` })
+@Component({
+  selector: 'app-host',
+  template: `<app-text [placeholder]="initialPlaceHolder" [id]="id" [isRightToLeft]="isTextRightToLeft"></app-text>`
+})
 class HostComponent {
   @ViewChild(TextComponent) textComponent!: TextComponent;
 
   initialPlaceHolder = 'initial placeholder text';
+  isTextRightToLeft: boolean = false;
   id?: string;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -282,11 +282,11 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   }
 
   get isLtr(): boolean {
-    return !this._isRightToLeft;
+    return !this._isRightToLeft && this.contentShowing;
   }
 
   get isRtl(): boolean {
-    return this._isRightToLeft;
+    return this._isRightToLeft && this.contentShowing;
   }
 
   get isSelectionAtSegmentEnd(): boolean {
@@ -310,6 +310,17 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
 
   get readOnlyEnabled(): boolean {
     return this.isReadOnly || (this.viewModel != null && this.viewModel.isEmpty);
+  }
+
+  get textDirection(): string {
+    if (this.contentShowing) {
+      return this.isRtl ? 'rtl' : 'ltr';
+    }
+    return 'auto';
+  }
+
+  private get contentShowing(): boolean {
+    return this.id != null && this.viewModel.isLoaded && !this.viewModel.isEmpty;
   }
 
   ngAfterViewInit(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.html
@@ -9,7 +9,12 @@
             <h2>{{ bookName }} {{ chapterNum }}</h2>
             <mdc-icon>keyboard_arrow_down</mdc-icon>
           </div>
-          <app-text #scriptureText [id]="textDocId" multiSegmentSelection="true"></app-text>
+          <app-text
+            #scriptureText
+            [id]="textDocId"
+            multiSegmentSelection="true"
+            [isRightToLeft]="isTextRightToLeft"
+          ></app-text>
           <p class="selection-preview">
             {{ (startClipped ? "…" : "") + (selectedText || "") + (endClipped ? "…" : "") }}
             <span class="selection-reference">{{ referenceForDisplay }}</span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
@@ -62,6 +62,7 @@ describe('TextChooserDialogComponent', () => {
 
   it('allows selecting text', fakeAsync(async () => {
     const env = new TestEnvironment({ start: 1, end: 10 }, 'verse_1_2/p_1', 'verse_1_3');
+    expect(env.component.isTextRightToLeft).toBe(false);
     expect(env.selectedText).toEqual('');
     env.fireSelectionChange();
     expect(env.selectedText).toEqual('target: chapter… (Matthew 1:3)');
@@ -312,6 +313,12 @@ describe('TextChooserDialogComponent', () => {
       startOffset: 'Lor'.length,
       endOffset: 'Lorem ipsum'.length
     });
+  }));
+
+  it('can handle right to left text', fakeAsync(() => {
+    const config: TextChooserDialogData = { ...TestEnvironment.defaultDialogData, isRightToLeft: true };
+    const env = new TestEnvironment([], 'verse_1_1', 'verse_1_2', config);
+    expect(env.component.isTextRightToLeft).toBe(true);
   }));
 });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
@@ -20,6 +20,7 @@ export interface TextChooserDialogData {
   chapterNum: number;
   projectId: string;
   textsByBookId: TextsByBookId;
+  isRightToLeft?: boolean;
   selectedText?: string;
   selectedVerses?: VerseRefData;
 }
@@ -75,6 +76,10 @@ export class TextChooserDialogComponent extends SubscriptionDisposable {
 
   get bookName(): string {
     return this.i18n.localizeBook(this.bookNum);
+  }
+
+  get isTextRightToLeft(): boolean {
+    return this.data.isRightToLeft == null ? false : this.data.isRightToLeft;
   }
 
   updateSelection() {


### PR DESCRIPTION
* provide isRightToLeft data to components checking text, question dialog and text chooser dialog
* set the dir attribute in the quill editor to auto when showing the placeholder

**BEFORE**
![Before isRightToLeft](https://user-images.githubusercontent.com/17931130/97497404-0a7cae80-1930-11eb-9130-339bcd7a157f.PNG)

**AFTER**
![After isRightToLeft](https://user-images.githubusercontent.com/17931130/97497445-1bc5bb00-1930-11eb-8375-da0f11270a61.PNG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/854)
<!-- Reviewable:end -->
