### PR TITLE
SF-1176 Allow re-opening project typeahead without blurring input

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.html
@@ -6,6 +6,7 @@
       [placeholder]="placeholder"
       [formControl]="paratextIdControl"
       [matAutocomplete]="auto"
+      (click)="inputClicked()"
     />
     <mat-autocomplete
       #auto="matAutocomplete"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.spec.ts
@@ -30,7 +30,7 @@ describe('ProjectSelectComponent', () => {
     expect(env.component.sourceParatextId.value).toBeNull();
     env.clickOption(0, 0);
     expect(env.component.sourceParatextId.value).toBe('p01');
-    env.openMenu();
+    env.clickInput();
     env.clickOption(1, 1);
     expect(env.component.sourceParatextId.value).toBe('r02');
   }));
@@ -40,7 +40,7 @@ describe('ProjectSelectComponent', () => {
     expect(env.component.sourceParatextId.value).toBeNull();
     env.clickOption(0, 0);
     expect(env.component.sourceParatextId.value).toBe('p01');
-    env.openMenu();
+    env.clickInput();
     env.clickOption(1, 1);
     expect(env.component.sourceParatextId.value).toBe('r02');
   }));
@@ -53,6 +53,16 @@ describe('ProjectSelectComponent', () => {
     expect(env.options(1).length).toBe(25);
     env.scrollMenu(2500);
     expect(env.options(1).length).toBe(50);
+  }));
+
+  it('opens the panel when input is clicked after already selecting a project', fakeAsync(() => {
+    const env = new TestEnvironment();
+    expect(env.component.sourceParatextId.value).toBeNull();
+    env.clickOption(0, 0);
+    expect(env.component.sourceParatextId.value).toBe('p01');
+    env.clickInput();
+    env.clickOption(1, 1);
+    expect(env.component.sourceParatextId.value).toBe('r02');
   }));
 });
 
@@ -113,11 +123,11 @@ class TestEnvironment {
 
     this.fixture.detectChanges();
     tick();
-    this.openMenu();
+    this.clickInput();
   }
 
-  openMenu() {
-    this.component.projectSelect.autocompleteTrigger.openPanel();
+  clickInput() {
+    (this.fixture.nativeElement as HTMLElement).querySelector('input')!.click();
     this.fixture.detectChanges();
     tick();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
@@ -122,6 +122,10 @@ export class ProjectSelectComponent extends SubscriptionDisposable implements Co
     });
   }
 
+  inputClicked() {
+    this.autocompleteTrigger.openPanel();
+  }
+
   private filterGroup(
     value: string | SelectableProject,
     collection: SelectableProject[],


### PR DESCRIPTION
Previously, if a user selected a project it would close the typeahead, but the input field would still be focused. Because of this, clicking the input would not open the typeahead again. The user would have to click outside the input to blur the element, and then click the input element again.

(If you want to test this, try selecting a project, and then "realize" you selected the wrong one and click in the input element again).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/920)
<!-- Reviewable:end -->
