### PR TITLE
Fix date localization test so it can pass in both Chromium 87 and 88

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -97,7 +97,8 @@ describe('I18nService', () => {
     service.setLocale('en-GB');
     expect(service.formatDate(date)).toEqual('25 Nov 1991, 5:28 pm');
     service.setLocale('zh-CN');
-    expect(service.formatDate(date)).toEqual('1991/11/25 下午5:28');
+    // Chromium 88 stopped including a space. This removal of spaces could be removed once everyone is on v88.
+    expect(service.formatDate(date).replace(' ', '')).toEqual('1991/11/25下午5:28');
     service.setLocale('az');
     expect(service.formatDate(date)).toEqual('25.11.1991 17:28');
   });


### PR DESCRIPTION
Chromium stopped including a space in the date format for zh-CN, which broke a test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/965)
<!-- Reviewable:end -->
