### PR TITLE
Remove unused C# imports

### DIFF
--- a/src/SIL.XForge.Scripture/Realtime/SFRealtimeServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Realtime/SFRealtimeServiceCollectionExtensions.cs
@@ -1,8 +1,6 @@
-using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using SIL.XForge.Configuration;
-using SIL.XForge.Models;
 using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
 

--- a/src/SIL.XForge.Scripture/Services/DotNetCoreAlert.cs
+++ b/src/SIL.XForge.Scripture/Services/DotNetCoreAlert.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using System.ComponentModel;
 using Microsoft.Extensions.Logging;
 using PtxUtils;

--- a/src/SIL.XForge.Scripture/Services/IParatextDataHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextDataHelper.cs
@@ -1,5 +1,4 @@
 using Paratext.Data;
-using Paratext.Data.Repository;
 
 namespace SIL.XForge.Scripture.Services
 {

--- a/src/SIL.XForge.Scripture/Services/InternetSharedRepositorySourceProvider.cs
+++ b/src/SIL.XForge.Scripture/Services/InternetSharedRepositorySourceProvider.cs
@@ -1,5 +1,4 @@
 using System;
-using Paratext.Data.Users;
 using SIL.XForge.Models;
 using SIL.XForge.Scripture.Models;
 

--- a/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
+++ b/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
@@ -1,5 +1,4 @@
 // This file is copied from Paratext DataAccessServer
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/SIL.XForge.Scripture/Services/PersistedParatextDataSettings.cs
+++ b/src/SIL.XForge.Scripture/Services/PersistedParatextDataSettings.cs
@@ -1,8 +1,5 @@
 using Paratext.Data;
 using PtxUtils;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace SIL.XForge.Scripture
 {

--- a/src/SIL.XForge.Scripture/Services/PersistedPtxUtilsSettings.cs
+++ b/src/SIL.XForge.Scripture/Services/PersistedPtxUtilsSettings.cs
@@ -1,7 +1,4 @@
 using PtxUtils;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace SIL.XForge.Scripture
 {

--- a/src/SIL.XForge.Scripture/Services/SFHgRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/SFHgRunner.cs
@@ -1,8 +1,5 @@
-using System;
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Paratext.Data;
-using PtxUtils;
 
 namespace SIL.XForge.Scripture.Services
 {

--- a/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
+++ b/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using Ionic.Zip;
-using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Paratext.Data;

--- a/src/SIL.XForge/Services/IUserService.cs
+++ b/src/SIL.XForge/Services/IUserService.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 
 namespace SIL.XForge.Services
 {

--- a/test/SIL.XForge.Scripture.Tests/Services/MockLazyScrTextCollection.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockLazyScrTextCollection.cs
@@ -1,5 +1,4 @@
 using Paratext.Data;
-using Paratext.Data.Users;
 using SIL.XForge.Scripture.Models;
 
 namespace SIL.XForge.Scripture.Services

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using NUnit.Framework;
-using SIL.Machine.FiniteState;
 using SIL.Machine.WebApi.Services;
 using SIL.XForge.Configuration;
 using SIL.XForge.DataAccess;

--- a/test/SIL.XForge.Tests/Services/UserServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/UserServiceTests.cs
@@ -1,10 +1,6 @@
 using System;
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
 using System.Threading.Tasks;
-using IdentityModel;
 using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json.Linq;
 using NSubstitute;
 using NUnit.Framework;


### PR DESCRIPTION
Frequently when I work in C# land I come across unused imports. So I just went through and removed them all at once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/945)
<!-- Reviewable:end -->
