### PR TITLE
SF-1142 Disable project sharing by default

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
@@ -374,7 +374,7 @@ class TestEnvironment {
         },
         checkingConfig: {
           checkingEnabled: settings.checkingEnabled,
-          shareEnabled: true,
+          shareEnabled: false,
           shareLevel: CheckingShareLevel.Specific,
           usersSeeEachOthersResponses: true
         },

--- a/src/SIL.XForge.Scripture/Models/CheckingConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/CheckingConfig.cs
@@ -4,7 +4,7 @@ namespace SIL.XForge.Scripture.Models
     {
         public bool CheckingEnabled { get; set; }
         public bool UsersSeeEachOthersResponses { get; set; } = true;
-        public bool ShareEnabled { get; set; } = true;
+        public bool ShareEnabled { get; set; } = false;
         public string ShareLevel { get; set; } = CheckingShareLevel.Specific;
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -539,6 +539,8 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsProject(sfProjectId), Is.True);
             Assert.That(env.RealtimeService.GetRepository<SFProject>().Query().Count(),
                 Is.EqualTo(projectCount + 1), "should have increased");
+            SFProject newProject = env.RealtimeService.GetRepository<SFProject>().Get(sfProjectId);
+            Assert.That(newProject.CheckingConfig.ShareEnabled, Is.False, "Should default to not shared (SF-1142)");
         }
 
         [Test]


### PR DESCRIPTION
- CheckingConfig.cs: Changing default setting in model.
- connect-project spec: Using new default value in case it ever
  matters or adds clarity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/871)
<!-- Reviewable:end -->
