### PR TITLE
SF-1136 Indicate in Paratext Notes when responses are audio-only

### DIFF
--- a/src/SIL.XForge.Scripture/Resources/SharedResource.resx
+++ b/src/SIL.XForge.Scripture/Resources/SharedResource.resx
@@ -117,6 +117,14 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AudioOnlyQuestion" xml:space="preserve">
+    <value>- {0} audio-only question -</value>
+    <comment>Text to show in Paratext Notes when question is audio-only</comment>
+  </data>
+  <data name="AudioOnlyResponse" xml:space="preserve">
+    <value>- {0} audio-only response -</value>
+    <comment>Text to show in Paratext Notes when response is audio-only</comment>
+  </data>
   <data name="EmailBad" xml:space="preserve">
     <value>Enter a valid email address</value>
   </data>

--- a/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
@@ -3,7 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
 using MongoDB.Bson;
+using SIL.XForge.Configuration;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
 using SIL.XForge.Realtime;
@@ -24,6 +27,8 @@ namespace SIL.XForge.Scripture.Services
     {
         private readonly IRepository<UserSecret> _userSecrets;
         private readonly IParatextService _paratextService;
+        private readonly IStringLocalizer<SharedResource> _localizer;
+        private readonly IOptions<SiteOptions> _siteOptions;
         private readonly Dictionary<string, SyncUser> _idToSyncUser = new Dictionary<string, SyncUser>();
         private readonly Dictionary<string, SyncUser> _usernameToSyncUser = new Dictionary<string, SyncUser>();
         private readonly Dictionary<string, string> _userIdToUsername = new Dictionary<string, string>();
@@ -33,10 +38,13 @@ namespace SIL.XForge.Scripture.Services
         private SFProjectSecret _projectSecret;
         private HashSet<string> _ptProjectUsersWhoCanWriteNotes;
 
-        public ParatextNotesMapper(IRepository<UserSecret> userSecrets, IParatextService paratextService)
+        public ParatextNotesMapper(IRepository<UserSecret> userSecrets, IParatextService paratextService,
+            IStringLocalizer<SharedResource> localizer, IOptions<SiteOptions> siteOptions)
         {
             _userSecrets = userSecrets;
             _paratextService = paratextService;
+            _localizer = localizer;
+            _siteOptions = siteOptions;
         }
 
         public List<SyncUser> NewSyncUsers { get; } = new List<SyncUser>();
@@ -90,7 +98,8 @@ namespace SIL.XForge.Scripture.Services
                             new XAttribute("selectedText", "")));
                     var answerPrefixContents = new List<object>();
                     // Questions that have empty texts will show in Paratext notes that it is audio-only
-                    string qText = string.IsNullOrEmpty(question.Text) ? "- audio-only question -" : question.Text;
+                    string qText = string.IsNullOrEmpty(question.Text)
+                        ? _localizer[SharedResource.Keys.AudioOnlyQuestion, _siteOptions.Value.Name] : question.Text;
                     answerPrefixContents.Add(new XElement("span", new XAttribute("style", "bold"), qText));
                     if (!string.IsNullOrEmpty(answer.ScriptureText))
                     {
@@ -168,7 +177,8 @@ namespace SIL.XForge.Scripture.Services
             commentElem.Add(new XAttribute("date", comment.DateCreated.ToString("o").Replace("Z", "+00:00")));
             var contentElem = new XElement("content");
             // Responses that have empty texts will show in Paratext notes that it is audio-only
-            string responseText = string.IsNullOrEmpty(comment.Text) ? "- audio-only response -" : comment.Text;
+            string responseText = string.IsNullOrEmpty(comment.Text)
+                ? _localizer[SharedResource.Keys.AudioOnlyResponse, _siteOptions.Value.Name] : comment.Text;
             if (prefixContent == null || prefixContent.Count == 0)
             {
                 contentElem.Add(responseText);

--- a/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
@@ -89,7 +89,9 @@ namespace SIL.XForge.Scripture.Services
                             new XAttribute("startPos", 0),
                             new XAttribute("selectedText", "")));
                     var answerPrefixContents = new List<object>();
-                    answerPrefixContents.Add(new XElement("span", new XAttribute("style", "bold"), question.Text));
+                    // Questions that have empty texts will show in Paratext notes that it is audio-only
+                    string qText = string.IsNullOrEmpty(question.Text) ? "- audio-only question -" : question.Text;
+                    answerPrefixContents.Add(new XElement("span", new XAttribute("style", "bold"), qText));
                     if (!string.IsNullOrEmpty(answer.ScriptureText))
                     {
                         string scriptureRef = answer.VerseRef.ToString();
@@ -165,15 +167,17 @@ namespace SIL.XForge.Scripture.Services
                 commentElem.Add(new XAttribute("extUser", comment.OwnerRef));
             commentElem.Add(new XAttribute("date", comment.DateCreated.ToString("o").Replace("Z", "+00:00")));
             var contentElem = new XElement("content");
+            // Responses that have empty texts will show in Paratext notes that it is audio-only
+            string responseText = string.IsNullOrEmpty(comment.Text) ? "- audio-only response -" : comment.Text;
             if (prefixContent == null || prefixContent.Count == 0)
             {
-                contentElem.Add(comment.Text);
+                contentElem.Add(responseText);
             }
             else
             {
                 foreach (object paraContent in prefixContent)
                     contentElem.Add(new XElement("p", paraContent));
-                contentElem.Add(new XElement("p", comment.Text));
+                contentElem.Add(new XElement("p", responseText));
             }
             commentElem.Add(contentElem);
 

--- a/src/SIL.XForge.Scripture/SharedResource.cs
+++ b/src/SIL.XForge.Scripture/SharedResource.cs
@@ -15,6 +15,8 @@ namespace SIL.XForge.Scripture
     {
         public static class Keys
         {
+            public const string AudioOnlyQuestion = "AudioOnlyQuestion";
+            public const string AudioOnlyResponse = "AudioOnlyResponse";
             public const string EmailBad = "EmailBad";
             public const string EmailMissing = "EmailMissing";
             public const string InviteEmailOption = "InviteEmailOption";


### PR DESCRIPTION
Questions or answers that are audio without any texts would appear as blank in Paratext. This adds a place holder for that situation in Paratext notes.
![Audio_only_response](https://user-images.githubusercontent.com/17931130/99591963-c15ad000-29ac-11eb-9bcb-676765ef86a3.PNG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/876)
<!-- Reviewable:end -->
