### PR TITLE
SF-1171 Update to ParatextData 9.2.4-alpha8, account for HexId

### DIFF
--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
     <!-- When using a new major or minor version of ParatextData, update where dependencies.yml copies the
          InternetSettings.xml file. Also update server config scriptureforge.org_v2.yml. -->
-    <PackageReference Include="ParatextData" Version="9.2.3-alpha" />
+    <PackageReference Include="ParatextData" Version="9.2.4-alpha8" />
     <PackageReference Include="SIL.Machine.WebApi" Version="$(MachineVersion)" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
   </ItemGroup>

--- a/src/SIL.XForge.Scripture/Services/ISFRestClient.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFRestClient.cs
@@ -26,18 +26,5 @@ namespace SIL.XForge.Scripture.Services
         {
             return Head(new CgiCallOptions(), cgiCall, queryvars);
         }
-
-        /// <summary>
-        /// Encode a HEAD cgi call with query vars.
-        /// </summary>
-        /// <param name="options">The CGI Call options.</param>
-        /// <param name="cgiCall">The CGI URL path (to be appended to BaseUri)
-        /// Do not include ? or query variable pairs</param>
-        /// <param name="queryvars">An even number of unencoded strings, paired
-        /// like so: "varname1", "value1", "varname2", "val2"</param>
-        /// <returns>
-        /// The web response as a string.
-        /// </returns>
-        public string Head(CgiCallOptions options, string cgiCall, params string[] queryvars);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
@@ -45,7 +45,7 @@ namespace SIL.XForge.Scripture.Services
             // Get bundle
             string guid = Guid.NewGuid().ToString();
             List<string> query = new List<string> { "guid", guid, "proj", pullRepo.ScrTextName, "projid",
-                        pullRepo.SendReceiveId, "type", "zstd-v2" };
+                        pullRepo.SendReceiveId.Id, "type", "zstd-v2" };
             if (tip != null)
             {
                 query.Add("base1");
@@ -81,7 +81,7 @@ namespace SIL.XForge.Scripture.Services
             // Send bundle
             string guid = Guid.NewGuid().ToString();
             client.PostStreaming(bundle, "pushbundle", "guid", guid, "proj", pushRepo.ScrTextName, "projid",
-                pushRepo.SendReceiveId, "registered", "yes", "userschanged", "no");
+                pushRepo.SendReceiveId.Id, "registered", "yes", "userschanged", "no");
 
             MarkSharedChangeSetsPublic(repository);
         }

--- a/src/SIL.XForge.Scripture/Services/JwtRestClient.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtRestClient.cs
@@ -13,21 +13,5 @@ namespace SIL.XForge.Scripture.Services
             this.JwtToken = jwtToken;
             ReflectionHelperLite.SetField(this, "authentication", null);
         }
-
-        /// <inheritdoc />
-        public string Head(CgiCallOptions options, string cgiCall, params string[] queryvars)
-        {
-            if (queryvars == null)
-            {
-                queryvars = Array.Empty<string>();
-            }
-
-            if (cgiCall == null)
-            {
-                cgiCall = string.Empty;
-            }
-
-            return ReflectionHelperLite.GetResult(this, "GetInternal", options, cgiCall, "HEAD", queryvars) as string;
-        }
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -158,7 +158,7 @@ namespace SIL.XForge.Scripture.Services
             IInternetSharedRepositorySource source = await GetInternetSharedRepositorySource(userSecret);
             IEnumerable<SharedRepository> repositories = source.GetRepositories();
             IEnumerable<ProjectMetadata> projectsMetadata = source.GetProjectsMetaData();
-            var projectGuids = projectsMetadata.Select(pmd => pmd.ProjectGuid);
+            IEnumerable<string> projectGuids = projectsMetadata.Select(pmd => pmd.ProjectGuid.Id);
             Dictionary<string, ParatextProject> ptProjectsAvailable =
                 GetProjects(userSecret, repositories, projectsMetadata).ToDictionary(ptProject => ptProject.ParatextId);
             if (!projectGuids.Contains(ptTargetId))
@@ -649,7 +649,7 @@ namespace SIL.XForge.Scripture.Services
             foreach (SharedRepository remotePtProject in remotePtProjects)
             {
                 SFProject correspondingSfProject =
-                    existingSfProjects.FirstOrDefault(sfProj => sfProj.ParatextId == remotePtProject.SendReceiveId);
+                    existingSfProjects.FirstOrDefault(sfProj => sfProj.ParatextId == remotePtProject.SendReceiveId.Id);
 
                 bool sfProjectExists = correspondingSfProject != null;
                 bool sfUserIsOnSfProject = correspondingSfProject?.UserRoles.ContainsKey(userSecret.Id) ?? false;
@@ -666,7 +666,7 @@ namespace SIL.XForge.Scripture.Services
 
                 paratextProjects.Add(new ParatextProject
                 {
-                    ParatextId = remotePtProject.SendReceiveId,
+                    ParatextId = remotePtProject.SendReceiveId.Id,
                     Name = fullOrShortName,
                     ShortName = remotePtProject.ScrTextName,
                     LanguageTag = correspondingSfProject?.WritingSystem.Tag,
@@ -727,7 +727,7 @@ namespace SIL.XForge.Scripture.Services
             }
             else if (targetNeedsCloned)
             {
-                SharedRepository targetRepo = new SharedRepository(target.ShortName, target.ParatextId,
+                SharedRepository targetRepo = new SharedRepository(target.ShortName, HexId.FromStr(target.ParatextId),
                     RepositoryType.Shared);
                 CloneProjectRepo(repositorySource, target.ParatextId, targetRepo);
             }
@@ -869,13 +869,14 @@ namespace SIL.XForge.Scripture.Services
             {
                 AvailableRevision = r.DBLRevision,
                 InstallableResource = includeInstallableResource ? r : null,
-                InstalledRevision = resourceRevisions.ContainsKey(r.DBLEntryUid) ? resourceRevisions[r.DBLEntryUid] : 0,
+                InstalledRevision = resourceRevisions
+                    .ContainsKey(r.DBLEntryUid.Id) ? resourceRevisions[r.DBLEntryUid.Id] : 0,
                 IsConnectable = false,
                 IsConnected = false,
-                IsInstalled = resourceRevisions.ContainsKey(r.DBLEntryUid),
+                IsInstalled = resourceRevisions.ContainsKey(r.DBLEntryUid.Id),
                 LanguageTag = r.LanguageID.Code,
                 Name = r.FullName,
-                ParatextId = r.DBLEntryUid,
+                ParatextId = r.DBLEntryUid.Id,
                 ProjectId = null,
                 ShortName = r.Name,
             }).ToArray();

--- a/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
+++ b/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
@@ -260,7 +260,7 @@ namespace SIL.XForge.Scripture.Services
                         jwtTokenHelper,
                         exceptionHandler,
                         baseUrl);
-                    return resources.Any(r => r.DBLEntryUid == id);
+                    return resources.Any(r => r.DBLEntryUid.Id == id);
                 }
                 else if (ex.Source == "NSubstitute")
                 {
@@ -351,9 +351,9 @@ namespace SIL.XForge.Scripture.Services
             {
                 throw new ArgumentNullException(nameof(path));
             }
-            else if (string.IsNullOrWhiteSpace(this.DBLEntryUid))
+            else if (string.IsNullOrWhiteSpace(this.DBLEntryUid.Id))
             {
-                throw new ArgumentNullException(nameof(this.DBLEntryUid));
+                throw new ArgumentNullException(nameof(this.DBLEntryUid.Id));
             }
             else if (string.IsNullOrWhiteSpace(this.Name))
             {
@@ -387,9 +387,9 @@ namespace SIL.XForge.Scripture.Services
             // Easier to check parameters here than fill the temp directory with files
             // NOTE: This is not an exhaustive list of the required parameters!
             //       You will need to refer to InstallableResource.Install() for that.
-            if (string.IsNullOrWhiteSpace(this.DBLEntryUid))
+            if (string.IsNullOrWhiteSpace(this.DBLEntryUid.Id))
             {
-                throw new ArgumentNullException(nameof(this.DBLEntryUid));
+                throw new ArgumentNullException(nameof(this.DBLEntryUid.Id));
             }
             else if (string.IsNullOrWhiteSpace(this.DblSourceUrl))
             {
@@ -635,7 +635,7 @@ namespace SIL.XForge.Scripture.Services
                         FullName = fullname,
                         LanguageID = languageId,
                         DblSourceUrl = url,
-                        DBLEntryUid = id,
+                        DBLEntryUid = HexId.FromStr(id),
                         DBLRevision = int.Parse(revision),
                         PermissionsChecksum = permissionsChecksum,
                         ManifestChecksum = manifestChecksum,

--- a/src/SIL.XForge.Scripture/Services/SharingLogicWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/SharingLogicWrapper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Paratext.Data;
 using Paratext.Data.Repository;
 
 namespace SIL.XForge.Scripture.Services
@@ -18,7 +19,7 @@ namespace SIL.XForge.Scripture.Services
         public SharedProject CreateSharedProject(string projId, string proj, SharedRepositorySource source,
             IEnumerable<SharedRepository> sourceRepositories)
         {
-            return SharingLogic.CreateSharedProject(projId, proj, source, sourceRepositories);
+            return SharingLogic.CreateSharedProject(HexId.FromStr(projId), proj, source, sourceRepositories);
         }
 
         public bool HandleErrors(Action action, bool throwExceptions = false)

--- a/test/SIL.XForge.Scripture.Tests/Services/MockScrText.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockScrText.cs
@@ -25,7 +25,7 @@ namespace SIL.XForge.Scripture.Services
             _language = new MockScrLanguage(this);
         }
 
-        public string CachedGuid
+        public HexId CachedGuid
         {
             set
             {

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -1033,7 +1033,7 @@ namespace SIL.XForge.Scripture.Services
                 string scrtextDir = Path.Combine(SyncDir, projectId, "target");
                 ProjectName projectName = new ProjectName() { ProjectPath = scrtextDir, ShortName = "Proj" };
                 var scrText = new MockScrText(associatedPtUser, projectName);
-                scrText.CachedGuid = HexId.FromStrSafe(projectId);
+                scrText.CachedGuid = HexId.FromStr(projectId);
                 scrText.Permissions.CreateFirstAdminUser();
                 scrText.Data.Add("RUT", ruthBookUsfm);
                 scrText.Settings.BooksPresentSet = new BookSet("RUT");

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -58,13 +58,13 @@ namespace SIL.XForge.Scripture.Services
             // TODO Make PT repos in data that should not be returned.
             foreach (string projectName in new string[] { env.Project01, env.Project03, env.Project02 })
             {
-                Assert.That(repos.Single(project => project.ParatextId == "paratext_" + projectName), Is.Not.Null);
+                Assert.That(repos.Single(project => project.ParatextId == env.PTProjectIds[projectName].Id), Is.Not.Null);
             }
 
             // Properties of one of the returned repos have the correct values.
             ParatextProject expectedProject01 = new ParatextProject
             {
-                ParatextId = "paratext_" + env.Project01,
+                ParatextId = env.PTProjectIds[env.Project01].Id,
                 Name = "Full Name " + env.Project01,
                 ShortName = "P01",
                 LanguageTag = "writingsystem_tag",
@@ -74,7 +74,7 @@ namespace SIL.XForge.Scripture.Services
                 // Is connected since is in SF database and user is on project
                 IsConnected = true
             };
-            Assert.That(repos.Single(project => project.ParatextId == "paratext_" + env.Project01).ToString(),
+            Assert.That(repos.Single(project => project.ParatextId == env.PTProjectIds[env.Project01].Id).ToString(),
                 Is.EqualTo(expectedProject01.ToString()));
 
             // Repos are returned in alphabetical order by paratext project name.
@@ -103,10 +103,10 @@ namespace SIL.XForge.Scripture.Services
             // Repos returned are the ones we expect.
             foreach (string projectName in new string[] { env.Project01, env.Project03, env.Project02 })
             {
-                Assert.That(repos.Single(project => project.ParatextId == "paratext_" + projectName), Is.Not.Null);
+                Assert.That(repos.Single(project => project.ParatextId == env.PTProjectIds[projectName].Id), Is.Not.Null);
             }
             // Not the ones we don't.
-            Assert.That(repos.Any<ParatextProject>(Project => Project.ParatextId == "paratext_" + env.Project04),
+            Assert.That(repos.Any<ParatextProject>(Project => Project.ParatextId == env.PTProjectIds[env.Project04].Id),
                 Is.False, "Should not have had project 4");
         }
 
@@ -118,7 +118,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
             IEnumerable<ParatextProject> projects = await env.Service.GetProjectsAsync(user01Secret);
 
-            ParatextProject project02 = projects.Single(p => p.ParatextId == "paratext_" + env.Project02);
+            ParatextProject project02 = projects.Single(p => p.ParatextId == env.PTProjectIds[env.Project02].Id);
             Assert.That(project02.Name, Is.EqualTo("Full Name " + env.Project02));
         }
 
@@ -138,7 +138,7 @@ namespace SIL.XForge.Scripture.Services
                 new
                 {
                     // Data
-                    paratextProjectId = "paratext_" + env.Project01,
+                    paratextProjectId = env.PTProjectIds[env.Project01].Id,
                     sfUserId = env.User01,
                     ptUsername = "user 01",
                     userSecret = user01Secret,
@@ -154,7 +154,7 @@ namespace SIL.XForge.Scripture.Services
                 },
                 new
                 {
-                    paratextProjectId = "paratext_" + env.Project01,
+                    paratextProjectId = env.PTProjectIds[env.Project01].Id,
                     sfUserId = env.User03,
                     ptUsername = "user 01",
                     userSecret = user03Secret,
@@ -170,7 +170,7 @@ namespace SIL.XForge.Scripture.Services
                 },
                 new
                 {
-                    paratextProjectId = "paratext_" + env.Project02,
+                    paratextProjectId = env.PTProjectIds[env.Project02].Id,
                     sfUserId = env.User01,
                     ptUsername = "user 01",
                     userSecret = user01Secret,
@@ -186,7 +186,7 @@ namespace SIL.XForge.Scripture.Services
                 },
                 new
                 {
-                    paratextProjectId = "paratext_" + env.Project02,
+                    paratextProjectId = env.PTProjectIds[env.Project02].Id,
                     sfUserId = env.User03,
                     ptUsername = "user 03",
                     userSecret = user03Secret,
@@ -217,7 +217,7 @@ namespace SIL.XForge.Scripture.Services
                 }
                 Assert.That(env.MockInternetSharedRepositorySourceProvider.GetSource(testCase.userSecret,
                     string.Empty, string.Empty, string.Empty).GetRepositories()
-                    .FirstOrDefault(sharedRepository => sharedRepository.SendReceiveId == testCase.paratextProjectId)
+                    .FirstOrDefault(sharedRepository => sharedRepository.SendReceiveId.Id == testCase.paratextProjectId)
                     .SourceUsers.GetRole(testCase.ptUsername) == UserRoles.Administrator,
                     Is.EqualTo(testCase.ptUserIsAdminOnPtProject),
                     "not set up - whether pt user is an admin on pt project");
@@ -409,7 +409,7 @@ namespace SIL.XForge.Scripture.Services
         public void GetBookText_NoSuchPtProjectKnown()
         {
             var env = new TestEnvironment();
-            string ptProjectId = "paratext_" + env.Project01;
+            string ptProjectId = env.PTProjectIds[env.Project01].Id;
             UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01);
             IInternetSharedRepositorySource mockSource =
                 env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
@@ -522,7 +522,7 @@ namespace SIL.XForge.Scripture.Services
             UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01);
             Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.SendReceiveAsync(null, null, null));
             Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.SendReceiveAsync(null,
-                "paratext_" + env.Project01, null));
+                env.PTProjectIds[env.Project01].Id, null));
             Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.SendReceiveAsync(user01Secret, null, null));
         }
 
@@ -566,9 +566,9 @@ namespace SIL.XForge.Scripture.Services
             // SUT 1
             await env.Service.SendReceiveAsync(user01Secret, ptProjectId, null);
             env.MockSharingLogicWrapper.Received(1).ShareChanges(Arg.Is<List<SharedProject>>(list =>
-                list.Count == 1 && list[0].SendReceiveId == ptProjectId), Arg.Any<SharedRepositorySource>(),
+                list.Count == 1 && list[0].SendReceiveId.Id == ptProjectId), Arg.Any<SharedRepositorySource>(),
                 out Arg.Any<List<SendReceiveResult>>(),
-                Arg.Is<List<SharedProject>>(list => list.Count == 1 && list[0].SendReceiveId == ptProjectId));
+                Arg.Is<List<SharedProject>>(list => list.Count == 1 && list[0].SendReceiveId.Id == ptProjectId));
             mockSource.DidNotReceive().Pull(Arg.Any<string>(), Arg.Any<SharedRepository>());
             env.MockSharingLogicWrapper.ClearReceivedCalls();
 
@@ -585,7 +585,7 @@ namespace SIL.XForge.Scripture.Services
         public async Task SendReceiveAsync_ProjectNotYetCloned()
         {
             var env = new TestEnvironment();
-            string ptProjectId = "paratext_" + env.Project02;
+            string ptProjectId = env.PTProjectIds[env.Project02].Id;
             UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01);
             IInternetSharedRepositorySource mockSource =
                 env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
@@ -612,7 +612,7 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             var associatedPtUser = new SFParatextUser(env.Username01);
             string targetProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            string sourceProjectId = "paratext_" + env.Project02;
+            string sourceProjectId = env.PTProjectIds[env.Project02].Id;
             UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01);
             IInternetSharedRepositorySource mockSource =
                 env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
@@ -632,14 +632,15 @@ namespace SIL.XForge.Scripture.Services
             env.MockSharingLogicWrapper.Received(2).ShareChanges(
                 Arg.Is<List<SharedProject>>(
                     list =>
-                    list.Count().Equals(1) && (list[0].SendReceiveId == targetProjectId || list[0].SendReceiveId == sourceProjectId)
-                        && Object.ReferenceEquals(list[0].Permissions, list[0].ScrText.Permissions)),
+                    list.Count().Equals(1) &&
+                        (list[0].SendReceiveId.Id == targetProjectId || list[0].SendReceiveId.Id == sourceProjectId) &&
+                        Object.ReferenceEquals(list[0].Permissions, list[0].ScrText.Permissions)),
                     Arg.Any<SharedRepositorySource>(), out Arg.Any<List<SendReceiveResult>>(),
                     Arg.Any<List<SharedProject>>());
             env.MockFileSystemService.DidNotReceive().DeleteDirectory(Arg.Any<string>());
 
             // Replaces obsolete source project if the source project has been changed
-            string newSourceProjectId = "paratext_" + env.Project03;
+            string newSourceProjectId = env.PTProjectIds[env.Project03].Id;
             string sourcePath = Path.Combine(env.SyncDir, newSourceProjectId, "target");
 
             // Only set the the new source ScrText when it is "cloned" to the filesystem
@@ -655,7 +656,7 @@ namespace SIL.XForge.Scripture.Services
             env.MockFileSystemService.DidNotReceive().DeleteDirectory(Arg.Any<string>());
             env.MockFileSystemService.Received(1).CreateDirectory(sourcePath);
             mockSource.Received(1).Pull(sourcePath, Arg.Is<SharedRepository>(repo =>
-                repo.SendReceiveId == newSourceProjectId));
+                repo.SendReceiveId.Id == newSourceProjectId));
             env.MockHgWrapper.Received(1).Update(sourcePath);
         }
 
@@ -710,6 +711,7 @@ namespace SIL.XForge.Scripture.Services
             public readonly string Project02 = "project02";
             public readonly string Project03 = "project03";
             public readonly string Project04 = "project04";
+            public readonly Dictionary<string, HexId> PTProjectIds = new Dictionary<string, HexId>();
             public readonly string User01 = "user01";
             public readonly string User02 = "user02";
             public readonly string User03 = "user03";
@@ -766,6 +768,11 @@ namespace SIL.XForge.Scripture.Services
                 Service.SharingLogicWrapper = MockSharingLogicWrapper;
                 Service.HgWrapper = MockHgWrapper;
                 Service.SyncDir = SyncDir;
+
+                PTProjectIds.Add(Project01, HexId.CreateNew());
+                PTProjectIds.Add(Project02, HexId.CreateNew());
+                PTProjectIds.Add(Project03, HexId.CreateNew());
+                PTProjectIds.Add(Project04, HexId.CreateNew());
 
                 MockJwtTokenHelper.GetParatextUsername(Arg.Any<UserSecret>()).Returns(User01);
                 MockJwtTokenHelper.GetJwtTokenFromUserSecret(Arg.Any<UserSecret>()).Returns("token_1234");
@@ -884,32 +891,32 @@ namespace SIL.XForge.Scripture.Services
                 IInternetSharedRepositorySource mockSource = Substitute.For<IInternetSharedRepositorySource>();
                 SharedRepository repo1 = new SharedRepository
                 {
-                    SendReceiveId = "paratext_" + Project01,
+                    SendReceiveId = PTProjectIds[Project01],
                     ScrTextName = "P01",
                     SourceUsers = sourceUsers
                 };
                 SharedRepository repo2 = new SharedRepository
                 {
-                    SendReceiveId = "paratext_" + Project02,
+                    SendReceiveId = PTProjectIds[Project02],
                     ScrTextName = "P02",
                     SourceUsers = sourceUsers
                 };
                 SharedRepository repo3 = new SharedRepository
                 {
-                    SendReceiveId = "paratext_" + Project03,
+                    SendReceiveId = PTProjectIds[Project03],
                     ScrTextName = "P03",
                     SourceUsers = sourceUsers
                 };
                 SharedRepository repo4 = new SharedRepository
                 {
-                    SendReceiveId = "paratext_" + Project04,
+                    SendReceiveId = PTProjectIds[Project04],
                     ScrTextName = "P04",
                     SourceUsers = sourceUsers
                 };
 
-                ProjectMetadata projMeta1 = GetMetadata("paratext_" + Project01, "Full Name " + Project01);
-                ProjectMetadata projMeta2 = GetMetadata("paratext_" + Project02, "Full Name " + Project02);
-                ProjectMetadata projMeta3 = GetMetadata("paratext_" + Project03, "Full Name " + Project03);
+                ProjectMetadata projMeta1 = GetMetadata(PTProjectIds[Project01].Id, "Full Name " + Project01);
+                ProjectMetadata projMeta2 = GetMetadata(PTProjectIds[Project02].Id, "Full Name " + Project02);
+                ProjectMetadata projMeta3 = GetMetadata(PTProjectIds[Project03].Id, "Full Name " + Project03);
 
                 var sharedRepositories = new List<SharedRepository> { repo1, repo3, repo2 };
                 if (extraSharedRepository)
@@ -931,7 +938,7 @@ namespace SIL.XForge.Scripture.Services
                         new SFProject
                         {
                             Id = "sf_id_" + Project01,
-                            ParatextId = "paratext_" + Project01,
+                            ParatextId = PTProjectIds[Project01].Id,
                             Name = "Full Name " + Project01,
                             ShortName = "P01",
                             WritingSystem = new WritingSystem
@@ -1012,8 +1019,8 @@ namespace SIL.XForge.Scripture.Services
 
             public string SetupProject(string baseId, ParatextUser associatedPtUser, bool hasEditPermission = true)
             {
-                string ptProjectId = "paratext_" + baseId;
-                ProjectScrText = GetScrText(associatedPtUser, baseId, hasEditPermission);
+                string ptProjectId = PTProjectIds[baseId].Id;
+                ProjectScrText = GetScrText(associatedPtUser, ptProjectId, hasEditPermission);
                 ProjectCommentManager = CommentManager.Get(ProjectScrText);
                 MockScrTextCollection.FindById(Arg.Any<string>(), ptProjectId)
                     .Returns(ProjectScrText);
@@ -1026,7 +1033,7 @@ namespace SIL.XForge.Scripture.Services
                 string scrtextDir = Path.Combine(SyncDir, projectId, "target");
                 ProjectName projectName = new ProjectName() { ProjectPath = scrtextDir, ShortName = "Proj" };
                 var scrText = new MockScrText(associatedPtUser, projectName);
-                scrText.CachedGuid = projectId;
+                scrText.CachedGuid = HexId.FromStrSafe(projectId);
                 scrText.Permissions.CreateFirstAdminUser();
                 scrText.Data.Add("RUT", ruthBookUsfm);
                 scrText.Settings.BooksPresentSet = new BookSet("RUT");
@@ -1039,7 +1046,10 @@ namespace SIL.XForge.Scripture.Services
             {
                 MockSharingLogicWrapper.CreateSharedProject(Arg.Any<string>(), Arg.Any<string>(),
                     Arg.Any<SharedRepositorySource>(), Arg.Any<IEnumerable<SharedRepository>>())
-                    .Returns(callInfo => new SharedProject() { SendReceiveId = callInfo.ArgAt<string>(0) });
+                    .Returns(callInfo => new SharedProject()
+                    {
+                        SendReceiveId = HexId.FromStr(callInfo.ArgAt<string>(0))
+                    });
                 MockSharingLogicWrapper.ShareChanges(Arg.Any<List<SharedProject>>(), Arg.Any<SharedRepositorySource>(),
                     out Arg.Any<List<SendReceiveResult>>(), Arg.Any<List<SharedProject>>()).Returns(true);
                 // Have the HandleErrors method run its first argument, which would be the ShareChanges() call.


### PR DESCRIPTION
ParatextData started using HexId for Paratext project IDs. There are
several places where we could draw the line between code using a
string for PT project ID, and code using a HexId for PT project ID.
This commit converts to/from HexId when using a type from
ParatextData, and attempts to retain the string type for PT project
IDs in SF code.
Also the code for a Head registry request was move into Paratext Data
and this removes it from SF.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/949)
<!-- Reviewable:end -->
