### PR TITLE
SF-1181b Fix 401 error on connect project page

### DIFF
--- a/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
@@ -66,6 +66,10 @@ namespace SIL.XForge.Scripture.Controllers
                 var resources = await _paratextService.GetResourcesAsync(_userAccessor.UserId);
                 return Ok(resources.ToDictionary(r => r.ParatextId, r => r.Name));
             }
+            catch (DataNotFoundException)
+            {
+                return NoContent();
+            }
             catch (SecurityException)
             {
                 return NoContent();


### PR DESCRIPTION
This isn't a very elegant solution, but I'm really not sure which abstraction layer should be responsible for checking whether we should proceed. One option is to allow an exception to be thrown, then catch it high up the stack. That doesn't seem very elegant either.

I would welcome arguments/reasons for why this should be done differently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/973)
<!-- Reviewable:end -->
