### PR TITLE
SF-1149 Include end verse when importing questions from Transcelerator

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
@@ -11,7 +11,7 @@ import { VerseRefData } from 'realtime-server/lib/scriptureforge/models/verse-re
 import { Canon } from 'realtime-server/lib/scriptureforge/scripture-utils/canon';
 import { VerseRef } from 'realtime-server/lib/scriptureforge/scripture-utils/verse-ref';
 import { Observable, of } from 'rxjs';
-import { anything, instance, mock, spy, verify, when } from 'ts-mockito';
+import { anything, capture, deepEqual, instance, mock, spy, verify, when } from 'ts-mockito';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
@@ -178,6 +178,23 @@ describe('ImportQuestionsDialogComponent', () => {
       'The version of Transcelerator used in this project is not supported. Please update to at least Transcelerator version 1.5.3.'
     );
   }));
+
+  it('should import questions that cover a verse range', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.selectQuestion(env.questionRows[0]);
+    env.click(env.submitButton);
+    verify(mockedProjectService.createQuestion('project01', anything(), undefined, undefined)).once();
+    const question = capture(mockedProjectService.createQuestion).last()[1];
+    expect(question.projectRef).toBe('project01');
+    expect(question.text).toBe('Transcelerator question 1:1');
+    expect(question.verseRef).toEqual({
+      bookNum: 40,
+      chapterNum: 1,
+      verseNum: 1,
+      verse: '1-3'
+    });
+    expect(question.transceleratorQuestionId).toBe('2');
+  }));
 });
 
 @Directive({
@@ -284,6 +301,10 @@ class TestEnvironment {
 
   get statusMessage(): string {
     return this.overlayContainerElement.querySelector('p')?.textContent || '';
+  }
+
+  get submitButton(): HTMLButtonElement {
+    return this.overlayContainerElement.querySelector('mdc-dialog-actions button[type="submit"]') as HTMLButtonElement;
   }
 
   clickSelectAll(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -271,7 +271,9 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable {
       verseNum: verse.verseNum,
       verse:
         // TODO Right now ignoring end chapter and verse if it's in a different chapter, since we don't yet support that
-        q.startChapter === q.endChapter && q.startVerse !== q.endVerse ? q.startVerse + '-' + q.endVerse : undefined
+        (q.endChapter == null || q.startChapter === q.endChapter) && q.startVerse !== q.endVerse
+          ? q.startVerse + '-' + q.endVerse
+          : undefined
     };
   }
 


### PR DESCRIPTION
The previous implementation mistakenly assumed that when a question is within a single chapter, endChapter will be defined and equal to startChapter. In reality it is undefined in this case, but with this fix no assumption is made as to whether it will be undefined or equal to startChapter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/875)
<!-- Reviewable:end -->
