### PR TITLE
Fix Transcelerator import determining whether question is edited

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
@@ -207,25 +207,6 @@ describe('ImportQuestionsDialogComponent', () => {
       verseNum: 2
     });
   }));
-
-  it('should prompt the user for importing a question that has had the reference changed', fakeAsync(() => {
-    const env = new TestEnvironment(true);
-    when(env.mockedImportQuestionsConfirmationMdcDialogRef.afterClosed()).thenReturn(
-      of({
-        questions: [
-          {
-            before: 'GEN 43:2 Now the famine was severe in the land.',
-            after: 'GEN 43:1 Now the famine was severe in the land.',
-            checked: true
-          }
-        ]
-      } as ImportQuestionsConfirmationDialogData)
-    );
-    env.selectQuestion(env.questionRows[1]);
-    verify(env.dialogSpy.open(anything(), anything())).once();
-    env.click(env.submitButton);
-    expect(env.editedTransceleratorQuestionIds).toEqual(['4']);
-  }));
 });
 
 @Directive({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -139,7 +139,10 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable {
           doc =>
             doc.data != null &&
             doc.data.transceleratorQuestionId != null &&
-            doc.data.transceleratorQuestionId === question.id
+            doc.data.transceleratorQuestionId === question.id &&
+            // The id should be unique for a given verse, but not across different verses
+            // Transcelerator does not allow changing the reference for a question, as of 2021-03-09
+            !this.verseRefDataDiffers(doc.data.verseRef, this.verseRefData(question))
         ) || null;
 
       this.questionList.push({


### PR DESCRIPTION
The question ids provided by Transcelerator are only unique for a given reference. Previously the Scripture Forge side of the integration assumed ids were unique within the project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/972)
<!-- Reviewable:end -->
