### PR TITLE
Add spacing around buttons

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_variables.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_variables.scss
@@ -32,3 +32,5 @@ $grid-breakpoints: (
 
 $questionAnswerBubbleColor: #fff;
 $questionAnswerBubbleBackgroundColor: $sf_grey;
+
+$button-spacing: 8px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -2,7 +2,7 @@
   <div fxLayout="row" fxLayoutAlign="start center" [ngClass]="{ 'reviewer-panels': !isProjectAdmin }">
     <mdc-icon fxFlex="32px">library_books</mdc-icon>
     <h2 fxFlex>{{ t("texts_with_questions") }}</h2>
-    <div fxFlexAlign="center" *ngIf="isProjectAdmin; else overallProgressChart">
+    <div fxFlexAlign="center" *ngIf="isProjectAdmin; else overallProgressChart" class="primary-actions">
       <button mdc-button type="button" *ngIf="hasTransceleratorQuestions" (click)="importDialog()" id="import-btn">
         {{ t("import_questions") }}
       </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
@@ -1,6 +1,10 @@
 @import 'src/variables';
 @import 'bootstrap/scss/mixins/breakpoints';
 
+.primary-actions .mdc-button:not(:first-child) {
+  margin-left: $button-spacing;
+}
+
 #add-question-button {
   @include media-breakpoint-only(xs) {
     min-width: 48px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
@@ -95,6 +95,9 @@
   .form-actions {
     display: flex;
     justify-content: flex-end;
+    .mdc-button:not(:first-child) {
+      margin-left: $button-spacing;
+    }
   }
   @include media-breakpoint-down(lg) {
     mdc-tab {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
@@ -75,7 +75,7 @@
         </mdc-dialog-content>
         <mdc-dialog-actions>
           <button mdcDialogButton mdcDialogAction="close" type="button">{{ t("cancel") }}</button>
-          <button mdc-button unelevated type="submit" (click)="importQuestions()">
+          <button mdcDialogButton unelevated type="submit" (click)="importQuestions()">
             {{ t("import_count_questions", { count: selectedCount }) }}
           </button>
         </mdc-dialog-actions>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
@@ -79,7 +79,14 @@
           <button mdcDialogButton mdcDialogAction="close" type="button" id="question-cancel-btn">
             {{ t("cancel") }}
           </button>
-          <button mdc-button unelevated form="question-form" type="submit" id="question-save-btn" (click)="submit()">
+          <button
+            mdcDialogButton
+            unelevated
+            form="question-form"
+            type="submit"
+            id="question-save-btn"
+            (click)="submit()"
+          >
             {{ t("save") }}
           </button>
         </mdc-dialog-actions>


### PR DESCRIPTION
Checking overview
![](https://user-images.githubusercontent.com/6140710/98856611-cdceae00-242b-11eb-9a1f-462ac2070517.png)
Answer question form
![](https://user-images.githubusercontent.com/6140710/98856949-5a796c00-242c-11eb-85f5-a164cc8292ce.png)
Import questions dialog
![](https://user-images.githubusercontent.com/6140710/98856952-5b120280-242c-11eb-8bf8-46cbe1aced51.png)
Create/edit question dialog
![](https://user-images.githubusercontent.com/6140710/98857133-a0cecb00-242c-11eb-81d8-809e668d6356.png)

MdcDialog automatically spaces buttons by 8px when buttons have the `mdcDialogButton` directive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/869)
<!-- Reviewable:end -->
