### PR TITLE
Allow route index.html

### DIFF
--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -37,7 +37,8 @@ namespace SIL.XForge.Scripture
             "vendor.js", "vendor.js.map",
             "main.js", "main.js.map",
             "manifest.json",
-            "sockjs-node"
+            "sockjs-node",
+            "index.html"
         };
         // examples of filenames are "main-es5.4e5295b95e4b6c37b696.js", "styles.a2f070be0b37085d72ba.css"
         private static readonly HashSet<string> ProductionSpaGetRoutes = new HashSet<string>


### PR DESCRIPTION
- The pwaTest frontend configuration results in requests to
index.html. This produces error:
> Accessing System.InvalidOperationException: The SPA default page
> middleware could not return the default page '/index.html' because
> it was not found, and no other middleware handled the request.

- I added this only to the dev route set since we haven't seen this be
a problem on the server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1002)
<!-- Reviewable:end -->
