### PR TITLE
SF-1181 Refresh access token if needed before fetching resources

### DIFF
--- a/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
@@ -61,13 +61,9 @@ namespace SIL.XForge.Scripture.Controllers
         [HttpGet("resources")]
         public async Task<ActionResult<Dictionary<string, string>>> ResourcesAsync()
         {
-            Attempt<UserSecret> attempt = await _userSecrets.TryGetAsync(_userAccessor.UserId);
-            if (!attempt.TryResult(out UserSecret userSecret))
-                return NoContent();
-
             try
             {
-                var resources = _paratextService.GetResources(userSecret);
+                var resources = await _paratextService.GetResourcesAsync(_userAccessor.UserId);
                 return Ok(resources.ToDictionary(r => r.ParatextId, r => r.Name));
             }
             catch (SecurityException)

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -16,8 +16,8 @@ namespace SIL.XForge.Scripture.Services
         Task<IReadOnlyDictionary<string, string>> GetProjectRolesAsync(UserSecret userSecret, string projectId);
         bool IsProjectLanguageRightToLeft(UserSecret userSecret, string ptProjectId);
 
-        IReadOnlyList<ParatextResource> GetResources(UserSecret userSecret);
-        Task<string> GetResourcePermissionAsync(UserSecret userSecret, string paratextId, string userId);
+        Task<IReadOnlyList<ParatextResource>> GetResourcesAsync(string userId);
+        Task<string> GetResourcePermissionAsync(string paratextId, string userId);
         Task<IReadOnlyDictionary<string, string>> GetParatextUsernameMappingAsync(UserSecret userSecret,
             string paratextId);
         Task<Dictionary<string, string>> GetPermissionsAsync(UserSecret userSecret, SFProject project,

--- a/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using Paratext;
-using Paratext.Data;
 using Paratext.Data.Repository;
 using Paratext.Data.Users;
 using Paratext.Data.RegistryServerAccess;

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -174,7 +174,7 @@ namespace SIL.XForge.Scripture.Services
                         foreach (string uid in usersToCheck)
                         {
                             string permission =
-                                await _paratextService.GetResourcePermissionAsync(_userSecret, sourceParatextId, uid);
+                                await _paratextService.GetResourcePermissionAsync(sourceParatextId, uid);
                             if (permission == TextInfoPermission.None)
                             {
                                 // As resource projects don't have administrators, connect as the user we are to remove

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -164,7 +164,7 @@ namespace SIL.XForge.Scripture.Services
             if (ptProject == null)
             {
                 // If it is not a project, see if there is a matching resource
-                IReadOnlyList<ParatextResource> resources = this._paratextService.GetResources(userSecret);
+                IReadOnlyList<ParatextResource> resources = await this._paratextService.GetResourcesAsync(curUserId);
                 ptProject = resources.SingleOrDefault(r => r.ParatextId == paratextId);
                 if (ptProject == null)
                 {
@@ -543,8 +543,7 @@ namespace SIL.XForge.Scripture.Services
                 if (project.ParatextId?.Length == SFInstallableDblResource.ResourceIdentifierLength)
                 {
                     // If the project is a resource, get the permission from the DBL
-                    string permission = await _paratextService.GetResourcePermissionAsync(
-                               userSecret, project.ParatextId, userId);
+                    string permission = await _paratextService.GetResourcePermissionAsync(project.ParatextId, userId);
                     return permission switch
                     {
                         TextInfoPermission.None => Attempt.Failure(ProjectRole.None),
@@ -652,7 +651,7 @@ namespace SIL.XForge.Scripture.Services
             if (sourcePTProject == null)
             {
                 // If it is not a project, see if there is a matching resource
-                IReadOnlyList<ParatextResource> resources = this._paratextService.GetResources(userSecret);
+                IReadOnlyList<ParatextResource> resources = await this._paratextService.GetResourcesAsync(curUserId);
                 sourcePTProject = resources.SingleOrDefault(r => r.ParatextId == paratextId);
                 if (sourcePTProject == null)
                 {

--- a/src/SIL.XForge/Models/Tokens.cs
+++ b/src/SIL.XForge/Models/Tokens.cs
@@ -24,6 +24,9 @@ namespace SIL.XForge.Models
             }
         }
 
+        /// <summary>
+        /// Checks whether the access token is valid and not about to expire within the next minute.
+        /// </summary>
         public bool ValidateLifetime()
         {
             if (AccessToken == null)
@@ -32,7 +35,7 @@ namespace SIL.XForge.Models
             }
             var accessToken = new JwtSecurityToken(AccessToken);
             var now = DateTime.UtcNow;
-            return now >= accessToken.ValidFrom && now <= accessToken.ValidTo;
+            return now >= accessToken.ValidFrom && now <= accessToken.ValidTo - TimeSpan.FromMinutes(1);
         }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -632,7 +632,7 @@ namespace SIL.XForge.Scripture.Services
             int projectCount = env.RealtimeService.GetRepository<SFProject>().Query().Count();
             env.ParatextService.TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>())
                .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Administrator)));
-            env.ParatextService.GetResourcePermissionAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), User01)
+            env.ParatextService.GetResourcePermissionAsync(Arg.Any<string>(), User01)
                 .Returns(Task.FromResult(TextInfoPermission.Read));
             // SUT
             string sfProjectId = await env.Service.CreateProjectAsync(User01, new SFProjectCreateSettings()
@@ -708,7 +708,7 @@ namespace SIL.XForge.Scripture.Services
         public async Task AddUserToResourceProjectAsync_UserResourcePermission()
         {
             var env = new TestEnvironment();
-            env.ParatextService.GetResourcePermissionAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), User01)
+            env.ParatextService.GetResourcePermissionAsync(Arg.Any<string>(), User01)
                 .Returns(Task.FromResult(TextInfoPermission.Read));
 
             User user = env.GetUser(User01);
@@ -724,7 +724,7 @@ namespace SIL.XForge.Scripture.Services
         public void AddUserToResourceProjectAsync_UserResourceNoPermission()
         {
             var env = new TestEnvironment();
-            env.ParatextService.GetResourcePermissionAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), User01)
+            env.ParatextService.GetResourcePermissionAsync(Arg.Any<string>(), User01)
                 .Returns(Task.FromResult(TextInfoPermission.None));
 
             User user = env.GetUser(User01);
@@ -962,7 +962,7 @@ namespace SIL.XForge.Scripture.Services
                         ParatextId = GetProject(Resource01).ParatextId
                     }
                 };
-                ParatextService.GetResources(Arg.Any<UserSecret>()).Returns(ptResources);
+                ParatextService.GetResourcesAsync(Arg.Any<string>()).Returns(ptResources);
                 var userSecrets = new MemoryRepository<UserSecret>(new[]
                 {
                     new UserSecret { Id = User01 },

--- a/test/SIL.XForge.Tests/Models/TokensTests.cs
+++ b/test/SIL.XForge.Tests/Models/TokensTests.cs
@@ -1,5 +1,6 @@
 using System;
 using NUnit.Framework;
+using SIL.XForge.Services;
 
 namespace SIL.XForge.Models
 {
@@ -30,6 +31,36 @@ namespace SIL.XForge.Models
             tokens.RefreshToken = "refresh-token-123";
             // SUT 2, where RefreshToken is not null.
             Assert.That(tokens.ValidateLifetime(), Is.False);
+        }
+
+        [Test]
+        public void ValidateLifetime_FalseIfAboutToExpire()
+        {
+            var issuedAt = DateTime.Now;
+            var expiration = issuedAt + TimeSpan.FromSeconds(50);
+            var tokens = new Tokens()
+            {
+                AccessToken = TokenHelper.CreateAccessToken(issuedAt, expiration),
+                RefreshToken = null
+            };
+
+            // SUT
+            Assert.That(tokens.ValidateLifetime(), Is.False);
+        }
+
+        [Test]
+        public void ValidateLifetime_TrueIfUnexpired()
+        {
+            var issuedAt = DateTime.Now;
+            var expiration = issuedAt + TimeSpan.FromSeconds(70);
+            var tokens = new Tokens()
+            {
+                AccessToken = TokenHelper.CreateAccessToken(issuedAt, expiration),
+                RefreshToken = null
+            };
+
+            // SUT
+            Assert.That(tokens.ValidateLifetime(), Is.True);
         }
     }
 }

--- a/test/SIL.XForge.Tests/Services/TokenHelper.cs
+++ b/test/SIL.XForge.Tests/Services/TokenHelper.cs
@@ -11,7 +11,7 @@ namespace SIL.XForge.Services
     /// </summary>
     public class TokenHelper
     {
-        public static string CreateAccessToken(DateTime issuedAt)
+        public static string CreateAccessToken(DateTime issuedAt, DateTime expiration)
         {
             var token = new JwtSecurityToken("ptreg_rsa", "pt-api",
                 new[]
@@ -19,9 +19,14 @@ namespace SIL.XForge.Services
                     new Claim(JwtClaimTypes.Subject, "paratext01"),
                     new Claim(JwtClaimTypes.IssuedAt, EpochTime.GetIntDate(issuedAt).ToString())
                 },
-                expires: issuedAt + TimeSpan.FromMinutes(5));
+                expires: expiration);
             var handler = new JwtSecurityTokenHandler();
             return handler.WriteToken(token);
+        }
+
+        public static string CreateAccessToken(DateTime issuedAt)
+        {
+            return TokenHelper.CreateAccessToken(issuedAt, issuedAt + TimeSpan.FromMinutes(5));
         }
 
         public static string CreateNewAccessToken()


### PR DESCRIPTION
- On the settings and connect project pages, we send two HTTP requests, one for projects and one for resources.
- Both requests cause the back end to send HTTP requests to Paratext.
- The access token for Paratext expires after 20 minutes and needs to be refreshed if it is expired.
- Previously only the projects endpoint refreshed the token (the request for resources did not, so if the token was expired, that request would fail).
- Now both requests cause the token to be refreshed, but if a refresh is in progress that the other request started, then a new refresh is not started (otherwise it would result in an error from Paratext).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/934)
<!-- Reviewable:end -->
