### PR TITLE
Deploy: Install 503 error page

### DIFF
--- a/scripts/build-and-ship
+++ b/scripts/build-and-ship
@@ -11,6 +11,8 @@ SERVICE_UNIT_SUFFIX=""
 if grep "beta" <<< "${APP_SUFFIX}"; then
   SERVICE_UNIT_SUFFIX="_beta"
 fi
+# Relative to repo root
+ERROR_PAGES_PATH="src/SIL.XForge.Scripture/ErrorPages"
 
 cd ..
 
@@ -44,5 +46,8 @@ sudo chown -R :www-data "${BUILD_OUTPUT}/app"
 
 rsync -progzlt --chmod=Dug=rwx,Fug=rwx,o-rwx --delete-during --stats --rsync-path="sudo rsync" \
   --rsh="ssh -v -i ${DEPLOY_CREDENTIALS}" artifacts/app/ root@"${DEPLOY_DESTINATION}:${DEPLOY_PATH}/app"
+
+rsync -vaz --rsync-path="sudo rsync" --rsh="ssh -v -i ${DEPLOY_CREDENTIALS}" \
+  "${ERROR_PAGES_PATH}/" root@"${DEPLOY_DESTINATION}:${DEPLOY_PATH}/htdocs"
 
 ssh root@"${DEPLOY_DESTINATION}" "systemctl restart ${APP_NAME}-web-app${SERVICE_UNIT_SUFFIX}"


### PR DESCRIPTION
- 503.html was being installed manually. Automate it. Any error pages
in the ErrorPages directory will be included.
- `-progzlt` was quite close to `-a`, which is basically `progltD`. I
include `v` so we can see the transfer in the TC log.
- I did not include `--chmod`. The 503.html on scriptureforge-live has
permissions of 644. Testing to scriptureforge-qa shows it still uses
mod 644.
--- 

This relates to a discussion with Ira regarding our ansible, so probably don't merge this PR without  @irahopkinson 's approving first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/969)
<!-- Reviewable:end -->
