### PR TITLE
Link to Beta site, but not when at Live

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -43,12 +43,16 @@
             </div>
           </div>
           <div mdcMenuSurfaceAnchor #helpMenuAnchor>
-            <mdc-icon mdcTopAppBarActionItem title="{{ t('help') }}" (click)="helpMenu.open = !helpMenu.open"
+            <mdc-icon
+              id="helpMenuIcon"
+              mdcTopAppBarActionItem
+              title="{{ t('help') }}"
+              (click)="helpMenu.open = !helpMenu.open"
               >help</mdc-icon
             >
             <mdc-menu #helpMenu [anchorCorner]="'bottomStart'" [anchorElement]="helpMenuAnchor">
               <mdc-list-group>
-                <mdc-list>
+                <mdc-list id="help-menu-list">
                   <a mdc-list-item target="_blank" [href]="helpsPage">{{ t("help") }}</a>
                   <a mdc-list-item target="_blank" [href]="issueMailTo">
                     <mdc-list-item-text
@@ -58,6 +62,7 @@
                       </mdc-list-item-secondary>
                     </mdc-list-item-text>
                   </a>
+                  <a *ngIf="!isBeta && !isLive" mdc-list-item [href]="correspondingBetaUrl">Go to beta site</a>
                   <mdc-list-divider></mdc-list-divider>
                   <div mdcListGroupSubheader class="version">{{ t("product_version", { version: version }) }}</div>
                 </mdc-list>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -150,6 +150,20 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     return environment.helps + '/' + (this.i18n.locale.helps || I18nService.defaultLocale.helps!);
   }
 
+  get correspondingBetaUrl(): string {
+    return environment.betaUrl + window.location.pathname;
+  }
+
+  /** @remarks Helps template get at the value. */
+  get isBeta(): boolean {
+    return environment.beta;
+  }
+
+  /** If is production server. */
+  get isLive(): boolean {
+    return environment.releaseStage === 'live';
+  }
+
   @ViewChild('topAppBar', { static: true })
   set topAppBar(value: MdcTopAppBar) {
     this._topAppBar = value;


### PR DESCRIPTION
- To help do testing on QA and dev machines.
- Did not localize the 'Beta site' string that should not be showing
in production.

See animation:

![beta-site-link](https://user-images.githubusercontent.com/7265309/114229605-497a4b80-9935-11eb-9ac8-dd5e87ffe79f.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1013)
<!-- Reviewable:end -->
