### PR TITLE
Turn on noImplicitReturns

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -328,6 +328,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     if (url != null && url !== '' && this.fileSources.has(url)) {
       return this.fileSources.get(url);
     }
+    return undefined;
   }
 
   selectScripture() {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -149,6 +149,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
     if (this.questionsPanel != null && this.book === this.questionsPanel.activeQuestionBook) {
       return this._activeQuestionVerseRef;
     }
+    return undefined;
   }
 
   get bookName(): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -234,6 +234,7 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable {
                 .set(q => q.dateModified, currentDate)
             );
           }
+          return undefined;
         } else {
           const newQuestion: Question = {
             dataId: objectId(),

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
@@ -117,6 +117,7 @@ export class FileService extends SubscriptionDisposable {
       return URL.createObjectURL(localFileData.blob);
     } catch (error) {
       await this.onCachingError(error);
+      return undefined;
     }
   }
 
@@ -230,6 +231,7 @@ export class FileService extends SubscriptionDisposable {
         return fileData;
       }
     } catch {}
+    return undefined;
   }
 
   private async syncFiles(): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/tsconfig.json
+++ b/src/SIL.XForge.Scripture/ClientApp/tsconfig.json
@@ -8,6 +8,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
+    "noImplicitReturns": true,
     "suppressImplicitAnyIndexErrors": true,
     "downlevelIteration": true,
     "esModuleInterop": true,


### PR DESCRIPTION


---

I'm looking at more strict or lint checks we can turn on. I like that noImplicitReturns makes us be more explicit. But the particular places it required a change in didn't seem very significant. And in import-questions-dialog.component.ts it seems conceptually wrong to return undefined in places where we don't want to add to the array.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/946)
<!-- Reviewable:end -->
