### PR TITLE
SF-1190 Refresh banner button overlaps nav bar menu

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -121,7 +121,7 @@
         </mdc-top-app-bar-section>
       </mdc-top-app-bar-row>
       <mdc-top-app-bar-row *ngIf="hasUpdate" class="update-banner">
-        <mdc-top-app-bar-section align="start">
+        <mdc-top-app-bar-section align="start" class="display-behind">
           <span class="refresh-message">{{ t("update_is_available") }}</span>
           <div>
             <button mat-raised-button color="accent" (click)="reloadWithUpdates()">{{ t("refresh") }}</button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -92,6 +92,9 @@
           color: var(--mdc-theme-text-secondary-on-background);
         }
       }
+      &.display-behind {
+        z-index: 0;
+      }
     }
 
     .mdc-top-app-bar--short-collapsed {


### PR DESCRIPTION
The button part of the refresh banner should now appear behind the menu.
![update_available_behind_menu](https://user-images.githubusercontent.com/17931130/107544683-b36db300-6b87-11eb-9c54-592cf90e60b3.PNG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/948)
<!-- Reviewable:end -->
