### PR TITLE
SF-1320a Detect when project data is out of sync with the hg repo

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/sync.ts
+++ b/src/RealtimeServer/scriptureforge/models/sync.ts
@@ -3,5 +3,6 @@ export interface Sync {
   percentCompleted?: number;
   lastSyncSuccessful?: boolean;
   dateLastSuccessfulSync?: string;
+  /** Indicates if PT project data from the last send/receive operation was incorporated into the SF project docs */
   dataInSync?: boolean;
 }

--- a/src/RealtimeServer/scriptureforge/models/sync.ts
+++ b/src/RealtimeServer/scriptureforge/models/sync.ts
@@ -3,4 +3,5 @@ export interface Sync {
   percentCompleted?: number;
   lastSyncSuccessful?: boolean;
   dateLastSuccessfulSync?: string;
+  dataInSync?: boolean;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -50,6 +50,9 @@
         <div *ngIf="!isValid && hasEditRight" class="invalid-warning">
           {{ t("cannot_edit_chapter_formatting_invalid") }}
         </div>
+        <div *ngIf="!dataInSync && hasEditRight" class="out-of-sync-warning">
+          {{ t("project_data_out_of_sync") }}
+        </div>
         <div #targetContainer class="text-container" [style.height]="textHeight">
           <app-text
             #target

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -111,7 +111,8 @@ app-text {
   overflow: hidden;
 }
 
-.invalid-warning {
+.invalid-warning,
+.out-of-sync-warning {
   color: #ff4118;
   margin-bottom: 3px;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -743,6 +743,7 @@ describe('EditorComponent', () => {
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
       expect(env.component.canEdit).toBe(true);
+      expect(env.outOfSyncWarning).toBeNull();
       expect(env.isSourceAreaHidden).toBe(true);
 
       env.setDataInSync('project01', false);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -744,6 +744,10 @@ describe('EditorComponent', () => {
       expect(selection).toBeNull();
       expect(env.component.canEdit).toBe(true);
       expect(env.isSourceAreaHidden).toBe(true);
+
+      env.setDataInSync('project01', false);
+      expect(env.component.canEdit).toBe(false);
+      expect(env.outOfSyncWarning).not.toBeNull();
       env.dispose();
     }));
 
@@ -1092,7 +1096,7 @@ class TestEnvironment {
       shareEnabled: true,
       shareLevel: CheckingShareLevel.Specific
     },
-    sync: { queuedCount: 0 },
+    sync: { queuedCount: 0, dataInSync: true },
     texts: [
       {
         bookNum: 40,
@@ -1271,6 +1275,10 @@ class TestEnvironment {
     return this.fixture.debugElement.query(By.css('.invalid-warning'));
   }
 
+  get outOfSyncWarning(): DebugElement {
+    return this.fixture.debugElement.query(By.css('.out-of-sync-warning'));
+  }
+
   get isSourceAreaHidden(): boolean {
     return this.sourceTextArea.nativeElement.style.display === 'none';
   }
@@ -1428,6 +1436,13 @@ class TestEnvironment {
 
   getTextDoc(textId: TextDocId): TextDoc {
     return this.realtimeService.get<TextDoc>(TextDoc.COLLECTION, textId.toString());
+  }
+
+  setDataInSync(projectId: string, isInSync: boolean): void {
+    const projectDoc: SFProjectDoc = this.realtimeService.get<SFProjectDoc>(SFProjectDoc.COLLECTION, projectId);
+    projectDoc.submitJson0Op(op => op.set(p => p.sync.dataInSync!, isInSync));
+    tick();
+    this.fixture.detectChanges();
   }
 
   wait(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -241,7 +241,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   get canEdit(): boolean {
-    return this.isValid && this.hasEditRight;
+    return this.isValid && this.hasEditRight && this.dataInSync;
   }
 
   get canShare(): boolean {
@@ -269,6 +269,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
     const chapter = this.text.chapters.find(c => c.number === this._chapter);
     return chapter != null && chapter.isValid;
+  }
+
+  get dataInSync(): boolean {
+    return this.projectDoc?.data?.sync?.dataInSync !== false;
   }
 
   private get hasSource(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -79,6 +79,7 @@
     "cannot_edit_chapter_formatting_invalid": "This chapter cannot be edited because the formatting is invalid. Please fix the formatting in Paratext.",
     "completed_successfully": "Completed successfully",
     "configure_translation_suggestions": "Configure translation suggestions",
+    "project_data_out_of_sync": "Your project data is out of sync. Please synchronize your project to edit this text.",
     "swap_source_and_target": "Swap source and target",
     "training": "Training",
     "training_completed_successfully": "Training completed successfully",

--- a/src/SIL.XForge.Scripture/Models/Sync.cs
+++ b/src/SIL.XForge.Scripture/Models/Sync.cs
@@ -8,5 +8,7 @@ namespace SIL.XForge.Scripture.Models
         public double? PercentCompleted { get; set; }
         public bool? LastSyncSuccessful { get; set; }
         public DateTime? DateLastSuccessfulSync { get; set; }
+        public string SyncedToRepositoryVersion { get; set; }
+        public bool? DataInSync { get; set; }
     }
 }

--- a/src/SIL.XForge.Scripture/Models/Sync.cs
+++ b/src/SIL.XForge.Scripture/Models/Sync.cs
@@ -8,6 +8,10 @@ namespace SIL.XForge.Scripture.Models
         public double? PercentCompleted { get; set; }
         public bool? LastSyncSuccessful { get; set; }
         public DateTime? DateLastSuccessfulSync { get; set; }
+        /// <summary>
+        /// The SF project was last successfully synchronized with PT project data at this repository
+        /// commit on the PT project send/receive server.
+        /// </summary>
         public string SyncedToRepositoryVersion { get; set; }
         public bool? DataInSync { get; set; }
     }

--- a/src/SIL.XForge.Scripture/Services/HgWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/HgWrapper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Paratext.Data.Repository;
 
 namespace SIL.XForge.Scripture.Services
@@ -25,6 +26,12 @@ namespace SIL.XForge.Scripture.Services
             if (Hg.Default == null)
                 throw new InvalidOperationException("Hg default has not been set.");
             return Hg.Default.Pull(repository, bundle, true);
+        }
+
+        public static string GetLastPublicRevision(string repository)
+        {
+            string ids = RunCommand(repository, "log --rev \"public()\" --template \"{node}\n\"");
+            return ids.Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries).LastOrDefault();
         }
 
         /// <summary> Set the default Mercurial installation. Must be called for all other methods to work. </summary>

--- a/src/SIL.XForge.Scripture/Services/HgWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/HgWrapper.cs
@@ -28,6 +28,9 @@ namespace SIL.XForge.Scripture.Services
             return Hg.Default.Pull(repository, bundle, true);
         }
 
+        /// <summary>
+        /// Get the most recent revision id of the commit from the last push or pull with the PT send/receive server.
+        /// </summary>
         public static string GetLastPublicRevision(string repository)
         {
             string ids = RunCommand(repository, "log --rev \"public()\" --template \"{node}\n\"");

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -29,6 +29,7 @@ namespace SIL.XForge.Scripture.Services
             Dictionary<int, string> chapterAuthors = null);
         string GetNotes(UserSecret userSecret, string ptProjectId, int bookNum);
         void PutNotes(UserSecret userSecret, string ptProjectId, string notesText);
+        string GetLatestSharedVersion(UserSecret userSecret, string ptProjectId);
 
         Task SendReceiveAsync(UserSecret userSecret, string ptTargetId, IProgress<ProgressState> progress = null);
     }

--- a/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
@@ -150,8 +150,7 @@ namespace SIL.XForge.Scripture.Services
         /// <summary> Get the latest public revision. </summary>
         private string GetBaseRevision(string repository)
         {
-            string ids = HgWrapper.RunCommand(repository, "log --rev \"public()\" --template \"{node}\n\"");
-            return ids.Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries).LastOrDefault();
+            return HgWrapper.GetLastPublicRevision(repository);
         }
 
         /// <summary> Mark all changesets available on the PT server public. </summary>

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -608,6 +608,9 @@ namespace SIL.XForge.Scripture.Services
             }
         }
 
+        /// <summary>
+        /// Get the most recent revision id of a commit from the last push or pull with the PT send/receive server.
+        /// </summary>
         public string GetLatestSharedVersion(UserSecret userSecret, string ptProjectId)
         {
             ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), ptProjectId);

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -752,7 +752,7 @@ namespace SIL.XForge.Scripture.Services
                     MockRestClientFactory);
                 Service.ScrTextCollection = MockScrTextCollection;
                 Service.SharingLogicWrapper = MockSharingLogicWrapper;
-                Service.HgWrapper = MockHgWrapper;
+                Service.HgHelper = MockHgWrapper;
                 Service.SyncDir = SyncDir;
 
                 PTProjectIds.Add(Project01, HexId.CreateNew());

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -33,9 +33,11 @@ namespace SIL.XForge.Scripture.Services
         {
             var env = new TestEnvironment();
             env.SetupSFData(true, true, true);
+            env.ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), "target").Returns("beforeSR");
 
             await env.Runner.RunAsync("project01", "user03", false);
-            env.VerifyProjectSync(false);
+            SFProject project = env.VerifyProjectSync(false);
+            Assert.That(project.Sync.DataInSync, Is.True);
         }
 
         [Test]

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -35,10 +35,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, true);
 
             await env.Runner.RunAsync("project01", "user03", false);
-
-            SFProject project = env.GetProject();
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.False);
+            env.VerifyProjectSync(false);
         }
 
         [Test]
@@ -50,10 +47,8 @@ namespace SIL.XForge.Scripture.Services
             env.DeltaUsxMapper.When(d => d.ToChapterDeltas(Arg.Any<XDocument>())).Do(x => throw new Exception());
 
             await env.Runner.RunAsync("project01", "user01", false);
-
-            SFProject project = env.GetProject();
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.False);
+            SFProject project = env.VerifyProjectSync(false);
+            Assert.That(project.Sync.DataInSync, Is.False);
         }
 
         [Test]
@@ -81,10 +76,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
 
             await env.EngineService.DidNotReceive().StartBuildByProjectIdAsync("project01");
-
-            SFProject project = env.GetProject();
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+            env.VerifyProjectSync(true);
         }
 
         [Test]
@@ -113,10 +105,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
 
             await env.EngineService.Received().StartBuildByProjectIdAsync("project01");
-
-            SFProject project = env.GetProject();
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+            env.VerifyProjectSync(true);
         }
 
         [Test]
@@ -145,10 +134,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
 
             await env.EngineService.Received().StartBuildByProjectIdAsync("project01");
-
-            SFProject project = env.GetProject();
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+            env.VerifyProjectSync(true);
         }
 
         [Test]
@@ -176,10 +162,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
 
             await env.EngineService.DidNotReceive().StartBuildByProjectIdAsync("project01");
-
-            SFProject project = env.GetProject();
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+            env.VerifyProjectSync(true);
         }
 
         [Test]
@@ -214,9 +197,7 @@ namespace SIL.XForge.Scripture.Services
             SFProjectSecret projectSecret = env.GetProjectSecret();
             Assert.That(projectSecret.SyncUsers.Count, Is.EqualTo(0));
 
-            SFProject project = env.GetProject();
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+            SFProject project = env.VerifyProjectSync(true);
             Assert.That(project.UserRoles["user01"], Is.EqualTo(SFProjectRole.Administrator));
             Assert.That(project.UserRoles["user02"], Is.EqualTo(SFProjectRole.Translator));
         }
@@ -257,10 +238,7 @@ namespace SIL.XForge.Scripture.Services
 
             SFProjectSecret projectSecret = env.GetProjectSecret();
             Assert.That(projectSecret.SyncUsers.Count, Is.EqualTo(1));
-
-            SFProject project = env.GetProject();
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+            env.VerifyProjectSync(true);
         }
 
         [Test]
@@ -299,10 +277,7 @@ namespace SIL.XForge.Scripture.Services
 
             SFProjectSecret projectSecret = env.GetProjectSecret();
             Assert.That(projectSecret.SyncUsers.Count, Is.EqualTo(1));
-
-            SFProject project = env.GetProject();
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+            env.VerifyProjectSync(true);
         }
 
         [Test]
@@ -323,10 +298,7 @@ namespace SIL.XForge.Scripture.Services
 
             Assert.That(env.ContainsQuestion("MAT", 2), Is.True);
             Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
-
-            SFProject project = env.GetProject();
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+            env.VerifyProjectSync(true);
         }
 
         [Test]
@@ -343,9 +315,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(project.Texts[0].Chapters[1].IsValid, Is.False);
             Assert.That(project.Texts[1].Chapters[0].IsValid, Is.True);
             Assert.That(project.Texts[1].Chapters[1].IsValid, Is.True);
-
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+            env.VerifyProjectSync(true);
         }
 
         [Test]
@@ -372,10 +342,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
             Assert.That(env.ContainsQuestion("MAT", 1), Is.True);
             Assert.That(env.ContainsQuestion("MAT", 2), Is.True);
-
-            SFProject project = env.GetProject();
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+            env.VerifyProjectSync(true);
         }
 
         [Test]
@@ -394,9 +361,7 @@ namespace SIL.XForge.Scripture.Services
 
             await env.Runner.RunAsync("project01", "user01", false);
 
-            SFProject project = env.GetProject();
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+            SFProject project = env.VerifyProjectSync(true);
             Assert.That(project.UserRoles["user01"], Is.EqualTo(SFProjectRole.Translator));
             await env.SFProjectService.Received().RemoveUserAsync("user01", "project01", "user02");
         }
@@ -425,9 +390,7 @@ namespace SIL.XForge.Scripture.Services
 
             await env.Runner.RunAsync("project01", "user01", false);
 
-            SFProject project = env.GetProject();
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+            SFProject project = env.VerifyProjectSync(true);
             Assert.That(project.Texts.First().Permissions["user02"], Is.EqualTo(TextInfoPermission.None));
         }
 
@@ -455,9 +418,7 @@ namespace SIL.XForge.Scripture.Services
 
             await env.Runner.RunAsync("project01", "user01", false);
 
-            SFProject project = env.GetProject();
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+            SFProject project = env.VerifyProjectSync(true);
             Assert.That(project.Texts.First().Chapters.First().Permissions["user02"], Is.EqualTo(TextInfoPermission.None));
         }
 
@@ -485,9 +446,7 @@ namespace SIL.XForge.Scripture.Services
 
             await env.Runner.RunAsync("project01", "user01", false);
 
-            SFProject project = env.GetProject();
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+            SFProject project = env.VerifyProjectSync(true);
             Assert.That(project.Texts.First().Permissions["user02"], Is.EqualTo(TextInfoPermission.Read));
         }
 
@@ -515,9 +474,7 @@ namespace SIL.XForge.Scripture.Services
 
             await env.Runner.RunAsync("project01", "user01", false);
 
-            SFProject project = env.GetProject();
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+            SFProject project = env.VerifyProjectSync(true);
             Assert.That(project.Texts.First().Chapters.First().Permissions["user02"], Is.EqualTo(TextInfoPermission.Read));
         }
 
@@ -540,9 +497,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(project.UserRoles["user02"], Is.EqualTo(SFProjectRole.CommunityChecker));
             await env.Runner.RunAsync("project01", "user01", false);
 
-            project = env.GetProject();
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+            env.VerifyProjectSync(true);
             await env.SFProjectService.DidNotReceiveWithAnyArgs().RemoveUserAsync("user01", "project01", "user02");
         }
 
@@ -586,10 +541,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.GetText("project01", "MRK", 2).DeepEquals(delta), Is.True);
             Assert.That(env.GetText("project01", "LUK", 1).DeepEquals(delta), Is.True);
             Assert.That(env.GetText("project01", "LUK", 2).DeepEquals(delta), Is.True);
-
-            SFProject project = env.GetProject();
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+            env.VerifyProjectSync(true);
         }
 
         [Test]
@@ -828,6 +780,10 @@ namespace SIL.XForge.Scripture.Services
                     .Do(x => _sendReceivedCalled = true);
                 ParatextService.IsProjectLanguageRightToLeft(Arg.Any<UserSecret>(), Arg.Any<string>())
                     .Returns(false);
+                ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), "target")
+                    .Returns("beforeSR", "afterSR");
+                ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), "source")
+                    .Returns("beforeSR", "afterSR");
                 RealtimeService = new SFMemoryRealtimeService();
                 DeltaUsxMapper = Substitute.For<IDeltaUsxMapper>();
                 _notesMapper = Substitute.For<IParatextNotesMapper>();
@@ -875,6 +831,16 @@ namespace SIL.XForge.Scripture.Services
             public Question GetQuestion(string bookId, int chapter)
             {
                 return RealtimeService.GetRepository<Question>().Get($"project01:question{bookId}{chapter}");
+            }
+
+            public SFProject VerifyProjectSync(bool successful)
+            {
+                SFProject project = GetProject();
+                Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
+                Assert.That(project.Sync.LastSyncSuccessful, Is.EqualTo(successful));
+                string repoVersion = successful ? "afterSR" : "beforeSR";
+                Assert.That(project.Sync.SyncedToRepositoryVersion, Is.EqualTo(repoVersion));
+                return project;
             }
 
             public void SetupSFData(bool translationSuggestionsEnabled, bool checkingEnabled, bool changed,
@@ -931,7 +897,8 @@ namespace SIL.XForge.Scripture.Services
                             Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
                             Sync = new Sync
                             {
-                                QueuedCount = 1
+                                QueuedCount = 1,
+                                SyncedToRepositoryVersion = "beforeSR"
                             }
                         },
                         new SFProject
@@ -957,7 +924,8 @@ namespace SIL.XForge.Scripture.Services
                             Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
                             Sync = new Sync
                             {
-                                QueuedCount = 0
+                                QueuedCount = 0,
+                                SyncedToRepositoryVersion = "beforeSR"
                             }
                         }
                     }));


### PR DESCRIPTION
* compare the data version to the version of the hg repo
* if out of sync, skip pushing any changes
* do not allow editing text in a project that is out of sync
* add method to Paratext service to report the hg repo revision

![Out_of_sync_warning](https://user-images.githubusercontent.com/17931130/118054555-b5d8d800-b343-11eb-9ff4-986fe2318119.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1039)
<!-- Reviewable:end -->
