### PR TITLE
SF-1239 Set manifest start_url to cached item

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/manifest.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/manifest.json
@@ -5,7 +5,7 @@
   "background_color": "#ffffff",
   "display": "standalone",
   "scope": "/",
-  "start_url": "/projects",
+  "start_url": "/index.html",
   "icons": [
     {
       "src": "assets/icons/sf-72x72.png",


### PR DESCRIPTION
- The Angular service worker isn't passing Chromium's check for
offline capability. This workaround makes the site pass Chromium's
check and does not appear to change what happens if a user goes to /
or /projects .
- This workaround can presumably be undone when
https://github.com/angular/angular/issues/41085 is fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1003)
<!-- Reviewable:end -->
