### PR TITLE
SF-1151 Fix error when Transcelerator question has multiple answers

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
@@ -327,7 +327,6 @@ class TestEnvironment {
         endChapter: '42',
         endVerse: '2',
         text: 'This proposal pleased Pharaoh and all his servants',
-        answer: 'Answer to 41:39',
         id: '1'
       },
       {
@@ -336,7 +335,6 @@ class TestEnvironment {
         startVerse: '1',
         endVerse: '3',
         text: 'Transcelerator question 1:1',
-        answer: 'Answer to 1:1',
         id: '2'
       },
       {
@@ -344,7 +342,6 @@ class TestEnvironment {
         startChapter: '1',
         startVerse: '2',
         text: 'Transcelerator question 1:2',
-        answer: 'Answer to 1:2',
         id: '3'
       }
     ];

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -41,7 +41,6 @@ export interface TransceleratorQuestion {
   endChapter?: string;
   endVerse?: string;
   text: string;
-  answer: string;
   id: string;
 }
 

--- a/src/SIL.XForge.Scripture/Models/TransceleratorQuestion.cs
+++ b/src/SIL.XForge.Scripture/Models/TransceleratorQuestion.cs
@@ -8,7 +8,6 @@ namespace SIL.XForge.Scripture.Models
         public string EndChapter { get; set; }
         public string EndVerse { get; set; }
         public string Text { get; set; }
-        public string Answer { get; set; }
         public string Id { get; set; }
     }
 }

--- a/src/SIL.XForge.Scripture/Services/TransceleratorService.cs
+++ b/src/SIL.XForge.Scripture/Services/TransceleratorService.cs
@@ -47,7 +47,6 @@ namespace SIL.XForge.Scripture.Services
                                 EndChapter = AttributeText(q, "endChapter"),
                                 EndVerse = AttributeText(q, "endVerse"),
                                 Text = NodeTextOfLanguage(q.SelectNodes("Q/StringAlt").Cast<XmlNode>(), lang),
-                                Answer = NodeTextOfLanguage(q.SelectNodes("Answers/A/StringAlt").Cast<XmlNode>(), lang),
                                 Id = AttributeText(q, "id")
                             }
                         );

--- a/test/SIL.XForge.Scripture.Tests/Services/TransceleratorServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/TransceleratorServiceTests.cs
@@ -46,7 +46,6 @@ namespace SIL.XForge.Scripture.Services
             Assert.AreEqual(questions[0].EndChapter, "2");
             Assert.AreEqual(questions[0].EndVerse, "3");
             Assert.AreEqual(questions[0].Text, "What are the main events recorded in this passage?");
-            Assert.AreEqual(questions[0].Answer, "");
             Assert.AreEqual(questions[0].Id, "Tell [me] the main events recorded in this passage.");
         }
 


### PR DESCRIPTION
- Answers are a feature of Transcelerator that I initially implemented support for, and then didn't use. It would have been good to rip this out before, but I left it.
- SF-1151 Is caused by an exception that is thrown when when `NodeTextOfLanguage(IEnumerable<XmlNode> nodes, string lang)` calls `SingleOrDefault()` on an `IEnumerable<string>` that has multiple stings. I assumed there would only ever be one example answer, with one at most one translation per language. However, there can be multiple example answers, with each answer having translations.

Here's the XML that was causing the error to occur:
``` xml


<Question id="Why is this true?" startChapter="3" startVerse="22">
	<Q>
		<StringAlt xml:lang="fr">Tell in your own words the basic meaning (theme) of what John said in these verses.</StringAlt>
		<StringAlt xml:lang="en-US">Why is this true?</StringAlt>
		<StringAlt xml:lang="es">¿Por qué es esto cierto?</StringAlt>
	</Q>
	<Answers>
		<A>
			<StringAlt xml:lang="en-US">This is true, because we obey his commands</StringAlt>
			<StringAlt xml:lang="es">Esto es verdad, porque obedecemos sus mandamientos</StringAlt>
			<StringAlt xml:lang="fr">C'est vrai, parce que nous obéissons à ses commandements</StringAlt>
		</A>
		<A>
			<StringAlt xml:lang="en-US">and do what pleases him. (22)</StringAlt>
			<StringAlt xml:lang="es">y hacer lo que le plazca. (22)</StringAlt>
			<StringAlt xml:lang="fr">et faire ce qui lui plaît. (22)</StringAlt>
		</A>
	</Answers>
</Question>
```
Note the multiple answers. Since we don't care about answers, the simplest solution was to remove the offending code as I should have earlier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/873)
<!-- Reviewable:end -->
