### PR TITLE
Return empty resource list if lookup error

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -299,6 +299,7 @@ namespace SIL.XForge.Scripture.Services
                         this._restClientFactory,
                         this._fileSystemService,
                         this._jwtTokenHelper,
+                        _exceptionHandler,
                         this._dblServerUri);
                 }
 
@@ -859,6 +860,7 @@ namespace SIL.XForge.Scripture.Services
                 this._restClientFactory,
                 this._fileSystemService,
                 this._jwtTokenHelper,
+                _exceptionHandler,
                 this._dblServerUri);
             IReadOnlyDictionary<string, int> resourceRevisions =
                 SFInstallableDblResource.GetInstalledResourceRevisions();


### PR DESCRIPTION
- Querying for resources can get an ephemeral error, such as 401
Unauthorized. Trying again can be successful.
- Give the user an empty resource list rather than a 500 internal
server error popup dialog.
- There is still an underlying problem that has been around for maybe
a long time. Log the occurrence to bugsnag.

----
There is some more discussion about this in chat.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/918)
<!-- Reviewable:end -->
