### PR TITLE
SF-1178b Fix error from adding projectUserConfig twice

### DIFF
--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -490,9 +490,6 @@ namespace SIL.XForge.Scripture.Services
                         // If they are in Paratext, add the user to the source project
                         await this.AddUserToProjectAsync(conn, sourceProjectDoc, userDoc, sourceProjectRole,
                             removeShareKeys);
-                        await conn.CreateAsync<SFProjectUserConfig>(
-                            SFProjectUserConfig.GetDocId(sourceProjectDoc.Id, userDoc.Id),
-                            new SFProjectUserConfig { ProjectRef = sourceProjectDoc.Id, OwnerRef = userDoc.Id });
                     }
                 }
             }


### PR DESCRIPTION
The problem that occurred was that if a source project existed, the AddUserToProject method would recursively call itself for the source project, which also creates a ProjectUserConfig. This change removes the unnecessary lines that add a ProjectUserConfig that has already been created.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/941)
<!-- Reviewable:end -->
