### PR TITLE
SF-1165a Update sharedb beta to prepare for future upgrade

### DIFF
--- a/src/RealtimeServer/common/services/doc-service.ts
+++ b/src/RealtimeServer/common/services/doc-service.ts
@@ -50,7 +50,7 @@ export abstract class DocService<T = any> {
   }
 
   protected addUpdateListener(server: RealtimeServer, handler: (docId: string, ops: any) => Promise<void>): void {
-    server.use('afterSubmit', (context, callback) => {
+    server.use('afterWrite', (context, callback) => {
       if (context.collection === this.collection) {
         handler(context.id, context.op.op)
           .then(() => callback())

--- a/src/RealtimeServer/common/services/project-data-service.ts
+++ b/src/RealtimeServer/common/services/project-data-service.ts
@@ -49,7 +49,7 @@ export abstract class ProjectDataService<T extends ProjectData> extends JsonDocS
   init(server: RealtimeServer): void {
     super.init(server);
     if (this.listenForUpdates) {
-      server.use('afterSubmit', (context, callback) => {
+      server.use('afterWrite', (context, callback) => {
         if (context.collection === this.collection) {
           this.handleAfterSubmit(context)
             .then(() => callback())

--- a/src/RealtimeServer/package-lock.json
+++ b/src/RealtimeServer/package-lock.json
@@ -1688,7 +1688,8 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
     },
     "deepmerge": {
       "version": "4.2.2",
@@ -4767,13 +4768,13 @@
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "sharedb": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-1.0.0-beta.23.tgz",
-      "integrity": "sha512-Kb2AhiiUNnHNqA4Ls9F3xcUn3hz577k0LxIwalKaFbptCDW6A5eGM1XLihXRAi+M4UV3KEbpB/0fG4vhQHkB4g==",
+      "version": "1.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-1.0.0-beta.31.tgz",
+      "integrity": "sha512-dSx3UHh+W/AiOmtF/0ck/MUa0BfwJAnHFtC6cVVR6clZhNvFp6bfVWeT2yDM2YVr2RZhshbEO8AO20oHu/D5cA==",
       "requires": {
         "arraydiff": "^0.1.1",
         "async": "^1.4.2",
-        "deep-is": "^0.1.3",
+        "fast-deep-equal": "^2.0.1",
         "hat": "0.0.3",
         "make-error": "^1.1.1",
         "ot-json0": "^1.0.1"

--- a/src/RealtimeServer/package.json
+++ b/src/RealtimeServer/package.json
@@ -21,7 +21,7 @@
     "mongodb": "^3.3.5",
     "ot-json0": "^1.1.0",
     "rich-text": "^3.1.0",
-    "sharedb": "^1.0.0-beta.23",
+    "sharedb": "1.0.0-beta.31",
     "sharedb-access": "^5.0.0",
     "sharedb-mongo": "^1.0.0-beta.11",
     "ts-object-path": "^0.1.2",

--- a/src/RealtimeServer/tsconfig.json
+++ b/src/RealtimeServer/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "noEmit": true,
     "sourceMap": true,
     "declaration": true,
     "target": "es6",

--- a/src/RealtimeServer/typings/sharedb/index.d.ts
+++ b/src/RealtimeServer/typings/sharedb/index.d.ts
@@ -121,9 +121,13 @@ declare namespace ShareDB {
   class Agent {
     constructor(backend: ShareDB, stream: any);
 
+    protected clientId: string;
+
     close(err: any): void;
     _open(): void;
-    _createOp(request: any): any;
+    _handleMessage(request: any, callback: (...args: any[]) => any): void;
+    _checkRequest(request: any): string | undefined;
+    _submit(collection: string, id: string, op: any, callback: (...args: any[]) => any): void;
   }
 
   abstract class PubSub {

--- a/src/RealtimeServer/typings/sharedb/index.d.ts
+++ b/src/RealtimeServer/typings/sharedb/index.d.ts
@@ -180,7 +180,7 @@ declare namespace ShareDB {
 
   namespace middleware {
     interface ActionContextMap {
-      afterSubmit: SubmitContext;
+      afterWrite: SubmitContext;
       apply: ApplyContext;
       commit: CommitContext;
       connect: ConnectContext;

--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -6163,11 +6163,6 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
-    "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
-    },
     "default-gateway": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
@@ -8427,7 +8422,8 @@
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "inquirer": {
       "version": "7.3.3",
@@ -16604,7 +16600,7 @@
         "mongodb": "^3.3.5",
         "ot-json0": "^1.1.0",
         "rich-text": "^3.1.0",
-        "sharedb": "^1.0.0-beta.23",
+        "sharedb": "1.0.0-beta.31",
         "sharedb-access": "^5.0.0",
         "sharedb-mongo": "^1.0.0-beta.11",
         "ts-object-path": "^0.1.2",
@@ -19980,9 +19976,9 @@
           }
         },
         "make-error": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-          "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+          "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
         },
         "makeerror": {
           "version": "1.0.11",
@@ -20974,13 +20970,13 @@
           "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
         },
         "sharedb": {
-          "version": "1.0.0-beta.23",
-          "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-1.0.0-beta.23.tgz",
-          "integrity": "sha512-Kb2AhiiUNnHNqA4Ls9F3xcUn3hz577k0LxIwalKaFbptCDW6A5eGM1XLihXRAi+M4UV3KEbpB/0fG4vhQHkB4g==",
+          "version": "1.0.0-beta.31",
+          "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-1.0.0-beta.31.tgz",
+          "integrity": "sha512-dSx3UHh+W/AiOmtF/0ck/MUa0BfwJAnHFtC6cVVR6clZhNvFp6bfVWeT2yDM2YVr2RZhshbEO8AO20oHu/D5cA==",
           "requires": {
             "arraydiff": "^0.1.1",
             "async": "^1.4.2",
-            "deep-is": "^0.1.3",
+            "fast-deep-equal": "^2.0.1",
             "hat": "0.0.3",
             "make-error": "^1.1.1",
             "ot-json0": "^1.0.1"
@@ -22809,13 +22805,13 @@
       }
     },
     "sharedb": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-1.0.0-beta.23.tgz",
-      "integrity": "sha512-Kb2AhiiUNnHNqA4Ls9F3xcUn3hz577k0LxIwalKaFbptCDW6A5eGM1XLihXRAi+M4UV3KEbpB/0fG4vhQHkB4g==",
+      "version": "1.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-1.0.0-beta.31.tgz",
+      "integrity": "sha512-dSx3UHh+W/AiOmtF/0ck/MUa0BfwJAnHFtC6cVVR6clZhNvFp6bfVWeT2yDM2YVr2RZhshbEO8AO20oHu/D5cA==",
       "requires": {
         "arraydiff": "^0.1.1",
         "async": "^1.4.2",
-        "deep-is": "^0.1.3",
+        "fast-deep-equal": "^2.0.1",
         "hat": "0.0.3",
         "make-error": "^1.1.1",
         "ot-json0": "^1.0.1"

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -64,7 +64,7 @@
     "recordrtc": "^5.5.7",
     "rich-text": "^3.1.0",
     "rxjs": "6.6.2",
-    "sharedb": "^1.0.0-beta.23",
+    "sharedb": "^1.0.0-beta.31",
     "tslib": "^2.0.3",
     "uuid": "^3.3.2",
     "xregexp": "^4.3.0",


### PR DESCRIPTION
In order to upgrade to sharedb v1.0.0 from the beta sharedb, we need to update to v1.0.0-beta.31 and allow users' browsers to update. This beta will be forward compatible to the v1.0.0 release. See [sharedb beta client compatibility](https://github.com/share/sharedb/wiki/Upgrading-to-sharedb@1.0.0-from-1.0.0-beta#beta-client-compatibility)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/897)
<!-- Reviewable:end -->
