### PR TITLE
Sync: Consider data to be in sync if no SyncedToRepositoryVersion or …

### DIFF
--- a/src/SIL.XForge.Scripture/Services/HgWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/HgWrapper.cs
@@ -31,9 +31,9 @@ namespace SIL.XForge.Scripture.Services
         /// <summary>
         /// Get the most recent revision id of the commit from the last push or pull with the PT send/receive server.
         /// </summary>
-        public static string GetLastPublicRevision(string repository)
+        public string GetLastPublicRevision(string repository)
         {
-            string ids = RunCommand(repository, "log --rev \"public()\" --template \"{node}\n\"");
+            string ids = HgWrapper.RunCommand(repository, "log --rev \"public()\" --template \"{node}\n\"");
             return ids.Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries).LastOrDefault();
         }
 

--- a/src/SIL.XForge.Scripture/Services/IHgWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/IHgWrapper.cs
@@ -7,5 +7,6 @@ namespace SIL.XForge.Scripture.Services
         void SetDefault(Hg hgDefault);
         void Init(string repository);
         void Update(string repository);
+        string GetLastPublicRevision(string repository);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/InternetSharedRepositorySourceProvider.cs
+++ b/src/SIL.XForge.Scripture/Services/InternetSharedRepositorySourceProvider.cs
@@ -13,11 +13,14 @@ namespace SIL.XForge.Scripture.Services
     {
         private readonly IJwtTokenHelper _jwtTokenHelper;
         private readonly IOptions<SiteOptions> _siteOptions;
+        private readonly IHgWrapper _hgWrapper;
 
-        public InternetSharedRepositorySourceProvider(IJwtTokenHelper jwtTokenHelper, IOptions<SiteOptions> siteOptions)
+        public InternetSharedRepositorySourceProvider(IJwtTokenHelper jwtTokenHelper, IOptions<SiteOptions> siteOptions,
+            IHgWrapper hgWrapper)
         {
             _jwtTokenHelper = jwtTokenHelper;
             _siteOptions = siteOptions;
+            _hgWrapper = hgWrapper;
         }
 
         public IInternetSharedRepositorySource GetSource(UserSecret userSecret, string sendReceiveServerUri,
@@ -34,7 +37,7 @@ namespace SIL.XForge.Scripture.Services
             JwtRestClient jwtClient = GenerateParatextRegistryJwtClient(userSecret, registryServerUri);
             IInternetSharedRepositorySource source =
                 new JwtInternetSharedRepositorySource(userSecret.ParatextTokens.AccessToken,
-                    jwtClient, ptUser, sendReceiveServerUri);
+                    jwtClient, _hgWrapper, ptUser, sendReceiveServerUri);
             source.RefreshToken(userSecret.ParatextTokens.AccessToken);
             return source;
         }

--- a/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
@@ -13,11 +13,14 @@ namespace SIL.XForge.Scripture.Services
     class JwtInternetSharedRepositorySource : InternetSharedRepositorySource, IInternetSharedRepositorySource
     {
         private readonly JwtRestClient _registryClient;
+        private readonly IHgWrapper _hgWrapper;
 
-        public JwtInternetSharedRepositorySource(string accessToken, JwtRestClient registryClient, ParatextUser authenticationPtUser, string srServerUri)
+        public JwtInternetSharedRepositorySource(string accessToken, JwtRestClient registryClient, IHgWrapper hgWrapper,
+            ParatextUser authenticationPtUser, string srServerUri)
             : base(authenticationPtUser, srServerUri)
         {
             _registryClient = registryClient;
+            _hgWrapper = hgWrapper;
             SetToken(accessToken);
         }
 
@@ -150,7 +153,7 @@ namespace SIL.XForge.Scripture.Services
         /// <summary> Get the latest public revision. </summary>
         private string GetBaseRevision(string repository)
         {
-            return HgWrapper.GetLastPublicRevision(repository);
+            return _hgWrapper.GetLastPublicRevision(repository);
         }
 
         /// <summary> Mark all changesets available on the PT server public. </summary>

--- a/src/SIL.XForge.Scripture/Services/SFServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/SFServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<IInternetSharedRepositorySourceProvider, InternetSharedRepositorySourceProvider>();
             services.AddSingleton<ITransceleratorService, TransceleratorService>();
             services.AddSingleton<ISFRestClientFactory, SFDblRestClientFactory>();
+            services.AddSingleton<IHgWrapper, HgWrapper>();
             return services;
         }
     }

--- a/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
@@ -60,7 +60,8 @@ namespace SIL.XForge.Scripture.Services
                     Origin = new Uri("http://localhost"),
                     SiteDir = "xforge"
                 });
-                Provider = new InternetSharedRepositorySourceProvider(MockJwtTokenHelper, siteOptions);
+                Provider = new InternetSharedRepositorySourceProvider(MockJwtTokenHelper, siteOptions,
+                    Substitute.For<IHgWrapper>());
             }
         }
     }


### PR DESCRIPTION
…is Res

- Projects that were last synced before we started recording
SyncedToRepositoryVersion will not have SyncedToRepositoryVersion set.
Currently that results in isDataInSync being false, and so we don't
write out SF data to the hg repo.
- Set isDataInSync = true if SyncedToRepositoryVersion == null.
- We might instead here to just set isDataInSync = true, and only
set it to false on certain conditions. But for now I'm spelling out
the
situations in code.

ParatextService:
- Make GetLatestShareVersion return null if the project id is for a
resource. There is no hg repository to examine for a commit id.
- Pass in IHgWrapper so we can mock it.

HgWrapper:
- GetLastPublicRevision() can't be easily mocked as a static method.
- Change it to a non-static method.
- Add method to IHgWrapper interface.
- JwtInternetSharedRepositorySource now has an instance of HgWrapper
so it can call GetLastPublicRevision().

===

I am still working on testing the result in a running SF, which has been difficult today because of network trouble getting to the PT servers.

I suggest that we review this here, and if approved and merged to sf-live, then we then cherry-pick to master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1057)
<!-- Reviewable:end -->
