### PR TITLE
SF-1199 Include project role in sharekey

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { obj } from 'realtime-server/lib/common/utils/obj-path';
 import { getQuestionDocId, Question } from 'realtime-server/lib/scriptureforge/models/question';
 import { SFProject, SF_PROJECTS_COLLECTION } from 'realtime-server/lib/scriptureforge/models/sf-project';
+import { SFProjectRole } from 'realtime-server/lib/scriptureforge/models/sf-project-role';
 import { getSFProjectUserConfigDocId } from 'realtime-server/lib/scriptureforge/models/sf-project-user-config';
 import { CommandService } from 'xforge-common/command.service';
 import { FileService } from 'xforge-common/file.service';
@@ -126,8 +127,8 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
     return this.onlineInvoke('checkLinkSharing', { projectId: id, shareKey });
   }
 
-  onlineInvite(id: string, email: string, locale: string): Promise<string | undefined> {
-    return this.onlineInvoke('invite', { projectId: id, email, locale });
+  onlineInvite(id: string, email: string, locale: string, role: string): Promise<string | undefined> {
+    return this.onlineInvoke('invite', { projectId: id, email, locale, role });
   }
 
   async onlineUninviteUser(projectId: string, emailToUninvite: string): Promise<string> {
@@ -136,6 +137,10 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
 
   async onlineIsSourceProject(projectId: string): Promise<boolean> {
     return (await this.onlineInvoke<boolean>('isSourceProject', { projectId }))!;
+  }
+
+  async onlineGetLinkSharingKey(projectId: string, role: SFProjectRole): Promise<string> {
+    return (await this.onlineInvoke<string>('linkSharingKey', { projectId, role })) ?? '';
   }
 
   async transceleratorQuestions(projectId: string): Promise<TransceleratorQuestion[]> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
@@ -2,6 +2,8 @@ import { MdcTextField } from '@angular-mdc/web/textfield';
 import { AfterViewInit, ChangeDetectorRef, Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { translate } from '@ngneat/transloco';
+import { SFProjectRole } from 'realtime-server/lib/scriptureforge/models/sf-project-role';
+import { combineLatest, Subject } from 'rxjs';
 import { I18nService } from 'xforge-common/i18n.service';
 import { LocationService } from 'xforge-common/location.service';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -19,7 +21,6 @@ import { SFProjectService } from '../../core/sf-project.service';
 export class ShareControlComponent extends SubscriptionDisposable implements AfterViewInit {
   /** Fires when an invitation is sent. */
   @Output() invited = new EventEmitter<void>();
-  @Input() readonly projectId?: string;
   @Input() readonly isLinkSharingEnabled: boolean = false;
   @ViewChild('shareLinkField') shareLinkField?: MdcTextField;
 
@@ -29,6 +30,10 @@ export class ShareControlComponent extends SubscriptionDisposable implements Aft
   isSubmitted: boolean = false;
   isAlreadyInvited: boolean = false;
   readonly alreadyProjectMemberResponse: string = 'alreadyProjectMember';
+
+  private _projectId?: string;
+  private linkSharingKey: string = '';
+  private projectId$: Subject<string> = new Subject<string>();
 
   constructor(
     readonly i18n: I18nService,
@@ -41,9 +46,22 @@ export class ShareControlComponent extends SubscriptionDisposable implements Aft
     super();
   }
 
+  @Input() set projectId(id: string | undefined) {
+    if (id == null) {
+      return;
+    }
+    this._projectId = id;
+    this.projectId$.next(id);
+  }
+
   ngAfterViewInit() {
-    this.subscribe(this.pwaService.onlineStatus, isOnline => {
+    // TODO: Allow user to select a role for the invitation link
+    const role = SFProjectRole.CommunityChecker;
+    this.subscribe(combineLatest([this.pwaService.onlineStatus, this.projectId$]), async ([isOnline, _]) => {
       if (isOnline) {
+        if (this._projectId != null) {
+          this.linkSharingKey = await this.projectService.onlineGetLinkSharingKey(this._projectId, role);
+        }
         this.sendInviteForm.enable();
       } else {
         this.sendInviteForm.disable();
@@ -54,7 +72,12 @@ export class ShareControlComponent extends SubscriptionDisposable implements Aft
   }
 
   get shareLink(): string {
-    return this.locationService.origin + '/projects/' + this.projectId + '?sharing=true';
+    if (this.linkSharingKey.length < 1) {
+      return '';
+    }
+    return (
+      this.locationService.origin + '/projects/' + this._projectId + '?sharing=true&shareKey=' + this.linkSharingKey
+    );
   }
 
   get isAppOnline(): boolean {
@@ -72,19 +95,26 @@ export class ShareControlComponent extends SubscriptionDisposable implements Aft
   }
 
   async onEmailInput(): Promise<void> {
-    if (this.projectId == null || this.email.invalid) {
+    if (this._projectId == null || this.email.invalid) {
       return;
     }
-    this.isAlreadyInvited = await this.projectService.onlineIsAlreadyInvited(this.projectId, this.email.value);
+    this.isAlreadyInvited = await this.projectService.onlineIsAlreadyInvited(this._projectId, this.email.value);
   }
 
   async sendEmail(): Promise<void> {
-    if (this.projectId == null || this.email.value === '' || this.email.value == null || !this.sendInviteForm.valid) {
+    if (this._projectId == null || this.email.value === '' || this.email.value == null || !this.sendInviteForm.valid) {
       return;
     }
 
     this.isSubmitted = true;
-    const response = await this.projectService.onlineInvite(this.projectId, this.email.value, this.localeControl.value);
+    // TODO: Allow user to select a role for the invitation link
+    const inviteRole: SFProjectRole = SFProjectRole.CommunityChecker;
+    const response = await this.projectService.onlineInvite(
+      this._projectId,
+      this.email.value,
+      this.localeControl.value,
+      inviteRole
+    );
     this.isSubmitted = false;
     this.isAlreadyInvited = false;
     let message = '';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share.component.spec.ts
@@ -79,7 +79,7 @@ describe('ShareComponent', () => {
     env.clickElement(env.shareButton);
 
     env.clickElement(env.closeButton);
-    verify(mockedProjectService.onlineInvite('project01', anything(), anything())).never();
+    verify(mockedProjectService.onlineInvite('project01', anything(), anything(), anything())).never();
     expect().nothing();
   }));
 });
@@ -106,7 +106,7 @@ class TestEnvironment {
   private readonly realtimeService: TestRealtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);
 
   constructor() {
-    when(mockedProjectService.onlineInvite('project01', anything(), anything())).thenResolve();
+    when(mockedProjectService.onlineInvite('project01', anything(), anything(), anything())).thenResolve();
     when(mockedNoticeService.show(anything())).thenResolve();
     when(mockedActivatedRoute.params).thenReturn(of({ projectId: 'project01' }));
     when(mockedLocationService.origin).thenReturn('https://scriptureforge.org');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
@@ -438,7 +438,7 @@ class TestEnvironment {
     }
     roles.set(NONE_ROLE.role, NONE_ROLE);
     when(mockedProjectService.roles).thenReturn(roles);
-    when(mockedProjectService.onlineInvite(this.project01Id, anything(), anything())).thenResolve();
+    when(mockedProjectService.onlineInvite(this.project01Id, anything(), anything(), anything())).thenResolve();
     when(mockedProjectService.onlineInvitedUsers(this.project01Id)).thenResolve([]);
     when(mockedNoticeService.show(anything())).thenResolve();
     when(mockedLocationService.origin).thenReturn('https://scriptureforge.org');
@@ -448,6 +448,7 @@ class TestEnvironment {
     when(mockedProjectService.get(anything())).thenCall(projectId =>
       this.realtimeService.subscribe(SFProjectDoc.COLLECTION, projectId)
     );
+    when(mockedProjectService.onlineGetLinkSharingKey(this.project01Id, anything())).thenResolve('linkSharingKey01');
     this.realtimeService.addSnapshots<UserProfile>(UserProfileDoc.COLLECTION, [
       {
         id: 'user01',

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -151,11 +151,11 @@ namespace SIL.XForge.Scripture.Controllers
             }
         }
 
-        public async Task<IRpcMethodResult> Invite(string projectId, string email, string locale)
+        public async Task<IRpcMethodResult> Invite(string projectId, string email, string locale, string role)
         {
             try
             {
-                if (await _projectService.InviteAsync(UserId, projectId, email, locale))
+                if (await _projectService.InviteAsync(UserId, projectId, email, locale, role))
                     return Ok();
                 return Ok(AlreadyProjectMemberResponse);
             }
@@ -243,6 +243,18 @@ namespace SIL.XForge.Scripture.Controllers
         public IRpcMethodResult IsSourceProject(string projectId)
         {
             return Ok(_projectService.IsSourceProject(projectId));
+        }
+
+        public async Task<IRpcMethodResult> LinkSharingKey(string projectId, string role)
+        {
+            try
+            {
+                return Ok(await _projectService.GetLinkSharingKeyAsync(projectId, role));
+            }
+            catch (DataNotFoundException dnfe)
+            {
+                return NotFoundError(dnfe.Message);
+            }
         }
 
         public async Task<IRpcMethodResult> AddTranslateMetrics(string projectId, TranslateMetrics metrics)

--- a/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
@@ -13,7 +13,8 @@ namespace SIL.XForge.Scripture.Services
         Task UpdateSettingsAsync(string curUserId, string projectId, SFProjectSettings settings);
         Task AddTranslateMetricsAsync(string curUserId, string projectId, TranslateMetrics metrics);
         Task SyncAsync(string curUserId, string projectId);
-        Task<bool> InviteAsync(string curUserId, string projectId, string email, string locale);
+        Task<bool> InviteAsync(string curUserId, string projectId, string email, string locale, string role);
+        Task<string> GetLinkSharingKeyAsync(string projectId, string role);
         Task<bool> IsAlreadyInvitedAsync(string curUserId, string projectId, string email);
         Task UninviteUserAsync(string curUserId, string projectId, string email);
         Task CheckLinkSharingAsync(string curUserId, string projectId, string shareKey = null);

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -318,7 +318,8 @@ namespace SIL.XForge.Scripture.Services
             await _syncService.SyncAsync(curUserId, projectId, false);
         }
 
-        public async Task<bool> InviteAsync(string curUserId, string projectId, string email, string locale)
+        public async Task<bool> InviteAsync(string curUserId, string projectId, string email, string locale,
+            string role)
         {
             SFProject project = await GetProjectAsync(projectId);
             if (await RealtimeService.QuerySnapshots<User>()
@@ -345,7 +346,14 @@ namespace SIL.XForge.Scripture.Services
             SFProjectSecret projectSecret = await ProjectSecrets.UpdateAsync(
                 p => p.Id == projectId && !p.ShareKeys.Any(sk => sk.Email == email),
                 update => update.Add(p => p.ShareKeys,
-                    new ShareKey { Email = email, Key = _securityService.GenerateKey(), ExpirationTime = expTime })
+                    new ShareKey
+                    {
+                        Email = email,
+                        Key = _securityService.GenerateKey(),
+                        ExpirationTime = expTime,
+                        ProjectRole = role
+                    }
+                )
             );
             if (projectSecret == null)
             {
@@ -374,6 +382,32 @@ namespace SIL.XForge.Scripture.Services
             var emailBody = $"{greeting}{linkExpires}{instructions}{pt}{google}{facebook}{withemail}{signoff}";
             await _emailService.SendEmailAsync(email, subject, emailBody);
             return true;
+        }
+
+        /// <summary> Get the link sharing key for a project if it exists, otherwise create a new one. </summary>
+        public async Task<string> GetLinkSharingKeyAsync(string projectId, string role)
+        {
+            SFProject project = await GetProjectAsync(projectId);
+            if (!(project.CheckingConfig.ShareEnabled && project.CheckingConfig.ShareLevel == "anyone"))
+                return null;
+            SFProjectSecret projectSecret = await ProjectSecrets.GetAsync(projectId);
+            string key = projectSecret.ShareKeys.SingleOrDefault(
+                sk => sk.Email == null && sk.ProjectRole == role)?.Key;
+            if (!string.IsNullOrEmpty(key))
+                return key;
+
+            // Generate a new link sharing key for the given role
+            key = _securityService.GenerateKey();
+            await ProjectSecrets.UpdateAsync(p => p.Id == projectId,
+                update => update.Add(p => p.ShareKeys,
+                new ShareKey
+                {
+                    Key = key,
+                    ProjectRole = role,
+                    ExpirationTime = null
+                }
+            ));
+            return key;
         }
 
         /// <summary>Cancel an outstanding project invitation.</summary>
@@ -419,11 +453,10 @@ namespace SIL.XForge.Scripture.Services
             SFProjectSecret projectSecret = await ProjectSecrets.GetAsync(projectId);
 
             DateTime now = DateTime.UtcNow;
-            return projectSecret.ShareKeys.Select(sk =>
+            return projectSecret.ShareKeys.Where(s => s.Email != null).Select(sk =>
                 new InviteeStatus { Email = sk.Email, Expired = sk.ExpirationTime < now }).ToArray();
         }
-
-        public async Task CheckLinkSharingAsync(string curUserId, string projectId, string shareKey = null)
+        public async Task CheckLinkSharingAsync(string curUserId, string projectId, string shareKey)
         {
             using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
             {
@@ -432,28 +465,34 @@ namespace SIL.XForge.Scripture.Services
                     return;
 
                 IDocument<User> userDoc = await conn.FetchAsync<User>(curUserId);
+                string projectRole;
                 Attempt<string> attempt = await TryGetProjectRoleAsync(projectDoc.Data, curUserId);
-                string projectRole = attempt.Result;
-
-                if (shareKey != null)
+                if (!attempt.TryResult(out projectRole))
                 {
-                    SFProjectSecret projectSecret = await ProjectSecrets.UpdateAsync(
-                        p => p.Id == projectId && p.ShareKeys.Any(
-                            sk => sk.Key == shareKey && sk.ExpirationTime > DateTime.UtcNow),
-                        update => update.RemoveAll(p => p.ShareKeys, sk => sk.Key == shareKey)
-                    );
-                    if (projectSecret != null)
-                    {
-                        await AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole, false);
-                        return;
-                    }
+                    // Get the project role that is specified in the sharekey
+                    Attempt<SFProjectSecret> psAttempt = await ProjectSecrets.TryGetAsync(projectId);
+                    if (psAttempt.TryResult(out SFProjectSecret ps))
+                        projectRole = ps.ShareKeys.SingleOrDefault(sk => sk.Key == shareKey)?.ProjectRole;
                 }
-                if (projectDoc.Data.CheckingConfig.ShareEnabled == true &&
-                    projectDoc.Data.CheckingConfig.ShareLevel == CheckingShareLevel.Anyone)
+                if (projectRole == null)
+                    throw new ForbiddenException();
+
+                bool linkSharing = projectDoc.Data.CheckingConfig.ShareEnabled &&
+                    projectDoc.Data.CheckingConfig.ShareLevel == CheckingShareLevel.Anyone;
+                if (linkSharing)
                 {
-                    // Users with the project link get added to the project. This also covers the case where
-                    // a user was emailed a share key and the invite was cancelled, but link sharing is enabled
-                    await AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole);
+                    await AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole, true);
+                    return;
+                }
+                // Look for a valid specific user share key
+                SFProjectSecret projectSecret = await ProjectSecrets.UpdateAsync(
+                    p => p.Id == projectId && p.ShareKeys.Any(
+                        sk => sk.Email != null && sk.Key == shareKey && sk.ExpirationTime > DateTime.UtcNow),
+                    update => update.RemoveAll(p => p.ShareKeys, sk => sk.Key == shareKey)
+                );
+                if (projectSecret != null)
+                {
+                    await AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole, false);
                     return;
                 }
                 throw new ForbiddenException();
@@ -562,7 +601,7 @@ namespace SIL.XForge.Scripture.Services
                 }
             }
 
-            return Attempt.Failure(SFProjectRole.CommunityChecker);
+            return Attempt.Failure(ProjectRole.None);
         }
 
         private async Task<IDocument<SFProject>> TryGetProjectDocAsync(string projectId, IConnection conn)

--- a/src/SIL.XForge/Models/ShareKey.cs
+++ b/src/SIL.XForge/Models/ShareKey.cs
@@ -7,6 +7,7 @@ namespace SIL.XForge.Models
         public string Email { get; set; }
         public string Key { get; set; }
         // Use a default expiration time for sharekeys without an expiration (sharekeys created prior to SF-753)
-        public DateTime ExpirationTime { get; set; } = new DateTime(2021, 12, 1, 0, 0, 0, DateTimeKind.Utc);
+        public DateTime? ExpirationTime { get; set; } = new DateTime(2021, 12, 1, 0, 0, 0, DateTimeKind.Utc);
+        public string ProjectRole { get; set; }
     }
 }

--- a/src/SIL.XForge/Models/ShareKey.cs
+++ b/src/SIL.XForge/Models/ShareKey.cs
@@ -6,8 +6,7 @@ namespace SIL.XForge.Models
     {
         public string Email { get; set; }
         public string Key { get; set; }
-        // Use a default expiration time for sharekeys without an expiration (sharekeys created prior to SF-753)
-        public DateTime? ExpirationTime { get; set; } = new DateTime(2021, 12, 1, 0, 0, 0, DateTimeKind.Utc);
+        public DateTime? ExpirationTime { get; set; }
         public string ProjectRole { get; set; }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -34,6 +34,7 @@ namespace SIL.XForge.Scripture.Services
         private const string User02 = "user02";
         private const string User03 = "user03";
         private const string User04 = "user04";
+        private const string LinkExpiredUser = "linkexpireduser";
         private const string SiteId = "xf";
 
         [Test]
@@ -41,12 +42,15 @@ namespace SIL.XForge.Scripture.Services
         {
             var env = new TestEnvironment();
             const string email = "newuser@example.com";
+            const string role = SFProjectRole.CommunityChecker;
 
-            await env.Service.InviteAsync(User01, Project01, email, "en");
+            await env.Service.InviteAsync(User01, Project01, email, "en", role);
             await env.EmailService.Received(1).SendEmailAsync(email, Arg.Any<string>(),
                 Arg.Is<string>(body =>
                     body.Contains($"http://localhost/projects/{Project01}?sharing=true&shareKey=1234abc")
                     && body.Contains("The project invitation link expires in 14 days")));
+            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project01);
+            Assert.That(projectSecret.ShareKeys.Single(sk => sk.Email == email).ProjectRole, Is.EqualTo(role));
         }
 
         [Test]
@@ -54,8 +58,9 @@ namespace SIL.XForge.Scripture.Services
         {
             var env = new TestEnvironment();
             const string email = "newuser@example.com";
+            const string role = SFProjectRole.CommunityChecker;
 
-            await env.Service.InviteAsync(User01, Project03, email, "en");
+            await env.Service.InviteAsync(User01, Project03, email, "en", role);
             await env.EmailService.Received(1).SendEmailAsync(email, Arg.Any<string>(),
                 Arg.Is<string>(body =>
                     body.Contains($"http://localhost/projects/{Project03}?sharing=true&shareKey=1234abc")
@@ -64,6 +69,7 @@ namespace SIL.XForge.Scripture.Services
             // Code was recorded in database and email address was encoded in ShareKeys
             SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
             Assert.That(projectSecret.ShareKeys.Single(sk => sk.Email == email).Key, Is.EqualTo("1234abc"));
+            Assert.That(projectSecret.ShareKeys.Single(sk => sk.Email == email).ProjectRole, Is.EqualTo(role));
         }
 
         [Test]
@@ -71,15 +77,16 @@ namespace SIL.XForge.Scripture.Services
         {
             var env = new TestEnvironment();
             const string email = "bob@example.com";
+            const string role = SFProjectRole.CommunityChecker;
 
             SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
             Assert.That(projectSecret.ShareKeys.Single(sk => sk.Email == email).ExpirationTime,
                 Is.LessThan(DateTime.UtcNow.AddDays(2)), "setup");
             var invitees = await env.Service.InvitedUsersAsync(User01, Project03);
             Assert.That(invitees.Select(i => i.Email), Is.EquivalentTo(
-                new[] { "bob@example.com", "user02@example.com", "user03@example.com", "bill@example.com" }), "setup");
+                new[] { "bob@example.com", "expired@example.com", "user03@example.com", "bill@example.com" }), "setup");
 
-            await env.Service.InviteAsync(User01, Project03, email, "en");
+            await env.Service.InviteAsync(User01, Project03, email, "en", role);
             // Invitation email was resent but with original code and updated time
             await env.EmailService.Received(1).SendEmailAsync(Arg.Is(email), Arg.Any<string>(),
                 Arg.Is<string>(body =>
@@ -90,24 +97,26 @@ namespace SIL.XForge.Scripture.Services
                 "Code should not have been changed");
             Assert.That(projectSecret.ShareKeys.Single(sk => sk.Email == email).ExpirationTime,
                 Is.GreaterThan(DateTime.UtcNow.AddDays(13)));
+            Assert.That(projectSecret.ShareKeys.Single(sk => sk.Email == email).ProjectRole, Is.EqualTo(role));
 
             invitees = await env.Service.InvitedUsersAsync(User01, Project03);
             Assert.That(invitees.Select(i => i.Email), Is.EquivalentTo(
-                new[] { "bob@example.com", "user02@example.com", "user03@example.com", "bill@example.com" }));
+                new[] { "bob@example.com", "expired@example.com", "user03@example.com", "bill@example.com" }));
         }
 
         [Test]
         public async Task Invite_SpecificSharingEnabledCodeExpired_UserInvitedWithNewCode()
         {
             var env = new TestEnvironment();
-            const string email = "user02@example.com";
+            const string email = "expired@example.com";
+            const string role = SFProjectRole.CommunityChecker;
 
             SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
             Assert.That(projectSecret.ShareKeys.Any(
                 sk => sk.Email == email && sk.ExpirationTime < DateTime.UtcNow), Is.True, "setup");
 
             env.SecurityService.GenerateKey().Returns("newkey");
-            await env.Service.InviteAsync(User01, Project03, email, "en");
+            await env.Service.InviteAsync(User01, Project03, email, "en", role);
             // Invitation email was sent with a new code
             await env.EmailService.Received(1).SendEmailAsync(Arg.Is(email), Arg.Any<string>(),
                 Arg.Is<string>(body =>
@@ -116,6 +125,7 @@ namespace SIL.XForge.Scripture.Services
             projectSecret = env.ProjectSecrets.Get(Project03);
             Assert.That(projectSecret.ShareKeys.Single(sk => sk.Email == email).Key, Is.EqualTo("newkey"),
                 "Code should not have been changed");
+            Assert.That(projectSecret.ShareKeys.Single(sk => sk.Email == email).ProjectRole, Is.EqualTo(role));
         }
 
         [Test]
@@ -127,20 +137,64 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(project.CheckingConfig.ShareLevel,
                 Is.EqualTo(CheckingShareLevel.Anyone), "setup: link sharing should be enabled");
             const string email = "newuser@example.com";
+            const string role = SFProjectRole.CommunityChecker;
             // SUT
-            await env.Service.InviteAsync(User01, Project02, email, "en");
+            await env.Service.InviteAsync(User01, Project02, email, "en", role);
             await env.EmailService.Received(1).SendEmailAsync(email, Arg.Any<string>(),
                 Arg.Is<string>(
                     body => body.Contains($"http://localhost/projects/{Project02}?sharing=true&shareKey=1234abc"))
             );
+            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project02);
+            Assert.That(projectSecret.ShareKeys.Single(sk => sk.Key == "1234abc").ProjectRole, Is.EqualTo(role));
+        }
+
+        [Test]
+        public async Task GetLinkSharingKeyAsync_LinkDoesNotExist_NewShareKeyCreated()
+        {
+            var env = new TestEnvironment();
+            await env.Service.UpdateSettingsAsync(User01, Project03, new SFProjectSettings { ShareLevel = "anyone" });
+            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
+            Assert.That(projectSecret.ShareKeys.Any(sk => sk.Email == null), Is.False);
+            env.SecurityService.GenerateKey().Returns("newkey");
+
+            string shareLink = await env.Service.GetLinkSharingKeyAsync(Project03, SFProjectRole.CommunityChecker);
+            Assert.That(shareLink, Is.EqualTo("newkey"));
+            projectSecret = env.ProjectSecrets.Get(Project03);
+            Assert.That(projectSecret.ShareKeys.Single(sk => sk.Email == null && sk.ExpirationTime == null).Key,
+                Is.EqualTo("newkey"));
+        }
+
+        [Test]
+        public async Task GetLinkSharingKeyAsync_LinkExists_ReturnsExistingKey()
+        {
+            var env = new TestEnvironment();
+            const string role = SFProjectRole.CommunityChecker;
+            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project02);
+
+            Assert.That(projectSecret.ShareKeys.Any(sk => sk.Email == null && sk.ProjectRole == role), Is.True,
+                "setup - a link sharing key should exist");
+            string shareLink = await env.Service.GetLinkSharingKeyAsync(Project02, role);
+            Assert.That(shareLink, Is.EqualTo("linksharing02"));
+        }
+
+        [Test]
+        public async Task GetLinkSharingKeyAsync_LinkSharingDisabled_ForbiddenError()
+        {
+            var env = new TestEnvironment();
+            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project01);
+            Assert.That(projectSecret.ShareKeys.Count, Is.EqualTo(0));
+            string key = await env.Service.GetLinkSharingKeyAsync(Project01, SFProjectRole.CommunityChecker);
+            Assert.That(key, Is.Null);
+            projectSecret = env.ProjectSecrets.Get(Project01);
+            Assert.That(projectSecret.ShareKeys.Count, Is.EqualTo(0));
         }
 
         [Test]
         public async Task InviteAsync_SharingDisabled_ForbiddenError()
         {
             var env = new TestEnvironment();
-            Assert.ThrowsAsync<ForbiddenException>(
-                () => env.Service.InviteAsync(User02, Project01, "newuser@example.com", "en"));
+            Assert.ThrowsAsync<ForbiddenException>(() => env.Service.InviteAsync(User02, Project01,
+                "newuser@example.com", "en", SFProjectRole.CommunityChecker));
             await env.EmailService.DidNotReceiveWithAnyArgs().SendEmailAsync(default, default, default);
         }
 
@@ -148,14 +202,16 @@ namespace SIL.XForge.Scripture.Services
         public async Task InviteAsync_SpecificSharingEnabled_ProjectUserNotInvited()
         {
             var env = new TestEnvironment();
-            const string email = "user01@example.com";
+            const string email = "user02@example.com";
+            const string role = SFProjectRole.CommunityChecker;
             SFProject project = env.GetProject(Project03);
-            Assert.That(project.UserRoles.ContainsKey(User01), Is.True,
+            Assert.That(project.UserRoles.TryGetValue(User02, out string userRole), Is.True,
                 "setup - user should already be a project user");
+            Assert.That(userRole, Is.EqualTo(role));
 
-            Assert.That(await env.Service.InviteAsync(User01, Project03, email, "en"), Is.False);
+            Assert.That(await env.Service.InviteAsync(User01, Project03, email, "en", role), Is.False);
             project = env.GetProject(Project03);
-            Assert.That(project.UserRoles.ContainsKey(User01), Is.True, "user should still be a project user");
+            Assert.That(project.UserRoles.ContainsKey(User02), Is.True, "user should still be a project user");
 
             SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
             Assert.That(projectSecret.ShareKeys.Any(sk => sk.Email == email), Is.False,
@@ -171,16 +227,18 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             SFProject project = env.GetProject(Project01);
             Assert.That(project.UserRoles.ContainsKey(User02), Is.True, "setup");
-            Assert.DoesNotThrowAsync(() => env.Service.CheckLinkSharingAsync(User02, Project01));
+            Assert.DoesNotThrowAsync(() => env.Service.CheckLinkSharingAsync(User02, Project01, "abcd"));
         }
 
         [Test]
-        public void CheckLinkSharingAsync_LinkSharingDisabledAndUserNotOnProject_Forbidden()
+        public async Task CheckLinkSharingAsync_LinkSharingDisabledAndUserNotOnProject_Forbidden()
         {
             var env = new TestEnvironment();
-            SFProject project = env.GetProject(Project01);
+            SFProject project = env.GetProject(Project02);
             Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
-            Assert.ThrowsAsync<ForbiddenException>(() => env.Service.CheckLinkSharingAsync(User03, Project01));
+            await env.Service.UpdateSettingsAsync(User02, Project02, new SFProjectSettings { ShareEnabled = false });
+            Assert.ThrowsAsync<ForbiddenException>(
+                () => env.Service.CheckLinkSharingAsync(User03, Project02, "linksharing02"));
         }
 
         [Test]
@@ -190,9 +248,10 @@ namespace SIL.XForge.Scripture.Services
             SFProject project = env.GetProject(Project02);
             Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
 
-            await env.Service.CheckLinkSharingAsync(User03, Project02);
+            await env.Service.CheckLinkSharingAsync(User03, Project02, "linksharing02");
             project = env.GetProject(Project02);
-            Assert.That(project.UserRoles.ContainsKey(User03), Is.True);
+            Assert.That(project.UserRoles.TryGetValue(User03, out string userRole), Is.True);
+            Assert.That(userRole, Is.EqualTo(SFProjectRole.CommunityChecker));
             User user = env.GetUser(User03);
             Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project02));
         }
@@ -201,19 +260,17 @@ namespace SIL.XForge.Scripture.Services
         public async Task CheckLinkSharingAsync_LinkSharingEnabledAndShareKeyExists_UserJoinedAndKeyRemoved()
         {
             var env = new TestEnvironment();
-            SFProject project = env.GetProject(Project03);
-            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
+            SFProject project = env.GetProject(Project02);
+            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project02);
 
             Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
-            Assert.That(projectSecret.ShareKeys.Any(sk => sk.Key == "key1234"), Is.True, "setup");
+            Assert.That(projectSecret.ShareKeys.Any(sk => sk.Key == "existingkeyuser03"), Is.True, "setup");
 
-            await env.Service.UpdateSettingsAsync(User01, Project03,
-                new SFProjectSettings { ShareLevel = CheckingShareLevel.Anyone });
-            await env.Service.CheckLinkSharingAsync(User03, Project03);
-            project = env.GetProject(Project03);
-            projectSecret = env.ProjectSecrets.Get(Project03);
+            await env.Service.CheckLinkSharingAsync(User03, Project02, "existingkeyuser03");
+            project = env.GetProject(Project02);
+            projectSecret = env.ProjectSecrets.Get(Project02);
             Assert.That(project.UserRoles.ContainsKey(User03), Is.True, "User should have been added to project");
-            Assert.That(projectSecret.ShareKeys.Any(sk => sk.Key == "key1234"), Is.False,
+            Assert.That(projectSecret.ShareKeys.Any(sk => sk.Key == "existingkeyuser03"), Is.False,
                 "Key should have been removed from project");
         }
 
@@ -227,7 +284,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(project.UserRoles.ContainsKey(User04), Is.False, "setup");
             var invitees = await env.Service.InvitedUsersAsync(User01, Project03);
             Assert.That(invitees.Select(i => i.Email), Is.EquivalentTo(
-                new[] { "bob@example.com", "user02@example.com", "user03@example.com", "bill@example.com" }), "setup");
+                new[] { "bob@example.com", "expired@example.com", "user03@example.com", "bill@example.com" }), "setup");
 
             // Use the sharekey linked to user03
             await env.Service.CheckLinkSharingAsync(User04, Project03, "key1234");
@@ -239,7 +296,7 @@ namespace SIL.XForge.Scripture.Services
 
             invitees = await env.Service.InvitedUsersAsync(User01, Project03);
             Assert.That(invitees.Select(i => i.Email), Is.EquivalentTo(
-                new[] { "bob@example.com", "user02@example.com", "bill@example.com" }));
+                new[] { "bob@example.com", "expired@example.com", "bill@example.com" }));
         }
 
         [Test]
@@ -249,15 +306,17 @@ namespace SIL.XForge.Scripture.Services
             SFProject project = env.GetProject(Project03);
             SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
 
-            Assert.That(project.UserRoles.ContainsKey(User02), Is.False, "setup");
-            Assert.That(projectSecret.ShareKeys.Any(sk => sk.Email == "user02@example.com"), Is.True, "setup");
+            Assert.That(project.UserRoles.ContainsKey(LinkExpiredUser), Is.False, "setup");
+            Assert.That(projectSecret.ShareKeys.Any(sk => sk.Email == "expired@example.com"), Is.True, "setup");
 
-            Assert.ThrowsAsync<ForbiddenException>(() => env.Service.CheckLinkSharingAsync(User02, Project03, "keyexp"),
-                "The user should be forbidden to join the project: Email was in ShareKeys, but code was expired.");
+            Assert.ThrowsAsync<ForbiddenException>(() =>
+                env.Service.CheckLinkSharingAsync(LinkExpiredUser, Project03, "keyexp"),
+                "The user should be forbidden to join the project: Email was in ShareKeys, but code was expired."
+            );
 
             var invitees = await env.Service.InvitedUsersAsync(User01, Project03);
             Assert.That(invitees.Select(i => i.Email), Is.EquivalentTo(new[] {
-                "bob@example.com", "user02@example.com", "user03@example.com", "bill@example.com" }));
+                "bob@example.com", "expired@example.com", "user03@example.com", "bill@example.com" }));
         }
 
         [Test]
@@ -270,7 +329,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
             Assert.That(projectSecret.ShareKeys.Any(sk => sk.Email == "user03@example.com"), Is.True, "setup");
 
-            Assert.ThrowsAsync<ForbiddenException>(() => env.Service.CheckLinkSharingAsync(User03, Project03),
+            Assert.ThrowsAsync<ForbiddenException>(() => env.Service.CheckLinkSharingAsync(User03, Project03, "badcode"),
                 "The user should be forbidden to join the project: Email address was in ShareKeys list, but wrong code was given.");
         }
 
@@ -357,21 +416,24 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(await env.Service.IsAlreadyInvitedAsync(User03, Project02, "nobody@example.com"), Is.False);
         }
 
+        [Test]
         public async Task InvitedUsers_Reports()
         {
             var env = new TestEnvironment();
             // Project with no outstanding invitations
             Assert.That((await env.Service.InvitedUsersAsync(User01, Project01)).Count, Is.EqualTo(0));
 
+            // Project with one specific shareKey and one link sharing shareKey record
+            IReadOnlyList<InviteeStatus> invitees = await env.Service.InvitedUsersAsync(User02, Project02);
+            Assert.That(invitees.Count, Is.EqualTo(1));
+            Assert.That(invitees.Select(i => i.Email), Is.EquivalentTo(new string[] { "user03@example.com" }));
+
             // Project with several outstanding invitations
-            IReadOnlyList<InviteeStatus> invitees = await env.Service.InvitedUsersAsync(User01, Project03);
+            invitees = await env.Service.InvitedUsersAsync(User01, Project03);
             Assert.That(invitees.Count, Is.EqualTo(4));
             string[] expectedEmailList =
-                { "bob@example.com", "user02@example.com", "user03@example.com", "bill@example.com" };
-            foreach (var expectedEmail in expectedEmailList)
-            {
-                Assert.That(invitees.Any(i => i.Email == expectedEmail), Is.True);
-            }
+                { "bob@example.com", "expired@example.com", "user03@example.com", "bill@example.com" };
+            Assert.That(invitees.Select(i => i.Email), Is.EquivalentTo(expectedEmailList));
         }
 
         [Test]
@@ -773,6 +835,12 @@ namespace SIL.XForge.Scripture.Services
                         Email = "user04@example.com",
                         Sites = new Dictionary<string,Site> { { SiteId, new Site() } },
                         Role = SystemRole.SystemAdmin
+                    },
+                    new User
+                    {
+                        Id = LinkExpiredUser,
+                        Email = "expired@example.com",
+                        Sites = new Dictionary<string, Site> { { SiteId, new Site() }}
                     }
                 }));
                 RealtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(
@@ -856,7 +924,8 @@ namespace SIL.XForge.Scripture.Services
                             },
                             UserRoles =
                             {
-                                { User01, SFProjectRole.Administrator }
+                                { User01, SFProjectRole.Administrator },
+                                { User02, SFProjectRole.CommunityChecker }
                             }
                         },
                         new SFProject
@@ -900,10 +969,29 @@ namespace SIL.XForge.Scripture.Services
                 });
                 var audioService = Substitute.For<IAudioService>();
                 EmailService = Substitute.For<IEmailService>();
+                var currentTime = DateTime.Now;
                 ProjectSecrets = new MemoryRepository<SFProjectSecret>(new[]
                 {
                     new SFProjectSecret { Id = Project01 },
-                    new SFProjectSecret { Id = Project02 },
+                    new SFProjectSecret
+                    {
+                        Id = Project02,
+                        ShareKeys = new List<ShareKey>
+                        {
+                            new ShareKey
+                            {
+                                Key = "linksharing02",
+                                ProjectRole = SFProjectRole.CommunityChecker
+                            },
+                            new ShareKey
+                            {
+                                Email = "user03@example.com",
+                                Key = "existingkeyuser03",
+                                ExpirationTime = currentTime.AddDays(1),
+                                ProjectRole = SFProjectRole.CommunityChecker
+                            }
+                        }
+                    },
                     new SFProjectSecret
                     {
                         Id = Project03,
@@ -913,16 +1001,28 @@ namespace SIL.XForge.Scripture.Services
                             {
                                 Email = "bob@example.com",
                                 Key = "key1111",
-                                ExpirationTime = DateTime.Now.AddDays(1)
+                                ExpirationTime = currentTime.AddDays(1),
+                                ProjectRole = SFProjectRole.CommunityChecker
                             },
                             new ShareKey
                             {
-                                Email = "user02@example.com",
+                                Email = "expired@example.com",
                                 Key = "keyexp",
-                                ExpirationTime = DateTime.Now.AddDays(-1)
+                                ExpirationTime = currentTime.AddDays(-1),
+                                ProjectRole = SFProjectRole.CommunityChecker,
                             },
-                            new ShareKey { Email = "user03@example.com", Key = "key1234" },
-                            new ShareKey { Email = "bill@example.com", Key = "key2222" }
+                            new ShareKey
+                            {
+                                Email = "user03@example.com",
+                                Key = "key1234",
+                                ProjectRole = SFProjectRole.CommunityChecker
+                            },
+                            new ShareKey
+                            {
+                                Email = "bill@example.com",
+                                Key = "key2222",
+                                ProjectRole = SFProjectRole.CommunityChecker
+                            }
                         }
                     },
                 });

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -1015,12 +1015,14 @@ namespace SIL.XForge.Scripture.Services
                             {
                                 Email = "user03@example.com",
                                 Key = "key1234",
+                                ExpirationTime = currentTime.AddDays(1),
                                 ProjectRole = SFProjectRole.CommunityChecker
                             },
                             new ShareKey
                             {
                                 Email = "bill@example.com",
                                 Key = "key2222",
+                                ExpirationTime = currentTime.AddDays(1),
                                 ProjectRole = SFProjectRole.CommunityChecker
                             }
                         }


### PR DESCRIPTION
* link sharing now uses a sharekey with a corresponding role
* the backend now expects a role whenever inviting a user
* the share control displays the share link with the sharekey

In order to test these changes, you must first run this command in the mongo shell:
```
use xforge
db.sf_project_secrets.updateMany(
	{ },
	{ $set: { "shareKeys.$[elem].projectRole": "sf_community_checker" } },
	{ arrayFilters: [ { "elem.projectRole": { $exists: false } } ] }
)
db.sf_project_secrets.updateMany(
	{ },
	{ $set: { "shareKeys.$[elem].expirationTime": new Date(2021, 11) } },
	{ arrayFilters: [ { "elem.expirationTime": { $exists: false } } ] }
)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/967)
<!-- Reviewable:end -->
