### PR TITLE
Prevent selecting a project as based on itself

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -60,6 +60,7 @@
                       [projects]="projects"
                       [resources]="resources"
                       [nonSelectableProjects]="nonSelectableProjects"
+                      [hideProjectId]="projectParatextId"
                     ></app-project-select>
                     <app-write-status
                       [state]="getControlState('sourceParatextId')"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -77,7 +77,11 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
   }
 
   get projectId(): string {
-    return this.projectDoc == null ? '' : this.projectDoc.id;
+    return this.projectDoc?.id || '';
+  }
+
+  get projectParatextId(): string | undefined {
+    return this.projectDoc?.data?.paratextId;
   }
 
   set isAppOnline(isOnline: boolean) {


### PR DESCRIPTION
This was overlooked in #899.

Since it was an issue with one component not providing information to another component, there isn't any change to the tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/907)
<!-- Reviewable:end -->
