### PR TITLE
More accurately mock onlineGetLinkSharingKey

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
@@ -76,7 +76,7 @@ export class ShareControlComponent extends SubscriptionDisposable implements Aft
   }
 
   get shareLink(): string {
-    if (this.linkSharingKey.length < 1) {
+    if (this.linkSharingKey === '') {
       return '';
     }
     return (

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share.component.spec.ts
@@ -113,6 +113,7 @@ class TestEnvironment {
     when(mockedProjectService.get('project01')).thenCall(() =>
       this.realtimeService.subscribe(SFProjectDoc.COLLECTION, 'project01')
     );
+    when(mockedProjectService.onlineGetLinkSharingKey(anything(), anything())).thenResolve('shareKey');
     when(mockedUserService.currentUserId).thenReturn('user01');
     when(mockedPwaService.isOnline).thenReturn(true);
     when(mockedPwaService.onlineStatus).thenReturn(of(true));


### PR DESCRIPTION
Fixes test error using null linkSharingKey. The tests were not properly mocking the project service.

I also changed how we check for an empty string:
``` diff
- if (this.linkSharingKey.length < 1) {
+ if (this.linkSharingKey === ''") {
```
As far as I can tell, these are nearly identical. The main difference is that the latter will not crash when `linkSharingKey` is null or undefined.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1000)
<!-- Reviewable:end -->
