### PR TITLE
SF-1130 - Chrome on iOS fails to record audio

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.ts
@@ -75,6 +75,11 @@ export class CheckingAudioRecorderComponent implements OnInit, OnDestroy {
 
   startRecording() {
     const mediaConstraints: MediaStreamConstraints = { audio: true };
+    if (this.navigator.mediaDevices == null) {
+      this.status.emit({ status: 'denied' });
+      this.noticeService.show(translate('checking_audio_recorder.not_available'));
+      return;
+    }
     this.navigator.mediaDevices
       .getUserMedia(mediaConstraints)
       .then(this.successCallback.bind(this), this.errorCallback.bind(this));

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -187,6 +187,7 @@
     "audio_cannot_be_previewed": "The audio is in a format that cannot be previewed. Save any changes and connect to the internet to play."
   },
   "checking_audio_recorder": {
+    "not_available": "Your browser currently does not support audio recording. Please try using another supported browser.",
     "mic_access_denied": "Access to your microphone was denied. Please enable the microphone from your browser.",
     "record": "Record",
     "stop_recording": "Stop Recording",


### PR DESCRIPTION
- Check to ensure mediaDevices is defined

This is more of a generic fix that will apply to any device/browser that doesn't have access to `mediaDevices` i.e. any browser other than Safari on iOS will now receive the improved message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/866)
<!-- Reviewable:end -->
