### PR TITLE
Tell the user and redirect if project is not found

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
@@ -1,6 +1,7 @@
+import { ErrorHandler } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ActivatedRoute, ActivatedRouteSnapshot, Router } from '@angular/router';
-import { TranslocoService } from '@ngneat/transloco';
+import { HashMap, TranslocoService } from '@ngneat/transloco';
 import { CheckingShareLevel } from 'realtime-server/lib/scriptureforge/models/checking-config';
 import { SFProject } from 'realtime-server/lib/scriptureforge/models/sf-project';
 import { SFProjectRole } from 'realtime-server/lib/scriptureforge/models/sf-project-role';
@@ -9,7 +10,7 @@ import {
   SFProjectUserConfig
 } from 'realtime-server/lib/scriptureforge/models/sf-project-user-config';
 import { of } from 'rxjs';
-import { anything, deepEqual, mock, verify, when } from 'ts-mockito';
+import { anything, capture, deepEqual, mock, verify, when } from 'ts-mockito';
 import { CommandError, CommandErrorCode } from 'xforge-common/command.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
@@ -29,6 +30,7 @@ const mockedRouter = mock(Router);
 const mockedSFProjectService = mock(SFProjectService);
 const mockedNoticeService = mock(NoticeService);
 const mockedTranslocoService = mock(TranslocoService);
+const mockedErrorHandler = mock(ErrorHandler);
 
 describe('ProjectComponent', () => {
   configureTestingModule(() => ({
@@ -40,6 +42,7 @@ describe('ProjectComponent', () => {
       { provide: Router, useMock: mockedRouter },
       { provide: SFProjectService, useMock: mockedSFProjectService },
       { provide: NoticeService, useMock: mockedNoticeService },
+      { provide: ErrorHandler, useMock: mockedErrorHandler },
       { provide: TranslocoService, useMock: mockedTranslocoService }
     ]
   }));
@@ -118,13 +121,22 @@ describe('ProjectComponent', () => {
     expect().nothing();
   }));
 
-  it('do not navigate when project does not exist', fakeAsync(() => {
+  it('if project does not exist, send user to /projects rather than show confusing blank page', fakeAsync(() => {
+    // If project.component.ts does not find a project, it just shows a blank page with a forever-going progress bar.
+    // This is confusing, and may be related to a couple issues (SF-1137, SF-1064). Tell the user that there was a
+    // problem and navigate to something with content.
+
     const env = new TestEnvironment();
     env.fixture.detectChanges();
     tick();
 
     verify(mockedSFProjectService.onlineCheckLinkSharing('project01')).never();
-    verify(mockedRouter.navigate(anything(), anything())).never();
+    verify(mockedErrorHandler.handleError(anything())).once();
+    const errorMessage: string = capture(mockedErrorHandler.handleError).last()[0].message;
+    expect(errorMessage).toContain('problem_finding_project');
+    expect(errorMessage).toContain('projectID=project01');
+    verify(mockedUserService.setCurrentProjectId()).once();
+    verify(mockedRouter.navigateByUrl('/projects', anything())).once();
     expect().nothing();
   }));
 
@@ -221,7 +233,19 @@ class TestEnvironment {
     when(mockedSFProjectService.get('project01')).thenCall(() =>
       this.realtimeService.subscribe(SFProjectDoc.COLLECTION, 'project01')
     );
-    when(mockedTranslocoService.translate<string>(anything())).thenReturn('The project link is invalid.');
+    when(mockedErrorHandler.handleError(anything())).thenReturn();
+    when(mockedTranslocoService.translate<string>(anything(), anything())).thenCall(
+      (translationStringKey: string, params: HashMap<any>) => {
+        if (params == null) {
+          return translationStringKey;
+        }
+        let output: string = translationStringKey;
+        for (const param of Object.keys(params)) {
+          output += `, ${param}=${params[param]}`;
+        }
+        return output;
+      }
+    );
     this.setLinkSharing(false);
 
     this.fixture = TestBed.createComponent(ProjectComponent);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ErrorHandler, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslocoService } from '@ngneat/transloco';
 import { SFProjectRole } from 'realtime-server/lib/scriptureforge/models/sf-project-role';
@@ -23,6 +23,7 @@ export class ProjectComponent extends DataLoadingComponent implements OnInit {
     private readonly router: Router,
     private readonly userService: UserService,
     private readonly transloco: TranslocoService,
+    private readonly errorHandler: ErrorHandler,
     noticeService: NoticeService
   ) {
     super(noticeService);
@@ -65,6 +66,13 @@ export class ProjectComponent extends DataLoadingComponent implements OnInit {
         const project = projectDoc.data;
 
         if (project == null || projectUserConfig == null) {
+          const message: string = this.transloco.translate('project.problem_finding_project', {
+            projectID: projectDoc.id
+          });
+          const error: Error = new Error(message);
+          this.errorHandler.handleError(error);
+          this.userService.setCurrentProjectId();
+          this.router.navigateByUrl('/projects', { replaceUrl: true });
           return;
         }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -262,7 +262,8 @@
     "dismiss": "Dismiss"
   },
   "project": {
-    "project_link_is_invalid": "The project link is invalid."
+    "project_link_is_invalid": "The project link is invalid.",
+    "problem_finding_project": "There was a problem finding a project ({{ projectID }}) or user specific information for the project. There may be a typo in the URL you specified. You may have tried to access a project that is no longer available."
   },
   "project_deleted_dialog": {
     "ok": "OK",


### PR DESCRIPTION
- Rather than sit at a blank page with a progress bar that keeps going
forever.
- Report to bugsnag so we can keep an eye on this happening.

-----

Animation showing behaviour when the user is in fact not on any project:



![bad-project-id](https://user-images.githubusercontent.com/7265309/105245156-b9dfb080-5b2e-11eb-87d9-8f33f15376d9.gif)



Animation showing behaviour when the user is on a project (i.e. another project):


![bad-project-id-have-project](https://user-images.githubusercontent.com/7265309/105245180-bfd59180-5b2e-11eb-8046-4ab36517ba9a.gif)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/927)
<!-- Reviewable:end -->
