### PR TITLE
SF-1121 Error when back translation not in registry

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
@@ -2,6 +2,7 @@ import { Component, ErrorHandler, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { TranslocoService } from '@ngneat/transloco';
+import { CommandErrorCode } from 'xforge-common/command.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -189,11 +190,14 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
       try {
         projectId = await this.projectService.onlineCreate(settings);
       } catch (err) {
-        if (!err.message?.includes(ConnectProjectComponent.errorAlreadyConnectedKey)) {
+        if (err.code === CommandErrorCode.Forbidden) {
+          err.message = this.translocoService.translate('connect_project.problem_connecting_permissions_or_not_found');
+        } else if (err.message?.includes(ConnectProjectComponent.errorAlreadyConnectedKey)) {
+          err.message = this.translocoService.translate('connect_project.problem_already_connected');
+        } else {
           throw err;
         }
 
-        err.message = this.translocoService.translate('connect_project.problem_already_connected');
         this.errorHandler.handleError(err);
         this.state = 'input';
         this.populateProjectList();

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -57,6 +57,7 @@
     "only_paratext_admins_can_start": "** You must be the Paratext Administrator of a project to start it here. Ask your Administrator to connect to your project then you can also connect to it here after that.",
     "paratext_project": "Paratext Project",
     "problem_already_connected": "The project is already connected. Maybe another project administrator connected the project at the same time. Please try again. If it continues to be a problem, please report the issue so we can get it fixed.",
+    "problem_connecting_permissions_or_not_found": "There was a problem connecting to the project. You may not have adequate permissions on the project, or the project may not have been found in the registry. Back translations or other projects that are not always in the registry would need to be registered separately in order to connect, as connecting to projects not listed in the Paratext Registry is not supported at this time.",
     "translation_suggestions": "Translation Suggestions",
     "translations_will_be_suggested_as_you_edit": "Translations for words and phrases will be suggested as you edit Scripture. It is recommended that your project is setup as a {{ boldStart }}Daughter Translation{{ boldEnd }} in Paratext.",
     "you_can_change_later": "You can change these later.",


### PR DESCRIPTION
- Give a useful message if the user tries to connect to a project that
  isn't actually listed in the registry, like back translation
  projects can be, as we don't support that right now.
- Add to already-connected error test to distinguish between kinds of
  errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/858)
<!-- Reviewable:end -->
