### PR TITLE
SF-753 Expire specific user invites and remove email constraint

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -11,6 +11,7 @@ import { ProjectService } from 'xforge-common/project.service';
 import { QueryParameters } from 'xforge-common/query-parameters';
 import { RealtimeService } from 'xforge-common/realtime.service';
 import { TransceleratorQuestion } from '../checking/import-questions-dialog/import-questions-dialog.component';
+import { InviteeStatus } from '../users/collaborators/collaborators.component';
 import { QuestionDoc } from './models/question-doc';
 import { SFProjectCreateSettings } from './models/sf-project-create-settings';
 import { SFProjectDoc } from './models/sf-project-doc';
@@ -116,8 +117,8 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
 
   /** Get list of email addresses that have outstanding invitations on project.
    * Caller must be an admin on the project. */
-  async onlineInvitedUsers(projectId: string): Promise<string[]> {
-    return (await this.onlineInvoke<string[]>('invitedUsers', { projectId }))!;
+  async onlineInvitedUsers(projectId: string): Promise<InviteeStatus[]> {
+    return (await this.onlineInvoke<InviteeStatus[]>('invitedUsers', { projectId }))!;
   }
 
   /** Get added into project, with optionally specified shareKey code. */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
@@ -41,16 +41,18 @@
           </ng-container>
           <ng-container matColumnDef="name">
             <td mat-cell *matCellDef="let userRow">
-              <div *ngIf="!userRow.isInvitee" class="display-name-label">
+              <div *ngIf="!userRow.inviteeStatus" class="display-name-label">
                 {{ userRow.user?.displayName }}
                 <b *ngIf="isCurrentUser(userRow)" class="current-user-label">&nbsp;{{ t("me") }}</b>
               </div>
               <div
-                *ngIf="userRow.isInvitee"
+                *ngIf="userRow.inviteeStatus"
                 [innerHtml]="
-                  i18n.translateAndInsertTags('collaborators.awaiting_response_from', {
-                    email: userRow.user?.email
-                  })
+                  userRow.inviteeStatus.expired
+                    ? i18n.translateAndInsertTags('collaborators.invitation_expired', { email: userRow.user?.email })
+                    : i18n.translateAndInsertTags('collaborators.awaiting_response_from', {
+                        email: userRow.user?.email
+                      })
                 "
               ></div>
             </td>
@@ -66,7 +68,7 @@
                 mdc-icon-button
                 icon="clear"
                 class="remove-user"
-                *ngIf="!userRow.isInvitee && !isCurrentUser(userRow)"
+                *ngIf="!userRow.inviteeStatus && !isCurrentUser(userRow)"
                 type="button"
                 [disabled]="!isAppOnline"
                 (click)="removeProjectUser(userRow.id)"
@@ -75,7 +77,7 @@
 
               <!-- 2 buttons below are 1 button displayed mutually exclusively, different style on breakpoints -->
               <button
-                *ngIf="userRow.isInvitee"
+                *ngIf="userRow.inviteeStatus"
                 fxHide.lt-sm
                 fxShow
                 mdc-button
@@ -93,7 +95,7 @@
                 icon="clear"
                 color="warn"
                 class="cancel-invite"
-                *ngIf="userRow.isInvitee"
+                *ngIf="userRow.inviteeStatus"
                 fxHide
                 fxShow.lt-sm
                 type="button"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
@@ -110,9 +110,9 @@ describe('CollaboratorsComponent', () => {
   it('displays invited users', fakeAsync(() => {
     const env = new TestEnvironment();
     when(mockedProjectService.onlineInvitedUsers(env.project01Id)).thenResolve([
-      'alice@a.aa',
-      'bob@b.bb',
-      'charles@c.cc'
+      { email: 'alice@a.aa', expired: false },
+      { email: 'bob@b.bb', expired: false },
+      { email: 'charles@c.cc', expired: true }
     ]);
 
     env.setupProjectData();
@@ -128,6 +128,10 @@ describe('CollaboratorsComponent', () => {
     const inviteeDisplay = env.elementTextContent(env.cell(inviteeRow, 1));
     expect(inviteeDisplay).toContain('Awaiting');
     expect(inviteeDisplay).toContain('alice@a.aa');
+    const expiredRow = 5;
+    const expiredInvitee = env.elementTextContent(env.cell(expiredRow, 1));
+    expect(expiredInvitee).toContain('Invitation has expired');
+    expect(expiredInvitee).toContain('charles@c.cc');
     // Invitee row has cancel button but not remove button.
     expect(env.removeUserButtonOnRow(inviteeRow)).toBeFalsy();
     expect(env.cancelInviteButtonOnRow(inviteeRow)).toBeTruthy();
@@ -173,7 +177,9 @@ describe('CollaboratorsComponent', () => {
 
   it('should refresh user list after inviting a new user', fakeAsync(() => {
     const env = new TestEnvironment();
-    when(mockedProjectService.onlineInvitedUsers(env.project01Id)).thenResolve(['alice@a.aa']);
+    when(mockedProjectService.onlineInvitedUsers(env.project01Id)).thenResolve([
+      { email: 'alice@a.aa', expired: false }
+    ]);
     env.setupProjectData();
     env.fixture.detectChanges();
     tick();
@@ -186,8 +192,8 @@ describe('CollaboratorsComponent', () => {
 
     // Simulate invitation event
     when(mockedProjectService.onlineInvitedUsers(env.project01Id)).thenResolve([
-      'alice@a.aa',
-      'new-invitee@example.com'
+      { email: 'alice@a.aa', expired: false },
+      { email: 'new-invitee@example.com', expired: false }
     ]);
     numInvitees++;
     env.component.onInvitationSent();
@@ -201,7 +207,9 @@ describe('CollaboratorsComponent', () => {
   it('should un-invite user from project', fakeAsync(() => {
     const env = new TestEnvironment();
     when(mockedProjectService.onlineUninviteUser(anything(), anything())).thenResolve();
-    when(mockedProjectService.onlineInvitedUsers(env.project01Id)).thenResolve(['alice@a.aa']);
+    when(mockedProjectService.onlineInvitedUsers(env.project01Id)).thenResolve([
+      { email: 'alice@a.aa', expired: false }
+    ]);
     env.setupProjectData();
     env.fixture.detectChanges();
     tick();
@@ -248,7 +256,9 @@ describe('CollaboratorsComponent', () => {
   it('should filter users', fakeAsync(() => {
     const env = new TestEnvironment();
     env.setupProjectData();
-    when(mockedProjectService.onlineInvitedUsers(env.project01Id)).thenResolve(['bob@example.com']);
+    when(mockedProjectService.onlineInvitedUsers(env.project01Id)).thenResolve([
+      { email: 'bob@example.com', expired: false }
+    ]);
     env.fixture.detectChanges();
     tick();
     env.fixture.detectChanges();
@@ -388,7 +398,9 @@ describe('CollaboratorsComponent', () => {
   it('should disable collaborators if not connected', fakeAsync(() => {
     const env = new TestEnvironment(false);
     env.setupProjectData();
-    when(mockedProjectService.onlineInvitedUsers(env.project01Id)).thenResolve(['alice@a.aa']);
+    when(mockedProjectService.onlineInvitedUsers(env.project01Id)).thenResolve([
+      { email: 'alice@a.aa', expired: false }
+    ]);
     env.fixture.detectChanges();
     tick();
     env.fixture.detectChanges();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.ts
@@ -24,7 +24,12 @@ interface Row {
   readonly id: string;
   readonly user: UserInfo;
   readonly role: string;
-  readonly isInvitee: boolean;
+  readonly inviteeStatus?: InviteeStatus;
+}
+
+export interface InviteeStatus {
+  email: string;
+  expired: boolean;
 }
 
 @Component({
@@ -219,10 +224,7 @@ export class CollaboratorsComponent extends DataLoadingComponent implements OnIn
       tasks.push(
         this.userService
           .getProfile(userId)
-          .then(
-            userProfileDoc =>
-              (userRows[index] = { id: userProfileDoc.id, user: userProfileDoc.data || {}, role, isInvitee: false })
-          )
+          .then(userProfileDoc => (userRows[index] = { id: userProfileDoc.id, user: userProfileDoc.data || {}, role }))
       );
     }
     await Promise.all(tasks);
@@ -231,9 +233,9 @@ export class CollaboratorsComponent extends DataLoadingComponent implements OnIn
       const invitees: Row[] = (await this.projectService.onlineInvitedUsers(this.projectId)).map(invitee => {
         return {
           id: '',
-          user: { email: invitee },
+          user: { email: invitee.email },
           role: '',
-          isInvitee: true
+          inviteeStatus: invitee
         } as Row;
       });
       this._userRows = userRows.concat(invitees);

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -36,6 +36,7 @@
     "change_roles_and_permissions": "Users' roles and permissions can {{ boldStart }}only{{ boldEnd }} be changed in {{ boldStart }}Paratext{{ boldEnd }}. Open the project in {{ boldStart }}Paratext{{ boldEnd }}, on the project window click {{ templateTagBoundary }}{{ templateTagBoundary }}, then {{ boldStart }}Project settings{{ boldEnd }}, then {{ boldStart }}User permissions{{ boldEnd }}. After a {{ italicsStart }}Send/Receive{{ italicsEnd }} in {{ boldStart }}Paratext{{ boldEnd }} and then a {{ italicsStart }}Synchronize{{ italicsEnd }} in {{ boldStart }}Scripture Forge{{ boldEnd }}, their role will come into effect here, once that user logs in with their {{ boldStart }}Paratext{{ boldEnd }} account.",
     "connect_network_to_manage_users": "User management is disabled while offline. Please connect to the internet to manage users.",
     "filter_users": "Filter users...",
+    "invitation_expired": "Invitation has expired for{{ newLine }}{{ email }}",
     "me": "me",
     "no_users_found": "No users found",
     "problem_loading_invited_users": "There was a problem loading the list of invited users.",

--- a/src/SIL.XForge.Scripture/Models/InviteeStatus.cs
+++ b/src/SIL.XForge.Scripture/Models/InviteeStatus.cs
@@ -1,0 +1,8 @@
+namespace SIL.XForge.Scripture.Models
+{
+    public class InviteeStatus
+    {
+        public string Email { get; set; }
+        public bool Expired { get; set; }
+    }
+}

--- a/src/SIL.XForge.Scripture/Resources/SharedResource.resx
+++ b/src/SIL.XForge.Scripture/Resources/SharedResource.resx
@@ -146,9 +146,8 @@
   <data name="InviteInstructions" xml:space="preserve">
     <value>If you are not already a {0} user, then after clicking the link, click {1}Sign Up{2} and do one of the following:</value>
   </data>
-  <data name="InviteLinkSharingOff" xml:space="preserve">
-    <value>This link will only work for this email address.</value>
-    <comment>Previously this text was used when link sharing was turned off for a project, but now it is always used when sending an invitation whether link sharing is on or off.</comment>
+  <data name="InviteLinkExpires" xml:space="preserve">
+    <value>The project invitation link expires in 14 days.</value>
   </data>
   <data name="InvitePTOption" xml:space="preserve">
     <value>Click {0}Sign up with Paratext{1} and follow the instructions to access {2} using an existing Paratext account, or</value>

--- a/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
@@ -17,7 +17,7 @@ namespace SIL.XForge.Scripture.Services
         Task<bool> IsAlreadyInvitedAsync(string curUserId, string projectId, string email);
         Task UninviteUserAsync(string curUserId, string projectId, string email);
         Task CheckLinkSharingAsync(string curUserId, string projectId, string shareKey = null);
-        Task<string[]> InvitedUsersAsync(string curUserId, string projectId);
+        Task<IReadOnlyList<InviteeStatus>> InvitedUsersAsync(string curUserId, string projectId);
         Task<IEnumerable<TransceleratorQuestion>> TransceleratorQuestions(string curUserId, string projectId);
         Task<bool> HasTransceleratorQuestions(string curUserId, string projectId);
     }

--- a/src/SIL.XForge.Scripture/SharedResource.cs
+++ b/src/SIL.XForge.Scripture/SharedResource.cs
@@ -24,7 +24,7 @@ namespace SIL.XForge.Scripture
             public const string InviteGoogleOption = "InviteGoogleOption";
             public const string InviteGreeting = "InviteGreeting";
             public const string InviteInstructions = "InviteInstructions";
-            public const string InviteLinkSharingOff = "InviteLinkSharingOff";
+            public const string InviteLinkExpires = "InviteLinkExpires";
             public const string InvitePTOption = "InvitePTOption";
             public const string InviteSignature = "InviteSignature";
             public const string InviteSubject = "InviteSubject";

--- a/src/SIL.XForge/Models/ShareKey.cs
+++ b/src/SIL.XForge/Models/ShareKey.cs
@@ -1,8 +1,12 @@
+using System;
+
 namespace SIL.XForge.Models
 {
     public class ShareKey
     {
         public string Email { get; set; }
         public string Key { get; set; }
+        // Use a default expiration time for sharekeys without an expiration (sharekeys created prior to SF-753)
+        public DateTime ExpirationTime { get; set; } = new DateTime(2021, 12, 1, 0, 0, 0, DateTimeKind.Utc);
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
@@ -15,7 +15,7 @@ namespace SIL.XForge.Scripture.Controllers
         {
             var env = new TestEnvironment();
             var output = ((await env.Controller.InvitedUsers("some-project-id")) as RpcMethodSuccessResult).ReturnObject;
-            Assert.That(output, Is.TypeOf(typeof(string[])));
+            Assert.That(output, Is.Not.Null);
         }
 
         [Test]


### PR DESCRIPTION
* email link expires in 14 days
* resending an email invitation renews the 14 day valid period
* user can choose any email to access the project
* expired invitations show as expired on users page
* notify user the link will expire

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/954)
<!-- Reviewable:end -->
