### PR TITLE
Improve Bugsnag Breadcrumbs

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
@@ -144,6 +144,11 @@ describe('ExceptionHandlingService', () => {
           selector: 'DIV.mdc-button__ripple',
           expectedText: 'Ripple text',
           expectedSelector: 'DIV.mdc-button__ripple'
+        },
+        {
+          selector: 'BUTTON.mdc-button.child-element > i',
+          expectedText: 'Child',
+          expectedSelector: 'BUTTON.mdc-button.child-element span'
         }
       ];
       for (const test of tests) {
@@ -166,6 +171,7 @@ interface BreadcrumbTests {
   template: `
     <button class="mdc-button plain-text">Plain text</button>
     <button class="mdc-button include-icon"><i>icon_name</i><span>Inside span</span></button>
+    <button class="mdc-button child-element"><i>icon_name</i><span>Child</span></button>
     <button
       id="activated_button"
       class="mdc-button mdc-ripple-upgraded mdc-ripple-upgraded--background-focused mdc-ripple-upgraded--foreground-activation"

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
@@ -1,6 +1,6 @@
 import { MdcDialog } from '@angular-mdc/web/dialog';
 import { Injectable, Injector, NgZone } from '@angular/core';
-import Bugsnag, { BrowserConfig } from '@bugsnag/js';
+import Bugsnag, { Breadcrumb, BrowserConfig } from '@bugsnag/js';
 import { BugsnagErrorHandler } from '@bugsnag/plugin-angular';
 import { translate } from '@ngneat/transloco';
 import { version } from '../../../version.json';
@@ -10,6 +10,12 @@ import { ErrorReportingService } from './error-reporting.service';
 import { ErrorAlert, ErrorComponent } from './error/error.component';
 import { NoticeService } from './notice.service';
 import { objectId } from './utils';
+
+export interface BreadcrumbSelector {
+  element: string;
+  selector: string;
+  useParent?: boolean;
+}
 
 export class AppError extends Error {
   constructor(message: string, private readonly data?: any) {
@@ -28,12 +34,86 @@ export class ExceptionHandlingService extends BugsnagErrorHandler {
       appType: 'angular',
       enabledReleaseStages: ['live', 'qa'],
       releaseStage: environment.releaseStage,
-      autoDetectErrors: false
+      autoDetectErrors: false,
+      onBreadcrumb: ExceptionHandlingService.handleBreadcrumb
     };
     if (environment.releaseStage === 'dev') {
       config.logger = null;
     }
     Bugsnag.start(config);
+  }
+
+  /**
+   * Bugsnag doesn't always do well trying to get the actual text from some MDC elements i.e. buttons
+   * This method does further investigation to try and determine the actual text before creating the breadcrumb
+   */
+  static handleBreadcrumb(breadcrumb: Breadcrumb) {
+    if (
+      !['targetSelector', 'targetText'].every(property => breadcrumb.metadata.hasOwnProperty(property)) ||
+      breadcrumb.message !== 'UI click'
+    ) {
+      return;
+    }
+    let targetSelector = breadcrumb.metadata.targetSelector;
+    let targetText = breadcrumb.metadata.targetText;
+    // Only check for MDC selectors Bugsnag has trouble with
+    const selectors: BreadcrumbSelector[] = [
+      { element: 'BUTTON', selector: 'span' },
+      { element: 'DIV.mdc-button__ripple', selector: 'span', useParent: true }
+    ];
+    const selector = selectors.filter(bs => targetSelector.startsWith(bs.element))[0];
+    if (selector == null) {
+      return;
+    }
+    let query;
+    const specificElement = selector.selector;
+    // Sometimes Bugsnag narrows it down to a nested element so we need to use the parent node
+    if (selector.useParent != null && selector.useParent) {
+      query = document.querySelector(targetSelector).parentNode;
+    } else {
+      // Strip out classes that are triggered on click
+      const classes = [
+        'mdc-ripple-upgraded--foreground-activation',
+        'mdc-ripple-upgraded--background-focused',
+        'mdc-ripple-upgraded'
+      ];
+      for (let cls of classes) {
+        cls = '.' + cls;
+        if (!targetSelector.includes(cls)) {
+          continue;
+        }
+        targetSelector = targetSelector.replace(cls, '');
+      }
+      // Remove CSS specific selectors that Bugsnag added as they aren't compatible with the querySelector
+      if (targetSelector.includes('>')) {
+        targetSelector = targetSelector.substr(0, targetSelector.indexOf('>'));
+      }
+      // Check we can still query the element
+      query = document.querySelector(targetSelector);
+      if (query === null) {
+        return;
+      }
+      // Append the more specific selector so long as something is still returned
+      const specificQuery = document.querySelector(targetSelector + ' ' + specificElement);
+      if (specificQuery !== null) {
+        targetSelector += ' ' + specificElement;
+        query = specificQuery;
+      }
+    }
+    // We only want the text part of this node
+    for (const node of query.childNodes) {
+      // Only want text nodes or the specific node element
+      if (node.nodeType !== 3 && node.nodeName.toLowerCase() !== specificElement) {
+        continue;
+      }
+      targetText = node.textContent.trim();
+    }
+    // If nothing useful is found then just use what Bugsnag already had as a fallback
+    if (targetText === '') {
+      return;
+    }
+    breadcrumb.metadata.targetText = targetText;
+    breadcrumb.metadata.targetSelector = targetSelector;
   }
 
   // Use injected console when it's available, for the sake of tests, but fall back to window.console if injection fails


### PR DESCRIPTION
- Added new static method handleBreadcrumb

This initial commit is targeted at buttons but it can be expanded to other elements as needed.

Aim of this is to resolve common struggles with Bugsnag trying to identify the label of buttons but not getting anything useful.

**BEFORE**
![image](https://user-images.githubusercontent.com/17464863/100673251-0547cf00-33c8-11eb-8a4a-44616ca6602a.png)

**AFTER**
![image](https://user-images.githubusercontent.com/17464863/100673369-31635000-33c8-11eb-815f-34a41fef0930.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/886)
<!-- Reviewable:end -->
