### PR TITLE
SF-967 - Console error appears on Translate Overview page when translation suggestions remotely disabled

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
@@ -104,11 +104,11 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
         this.projectDataChangesSub.unsubscribe();
       }
       this.projectDataChangesSub = this.projectDoc.remoteChanges$.subscribe(async ops => {
+        if (this.translationEngine == null || !this.translationSuggestionsEnabled) {
+          this.setupTranslationEngine();
+        }
         if (ops.some(op => TEXT_PATH_TEMPLATE.matches(op.p))) {
           this.loadingStarted();
-          if (this.translationEngine == null || !this.translationSuggestionsEnabled) {
-            this.setupTranslationEngine();
-          }
           try {
             await Promise.all([this.calculateProgress(), this.updateEngineStats()]);
           } finally {


### PR DESCRIPTION
 - Reset translate engine on remote changes to the projectDoc
 - Created a test to ensure the translate engine correctly starts if not initially started or stopped and then started again

As part of this fix it also resolved another issue where the translate engine would not start if it was initially disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/868)
<!-- Reviewable:end -->
