### PR TITLE
Fix importing of questions on a single verse

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
@@ -195,6 +195,19 @@ describe('ImportQuestionsDialogComponent', () => {
     });
     expect(question.transceleratorQuestionId).toBe('2');
   }));
+
+  it('should properly import questions that are on a single verse', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.selectQuestion(env.questionRows[1]);
+    env.click(env.submitButton);
+    verify(mockedProjectService.createQuestion('project01', anything(), undefined, undefined)).once();
+    const question = capture(mockedProjectService.createQuestion).last()[1];
+    expect(question.verseRef).toEqual({
+      bookNum: 40,
+      chapterNum: 1,
+      verseNum: 2
+    });
+  }));
 });
 
 @Directive({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -265,16 +265,17 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable {
 
   private verseRefData(q: TransceleratorQuestion): VerseRefData {
     const verse = new VerseRef(q.book, q.startChapter, q.startVerse);
-    return {
+    const verseRefData: VerseRefData = {
       bookNum: verse.bookNum,
       chapterNum: verse.chapterNum,
-      verseNum: verse.verseNum,
-      verse:
-        // TODO Right now ignoring end chapter and verse if it's in a different chapter, since we don't yet support that
-        (q.endChapter == null || q.startChapter === q.endChapter) && q.startVerse !== q.endVerse
-          ? q.startVerse + '-' + q.endVerse
-          : undefined
+      verseNum: verse.verseNum
     };
+    // TODO Right now ignoring end chapter and verse if it's in a different chapter, since we don't yet support that
+    const sameChapter = q.endChapter == null || q.endChapter === q.startChapter;
+    if (sameChapter && q.endVerse != null && q.endVerse !== q.startVerse) {
+      verseRefData.verse = q.startVerse + '-' + q.endVerse;
+    }
+    return verseRefData;
   }
 
   // TODO should consider verse ranges, rather than just starting verse


### PR DESCRIPTION
After importing a question from Transcelerator I went to edit the question and found this:

![](https://user-images.githubusercontent.com/6140710/99842280-863bd680-2b3d-11eb-890f-2107eb0cbd8f.png)

While the mistake was in the original import logic, it was unveiled by the recent fix in #875 (SF-1149 Include end verse when importing questions from Transcelerator). Questions with no end verse are getting saved with a range of e.g. "1-undefined".

This fix basically consists of two changes:
- The setting of `verse` on `verseRefData` is now conditional. Previously it would sometimes get set to `undefined`, but that's not the same as not setting it.
- Ensure the end verse actually exists before setting the verse range. Previously it just checked that it differs from the start verse, which is not sufficient.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/880)
<!-- Reviewable:end -->
