### PR TITLE
SF-1251 - Editing new offline data is not saved in IndexDB

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
@@ -186,12 +186,14 @@ export abstract class RealtimeDoc<T = any, Ops = any> {
       return;
     }
 
-    const pendingOps = this.adapter.pendingOps.map(op => this.prepareDataForStore(op));
-
     // if the snapshot hasn't changed, then don't bother to update
-    if (pendingOps.length === 0 && this.adapter.version === this.offlineSnapshotVersion) {
+    if (this.adapter.pendingOps.length === 0 && this.adapter.version === this.offlineSnapshotVersion) {
       return;
     }
+
+    const pendingOps = this.adapter.pendingOps
+      .filter(opInfo => opInfo.op != null)
+      .map(opInfo => this.prepareDataForStore(opInfo.op));
 
     this.offlineSnapshotVersion = this.adapter.version;
     const offlineData: RealtimeOfflineData = {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
@@ -128,7 +128,7 @@ export class SharedbRealtimeDocAdapter implements RealtimeDocAdapter {
   get pendingOps(): any[] {
     let pendingOps = [];
     if (this.doc.hasWritePending()) {
-      pendingOps = this.doc.pendingOps;
+      pendingOps = this.doc.pendingOps.slice();
 
       if (this.doc.inflightOp != null && this.doc.inflightOp.op != null) {
         pendingOps.push(this.doc.inflightOp);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
@@ -126,16 +126,12 @@ export class SharedbRealtimeDocAdapter implements RealtimeDocAdapter {
   }
 
   get pendingOps(): any[] {
-    const pendingOps = [];
+    let pendingOps = [];
     if (this.doc.hasWritePending()) {
-      if (this.doc.inflightOp != null && this.doc.inflightOp.op != null) {
-        pendingOps.push(this.doc.inflightOp.op);
-      }
+      pendingOps = this.doc.pendingOps;
 
-      for (const opInfo of this.doc.pendingOps) {
-        if (opInfo.op != null) {
-          pendingOps.push(opInfo.op);
-        }
+      if (this.doc.inflightOp != null && this.doc.inflightOp.op != null) {
+        pendingOps.push(this.doc.inflightOp);
       }
     }
     return pendingOps;


### PR DESCRIPTION
- Remove filtering on pending ops in sharedb-realtime-remote-store.ts
- Add filtering of pending ops prior to updating IndexDB

This update allows us to check for any pending operations from sharedb in order to determine if IndexDB needs to be updated. After that check we can filter out any operations that we don't need to store in IndexDB which is what was originally taking place in `SharedbRealtimeDocAdapter`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1022)
<!-- Reviewable:end -->
