### PR TITLE
SF-1299 - Increase source highlight contrast

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -24,7 +24,7 @@ quill-editor {
     }
 
     .highlight-segment {
-      background-color: #ffffce;
+      background-color: #ffeb3b;
     }
 
     .question-segment {


### PR DESCRIPTION
- Change the scripture verse highlight background colour

Technically the contrast between the text colour and the background has decreased in percentage but the new background yellow is much deeper and easier to see on devices. We viewed this across multiple contrast and colour blindness filters to ensure it stood out intended - the previous colour did get washed out very quickly and became invisible. This will also help with monitors having a high contrast or brightness set which can also wash everything out.

This updates quill for both the translate and checking app.

**BEFORE**

![image](https://user-images.githubusercontent.com/17464863/116335882-b180cb00-a82b-11eb-9831-a0d90f5bcfa0.png)



**AFTER**

![image](https://user-images.githubusercontent.com/17464863/116335922-c1001400-a82b-11eb-980b-bbdd0fb22bf1.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1027)
<!-- Reviewable:end -->
