### PR TITLE
SF-1232 Inform user when sharing link is unavailable offline

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
@@ -1,8 +1,15 @@
 <ng-container *transloco="let t; read: 'share_control'">
   <div fxLayout="column" fxLayoutGap="20px">
-    <div *ngIf="isLinkSharingEnabled">
+    <div *ngIf="isLinkSharingEnabled" class="invite-by-link">
       <div mdcSubtitle1>{{ t("link_sharing") }}</div>
-      <mdc-text-field id="share-link" #shareLinkField outlined [value]="shareLink" [readonly]="true">
+      <mdc-text-field
+        id="share-link"
+        #shareLinkField
+        outlined
+        [value]="shareLink"
+        [disabled]="!shareLink"
+        [readonly]="true"
+      >
         <mdc-icon
           id="share-link-copy-icon"
           mdcTextFieldIcon
@@ -13,8 +20,9 @@
           >file_copy
         </mdc-icon>
       </mdc-text-field>
+      <div *ngIf="showLinkSharingUnavailable" class="offline-text">{{ t("link_sharing_not_available_offline") }}</div>
     </div>
-    <div>
+    <div class="invite-by-email">
       <div mdcSubtitle1>{{ t("invite_people") }}</div>
       <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="10px">
         <form fxFlex="100%" fxLayout.gt-xs="row" fxLayout.xs="column" id="email-form" [formGroup]="sendInviteForm">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.scss
@@ -11,3 +11,7 @@ mdc-text-field {
   // add margin that is same height as the text field helper text, so the button is centered properly
   margin-bottom: 19px;
 }
+
+.invite-by-link .offline-text {
+  margin-top: 20px;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.spec.ts
@@ -162,11 +162,11 @@ describe('ShareControlComponent', () => {
     env.wait();
     expect(env.component.sendInviteForm.enabled).toEqual(true);
     expect((env.inputElement.nativeElement as HTMLInputElement).disabled).toEqual(false);
-    expect(env.offlineMessage).toBeNull();
+    expect(env.emailSharingOfflineMessage).toBeNull();
     env.onlineStatus = false;
     expect(env.component.sendInviteForm.enabled).toEqual(false);
     expect((env.inputElement.nativeElement as HTMLInputElement).disabled).toEqual(true);
-    expect(env.offlineMessage).not.toBeNull();
+    expect(env.emailSharingOfflineMessage).not.toBeNull();
   }));
 
   it('share link should be hidden if link sharing is turned off', fakeAsync(() => {
@@ -175,6 +175,15 @@ describe('ShareControlComponent', () => {
     env.hostComponent.isLinkSharingEnabled = true;
     env.wait();
     expect(env.shareLink).not.toBeNull();
+  }));
+
+  it('share link should not be shown when offline', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.onlineStatus = false;
+    env.hostComponent.isLinkSharingEnabled = true;
+    env.wait();
+    expect(env.shareLink.nativeElement.value).toEqual('');
+    expect(env.linkSharingOfflineMessage).not.toBeNull();
   }));
 
   it('clicking copy link icon should copy link to clipboard', fakeAsync(() => {
@@ -284,8 +293,12 @@ class TestEnvironment {
     return this.emailTextField.query(By.css('input[type="email"]'));
   }
 
-  get offlineMessage(): DebugElement {
-    return this.fetchElement('.offline-text');
+  get linkSharingOfflineMessage(): DebugElement {
+    return this.fetchElement('.invite-by-link .offline-text');
+  }
+
+  get emailSharingOfflineMessage(): DebugElement {
+    return this.fetchElement('.invite-by-email .offline-text');
   }
 
   get shareLink(): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
@@ -88,6 +88,10 @@ export class ShareControlComponent extends SubscriptionDisposable implements Aft
     return this.pwaService.isOnline;
   }
 
+  get showLinkSharingUnavailable(): boolean {
+    return this.isLinkSharingEnabled && !this.isAppOnline && !this.shareLink;
+  }
+
   copyShareLink(): void {
     if (this.shareLinkField == null) {
       return;

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -301,6 +301,7 @@
     "invitation_sent": "An invitation email has been sent to {{ email }}",
     "invite_people": "Invite people",
     "link_copied": "Link copied to clipboard",
+    "link_sharing_not_available_offline": "Inviting users by link sharing is unavailable while offline.",
     "link_sharing": "Link sharing",
     "not_inviting_already_member": "Not inviting: User is already a member of this project",
     "resend": "Resend",


### PR DESCRIPTION
The user should be informed when the link sharing URL is not available due to being offline. Here are some screenshots showing two scenarios, one where the page is loaded and then the user goes offline, and the other where the user is already offline when the page is loaded.

Online, then going offline (share link still available) | Offline at the point of visiting the page
-------------------------------------------------------------------|----------------------------------------------------
![](https://user-images.githubusercontent.com/6140710/114794716-023bf280-9d5b-11eb-8d54-ea89fae48887.png) | ![](https://user-images.githubusercontent.com/6140710/114794718-02d48900-9d5b-11eb-91a6-450a16cb476a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1019)
<!-- Reviewable:end -->
