### PR TITLE
Fix error when cloning a resource

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -322,6 +322,12 @@ namespace SIL.XForge.Scripture.Services
         public async Task<IReadOnlyDictionary<string, string>> GetParatextUsernameMappingAsync(UserSecret userSecret,
             string paratextId)
         {
+            // See if the project is a resource
+            if (paratextId.Length == SFInstallableDblResource.ResourceIdentifierLength)
+            {
+                return new Dictionary<string, string>();
+            }
+
             // Get the mapping for paratext users ids to usernames from the registry
             string response = await CallApiAsync(_registryClient, userSecret, HttpMethod.Get,
                 $"projects/{paratextId}/members");
@@ -335,6 +341,7 @@ namespace SIL.XForge.Scripture.Services
                     .Where(u => paratextMapping.Keys.Contains(u.ParatextId))
                     .ToDictionaryAsync(u => u.Id, u => paratextMapping[u.ParatextId]);
         }
+
         /// <summary>
         /// Gets the permissions for a project or resource.
         /// </summary>

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -186,12 +186,12 @@ namespace SIL.XForge.Scripture.Services
 
                 // Get Paratext username mapping
                 IReadOnlyDictionary<string, string> ptUsernameMapping =
-                    await _paratextService.GetParatextUsernameMappingAsync(_userSecret, _projectDoc.Data.ParatextId);
+                    await _paratextService.GetParatextUsernameMappingAsync(_userSecret, targetParatextId);
 
                 // Get the permissions if this is a resource
                 // Resources do not have per-book permissions
                 Dictionary<string, string> permissions;
-                if (_projectDoc.Data.ParatextId.Length == SFInstallableDblResource.ResourceIdentifierLength)
+                if (targetParatextId.Length == SFInstallableDblResource.ResourceIdentifierLength)
                 {
                     permissions = await _paratextService.GetPermissionsAsync(_userSecret, _projectDoc.Data,
                         ptUsernameMapping);
@@ -229,7 +229,7 @@ namespace SIL.XForge.Scripture.Services
                     }
 
                     // Get the permissions for the book and chapters if this is not a resource
-                    if (_projectDoc.Data.ParatextId.Length == SFInstallableDblResource.ResourceIdentifierLength)
+                    if (targetParatextId.Length == SFInstallableDblResource.ResourceIdentifierLength)
                     {
                         // Add chapter permissions for the resource
                         foreach (Chapter chapter in newChapters)


### PR DESCRIPTION
- after PR #905 it had a 404 when cloning a resource
- this fix ensures paratextService.GetParatextUsernameMappingAsync doesn't get called for resources like the code was before the PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/917)
<!-- Reviewable:end -->
