### PR TITLE
Remove notes when permanently removed in Paratext

### DIFF
--- a/src/SIL.XForge.Scripture/Models/ParatextNoteThreadChange.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextNoteThreadChange.cs
@@ -19,13 +19,21 @@ namespace SIL.XForge.Scripture.Models
         public string ContextAfter { get; set; }
         public int StartPosition { get; set; }
         public string TagIcon { get; set; }
+        /// <summary> True if the thread has been permanently removed. </summary>
+        public bool ThreadRemoved { get; set; }
         public List<Note> NotesAdded { get; set; } = new List<Note>();
         public List<Note> NotesUpdated { get; set; } = new List<Note>();
         public List<Note> NotesDeleted { get; set; } = new List<Note>();
+        /// <summary> IDs for notes that have been permanently removed. </summary>
+        public List<string> NoteIdsRemoved { get; set; } = new List<string>();
 
         public bool HasChange
         {
-            get { return NotesAdded.Count > 0 || NotesUpdated.Count > 0 || NotesDeleted.Count > 0; }
+            get
+            {
+                return NotesAdded.Count > 0 || NotesUpdated.Count > 0 || NotesDeleted.Count > 0 ||
+                    NoteIdsRemoved.Count > 0 || ThreadRemoved;
+            }
         }
 
         public ParatextNoteThreadChange(string threadId, string verseRef, string selectedText, string contextBefore,

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -573,7 +573,6 @@ namespace SIL.XForge.Scripture.Services
 
             foreach (var threadDoc in noteThreadDocs)
             {
-                List<string> noteIdsRemoved = new List<string>();
                 List<string> matchedCommentIds = new List<string>();
                 ParatextNoteThreadChange threadChange = new ParatextNoteThreadChange(threadDoc.Data.DataId,
                     threadDoc.Data.VerseRef.ToString(), threadDoc.Data.SelectedText, threadDoc.Data.ContextBefore,
@@ -995,7 +994,6 @@ namespace SIL.XForge.Scripture.Services
             List<List<Paratext.Data.ProjectComments.Comment>> changes =
                 new List<List<Paratext.Data.ProjectComments.Comment>>();
             IEnumerable<IDocument<ParatextNoteThread>> activeThreadDocs = noteThreadDocs.Where(t => t.Data != null);
-            List<string> matchedThreadIds = new List<string>();
             foreach (IDocument<ParatextNoteThread> threadDoc in activeThreadDocs)
             {
                 List<Paratext.Data.ProjectComments.Comment> thread = new List<Paratext.Data.ProjectComments.Comment>();

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -590,13 +590,16 @@ namespace SIL.XForge.Scripture.Services
         /// Apply the changes to a ParatextNoteThread doc.
         /// TODO: Handle if verseRef changes
         /// </summary>
-        private Task SubmitChangesOnNoteThreadDocAsync(IDocument<ParatextNoteThread> threadDoc,
+        private async Task SubmitChangesOnNoteThreadDocAsync(IDocument<ParatextNoteThread> threadDoc,
             ParatextNoteThreadChange change, Dictionary<string, string> usernamesToUserIds)
         {
             if (change.ThreadRemoved)
-                return threadDoc.DeleteAsync();
+            {
+                await threadDoc.DeleteAsync();
+                return;
+            }
 
-            return threadDoc.SubmitJson0OpAsync(op =>
+            await threadDoc.SubmitJson0OpAsync(op =>
             {
                 // Update content for updated notes
                 foreach (Note updated in change.NotesUpdated)


### PR DESCRIPTION
* detect when a Paratext comment has been permanently removed in Paratext
* remove the note from the note thread doc
* detect when a Paratext comment thread has been permanently removed
* delete the note thread doc when comment thread has been removed
* also refactor to get username mappings from Paratext service

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1038)
<!-- Reviewable:end -->
