### PR TITLE
SF-1162b fix missing permissions

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -205,7 +205,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     if (SF_PROJECT_RIGHTS.hasRight(projectRole, { projectDomain: SFProjectDomain.Texts, operation: Operation.Edit })) {
       // Check for chapter rights
       const chapter = this.text?.chapters.find(c => c.number === this._chapter);
-      if (chapter != null) {
+      // Even though permissions is guaranteed to be there in the model, its not in IndexedDB the first time the project
+      // is accessed after migration
+      if (chapter != null && chapter.permissions != null) {
         return chapter.permissions[this.userService.currentUserId] === TextInfoPermission.Write;
       }
     }
@@ -222,7 +224,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     if (SF_PROJECT_RIGHTS.hasRight(projectRole, { projectDomain: SFProjectDomain.Texts, operation: Operation.View })) {
       // Check for chapter rights
       const chapter = this.sourceText?.chapters.find(c => c.number === this._chapter);
-      if (chapter != null) {
+      // Even though permissions is guaranteed to be there in the model, its not in IndexedDB the first time the project
+      // is accessed after migration
+      if (chapter != null && chapter.permissions != null) {
         return chapter.permissions[this.userService.currentUserId] !== TextInfoPermission.None;
       }
     }


### PR DESCRIPTION
- problem #1: an optimistic query will return the data in IndexedDB without permissions and then the server will return the data with permissions, on the first access after migration

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/951)
<!-- Reviewable:end -->
