### PR TITLE
Fix chapter permissions migration

### DIFF
--- a/src/Migrations/SourceTargetSplitting/ObjectMigrator.cs
+++ b/src/Migrations/SourceTargetSplitting/ObjectMigrator.cs
@@ -515,7 +515,7 @@ namespace SourceTargetSplitting
                             }
 
                             // Store the chapter permissions operation in a tuple
-                            chapterPermissionOperations.Add((i, j, bookPermissions));
+                            chapterPermissionOperations.Add((i, j, chapterPermissions));
                         }
                     }
 


### PR DESCRIPTION
This fix for the develop branch fixes an issue where the book permissions were being written to the chapter permissions collection when the migrator was run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/900)
<!-- Reviewable:end -->
