### PR TITLE
SF-1238 - Unauthorized error after 2 hours

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.ts
@@ -1,6 +1,6 @@
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { Injectable, Injector } from '@angular/core';
-import { Observable } from 'rxjs';
+import { from, Observable } from 'rxjs';
 import { AuthService } from './auth.service';
 
 const AUTH_APIS = ['paratext-api', 'machine-api', 'command-api'];
@@ -15,14 +15,19 @@ export class AuthHttpInterceptor implements HttpInterceptor {
     if (AUTH_APIS.every(api => !req.url.startsWith(api))) {
       return next.handle(req);
     }
+    return from(this.handle(req, next));
+  }
 
+  async handle(req: HttpRequest<any>, next: HttpHandler): Promise<HttpEvent<any>> {
     if (this.authService == null) {
       this.authService = this.injector.get<AuthService>(AuthService);
     }
-
+    // Make sure the user is authenticated with a valid access token
+    await this.authService.isAuthenticated();
+    // Add access token to the request header
     const authReq = req.clone({
       headers: req.headers.set('Authorization', 'Bearer ' + this.authService.accessToken)
     });
-    return next.handle(authReq);
+    return next.handle(authReq).toPromise();
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.ts
@@ -28,6 +28,6 @@ export class AuthHttpInterceptor implements HttpInterceptor {
     const authReq = req.clone({
       headers: req.headers.set('Authorization', 'Bearer ' + this.authService.accessToken)
     });
-    return next.handle(authReq).toPromise();
+    return await next.handle(authReq).toPromise();
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -312,7 +312,7 @@ export class AuthService {
       mergeMap(expAt => {
         const now = Date.now();
         // Expiry 30 seconds sooner than the actual expiry date to avoid any inflight expiry issues
-        return timer(Math.max(1, expAt - now - 7158000));
+        return timer(Math.max(1, expAt - now - 30000));
       }),
       filter(() => this.pwaService.isOnline)
     );


### PR DESCRIPTION
- Adjusted http intercept handler to ensure the user is authenticated before adding access token to the header

This fix will ensure no requests to the backend will be made unless the user is authenticated with a valid access token that hasn't expired. Any requests made while there is an expired token will await auth0 (via `checkSession`) before it proceeds. This all happens silently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/992)
<!-- Reviewable:end -->
