### PR TITLE
SF-1148 Improve message when audio recording is not supported

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -25,7 +25,10 @@ import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { PwaService } from 'xforge-common/pwa.service';
-import { SupportedBrowsersDialogComponent } from 'xforge-common/supported-browsers-dialog/supported-browsers-dialog.component';
+import {
+  BrowserIssue,
+  SupportedBrowsersDialogComponent
+} from 'xforge-common/supported-browsers-dialog/supported-browsers-dialog.component';
 import { UserService } from 'xforge-common/user.service';
 import { issuesEmailTemplate, supportedBrowser } from 'xforge-common/utils';
 import { version } from '../../../version.json';
@@ -264,7 +267,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       const isBrowserSupported = supportedBrowser();
       this.reportingService.addMeta({ isBrowserSupported });
       if (isNewlyLoggedIn && !isBrowserSupported) {
-        this.dialog.open(SupportedBrowsersDialogComponent, { autoFocus: false });
+        this.dialog.open(SupportedBrowsersDialogComponent, { autoFocus: false, data: BrowserIssue.upgrade });
       }
 
       const projectDocs$ = this.currentUserDoc.remoteChanges$.pipe(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.spec.ts
@@ -85,6 +85,8 @@ describe('CheckingAudioRecorderComponent', () => {
     await env.waitForRecorder(100);
     verify(mockedDialog.open(SupportedBrowsersDialogComponent, anything())).once();
     env.component.mediaDevicesUnsupported = false;
+    env.clickButton(env.recordButton);
+    await env.waitForRecorder(100);
     verify(mockedDialog.open(SupportedBrowsersDialogComponent, anything())).once();
     expect().nothing();
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.spec.ts
@@ -1,3 +1,4 @@
+import { MdcDialog } from '@angular-mdc/web';
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -7,6 +8,7 @@ import { NAVIGATOR } from 'xforge-common/browser-globals';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { PwaService } from 'xforge-common/pwa.service';
+import { SupportedBrowsersDialogComponent } from 'xforge-common/supported-browsers-dialog/supported-browsers-dialog.component';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
@@ -20,6 +22,7 @@ const mockedUserService = mock(UserService);
 const mockedNoticeService = mock(NoticeService);
 const mockedNavigator = mock(Navigator);
 const mockedPwaService = mock(PwaService);
+const mockedDialog = mock(MdcDialog);
 
 describe('CheckingAudioRecorderComponent', () => {
   configureTestingModule(() => ({
@@ -29,7 +32,8 @@ describe('CheckingAudioRecorderComponent', () => {
       { provide: UserService, useMock: mockedUserService },
       { provide: NoticeService, useMock: mockedNoticeService },
       { provide: NAVIGATOR, useMock: mockedNavigator },
-      { provide: PwaService, useMock: mockedPwaService }
+      { provide: PwaService, useMock: mockedPwaService },
+      { provide: MdcDialog, useMock: mockedDialog }
     ]
   }));
 
@@ -73,6 +77,16 @@ describe('CheckingAudioRecorderComponent', () => {
     env.clickButton(env.stopRecordingButton);
     await env.waitForRecorder(100);
     expect(env.component.hasAudioAttachment).toBe(true);
+  });
+
+  it('should show browser unsupported dialog', async () => {
+    env.component.mediaDevicesUnsupported = true;
+    env.clickButton(env.recordButton);
+    await env.waitForRecorder(100);
+    verify(mockedDialog.open(SupportedBrowsersDialogComponent, anything())).once();
+    env.component.mediaDevicesUnsupported = false;
+    verify(mockedDialog.open(SupportedBrowsersDialogComponent, anything())).once();
+    expect().nothing();
   });
 });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -231,6 +231,7 @@
     "error_occurred": "An error has occurred",
     "firefox": "Firefox",
     "hide_details": "Hide details",
+    "safari": "Safari",
     "show_details": "Show details",
     "to_report_issue_email": "To report an issue, email {{ issueEmailLink }}.",
     "unsupported_browser": "You are using an unsupported browser, which may be the reason for this error. We recommend upgrading to the latest {{ chromeLink }} or {{ firefoxLink }}."
@@ -297,9 +298,13 @@
     "not_connected_to_any_projects": "Looks like you aren't connected to any projects yet."
   },
   "supported_browsers_dialog": {
+    "audio_recording_not_supported": "Audio recording is not supported in this browser.",
     "dismiss": "Dismiss",
     "browser_unsupported": "This browser is unsupported",
-    "upgrade_chrome_firefox": "Some of the features of this website may not work correctly with your browser. We recommend upgrading to the latest {{ chromeLink }} or {{ firefoxLink }}."
+    "safari_for_audio_on_ios": "Audio recording on iPhone and iPad only works in Safari.",
+    "some_features_may_not_work": "Some of the features of this website may not work correctly with your browser.",
+    "upgrade_chrome_firefox": " We recommend upgrading to the latest {{ chromeLink }} or {{ firefoxLink }}.",
+    "upgrade_safari": "We recommend upgrading to the latest {{ safariLink }}."
   },
   "text_chooser_dialog": {
     "cancel": "Cancel",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -303,8 +303,8 @@
     "browser_unsupported": "This browser is unsupported",
     "safari_for_audio_on_ios": "Audio recording on iPhone and iPad only works in Safari.",
     "some_features_may_not_work": "Some of the features of this website may not work correctly with your browser.",
-    "upgrade_chrome_firefox": " We recommend upgrading to the latest {{ chromeLink }} or {{ firefoxLink }}.",
-    "upgrade_safari": "We recommend upgrading to the latest {{ safariLink }}."
+    "upgrade_chrome_firefox": "{{ newLine }}We recommend upgrading to the latest {{ chromeLink }} or {{ firefoxLink }}.",
+    "upgrade_safari": "{{ newLine }}We recommend upgrading to the latest {{ safariLink }}."
   },
   "text_chooser_dialog": {
     "cancel": "Cancel",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/supported-browsers-dialog/supported-browsers-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/supported-browsers-dialog/supported-browsers-dialog.component.html
@@ -3,7 +3,24 @@
     <mdc-dialog-container>
       <mdc-dialog-surface>
         <mdc-dialog-title>{{ t("browser_unsupported") }}</mdc-dialog-title>
-        <mdc-dialog-content> <p [innerHTML]="t('upgrade_chrome_firefox', browserLinks)"></p> </mdc-dialog-content>
+        <mdc-dialog-content>
+          <p
+            *ngIf="upgradeChromeFirefox"
+            [innerHTML]="t('some_features_may_not_work') + ' ' + t('upgrade_chrome_firefox', browserLinks)"
+          ></p>
+          <p
+            *ngIf="upgradeSafari"
+            [innerHTML]="t('some_features_may_not_work') + ' ' + t('upgrade_safari', browserLinks)"
+          ></p>
+          <p
+            *ngIf="audioRecordingNotSupported"
+            [innerHTML]="t('audio_recording_not_supported') + ' ' + t('upgrade_chrome_firefox', browserLinks)"
+          ></p>
+          <p
+            *ngIf="iosRecordingNotSupported"
+            [innerHTML]="t('safari_for_audio_on_ios') + ' ' + t('upgrade_safari', browserLinks)"
+          ></p>
+        </mdc-dialog-content>
         <mdc-dialog-actions>
           <button mdcDialogButton type="button" mdcDialogAction="close">{{ t("dismiss") }}</button>
         </mdc-dialog-actions>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/supported-browsers-dialog/supported-browsers-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/supported-browsers-dialog/supported-browsers-dialog.component.html
@@ -4,22 +4,7 @@
       <mdc-dialog-surface>
         <mdc-dialog-title>{{ t("browser_unsupported") }}</mdc-dialog-title>
         <mdc-dialog-content>
-          <p
-            *ngIf="upgradeChromeFirefox"
-            [innerHTML]="t('some_features_may_not_work') + ' ' + t('upgrade_chrome_firefox', browserLinks)"
-          ></p>
-          <p
-            *ngIf="upgradeSafari"
-            [innerHTML]="t('some_features_may_not_work') + ' ' + t('upgrade_safari', browserLinks)"
-          ></p>
-          <p
-            *ngIf="audioRecordingNotSupported"
-            [innerHTML]="t('audio_recording_not_supported') + ' ' + t('upgrade_chrome_firefox', browserLinks)"
-          ></p>
-          <p
-            *ngIf="iosRecordingNotSupported"
-            [innerHTML]="t('safari_for_audio_on_ios') + ' ' + t('upgrade_safari', browserLinks)"
-          ></p>
+          <p [innerHTML]="dialogMessage"></p>
         </mdc-dialog-content>
         <mdc-dialog-actions>
           <button mdcDialogButton type="button" mdcDialogAction="close">{{ t("dismiss") }}</button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/supported-browsers-dialog/supported-browsers-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/supported-browsers-dialog/supported-browsers-dialog.component.ts
@@ -1,5 +1,7 @@
 import { MDC_DIALOG_DATA } from '@angular-mdc/web';
 import { Component, Inject } from '@angular/core';
+import { translate } from '@ngneat/transloco';
+import { I18nService } from 'xforge-common/i18n.service';
 import { browserLinks, isIosDevice } from 'xforge-common/utils';
 
 export enum BrowserIssue {
@@ -12,25 +14,24 @@ export enum BrowserIssue {
   templateUrl: './supported-browsers-dialog.component.html'
 })
 export class SupportedBrowsersDialogComponent {
-  constructor(@Inject(MDC_DIALOG_DATA) public data: BrowserIssue) {}
+  constructor(@Inject(MDC_DIALOG_DATA) public data: BrowserIssue, private readonly i18n: I18nService) {}
 
   get browserLinks() {
     return browserLinks();
   }
 
-  get audioRecordingNotSupported(): boolean {
-    return this.data === BrowserIssue.audioRecording && isIosDevice();
+  get dialogMessage(): string {
+    if (this.data === BrowserIssue.audioRecording) {
+      return isIosDevice()
+        ? translate('supported_browsers_dialog.safari_for_audio_on_ios') + this.recommendedBrowserText
+        : translate('supported_browsers_dialog.audio_recording_not_supported') + this.recommendedBrowserText;
+    }
+    return translate('supported_browsers_dialog.some_features_may_not_work') + this.recommendedBrowserText;
   }
 
-  get iosRecordingNotSupported(): boolean {
-    return this.data === BrowserIssue.audioRecording && !isIosDevice();
-  }
-
-  get upgradeChromeFirefox(): boolean {
-    return this.data === BrowserIssue.upgrade && !isIosDevice();
-  }
-
-  get upgradeSafari(): boolean {
-    return this.data === BrowserIssue.upgrade && isIosDevice();
+  get recommendedBrowserText(): string {
+    return isIosDevice()
+      ? this.i18n.translateAndInsertTags('supported_browsers_dialog.upgrade_safari', this.browserLinks)
+      : this.i18n.translateAndInsertTags('supported_browsers_dialog.upgrade_chrome_firefox', this.browserLinks);
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/supported-browsers-dialog/supported-browsers-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/supported-browsers-dialog/supported-browsers-dialog.component.ts
@@ -1,14 +1,36 @@
-import { Component } from '@angular/core';
-import { browserLinks } from 'xforge-common/utils';
+import { MDC_DIALOG_DATA } from '@angular-mdc/web';
+import { Component, Inject } from '@angular/core';
+import { browserLinks, isIosDevice } from 'xforge-common/utils';
+
+export enum BrowserIssue {
+  upgrade = 'upgrade_chrome_firefox',
+  audioRecording = 'audio_recording_not_supported'
+}
 
 @Component({
   selector: 'app-supported-browsers-dialog',
   templateUrl: './supported-browsers-dialog.component.html'
 })
 export class SupportedBrowsersDialogComponent {
-  constructor() {}
+  constructor(@Inject(MDC_DIALOG_DATA) public data: BrowserIssue) {}
 
   get browserLinks() {
     return browserLinks();
+  }
+
+  get audioRecordingNotSupported(): boolean {
+    return this.data === BrowserIssue.audioRecording && isIosDevice();
+  }
+
+  get iosRecordingNotSupported(): boolean {
+    return this.data === BrowserIssue.audioRecording && !isIosDevice();
+  }
+
+  get upgradeChromeFirefox(): boolean {
+    return this.data === BrowserIssue.upgrade && !isIosDevice();
+  }
+
+  get upgradeSafari(): boolean {
+    return this.data === BrowserIssue.upgrade && isIosDevice();
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -38,6 +38,10 @@ export function supportedBrowser(): boolean {
   return isSupportedBrowser ? true : false;
 }
 
+export function isIosDevice(): boolean {
+  return BROWSER.getOSName(true) === 'ios';
+}
+
 export function getBrowserEngine(): string {
   const engine = BROWSER.getEngine().name;
   return engine == null ? '' : engine.toLowerCase();
@@ -109,7 +113,8 @@ export function getI18nLocales(): Locale[] {
 export function browserLinks() {
   return {
     chromeLink: getLinkHTML(translate('error.chrome'), 'https://www.google.com/chrome/'),
-    firefoxLink: getLinkHTML(translate('error.firefox'), 'https://firefox.com')
+    firefoxLink: getLinkHTML(translate('error.firefox'), 'https://firefox.com'),
+    safariLink: getLinkHTML(translate('error.safari'), 'https://www.apple.com/safari/')
   };
 }
 


### PR DESCRIPTION
* iOS devices specifically mention using Safari
* supportedBrowser component updated to show OS specific messages

![Safari_for_iOS](https://user-images.githubusercontent.com/17931130/101077722-74f1c180-3562-11eb-9e92-d5fe9cd8fef4.PNG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/891)
<!-- Reviewable:end -->
