### PR TITLE
SF-1253 - Migration dialog keeps appearing

### DIFF
--- a/src/SIL.XForge.Scripture/DataAccess/SFDataAccessApplicationBuilderExtensions.cs
+++ b/src/SIL.XForge.Scripture/DataAccess/SFDataAccessApplicationBuilderExtensions.cs
@@ -4,9 +4,9 @@ namespace Microsoft.AspNetCore.Builder
 {
     public static class SFDataAccessApplicationBuilderExtensions
     {
-        public static void UseSFDataAccess(this IApplicationBuilder app)
+        public static void UseSFDataAccess(this IApplicationBuilder app, bool isBeta)
         {
-            app.UseDataAccess();
+            app.UseDataAccess(isBeta);
 
             app.InitRepository<TranslateMetrics>();
             app.InitRepository<SFProjectSecret>();

--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -132,10 +132,7 @@ namespace SIL.XForge.Scripture
 
             services.AddXFAuthentication(Configuration);
 
-            if (!Environment.EnvironmentName.EndsWith("Beta"))
-            {
-                services.AddSFDataAccess(Configuration);
-            }
+            services.AddSFDataAccess(Configuration);
 
             services.Configure<RequestLocalizationOptions>(
                 opts =>
@@ -240,8 +237,9 @@ namespace SIL.XForge.Scripture
 
                 app.UseSFServices();
 
-                app.UseSFDataAccess();
             }
+
+            app.UseSFDataAccess(Environment.EnvironmentName.EndsWith("Beta"));
 
             app.UsePing();
 

--- a/src/SIL.XForge/DataAccess/DataAccessApplicationBuilderExtensions.cs
+++ b/src/SIL.XForge/DataAccess/DataAccessApplicationBuilderExtensions.cs
@@ -7,10 +7,13 @@ namespace Microsoft.AspNetCore.Builder
 {
     public static class DataAccessApplicationBuilderExtensions
     {
-        public static void UseDataAccess(this IApplicationBuilder app)
+        public static void UseDataAccess(this IApplicationBuilder app, bool isBeta)
         {
-            app.UseHangfireServer();
-            app.UseHangfireDashboard();
+            if (!isBeta)
+            {
+                app.UseHangfireServer();
+                app.UseHangfireDashboard();
+            }
 
             app.InitRepository<UserSecret>();
             app.InitRepository<BetaMigration>();


### PR DESCRIPTION
- Don't use Hangfire server in beta

This relates to #1004 which caused a side effect where the beta site could no longer run an `onlinveInvoke` to finish the migration process. It was mentioned that Hangfire was the main reason for the changes made in #1004 so this PR just disables that. I can confirm migrating data between beta and non-beta still works and the `onlineInvoke` works again and mongo is updated.