### PR TITLE
SF-1141 Always invite with code

### DIFF
--- a/src/SIL.XForge.Scripture/Resources/SharedResource.resx
+++ b/src/SIL.XForge.Scripture/Resources/SharedResource.resx
@@ -140,9 +140,7 @@
   </data>
   <data name="InviteLinkSharingOff" xml:space="preserve">
     <value>This link will only work for this email address.</value>
-  </data>
-  <data name="InviteLinkSharingOn" xml:space="preserve">
-    <value>This link can be shared with others so they can join the project too.</value>
+    <comment>Previously this text was used when link sharing was turned off for a project, but now it is always used when sending an invitation whether link sharing is on or off.</comment>
   </data>
   <data name="InvitePTOption" xml:space="preserve">
     <value>Click {0}Sign up with Paratext{1} and follow the instructions to access {2} using an existing Paratext account, or</value>

--- a/src/SIL.XForge.Scripture/SharedResource.cs
+++ b/src/SIL.XForge.Scripture/SharedResource.cs
@@ -23,7 +23,6 @@ namespace SIL.XForge.Scripture
             public const string InviteGreeting = "InviteGreeting";
             public const string InviteInstructions = "InviteInstructions";
             public const string InviteLinkSharingOff = "InviteLinkSharingOff";
-            public const string InviteLinkSharingOn = "InviteLinkSharingOn";
             public const string InvitePTOption = "InvitePTOption";
             public const string InviteSignature = "InviteSignature";
             public const string InviteSubject = "InviteSubject";

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -99,11 +98,14 @@ namespace SIL.XForge.Scripture.Services
         public async Task InviteAsync_LinkSharingEnabled_UserInvited()
         {
             var env = new TestEnvironment();
+            SFProject project = env.GetProject(Project02);
+            Assert.That(project.CheckingConfig.ShareEnabled, Is.True, "setup");
+            Assert.That(project.CheckingConfig.ShareLevel, Is.EqualTo(CheckingShareLevel.Anyone), "setup: link sharing should be enabled");
             const string email = "newuser@example.com";
+            // SUT
             await env.Service.InviteAsync(User01, Project02, email);
             await env.EmailService.Received(1).SendEmailAsync(email, Arg.Any<string>(),
-                Arg.Is<string>(body => body.Contains($"http://localhost/projects/{Project02}?sharing=true")
-                    && body.Contains("link can be shared with others")));
+                Arg.Is<string>(body => body.Contains($"http://localhost/projects/{Project02}?sharing=true&shareKey=1234abc")));
         }
 
         [Test]


### PR DESCRIPTION
SFProjectService.cs:
- InviteAsync() no longer sends a link that anyone can use to join the
  project, even with the project is being shared to "Anyone with a
  link". All invitation emails are now sent with a code that is
  specific to the invited email address.
- Clean up method a bit now that the functionality is simplified.

SharedResource.resx:
- Remove no longer used InviteLinkSharingOn.
- The InviteLinkSharingOff name is not very helpful, but I don't want
  to change it lest it require re-translations. So I added a comment
  to address the change. The name should probably be something like
  LinkIsEmailAddressSpecific.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/872)
<!-- Reviewable:end -->
