### PR TITLE
Add spacing around several dialog buttons

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.html
@@ -24,7 +24,7 @@
         <mdc-dialog-actions>
           <button mdcDialogButton type="button" id="cancel-btn" mdcDialogAction="cancel">{{ t("cancel") }}</button>
           <button
-            mdc-button
+            mdcDialogButton
             type="button"
             id="project-delete-btn"
             outlined

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.html
@@ -22,8 +22,8 @@
           <span class="error-message" *ngIf="showError">{{ t("select_text_error_message") }}</span>
         </mdc-dialog-content>
         <mdc-dialog-actions>
-          <button mdcDialogAction="close" type="button" mdc-button>{{ t("cancel") }}</button>
-          <button type="submit" mdc-button unelevated default (click)="submit()">{{ t("save") }}</button>
+          <button mdcDialogButton mdcDialogAction="close" type="button">{{ t("cancel") }}</button>
+          <button mdcDialogButton type="submit" unelevated default (click)="submit()">{{ t("save") }}</button>
         </mdc-dialog-actions>
       </mdc-dialog-surface>
     </mdc-dialog-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.html
@@ -24,7 +24,7 @@
           >
             {{ t("cancel") }}
           </button>
-          <button form="name-form" mdc-button unelevated type="submit" (click)="submitDialog()" id="submit-button">
+          <button mdcDialogButton form="name-form" unelevated type="submit" (click)="submitDialog()" id="submit-button">
             {{ data.isConfirmation ? t("confirm") : t("update") }}
           </button>
         </mdc-dialog-actions>


### PR DESCRIPTION
This is essentially a sequel to #869, which addressed it in some places, but left several dialogs untouched.

The `mdcDialogButton` directive takes care of placing a small amount of spacing between buttons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/890)
<!-- Reviewable:end -->
