### PR TITLE
Require tests to clean up overlay

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -356,6 +356,7 @@ describe('AppComponent', () => {
     // SUT2 is in ngOnInit()
     tick();
     verify(mockedMdcDialog.open(BetaMigrationDialogComponent, anything())).once();
+    expect().nothing();
   }));
 
   describe('Community Checking', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-confirmation-dialog/import-questions-confirmation-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-confirmation-dialog/import-questions-confirmation-dialog.component.spec.ts
@@ -17,7 +17,7 @@ describe('ImportQuestionsConfirmationDialogComponent', () => {
     imports: [ReactiveFormsModule, FormsModule, DialogTestModule]
   }));
 
-  it('Allows selecting and unselecting all questions', fakeAsync(() => {
+  it('Allows selecting and unselecting all questions', fakeAsync(async () => {
     const env = new TestEnvironment();
     expect(env.questionRows.length).toBe(2);
     expect(env.rowCheckboxes.length).toBe(2);
@@ -28,9 +28,10 @@ describe('ImportQuestionsConfirmationDialogComponent', () => {
     env.click(env.selectAllCheckbox);
     expect(env.selectAllCheckbox.checked).toBe(false);
     env.rowCheckboxes.forEach(n => expect(n.checked).toBe(false));
+    await env.closeDialog();
   }));
 
-  it('Can handle a single question', fakeAsync(() => {
+  it('Can handle a single question', fakeAsync(async () => {
     const env = new TestEnvironment(1);
     expect(env.questionRows.length).toBe(1);
     expect(env.rowCheckboxes.length).toBe(1);
@@ -45,20 +46,18 @@ describe('ImportQuestionsConfirmationDialogComponent', () => {
     env.click(env.selectAllCheckbox);
     expect(env.selectAllCheckbox.checked).toBe(true);
     expect(env.rowCheckboxes[0].checked).toBe(true);
-
-    env.closeDialog().then(value =>
-      expect(value.questions).toEqual([
-        {
-          before: 'Original question 1',
-          after: 'Edited question 1',
-          answerCount: 0,
-          checked: true
-        }
-      ])
-    );
+    const dialogResult: ImportQuestionsConfirmationDialogResult = await env.closeDialog();
+    expect(dialogResult.questions).toEqual([
+      {
+        before: 'Original question 1',
+        after: 'Edited question 1',
+        answerCount: 0,
+        checked: true
+      }
+    ]);
   }));
 
-  it('Allows selecting a subset of questions', fakeAsync(() => {
+  it('Allows selecting a subset of questions', fakeAsync(async () => {
     const env = new TestEnvironment(3);
     expect(env.questionRows.length).toBe(3);
     expect(env.rowCheckboxes.length).toBe(3);
@@ -71,28 +70,27 @@ describe('ImportQuestionsConfirmationDialogComponent', () => {
     expect(env.rowCheckboxes[2].checked).toBe(true);
     expect(env.selectAllCheckbox.indeterminate).toBe(true);
 
-    env.closeDialog().then(value =>
-      expect(value.questions).toEqual([
-        {
-          before: 'Original question 1',
-          after: 'Edited question 1',
-          answerCount: 0,
-          checked: false
-        },
-        {
-          before: 'Original question 2',
-          after: 'Edited question 2',
-          answerCount: 0,
-          checked: false
-        },
-        {
-          before: 'Original question 3',
-          after: 'Edited question 3',
-          answerCount: 0,
-          checked: true
-        }
-      ])
-    );
+    const dialogResult: ImportQuestionsConfirmationDialogResult = await env.closeDialog();
+    expect(dialogResult.questions).toEqual([
+      {
+        before: 'Original question 1',
+        after: 'Edited question 1',
+        answerCount: 0,
+        checked: false
+      },
+      {
+        before: 'Original question 2',
+        after: 'Edited question 2',
+        answerCount: 0,
+        checked: false
+      },
+      {
+        before: 'Original question 3',
+        after: 'Edited question 3',
+        answerCount: 0,
+        checked: true
+      }
+    ]);
   }));
 });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
@@ -1,7 +1,7 @@
 import { MdcCheckbox, MdcDialog, MdcDialogRef } from '@angular-mdc/web';
 import { CommonModule } from '@angular/common';
 import { Component, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Answer } from 'realtime-server/lib/scriptureforge/models/answer';
 import { Question } from 'realtime-server/lib/scriptureforge/models/question';
@@ -41,6 +41,7 @@ describe('ImportQuestionsDialogComponent', () => {
     expect(env.getRowQuestion(questions[0])).toBe('Transcelerator question 1:1');
     expect(env.getRowReference(questions[1])).toBe('MAT 1:2');
     expect(env.getRowQuestion(questions[1])).toBe('Transcelerator question 1:2');
+    env.click(env.cancelButton);
   }));
 
   it('can select questions in the list', fakeAsync(() => {
@@ -67,6 +68,7 @@ describe('ImportQuestionsDialogComponent', () => {
     expect(env.component.filteredList[0].checked).toBe(false);
     expect(env.selectAllCheckbox.checked).toBe(false);
     expect(env.selectAllCheckbox.indeterminate).toBe(true);
+    env.click(env.cancelButton);
   }));
 
   it('select all selects and deselects all visible questions', fakeAsync(() => {
@@ -95,6 +97,7 @@ describe('ImportQuestionsDialogComponent', () => {
     env.clickSelectAll();
     expect(env.component.filteredList[0].checked).toBe(true);
     expect(env.component.filteredList[1].checked).toBe(true);
+    env.click(env.cancelButton);
   }));
 
   it('can filter questions for text', fakeAsync(() => {
@@ -102,6 +105,7 @@ describe('ImportQuestionsDialogComponent', () => {
     expect(env.questionRows.length).toBe(2);
     env.setControlValue(env.component.filterControl, '1:2');
     expect(env.questionRows.length).toBe(1);
+    env.click(env.cancelButton);
   }));
 
   it('clears text from filter when show all is clicked', fakeAsync(() => {
@@ -116,6 +120,7 @@ describe('ImportQuestionsDialogComponent', () => {
     env.click(env.showAllButton);
     expect(env.component.fromControl.value).toBe('');
     expect(env.component.toControl.value).toBe('');
+    env.click(env.cancelButton);
   }));
 
   it('can filter questions with verse reference', fakeAsync(() => {
@@ -135,6 +140,7 @@ describe('ImportQuestionsDialogComponent', () => {
     expect(env.questionRows.length).toBe(1);
     env.setControlValue(env.component.toControl, 'MAL 1:1');
     expect(env.questionRows.length).toBe(0);
+    env.click(env.cancelButton);
   }));
 
   it('show scripture chooser dialog', fakeAsync(() => {
@@ -143,6 +149,7 @@ describe('ImportQuestionsDialogComponent', () => {
     env.openFromScriptureChooser();
     verify(env.dialogSpy.open(anything(), anything())).once();
     expect(env.component.fromControl.value).toBe('MAT 1:1');
+    env.click(env.cancelButton);
   }));
 
   it('prompts for edited questions that have already been imported', fakeAsync(() => {
@@ -169,6 +176,7 @@ describe('ImportQuestionsDialogComponent', () => {
     expect(env.component.filteredList[0].checked).toBe(false);
     expect(env.component.filteredList[1].checked).toBe(true);
     expect(env.component.filteredList[2].checked).toBe(true);
+    env.click(env.cancelButton);
   }));
 
   it('should inform the user when Transcelerator version is unsupported', fakeAsync(() => {
@@ -176,6 +184,7 @@ describe('ImportQuestionsDialogComponent', () => {
     expect(env.statusMessage).toEqual(
       'The version of Transcelerator used in this project is not supported. Please update to at least Transcelerator version 1.5.3.'
     );
+    env.click(env.cancelButton);
   }));
 
   it('should import questions that cover a verse range', fakeAsync(() => {
@@ -327,6 +336,12 @@ class TestEnvironment {
     return this.overlayContainerElement.querySelector('mdc-dialog-actions button[type="submit"]') as HTMLButtonElement;
   }
 
+  get cancelButton(): HTMLButtonElement {
+    return this.overlayContainerElement.querySelector(
+      'mdc-dialog-actions button[mdcdialogaction="close"]'
+    ) as HTMLButtonElement;
+  }
+
   clickSelectAll(): void {
     this.click(this.selectAllCheckbox._inputElement.nativeElement);
   }
@@ -359,6 +374,7 @@ class TestEnvironment {
     element.click();
     tick();
     this.fixture.detectChanges();
+    flush();
   }
 
   private setupTransceleratorQuestions(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -57,15 +57,18 @@ describe('QuestionDialogComponent', () => {
     ]
   }));
 
+  let env: TestEnvironment;
+  afterEach(() => env.dialogRef.close());
+
   it('should allow user to cancel', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     env.clickElement(env.cancelButton);
     flush();
     expect(env.afterCloseCallback).toHaveBeenCalledWith('close');
   }));
 
   it('should not allow Save without required fields', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     env.clickElement(env.saveButton);
     flush();
     expect(env.afterCloseCallback).not.toHaveBeenCalled();
@@ -76,7 +79,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('does not accept just whitespace for a question', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     flush();
 
     env.inputValue(env.questionInput, 'Hello?');
@@ -97,7 +100,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('should validate verse fields', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     flush();
     expect(env.component.questionForm.valid).toBe(false);
     expect(env.component.scriptureStart.valid).toBe(false);
@@ -137,7 +140,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('should produce error', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     flush();
     const invalidVerses = [
       'MAT 1',
@@ -165,14 +168,14 @@ describe('QuestionDialogComponent', () => {
 
   it('should set default verse and text direction when provided', fakeAsync(() => {
     const verseRef: VerseRef = VerseRef.parse('LUK 1:1');
-    const env = new TestEnvironment(undefined, verseRef, true);
+    env = new TestEnvironment(undefined, verseRef, true);
     flush();
     expect(env.component.scriptureStart.value).toBe('LUK 1:1');
     expect(env.component.isTextRightToLeft).toBe(true);
   }));
 
   it('should validate matching book and chapter', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     flush();
     env.component.scriptureStart.setValue('MAT 1:2');
     expect(env.component.scriptureStart.valid).toBe(true);
@@ -192,7 +195,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('should validate start verse is before or same as end verse', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     flush();
     env.component.scriptureStart.setValue('MAT 1:2');
     expect(env.component.scriptureStart.valid).toBe(true);
@@ -212,7 +215,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('opens reference chooser, uses result', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     flush();
     env.component.scriptureStart.setValue('MAT 3:4');
     expect(env.component.scriptureStart.value).not.toEqual('LUK 1:2');
@@ -226,7 +229,7 @@ describe('QuestionDialogComponent', () => {
 
   // Needed for validation error messages to appear
   it('control marked as touched+dirty after reference chooser', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     flush();
     // scriptureStart control starts off untouched+undirty and changes
     env.component.scriptureStart.setValue('MAT 3:4');
@@ -250,7 +253,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('passes start reference to end-reference chooser', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     flush();
     env.component.scriptureStart.setValue('LUK 1:1');
     env.component.scriptureEnd.setValue('GEN 5:6');
@@ -270,7 +273,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('does not pass start reference as range start when opening start-reference chooser', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     flush();
     env.component.scriptureStart.setValue('LUK 1:1');
 
@@ -288,7 +291,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('disables end-reference if start-reference is invalid', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     flush();
     env.inputValue(env.scriptureStartInput, 'LUK 1:1');
     expect(env.component.scriptureEnd.disabled).toBe(false);
@@ -300,7 +303,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('does not enable end-reference until start-reference is changed', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     flush();
     expect(env.component.scriptureEnd.disabled).toBe(true);
     env.inputValue(env.scriptureStartInput, 'LUK 1:1');
@@ -308,7 +311,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('allows a question without text if audio is provided', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     flush();
     env.inputValue(env.questionInput, '');
     expect(env.component.questionText.valid).toBe(false);
@@ -324,7 +327,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('should not save with no text and audio permission is denied', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     flush();
     env.inputValue(env.questionInput, '');
     expect(env.component.questionText.valid).toBe(false);
@@ -336,7 +339,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('display quill editor', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     flush();
     expect(env.quillEditor).not.toBeNull();
     expect(env.component.textDocId).toBeUndefined();
@@ -352,7 +355,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('retrieves scripture text on editing a question', fakeAsync(() => {
-    const env = new TestEnvironment({
+    env = new TestEnvironment({
       dataId: 'question01',
       ownerRef: 'user01',
       projectRef: 'project01',
@@ -372,7 +375,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('displays error editing end reference to different book', fakeAsync(() => {
-    const env = new TestEnvironment({
+    env = new TestEnvironment({
       dataId: 'question01',
       ownerRef: 'user01',
       projectRef: 'project01',
@@ -395,7 +398,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('displays error editing start reference to a different book', fakeAsync(() => {
-    const env = new TestEnvironment({
+    env = new TestEnvironment({
       dataId: 'question01',
       ownerRef: 'user01',
       projectRef: 'project01',
@@ -415,7 +418,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('generate correct verse ref when start and end mismatch only by case or insignificant zero', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     flush();
     env.component.scriptureStart.setValue('LUK 1:1');
     env.component.scriptureEnd.setValue('luk 1:1');
@@ -429,7 +432,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('should handle invalid start reference when end reference exists', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     flush();
     env.component.scriptureStart.setValue('nonsense');
     env.component.scriptureEnd.setValue('LUK 1:1');
@@ -439,7 +442,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('should not highlight range if chapter or book differ', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     flush();
     env.component.scriptureStart.setValue('MAT 1:1');
     env.component.scriptureEnd.setValue('LUK 1:2');
@@ -450,7 +453,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('should clear highlight when starting ref is cleared', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     flush();
     env.component.scriptureStart.setValue('LUK 1:1');
     tick(500);
@@ -476,7 +479,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('should clear highlight when end ref is invalid', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     flush();
     env.component.scriptureStart.setValue('LUK 1:1');
     env.component.scriptureEnd.setValue('LUK 1:2');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
@@ -103,6 +103,7 @@ describe('ConnectProjectComponent', () => {
     expect(env.selectableSourceProjectsAndResources.projects[2]).toBe('Thai');
     expect(env.selectableSourceProjectsAndResources.resources[0]).toBe('Sob Jonah and Luke');
     expect(env.component.connectProjectForm.valid).toBe(true);
+    env.clickElement(env.submitButton);
   }));
 
   it('should do nothing when form is invalid', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.spec.ts
@@ -25,15 +25,18 @@ describe('ScriptureChooserDialog', () => {
     ]
   }));
 
+  let env: TestEnvironment;
+  afterEach(() => env.dialogRef.close());
+
   it('initially shows book chooser, close button', () => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     expect(env.dialogText).toContain(env.closeIconName);
     expect(env.dialogText).toContain('book');
     expect(env.dialogText).toContain('Matthew');
   });
 
   it('clicking book goes to chapter chooser, shows back button', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     env.click(env.bookEphesians);
     expect(env.reference.trim()).toEqual('Ephesians');
     expect(env.dialogText).not.toContain(env.closeIconName);
@@ -45,7 +48,7 @@ describe('ScriptureChooserDialog', () => {
   }));
 
   it('clicking chapter goes to verse chooser, shows back button', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     env.click(env.bookEphesians);
     env.click(env.chapter3);
     expect(env.reference).toEqual('Ephesians 3');
@@ -58,7 +61,7 @@ describe('ScriptureChooserDialog', () => {
   }));
 
   it('clicking verse closes and reports selection', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     env.click(env.bookEphesians);
     env.click(env.chapter3);
     env.click(env.verse21);
@@ -66,13 +69,13 @@ describe('ScriptureChooserDialog', () => {
   }));
 
   it('clicking X closes. dialog reports cancelled.', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     env.click(env.backoutButton);
     expect(env.dialogResult).toEqual('close');
   }));
 
   it('clicking back at chapter selection goes to book selection', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     env.click(env.bookEphesians);
     env.click(env.backoutButton);
     expect(env.dialogText).toContain(env.closeIconName);
@@ -81,7 +84,7 @@ describe('ScriptureChooserDialog', () => {
   }));
 
   it('clicking back at verse selection goes to chapter selection', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     env.click(env.bookEphesians);
     env.click(env.chapter3);
     env.click(env.backoutButton);
@@ -91,76 +94,76 @@ describe('ScriptureChooserDialog', () => {
   }));
 
   it('book not highlighted, if no (undefined) incoming reference', fakeAsync(() => {
-    const env = new TestEnvironment({ inputScriptureReference: undefined });
+    env = new TestEnvironment({ inputScriptureReference: undefined });
     expect(env.highlightedButton).toBeNull();
   }));
 
   it('book not highlighted, if no (omitted) incoming reference', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     expect(env.highlightedButton).toBeNull();
   }));
 
   it('book highlighted', fakeAsync(() => {
-    const env = new TestEnvironment({ inputScriptureReference: new VerseRef('ROM', '11', '33') });
+    env = new TestEnvironment({ inputScriptureReference: new VerseRef('ROM', '11', '33') });
     env.fixture.detectChanges();
     expect(env.highlightedButton).not.toBeNull();
   }));
 
   it('chapter not highlighted, if no incoming reference', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     env.click(env.bookRomans);
     expect(env.highlightedButton).toBeNull();
   }));
 
   it('chapter highlighted, if showing incoming book reference', fakeAsync(() => {
-    const env = new TestEnvironment({ inputScriptureReference: new VerseRef('ROM', '11', '33') });
+    env = new TestEnvironment({ inputScriptureReference: new VerseRef('ROM', '11', '33') });
     env.click(env.bookRomans);
     expect(env.highlightedButton).not.toBeNull();
   }));
 
   it('chapter not highlighted if not in right book', fakeAsync(() => {
-    const env = new TestEnvironment({ inputScriptureReference: new VerseRef('ROM', '11', '33') });
+    env = new TestEnvironment({ inputScriptureReference: new VerseRef('ROM', '11', '33') });
     env.click(env.bookEphesians);
     expect(env.highlightedButton).toBeNull();
   }));
 
   it('verse not highlighted, if no incoming reference', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     env.click(env.bookRomans);
     env.click(env.chapter11);
     expect(env.highlightedButton).toBeNull();
   }));
 
   it('verse highlighted, if showing incoming book and chapter reference', fakeAsync(() => {
-    const env = new TestEnvironment({ inputScriptureReference: new VerseRef('ROM', '11', '33') });
+    env = new TestEnvironment({ inputScriptureReference: new VerseRef('ROM', '11', '33') });
     env.click(env.bookRomans);
     env.click(env.chapter11);
     expect(env.highlightedButton).not.toBeNull();
   }));
 
   it('verse not highlighted if in right book but wrong chapter', fakeAsync(() => {
-    const env = new TestEnvironment({ inputScriptureReference: new VerseRef('ROM', '11', '33') });
+    env = new TestEnvironment({ inputScriptureReference: new VerseRef('ROM', '11', '33') });
     env.click(env.bookRomans);
     env.click(env.chapter3);
     expect(env.highlightedButton).toBeNull();
   }));
 
   it('verse not highlighted if in right chapter number but wrong book', fakeAsync(() => {
-    const env = new TestEnvironment({ inputScriptureReference: new VerseRef('ROM', '3', '1') });
+    env = new TestEnvironment({ inputScriptureReference: new VerseRef('ROM', '3', '1') });
     env.click(env.bookEphesians);
     env.click(env.chapter3);
     expect(env.highlightedButton).toBeNull();
   }));
 
   it('input is received', fakeAsync(() => {
-    const env = new TestEnvironment({ inputScriptureReference: new VerseRef('EPH', '3', '21') });
+    env = new TestEnvironment({ inputScriptureReference: new VerseRef('EPH', '3', '21') });
     expect(env.component.data.input!.book).toEqual('EPH');
     expect(env.component.data.input!.chapter).toEqual('3');
     expect(env.component.data.input!.verse).toEqual('21');
   }));
 
   it('only shows books that we seed (from project)', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     expect(env.dialogText).toContain('Exodus');
     expect(env.dialogText).toContain('Matthew');
     expect(env.dialogText).not.toContain('Genesis');
@@ -168,7 +171,7 @@ describe('ScriptureChooserDialog', () => {
   }));
 
   it('only shows chapters that we seed (from project)', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     env.click(env.bookRomans);
     expect(env.dialogText).toContain('11');
     expect(env.dialogText).toContain('12');
@@ -176,7 +179,7 @@ describe('ScriptureChooserDialog', () => {
   }));
 
   it('shows correct number of verses for a given book and chapter', fakeAsync(() => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     env.click(env.bookRomans);
     env.click(env.chapter11);
     expect(env.dialogText).toContain('1');
@@ -191,14 +194,14 @@ describe('ScriptureChooserDialog', () => {
   }));
 
   it('identifies OT book', () => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     expect(env.component.isOT('GEN')).toBe(true);
     expect(env.component.isOT('LUK')).toBe(false);
     expect(env.component.isOT('XYZ')).toBe(false);
   });
 
   it('splits input books by OT and NT', () => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     expect(env.component.otBooks.includes('EXO')).toBe(true);
     expect(env.component.ntBooks.includes('EXO')).toBe(false);
     expect(env.component.ntBooks.includes('MAT')).toBe(true);
@@ -208,7 +211,7 @@ describe('ScriptureChooserDialog', () => {
   });
 
   it('knows if project has any OT books', () => {
-    const env = new TestEnvironment();
+    env = new TestEnvironment();
     expect(env.component.hasOTBooks).toBe(true);
   });
 
@@ -231,12 +234,12 @@ describe('ScriptureChooserDialog', () => {
         permissions: {}
       }
     ];
-    const env = new TestEnvironment({ textsInProject: onlyNTTexts });
+    env = new TestEnvironment({ textsInProject: onlyNTTexts });
     expect(env.component.hasOTBooks).toBe(false);
   });
 
   it('only shows verses if providing end-selection', fakeAsync(() => {
-    const env = new TestEnvironment({
+    env = new TestEnvironment({
       inputScriptureReference: new VerseRef('EPH', '3', '17'),
       rangeStart: new VerseRef('EPH', '3', '15')
     });
@@ -255,7 +258,7 @@ describe('ScriptureChooserDialog', () => {
   }));
 
   it('close button works for end-selection chooser', fakeAsync(() => {
-    const env = new TestEnvironment({
+    env = new TestEnvironment({
       rangeStart: new VerseRef('EPH', '3', '15')
     });
     expect(env.dialogText).toContain(env.closeIconName);
@@ -285,7 +288,7 @@ describe('ScriptureChooserDialog', () => {
       // No RUT text
     ];
 
-    const env = new TestEnvironment({
+    env = new TestEnvironment({
       inputScriptureReference: new VerseRef('EPH', '3', '17'),
       textsInProject: texts,
       // rangeStart is for book that is not in texts
@@ -329,7 +332,7 @@ describe('ScriptureChooserDialog', () => {
       }
     ];
 
-    const env = new TestEnvironment({
+    env = new TestEnvironment({
       inputScriptureReference: new VerseRef('EPH', '3', '17'),
       textsInProject: texts,
       // rangeStart is for chapter that is not in texts
@@ -373,7 +376,7 @@ describe('ScriptureChooserDialog', () => {
       }
     ];
 
-    const env = new TestEnvironment({
+    env = new TestEnvironment({
       inputScriptureReference: new VerseRef('EPH', '3', '17'),
       textsInProject: texts,
       // rangeStart is for invalid verse

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.spec.ts
@@ -38,6 +38,9 @@ describe('DeleteProjectDialogComponent', () => {
     env.clickElement(env.deleteButton);
     flush();
     expect(env.afterCloseCallback).toHaveBeenCalledTimes(0);
+    env.clickElement(env.cancelButton);
+    flush();
+    expect(env.afterCloseCallback).toHaveBeenCalledWith('cancel');
   }));
 
   it('should allow user to cancel', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
@@ -282,6 +282,7 @@ describe('TextChooserDialogComponent', () => {
     expect(dividingNode.textContent).toEqual(' text');
     expect(env.component.textContent(element, dividingNode, 3, true)).toEqual('xt');
     expect(env.component.textContent(element, dividingNode, 3, false)).toEqual('Here  te');
+    env.closeDialog();
   }));
 
   it('calculates range offsets correctly', fakeAsync(() => {
@@ -312,12 +313,14 @@ describe('TextChooserDialogComponent', () => {
       startOffset: 'Lor'.length,
       endOffset: 'Lorem ipsum'.length
     });
+    env.closeDialog();
   }));
 
   it('can handle right to left text', fakeAsync(() => {
     const config: TextChooserDialogData = { ...TestEnvironment.defaultDialogData, isRightToLeft: true };
     const env = new TestEnvironment([], 'verse_1_1', 'verse_1_2', config);
     expect(env.component.isTextRightToLeft).toBe(true);
+    env.closeDialog();
   }));
 });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
@@ -3,7 +3,7 @@ import { MdcDialog, MdcDialogConfig } from '@angular-mdc/web/dialog';
 import { MdcSlider } from '@angular-mdc/web/slider';
 import { CommonModule } from '@angular/common';
 import { Component, DebugElement, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import cloneDeep from 'lodash-es/cloneDeep';
 import {
@@ -43,6 +43,7 @@ describe('SuggestionsSettingsDialogComponent', () => {
     expect(env.component!.confidenceThreshold).toEqual(60);
     const userConfigDoc = env.getProjectUserConfigDoc();
     expect(userConfigDoc.data!.confidenceThreshold).toEqual(0.6);
+    env.click(env.closeButton);
   }));
 
   it('update suggestions enabled', fakeAsync(() => {
@@ -54,6 +55,7 @@ describe('SuggestionsSettingsDialogComponent', () => {
     expect(env.component!.translationSuggestionsUserEnabled).toBe(false);
     const userConfigDoc = env.getProjectUserConfigDoc();
     expect(userConfigDoc.data!.translationSuggestionsEnabled).toBe(false);
+    env.click(env.closeButton);
   }));
 
   it('update num suggestions', fakeAsync(() => {
@@ -65,12 +67,14 @@ describe('SuggestionsSettingsDialogComponent', () => {
     expect(env.component!.numSuggestions).toEqual('2');
     const userConfigDoc = env.getProjectUserConfigDoc();
     expect(userConfigDoc.data!.numSuggestions).toEqual(2);
+    env.click(env.closeButton);
   }));
 
   it('shows correct confidence threshold even when suggestions disabled', fakeAsync(() => {
     const env = new TestEnvironment(false);
     env.openDialog();
     expect(env.confidenceThresholdSlider.value).toEqual(50);
+    env.click(env.closeButton);
   }));
 
   it('disables settings when offline', fakeAsync(() => {
@@ -88,6 +92,7 @@ describe('SuggestionsSettingsDialogComponent', () => {
     expect(env.suggestionsEnabledSwitch.disabled).toBe(true);
     expect(env.confidenceThresholdSlider.disabled).toBe(true);
     expect(env.mdcNumSuggestionsSelect.disabled).toBe(true);
+    env.click(env.closeButton);
   }));
 
   it('the suggestions toggle is switched on when the dialog opens while offline', fakeAsync(() => {
@@ -97,6 +102,7 @@ describe('SuggestionsSettingsDialogComponent', () => {
 
     expect(env.suggestionsEnabledSwitch.disabled).toBe(true);
     expect(env.suggestionsEnabledSwitch.checked).toBe(true);
+    env.click(env.closeButton);
   }));
 });
 
@@ -172,6 +178,10 @@ class TestEnvironment {
     return this.fixture.debugElement.query(By.css('.offline-text'));
   }
 
+  get closeButton(): HTMLElement {
+    return this.overlayContainerElement.querySelector('button[mdcdialogaction="close"]') as HTMLElement;
+  }
+
   set isOnline(value: boolean) {
     this.onlineStatus.next(value);
     this.fixture.detectChanges();
@@ -219,8 +229,13 @@ class TestEnvironment {
   }
 
   clickSwitch(element: HTMLElement) {
-    const inputElem = element.querySelector('input');
-    inputElem!.click();
+    const inputElem = element.querySelector('input')!;
+    this.click(inputElem);
+  }
+
+  click(element: HTMLElement) {
+    element.click();
+    flush();
     this.fixture.detectChanges();
     tick();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.spec.ts
@@ -1,8 +1,7 @@
 import { MdcDialog, MdcDialogConfig } from '@angular-mdc/web/dialog';
-import { OverlayContainer } from '@angular/cdk/overlay';
 import { CommonModule } from '@angular/common';
 import { Component, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { configureTestingModule, TestTranslocoModule } from '../test-utils';
 import { UICommonModule } from '../ui-common.module';
 import { ErrorAlert, ErrorComponent } from './error.component';
@@ -37,6 +36,8 @@ describe('ErrorComponent', () => {
     expect(env.showDetails.textContent).toBe('Show details');
     expect(env.stackTrace.style.display).toBe('none');
     expect(env.errorId.style.display).toBe('none');
+    env.closeButton.click();
+    flush();
   }));
 });
 
@@ -104,7 +105,7 @@ class TestEnvironment {
   }
 
   get closeButton(): HTMLElement {
-    return this.selectElement('button')!;
+    return this.selectElement('button[mdcdialogaction="close"]')!;
   }
 
   private selectElement(selector: string): HTMLElement | null {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-utils.ts
@@ -41,6 +41,13 @@ export const configureTestingModule = (createModuleDef: () => TestModuleMetadata
     for (const mock of mocks) {
       reset(mock);
     }
+    const overlay: Element | null = document.body.querySelector('.cdk-overlay-container');
+    if (overlay?.hasChildNodes()) {
+      overlay.remove();
+      // Subsequent tests can have trouble with content left in the overlay container.
+      // (Don't try to fix the problem here because not all tests use configureTestingModule, and it's not its job)
+      throw new Error('Test did not clean up its overlay container content.');
+    }
   });
 };
 


### PR DESCRIPTION
- Tests leave dialog and other content in the HTML overlay. This can
cause problems to following tests as they look for the presence or
properties of elements. Whether it's a problem can vary by the order
the tests are run in.
- test-utils.ts: Require that tests clean up the overlay by at least
removing added content (if not the whole overlay). Throw an error for
any test that does not clean up. Note that this only applies for tests
that use configureTestingModule.
- Adjust existing tests so that they clean up the overlay, such as by
clicking a dialog Close button.
- delete-project-dialog.component.spec.ts: Add an additional check
that the correct dialog result occurred, since more than one dialog
button was clicked.
- Add some expect().nothing().
- import-questions-confirmation-dialog.component.spec.ts: Use async
and await rather than just .then to ensure the closing processes.

Co-authored-by: MarkS <marksvc@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/999)
<!-- Reviewable:end -->
