### PR TITLE
SF-1255 - Migration problem retrying

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -9,6 +9,7 @@ import { CookieService } from 'ngx-cookie-service';
 import { SystemRole } from 'realtime-server/lib/common/models/system-role';
 import { of, Subscription, timer } from 'rxjs';
 import { filter, mergeMap } from 'rxjs/operators';
+import { BetaMigrationMessage } from 'xforge-common/beta-migration/beta-migration.component';
 import { PwaService } from 'xforge-common/pwa.service';
 import { environment } from '../environments/environment';
 import { CommandError, CommandService } from './command.service';
@@ -174,6 +175,9 @@ export class AuthService {
     const authOptions: AuthorizeOptions = { state: JSON.stringify(state), language: JSON.stringify({ tag, options }) };
     if (signUp) {
       authOptions.login_hint = 'signUp';
+    }
+    if (environment.beta) {
+      window.parent.postMessage(<BetaMigrationMessage>{ message: 'login_required' }, environment.masterUrl);
     }
     this.auth0.authorize(authOptions);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/beta-migration/beta-migration-dialog/beta-migration-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/beta-migration/beta-migration-dialog/beta-migration-dialog.component.ts
@@ -2,8 +2,10 @@ import { Component, EventEmitter } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { interval } from 'rxjs';
 import { takeWhile } from 'rxjs/operators';
+import { AuthService } from 'xforge-common/auth.service';
 import { BetaMigrationMessage } from 'xforge-common/beta-migration/beta-migration.component';
 import { I18nService, TextAroundTemplate } from 'xforge-common/i18n.service';
+import { LocationService } from 'xforge-common/location.service';
 import { environment } from '../../../environments/environment';
 
 @Component({
@@ -19,7 +21,12 @@ export class BetaMigrationDialogComponent {
   private hasLoaded: boolean = false;
   private message: BetaMigrationMessage = { message: 'loading', progress: 0 };
 
-  constructor(private sanitizer: DomSanitizer, private readonly i18n: I18nService) {
+  constructor(
+    private sanitizer: DomSanitizer,
+    private readonly locationService: LocationService,
+    private readonly authService: AuthService,
+    private readonly i18n: I18nService
+  ) {
     this.betaUrl = this.migrationUrl;
     window.addEventListener('message', event => {
       if (event.origin !== environment.betaUrl) {
@@ -30,7 +37,7 @@ export class BetaMigrationDialogComponent {
       this.onProgress.emit(this.progress);
       // Check if login is required
       if (this.label === 'login_required') {
-        window.location.href = environment.betaUrl + window.location.pathname;
+        this.authService.logIn(this.locationService.pathname + this.locationService.search);
       }
     });
 


### PR DESCRIPTION
- Changed beta dialog to login again on the event of a login_required event from the beta site
- Post message from beta to non-beta if a login is required

This issue occurs when the beta site fails to validate a token with auth0 for whatever reason which leaves it in a logged out state. The non-beta still thinks it is logged in and so keeps on trying to migrate.

The fix takes a prompt from the beta site that a login needs to occur and the non-beta site then triggers a login to occur. After the login has taken place the migration dialog will appear again and this time the beta site will load correctly.

Although I wasn't able to replicate the token issues on localhost there are quite a number of occurances in bugsnag. 
Here are a few of the responses returned from auth0 with the `invalid_token` error:
- Nonce (nonce) claim value mismatch in the ID token; expected \"F4X0t4y1drrAVByzl0ygHUrqbHO3b7XG\", found \"basQbzZv08EvMODEYCJ~SYDwX6_UOBj0\"
- NetworkError when attempting to fetch resource.
- The operation was aborted.
- NetworkError when attempting to fetch resource.

I was able to test the login code by creating a button to manually trigger the migration dialog. From here did the following steps:
1. Logged in on both beta and non-beta and make sure the app is fully loaded
2. Log out of the beta site - the non-beta site should still be running
3. Manually trigger the migration dialog. 

Without this fix you will be in an endless retrying loop as the hidden iframe is redirected to the auth0 site for login.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1017)
<!-- Reviewable:end -->
