### PR TITLE
SF-1121 Don't show not-registered projects in connect list

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -212,8 +212,13 @@ namespace SIL.XForge.Scripture.Services
         public async Task<IReadOnlyList<ParatextProject>> GetProjectsAsync(UserSecret userSecret)
         {
             IInternetSharedRepositorySource ptRepoSource = await GetInternetSharedRepositorySource(userSecret);
-            IEnumerable<SharedRepository> remotePtProjects = ptRepoSource.GetRepositories();
-            return GetProjects(userSecret, remotePtProjects, ptRepoSource.GetProjectsMetaData());
+            List<SharedRepository> remotePtProjects = ptRepoSource.GetRepositories().ToList();
+            List<ProjectMetadata> projectMetadata = ptRepoSource.GetProjectsMetaData().ToList();
+
+            // Omit projects that are not in the PT Registry until we support connecting to such projects.
+            remotePtProjects.RemoveAll((SharedRepository project) =>
+                !projectMetadata.Any((ProjectMetadata metadata) => metadata.ProjectGuid == project.SendReceiveId));
+            return GetProjects(userSecret, remotePtProjects, projectMetadata);
         }
 
         public async Task<Attempt<string>> TryGetProjectRoleAsync(UserSecret userSecret, string paratextId)


### PR DESCRIPTION
- We don't currently support connecting to a project that isn't listed
  in the PT Registry, like back translation projects can be.
- Omit such not-registered projects from the list returned by
  ParatextService GetProjectsAsync().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/862)
<!-- Reviewable:end -->
