### PR TITLE
SF-1160 Improve import question dialog layout and mobile view

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
@@ -5,53 +5,42 @@
         <mdc-dialog-title> <i class="material-icons">help</i> {{ t("import_from_transcelerator") }} </mdc-dialog-title>
         <mdc-dialog-content>
           <form [formGroup]="filterForm" autocomplete="off">
+            <div class="filter-references">
+              <mdc-form-field>
+                <mdc-text-field formControlName="from" label="{{ t('reference_from') }}" outlined>
+                  <mdc-icon #fromRef mdcTextFieldIcon trailing clickable (click)="openScriptureChooser(fromControl)">
+                    expand_more
+                  </mdc-icon>
+                </mdc-text-field>
+                <mdc-helper-text validation>{{ t("must_be_valid_reference") }}</mdc-helper-text>
+              </mdc-form-field>
+              <mdc-form-field>
+                <mdc-text-field formControlName="to" label="{{ t('reference_to') }}" outlined>
+                  <mdc-icon mdcTextFieldIcon trailing clickable (click)="openScriptureChooser(toControl)">
+                    expand_more
+                  </mdc-icon>
+                </mdc-text-field>
+                <mdc-helper-text validation>{{ t("must_be_valid_reference") }}</mdc-helper-text>
+              </mdc-form-field>
+            </div>
+            <div colspan="2" class="filter-text">
+              <div>
+                <mdc-text-field formControlName="filter" placeholder="{{ t('filter_questions') }}"></mdc-text-field>
+                <button mdc-button type="button" (click)="clearFilters()">{{ t("show_all") }}</button>
+              </div>
+            </div>
             <mdc-data-table>
               <table mdcDataTableTable>
                 <thead>
                   <tr mdcDataTableHeaderRow>
-                    <th>
+                    <th mdcDataTableHeaderCell>
                       <mdc-form-field class="select-all-checkbox">
                         <mdc-checkbox #selectAllCheckbox (change)="selectAllChanged($event)"></mdc-checkbox>
-                        <label>{{ t("select_all") }}</label>
+                        <label fxShow fxHide.xs>{{ t("select_all") }}</label>
+                        <label fxHide fxShow.xs>{{ t("all") }}</label>
                       </mdc-form-field>
                     </th>
-                    <th class="filter-references">
-                      <div>
-                        <mdc-form-field>
-                          <mdc-text-field formControlName="from" label="{{ t('reference_from') }}" outlined>
-                            <mdc-icon
-                              #fromRef
-                              mdcTextFieldIcon
-                              trailing
-                              clickable
-                              (click)="openScriptureChooser(fromControl)"
-                            >
-                              expand_more
-                            </mdc-icon>
-                          </mdc-text-field>
-                          <mdc-helper-text validation>{{ t("must_be_valid_reference") }}</mdc-helper-text>
-                        </mdc-form-field>
-                        <mdc-form-field>
-                          <mdc-text-field formControlName="to" label="{{ t('reference_to') }}" outlined>
-                            <mdc-icon mdcTextFieldIcon trailing clickable (click)="openScriptureChooser(toControl)">
-                              expand_more
-                            </mdc-icon>
-                          </mdc-text-field>
-                          <mdc-helper-text validation>{{ t("must_be_valid_reference") }}</mdc-helper-text>
-                        </mdc-form-field>
-                      </div>
-                    </th>
-                  </tr>
-                  <tr mdcDataTableHeaderRow>
-                    <th colspan="2" class="filter-text">
-                      <div>
-                        <mdc-text-field
-                          formControlName="filter"
-                          placeholder="{{ t('filter_questions') }}"
-                        ></mdc-text-field>
-                        <button mdc-button type="button" (click)="clearFilters()">{{ t("show_all") }}</button>
-                      </div>
-                    </th>
+                    <th mdcDataTableHeaderCell>{{ t("question") }}</th>
                   </tr>
                 </thead>
                 <tbody mdcDataTableContent>
@@ -76,7 +65,8 @@
         <mdc-dialog-actions>
           <button mdcDialogButton mdcDialogAction="close" type="button">{{ t("cancel") }}</button>
           <button mdcDialogButton unelevated type="submit" (click)="importQuestions()">
-            {{ t("import_count_questions", { count: selectedCount }) }}
+            <span fxShow fxHide.xs>{{ t("import_count_questions", { count: selectedCount }) }}</span>
+            <span fxHide fxShow.xs>{{ t("import") }}</span>
           </button>
         </mdc-dialog-actions>
       </mdc-dialog-surface>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.scss
@@ -1,5 +1,8 @@
 @use '@material/textfield/mixins' as textfield;
 
+@import 'src/variables';
+@import 'bootstrap/scss/mixins/breakpoints';
+
 mdc-dialog-title .material-icons {
   vertical-align: text-bottom;
 }
@@ -28,16 +31,18 @@ mdc-text-field ::ng-deep {
   }
 }
 
-.filter-references div {
-  display: flex;
+.filter-references {
   margin-top: 0.4em;
-  ::ng-deep {
-    mdc-form-field:first-child .mdc-notched-outline__trailing {
-      border-radius: 0 !important;
-    }
-    mdc-form-field:last-child {
-      .mdc-notched-outline__leading {
+  @include media-breakpoint-up(sm) {
+    display: flex;
+    ::ng-deep {
+      mdc-form-field:first-child .mdc-notched-outline__trailing {
         border-radius: 0 !important;
+      }
+      mdc-form-field:last-child {
+        .mdc-notched-outline__leading {
+          border-radius: 0 !important;
+        }
       }
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
@@ -324,12 +324,8 @@ class TestEnvironment {
     return this.component.selectAllCheckbox;
   }
 
-  get filterInput(): HTMLInputElement {
-    return this.table.querySelector('.filter-text div mdc-text-field input') as HTMLInputElement;
-  }
-
   get showAllButton(): HTMLButtonElement {
-    return this.table.querySelector('.filter-text div button') as HTMLButtonElement;
+    return this.overlayContainerElement.querySelector('.filter-text div button') as HTMLButtonElement;
   }
 
   get statusMessage(): string {
@@ -345,7 +341,9 @@ class TestEnvironment {
   }
 
   openFromScriptureChooser(): void {
-    this.click(this.table.querySelector('mdc-text-field[formControlName="from"] mdc-icon') as HTMLInputElement);
+    this.click(
+      this.overlayContainerElement.querySelector('mdc-text-field[formControlName="from"] mdc-icon') as HTMLInputElement
+    );
   }
 
   setControlValue(control: FormControl, value: string) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -90,14 +90,17 @@
     "transcelerator": "Transcelerator"
   },
   "import_questions_dialog": {
+    "all": "All",
     "cancel": "Cancel",
     "filter_questions": "Filter questions",
+    "import": "Import",
     "import_count_questions": "Import {{ count }} Selected Questions",
     "import_from_transcelerator": "Import Questions from Transcelerator",
     "importing_questions": "Importing {{ count }} questions...",
     "loading": "Loading...",
     "must_be_valid_reference": "Must be a valid reference",
     "no_questions_available": "There are no questions for the books in this project.",
+    "question": "Question",
     "reference_from": "Reference from",
     "reference_to": "Reference to",
     "select_all": "Select All",


### PR DESCRIPTION
* extract filtering controls from table header
* shorten some text to display on mobile
* stack reference filter fields on mobile

Before
![Before_import_xs](https://user-images.githubusercontent.com/17931130/100677536-6ddf6f00-3328-11eb-8af6-dce6938c9059.PNG)
![Before_import_sm](https://user-images.githubusercontent.com/17931130/100677553-73d55000-3328-11eb-8fdc-59463d76c01d.PNG)

After
![After_import_xs](https://user-images.githubusercontent.com/17931130/100677151-a3378d00-3327-11eb-97c6-850aeaaacd4a.PNG)
![After_import_sm](https://user-images.githubusercontent.com/17931130/100677156-a6327d80-3327-11eb-879d-c54d8cb1745f.PNG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/887)
<!-- Reviewable:end -->
