### PR TITLE
SF-1154 Allow selecting resource a project is based on

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
@@ -19,6 +19,7 @@ import { CheckingModule } from './checking/checking.module';
 import { ConnectProjectComponent } from './connect-project/connect-project.component';
 import { CoreModule } from './core/core.module';
 import { ProjectDeletedDialogComponent } from './project-deleted-dialog/project-deleted-dialog.component';
+import { ProjectSelectComponent } from './project-select/project-select.component';
 import { ProjectComponent } from './project/project.component';
 import { ScriptureChooserDialogComponent } from './scripture-chooser-dialog/scripture-chooser-dialog.component';
 import { DeleteProjectDialogComponent } from './settings/delete-project-dialog/delete-project-dialog.component';
@@ -41,7 +42,8 @@ import { UsersModule } from './users/users.module';
     ScriptureChooserDialogComponent,
     SupportedBrowsersDialogComponent,
     ErrorComponent,
-    EditNameDialogComponent
+    EditNameDialogComponent,
+    ProjectSelectComponent
   ],
   imports: [
     BrowserModule.withServerTransition({ appId: 'ng-cli-universal' }),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -39,7 +39,6 @@ import { Snapshot } from 'xforge-common/models/snapshot';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { UserProfileDoc } from 'xforge-common/models/user-profile-doc';
 import { NoticeService } from 'xforge-common/notice.service';
-import { ProjectService } from 'xforge-common/project.service';
 import { PwaService } from 'xforge-common/pwa.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
@@ -84,18 +84,16 @@
             class="indented-field-row"
           >
             <div fxFlex="44px" class="indent"></div>
-            <mdc-form-field fxLayout="column" fxLayoutAlign="start" id="based-on-field">
-              <mdc-select placeholder="{{ t('based_on') }}" formControlName="sourceParatextId">
-                <mdc-menu>
-                  <mdc-list>
-                    <mdc-list-item *ngFor="let project of sourceProjects" [value]="project.paratextId">
-                      {{ project.name }}
-                    </mdc-list-item>
-                  </mdc-list>
-                </mdc-menu>
-              </mdc-select>
+            <div fxLayout="column" fxFlex="grow">
+              <app-project-select
+                formControlName="sourceParatextId"
+                placeholder="{{ t('based_on') }}"
+                [projects]="projects"
+                [resources]="resources"
+                [hideProjectId]="paratextIdControl.value"
+              ></app-project-select>
               <div class="helper-text">{{ t("choose_the_mother_project") }}</div>
-            </mdc-form-field>
+            </div>
           </div>
         </div>
         <mdc-list-divider></mdc-list-divider>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -11,7 +11,6 @@ import { ProjectService } from 'xforge-common/project.service';
 import { QueryParameters } from 'xforge-common/query-parameters';
 import { RealtimeService } from 'xforge-common/realtime.service';
 import { TransceleratorQuestion } from '../checking/import-questions-dialog/import-questions-dialog.component';
-import { MachineHttpClient } from './machine-http-client';
 import { QuestionDoc } from './models/question-doc';
 import { SFProjectCreateSettings } from './models/sf-project-create-settings';
 import { SFProjectDoc } from './models/sf-project-doc';
@@ -30,7 +29,6 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
   constructor(
     realtimeService: RealtimeService,
     commandService: CommandService,
-    private readonly machineHttp: MachineHttpClient,
     private readonly fileService: FileService
   ) {
     super(realtimeService, commandService, SF_PROJECT_ROLES);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.html
@@ -1,0 +1,24 @@
+<ng-container *transloco="let t; read: 'project_select'">
+  <mat-form-field>
+    <input
+      type="text"
+      matInput
+      [placeholder]="placeholder"
+      [formControl]="paratextIdControl"
+      [matAutocomplete]="auto"
+    />
+    <mat-autocomplete
+      #auto="matAutocomplete"
+      [displayWith]="projectDisplayText"
+      (opened)="autocompleteOpened()"
+      class="project-select"
+    >
+      <mat-optgroup label="{{ t('projects') }}" *ngIf="(projects$ | async).length > 0">
+        <mat-option *ngFor="let project of projects$ | async" [value]="project">{{ project.name }}</mat-option>
+      </mat-optgroup>
+      <mat-optgroup label="{{ t('resources') }}" *ngIf="(resources$ | async).length > 0">
+        <mat-option *ngFor="let resource of resources$ | async" [value]="resource">{{ resource.name }}</mat-option>
+      </mat-optgroup>
+    </mat-autocomplete>
+  </mat-form-field>
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.scss
@@ -1,0 +1,13 @@
+:host,
+mat-form-field {
+  width: 100%;
+}
+
+::ng-deep .mat-autocomplete-panel.project-select mat-option {
+  height: unset;
+  white-space: initial;
+  min-height: 48px;
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+  line-height: 1.5em;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.spec.ts
@@ -1,0 +1,158 @@
+import { Component, ViewChild } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { FormControl, FormGroup } from '@angular/forms';
+import { MatAutocomplete } from '@angular/material/autocomplete';
+import { MatFormField } from '@angular/material/form-field';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TestTranslocoModule } from 'xforge-common/test-utils';
+import { UICommonModule } from 'xforge-common/ui-common.module';
+import { SelectableProject } from '../core/paratext.service';
+import { ProjectSelectComponent } from './project-select.component';
+
+describe('ProjectSelectComponent', () => {
+  it('should list projects and resources', fakeAsync(() => {
+    const env = new TestEnvironment('p02');
+    // Expect two projects and two resources (one of the projects should be hidden)
+    expect(env.groupLabels.length).toBe(2);
+    expect(env.groupLabels[0]).toBe('Projects');
+    expect(env.groupLabels[1]).toBe('Resources');
+    expect(env.optionsText(0)).toEqual(['Project 1', 'Project 3']);
+    expect(env.optionsText(1)).toEqual(['Resource 1', 'Resource 2']);
+  }));
+
+  it('it only lists groups with menu items', fakeAsync(() => {
+    const env = new TestEnvironment(undefined, undefined, []);
+    expect(env.groupLabels.length).toBe(1);
+  }));
+
+  it('functions as a form control', fakeAsync(() => {
+    const env = new TestEnvironment();
+    expect(env.component.sourceParatextId.value).toBeNull();
+    env.clickOption(0, 0);
+    expect(env.component.sourceParatextId.value).toBe('p01');
+    env.openMenu();
+    env.clickOption(1, 1);
+    expect(env.component.sourceParatextId.value).toBe('r02');
+  }));
+
+  it("doesn't list hidden projects", fakeAsync(() => {
+    const env = new TestEnvironment();
+    expect(env.component.sourceParatextId.value).toBeNull();
+    env.clickOption(0, 0);
+    expect(env.component.sourceParatextId.value).toBe('p01');
+    env.openMenu();
+    env.clickOption(1, 1);
+    expect(env.component.sourceParatextId.value).toBe('r02');
+  }));
+
+  it('adds list items as the user scrolls the list', fakeAsync(() => {
+    const resources = [...Array(100).keys()].map(key => ({ paratextId: 'r' + key, name: 'Resource ' + (key + 1) }));
+    const env = new TestEnvironment('p03', undefined, resources);
+    expect(env.optGroups.length).toBe(2);
+    expect(env.optionsText(0)).toEqual(['Project 1', 'Project 2']);
+    expect(env.options(1).length).toBe(25);
+    env.scrollMenu(2500);
+    expect(env.options(1).length).toBe(50);
+  }));
+});
+
+@Component({
+  selector: 'app-host',
+  template: `<form [formGroup]="connectProjectForm">
+    <app-project-select
+      formControlName="sourceParatextId"
+      placeholder="Based on"
+      [projects]="projects"
+      [resources]="resources"
+      [hideProjectId]="hideProjectId"
+      [nonSelectableProjects]="nonSelectableProjects"
+    ></app-project-select>
+  </form>`
+})
+class HostComponent {
+  readonly sourceParatextId = new FormControl(undefined);
+  readonly connectProjectForm = new FormGroup({ sourceParatextId: this.sourceParatextId });
+
+  @ViewChild(ProjectSelectComponent) projectSelect!: ProjectSelectComponent;
+
+  projects: SelectableProject[] = [
+    { name: 'Project 1', paratextId: 'p01' },
+    { name: 'Project 2', paratextId: 'p02' },
+    { name: 'Project 3', paratextId: 'p03' }
+  ];
+  resources: SelectableProject[] = [
+    { name: 'Resource 1', paratextId: 'r01' },
+    { name: 'Resource 2', paratextId: 'r02' }
+  ];
+  nonSelectableProjects: SelectableProject[] = [{ name: 'Project 1', paratextId: 'p01' }];
+  hideProjectId: string = '';
+}
+
+class TestEnvironment {
+  readonly fixture: ComponentFixture<HostComponent>;
+  component: HostComponent;
+
+  constructor(
+    hideProjectId?: string,
+    projects?: SelectableProject[],
+    resources?: SelectableProject[],
+    nonSelectableProjects?: SelectableProject[]
+  ) {
+    TestBed.configureTestingModule({
+      declarations: [HostComponent, ProjectSelectComponent, MatFormField, MatAutocomplete],
+      imports: [UICommonModule, TestTranslocoModule, NoopAnimationsModule]
+    });
+
+    this.fixture = TestBed.createComponent(HostComponent);
+    this.component = this.fixture.componentInstance;
+
+    this.component.projects = projects || this.component.projects;
+    this.component.resources = resources || this.component.resources;
+    this.component.nonSelectableProjects = nonSelectableProjects || this.component.nonSelectableProjects;
+    this.component.hideProjectId = hideProjectId || this.component.hideProjectId;
+
+    this.fixture.detectChanges();
+    tick();
+    this.openMenu();
+  }
+
+  openMenu() {
+    this.component.projectSelect.autocompleteTrigger.openPanel();
+    this.fixture.detectChanges();
+    tick();
+  }
+
+  options(group: number) {
+    return Array.from(this.optGroups[group].querySelectorAll('mat-option'));
+  }
+
+  optionsText(group: number): string[] {
+    return this.options(group).map(option => option.textContent || '');
+  }
+
+  clickOption(group: number, item: number) {
+    (this.options(group)[item] as HTMLElement).click();
+    this.fixture.detectChanges();
+    tick();
+  }
+
+  scrollMenu(top: number) {
+    this.panel.scrollTop = 2500;
+    // Just scrolling the element doesn't cause the event to be fired
+    this.panel.dispatchEvent(new Event('scroll'));
+    this.fixture.detectChanges();
+    tick();
+  }
+
+  get panel(): HTMLElement {
+    return this.component.projectSelect.autocomplete.panel.nativeElement as HTMLElement;
+  }
+
+  get optGroups() {
+    return Array.from(this.panel.querySelectorAll('mat-optgroup'));
+  }
+
+  get groupLabels(): string[] {
+    return Array.from(this.panel.querySelectorAll('mat-optgroup label')).map(e => e.textContent?.trim() || '');
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
@@ -1,0 +1,136 @@
+import { Component, EventEmitter, forwardRef, Input, Output, ViewChild } from '@angular/core';
+import { ControlValueAccessor, FormControl, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { MatAutocomplete, MatAutocompleteTrigger } from '@angular/material/autocomplete';
+import { BehaviorSubject, combineLatest, fromEvent, Observable } from 'rxjs';
+import { map, startWith, takeUntil, tap } from 'rxjs/operators';
+import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
+import { SelectableProject } from '../core/paratext.service';
+
+// A value accessor is necessary in order to create a custom form control
+export const PROJECT_SELECT_VALUE_ACCESSOR: any = {
+  provide: NG_VALUE_ACCESSOR,
+  useExisting: forwardRef(() => ProjectSelectComponent),
+  multi: true
+};
+
+@Component({
+  selector: 'app-project-select',
+  templateUrl: 'project-select.component.html',
+  styleUrls: ['project-select.component.scss'],
+  providers: [PROJECT_SELECT_VALUE_ACCESSOR]
+})
+export class ProjectSelectComponent extends SubscriptionDisposable implements ControlValueAccessor {
+  @Output() valueChange: EventEmitter<string> = new EventEmitter<string>(true);
+
+  @Input() placeholder = '';
+
+  @ViewChild(MatAutocomplete) autocomplete!: MatAutocomplete;
+  @ViewChild(MatAutocompleteTrigger) autocompleteTrigger!: MatAutocompleteTrigger;
+
+  readonly paratextIdControl = new FormControl();
+
+  @Input() projects?: SelectableProject[];
+  @Input() resources?: SelectableProject[];
+  /** Projects that can be an already selected value, but not given as an option in the menu */
+  @Input() nonSelectableProjects?: SelectableProject[];
+
+  hideProjectId$ = new BehaviorSubject<string>('');
+
+  resourceCountLimit$ = new BehaviorSubject<number>(25);
+
+  projects$: Observable<SelectableProject[]> = combineLatest(
+    this.paratextIdControl.valueChanges.pipe(startWith('')),
+    this.hideProjectId$
+  ).pipe(map(value => this.filterGroup(value[0], this.projects || [])));
+
+  resources$: Observable<SelectableProject[]> = combineLatest(
+    this.paratextIdControl.valueChanges.pipe(startWith('')),
+    this.resourceCountLimit$,
+    this.hideProjectId$
+  ).pipe(map(value => this.filterGroup(value[0], this.resources || [], value[1])));
+
+  constructor() {
+    super();
+    this.subscribe(this.paratextIdControl.valueChanges, (value: SelectableProject) =>
+      this.valueChange.next(value.paratextId)
+    );
+  }
+
+  @Input() set value(id: string) {
+    const project =
+      this.projects?.find(p => p.paratextId === id) ||
+      this.resources?.find(r => r.paratextId === id) ||
+      this.nonSelectableProjects?.find(p => p.paratextId === id);
+    if (project != null) {
+      this.paratextIdControl.setValue(project);
+    }
+  }
+
+  @Input() set disabled(value: boolean) {
+    if (value) {
+      this.paratextIdControl.disable();
+    } else {
+      this.paratextIdControl.enable();
+    }
+  }
+  get disabled(): boolean {
+    return this.paratextIdControl.disabled;
+  }
+
+  @Input() set hideProjectId(value: string) {
+    if (this.paratextIdControl.value?.paratextId === value) {
+      this.paratextIdControl.setValue('');
+    }
+    this.hideProjectId$.next(value);
+  }
+  get hideProjectId(): string {
+    return this.hideProjectId$.getValue();
+  }
+
+  writeValue(value: any): void {
+    this.value = value;
+  }
+
+  registerOnChange(fn: any): void {
+    this.subscribe(this.valueChange, fn);
+  }
+
+  registerOnTouched(fn: any): void {
+    this.subscribe(this.valueChange, fn);
+  }
+
+  projectDisplayText(project?: SelectableProject): string {
+    return project?.name || '';
+  }
+
+  autocompleteOpened() {
+    setTimeout(() => {
+      if (this.autocomplete && this.autocomplete.panel && this.autocompleteTrigger) {
+        fromEvent(this.autocomplete.panel.nativeElement, 'scroll')
+          .pipe(
+            map(() => this.autocomplete.panel.nativeElement.scrollTop),
+            takeUntil(this.autocompleteTrigger.panelClosingActions.pipe(tap(() => this.resourceCountLimit$.next(25))))
+          )
+          .subscribe(() => {
+            const panel = this.autocomplete.panel.nativeElement;
+            // if scrolled to within 100px of bottom, display more resources
+            if (this.resources != null && panel.scrollHeight <= panel.scrollTop + panel.clientHeight + 100) {
+              this.resourceCountLimit$.next(Math.min(this.resourceCountLimit$.getValue() + 25, this.resources.length));
+            }
+          });
+      }
+    });
+  }
+
+  private filterGroup(
+    value: string | SelectableProject,
+    collection: SelectableProject[],
+    limit?: number
+  ): SelectableProject[] {
+    const valueLower = typeof value === 'string' ? value.toLocaleLowerCase() : '';
+    return collection
+      .filter(project => project.name.toLowerCase().includes(valueLower) && project.paratextId !== this.hideProjectId)
+      .sort((a, b) => a.name.toLowerCase().indexOf(valueLower) - b.name.toLowerCase().indexOf(valueLower))
+      .slice(0, limit);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -54,21 +54,13 @@
               <ng-container *ngIf="translationSuggestionsEnabled && isLoggedInToParatext">
                 <div class="tool-setting select-indent">
                   <div class="tool-setting-field">
-                    <mdc-form-field fxFlexFill>
-                      <mdc-select
-                        placeholder="{{ t('based_on') }}"
-                        formControlName="sourceParatextId"
-                        id="based-on-select"
-                      >
-                        <mdc-menu>
-                          <mdc-list>
-                            <mdc-list-item *ngFor="let project of sourceProjects" [value]="project.paratextId">
-                              {{ project.name }}
-                            </mdc-list-item>
-                          </mdc-list>
-                        </mdc-menu>
-                      </mdc-select>
-                    </mdc-form-field>
+                    <app-project-select
+                      formControlName="sourceParatextId"
+                      placeholder="{{ t('based_on') }}"
+                      [projects]="projects"
+                      [resources]="resources"
+                      [nonSelectableProjects]="nonSelectableProjects"
+                    ></app-project-select>
                     <app-write-status
                       [state]="getControlState('sourceParatextId')"
                       [formGroup]="form"

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -113,6 +113,10 @@
     "previous_page": "Previous page",
     "range_label": "{{ startIndex }} - {{ endIndex }} of {{ length }}"
   },
+  "project_select": {
+    "projects": "Projects",
+    "resources": "Resources"
+  },
   "question_answered_dialog": {
     "cancel": "Cancel",
     "consider_creating_new_question": "Consider creating a new question instead of editing this question.",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -24,8 +24,10 @@ import { MdcTypographyModule } from '@angular-mdc/web/typography';
 import { NgModule } from '@angular/core';
 import { BREAKPOINT, FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatOptionModule } from '@angular/material/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
 import { MatPaginatorIntl, MatPaginatorModule } from '@angular/material/paginator';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSelectModule } from '@angular/material/select';
@@ -43,6 +45,8 @@ const modules = [
   DonutChartModule,
   FlexLayoutModule,
   FormsModule,
+  MatAutocompleteModule,
+  MatInputModule,
   MatFormFieldModule,
   MatOptionModule,
   MatPaginatorModule,

--- a/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Security;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -58,7 +59,7 @@ namespace SIL.XForge.Scripture.Controllers
         /// so we just return the base class <see cref="ParatextProject" />.
         /// </remarks>
         [HttpGet("resources")]
-        public async Task<ActionResult<IEnumerable<ParatextProject>>> ResourcesAsync()
+        public async Task<ActionResult<Dictionary<string, string>>> ResourcesAsync()
         {
             Attempt<UserSecret> attempt = await _userSecrets.TryGetAsync(_userAccessor.UserId);
             if (!attempt.TryResult(out UserSecret userSecret))
@@ -67,7 +68,7 @@ namespace SIL.XForge.Scripture.Controllers
             try
             {
                 var resources = _paratextService.GetResources(userSecret);
-                return Ok(resources);
+                return Ok(resources.ToDictionary(r => r.ParatextId, r => r.Name));
             }
             catch (SecurityException)
             {


### PR DESCRIPTION
This change does not wait until the user enables translation suggestions before fetching the projects and resources (as was requested in the issue), for a couple reasons:
- Almost all the delay was with updating the DOM, not with the network request.
- This change _does_ make the request for resources _significantly_ faster, by fetching in parallel with the request for projects, and by returning only the data that is actually needed.
- I thought it better to get this PR out now and get feedback rather than delaying it further. Additionally, since the loading speed has been dramatically improved, it warrants reassessing what further optimization is necessary, and gzipping the response may be a better alternative than lazy loading.

![](https://user-images.githubusercontent.com/6140710/102944320-6d9a4580-4488-11eb-8282-75a96b919661.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/899)
<!-- Reviewable:end -->
