### PR TITLE
SF-1048: Added Cancel ability when synchronizing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -65,6 +65,7 @@
     "transcelerator",
     "transloco",
     "uncheck",
+    "unelevated",
     "uninvite",
     "unsynchronized",
     "usfm",

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -116,6 +116,10 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
     return this.onlineInvoke('sync', { projectId: id });
   }
 
+  onlineCancelSync(id: string): Promise<void> {
+    return this.onlineInvoke('cancelSync', { projectId: id });
+  }
+
   onlineUpdateSettings(id: string, settings: SFProjectSettings): Promise<void> {
     return this.onlineInvoke('updateSettings', { projectId: id, settings });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
@@ -40,6 +40,17 @@
             [projectDoc]="projectDoc"
             (inProgress)="syncActive = $event"
           ></app-sync-progress>
+          <button
+            *ngIf="syncActive"
+            class="action-button"
+            mdc-button
+            type="button"
+            (click)="cancelSync()"
+            [disabled]="isLoading || !isAppOnline || syncDisabled"
+            id="btn-cancel-sync"
+          >
+            {{ t("cancel") }}
+          </button>
           <span *ngIf="!syncActive" [title]="lastSyncDate" id="date-last-sync" class="sync-info">
             {{ lastSyncNotice }}
           </span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
@@ -20,7 +20,8 @@ h2 {
   align-self: center;
 }
 
-#btn-sync {
+#btn-sync,
+.progress-bar {
   margin-bottom: 1rem;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
@@ -106,7 +106,7 @@ describe('SyncComponent', () => {
     expect(env.component.syncActive).toBe(true);
     expect(env.progressBar).not.toBeNull();
     // Simulate sync in progress
-    env.emitSyncProgress(0, 'testProject01');
+    env.emitSyncProgress(0.25, 'testProject01');
     // Simulate sync error
     env.emitSyncComplete(false, 'testProject01');
     expect(env.component.syncActive).toBe(false);
@@ -131,6 +131,21 @@ describe('SyncComponent', () => {
     const env = new TestEnvironment(true, false, true, false);
     expect(env.syncButton.nativeElement.disabled).toBe(false);
     expect(env.syncDisabledMessage).toBeNull();
+  }));
+
+  it('should report cancelled if sync was cancelled', fakeAsync(() => {
+    const env = new TestEnvironment(true);
+    verify(mockedProjectService.get('testProject01')).once();
+    env.clickElement(env.syncButton);
+    verify(mockedProjectService.onlineSync('testProject01')).once();
+    expect(env.component.syncActive).toBe(true);
+    expect(env.progressBar).not.toBeNull();
+
+    env.clickElement(env.cancelButton);
+    env.emitSyncComplete(false, 'testProject01');
+
+    expect(env.component.syncActive).toBe(false);
+    verify(mockedNoticeService.show('Synchronize for Sync Test Project was cancelled.')).once();
   }));
 });
 
@@ -208,6 +223,10 @@ class TestEnvironment {
 
   get syncButton(): DebugElement {
     return this.fixture.debugElement.query(By.css('#btn-sync'));
+  }
+
+  get cancelButton(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#btn-cancel-sync'));
   }
 
   get progressBar(): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -194,6 +194,7 @@
     "translation_suggestions_settings": "Translation suggestions settings"
   },
   "sync": {
+    "cancel": "Cancel",
     "connect_network_to_synchronize": "Please connect to the internet to synchronize this project",
     "last_synced_time_stamp": "Last synced on {{ timeStamp }}",
     "log_in_to_paratext": "Log in to Paratext",
@@ -201,6 +202,7 @@
     "something_went_wrong_synchronizing_this_project": "Something went wrong while synchronizing {{ projectName }} with Paratext. Please try again.",
     "successfully_synchronized_with_paratext": "Successfully synchronized {{ projectName }} with Paratext.",
     "synchronize": "Synchronize",
+    "synchronize_was_cancelled": "Synchronize for {{ projectName }} was cancelled.",
     "synchronize_project": "Synchronize {{ projectName }} with Paratext",
     "your_project_is_being_synchronized": "Your project is being synchronized...",
     "sync_is_disabled": "Synchronization for this project needed to be disabled, so it is not available at this time. Please contact {{ email }} to discuss what needs to be done so project synchronization can be enabled again."

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -291,6 +291,23 @@ namespace SIL.XForge.Scripture.Controllers
             }
         }
 
+        public async Task<IRpcMethodResult> CancelSync(string projectId)
+        {
+            try
+            {
+                await _projectService.CancelSyncAsync(UserId, projectId);
+                return Ok();
+            }
+            catch (ForbiddenException)
+            {
+                return ForbiddenError();
+            }
+            catch (DataNotFoundException dnfe)
+            {
+                return NotFoundError(dnfe.Message);
+            }
+        }
+
         public async Task<IRpcMethodResult> DeleteAudio(string projectId, string ownerId, string dataId)
         {
             try

--- a/src/SIL.XForge.Scripture/Models/SFProjectSecret.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectSecret.cs
@@ -6,6 +6,17 @@ namespace SIL.XForge.Scripture.Models
     public class SFProjectSecret : ProjectSecret
     {
         /// <summary>
+        /// The queued or active Hangfire Job Ids for the project.
+        /// </summary>
+        /// <value>
+        /// The Hangfire Job Ids.
+        /// </value>
+        /// <remarks>
+        /// The <see cref="List{T}.Count">Count</see> should correspond to <see cref="QueuedCount" />.
+        /// </remarks>
+        public List<string> JobIds { get; set; } = new List<string>();
+
+        /// <summary>
         /// Keeps track of all Paratext usernames that have been used to sync notes with Paratext
         /// </summary>
         public List<SyncUser> SyncUsers { get; set; } = new List<SyncUser>();

--- a/src/SIL.XForge.Scripture/Services/IJwtTokenHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/IJwtTokenHelper.cs
@@ -1,4 +1,5 @@
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using SIL.XForge.Configuration;
 using SIL.XForge.Models;
@@ -9,6 +10,7 @@ namespace SIL.XForge.Scripture.Services
     {
         string GetParatextUsername(UserSecret userSecret);
         string GetJwtTokenFromUserSecret(UserSecret userSecret);
-        Task<Tokens> RefreshAccessTokenAsync(ParatextOptions options, Tokens paratextTokens, HttpClient client);
+        Task<Tokens> RefreshAccessTokenAsync(ParatextOptions options, Tokens paratextTokens, HttpClient client,
+            CancellationToken token);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/IParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextNotesMapper.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using SIL.XForge.Models;
@@ -12,7 +13,7 @@ namespace SIL.XForge.Scripture.Services
         List<SyncUser> NewSyncUsers { get; }
 
         Task InitAsync(UserSecret currentUserSecret, SFProjectSecret projectSecret, List<User> ptUsers,
-            string paratextProjectId);
+            string paratextProjectId, CancellationToken token);
         Task<XElement> GetNotesChangelistAsync(XElement oldNotesElem, IEnumerable<IDocument<Question>> questionsDocs);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using SIL.XForge.Models;
 using SIL.XForge.Scripture.Models;
@@ -12,17 +13,19 @@ namespace SIL.XForge.Scripture.Services
         void Init();
         Task<IReadOnlyList<ParatextProject>> GetProjectsAsync(UserSecret userSecret);
         string GetParatextUsername(UserSecret userSecret);
-        Task<Attempt<string>> TryGetProjectRoleAsync(UserSecret userSecret, string paratextId);
-        Task<IReadOnlyDictionary<string, string>> GetProjectRolesAsync(UserSecret userSecret, string paratextId);
+        Task<Attempt<string>> TryGetProjectRoleAsync(UserSecret userSecret, string paratextId, CancellationToken token);
+        Task<IReadOnlyDictionary<string, string>> GetProjectRolesAsync(UserSecret userSecret, string paratextId,
+            CancellationToken token);
         bool IsProjectLanguageRightToLeft(UserSecret userSecret, string paratextId);
 
         Task<IReadOnlyList<ParatextResource>> GetResourcesAsync(string userId);
         bool IsResource(string paratextId);
-        Task<string> GetResourcePermissionAsync(string paratextId, string userId);
+        Task<string> GetResourcePermissionAsync(string paratextId, string userId, CancellationToken token);
         Task<IReadOnlyDictionary<string, string>> GetParatextUsernameMappingAsync(UserSecret userSecret,
-            string paratextId);
+            string paratextId, CancellationToken token);
         Task<Dictionary<string, string>> GetPermissionsAsync(UserSecret userSecret, SFProject project,
-            IReadOnlyDictionary<string, string> ptUsernameMapping, int book = 0, int chapter = 0);
+            IReadOnlyDictionary<string, string> ptUsernameMapping, int book = 0, int chapter = 0,
+            CancellationToken token = default);
 
         IReadOnlyList<int> GetBookList(UserSecret userSecret, string paratextId);
         string GetBookText(UserSecret userSecret, string paratextId, int bookNum);
@@ -32,6 +35,7 @@ namespace SIL.XForge.Scripture.Services
         void PutNotes(UserSecret userSecret, string paratextId, string notesText);
         string GetLatestSharedVersion(UserSecret userSecret, string paratextId);
 
-        Task SendReceiveAsync(UserSecret userSecret, string paratextId, IProgress<ProgressState> progress = null);
+        Task SendReceiveAsync(UserSecret userSecret, string paratextId, IProgress<ProgressState> progress = null,
+            CancellationToken token = default);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/IParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextSyncRunner.cs
@@ -1,9 +1,10 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SIL.XForge.Scripture.Services
 {
     public interface IParatextSyncRunner
     {
-        Task RunAsync(string projectId, string userId, bool trainEngine);
+        Task RunAsync(string projectId, string userId, bool trainEngine, CancellationToken token);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
@@ -1,8 +1,9 @@
-using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Services;
-using SIL.XForge.Realtime;
 
 namespace SIL.XForge.Scripture.Services
 {
@@ -24,6 +25,6 @@ namespace SIL.XForge.Scripture.Services
         bool IsSourceProject(string projectId);
         Task<IEnumerable<TransceleratorQuestion>> TransceleratorQuestions(string curUserId, string projectId);
         Task<bool> HasTransceleratorQuestions(string curUserId, string projectId);
-        Task UpdatePermissionsAsync(string curUserId, IDocument<SFProject> projectDoc);
+        Task UpdatePermissionsAsync(string curUserId, IDocument<SFProject> projectDoc, CancellationToken token);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
@@ -14,6 +14,7 @@ namespace SIL.XForge.Scripture.Services
         Task UpdateSettingsAsync(string curUserId, string projectId, SFProjectSettings settings);
         Task AddTranslateMetricsAsync(string curUserId, string projectId, TranslateMetrics metrics);
         Task SyncAsync(string curUserId, string projectId);
+        Task CancelSyncAsync(string curUserId, string projectId);
         Task<bool> InviteAsync(string curUserId, string projectId, string email, string locale, string role);
         Task<string> GetLinkSharingKeyAsync(string projectId, string role);
         Task<bool> IsAlreadyInvitedAsync(string curUserId, string projectId, string email);

--- a/src/SIL.XForge.Scripture/Services/ISyncService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISyncService.cs
@@ -5,5 +5,6 @@ namespace SIL.XForge.Scripture.Services
     public interface ISyncService
     {
         Task SyncAsync(string curUserId, string projectId, bool trainEngine);
+        Task CancelSyncAsync(string curUserId, string projectId);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/JwtTokenHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtTokenHelper.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using SIL.XForge.Configuration;
@@ -44,7 +45,7 @@ namespace SIL.XForge.Scripture.Services
 
         /// <summary> Refresh the Paratext access token if expired with the given HttpClient. </summary>
         public async Task<Tokens> RefreshAccessTokenAsync(ParatextOptions options, Tokens paratextTokens,
-            HttpClient client)
+            HttpClient client, CancellationToken token)
         {
             bool expired = !paratextTokens.ValidateLifetime();
             if (!expired)
@@ -57,7 +58,7 @@ namespace SIL.XForge.Scripture.Services
                     new JProperty("client_secret", options.ClientSecret),
                     new JProperty("refresh_token", paratextTokens.RefreshToken));
                 request.Content = new StringContent(requestObj.ToString(), Encoding.Default, "application/json");
-                HttpResponseMessage response = await client.SendAsync(request);
+                HttpResponseMessage response = await client.SendAsync(request, token);
                 await _exceptionHandler.EnsureSuccessStatusCode(response);
 
                 string responseJson = await response.Content.ReadAsStringAsync();

--- a/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Extensions.Localization;
@@ -49,7 +50,7 @@ namespace SIL.XForge.Scripture.Services
         public List<SyncUser> NewSyncUsers { get; } = new List<SyncUser>();
 
         public async Task InitAsync(UserSecret currentUserSecret, SFProjectSecret projectSecret, List<User> ptUsers,
-            string paratextProjectId)
+            string paratextProjectId, CancellationToken token)
         {
             _currentUserSecret = currentUserSecret;
             _currentParatextUsername = _paratextService.GetParatextUsername(currentUserSecret);
@@ -63,7 +64,7 @@ namespace SIL.XForge.Scripture.Services
             }
             _ptProjectUsersWhoCanWriteNotes = new HashSet<string>();
             IReadOnlyDictionary<string, string> roles = await _paratextService.GetProjectRolesAsync(currentUserSecret,
-                paratextProjectId);
+                paratextProjectId, token);
             var ptRolesCanWriteNote = new HashSet<string> { SFProjectRole.Administrator, SFProjectRole.Translator,
                 SFProjectRole.Consultant, SFProjectRole.WriteNote };
             foreach (User user in ptUsers)

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
@@ -85,7 +86,7 @@ namespace SIL.XForge.Scripture.Services
         // Do not allow multiple sync jobs to run in parallel on the same project by creating a mutex on the projectId
         // parameter, i.e. "{0}"
         [Mutex("{0}")]
-        public async Task RunAsync(string projectId, string userId, bool trainEngine)
+        public async Task RunAsync(string projectId, string userId, bool trainEngine, CancellationToken token)
         {
             try
             {

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -327,6 +327,18 @@ namespace SIL.XForge.Scripture.Services
             await _syncService.SyncAsync(curUserId, projectId, false);
         }
 
+        public async Task CancelSyncAsync(string curUserId, string projectId)
+        {
+            Attempt<SFProject> attempt = await RealtimeService.TryGetSnapshotAsync<SFProject>(projectId);
+            if (!attempt.TryResult(out SFProject project))
+                throw new DataNotFoundException("The project does not exist.");
+
+            if (!IsProjectAdmin(project, curUserId))
+                throw new ForbiddenException();
+
+            await _syncService.CancelSyncAsync(curUserId, projectId);
+        }
+
         public async Task<bool> InviteAsync(string curUserId, string projectId, string email, string locale,
             string role)
         {

--- a/src/SIL.XForge.Scripture/Services/SyncService.cs
+++ b/src/SIL.XForge.Scripture/Services/SyncService.cs
@@ -1,7 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Hangfire;
+using Hangfire.States;
+using SIL.XForge.DataAccess;
 using SIL.XForge.Realtime;
 using SIL.XForge.Realtime.Json0;
 using SIL.XForge.Scripture.Models;
@@ -15,33 +18,38 @@ namespace SIL.XForge.Scripture.Services
     public class SyncService : ISyncService
     {
         private readonly IBackgroundJobClient _backgroundJobClient;
+        private readonly IRepository<SFProjectSecret> _projectSecrets;
         private readonly IRealtimeService _realtimeService;
-        private readonly Dictionary<string, string> _jobIdsByProjectId = new Dictionary<string, string>();
-        private readonly Dictionary<string, string> _sourceJobIdsByProjectId = new Dictionary<string, string>();
 
         public SyncService(
             IBackgroundJobClient backgroundJobClient,
+            IRepository<SFProjectSecret> projectSecrets,
             IRealtimeService realtimeService)
         {
             _backgroundJobClient = backgroundJobClient;
+            _projectSecrets = projectSecrets;
             _realtimeService = realtimeService;
         }
 
         public async Task SyncAsync(string curUserId, string projectId, bool trainEngine)
         {
-            string sourceProjectId = null;
             using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
             {
+                // Load the project document
                 IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
                 if (projectDoc.Data.SyncDisabled)
                 {
                     throw new ForbiddenException();
                 }
 
-                sourceProjectId = projectDoc.Data.TranslateConfig.Source?.ProjectRef;
-                await projectDoc.SubmitJson0OpAsync(op => op.Inc(pd => pd.Sync.QueuedCount));
+                // Load the target project secrets, so we can store the job id
+                if (!(await _projectSecrets.TryGetAsync(projectId)).TryResult(out SFProjectSecret projectSecret))
+                {
+                    throw new ArgumentException("The target project secret cannot be found.");
+                }
 
                 // See if we can sync the source project
+                string sourceProjectId = projectDoc.Data.TranslateConfig.Source?.ProjectRef;
                 if (!string.IsNullOrWhiteSpace(sourceProjectId))
                 {
                     IDocument<SFProject> sourceProjectDoc = await conn.FetchAsync<SFProject>(sourceProjectId);
@@ -51,48 +59,140 @@ namespace SIL.XForge.Scripture.Services
                     }
                     else
                     {
-                        await sourceProjectDoc.SubmitJson0OpAsync(op => op.Inc(pd => pd.Sync.QueuedCount));
+                        // Load the source project secrets, so we can store the job id
+                        if (!(await _projectSecrets.TryGetAsync(sourceProjectId)).TryResult(out SFProjectSecret sourceProjectSecret))
+                        {
+                            throw new ArgumentException("The source project secret cannot be found.");
+                        }
+
+                        // Schedule the sync for 5 minutes to give us enough time to update the project's sync object
+                        // We do this because there is no "draft" status in hangfire - this is close enough
+                        // After we do that, we will enqueue the job. We do it this way because we don't want to start
+                        // the job unless the queued count and job ids have been incremented appropriately.
+                        // We need to sync the source first so that we can link the source texts and train the engine.
+                        string sourceJobId = _backgroundJobClient.Schedule<ParatextSyncRunner>(
+                            r => r.RunAsync(sourceProjectId, curUserId, false, CancellationToken.None),
+                            TimeSpan.FromMinutes(5));
+                        string targetJobId = _backgroundJobClient.ContinueJobWith<ParatextSyncRunner>(sourceJobId,
+                            r => r.RunAsync(projectId, curUserId, trainEngine, CancellationToken.None), null,
+                            JobContinuationOptions.OnAnyFinishedState);
+                        try
+                        {
+                            await sourceProjectDoc.SubmitJson0OpAsync(op =>
+                            {
+                                op.Inc(pd => pd.Sync.QueuedCount);
+                            });
+                            await projectDoc.SubmitJson0OpAsync(op =>
+                            {
+                                op.Inc(pd => pd.Sync.QueuedCount);
+                            });
+
+                            // Store the source job id so we can cancel the job later if needed
+                            await _projectSecrets.UpdateAsync(sourceProjectSecret.Id, u =>
+                            {
+                                u.Add(p => p.JobIds, sourceJobId);
+                            });
+
+                            // Store the target job id so we can cancel the job later if needed
+                            await _projectSecrets.UpdateAsync(projectSecret.Id, u =>
+                            {
+                                u.Add(p => p.JobIds, targetJobId);
+                            });
+
+                            _backgroundJobClient.ChangeState(sourceJobId, new EnqueuedState());
+                        }
+                        catch (Exception)
+                        {
+                            // Delete the jobs on error, and notify the user
+                            _backgroundJobClient.Delete(targetJobId);
+                            _backgroundJobClient.Delete(sourceJobId);
+                            throw;
+                        }
+
+                        // Exit so we don't queue the target again, in the following block
+                        return;
                     }
                 }
-            }
 
-            if (!string.IsNullOrWhiteSpace(sourceProjectId))
-            {
-                // We need to sync the source first so that we can link the source texts and train the engine
-                string sourceJobId = _backgroundJobClient.Enqueue<ParatextSyncRunner>(
-                    r => r.RunAsync(sourceProjectId, curUserId, false, CancellationToken.None));
-                _sourceJobIdsByProjectId[projectId] = sourceJobId;
-                _jobIdsByProjectId[projectId] = _backgroundJobClient.ContinueJobWith<ParatextSyncRunner>(sourceJobId,
-                    r => r.RunAsync(projectId, curUserId, trainEngine, CancellationToken.None));
-            }
-            else
-            {
-                _jobIdsByProjectId[projectId] = _backgroundJobClient.Enqueue<ParatextSyncRunner>(
-                    r => r.RunAsync(projectId, curUserId, trainEngine, CancellationToken.None));
+                // Sync the target project only, as it does not have a source, or the source cannot be synced
+                // See the comments in the block above regarding scheduling for rationale on the process
+                string jobId = _backgroundJobClient.Schedule<ParatextSyncRunner>(
+                    r => r.RunAsync(projectId, curUserId, trainEngine, CancellationToken.None),
+                    TimeSpan.FromMinutes(5));
+                try
+                {
+                    await projectDoc.SubmitJson0OpAsync(op =>
+                    {
+                        op.Inc(pd => pd.Sync.QueuedCount);
+                    });
+
+                    // Store the job id so we can cancel the job later if needed
+                    await _projectSecrets.UpdateAsync(projectSecret.Id, u =>
+                    {
+                        u.Add(p => p.JobIds, jobId);
+                    });
+
+                    _backgroundJobClient.ChangeState(jobId, new EnqueuedState());
+                }
+                catch (Exception)
+                {
+                    // Delete the job on error, and notify the user
+                    _backgroundJobClient.Delete(jobId);
+                    throw;
+                }
             }
         }
 
         public async Task CancelSyncAsync(string curUserId, string projectId)
         {
-            if (_sourceJobIdsByProjectId.TryGetValue(projectId, out string sourceJobId))
-                _backgroundJobClient.Delete(sourceJobId);
-            if (_jobIdsByProjectId.TryGetValue(projectId, out string jobId))
-                _backgroundJobClient.Delete(jobId);
-
             using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
             {
                 IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
-                if (projectDoc.Data.SyncDisabled)
-                {
-                    throw new ForbiddenException();
-                }
                 if (projectDoc.Data.Sync.QueuedCount > 0)
-                    await projectDoc.SubmitJson0OpAsync(op =>
+                {
+                    await CancelProjectDocumentSyncAsync(projectDoc);
+
+                    // Cancel all jobs for the source (if present)
+                    string sourceProjectId = projectDoc.Data.TranslateConfig.Source?.ProjectRef;
+                    if (!string.IsNullOrWhiteSpace(sourceProjectId))
                     {
-                        op.Inc(pd => pd.Sync.QueuedCount, -1);
-                        op.Unset(pd => pd.Sync.PercentCompleted);
-                        op.Set(pd => pd.Sync.LastSyncSuccessful, false);
-                    });
+                        IDocument<SFProject> sourceProjectDoc = await conn.FetchAsync<SFProject>(sourceProjectId);
+                        if (sourceProjectDoc.IsLoaded && !sourceProjectDoc.Data.SyncDisabled)
+                        {
+                            if (sourceProjectDoc.Data.Sync.QueuedCount > 0)
+                            {
+                                await CancelProjectDocumentSyncAsync(sourceProjectDoc);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private async Task CancelProjectDocumentSyncAsync(IDocument<SFProject> projectDoc)
+        {
+            // Load the project secrets, so we can get any job ids
+            if ((await _projectSecrets.TryGetAsync(projectDoc.Data.Id)).TryResult(out SFProjectSecret projectSecret))
+            {
+                // Cancel all jobs for the project
+                foreach (string jobId in projectSecret.JobIds)
+                {
+                    _backgroundJobClient.Delete(jobId);
+                }
+
+                // Remove all job ids from the project secrets
+                await _projectSecrets.UpdateAsync(projectSecret.Id, u =>
+                {
+                    u.Set(p => p.JobIds, new List<string>());
+                });
+
+                // Mark sync as cancelled
+                await projectDoc.SubmitJson0OpAsync(op =>
+                {
+                    op.Set(pd => pd.Sync.QueuedCount, 0);
+                    op.Unset(pd => pd.Sync.PercentCompleted);
+                    op.Set(pd => pd.Sync.LastSyncSuccessful, false);
+                });
             }
         }
     }

--- a/src/SIL.XForge/DataAccess/IUpdateBuilder.cs
+++ b/src/SIL.XForge/DataAccess/IUpdateBuilder.cs
@@ -18,6 +18,8 @@ namespace SIL.XForge.DataAccess
         IUpdateBuilder<T> RemoveAll<TItem>(Expression<Func<T, IEnumerable<TItem>>> field,
             Expression<Func<TItem, bool>> predicate);
 
+        IUpdateBuilder<T> Remove<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value);
+
         IUpdateBuilder<T> Add<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value);
     }
 }

--- a/src/SIL.XForge/DataAccess/MemoryUpdateBuilder.cs
+++ b/src/SIL.XForge/DataAccess/MemoryUpdateBuilder.cs
@@ -87,6 +87,15 @@ namespace SIL.XForge.DataAccess
             return this;
         }
 
+        public IUpdateBuilder<T> Remove<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value)
+        {
+            Func<T, IEnumerable<TItem>> getCollection = field.Compile();
+            IEnumerable<TItem> collection = getCollection(_entity);
+            MethodInfo addMethod = collection.GetType().GetMethod("Remove");
+            addMethod.Invoke(collection, new object[] { value });
+            return this;
+        }
+
         public IUpdateBuilder<T> Add<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value)
         {
             Func<T, IEnumerable<TItem>> getCollection = field.Compile();

--- a/src/SIL.XForge/DataAccess/MongoUpdateBuilder.cs
+++ b/src/SIL.XForge/DataAccess/MongoUpdateBuilder.cs
@@ -49,6 +49,12 @@ namespace SIL.XForge.DataAccess
             return this;
         }
 
+        public IUpdateBuilder<T> Remove<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value)
+        {
+            _defs.Add(_builder.Pull(ToFieldDefinition(field), value));
+            return this;
+        }
+
         public IUpdateBuilder<T> Add<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value)
         {
             _defs.Add(_builder.Push(ToFieldDefinition(field), value));

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Extensions.Localization;
@@ -418,7 +419,7 @@ namespace SIL.XForge.Scripture.Services
             public async Task InitMapperAsync(bool includeSyncUsers, bool twoPtUsersOnProject)
             {
                 await Mapper.InitAsync(UserSecrets.Get("user01"), ProjectSecret(includeSyncUsers),
-                    ParatextUsersOnProject(twoPtUsersOnProject), "paratextId");
+                    ParatextUsersOnProject(twoPtUsersOnProject), "paratextId", CancellationToken.None);
             }
 
             public void AddData(string answerSyncUserId1, string answerSyncUserId2, string commentSyncUserId1,
@@ -491,7 +492,8 @@ namespace SIL.XForge.Scripture.Services
                 ptUserRoles["ptuser01"] = "pt_administrator";
                 if (twoPtUserOnProject)
                     ptUserRoles["ptuser03"] = "pt_translator";
-                ParatextService.GetProjectRolesAsync(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(ptUserRoles);
+                ParatextService.GetProjectRolesAsync(Arg.Any<UserSecret>(), Arg.Any<string>(),
+                    Arg.Any<CancellationToken>()).Returns(ptUserRoles);
             }
 
             private static SFProjectSecret ProjectSecret(bool includeSyncUsers)

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.Hosting;
@@ -356,7 +357,7 @@ namespace SIL.XForge.Scripture.Services
                 .Returns(mockClient);
 
             var paratextId = "resid_is_16_char";
-            var permission = await env.Service.GetResourcePermissionAsync(paratextId, env.User01);
+            var permission = await env.Service.GetResourcePermissionAsync(paratextId, env.User01, CancellationToken.None);
             Assert.That(permission, Is.EqualTo(TextInfoPermission.None));
         }
 
@@ -377,7 +378,7 @@ namespace SIL.XForge.Scripture.Services
 
             var paratextId = "resid_is_16_char";
 
-            var permission = await env.Service.GetResourcePermissionAsync(paratextId, env.User01);
+            var permission = await env.Service.GetResourcePermissionAsync(paratextId, env.User01, CancellationToken.None);
             Assert.That(permission, Is.EqualTo(TextInfoPermission.Read));
         }
 
@@ -710,12 +711,13 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             const string resourceId = "1234567890abcdef";
             Assert.That(resourceId.Length, Is.EqualTo(SFInstallableDblResource.ResourceIdentifierLength));
-            var mapping = await env.Service.GetParatextUsernameMappingAsync(env.MakeUserSecret(env.User01, env.Username01), resourceId);
+            var mapping = await env.Service.GetParatextUsernameMappingAsync(env.MakeUserSecret(env.User01, env.Username01),
+                resourceId, CancellationToken.None);
             Assert.That(mapping.Count, Is.EqualTo(0));
         }
 
         [Test]
-        public async Task GetLatestSharedVersion_ForPTProject()
+        public void GetLatestSharedVersion_ForPTProject()
         {
             var env = new TestEnvironment();
             var associatedPtUser = new SFParatextUser(env.Username01);
@@ -733,10 +735,9 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task GetLatestSharedVersion_ForDBLResource()
+        public void GetLatestSharedVersion_ForDBLResource()
         {
             var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
             UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01);
 
             string resourcePTId = "1234567890123456";
@@ -833,7 +834,7 @@ namespace SIL.XForge.Scripture.Services
                 MockJwtTokenHelper.GetParatextUsername(Arg.Any<UserSecret>()).Returns(User01);
                 MockJwtTokenHelper.GetJwtTokenFromUserSecret(Arg.Any<UserSecret>()).Returns(accessToken);
                 MockJwtTokenHelper.RefreshAccessTokenAsync(Arg.Any<ParatextOptions>(), Arg.Any<Tokens>(),
-                    Arg.Any<HttpClient>())
+                    Arg.Any<HttpClient>(), Arg.Any<CancellationToken>())
                     .Returns(Task.FromResult(new Tokens
                     {
                         AccessToken = accessToken,

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
@@ -25,7 +26,7 @@ namespace SIL.XForge.Scripture.Services
         {
             var env = new TestEnvironment();
 
-            await env.Runner.RunAsync("project03", "user01", false);
+            await env.Runner.RunAsync("project03", "user01", false, CancellationToken.None);
         }
 
         [Test]
@@ -35,7 +36,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, true);
             env.ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), "target").Returns("beforeSR");
 
-            await env.Runner.RunAsync("project01", "user03", false);
+            await env.Runner.RunAsync("project01", "user03", false, CancellationToken.None);
+
             SFProject project = env.VerifyProjectSync(false);
             Assert.That(project.Sync.DataInSync, Is.True);
         }
@@ -48,7 +50,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
             env.DeltaUsxMapper.When(d => d.ToChapterDeltas(Arg.Any<XDocument>())).Do(x => throw new Exception());
 
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+
             SFProject project = env.VerifyProjectSync(false);
             Assert.That(project.Sync.DataInSync, Is.False);
         }
@@ -60,7 +63,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(false, false, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
 
-            await env.Runner.RunAsync("project01", "user01", true);
+            await env.Runner.RunAsync("project01", "user01", true, CancellationToken.None);
 
             Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
             Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
@@ -88,8 +91,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
 
-            await env.Runner.RunAsync("project02", "user01", true);
-            await env.Runner.RunAsync("project01", "user01", true);
+            await env.Runner.RunAsync("project02", "user01", true, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", true, CancellationToken.None);
 
             Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
             Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
@@ -117,8 +120,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, false, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
 
-            await env.Runner.RunAsync("project02", "user01", true);
-            await env.Runner.RunAsync("project01", "user01", true);
+            await env.Runner.RunAsync("project02", "user01", true, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", true, CancellationToken.None);
 
             Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
             Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
@@ -146,7 +149,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(false, true, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
 
-            await env.Runner.RunAsync("project01", "user01", true);
+            await env.Runner.RunAsync("project01", "user01", true, CancellationToken.None);
 
             Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
             Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
@@ -175,7 +178,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, false, books);
             env.SetupPTData(books);
 
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             await env.ParatextService.DidNotReceive().PutBookText(Arg.Any<UserSecret>(), "target", 40, Arg.Any<string>());
             await env.ParatextService.DidNotReceive().PutBookText(Arg.Any<UserSecret>(), "target", 41, Arg.Any<string>());
@@ -212,8 +215,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, true, books);
             env.SetupPTData(books);
 
-            await env.Runner.RunAsync("project02", "user01", false);
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             await env.ParatextService.Received()
                 .PutBookText(Arg.Any<UserSecret>(), "target", 40, Arg.Any<string>(), Arg.Any<Dictionary<int, string>>());
@@ -251,8 +254,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, false, true, books);
             env.SetupPTData(books);
 
-            await env.Runner.RunAsync("project02", "user01", false);
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             await env.ParatextService.Received()
                 .PutBookText(Arg.Any<UserSecret>(), "target", 40, Arg.Any<string>(), Arg.Any<Dictionary<int, string>>());
@@ -289,8 +292,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, false, new Book("MAT", 2), new Book("MRK", 2));
             env.SetupPTData(new Book("MAT", 3), new Book("MRK", 1));
 
-            await env.Runner.RunAsync("project02", "user01", false);
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             Assert.That(env.ContainsText("project01", "MAT", 3), Is.True);
             Assert.That(env.ContainsText("project01", "MRK", 2), Is.False);
@@ -310,7 +313,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, false, new Book("MAT", 2), new Book("MRK", 2) { InvalidChapters = { 1 } });
             env.SetupPTData(new Book("MAT", 2) { InvalidChapters = { 2 } }, new Book("MRK", 2));
 
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             SFProject project = env.GetProject();
             Assert.That(project.Texts[0].Chapters[0].IsValid, Is.True);
@@ -327,8 +330,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, false, new Book("MAT", 2), new Book("MRK", 2));
             env.SetupPTData(new Book("MAT", 2), new Book("LUK", 2));
 
-            await env.Runner.RunAsync("project02", "user01", false);
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             Assert.That(env.ContainsText("project01", "MRK", 1), Is.False);
             Assert.That(env.ContainsText("project01", "MRK", 2), Is.False);
@@ -361,7 +364,7 @@ namespace SIL.XForge.Scripture.Services
             env.ParatextService.GetProjectRolesAsync(Arg.Any<UserSecret>(), "target")
                 .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
 
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             SFProject project = env.VerifyProjectSync(true);
             Assert.That(project.UserRoles["user01"], Is.EqualTo(SFProjectRole.Translator));
@@ -381,9 +384,100 @@ namespace SIL.XForge.Scripture.Services
             };
             env.ParatextService.GetProjectRolesAsync(Arg.Any<UserSecret>(), "target")
                 .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+            var ptSourcePermissions = new Dictionary<string, string>()
+            {
+                { "user01", TextInfoPermission.Read },
+                { "user02", TextInfoPermission.None },
+            };
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(), Arg.Any<SFProject>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Any<int>())
+                .Returns(Task.FromResult(ptSourcePermissions));
 
-            // SUT
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+
+            SFProject project = env.VerifyProjectSync(true);
+            Assert.That(project.Texts.First().Permissions["user02"], Is.EqualTo(TextInfoPermission.None));
+        }
+
+        [Test]
+        public async Task SyncAsync_UserHasNoChapterPermission()
+        {
+            var env = new TestEnvironment();
+            Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+            env.SetupSFData(true, true, false, books);
+            env.SetupPTData(books);
+            var ptUserRoles = new Dictionary<string, string>
+            {
+                { "pt01", SFProjectRole.Translator }
+            };
+            env.ParatextService.GetProjectRolesAsync(Arg.Any<UserSecret>(), "target")
+                .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+            var ptChapterPermissions = new Dictionary<string, string>()
+            {
+                { "user01", TextInfoPermission.Read },
+                { "user02", TextInfoPermission.None },
+            };
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(), Arg.Any<SFProject>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Any<int>())
+                .Returns(Task.FromResult(ptChapterPermissions));
+
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+
+            SFProject project = env.VerifyProjectSync(true);
+            Assert.That(project.Texts.First().Chapters.First().Permissions["user02"], Is.EqualTo(TextInfoPermission.None));
+        }
+
+        [Test]
+        public async Task SyncAsync_UserHasResourcePermission()
+        {
+            var env = new TestEnvironment();
+            Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+            env.SetupSFData(true, true, false, books);
+            env.SetupPTData(books);
+            var ptUserRoles = new Dictionary<string, string>
+            {
+                { "pt01", SFProjectRole.Translator }
+            };
+            env.ParatextService.GetProjectRolesAsync(Arg.Any<UserSecret>(), "target")
+                .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+            var ptSourcePermissions = new Dictionary<string, string>()
+            {
+                { "user01", TextInfoPermission.Read },
+                { "user02", TextInfoPermission.Read },
+            };
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(), Arg.Any<SFProject>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Any<int>())
+                .Returns(Task.FromResult(ptSourcePermissions));
+
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+
+            SFProject project = env.VerifyProjectSync(true);
+            Assert.That(project.Texts.First().Permissions["user02"], Is.EqualTo(TextInfoPermission.Read));
+        }
+
+        [Test]
+        public async Task SyncAsync_UserHasChapterPermission()
+        {
+            var env = new TestEnvironment();
+            Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+            env.SetupSFData(true, true, false, books);
+            env.SetupPTData(books);
+            var ptUserRoles = new Dictionary<string, string>
+            {
+                { "pt01", SFProjectRole.Translator }
+            };
+            env.ParatextService.GetProjectRolesAsync(Arg.Any<UserSecret>(), "target")
+                .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+            var ptChapterPermissions = new Dictionary<string, string>()
+            {
+                { "user01", TextInfoPermission.Read },
+                { "user02", TextInfoPermission.Read },
+            };
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(), Arg.Any<SFProject>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Any<int>())
+                .Returns(Task.FromResult(ptChapterPermissions));
+
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             env.SFProjectService.Received().UpdatePermissionsAsync("user01",
                 Arg.Is<IDocument<SFProject>>((IDocument<SFProject> sfProjDoc) =>
@@ -407,7 +501,7 @@ namespace SIL.XForge.Scripture.Services
             await env.SetUserRole("user02", SFProjectRole.CommunityChecker);
             SFProject project = env.GetProject();
             Assert.That(project.UserRoles["user02"], Is.EqualTo(SFProjectRole.CommunityChecker));
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             env.VerifyProjectSync(true);
             await env.SFProjectService.DidNotReceiveWithAnyArgs().RemoveUserAsync("user01", "project01", "user02");
@@ -423,7 +517,7 @@ namespace SIL.XForge.Scripture.Services
 
             env.ParatextService.IsProjectLanguageRightToLeft(Arg.Any<UserSecret>(), "target")
                 .Returns(true);
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             SFProject project = env.GetProject();
             env.ParatextService.Received().IsProjectLanguageRightToLeft(Arg.Any<UserSecret>(), "target");
@@ -444,7 +538,7 @@ namespace SIL.XForge.Scripture.Services
                 });
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2), new Book("LUK", 2));
 
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             var delta = Delta.New().InsertText("text");
             Assert.That(env.GetText("project01", "MAT", 1).DeepEquals(delta), Is.True);
@@ -469,8 +563,8 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
 
             // SUT
-            await env.Runner.RunAsync("project02", "user01", false);
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             env.Logger.DidNotReceiveWithAnyArgs().LogError(Arg.Any<Exception>(), default, default);
 
@@ -502,8 +596,8 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsText("project02", "MAT", 3), Is.True);
 
             // SUT
-            await env.Runner.RunAsync("project02", "user01", false);
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             env.Logger.DidNotReceiveWithAnyArgs().LogError(Arg.Any<Exception>(), default, default);
 
@@ -529,7 +623,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
 
             // SUT
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             env.Logger.DidNotReceiveWithAnyArgs().LogError(Arg.Any<Exception>(), default, default);
 
@@ -557,8 +651,8 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsText("project02", "MAT", 3), Is.True);
 
             // SUT
-            await env.Runner.RunAsync("project02", "user01", false);
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             env.Logger.DidNotReceiveWithAnyArgs().LogError(Arg.Any<Exception>(), default, default);
 
@@ -597,7 +691,7 @@ namespace SIL.XForge.Scripture.Services
                     .Returns("1", "2");
 
                 // SUT
-                await env.Runner.RunAsync(projectSFId, userId, false);
+                await env.Runner.RunAsync(projectSFId, userId, false, CancellationToken.None);
 
                 project = env.GetProject(projectSFId);
                 // We should get into UpdateParatextBook() and fetch and perhaps put books.
@@ -644,7 +738,7 @@ namespace SIL.XForge.Scripture.Services
                     .Returns("1", "2");
 
                 // SUT
-                await env.Runner.RunAsync(projectSFId, userId, false);
+                await env.Runner.RunAsync(projectSFId, userId, false, CancellationToken.None);
 
                 project = env.GetProject(projectSFId);
                 // We are in an out-of-sync situation and so should not be writing to PT.

--- a/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
@@ -1,11 +1,14 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
 using NSubstitute;
 using NUnit.Framework;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Scripture.Realtime;
-using Hangfire;
 using SIL.XForge.Services;
 
 namespace SIL.XForge.Scripture.Services
@@ -15,6 +18,118 @@ namespace SIL.XForge.Scripture.Services
     {
         private static readonly string Project01 = "project01";
         private static readonly string Project02 = "project02";
+        private static readonly string Project03 = "project03";
+
+        [Test]
+        public async Task SyncAsync_CancelSourceAndTarget()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project03, false);
+
+            // Verify that the jobs were queued correctly
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
+
+            // Cancel sync
+            await env.Service.CancelSyncAsync("userid", Project03);
+
+            // Verify that the job was cancelled correctly
+            env.BackgroundJobClient.Received(2).ChangeState("jobid", Arg.Any<DeletedState>(), null); // Same as Delete()
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
+        }
+
+        [Test]
+        public async Task SyncAsync_CancelSourceNotTarget()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project03, false);
+
+            // Verify that the jobs were queued correctly
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
+
+            // Cancel sync
+            await env.Service.CancelSyncAsync("userid", Project01);
+
+            // Verify that the job was cancelled correctly
+            env.BackgroundJobClient.Received(1).ChangeState("jobid", Arg.Any<DeletedState>(), null); // Same as Delete()
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
+        }
+
+        [Test]
+        public async Task SyncAsync_CancelTargetWithoutSource()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project01, false);
+
+            // Verify that the job was queued correctly
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
+
+            // Cancel sync
+            await env.Service.CancelSyncAsync("userid", Project01);
+
+            // Verify that the job was cancelled correctly
+            env.BackgroundJobClient.Received(1).ChangeState("jobid", Arg.Any<DeletedState>(), null); // Same as Delete()
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
+        }
 
         [Test]
         public void SyncAsync_Enqueues()
@@ -23,6 +138,50 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).SyncDisabled, Is.False);
             // SUT
             Assert.DoesNotThrowAsync(() => env.Service.SyncAsync("userid", Project01, false));
+        }
+
+        [Test]
+        public async Task SyncAsync_EnqueuesSourceAndTarget()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project03, false);
+
+            // Verify that the jobs were queued correctly
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
+        }
+
+        [Test]
+        public async Task SyncAsync_EnqueuedTargetWithoutSource()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project01, false);
+
+            // Verify that the job was queued correctly
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
         }
 
         [Test]
@@ -38,6 +197,12 @@ namespace SIL.XForge.Scripture.Services
             public TestEnvironment()
             {
                 BackgroundJobClient = Substitute.For<IBackgroundJobClient>();
+                ProjectSecrets = new MemoryRepository<SFProjectSecret>(new[]
+                {
+                    new SFProjectSecret { Id = "project01" },
+                    new SFProjectSecret { Id = "project02" },
+                    new SFProjectSecret { Id = "project03" },
+                });
                 RealtimeService = new SFMemoryRealtimeService();
 
                 RealtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(
@@ -70,13 +235,34 @@ namespace SIL.XForge.Scripture.Services
                             },
                             SyncDisabled = true
                         },
+                        new SFProject
+                        {
+                            Id = Project03,
+                            Name = "project03",
+                            ShortName = "P03",
+                            CheckingConfig = new CheckingConfig
+                            {
+                                ShareEnabled = false
+                            },
+                            UserRoles = new Dictionary<string, string>
+                            {
+                            },
+                            TranslateConfig = new TranslateConfig
+                            {
+                                Source = new TranslateSource
+                                {
+                                    ProjectRef = Project01
+                                }
+                            }
+                        }
                 }));
 
-                Service = new SyncService(BackgroundJobClient, RealtimeService);
+                Service = new SyncService(BackgroundJobClient, ProjectSecrets, RealtimeService);
             }
 
             public SyncService Service { get; }
             public IBackgroundJobClient BackgroundJobClient { get; }
+            public MemoryRepository<SFProjectSecret> ProjectSecrets { get; }
             public SFMemoryRealtimeService RealtimeService { get; }
         }
     }

--- a/test/SIL.XForge.Tests/DataAccess/MemoryUpdateBuilderTests.cs
+++ b/test/SIL.XForge.Tests/DataAccess/MemoryUpdateBuilderTests.cs
@@ -1,0 +1,154 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using SIL.XForge.Models;
+
+namespace SIL.XForge.DataAccess
+{
+    [TestFixture]
+    public class MemoryUpdateBuilderTests
+    {
+        [Test]
+        public void MemoryUpdateBuilder_Add()
+        {
+            // Setup environment
+            var env = new TestEnvironment();
+            int oldCount = env.TestEntity.TestChildCollection.Count;
+
+            // Test collection add
+            env.MemoryUpdateBuilder.Add(e => e.TestChildCollection, new TestEntity { Id = "test_id_3" });
+            Assert.AreEqual(oldCount + 1, env.TestEntity.TestChildCollection.Count);
+        }
+
+        [Test]
+        public void MemoryUpdateBuilder_Inc()
+        {
+            var env = new TestEnvironment();
+            int oldValue = env.TestEntity.TestChildCollection.Count;
+
+            // Test increment
+            env.MemoryUpdateBuilder.Inc(e => e.TestNumber, 1);
+            Assert.AreEqual(oldValue + 1, env.TestEntity.TestNumber);
+
+            // Test decrement
+            env.MemoryUpdateBuilder.Inc(e => e.TestNumber, -1);
+            Assert.AreEqual(oldValue, env.TestEntity.TestNumber);
+        }
+
+        [Test]
+        public void MemoryUpdateBuilder_Remove()
+        {
+            // Setup environment
+            var env = new TestEnvironment();
+            int oldCount = env.TestEntity.TestStringCollection.Count;
+
+            // Test string collection remove
+            env.MemoryUpdateBuilder.Remove(e => e.TestStringCollection, "test_value_2");
+            Assert.AreEqual(oldCount - 1, env.TestEntity.TestStringCollection.Count);
+        }
+
+        [Test]
+        public void MemoryUpdateBuilder_RemoveAll()
+        {
+            // Setup environment
+            var env = new TestEnvironment();
+            int oldCount = env.TestEntity.TestChildCollection.Count;
+
+            // Test string collection remove all
+            env.MemoryUpdateBuilder.RemoveAll(e => e.TestChildCollection, e => e.Id == "test_id_2");
+            Assert.AreEqual(oldCount - 1, env.TestEntity.TestChildCollection.Count);
+        }
+
+        [Test]
+        public void MemoryUpdateBuilder_Set()
+        {
+            // Setup environment
+            var env = new TestEnvironment();
+            string oldValue = env.TestEntity.TestStringField;
+            string expected = "updated_test_value";
+
+            // Test string field set
+            Assert.AreNotEqual(expected, env.TestEntity.TestStringField);
+            env.MemoryUpdateBuilder.Set(e => e.TestStringField, expected);
+            Assert.AreEqual(expected, env.TestEntity.TestStringField);
+        }
+
+        [Test]
+        public void MemoryUpdateBuilder_SetOnInsertDisabled()
+        {
+            // Setup environment
+            var env = new TestEnvironment(false);
+            string oldValue = env.TestEntity.TestStringField;
+            string expected = "updated_test_value";
+
+            // Test string field set
+            Assert.AreNotEqual(expected, env.TestEntity.TestStringField);
+            env.MemoryUpdateBuilder.SetOnInsert(e => e.TestStringField, expected);
+            Assert.AreEqual(oldValue, env.TestEntity.TestStringField);
+        }
+
+        [Test]
+        public void MemoryUpdateBuilder_SetOnInsertEnabled()
+        {
+            // Setup environment
+            var env = new TestEnvironment(true);
+            string oldValue = env.TestEntity.TestStringField;
+            string expected = "updated_test_value";
+
+            // Test string field set
+            Assert.AreNotEqual(expected, env.TestEntity.TestStringField);
+            env.MemoryUpdateBuilder.SetOnInsert(e => e.TestStringField, expected);
+            Assert.AreEqual(expected, env.TestEntity.TestStringField);
+        }
+
+        [Test]
+        public void MemoryUpdateBuilder_Unset()
+        {
+            // Setup environment
+            var env = new TestEnvironment();
+            string expected = null;
+
+            // Test string field unset
+            Assert.AreNotEqual(expected, env.TestEntity.TestStringField);
+            env.MemoryUpdateBuilder.Unset(e => e.TestStringField);
+            Assert.AreEqual(expected, env.TestEntity.TestStringField);
+        }
+
+        private class TestEntity : IIdentifiable
+        {
+            public string Id { get; set; }
+            public int TestNumber { get; set; }
+            public List<TestEntity> TestChildCollection { get; set; } = new List<TestEntity>();
+            public List<string> TestStringCollection { get; set; } = new List<string>();
+            public string TestStringField { get; set; }
+        }
+
+        private class TestEnvironment
+        {
+            public TestEnvironment(bool setOnInsert = false)
+            {
+                // Set up the test entity
+                TestEntity = new TestEntity
+                {
+                    Id = "test_id_1",
+                    TestChildCollection = new List<TestEntity>
+                    {
+                        new TestEntity { Id = "test_id_2" },
+                    },
+                    TestNumber = 1,
+                    TestStringCollection = new List<string>
+                    {
+                        "test_value_1",
+                        "test_value_2",
+                    },
+                    TestStringField = "test_value",
+                };
+
+                // Set up the memory update builder for the test entity
+                MemoryUpdateBuilder =
+                    new MemoryUpdateBuilder<TestEntity>(e => e.Id == TestEntity.Id, TestEntity, setOnInsert);
+            }
+            public MemoryUpdateBuilder<TestEntity> MemoryUpdateBuilder { get; }
+            public TestEntity TestEntity { get; }
+        }
+    }
+}


### PR DESCRIPTION
This adds support for cancelling a sync that is queued or in progress.

Cancellation is handled via a `CancellationToken`, with this passed to logic that will accept it with the exception of ParatextData, which uses a static system-wide cancellation method (calling this would be catastrophic for any calls being made to ParatextData in other threads concurrently). The `ParatextSyncRunner.RunAsync()` method polls this value at specific places so that cancellation can be handled without causing corruption. If the job was cancelled after the data was downloaded from Paratext, but before it could fully be loaded into the database, the logic utilizing the `Sync.DataInSync` property from SF-1320a will ensure that the user cannot make modifications to the data until they complete a successful resync.

A `jobIds` array is added to the Project Sync object, storing the job ids from Hangfire for any jobs that have been created.

Cancelling a sync for a project cancels all jobs associated with that project - the reason for this is that it is not exactly possible to know which sync task the user actually wants to cancel (if there are multiple jobs associate with a project), and multiple jobs queued for a project are either accidental or caused by concurrent users. Either way, the user(s) will be notified that the job has failed, and can reschedule a sync if they require.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1051)
<!-- Reviewable:end -->
