### PR TITLE
Show conflict note icon and note on blank segments

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -482,12 +482,14 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       return;
     }
 
-    const verseSegments = this.getVerseSegments(verseRef);
+    // A single verse can be associated with multiple segments (e.g verse_1_1, verse_1_1/p_1)
+    const verseSegments: string[] = this.getVerseSegments(verseRef);
     let noteRange: RangeStatic | undefined = this.getSegmentRange(verseSegments[0]);
     let startPosition = 0;
+    let selectionLength = 0;
     for (const vs of verseSegments) {
-      const text = this.getSegmentText(vs);
-      const range = this.getSegmentRange(vs);
+      const text: string = this.getSegmentText(vs);
+      const range: RangeStatic | undefined = this.getSegmentRange(vs);
       if (range == null) {
         continue;
       } else if (selectedText === '') {
@@ -503,6 +505,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
           // TODO: Find a better way to match a note to its selected text
           startPosition = start;
           noteRange = range;
+          selectionLength = selectedText.length;
           break;
         }
       }
@@ -511,10 +514,10 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     if (noteRange == null) {
       return;
     }
-    // Limit the length of the format to the length of the range
-    let textLength = selectedText?.length ?? 1;
-    textLength = textLength < 1 ? 1 : textLength;
-    this.editor.formatText(noteRange.index + startPosition, textLength, formatName, format, 'silent');
+    if (selectionLength === 0) {
+      selectionLength = noteRange.length;
+    }
+    this.editor.formatText(noteRange.index + startPosition, selectionLength, formatName, format, 'silent');
   }
 
   onContentChanged(delta: DeltaStatic, source: Sources): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -58,8 +58,7 @@ export interface TextUpdatedEvent {
 export interface FeaturedVerseRefInfo {
   verseRef: VerseRef;
   iconName?: string;
-  startPos?: number;
-  selectionLength?: number;
+  selectedText?: string;
   preview?: string;
 }
 
@@ -420,8 +419,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       }
       // Check for related segments like this verse i.e. verse_1_2/q1
       for (const relatedSegment of this.getRelatedSegmentRefs(segment)) {
-        const text = this.getSegmentText(relatedSegment);
-        if (text !== '' && !segments.includes(relatedSegment)) {
+        if (!segments.includes(relatedSegment)) {
           segments.push(relatedSegment);
         }
       }
@@ -479,17 +477,44 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     return segments;
   }
 
-  toggleInlineFormat(segment: string, startPos: number, formatLength: number, formatName: string, format: any): void {
+  toggleInlineFormat(verseRef: VerseRef, selectedText: string, formatName: string, format: any): void {
     if (this.editor == null) {
       return;
     }
-    const range = this.getSegmentRange(segment);
-    if (range == null) {
+
+    const verseSegments = this.getVerseSegments(verseRef);
+    let noteRange: RangeStatic | undefined = this.getSegmentRange(verseSegments[0]);
+    let startPosition = 0;
+    for (const vs of verseSegments) {
+      const text = this.getSegmentText(vs);
+      const range = this.getSegmentRange(vs);
+      if (range == null) {
+        continue;
+      } else if (selectedText === '') {
+        if (text === '') {
+          // blank segments matches to blank text
+          noteRange = range;
+          break;
+        }
+      } else {
+        const start = text.indexOf(selectedText);
+        if (start >= 0) {
+          // the selected text exists in the verse
+          // TODO: Find a better way to match a note to its selected text
+          startPosition = start;
+          noteRange = range;
+          break;
+        }
+      }
+    }
+
+    if (noteRange == null) {
       return;
     }
     // Limit the length of the format to the length of the range
-    const textLength = formatLength > range.length ? range.length : formatLength;
-    this.editor.formatText(range.index + startPos, textLength, formatName, format, 'silent');
+    let textLength = selectedText?.length ?? 1;
+    textLength = textLength < 1 ? 1 : textLength;
+    this.editor.formatText(noteRange.index + startPosition, textLength, formatName, format, 'silent');
   }
 
   onContentChanged(delta: DeltaStatic, source: Sources): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -904,7 +904,7 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('adds note thread segment attribute to element', fakeAsync(() => {
+    it('adds display-note tag to element', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
       env.wait();
@@ -921,6 +921,17 @@ describe('EditorComponent', () => {
       expect(note.hasAttribute('title')).toBe(true);
       expect(note.getAttribute('title')).toEqual('Note from user01\n--- 2 more note(s) ---');
       expect(note.innerText).toEqual('chapter 1');
+
+      const emptySegment: HTMLElement = env.targetTextEditor.nativeElement.querySelector(
+        'usx-segment[data-segment="verse_1_4/p_1"]'
+      )!;
+      expect(emptySegment).not.toBeNull();
+      const emptySegmentNote = emptySegment.querySelector('display-note')! as HTMLElement;
+      expect(emptySegmentNote).not.toBeNull();
+      expect(emptySegmentNote.hasAttribute('style')).toBe(true);
+      expect(emptySegmentNote.getAttribute('style')).toEqual('--icon-file: url(/assets/icons/TagIcons/01flag1.png);');
+      expect(emptySegmentNote.hasAttribute('title')).toBe(true);
+      expect(emptySegmentNote.getAttribute('title')).toEqual('Note from user01');
       env.dispose();
     }));
   });
@@ -1226,7 +1237,8 @@ class TestEnvironment {
       instance(this.mockedRemoteTranslationEngine)
     );
     this.setupProject();
-    this.addParatextNoteThread(['user01', 'user02', 'user03']);
+    this.addParatextNoteThread(1, 'chapter 1', ['user01', 'user02', 'user03']);
+    this.addParatextNoteThread(4, '', ['user01']);
     when(this.mockedRemoteTranslationEngine.getWordGraph(anything())).thenCall(segment =>
       Promise.resolve(this.createWordGraph(segment))
     );
@@ -1619,35 +1631,36 @@ class TestEnvironment {
     });
   }
 
-  private addParatextNoteThread(userIds: string[]): void {
+  private addParatextNoteThread(threadNum: number, selectedText: string, userIds: string[]): void {
+    const threadId: string = `thread0${threadNum}`;
     const notes: Note[] = [];
     for (let i = 0; i < userIds.length; i++) {
       const id = userIds[i];
       const date = new Date('2021-03-01T12:00:00');
       date.setHours(date.getHours() + i);
       const note: Note = {
-        threadId: 'thread01',
+        threadId: threadId,
         ownerRef: id,
         dataId: `thread01_note${id}`,
         dateCreated: date.toJSON(),
         dateModified: date.toJSON(),
         content: `<p><bold>Note from ${id}</bold></p>`,
-        extUserId: 'ext_user_01',
+        extUserId: id,
         deleted: false,
         tagIcon: `01flag${i + 1}`
       };
       notes.push(note);
     }
 
-    const vrd: VerseRefData = { bookNum: 40, chapterNum: 1, verseNum: 1 };
+    const vrd: VerseRefData = { bookNum: 40, chapterNum: 1, verseNum: threadNum };
     this.realtimeService.addSnapshot<ParatextNoteThread>(ParatextNoteThreadDoc.COLLECTION, {
-      id: 'project01:thread01',
+      id: `project01:${threadId}`,
       data: {
         projectRef: 'project01',
-        dataId: 'thread01',
+        dataId: threadId,
         verseRef: vrd,
         ownerRef: 'user01',
-        selectedText: 'chapter 1',
+        selectedText,
         notes,
         tagIcon: '01flag1',
         contextBefore: '\\v 1 target: ',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -922,16 +922,14 @@ describe('EditorComponent', () => {
       expect(note.getAttribute('title')).toEqual('Note from user01\n--- 2 more note(s) ---');
       expect(note.innerText).toEqual('chapter 1');
 
-      const emptySegment: HTMLElement = env.targetTextEditor.nativeElement.querySelector(
-        'usx-segment[data-segment="verse_1_4/p_1"]'
-      )!;
-      expect(emptySegment).not.toBeNull();
-      const emptySegmentNote = emptySegment.querySelector('display-note')! as HTMLElement;
-      expect(emptySegmentNote).not.toBeNull();
-      expect(emptySegmentNote.hasAttribute('style')).toBe(true);
-      expect(emptySegmentNote.getAttribute('style')).toEqual('--icon-file: url(/assets/icons/TagIcons/01flag1.png);');
-      expect(emptySegmentNote.hasAttribute('title')).toBe(true);
-      expect(emptySegmentNote.getAttribute('title')).toEqual('Note from user01');
+      const blankSegmentNote = env.targetTextEditor.nativeElement.querySelector(
+        'usx-segment[data-segment="verse_1_4/p_1"] display-note'
+      )! as HTMLElement;
+      expect(blankSegmentNote).not.toBeNull();
+      expect(blankSegmentNote.hasAttribute('style')).toBe(true);
+      expect(blankSegmentNote.getAttribute('style')).toEqual('--icon-file: url(/assets/icons/TagIcons/01flag1.png);');
+      expect(blankSegmentNote.hasAttribute('title')).toBe(true);
+      expect(blankSegmentNote.getAttribute('title')).toEqual('Note from user01');
       env.dispose();
     }));
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -37,7 +37,6 @@ import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { PwaService } from 'xforge-common/pwa.service';
 import { UserService } from 'xforge-common/user.service';
-import { verseSlug } from 'xforge-common/utils';
 import XRegExp from 'xregexp';
 import { environment } from '../../../environments/environment';
 import { ParatextNoteThreadDoc } from '../../core/models/paratext-note-thread-doc';
@@ -617,13 +616,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       const iconName: string = featured.iconName ?? '01flag1';
       const nodeProp: string = iconSourceProp(iconName);
       const format = value ? { iconsrc: nodeProp, preview: featured.preview } : {};
-      this.target.toggleInlineFormat(
-        verseSegments[0],
-        featured.startPos ?? 0,
-        featured.selectionLength ?? 1,
-        'note-thread',
-        format
-      );
+      this.target.toggleInlineFormat(featured.verseRef, featured.selectedText ?? '', 'note-thread', format);
     }
 
     if (value) {
@@ -961,15 +954,11 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       preview += '\n' + translate('editor.more_notes', { count: notes.length - 1 });
     }
     const iconDefinedNotes = notes.filter(n => n.tagIcon != null);
-    const segment: string = verseSlug(toVerseRef(thread.verseRef));
-    const segmentText: string = this.target!.getSegmentText(segment);
-    const contentStartPos: number = segmentText.indexOf(thread.selectedText);
     return {
       verseRef: toVerseRef(thread.verseRef),
       preview,
       iconName: iconDefinedNotes.length === 0 ? thread.tagIcon : iconDefinedNotes[iconDefinedNotes.length - 1].tagIcon,
-      startPos: contentStartPos >= 0 ? contentStartPos : 0,
-      selectionLength: thread.selectedText.length
+      selectedText: thread.selectedText
     };
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -479,13 +479,14 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
           this.target.editor.setSelection(selectIndex, 0, 'user');
         }
 
+        // Filter for note thread docs that match the current book and the edited segment
         const threadDocs: ParatextNoteThreadDoc[] | undefined = this.noteThreadQuery?.docs.filter(
-          n =>
-            n.data != null &&
-            this.bookNum === n.data.verseRef.bookNum &&
-            segment?.ref.startsWith(verseSlug(toVerseRef(n.data.verseRef)))
+          td =>
+            td.data != null &&
+            this.bookNum === td.data.verseRef.bookNum &&
+            segment?.ref.startsWith(verseSlug(toVerseRef(td.data.verseRef)))
         );
-        const segmentHasNote = threadDocs == null || threadDocs.length < 1 ? null : threadDocs[0].data != null;
+        const segmentHasNote = threadDocs == null || threadDocs.length > 0;
         if (segmentHasNote) {
           // Check whether an edit operation occurs at the beginning of an empty segment with a note
           if (

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -479,21 +479,22 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
           this.target.editor.setSelection(selectIndex, 0, 'user');
         }
 
-        // reset note icon was blank or is newly blank
         const threadDocs: ParatextNoteThreadDoc[] | undefined = this.noteThreadQuery?.docs.filter(
           n =>
             n.data != null &&
             this.bookNum === n.data.verseRef.bookNum &&
             segment?.ref.startsWith(verseSlug(toVerseRef(n.data.verseRef)))
         );
-        const noteThread = threadDocs == null || threadDocs.length < 1 ? null : threadDocs[0];
-        if (noteThread?.data != null) {
-          // check whether an edit operation occurs at the beginning of an empty verse with a note
+        const segmentHasNote = threadDocs == null || threadDocs.length < 1 ? null : threadDocs[0].data != null;
+        if (segmentHasNote) {
+          // Check whether an edit operation occurs at the beginning of an empty segment with a note
           if (
             segment?.range.length === 1 &&
             delta.ops[0].retain === segment?.range.index &&
             (delta.ops[1].insert != null || delta.ops[1].delete != null)
           ) {
+            // Recalculate the note icon positioning when editing a blank segment or blanking out a segment
+            // This can be optimize later when we are satisfied with how notes are anchored to text
             this.toggleNoteThreadVerses(false);
             this.toggleNoteThreadVerses(true);
           }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -628,9 +628,9 @@ namespace SIL.XForge.Scripture.Services
                 Paratext.Data.ProjectComments.Comment info = thread.Comments[0];
 
                 int tagId = info.TagsAdded != null && info.TagsAdded.Length > 0 ? int.Parse(info.TagsAdded[0]) : 1;
-                string originalTagIcon = commentTags.Get(tagId).Icon;
+                CommentTag initialTag = info.Type == NoteType.Conflict ? CommentTag.ConflictTag : commentTags.Get(tagId);
                 ParatextNoteThreadChange newThread = new ParatextNoteThreadChange(threadId, info.VerseRefStr,
-                    info.SelectedText, info.ContextBefore, info.ContextAfter, info.StartPosition, originalTagIcon);
+                    info.SelectedText, info.ContextBefore, info.ContextAfter, info.StartPosition, initialTag.Icon);
                 foreach (var comm in thread.Comments)
                 {
                     SyncUser syncUser = FindOrCreateSyncUser(comm.User, syncUsers);
@@ -1097,8 +1097,8 @@ namespace SIL.XForge.Scripture.Services
         private Note CreateNoteFromComment(string noteId, Paratext.Data.ProjectComments.Comment comment,
             CommentTags commentTags, SyncUser syncUser)
         {
-            var tag = comment.TagsAdded == null || comment.TagsAdded.Length == 0
-                ? null
+            CommentTag tag = comment.TagsAdded == null || comment.TagsAdded.Length == 0
+                ? comment.Type == NoteType.Conflict ? CommentTag.ConflictTag : null
                 : commentTags.Get(int.Parse(comment.TagsAdded[0]));
             return new Note
             {

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1098,7 +1098,7 @@ namespace SIL.XForge.Scripture.Services
             CommentTags commentTags, SyncUser syncUser)
         {
             CommentTag tag = comment.TagsAdded == null || comment.TagsAdded.Length == 0
-                ? comment.Type == NoteType.Conflict ? CommentTag.ConflictTag : null
+                ? (comment.Type == NoteType.Conflict ? CommentTag.ConflictTag : null)
                 : commentTags.Get(int.Parse(comment.TagsAdded[0]));
             return new Note
             {

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -566,12 +566,13 @@ namespace SIL.XForge.Scripture.Services
                 Assert.That(change05.ThreadChangeToString(),
                     Is.EqualTo("Context before Text selected thread05 context after-Start:15-MAT 1:5"));
                 Assert.That(change05.ThreadRemoved, Is.True);
+
                 // Added conflict comment
                 ParatextNoteThreadChange change06 = changes.Where(c => c.ThreadId == "thread06").Single();
-                Assert.That(change04.ThreadChangeToString(),
+                Assert.That(change06.ThreadChangeToString(),
                     Is.EqualTo("Context before Text selected thread06 context after-Start:15-MAT 1:6-conflict1"));
-                string expected4 = "thread06-syncuser01-user02-<p>thread06 note 1.</p>-conflict1";
-                Assert.That(change04.NotesAdded[0].NoteToString(), Is.EqualTo(expected4));
+                string expected6 = "thread06-syncuser01-user02-<p>thread06 note 1.</p>-conflict1";
+                Assert.That(change06.NotesAdded[0].NoteToString(), Is.EqualTo(expected6));
             }
         }
 


### PR DESCRIPTION
- Notes on blank segments will now appear
- show notes attached related segments in poetry
- Specifically handle conflict notes by setting the icon on the thread

![image](https://user-images.githubusercontent.com/17931130/118330149-96b58400-b4c4-11eb-8384-0af48df32016.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1041)
<!-- Reviewable:end -->
