### PR TITLE
SF-1155 Support beta.localhost:9000 and simultaneous localhost:5000

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/angular.json
+++ b/src/SIL.XForge.Scripture/ClientApp/angular.json
@@ -181,7 +181,8 @@
             },
             "developmentBeta": {
               "browserTarget": "SIL.XForge.Scripture:build:developmentBeta",
-              "port": 9200
+              "port": 9200,
+              "host": "beta.localhost"
             }
           }
         },

--- a/src/SIL.XForge.Scripture/ClientApp/angular.json
+++ b/src/SIL.XForge.Scripture/ClientApp/angular.json
@@ -70,6 +70,30 @@
               "buildOptimizer": true,
               "serviceWorker": true
             },
+            "productionBeta": {
+              "budgets": [
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "6kb"
+                }
+              ],
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prodBeta.ts"
+                }
+              ],
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": true,
+              "extractCss": true,
+              "namedChunks": false,
+              "aot": true,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true,
+              "serviceWorker": true
+            },
             "staging": {
               "budgets": [
                 {
@@ -81,6 +105,30 @@
                 {
                   "replace": "src/environments/environment.ts",
                   "with": "src/environments/environment.staging.ts"
+                }
+              ],
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": true,
+              "extractCss": true,
+              "namedChunks": false,
+              "aot": true,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true,
+              "serviceWorker": true
+            },
+            "stagingBeta": {
+              "budgets": [
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "6kb"
+                }
+              ],
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.stagingBeta.ts"
                 }
               ],
               "optimization": true,
@@ -111,6 +159,14 @@
               "vendorChunk": false,
               "buildOptimizer": false,
               "serviceWorker": true
+            },
+            "developmentBeta": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.developmentBeta.ts"
+                }
+              ]
             }
           }
         },
@@ -122,6 +178,10 @@
           "configurations": {
             "production": {
               "browserTarget": "SIL.XForge.Scripture:build:production"
+            },
+            "developmentBeta": {
+              "browserTarget": "SIL.XForge.Scripture:build:developmentBeta",
+              "port": 9200
             }
           }
         },

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
+    "startBeta": "ng serve --configuration=developmentBeta",
     "start:no-progress": "ng serve --progress=false",
     "start:no-reload": "ng serve --liveReload=false",
     "build": "ng build",

--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.developmentBeta.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.developmentBeta.ts
@@ -17,7 +17,7 @@ export const environment = {
   assets: '/assets/',
   helps: 'https://help.scriptureforge.org',
   bugsnagApiKey: 'b72a46a8924a3cd161d4c5534287923c',
-  realtimePort: 9003,
+  realtimePort: 5003,
   realtimeUrl: '/',
   authDomain: 'sil-appbuilder.auth0.com',
   authClientId: 'aoAGb9Yx1H5WIsvCW6JJCteJhSa37ftH',

--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.developmentBeta.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.developmentBeta.ts
@@ -1,0 +1,25 @@
+// The file contents for the current environment will overwrite these during build.
+// The build system defaults to the dev environment which uses `environment.ts`, but if you do
+// `ng build --prod` then `environment.prod.ts` will be used instead. And if you do
+// `ng build --configuration=pwaTest` then `environment.pwa-test.ts` will be used instead.
+// The list of which env maps to which file can be found in `angular.json`.
+// The environment object should not be generated dynamically. This seems to cause problems with production builds.
+
+export const environment = {
+  releaseStage: 'dev',
+  pwaTest: false,
+  production: false,
+  issueEmail: 'scriptureforgeissues@sil.org',
+  siteName: 'Scripture Forge',
+  audience: 'https://scriptureforge.org/',
+  scope: 'sf_data',
+  siteId: 'sf',
+  assets: '/assets/',
+  helps: 'https://help.scriptureforge.org',
+  bugsnagApiKey: 'b72a46a8924a3cd161d4c5534287923c',
+  realtimePort: 9003,
+  realtimeUrl: '/',
+  authDomain: 'sil-appbuilder.auth0.com',
+  authClientId: 'aoAGb9Yx1H5WIsvCW6JJCteJhSa37ftH',
+  offlineDBVersion: 4
+};

--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.prodBeta.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.prodBeta.ts
@@ -1,0 +1,18 @@
+export const environment = {
+  releaseStage: 'live',
+  pwaTest: false,
+  production: true,
+  issueEmail: 'scriptureforgeissues@sil.org',
+  siteName: 'Scripture Forge',
+  audience: 'https://scriptureforge.org/',
+  scope: 'sf_data',
+  siteId: 'sf',
+  assets: '/assets/',
+  helps: 'https://help.scriptureforge.org',
+  bugsnagApiKey: 'b72a46a8924a3cd161d4c5534287923c',
+  realtimePort: 9003,
+  realtimeUrl: '/realtime-api/',
+  authDomain: 'login.languagetechnology.org',
+  authClientId: 'tY2wXn40fsL5VsPM4uIHNtU6ZUEXGeFn',
+  offlineDBVersion: 4
+};

--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.stagingBeta.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.stagingBeta.ts
@@ -1,0 +1,18 @@
+export const environment = {
+  releaseStage: 'qa',
+  pwaTest: false,
+  production: true,
+  issueEmail: 'scriptureforgeissues@sil.org',
+  siteName: 'Scripture Forge',
+  audience: 'https://scriptureforge.org/',
+  scope: 'sf_data',
+  siteId: 'sf',
+  assets: '/assets/',
+  helps: 'https://help.scriptureforge.org',
+  bugsnagApiKey: 'b72a46a8924a3cd161d4c5534287923c',
+  realtimePort: 9003,
+  realtimeUrl: '/realtime-api/',
+  authDomain: 'dev-sillsdev.auth0.com',
+  authClientId: '4eHLjo40mAEGFU6zUxdYjnpnC1K1Ydnj',
+  offlineDBVersion: 4
+};

--- a/src/SIL.XForge.Scripture/Pages/Shared/_SelectLanguagePartial.cshtml
+++ b/src/SIL.XForge.Scripture/Pages/Shared/_SelectLanguagePartial.cshtml
@@ -12,15 +12,16 @@
 @{
     var requestCulture = Context.Features.Get<IRequestCultureFeature>();
     var cultureItems = LocOptions.Value.SupportedUICultures
-        .Where(c => SharedResource.Cultures[c.IetfLanguageTag].Production || !env.IsStaging() && !env.IsProduction())
-        .Select(c => new SelectListItem
-            {
-                Value = c.Name,
-                Text = SharedResource.Cultures[c.IetfLanguageTag].LocalName +
-                    (SharedResource.Cultures[c.IetfLanguageTag].Production ? "" : " *")
-            }
-        )
-        .ToList();
+        .Where(c => SharedResource.Cultures[c.IetfLanguageTag].Production || !env.IsStaging() &&
+    !env.IsEnvironment("StagingBeta") && !env.IsProduction() && !env.IsEnvironment("Beta"))
+    .Select(c => new SelectListItem
+    {
+        Value = c.Name,
+        Text = SharedResource.Cultures[c.IetfLanguageTag].LocalName +
+        (SharedResource.Cultures[c.IetfLanguageTag].Production ? "" : " *")
+    }
+    )
+    .ToList();
 }
 
 <div title="@SharedLocalizer[SharedResource.Keys.Language]">

--- a/src/SIL.XForge.Scripture/Program.cs
+++ b/src/SIL.XForge.Scripture/Program.cs
@@ -27,15 +27,15 @@ namespace SIL.XForge.Scripture
 
             return builder
                 .UseLibuv()
-                .UseUrls("http://localhost:5000")
                 .ConfigureAppConfiguration((context, config) =>
                     {
                         IWebHostEnvironment env = context.HostingEnvironment;
-                        if (env.IsDevelopment() || env.IsEnvironment("Testing"))
+                        if (env.IsDevelopment() || env.IsEnvironment("DevelopmentBeta") || env.IsEnvironment("Testing") || env.IsEnvironment("TestingBeta"))
                             config.AddJsonFile("appsettings.user.json", true);
                         else
                             config.AddJsonFile("secrets.json", true, true);
-                        if (env.IsEnvironment("Testing"))
+                        // Manually read in secrets for development-related environments that aren't specifically "Development".
+                        if (env.IsEnvironment("Testing") || env.IsEnvironment("TestingBeta") || env.IsEnvironment("DevelopmentBeta"))
                         {
                             var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
                             if (appAssembly != null)

--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -84,7 +84,7 @@
     <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
   </Target>
 
-  <Target Name="BuildRealtimeServer" DependsOnTargets="EnsureNodeInstalled" BeforeTargets="AssignTargetPaths" Condition="'$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Development' Or '$(Configuration)' == 'DevelopmentBeta'">
+  <Target Name="BuildRealtimeServer" DependsOnTargets="EnsureNodeInstalled" BeforeTargets="AssignTargetPaths" Condition="'$(Configuration)' == 'Debug'">
     <Message Importance="high" Text="Building real-time server..." />
     <Exec WorkingDirectory="$(RealtimeServerRoot)" Command="npm install" Condition="!Exists('$(RealtimeServerRoot)node_modules') Or '$(NpmInstall)' == 'true'" />
     <Exec WorkingDirectory="$(RealtimeServerRoot)" Command="npm run build" Condition="Exists('$(RealtimeServerRoot)node_modules') And '$(NpmInstall)' != 'true' " />

--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -84,7 +84,7 @@
     <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
   </Target>
 
-  <Target Name="BuildRealtimeServer" DependsOnTargets="EnsureNodeInstalled" BeforeTargets="AssignTargetPaths" Condition="'$(Configuration)' == 'Debug'">
+  <Target Name="BuildRealtimeServer" DependsOnTargets="EnsureNodeInstalled" BeforeTargets="AssignTargetPaths" Condition="'$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Development' Or '$(Configuration)' == 'DevelopmentBeta'">
     <Message Importance="high" Text="Building real-time server..." />
     <Exec WorkingDirectory="$(RealtimeServerRoot)" Command="npm install" Condition="!Exists('$(RealtimeServerRoot)node_modules') Or '$(NpmInstall)' == 'true'" />
     <Exec WorkingDirectory="$(RealtimeServerRoot)" Command="npm run build" Condition="Exists('$(RealtimeServerRoot)node_modules') And '$(NpmInstall)' != 'true' " />

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -82,7 +82,7 @@ namespace SIL.XForge.Scripture.Services
 
             _httpClientHandler = new HttpClientHandler();
             _registryClient = new HttpClient(_httpClientHandler);
-            if (env.IsDevelopment() || env.IsEnvironment("Testing"))
+            if (env.IsDevelopment() || env.IsEnvironment("DevelopmentBeta") || env.IsEnvironment("Testing") || env.IsEnvironment("TestingBeta"))
             {
                 _httpClientHandler.ServerCertificateCustomValidationCallback
                     = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;

--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -44,7 +44,7 @@ namespace SIL.XForge.Scripture
         {
             get
             {
-                if (Environment.IsDevelopment())
+                if (IsDevelopmentEnvironment)
                 {
                     string startNgServe = Configuration.GetValue("start-ng-serve", "yes");
                     switch (startNgServe)
@@ -55,7 +55,7 @@ namespace SIL.XForge.Scripture
                             return SpaDevServerStartup.Listen;
                     }
                 }
-                else if (Environment.IsEnvironment("Testing"))
+                else if (IsTestingEnvironment)
                 {
                     return SpaDevServerStartup.Listen;
                 }
@@ -63,7 +63,8 @@ namespace SIL.XForge.Scripture
             }
         }
 
-        private bool IsDevelopment => Environment.IsDevelopment() || Environment.IsEnvironment("Testing");
+        private bool IsDevelopmentEnvironment => Environment.IsDevelopment() || Environment.IsEnvironment("DevelopmentBeta");
+        private bool IsTestingEnvironment => Environment.IsEnvironment("Testing") || Environment.IsEnvironment("TestingBeta");
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public IServiceProvider ConfigureServices(IServiceCollection services)
@@ -74,7 +75,7 @@ namespace SIL.XForge.Scripture
 
             services.AddConfiguration(Configuration);
 
-            services.AddSFRealtimeServer(LoggerFactory, Configuration, IsDevelopment);
+            services.AddSFRealtimeServer(LoggerFactory, Configuration, IsDevelopmentEnvironment || IsTestingEnvironment);
 
             services.AddSFServices();
 
@@ -133,7 +134,7 @@ namespace SIL.XForge.Scripture
         public void Configure(IApplicationBuilder app, IHostApplicationLifetime appLifetime,
             IExceptionHandler exceptionHandler)
         {
-            if (IsDevelopment)
+            if (IsDevelopmentEnvironment || IsTestingEnvironment)
             {
                 app.UseDeveloperExceptionPage();
             }
@@ -203,11 +204,24 @@ namespace SIL.XForge.Scripture
                 switch (SpaDevServerStartup)
                 {
                     case SpaDevServerStartup.Start:
-                        spa.UseAngularCliServer(npmScript: "start:no-progress");
+                        string npmScript = "start";
+                        if (Environment.IsEnvironment("DevelopmentBeta"))
+                        {
+                            npmScript = "startBeta";
+                        }
+                        Console.WriteLine($"Info: SF is serving angular using script {npmScript}.");
+                        spa.UseAngularCliServer(npmScript);
                         break;
 
                     case SpaDevServerStartup.Listen:
-                        spa.UseProxyToSpaDevelopmentServer("http://localhost:4200");
+                        int port = 4200;
+                        if (Environment.IsEnvironment("DevelopmentBeta"))
+                        {
+                            port = 9200;
+                        }
+                        string ngServeUri = $"http://localhost:{port}";
+                        Console.WriteLine($"Info: SF will use an existing angular serve at {ngServeUri}.");
+                        spa.UseProxyToSpaDevelopmentServer(ngServeUri);
                         break;
                 }
             });

--- a/src/SIL.XForge.Scripture/appsettings.Beta.json
+++ b/src/SIL.XForge.Scripture/appsettings.Beta.json
@@ -9,7 +9,7 @@
   "Site": {
     "Id": "sf",
     "Name": "Scripture Forge",
-    "Origin": "https://scriptureforge.org",
+    "Origin": "https://beta.scriptureforge.org",
     "SmtpServer": "localhost",
     "PortNumber": "25",
     "EmailFromAddress": "no-reply@scriptureforge.org",
@@ -23,7 +23,7 @@
     "Prefix": "sf"
   },
   "Realtime": {
-    "Port": 5003
+    "Port": 9003
   },
   "Bugsnag": {
     "ApiKey": "b72a46a8924a3cd161d4c5534287923c",

--- a/src/SIL.XForge.Scripture/appsettings.DevelopmentBeta.json
+++ b/src/SIL.XForge.Scripture/appsettings.DevelopmentBeta.json
@@ -22,7 +22,7 @@
     "ConnectionString": "mongodb://localhost:27017"
   },
   "Realtime": {
-    "Port": 9003
+    "Port": 5003
   },
   "Paratext": {
     "HgExe": "/usr/local/bin/hg"

--- a/src/SIL.XForge.Scripture/appsettings.DevelopmentBeta.json
+++ b/src/SIL.XForge.Scripture/appsettings.DevelopmentBeta.json
@@ -1,0 +1,30 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information"
+    }
+  },
+  "Site": {
+    "Origin": "http://beta.localhost:9000",
+    "EmailFromAddress": "no-reply@localhost",
+    "SendEmail": "false"
+  },
+  "Bugsnag": {
+    "ReleaseStage": "development"
+  },
+  "Auth": {
+    "Domain": "sil-appbuilder.auth0.com",
+    "ManagementAudience": "https://sil-appbuilder.auth0.com/api/v2/",
+    "FrontendClientId": "aoAGb9Yx1H5WIsvCW6JJCteJhSa37ftH",
+    "BackendClientId": "D7bF2gHmMVAaC67a1GF6f0DdQdRpqQwA"
+  },
+  "DataAccess": {
+    "ConnectionString": "mongodb://localhost:27017"
+  },
+  "Realtime": {
+    "Port": 9003
+  },
+  "Paratext": {
+    "HgExe": "/usr/local/bin/hg"
+  }
+}

--- a/src/SIL.XForge.Scripture/appsettings.DevelopmentBeta.json
+++ b/src/SIL.XForge.Scripture/appsettings.DevelopmentBeta.json
@@ -22,7 +22,7 @@
     "ConnectionString": "mongodb://localhost:27017"
   },
   "Realtime": {
-    "Port": 5003
+    "Port": 9003
   },
   "Paratext": {
     "HgExe": "/usr/local/bin/hg"

--- a/src/SIL.XForge.Scripture/appsettings.StagingBeta.json
+++ b/src/SIL.XForge.Scripture/appsettings.StagingBeta.json
@@ -1,10 +1,13 @@
 {
   "Site": {
     "Name": "Scripture Forge QA",
-    "Origin": "https://qa.scriptureforge.org"
+    "Origin": "https://qa.beta.scriptureforge.org"
   },
   "DataAccess": {
     "ConnectionString": "mongodb://qa.mongo.xforge.org:27017"
+  },
+  "Realtime": {
+    "Port": 9003
   },
   "Bugsnag": {
     "ReleaseStage": "qa"

--- a/src/SIL.XForge.Scripture/appsettings.TestingBeta.json
+++ b/src/SIL.XForge.Scripture/appsettings.TestingBeta.json
@@ -1,0 +1,34 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  },
+  "Site": {
+    "Origin": "http://beta.localhost:9000",
+    "EmailFromAddress": "no-reply@localhost",
+    "SendEmail": "false"
+  },
+  "DataAccess": {
+    "ConnectionString": "mongodb://localhost:27017",
+    "MongoDatabaseName": "xforge_test",
+    "JobDatabaseName": "sf_jobs_test"
+  },
+  "Realtime": {
+    "Port": 9003
+  },
+  "Bugsnag": {
+    "ReleaseStage": "development"
+  },
+  "Auth": {
+    "Domain": "sil-appbuilder.auth0.com",
+    "ManagementAudience": "https://sil-appbuilder.auth0.com/api/v2/",
+    "FrontendClientId": "aoAGb9Yx1H5WIsvCW6JJCteJhSa37ftH",
+    "BackendClientId": "D7bF2gHmMVAaC67a1GF6f0DdQdRpqQwA"
+  },
+  "Paratext": {
+    "HgExe": "/usr/local/bin/hg"
+  }
+}

--- a/src/SIL.XForge.Scripture/hosting.Beta.json
+++ b/src/SIL.XForge.Scripture/hosting.Beta.json
@@ -1,0 +1,3 @@
+{
+  "urls": "http://unix:/var/run/scriptureforge-web-app_beta/scriptureforge-web-app_beta.sock"
+}

--- a/src/SIL.XForge.Scripture/hosting.DevelopmentBeta.json
+++ b/src/SIL.XForge.Scripture/hosting.DevelopmentBeta.json
@@ -1,0 +1,3 @@
+{
+  "urls": "http://beta.localhost:9000"
+}

--- a/src/SIL.XForge.Scripture/hosting.Staging.json
+++ b/src/SIL.XForge.Scripture/hosting.Staging.json
@@ -1,3 +1,3 @@
 {
-  "urls": "http://unix:/var/run/scriptureforge-web-app_beta_qa/scriptureforge-web-app_beta_qa.sock"
+  "urls": "http://unix:/var/run/scriptureforge-web-app_qa/scriptureforge-web-app_qa.sock"
 }

--- a/src/SIL.XForge.Scripture/hosting.StagingBeta.json
+++ b/src/SIL.XForge.Scripture/hosting.StagingBeta.json
@@ -1,0 +1,3 @@
+{
+  "urls": "http://unix:/var/run/scriptureforge-web-app_beta_qa/scriptureforge-web-app_beta_qa.sock"
+}

--- a/src/SIL.XForge.Scripture/hosting.TestingBeta.json
+++ b/src/SIL.XForge.Scripture/hosting.TestingBeta.json
@@ -1,0 +1,3 @@
+{
+  "urls": "http://beta.localhost:9000"
+}

--- a/src/SIL.XForge.Scripture/hosting.json
+++ b/src/SIL.XForge.Scripture/hosting.json
@@ -1,3 +1,3 @@
 {
-  "urls": "http://unix:/var/run/scriptureforge-web-app_beta/scriptureforge-web-app_beta.sock"
+  "urls": "http://unix:/var/run/scriptureforge-web-app/scriptureforge-web-app.sock"
 }

--- a/src/SIL.XForge/Configuration/RealtimeOptions.cs
+++ b/src/SIL.XForge/Configuration/RealtimeOptions.cs
@@ -9,7 +9,7 @@ namespace SIL.XForge.Configuration
     public class RealtimeOptions
     {
         public string AppModuleName { get; set; }
-        public int Port { get; set; } = 5003;
+        public int Port { get; set; }
         public DocConfig UserDoc { get; set; } = new DocConfig("users", typeof(User));
         public DocConfig ProjectDoc { get; set; }
         public List<DocConfig> ProjectDataDocs { get; set; } = new List<DocConfig>();

--- a/src/SIL.XForge/Controllers/UsersRpcController.cs
+++ b/src/SIL.XForge/Controllers/UsersRpcController.cs
@@ -42,7 +42,7 @@ namespace SIL.XForge.Controllers
         /// </summary>
         public async Task<IRpcMethodResult> PullAuthUserProfile()
         {
-            if (!_hostingEnv.IsDevelopment())
+            if (!(_hostingEnv.IsDevelopment() || _hostingEnv.IsEnvironment("DevelopmentBeta")))
                 return ForbiddenError();
 
             string userProfile = await _authService.GetUserAsync(AuthId);

--- a/src/SIL.XForge/Services/AuthService.cs
+++ b/src/SIL.XForge/Services/AuthService.cs
@@ -107,6 +107,10 @@ namespace SIL.XForge.Services
                         new JProperty("client_secret", options.BackendClientSecret),
                         new JProperty("audience", _authOptions.Value.ManagementAudience));
                     request.Content = new StringContent(requestObj.ToString(), Encoding.UTF8, "application/json");
+                    if (string.IsNullOrEmpty(options.BackendClientSecret))
+                    {
+                        Console.WriteLine("Note: AuthService is using an empty BackendClientSecret.");
+                    }
                     HttpResponseMessage response = await _httpClient.SendAsync(request);
                     await _exceptionHandler.EnsureSuccessStatusCode(response);
 


### PR DESCRIPTION
  - This change allows two SF apps to be run from the codebase at the
    same time. One serves requests to beta.localhost:9000 and the
    other serves requests to localhost:5000. This is to help with
    development of a beta.scriptureforge.org to scriptureforge.org
    transition.
  - In production, Angular is precompiled and used from
    ClientApp/Dist. In development, Angular is provided via
    `ng serve`. SF Startup.cs will either start an `ng serve`, or
    listen to an existing one, depending on
    --start-ng-serve={yes,listen}.
  - `dotnet run --start-ng-serve=yes --configuration=Development` will
    result in Startup.cs using package.json script `start` to run
    `ng serve`. `--configuration=DevelopmentBeta` will result in
    script `startBeta` being used instead, to run
    `ng serve --configuration=developmentBeta`.
  - The dotnet --configuration and the ng --configuration correspond
    to different appsettings.*.json, hosting.*.json, and
    environment.*.ts files. The configurations are also checked at
    runtime in code.
  - Program.cs:
    - Expand check for Development and Testing configurations to
      include DevelopmentBeta and TestingBeta. (Alternatively, a
      custom IWebHostEnvironment implementation could return true on
      IsDevelopment() if configuration is Development or
      DevelopmentBeta.)
    - Secrets are automatically read in for Development. Manually
      bring them in for DevelopmentBeta.
    - Omit `UseUrls()`, since doesn't seem to matter and is already
      specified in hosting.*.json files. (Tho maybe they should set
      "server.urls" instead?)
  - Startup.cs:
    - Expand checking to DevelopmentBeta and TestingBeta similarly.
    - Waiting for `ng serve` to be ready, with no output, is annoying
      and misleading, so launch `ng serve` with progress.
      Unfortunately this progress is seen as a series of "fail"
      messages in the dotnet output.
    - Launch `ng serve` via beta or non-beta configuration.
    - Interface with an existing `ng serve` using a beta or non-beta
      port.
    - Output how we are using angular.
  - ParatextService.cs, UsersRpcController.cs, and
    _SelectLanguagePartial.cshtml: Apply similar checking for FooBeta
    configurations.
  - AuthService.cs: When not configured properly,
    GetAccessTokenAsync() will try to communicate with auth0 with an
    empty secret. Write a note to the output if this happens again to
    assist in troubleshooting.
  - angular.json: Add build and serve configurations for fooBeta
    configurations. This will result in different environment.*.ts
    files being used, and a different port for `ng serve` when using
    configuration developmentBeta.
  - This change does not include changes to launchSettings.json, which
    didn't appear to be needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/892)
<!-- Reviewable:end -->
