### PR TITLE
Use alternate DBL qa server

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -88,7 +88,7 @@ namespace SIL.XForge.Scripture.Services
             {
                 _httpClientHandler.ServerCertificateCustomValidationCallback
                     = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
-                _dblServerUri = "https://paratext-qa.thedigitalbiblelibrary.org/";
+                _dblServerUri = "https://qa.thedigitalbiblelibrary.org/";
                 _registryServerUri = "https://registry-dev.paratext.org";
                 _registryClient.BaseAddress = new Uri(_registryServerUri);
                 _sendReceiveServerUri = InternetAccess.uriDevelopment;


### PR DESCRIPTION
I am unsure if there is a real difference between the two urls. It appears that the older url tries to get to a server that is offline at the moment (at least for me and for testers). This may be needed to get testers unblocked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/963)
<!-- Reviewable:end -->
