### PR TITLE
QA Only: A hotfix to ignore extra elements in the BSON

### DIFF
--- a/src/SIL.XForge.Scripture/Models/Chapter.cs
+++ b/src/SIL.XForge.Scripture/Models/Chapter.cs
@@ -1,5 +1,8 @@
+using MongoDB.Bson.Serialization.Attributes;
+
 namespace SIL.XForge.Scripture.Models
 {
+    [BsonIgnoreExtraElements]
     public class Chapter
     {
         public int Number { get; set; }

--- a/src/SIL.XForge.Scripture/Models/TextInfo.cs
+++ b/src/SIL.XForge.Scripture/Models/TextInfo.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.ComponentModel;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace SIL.XForge.Scripture.Models
 {
@@ -29,6 +30,7 @@ namespace SIL.XForge.Scripture.Models
         }
     }
 
+    [BsonIgnoreExtraElements]
     public class TextInfo
     {
         public int BookNum { get; set; }

--- a/src/SIL.XForge.Scripture/Models/TranslateSource.cs
+++ b/src/SIL.XForge.Scripture/Models/TranslateSource.cs
@@ -1,7 +1,9 @@
+using MongoDB.Bson.Serialization.Attributes;
 using SIL.XForge.Models;
 
 namespace SIL.XForge.Scripture.Models
 {
+    [BsonIgnoreExtraElements]
     public class TranslateSource
     {
         public string ParatextId { get; set; }


### PR DESCRIPTION
This is a hotfix to correct the issue on QA:

```
System.FormatException: An error occurred while deserializing the Texts property of class SIL.XForge.Scripture.Models.SFProject: Element 'permissions' does not match any field or property of class SIL.XForge.Scripture.Models.TextInfo.
 ---> System.FormatException: Element 'permissions' does not match any field or property of class SIL.XForge.Scripture.Models.TextInfo.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/893)
<!-- Reviewable:end -->
