### PR TITLE
SF-798 Remove user docs and project associations

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-owner/checking-owner.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-owner/checking-owner.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { translate } from '@ngneat/transloco';
+import { TranslocoService } from '@ngneat/transloco';
 import { UserProfile } from 'realtime-server/lib/common/models/user';
 import { I18nService } from 'xforge-common/i18n.service';
 import { UserProfileDoc } from 'xforge-common/models/user-profile-doc';
@@ -17,7 +17,11 @@ export class CheckingOwnerComponent implements OnInit {
   @Input() layoutStacked: boolean = false;
   private ownerDoc?: UserProfileDoc;
 
-  constructor(private readonly userService: UserService, readonly i18n: I18nService) {}
+  constructor(
+    private readonly userService: UserService,
+    readonly i18n: I18nService,
+    private readonly translocoService: TranslocoService
+  ) {}
 
   get date(): Date {
     return new Date(this.dateTime);
@@ -25,10 +29,10 @@ export class CheckingOwnerComponent implements OnInit {
 
   get name(): string {
     if (this.ownerDoc == null || this.ownerDoc.data == null) {
-      return '';
+      return this.translocoService.translate('checking.unknown_author');
     }
     return this.userService.currentUserId === this.ownerDoc.id
-      ? translate('checking.me')
+      ? this.translocoService.translate('checking.me')
       : this.ownerDoc.data.displayName;
   }
 
@@ -36,9 +40,9 @@ export class CheckingOwnerComponent implements OnInit {
     return this.ownerDoc == null ? undefined : this.ownerDoc.data;
   }
 
-  ngOnInit(): void {
+  async ngOnInit(): Promise<void> {
     if (this.ownerRef != null) {
-      this.userService.getProfile(this.ownerRef).then(u => (this.ownerDoc = u));
+      this.ownerDoc = await this.userService.getProfile(this.ownerRef);
     }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -151,6 +151,7 @@
   },
   "checking": {
     "me": "Me",
+    "unknown_author": "Unknown author",
     "next": "Next",
     "previous": "Previous",
     "questions": "Questions ({{ count }})",

--- a/src/SIL.XForge.Scripture/Models/SyncUser.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncUser.cs
@@ -5,6 +5,9 @@ namespace SIL.XForge.Scripture.Models
     /// </summary>
     public class SyncUser
     {
+        /// <summary>
+        /// Unique id of a SyncUser. Not intended to match a user id.
+        /// </summary>
         public string Id { get; set; }
         public string ParatextUsername { get; set; }
     }

--- a/src/SIL.XForge.Scripture/Realtime/SFRealtimeServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Realtime/SFRealtimeServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using SIL.XForge.Configuration;
+using SIL.XForge.Models;
 using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
 
@@ -25,6 +27,10 @@ namespace Microsoft.Extensions.DependencyInjection
                         new DocConfig("sf_project_user_configs", typeof(SFProjectUserConfig)),
                         new DocConfig("texts", typeof(TextData), OTType.RichText),
                         new DocConfig("questions", typeof(Question))
+                    });
+                    o.UserDataDocs.AddRange(new[]
+                    {
+                        new DocConfig("sf_project_user_configs", typeof(SFProjectUserConfig))
                     });
                 }, launchWithDebugging);
             return services;

--- a/src/SIL.XForge.Scripture/Services/SFServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/SFServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Paratext.Data;
 using Paratext.Data.Archiving;
 using SIL.XForge.Scripture.Services;
+using SIL.XForge.Services;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -18,6 +19,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddTransient<IParatextNotesMapper, ParatextNotesMapper>();
             services.AddSingleton<IGuidService, GuidService>();
             services.AddSingleton<ISFProjectService, SFProjectService>();
+            // When UserService requests an IProjectService, satisfy it with the SFProjectService.
+            services.AddSingleton<IProjectService, SFProjectService>();
             services.AddSingleton<IJwtTokenHelper, JwtTokenHelper>();
             services.AddSingleton<IParatextDataHelper, ParatextDataHelper>();
             services.AddSingleton<IInternetSharedRepositorySourceProvider, InternetSharedRepositorySourceProvider>();

--- a/src/SIL.XForge.Scripture/Services/SFServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/SFServiceCollectionExtensions.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddTransient<IParatextNotesMapper, ParatextNotesMapper>();
             services.AddSingleton<IGuidService, GuidService>();
             services.AddSingleton<ISFProjectService, SFProjectService>();
-            // When UserService requests an IProjectService, satisfy it with the SFProjectService.
             services.AddSingleton<IProjectService, SFProjectService>();
             services.AddSingleton<IJwtTokenHelper, JwtTokenHelper>();
             services.AddSingleton<IParatextDataHelper, ParatextDataHelper>();

--- a/src/SIL.XForge/Configuration/DocConfig.cs
+++ b/src/SIL.XForge/Configuration/DocConfig.cs
@@ -17,6 +17,10 @@ namespace SIL.XForge.Configuration
 
         public string CollectionName { get; }
         public Type Type { get; }
+
+        /// <summary>
+        /// Or `null` if there is no corresponding "o_..." collection for this document type.
+        /// </summary>
         public string OTTypeName { get; }
     }
 }

--- a/src/SIL.XForge/Configuration/RealtimeOptions.cs
+++ b/src/SIL.XForge/Configuration/RealtimeOptions.cs
@@ -13,6 +13,18 @@ namespace SIL.XForge.Configuration
         public bool MigrationsDisabled = false;
         public DocConfig UserDoc { get; set; } = new DocConfig("users", typeof(User));
         public DocConfig ProjectDoc { get; set; }
+
+        /// <summary>
+        /// Additional document types (importantly, collection names) that have project related data. Defining this
+        /// helps identify and delete project data when removing a project.
+        /// </summary>
         public List<DocConfig> ProjectDataDocs { get; set; } = new List<DocConfig>();
+
+        /// <summary>
+        /// Document types (importantly, collection names) that have user information, from which to delete records
+        /// when removing a user from the database.
+        /// </summary>
+        public List<DocConfig> UserDataDocs { get; set; } = new List<DocConfig>();
     }
+
 }

--- a/src/SIL.XForge/Realtime/Document.cs
+++ b/src/SIL.XForge/Realtime/Document.cs
@@ -10,11 +10,11 @@ namespace SIL.XForge.Realtime
     /// </summary>
     public class Document<T> : IDocument<T> where T : IIdentifiable
     {
-        private readonly RealtimeServer _server;
+        private readonly IRealtimeServer _server;
         private readonly int _connHandle;
         private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
 
-        internal Document(RealtimeServer server, int connHandle, string otTypeName, string collection, string id)
+        internal Document(IRealtimeServer server, int connHandle, string otTypeName, string collection, string id)
         {
             _server = server;
             _connHandle = connHandle;

--- a/src/SIL.XForge/Realtime/IRealtimeServer.cs
+++ b/src/SIL.XForge/Realtime/IRealtimeServer.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+
+namespace SIL.XForge.Realtime
+{
+    public interface IRealtimeServer
+    {
+        Task<T> ApplyOpAsync<T>(string otTypeName, T data, object op);
+        Task<int> ConnectAsync(string userId = null);
+        Task<Snapshot<T>> CreateDocAsync<T>(int handle, string collection, string id, T data, string otTypeName);
+        Task DeleteDocAsync(int handle, string collection, string id);
+        void Disconnect(int handle);
+        Task<Snapshot<T>> FetchDocAsync<T>(int handle, string collection, string id);
+        void Start(object options);
+        void Stop();
+        Task<Snapshot<T>> SubmitOpAsync<T>(int handle, string collection, string id, object op);
+    }
+}

--- a/src/SIL.XForge/Realtime/IRealtimeService.cs
+++ b/src/SIL.XForge/Realtime/IRealtimeService.cs
@@ -16,5 +16,6 @@ namespace SIL.XForge.Realtime
         IQueryable<T> QuerySnapshots<T>() where T : IIdentifiable;
 
         Task DeleteProjectAsync(string projectId);
+        Task DeleteUserAsync(string userId);
     }
 }

--- a/src/SIL.XForge/Realtime/MemoryRealtimeService.cs
+++ b/src/SIL.XForge/Realtime/MemoryRealtimeService.cs
@@ -41,6 +41,11 @@ namespace SIL.XForge.Realtime
             _docConfigs = new Dictionary<Type, DocConfig>();
         }
 
+        /// <summary>
+        /// Count of calls to DeleteUserAsync(), for tests.
+        /// </summary>
+        internal int CallCountDeleteUserAsync { get; set; } = 0;
+
         public void StartServer()
         {
         }
@@ -56,6 +61,12 @@ namespace SIL.XForge.Realtime
 
         public virtual Task DeleteProjectAsync(string projectId)
         {
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteUserAsync(string userId)
+        {
+            CallCountDeleteUserAsync++;
             return Task.CompletedTask;
         }
 

--- a/src/SIL.XForge/Realtime/RealtimeServer.cs
+++ b/src/SIL.XForge/Realtime/RealtimeServer.cs
@@ -4,7 +4,7 @@ using Jering.Javascript.NodeJS;
 
 namespace SIL.XForge.Realtime
 {
-    public class RealtimeServer
+    public class RealtimeServer : IRealtimeServer
     {
         private readonly INodeJSService _nodeJSService;
         private readonly string _modulePath;

--- a/src/SIL.XForge/Realtime/RealtimeService.cs
+++ b/src/SIL.XForge/Realtime/RealtimeService.cs
@@ -26,7 +26,7 @@ namespace SIL.XForge.Realtime
         private readonly Dictionary<Type, DocConfig> _docConfigs;
         private readonly IConfiguration _configuration;
 
-        public RealtimeService(RealtimeServer server, IOptions<SiteOptions> siteOptions,
+        public RealtimeService(IRealtimeServer server, IOptions<SiteOptions> siteOptions,
             IOptions<DataAccessOptions> dataAccessOptions, IOptions<RealtimeOptions> realtimeOptions,
             IOptions<AuthOptions> authOptions, IMongoClient mongoClient, IConfiguration configuration)
         {
@@ -46,7 +46,7 @@ namespace SIL.XForge.Realtime
                 AddDocConfig(projectDataDoc);
         }
 
-        internal RealtimeServer Server { get; }
+        internal IRealtimeServer Server { get; }
 
         public void StartServer()
         {
@@ -80,8 +80,16 @@ namespace SIL.XForge.Realtime
             return docConfig.CollectionName;
         }
 
+        /// <summary>
+        /// Delete project-related docs from various collections.
+        /// </summary>
         public async Task DeleteProjectAsync(string projectId)
         {
+            if (string.IsNullOrEmpty(projectId))
+            {
+                throw new ArgumentException("", nameof(projectId));
+            }
+
             RealtimeOptions options = _realtimeOptions.Value;
             var tasks = new List<Task>();
             foreach (DocConfig docConfig in options.ProjectDataDocs)

--- a/src/SIL.XForge/Realtime/RealtimeServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Realtime/RealtimeServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<IJsonService, RealtimeJsonService>();
 
             services.Configure(configureOptions);
-            services.AddSingleton<RealtimeServer>();
+            services.AddSingleton<IRealtimeServer, RealtimeServer>();
             services.AddSingleton<IRealtimeService, RealtimeService>();
             return services;
         }

--- a/src/SIL.XForge/Services/IProjectService.cs
+++ b/src/SIL.XForge/Services/IProjectService.cs
@@ -13,5 +13,6 @@ namespace SIL.XForge.Services
             Stream inputStream);
         Task DeleteAudioAsync(string curUserId, string projectId, string ownerId, string dataId);
         Task SetSyncDisabledAsync(string curUserId, string systemRole, string projectId, bool isDisabled);
+        Task RemoveUserFromAllProjectsAsync(string curUserId, string projectUserId);
     }
 }

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using SIL.XForge.Configuration;
@@ -54,8 +57,15 @@ namespace SIL.XForge.Services
             }
         }
 
+        /// <summary>
+        /// Disassociate user projectUserId from project projectId, if curUserId is allowed to cause that.
+        /// </summary>
         public async Task RemoveUserAsync(string curUserId, string projectId, string projectUserId)
         {
+            if (curUserId == null || projectId == null || projectUserId == null)
+            {
+                throw new ArgumentNullException();
+            }
             using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
             {
                 IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
@@ -164,9 +174,13 @@ namespace SIL.XForge.Services
             await userDoc.SubmitJson0OpAsync(op => op.Add(u => u.Sites[siteId].Projects, projectDoc.Id));
         }
 
-        protected virtual async Task RemoveUserFromProjectAsync(IConnection conn, IDocument<TModel> projectDoc,
+        internal protected virtual async Task RemoveUserFromProjectAsync(IConnection conn, IDocument<TModel> projectDoc,
             IDocument<User> userDoc)
         {
+            if (conn == null || projectDoc == null || userDoc == null)
+            {
+                throw new ArgumentNullException();
+            }
             if (projectDoc.IsLoaded)
                 await projectDoc.SubmitJson0OpAsync(op => op.Unset(p => p.UserRoles[userDoc.Id]));
             string siteId = SiteOptions.Value.Id;

--- a/src/SIL.XForge/Services/UserService.cs
+++ b/src/SIL.XForge/Services/UserService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -127,8 +128,25 @@ namespace SIL.XForge.Services
             }
         }
 
+        /// <summary>
+        /// Delete user with SF user id userId. curUserId and systemRole are the SF user id and SF system role of the
+        /// user who is requesting the action.
+        /// </summary>
         public async Task DeleteAsync(string curUserId, string systemRole, string userId)
         {
+            if (string.IsNullOrEmpty(curUserId))
+            {
+                throw new ArgumentException("", nameof(curUserId));
+            }
+            if (string.IsNullOrEmpty(systemRole))
+            {
+                throw new ArgumentException("", nameof(systemRole));
+            }
+            if (string.IsNullOrEmpty(userId))
+            {
+                throw new ArgumentException("", nameof(userId));
+            }
+
             if (systemRole != SystemRole.SystemAdmin && userId != curUserId)
                 throw new ForbiddenException();
 

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -518,6 +518,8 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             string ptProjectDir = Path.Combine("xforge", "sync", "paratext_" + Project01);
             env.FileSystemService.DirectoryExists(ptProjectDir).Returns(true);
+            Assert.That(env.ProjectSecrets.Contains(Project01), Is.True, "setup");
+            // SUT
             await env.Service.DeleteProjectAsync(User01, Project01);
 
             Assert.That(env.ContainsProject(Project01), Is.False);

--- a/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
@@ -30,8 +30,11 @@ namespace SIL.XForge.Realtime
             var env = new TestEnvironment();
             string projectId = "project1id";
 
-            // Set of collections that should be filtered thru to remove matching docs. This set could be different per application (like Scripture Forge, Language Forge, etc.), and the set used here should match what is defined in TestEnvironment.
-            Dictionary<string, IMongoCollection<BsonDocument>> collectionsToBePruned = new Dictionary<string, IMongoCollection<BsonDocument>>();
+            // Set of collections that should be filtered thru to remove matching docs. This set could be different
+            // per application (like Scripture Forge, Language Forge, etc.), and the set used here should match what
+            // is defined in TestEnvironment.
+            Dictionary<string, IMongoCollection<BsonDocument>> collectionsToBePruned =
+                new Dictionary<string, IMongoCollection<BsonDocument>>();
             foreach (string collectionName in (new string[] {
                 "some_projects",
                 "favorite_numbers",
@@ -45,7 +48,8 @@ namespace SIL.XForge.Realtime
             {
                 IMongoCollection<BsonDocument> collection = Substitute.For<IMongoCollection<BsonDocument>>();
                 collectionsToBePruned.Add(collectionName, collection);
-                env.MongoDatabase.GetCollection<BsonDocument>(collectionName).Returns<IMongoCollection<BsonDocument>>(collection);
+                env.MongoDatabase.GetCollection<BsonDocument>(collectionName)
+                    .Returns<IMongoCollection<BsonDocument>>(collection);
             }
             // SUT
             await env.Service.DeleteProjectAsync(projectId);
@@ -56,6 +60,50 @@ namespace SIL.XForge.Realtime
             }
         }
 
+        [Test]
+        public void DeleteUserAsync_BadArguments()
+        {
+            var env = new TestEnvironment();
+            Assert.ThrowsAsync<ArgumentException>(() => env.Service.DeleteUserAsync(null));
+            Assert.ThrowsAsync<ArgumentException>(() => env.Service.DeleteUserAsync(""));
+        }
+
+
+        [Test]
+        public async Task DeleteUserAsync_RequestsDocRemovalsInCollections()
+        {
+            var env = new TestEnvironment();
+            string projectId = "project1id";
+
+            // Set of collections that should be filtered thru to remove matching docs.
+            // This set could be different
+            // per application (like Scripture Forge, Language Forge, etc.), and the set used here should match what
+            // is defined in TestEnvironment.
+            Dictionary<string, IMongoCollection<BsonDocument>> collectionsToBePruned =
+                new Dictionary<string, IMongoCollection<BsonDocument>>();
+            string[] collectionNames = new string[] {
+                "users",
+                "o_users",
+                "favorite_animals",
+                "o_favorite_animals",
+            };
+            foreach (string collectionName in collectionNames)
+            {
+                IMongoCollection<BsonDocument> collection = Substitute.For<IMongoCollection<BsonDocument>>();
+                collectionsToBePruned.Add(collectionName, collection);
+                env.MongoDatabase.GetCollection<BsonDocument>(collectionName)
+                    .Returns<IMongoCollection<BsonDocument>>(collection);
+            }
+            // SUT
+            await env.Service.DeleteUserAsync(projectId);
+            foreach (IMongoCollection<BsonDocument> collectionToPrune in collectionsToBePruned.Values)
+            {
+                // A further enhancement would be checking that the filter._value is the desired regex.
+                collectionToPrune.Received(1).DeleteManyAsync(Arg.Any<FilterDefinition<BsonDocument>>());
+            }
+            env.MongoDatabase.Received(collectionNames.Length).GetCollection<BsonDocument>(Arg.Any<string>());
+        }
+
         private class TestEnvironment
         {
             public RealtimeService Service = null;
@@ -64,23 +112,34 @@ namespace SIL.XForge.Realtime
             {
                 IRealtimeServer realtimeServer = Substitute.For<IRealtimeServer>();
                 IOptions<SiteOptions> siteOptions = Substitute.For<IOptions<SiteOptions>>();
-                IOptions<DataAccessOptions> dataAccessOptions = Microsoft.Extensions.Options.Options.Create<DataAccessOptions>(new DataAccessOptions() { MongoDatabaseName = "mongoDatabaseName" });
-                IOptions<RealtimeOptions> realtimeOptions = Microsoft.Extensions.Options.Options.Create<RealtimeOptions>(new RealtimeOptions()
-                {
-                    ProjectDoc = new DocConfig("some_projects", typeof(Project)),
-                    ProjectDataDocs = new List<DocConfig> {
-                        new DocConfig("favorite_numbers", typeof(int)),
-                        new DocConfig("favorite_things", typeof(object)),
-                        new DocConfig("favorite_verses", typeof(string))
-                    }
-                });
+                IOptions<DataAccessOptions> dataAccessOptions =
+                    Microsoft.Extensions.Options.Options.Create<DataAccessOptions>(new DataAccessOptions()
+                    {
+                        MongoDatabaseName = "mongoDatabaseName"
+                    });
+                IOptions<RealtimeOptions> realtimeOptions =
+                    Microsoft.Extensions.Options.Options.Create<RealtimeOptions>(new RealtimeOptions()
+                    {
+                        ProjectDoc = new DocConfig("some_projects", typeof(Project)),
+                        ProjectDataDocs = new List<DocConfig>
+                        {
+                            new DocConfig("favorite_numbers", typeof(int)),
+                            new DocConfig("favorite_things", typeof(object)),
+                            new DocConfig("favorite_verses", typeof(string))
+                        },
+                        UserDataDocs = new List<DocConfig>
+                        {
+                            new DocConfig("favorite_animals", typeof(object)),
+                        }
+                    });
                 IOptions<AuthOptions> authOptions = Substitute.For<IOptions<AuthOptions>>();
 
                 IMongoClient mongoClient = Substitute.For<IMongoClient>();
                 mongoClient.GetDatabase(Arg.Any<string>()).Returns(MongoDatabase);
                 IConfiguration configuration = Substitute.For<IConfiguration>();
 
-                Service = new RealtimeService(realtimeServer, siteOptions, dataAccessOptions, realtimeOptions, authOptions, mongoClient, configuration);
+                Service = new RealtimeService(realtimeServer, siteOptions, dataAccessOptions, realtimeOptions,
+                    authOptions, mongoClient, configuration);
             }
         }
     }

--- a/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+using NSubstitute;
+using NUnit.Framework;
+using SIL.XForge.Configuration;
+using System.Collections.Generic;
+using System;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using SIL.XForge.Models;
+
+namespace SIL.XForge.Realtime
+{
+    [TestFixture]
+    public class RealtimeServiceTests
+    {
+
+        [Test]
+        public void DeleteProjectAsync_BadArguments()
+        {
+            var env = new TestEnvironment();
+            Assert.ThrowsAsync<ArgumentException>(() => env.Service.DeleteProjectAsync(null));
+            Assert.ThrowsAsync<ArgumentException>(() => env.Service.DeleteProjectAsync(""));
+        }
+
+        [Test]
+        public async Task DeleteProjectAsync_RequestsDocRemovalsInCollections()
+        {
+            var env = new TestEnvironment();
+            string projectId = "project1id";
+
+            // Set of collections that should be filtered thru to remove matching docs. This set could be different per application (like Scripture Forge, Language Forge, etc.), and the set used here should match what is defined in TestEnvironment.
+            Dictionary<string, IMongoCollection<BsonDocument>> collectionsToBePruned = new Dictionary<string, IMongoCollection<BsonDocument>>();
+            foreach (string collectionName in (new string[] {
+                "some_projects",
+                "favorite_numbers",
+                "favorite_things",
+                "favorite_verses",
+                "o_some_projects",
+                "o_favorite_numbers",
+                "o_favorite_things",
+                "o_favorite_verses",
+                }))
+            {
+                IMongoCollection<BsonDocument> collection = Substitute.For<IMongoCollection<BsonDocument>>();
+                collectionsToBePruned.Add(collectionName, collection);
+                env.MongoDatabase.GetCollection<BsonDocument>(collectionName).Returns<IMongoCollection<BsonDocument>>(collection);
+            }
+            // SUT
+            await env.Service.DeleteProjectAsync(projectId);
+            foreach (IMongoCollection<BsonDocument> collectionToPrune in collectionsToBePruned.Values)
+            {
+                // A further enhancement would be checking that the filter._value is the desired regex.
+                collectionToPrune.Received(1).DeleteManyAsync(Arg.Any<FilterDefinition<BsonDocument>>());
+            }
+        }
+
+        private class TestEnvironment
+        {
+            public RealtimeService Service = null;
+            public IMongoDatabase MongoDatabase = Substitute.For<IMongoDatabase>();
+            public TestEnvironment()
+            {
+                IRealtimeServer realtimeServer = Substitute.For<IRealtimeServer>();
+                IOptions<SiteOptions> siteOptions = Substitute.For<IOptions<SiteOptions>>();
+                IOptions<DataAccessOptions> dataAccessOptions = Microsoft.Extensions.Options.Options.Create<DataAccessOptions>(new DataAccessOptions() { MongoDatabaseName = "mongoDatabaseName" });
+                IOptions<RealtimeOptions> realtimeOptions = Microsoft.Extensions.Options.Options.Create<RealtimeOptions>(new RealtimeOptions()
+                {
+                    ProjectDoc = new DocConfig("some_projects", typeof(Project)),
+                    ProjectDataDocs = new List<DocConfig> {
+                        new DocConfig("favorite_numbers", typeof(int)),
+                        new DocConfig("favorite_things", typeof(object)),
+                        new DocConfig("favorite_verses", typeof(string))
+                    }
+                });
+                IOptions<AuthOptions> authOptions = Substitute.For<IOptions<AuthOptions>>();
+
+                IMongoClient mongoClient = Substitute.For<IMongoClient>();
+                mongoClient.GetDatabase(Arg.Any<string>()).Returns(MongoDatabase);
+                IConfiguration configuration = Substitute.For<IConfiguration>();
+
+                Service = new RealtimeService(realtimeServer, siteOptions, dataAccessOptions, realtimeOptions, authOptions, mongoClient, configuration);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR is broken into two commits [for code review. We can squash to one commit for merging.]. The first commit adds some tests and makes some changes to allow for testing. Its commit message is:

SF-798 First add tests and prepare for delete-user implementation

- Add comments.
- Introduce IRealtimeServer to allow mocking.
- Add early-crash argument checking to some methods. This should be
the commit's only behavioural change.
- Expose RemoveUserFromProjectAsync() as internal for unit testing.
- Add tests for existing functionality.
- ProjectServiceTests Sites are expanded to be consistent with
TestProject documents, for these or follow-up tests.

The second commit makes the actual changes for SF-798. Some items to point out are:

- ProjectService RemoveUserAsync() can silently fail if there are
  simultaneous requests. So wrap in a mutex.
- When a sysadmin deletes a user, SF runs UserService
  DeleteAsync(), which calls:
  - ProjectService.RemoveUserFromAllProjectsAsync()
    which calls RemoveUserCoreAsync() for each user doc Sites.Projects
      which calls RemoveUserFromProjectAsync().
  - RealtimeService.DeleteUserAsync(), removing docs from collections
    users, user_secrets, sf_project_user_configs,
    o_users, and o_sf_project_user_configs.
  - And no longer userDoc.DeleteAsync(), which shouldn't be needed
    now.
- RealtimeService DeleteUserAsync() removes docs that are matched by
  '_id' or 'd'. Some of these matches are for the whole field. Some
  matches are just for the ending part of the field (for example a
  sf_project_user_configs, which uses an _id of the format
  project_id:user_id. Further, some collections have corresponding o_
  OT collections, and some do not. How to match the '_id' and 'd', and
  whether there is a corresponding o_ OT collection, is collected in
  an anonymous type that makes use of a Location enum.
  Location.Beginning is included in the enum for completeness.
- The knowledge for what collections to look in, and how to match
  documents to ids, can be defined per-application, and here is done
  in SFRealtimeServiceCollectionExtensions.cs.
- RealtimeService.cs: `foreach.. AddDocConfig(userDataDoc)` may not
  have been necessary, but looked like it could be helpful.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/896)
<!-- Reviewable:end -->
