### PR TITLE
SF-982 Retrieve sorted texts without modifying project texts property

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -229,7 +229,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   get texts(): TextInfo[] {
     return this.selectedProjectDoc == null || this.selectedProjectDoc.data == null
       ? []
-      : this.selectedProjectDoc.data.texts.sort((a, b) => a.bookNum - b.bookNum);
+      : Array.from(this.selectedProjectDoc.data.texts).sort((a, b) => a.bookNum - b.bookNum);
   }
 
   get showAllQuestions(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -227,9 +227,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   }
 
   get texts(): TextInfo[] {
-    return this.selectedProjectDoc == null || this.selectedProjectDoc.data == null
-      ? []
-      : Array.from(this.selectedProjectDoc.data.texts).sort((a, b) => a.bookNum - b.bookNum);
+    return this.selectedProjectDoc?.data?.texts.slice().sort((a, b) => a.bookNum - b.bookNum) || [];
   }
 
   get showAllQuestions(): boolean {

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -144,7 +144,9 @@ namespace SIL.XForge.Scripture.Services
                     {
                         int textIndex = _projectDoc.Data.Texts.FindIndex(t => t.BookNum == bookNum);
                         TextInfo text = _projectDoc.Data.Texts[textIndex];
-                        await _projectDoc.SubmitJson0OpAsync(op => op.Remove(pd => pd.Texts, textIndex));
+                        List<TextInfo> updatedTexts = new List<TextInfo>(_projectDoc.Data.Texts);
+                        updatedTexts.RemoveAt(textIndex);
+                        await _projectDoc.SubmitJson0OpAsync(op => op.Set(pd => pd.Texts, updatedTexts));
 
                         await DeleteAllTextDocsForBookAsync(text, TextType.Target);
                         await DeleteAllQuestionsDocsForBookAsync(text);

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -144,9 +144,7 @@ namespace SIL.XForge.Scripture.Services
                     {
                         int textIndex = _projectDoc.Data.Texts.FindIndex(t => t.BookNum == bookNum);
                         TextInfo text = _projectDoc.Data.Texts[textIndex];
-                        List<TextInfo> updatedTexts = new List<TextInfo>(_projectDoc.Data.Texts);
-                        updatedTexts.RemoveAt(textIndex);
-                        await _projectDoc.SubmitJson0OpAsync(op => op.Set(pd => pd.Texts, updatedTexts));
+                        await _projectDoc.SubmitJson0OpAsync(op => op.Remove(pd => pd.Texts, textIndex));
 
                         await DeleteAllTextDocsForBookAsync(text, TextType.Target);
                         await DeleteAllQuestionsDocsForBookAsync(text);


### PR DESCRIPTION
When adding a book, the book is appended to the end of the list of Texts in a SFProject. However, the front end SFProject represents the texts in a list that is sorted by bookNum. When we send an op to remove a specific index, it removes it correctly on the backend, but that index doesn't correspond to the correct text on the front end. Currently, I only see this being an issue on deleting books, but this can certainly be an app wide issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/865)
<!-- Reviewable:end -->
