### PR TITLE
Fix NRE in migrator

### DIFF
--- a/src/Migrations/SourceTargetSplitting/ObjectMigrator.cs
+++ b/src/Migrations/SourceTargetSplitting/ObjectMigrator.cs
@@ -413,8 +413,8 @@ namespace SourceTargetSplitting
                 if (!doWrite && this._testProjectCollection.Contains(project))
                 {
                     // If we are in testing, find the original target project to get the source ScrText object
-                    SFProject? targetProject =
-                        existingProjects.FirstOrDefault(p => p.TranslateConfig.Source.ParatextId == project.ParatextId);
+                    SFProject? targetProject = existingProjects
+                        .FirstOrDefault(p => p.TranslateConfig.Source?.ParatextId == project.ParatextId);
                     if (targetProject != null)
                     {
                         scrText = this.SourceScrTextCollection.FindById("admin", targetProject.ParatextId);


### PR DESCRIPTION
- skip searching projects that don't have a source

See **Local scenario 6** in GDoc **Migration: Split Out Source Project**.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/906)
<!-- Reviewable:end -->
