### PR TITLE
SF-1144 Overlapping text on connect project page in Safari

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
@@ -55,12 +55,12 @@
         ></p>
       </ng-template>
       <mdc-card id="settings-card" *ngIf="showSettings" outlined formGroupName="settings">
-        <div fxLayout="column" fxLayoutAlign="start" class="card-title">
+        <div class="card-title">
           <div mdcHeadline6>{{ t("additional_settings") }}</div>
           <div mdcBody2>{{ t("you_can_change_later") }}</div>
         </div>
         <div class="card-content">
-          <div fxLayout="row" fxLayoutAlign="start center">
+          <div>
             <mdc-form-field>
               <mdc-checkbox
                 formControlName="translationSuggestions"
@@ -69,7 +69,7 @@
               <label>{{ t("translation_suggestions") }}</label>
             </mdc-form-field>
           </div>
-          <div fxLayout="row" fxLayoutAlign="start center">
+          <div>
             <div fxFlex="44px" class="indent"></div>
             <p
               fxFlex
@@ -100,13 +100,13 @@
         </div>
         <mdc-list-divider></mdc-list-divider>
         <div class="card-content">
-          <div fxLayout="row" fxLayoutAlign="start center">
+          <div>
             <mdc-form-field>
               <mdc-checkbox formControlName="checking" id="checking-checkbox"></mdc-checkbox>
               <label>{{ t("community_checking") }}</label>
             </mdc-form-field>
           </div>
-          <div fxLayout="row" fxLayoutAlign="start center">
+          <div>
             <div fxFlex="44px" class="indent"></div>
             <p fxFlex class="helper-text">{{ t("engage_the_wider_community_to_check_scripture") }}</p>
           </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
@@ -18,8 +18,6 @@
 }
 
 .content {
-  display: flex;
-  flex-direction: column;
   max-width: 512px;
   width: 100%;
 
@@ -69,9 +67,6 @@
       margin-top: 32px;
 
       .card-title {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
         margin: 8px 16px 0 16px;
       }
 
@@ -86,7 +81,7 @@
 
     #connect-submit-button {
       align-self: center;
-      margin-top: 32px;
+      margin: 32px 0;
       @include button.filled-accessible($pt-button-green);
     }
 


### PR DESCRIPTION
 - Removed unneeded flex layout options

This appears to have been a Safari specific issue rather than Chrome on iOS as it also happened on a Mac. It appears Safari can struggle with flex and calculating heights correctly when inside a `flex-direction: column`. It is likely there is a good combination of CSS that can be added if that property is really needed but, this instance, it simply didn't need to be there in the first place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/879)
<!-- Reviewable:end -->
