### PR TITLE
SF-1153 Store activity time, not use event.timeStamp 

### DIFF
--- a/src/SIL.XForge.Scripture/Models/TranslateMetrics.cs
+++ b/src/SIL.XForge.Scripture/Models/TranslateMetrics.cs
@@ -3,6 +3,9 @@ using SIL.XForge.Models;
 
 namespace SIL.XForge.Scripture.Models
 {
+    /// <summary>
+    /// Usage information for a short amount of user activity in the editor component.
+    /// </summary>
     public class TranslateMetrics : IIdentifiable
     {
         public string Id { get; set; }
@@ -24,6 +27,7 @@ namespace SIL.XForge.Scripture.Models
         public int? ProductiveCharacterCount { get; set; }
         public int? SuggestionAcceptedCount { get; set; }
         public int? SuggestionTotalCount { get; set; }
+        /// <remarks>In milliseconds.</remarks>
         public int? TimeEditActive { get; set; }
         public string EditEndEvent { get; set; }
 


### PR DESCRIPTION
- Event timeStamp gives huge numbers in iOS Safari, but numbers of ms
on other platforms.
- So don't use Event timeStamp, and instead store the activity start
time another way, by writing to an activity whenStarted the ms
reported from `Date.now()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/959)
<!-- Reviewable:end -->
