### PR TITLE
SF-1184 Add custom theming for angular material components

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.html
@@ -3,5 +3,5 @@
   [mode]="mode"
   [value]="syncProgressPercent"
   [bufferValue]="1"
-  [color]="'accent'"
+  color="accent"
 ></mat-progress-bar>

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -1,18 +1,65 @@
+@import 'variables';
 @import '~@angular/material/theming';
 
 @include mat-core();
 
+$mat-sf-purple: (
+  200: $purpleLight,
+  500: $purpleMedium,
+  800: $purpleDark,
+  contrast: (
+    200: $dark-primary-text,
+    500: $light-primary-text,
+    800: $light-primary-text
+  )
+);
+
+$mat-sf-grey: (
+  200: $greyLight,
+  800: $greyDark,
+  contrast: (
+    200: $dark-primary-text,
+    800: $light-primary-text
+  )
+);
+
+$mat-sf-green: (
+  200: #dcedc8,
+  500: $greenLight,
+  800: $greenDark,
+  contrast: (
+    200: $dark-primary-text,
+    500: $dark-primary-text,
+    800: $light-primary-text
+  )
+);
+
+$mat-sf-blue: (
+  500: $blueMedium,
+  contrast: (
+    500: $light-primary-text
+  )
+);
+
+$mat-sf-orange: (
+  500: #ff7300,
+  contrast: (
+    500: $light-primary-text
+  )
+);
+
 // Styles for angular material components. Refer to https://material.angular.io/guide/theming
-$greyDark: mat-palette($mat-gray, 800);
-$greenLight: mat-palette($mat-light-green, 300);
+$matGrey: mat-palette($mat-sf-grey, 800);
+$matGreenLight: mat-palette($mat-sf-green, 500, 200);
 
 $material-app-theme: mat-light-theme(
   (
     color: (
-      primary: $greyDark,
-      accent: $greenLight
+      primary: $matGrey,
+      accent: $matGreenLight
     )
   )
 );
 
-@include angular-material-theme($material-app-theme);
+@include mat-button-theme($material-app-theme);
+@include mat-progress-bar-theme($material-app-theme);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -25,6 +25,7 @@ import { NgModule } from '@angular/core';
 import { BREAKPOINT, FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatButtonModule } from '@angular/material/button';
 import { MatOptionModule } from '@angular/material/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -47,6 +48,7 @@ const modules = [
   FlexLayoutModule,
   FormsModule,
   MatAutocompleteModule,
+  MatButtonModule,
   MatInputModule,
   MatFormFieldModule,
   MatOptionModule,


### PR DESCRIPTION
This adds SF custom colors to be applied to angular material components. Material design has its defined [color palette](https://material.io/design/color), but it was difficult to adapt this to the SF theme we currently have, therefore this defines a custom color palette.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/930)
<!-- Reviewable:end -->
