### PR TITLE
- Only allow the migration component to run on beta

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -108,8 +108,8 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       // Check authentication when coming back online
       // This is also run on first load when the websocket connects for the first time
       if (this.isAppOnline && !this.isAppLoading) {
-        // Redirect to the master site unless the referrer was the master site
-        if (environment.beta && !document.referrer.includes(environment.masterUrl)) {
+        // Redirect to the master site unless operating in the migration iframe
+        if (environment.beta && (window.self === window.top || this.locationService.pathname !== '/migration')) {
           this.locationService.go(environment.masterUrl + window.location.pathname);
         }
         this.authService.checkOnlineAuth();

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/beta-migration/beta-migration.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/beta-migration/beta-migration.component.ts
@@ -34,7 +34,7 @@ export class BetaMigrationComponent {
     const documentPromises: Promise<RealtimeDoc>[] = [];
 
     // Only run if we're in an iframe from master
-    if (window.self === window.top) {
+    if (!environment.beta || window.self === window.top) {
       this.router.navigateByUrl('/projects');
       return;
     }


### PR DESCRIPTION
- Removed reliance on document referrer and instead did a frame check along with the migration path

This isn't full proof and it will stop being able to browse the site in beta mode but I believe we're beyond the need to do that now.

----
I tested this on my workstation and showed that it fixes the migration dialog loop in Firefox, and that Chromium still works ok.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1023)
<!-- Reviewable:end -->
