### PR TITLE
Switch local DBL access from paratext-qa to qa subdomain

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -89,7 +89,9 @@ namespace SIL.XForge.Scripture.Services
             {
                 _httpClientHandler.ServerCertificateCustomValidationCallback
                     = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
-                _dblServerUri = "https://paratext-qa.thedigitalbiblelibrary.org/";
+                // This should be paratext-qa.thedigitalbiblelibrary.org, but it's broken as of 2021-04 and
+                // qa.thedigitalbiblelibrary.org should be just as good, at least for the time being.
+                _dblServerUri = "https://qa.thedigitalbiblelibrary.org/";
                 _registryServerUri = "https://registry-dev.paratext.org";
                 _registryClient.BaseAddress = new Uri(_registryServerUri);
                 _sendReceiveServerUri = InternetAccess.uriDevelopment;


### PR DESCRIPTION
paratext-qa.thedigitalbiblelibrary.org is currently broken

We discussed this at the most recent planning meeting.

I don't think this needs to wait for the next release, because it only affects dev and testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1012)
<!-- Reviewable:end -->
