### PR TITLE
Deploy: Restart correct service

### DIFF
--- a/scripts/build-and-upload-beta.sh
+++ b/scripts/build-and-upload-beta.sh
@@ -5,6 +5,10 @@ DEPLOY_RUNTIME=${DEPLOY_RUNTIME:-linux-x64}
 ANGULAR_CONFIG=${ANGULAR_CONFIG:-production}
 BUILD_OUTPUT=artifacts
 DEPLOY_PATH=/var/www/$APP_NAME.org$APP_SUFFIX
+SERVICE_UNIT_SUFFIX=""
+if grep "beta" <<< ${APP_SUFFIX}; then
+  SERVICE_UNIT_SUFFIX="_beta"
+fi
 
 pushd .. > /dev/null
 
@@ -39,4 +43,4 @@ rsync -progzlt --chmod=Dug=rwx,Fug=rwx,o-rwx --delete-during --stats --rsync-pat
 
 popd > /dev/null
 
-ssh root@$DEPLOY_DESTINATION "systemctl restart $APP_NAME-web-app"
+ssh root@${DEPLOY_DESTINATION} "systemctl restart ${APP_NAME}-web-app${SERVICE_UNIT_SUFFIX}"


### PR DESCRIPTION
- When deploying SF Beta, restart scriptureforge-web-app_beta, not
scriptureforge-web-app.
- APP_SUFFIX is a string like one of "_beta_qa", "_beta", "_qa", "".
From those options, derive "_beta" or "".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/983)
<!-- Reviewable:end -->
