### PR TITLE
SF-1287 Update text permissions on user join

### DIFF
--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -13,24 +13,25 @@ namespace SIL.XForge.Scripture.Services
         Task<IReadOnlyList<ParatextProject>> GetProjectsAsync(UserSecret userSecret);
         string GetParatextUsername(UserSecret userSecret);
         Task<Attempt<string>> TryGetProjectRoleAsync(UserSecret userSecret, string paratextId);
-        Task<IReadOnlyDictionary<string, string>> GetProjectRolesAsync(UserSecret userSecret, string projectId);
-        bool IsProjectLanguageRightToLeft(UserSecret userSecret, string ptProjectId);
+        Task<IReadOnlyDictionary<string, string>> GetProjectRolesAsync(UserSecret userSecret, string paratextId);
+        bool IsProjectLanguageRightToLeft(UserSecret userSecret, string paratextId);
 
         Task<IReadOnlyList<ParatextResource>> GetResourcesAsync(string userId);
+        bool IsResource(string paratextId);
         Task<string> GetResourcePermissionAsync(string paratextId, string userId);
         Task<IReadOnlyDictionary<string, string>> GetParatextUsernameMappingAsync(UserSecret userSecret,
             string paratextId);
         Task<Dictionary<string, string>> GetPermissionsAsync(UserSecret userSecret, SFProject project,
             IReadOnlyDictionary<string, string> ptUsernameMapping, int book = 0, int chapter = 0);
 
-        IReadOnlyList<int> GetBookList(UserSecret userSecret, string ptProjectId);
-        string GetBookText(UserSecret userSecret, string ptProjectId, int bookNum);
-        Task PutBookText(UserSecret userSecret, string ptProjectId, int bookNum, string usx,
+        IReadOnlyList<int> GetBookList(UserSecret userSecret, string paratextId);
+        string GetBookText(UserSecret userSecret, string paratextId, int bookNum);
+        Task PutBookText(UserSecret userSecret, string paratextId, int bookNum, string usx,
             Dictionary<int, string> chapterAuthors = null);
-        string GetNotes(UserSecret userSecret, string ptProjectId, int bookNum);
-        void PutNotes(UserSecret userSecret, string ptProjectId, string notesText);
-        string GetLatestSharedVersion(UserSecret userSecret, string ptProjectId);
+        string GetNotes(UserSecret userSecret, string paratextId, int bookNum);
+        void PutNotes(UserSecret userSecret, string paratextId, string notesText);
+        string GetLatestSharedVersion(UserSecret userSecret, string paratextId);
 
-        Task SendReceiveAsync(UserSecret userSecret, string ptTargetId, IProgress<ProgressState> progress = null);
+        Task SendReceiveAsync(UserSecret userSecret, string paratextId, IProgress<ProgressState> progress = null);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Services;
+using SIL.XForge.Realtime;
 
 namespace SIL.XForge.Scripture.Services
 {
@@ -22,5 +23,6 @@ namespace SIL.XForge.Scripture.Services
         bool IsSourceProject(string projectId);
         Task<IEnumerable<TransceleratorQuestion>> TransceleratorQuestions(string curUserId, string projectId);
         Task<bool> HasTransceleratorQuestions(string curUserId, string projectId);
+        Task UpdatePermissionsAsync(string curUserId, IDocument<SFProject> projectDoc);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
+++ b/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
@@ -185,7 +185,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         /// <summary>
-        /// Checks the resource permission.
+        /// Checks the resource permission, according to a DBL server.
         /// </summary>
         /// <param name="id">The identifier.</param>
         /// <param name="userSecret">The user secret.</param>

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -564,6 +564,14 @@ namespace SIL.XForge.Scripture.Services
             // Listeners can now assume the ProjectUserConfig is ready when the user is added.
             await base.AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole, removeShareKeys);
 
+            // Update book and chapter permissions on SF project/resource, but only if user
+            // has a role on the PT project or permissions to the DBL resource. These permissions are needed
+            // in order to query the PT roles and DBL permissions of other SF project/resource users.
+            if ((await TryGetProjectRoleAsync(projectDoc.Data, userDoc.Id)).Success)
+            {
+                await UpdatePermissionsAsync(userDoc.Id, projectDoc);
+            }
+
             // Add to the source project, if required
             bool translationSuggestionsEnabled = projectDoc.Data.TranslateConfig.TranslationSuggestionsEnabled;
             string sourceProjectId = projectDoc.Data.TranslateConfig.Source?.ProjectRef;
@@ -590,6 +598,100 @@ namespace SIL.XForge.Scripture.Services
             }
         }
 
+        /// <summary>
+        /// Update all user permissions on books and chapters in an SF project, from PT project permissions. For Paratext
+        /// projects, permissions are acquired from ScrText objects, and so presumably only what was received from
+        /// Paratext in the last synchronize. For Resources, permissions are fetched from a DBL server, and so permissions
+        /// may be ahead of the last sync.
+        /// Note that this method is not necessarily applying permissions for user `curUserId`, but rather using that
+        /// user to perform PT queries and set values in the SF DB.
+        /// </summary>
+        public async Task UpdatePermissionsAsync(string curUserId, IDocument<SFProject> projectDoc)
+        {
+            Attempt<UserSecret> userSecretAttempt = await _userSecrets.TryGetAsync(curUserId);
+            if (!userSecretAttempt.TryResult(out UserSecret userSecret))
+            {
+                throw new DataNotFoundException("No matching user secrets found.");
+            }
+
+            string paratextId = projectDoc.Data.ParatextId;
+            HashSet<int> booksInProject = new HashSet<int>(_paratextService.GetBookList(userSecret, paratextId));
+            IReadOnlyDictionary<string, string> ptUsernameMapping =
+                await _paratextService.GetParatextUsernameMappingAsync(userSecret, paratextId);
+            bool isResource = _paratextService.IsResource(paratextId);
+            // Place to collect all chapter permissions to record in the project.
+            var projectChapterPermissions =
+                new List<(int bookIndex, int chapterIndex, Dictionary<string, string> chapterPermissions)>();
+            // Place to collect all book permissions to record in the project.
+            var projectBookPermissions = new List<(int bookIndex, Dictionary<string, string> bookPermissions)>();
+
+            Dictionary<string, string> resourcePermissions = null;
+            if (isResource)
+            {
+                // Note that DBL specifies permission for a resource with granularity of the whole resource. We will
+                // write in the SF DB that whole-resource permission but on each book and chapter.
+                resourcePermissions =
+                    await _paratextService.GetPermissionsAsync(userSecret, projectDoc.Data, ptUsernameMapping);
+            }
+
+            foreach (int bookNum in booksInProject)
+            {
+                int textIndex = projectDoc.Data.Texts.FindIndex(t => t.BookNum == bookNum);
+                if (textIndex == -1)
+                {
+                    // Project does not contain specified book.
+                    // This is expected if a user is connecting a project for the first time, as the project may not
+                    // have been synchronized yet.
+                    continue;
+                }
+                Models.TextInfo text = projectDoc.Data.Texts[textIndex];
+                List<Chapter> chapters = text.Chapters;
+                Dictionary<string, string> bookPermissions = null;
+                IEnumerable<(int bookIndex, int chapterIndex, Dictionary<string, string> chapterPermissions)>
+                    chapterPermissionsInBook = null;
+
+                if (isResource)
+                {
+                    bookPermissions = resourcePermissions;
+                    // Prepare to write the same resource permission for each chapter in the book/text.
+                    chapterPermissionsInBook = chapters.Select(
+                        (Chapter chapter, int chapterIndex) => (textIndex, chapterIndex, bookPermissions));
+                }
+                else
+                {
+                    bookPermissions = await _paratextService.GetPermissionsAsync(userSecret, projectDoc.Data,
+                        ptUsernameMapping, bookNum);
+
+                    // Get the project permissions for the chapters
+                    chapterPermissionsInBook = await Task.WhenAll(chapters.Select(
+                        async (Chapter chapter, int chapterIndex) =>
+                        {
+                            Dictionary<string, string> chapterPermissions = await _paratextService.GetPermissionsAsync(
+                                userSecret, projectDoc.Data, ptUsernameMapping, bookNum, chapter.Number);
+                            return (textIndex, chapterIndex, chapterPermissions);
+                        }
+                    ));
+                }
+                projectChapterPermissions.AddRange(chapterPermissionsInBook);
+                projectBookPermissions.Add((textIndex, bookPermissions));
+            }
+
+            // Update project metadata
+            await projectDoc.SubmitJson0OpAsync(op =>
+            {
+                foreach ((int bookIndex, Dictionary<string, string> bookPermissions) in projectBookPermissions)
+                {
+                    op.Set(pd => pd.Texts[bookIndex].Permissions, bookPermissions,
+                        ParatextSyncRunner.PermissionDictionaryEqualityComparer);
+                }
+                foreach ((int bookIndex, int chapterIndex, Dictionary<string, string> chapterPermissions)
+                    in projectChapterPermissions)
+                {
+                    op.Set(pd => pd.Texts[bookIndex].Chapters[chapterIndex].Permissions, chapterPermissions);
+                }
+            });
+        }
+
         protected override async Task RemoveUserFromProjectAsync(IConnection conn, IDocument<SFProject> projectDoc,
             IDocument<User> userDoc)
         {
@@ -599,12 +701,17 @@ namespace SIL.XForge.Scripture.Services
             await projectUserConfigDoc.DeleteAsync();
         }
 
+        /// <summary>
+        /// Returns `userId`'s role on project or resource `project`.
+        /// The role may be the PT role from PT Registry, or a SF role.
+        /// The returned Attempt will be Success if they have a non-None role, or otherwise Failure.
+        /// </summary>
         protected async override Task<Attempt<string>> TryGetProjectRoleAsync(SFProject project, string userId)
         {
             Attempt<UserSecret> userSecretAttempt = await _userSecrets.TryGetAsync(userId);
             if (userSecretAttempt.TryResult(out UserSecret userSecret))
             {
-                if (project.ParatextId?.Length == SFInstallableDblResource.ResourceIdentifierLength)
+                if (_paratextService.IsResource(project.ParatextId))
                 {
                     // If the project is a resource, get the permission from the DBL
                     string permission = await _paratextService.GetResourcePermissionAsync(project.ParatextId, userId);
@@ -612,7 +719,8 @@ namespace SIL.XForge.Scripture.Services
                     {
                         TextInfoPermission.None => Attempt.Failure(ProjectRole.None),
                         TextInfoPermission.Read => Attempt.Success(SFProjectRole.Observer),
-                        _ => throw new ArgumentException("Unknown resource permission", nameof(permission)),
+                        _ => throw new ArgumentException($"Unknown resource permission: '{permission}'",
+                            nameof(permission)),
                     };
                 }
                 else

--- a/src/SIL.XForge/Realtime/Json0/Json0OpBuilder.cs
+++ b/src/SIL.XForge/Realtime/Json0/Json0OpBuilder.cs
@@ -6,6 +6,10 @@ using SIL.XForge.Utils;
 
 namespace SIL.XForge.Realtime.Json0
 {
+    /// <summary>
+    /// Helps build up operations to manipulate RealtimeServer data.
+    /// Note: When setting or replacing data, if the request is already true in the `_data` object, then an op may not be created.
+    /// </summary>
     public class Json0OpBuilder<T>
     {
         private readonly T _data;

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.Hosting;
@@ -269,6 +268,38 @@ namespace SIL.XForge.Scripture.Services
             Assert.AreEqual(0, resources.Count(), "An empty set of resources should have been returned");
             env.MockExceptionHandler.Received().ReportException(Arg.Is<Exception>((Exception e) =>
                 e.Message.Contains("inquire about resources and is ignoring error")));
+        }
+
+        [Test]
+        public void IsResource_JunkInput_No()
+        {
+            var env = new TestEnvironment();
+            // SUTs
+            Assert.That(env.Service.IsResource(null), Is.False);
+            Assert.That(env.Service.IsResource(""), Is.False);
+            Assert.That(env.Service.IsResource("junk"), Is.False);
+        }
+
+        [Test]
+        public void IsResource_NonResourceProjectId_No()
+        {
+            var env = new TestEnvironment();
+            const int lengthOfParatextProjectIds = 40;
+            string id = "1234567890abcdef1234567890abcdef12345678";
+            Assert.That(id.Length, Is.EqualTo(lengthOfParatextProjectIds), "setup. Use an ID of Paratext-ID-length.");
+            // SUT
+            Assert.That(env.Service.IsResource(id), Is.False);
+        }
+
+        [Test]
+        public void IsResource_ResourceProjectId_Yes()
+        {
+            var env = new TestEnvironment();
+            const int lengthOfDblResourceId = 16;
+            string id = "1234567890abcdef";
+            Assert.That(id.Length, Is.EqualTo(lengthOfDblResourceId), "setup. Use an ID of DBL-Resource-ID-length.");
+            // SUT
+            Assert.That(env.Service.IsResource(id), Is.True);
         }
 
         [Test]
@@ -708,12 +739,12 @@ namespace SIL.XForge.Scripture.Services
             var associatedPtUser = new SFParatextUser(env.Username01);
             UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01);
 
-            string resourcePTID = "1234567890123456";
-            Assert.That(resourcePTID, Has.Length.EqualTo(SFInstallableDblResource.ResourceIdentifierLength),
+            string resourcePTId = "1234567890123456";
+            Assert.That(resourcePTId, Has.Length.EqualTo(SFInstallableDblResource.ResourceIdentifierLength),
                 "setup. Should be using a project ID that is a resource ID");
 
             // SUT
-            string latestSharedVersion = env.Service.GetLatestSharedVersion(user01Secret, resourcePTID);
+            string latestSharedVersion = env.Service.GetLatestSharedVersion(user01Secret, resourcePTId);
 
             Assert.That(latestSharedVersion, Is.Null,
                 "DBL resources do not have hg repositories to have a last pushed or pulled hg commit id.");

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -29,14 +29,17 @@ namespace SIL.XForge.Scripture.Services
         private const string Project02 = "project02";
         private const string Project03 = "project03";
         private const string Project04 = "project04";
+        private const string Project05 = "project05";
         private const string Resource01 = "resource_project";
         private const string DisabledSource = "disabled_source";
+        private const string Resource01PTId = "resid_is_16_char";
         private const string User01 = "user01";
         private const string User02 = "user02";
         private const string User03 = "user03";
         private const string User04 = "user04";
         private const string LinkExpiredUser = "linkexpireduser";
         private const string SiteId = "xf";
+        private const string PTProjectIdNotYetInSF = "paratext_notYetInSF";
 
         [Test]
         public async Task InviteAsync_ProjectAdminSharingDisabled_UserInvited()
@@ -379,6 +382,398 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
+        public async Task CheckLinkSharingAsync_PTUserHasPTPermissions()
+        {
+            // If a user is invited to a project, and goes to the invitation link, the user being added to the project
+            // should have their PT permissions for text books and chapters.
+
+            var env = new TestEnvironment();
+            string project05PTId = "paratext_" + Project05;
+            SFProject project = env.GetProject(Project05);
+            SFProject resource = env.GetProject(Resource01);
+
+            Assert.That(env.UserSecrets.Contains(User03), Is.True, "setup. PT user should have user secrets.");
+            User user = env.GetUser(User03);
+            Assert.That(user.ParatextId, Is.Not.Null, "setup. PT user should have a PT User ID.");
+
+            string userRoleOnPTProject = SFProjectRole.Translator;
+            Assert.That(userRoleOnPTProject, Is.Not.EqualTo(SFProjectRole.CommunityChecker),
+                "setup. role should be different than community checker for purposes of part of what this test is testing.");
+            string shareKeyCode = "key12345";
+            ShareKey shareKeyForUserInvitation = env.ProjectSecrets.Get(project.Id).ShareKeys.First(
+                (ShareKey shareKey) => shareKey.Key == shareKeyCode);
+            Assert.That(shareKeyForUserInvitation.ProjectRole, Is.EqualTo(SFProjectRole.CommunityChecker),
+                "setup. the user should be being invited as a community checker.");
+            env.ParatextService.TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>())
+                .Returns(Task.FromResult(Attempt.Success(userRoleOnPTProject)));
+            string userDBLPermissionForResource = TextInfoPermission.Read;
+            env.ParatextService.GetResourcePermissionAsync(Arg.Any<string>(), User03)
+                .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
+
+            Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
+            Assert.That(project.Texts.First().Permissions.ContainsKey(User03), Is.False, "setup");
+            Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
+            Assert.That(resource.UserRoles.ContainsKey(User03), Is.False, "setup");
+            Assert.That(project.Texts.First().Permissions.ContainsKey(User03), Is.False, "setup");
+            Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
+
+            var bookList = new List<int>() { 40, 41 };
+            env.ParatextService.GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(bookList);
+
+            // PT will answer with these permissions.
+            var ptBookPermissions = new Dictionary<string, string>()
+            {
+                { User03, TextInfoPermission.Read },
+                { User01, TextInfoPermission.Read },
+            };
+            var ptChapterPermissions = new Dictionary<string, string>()
+            {
+                { User03, TextInfoPermission.Write },
+                { User01, TextInfoPermission.Read },
+            };
+            var ptSourcePermissions = new Dictionary<string, string>()
+            {
+                { User03, userDBLPermissionForResource },
+                { User01, TextInfoPermission.None },
+            };
+            const int bookValueToIndicateWholeResource = 0;
+            const int chapterValueToIndicateWholeBook = 0;
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), chapterValueToIndicateWholeBook)
+                .Returns(Task.FromResult(ptBookPermissions));
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Is<int>((int arg) => arg > 0))
+                .Returns(Task.FromResult(ptChapterPermissions));
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                bookValueToIndicateWholeResource,
+                chapterValueToIndicateWholeBook)
+                .Returns(Task.FromResult(ptSourcePermissions));
+
+            // SUT
+            await env.Service.CheckLinkSharingAsync(User03, Project05, shareKeyCode);
+
+            project = env.GetProject(Project05);
+            Assert.That(project.UserRoles.TryGetValue(User03, out string userRole), Is.True,
+            "user should be added to project");
+            // This user was invited as a community checker (according to the share key). But their project role and
+            // permissions will reflect what is set on the PT project. The user will have a translator role rather than
+            // a community checker role.
+            Assert.That(userRole, Is.EqualTo(userRoleOnPTProject));
+            user = env.GetUser(User03);
+            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project05));
+
+            Assert.That(project.Texts.First().Permissions[User03], Is.EqualTo(TextInfoPermission.Read));
+            Assert.That(project.Texts.First().Chapters.First().Permissions[User03], Is.EqualTo(TextInfoPermission.Write));
+
+            resource = env.GetProject(Resource01);
+            Assert.That(resource.UserRoles.TryGetValue(User03, out string resourceUserRole), Is.True,
+                "user should have been added to resource");
+            Assert.That(resourceUserRole, Is.EqualTo(SFProjectRole.Observer),
+                "user role not set correctly on resource");
+            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Resource01), "user not added to resource correctly");
+            Assert.That(resource.Texts.First().Permissions[User03], Is.EqualTo(userDBLPermissionForResource));
+            Assert.That(resource.Texts.First().Chapters.First().Permissions[User03],
+                Is.EqualTo(userDBLPermissionForResource));
+        }
+
+        [Test]
+        public async Task CheckLinkSharingAsync_NonPTUser()
+        {
+            var env = new TestEnvironment();
+            SFProject project = env.GetProject(Project05);
+
+            Assert.That(env.UserSecrets.Contains(User04), Is.False,
+                "setup. Non-PT user is not expected to have user secrets.");
+            User user = env.GetUser(User04);
+            Assert.That(user.ParatextId, Is.Null, "setup. Non-PT user should not have a PT User ID.");
+
+            Assert.That(project.UserRoles.ContainsKey(User04), Is.False, "setup");
+            Assert.That(project.Texts.First().Permissions.ContainsKey(User04), Is.False, "setup");
+            Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User04), Is.False, "setup");
+
+            // SUT
+            await env.Service.CheckLinkSharingAsync(User04, Project05, "key12345");
+
+            project = env.GetProject(Project05);
+            Assert.That(project.UserRoles.TryGetValue(User04, out string userRole), Is.True,
+                "user was added to project");
+            Assert.That(userRole, Is.EqualTo(SFProjectRole.CommunityChecker));
+            user = env.GetUser(User04);
+            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project05));
+
+            Assert.That(project.Texts.First().Permissions.ContainsKey(User04), Is.False,
+                "no permissions should have been specified for user");
+            Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User04), Is.False,
+                "no permissions should have been specified for user");
+
+            // The get permission methods shouldn't have even been called.
+            env.ParatextService.DidNotReceiveWithAnyArgs().GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Any<SFProject>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                Arg.Any<int>());
+            env.ParatextService.DidNotReceiveWithAnyArgs().GetResourcePermissionAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>());
+        }
+
+        [Test]
+        public async Task CheckLinkSharingAsync_PTUserButNotOfThisProjectAndCannotReadResource()
+        {
+            // The user joining the project _is_ a PT user, but they do not have a PT role on this particular project.
+            // Further, they do not have permission to read the DBL resource.
+
+            var env = new TestEnvironment();
+            string project05PTId = "paratext_" + Project05;
+            SFProject project = env.GetProject(Project05);
+            SFProject resource = env.GetProject(Resource01);
+
+            Assert.That(env.UserSecrets.Contains(User03), Is.True,
+                "setup. This is a PT user and is expected to have user secrets.");
+            User user = env.GetUser(User03);
+            Assert.That(user.ParatextId, Is.Not.Null, "setup. PT user should have a PT User ID.");
+
+            Assert.That(project.UserRoles.ContainsKey(User03), Is.False,
+                "setup. User should not already be on the project.");
+            Assert.That(project.Texts.First().Permissions.ContainsKey(User03), Is.False,
+                "setup. User should not already have permissions on the project.");
+            Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
+            Assert.That(resource.UserRoles.ContainsKey(User03), Is.False,
+                "setup. User should not already be on the project.");
+            Assert.That(resource.Texts.First().Permissions.ContainsKey(User03), Is.False,
+                "setup. User should not have permissions.");
+            Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
+
+            // If the user is not a member of the paratext project, then
+            // "GET https://registry-dev.paratext.org/api8/projects/PT_PROJECT_ID/members" will return a 404 Not Found,
+            // and in ParatextService.CallApiAsync() there originates a System.Net.Http.HttpRequestException or perhaps
+            // EdjCase.JsonRpc.Common.RpcException. Our test should not end up doing down a path that causes this
+            // exception.
+            env.ParatextService.GetParatextUsernameMappingAsync(
+                Arg.Is<UserSecret>((UserSecret userSecret) => userSecret.Id == User03),
+                Arg.Is<string>((string paratextId) => paratextId == project05PTId))
+                .Returns(async x => throw new System.Net.Http.HttpRequestException());
+
+            string userRoleOnPTProject = (string)null;
+            env.ParatextService.TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>())
+                .Returns(Task.FromResult(Attempt.Failure(userRoleOnPTProject)));
+            string userDBLPermissionForResource = TextInfoPermission.None;
+            env.ParatextService.GetResourcePermissionAsync(Arg.Any<string>(), User03)
+                .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
+
+            env.ParatextService.GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>())
+                .Returns(x => throw new Exception("Probably can not do this."));
+
+            // PT could answer with these permissions.
+            var ptBookPermissions = new Dictionary<string, string>()
+            {
+                { User02, TextInfoPermission.Read },
+                { User01, TextInfoPermission.Read },
+            };
+            var ptChapterPermissions = new Dictionary<string, string>()
+            {
+                { User02, TextInfoPermission.Write },
+                { User01, TextInfoPermission.Read },
+            };
+            var ptSourcePermissions = new Dictionary<string, string>()
+            {
+                { User02, TextInfoPermission.Read },
+                { User01, TextInfoPermission.Read },
+            };
+            const int bookValueToIndicateWholeResource = 0;
+            const int chapterValueToIndicateWholeBook = 0;
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), chapterValueToIndicateWholeBook)
+                .Returns(Task.FromResult(ptBookPermissions));
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Is<int>((int arg) => arg > 0))
+                .Returns(Task.FromResult(ptChapterPermissions));
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                bookValueToIndicateWholeResource,
+                chapterValueToIndicateWholeBook)
+                .Returns(Task.FromResult(ptSourcePermissions));
+
+            // SUT
+            await env.Service.CheckLinkSharingAsync(User03, Project05, "key12345");
+
+            project = env.GetProject(Project05);
+            Assert.That(project.UserRoles.TryGetValue(User03, out string userRole), Is.True,
+                "user should have been added to project");
+            Assert.That(userRole, Is.EqualTo(SFProjectRole.CommunityChecker));
+            user = env.GetUser(User03);
+            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project05),
+                "user not added to project correctly");
+
+            Assert.That(project.Texts.First().Permissions.ContainsKey(User03), Is.False,
+                "no project permissions should have been specified for user");
+            Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False,
+                "no project permissions should have been specified for user");
+
+            // User03 is not added to the target or source, nor do they have any permissions listed in the source.
+            resource = env.GetProject(Resource01);
+            Assert.That(resource.UserRoles.ContainsKey(User03), Is.False,
+                "user should not have been added to resource project");
+            Assert.That(resource.Texts.First().Permissions.ContainsKey(User03), Is.False,
+                "user should not have permissions to resource");
+            Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False,
+                "user should not have permissions to resource");
+            Assert.That(user.Sites[SiteId].Projects, Does.Not.Contain(Resource01), "user should not have been added to");
+
+            // With the current implementation, both ParatextService.GetPermissionsAsync(for the source resource) and
+            // ParatextService.GetPermissionsAsync(for the target project) should be called never. In a future change to
+            // the SUT, it's okay if it is called, as long as the permissions don't get applied. But for now, not
+            // getting called is a helpful indication of expected operation.
+            // The mocks above regarding env.ParatextService.GetPermissionsAsync(for the target project) are left in
+            // place in case they begin to be used.
+            env.ParatextService.DidNotReceive().GetPermissionsAsync(
+                Arg.Any<UserSecret>(), Arg.Is<SFProject>((SFProject sfProject) => sfProject.Id == Project05),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Any<int>());
+            env.ParatextService.DidNotReceive().GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject sfProject) => sfProject.Id == Resource01),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Any<int>());
+
+            // We may not be able to query a book list for the target project without the user having a PT project role,
+            // or of the DBL resource, without the user having read permission.
+            env.ParatextService.DidNotReceive().GetBookList(Arg.Any<UserSecret>(), project05PTId);
+            env.ParatextService.DidNotReceive().GetBookList(Arg.Any<UserSecret>(), Resource01PTId);
+        }
+
+        [Test]
+        public async Task CheckLinkSharingAsync_PTUserButNotOfThisProjectYetReadsResource()
+        {
+            // The user joining the project _is_ a PT user, but they do not have a PT role on this particular project.
+            // Though they do have permission to read the DBL resource.
+
+            var env = new TestEnvironment();
+            string project05PTId = "paratext_" + Project05;
+            SFProject project = env.GetProject(Project05);
+            SFProject resource = env.GetProject(Resource01);
+
+            Assert.That(env.UserSecrets.Contains(User03), Is.True,
+                "setup. This is a PT user and is expected to have user secrets.");
+            User user = env.GetUser(User03);
+            Assert.That(user.ParatextId, Is.Not.Null,
+                "setup. PT user should have a PT User ID.");
+
+            Assert.That(project.UserRoles.ContainsKey(User03), Is.False,
+                "setup. User should not already be on the project.");
+            Assert.That(project.Texts.First().Permissions.ContainsKey(User03), Is.False,
+                "setup. User should not already have permissions on the project.");
+            Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
+            Assert.That(resource.UserRoles.ContainsKey(User03), Is.False,
+                "setup. User should not already be on the project, for purposes of testing that they are later.");
+            Assert.That(resource.Texts.First().Permissions.ContainsKey(User03), Is.False,
+                "setup. User should not already have permissions.");
+            Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
+
+            env.ParatextService.GetParatextUsernameMappingAsync(
+                Arg.Is<UserSecret>((UserSecret userSecret) => userSecret.Id == User03),
+                Arg.Is<string>((string paratextId) => paratextId == project05PTId))
+                .Returns(async x => throw new System.Net.Http.HttpRequestException());
+
+            string userRoleOnPTProject = (string)null;
+            env.ParatextService.TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>())
+                .Returns(Task.FromResult(Attempt.Failure(userRoleOnPTProject)));
+            string userDBLPermissionForResource = TextInfoPermission.Read;
+            env.ParatextService.GetResourcePermissionAsync(Arg.Any<string>(), User03)
+                .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
+
+            var bookList = new List<int>() { 40, 41 };
+            env.ParatextService.GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(bookList);
+
+            // PT could answer with these permissions.
+            var ptBookPermissions = new Dictionary<string, string>()
+            {
+                { User02, TextInfoPermission.Read },
+                { User01, TextInfoPermission.Read },
+            };
+            var ptChapterPermissions = new Dictionary<string, string>()
+            {
+                { User02, TextInfoPermission.Write },
+                { User01, TextInfoPermission.Read },
+            };
+            var ptSourcePermissions = new Dictionary<string, string>()
+            {
+                { User03, userDBLPermissionForResource },
+                { User02, TextInfoPermission.Read },
+                { User01, TextInfoPermission.Read },
+            };
+            const int bookValueToIndicateWholeResource = 0;
+            const int chapterValueToIndicateWholeBook = 0;
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), chapterValueToIndicateWholeBook)
+                .Returns(Task.FromResult(ptBookPermissions));
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Is<int>((int arg) => arg > 0))
+                .Returns(Task.FromResult(ptChapterPermissions));
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                bookValueToIndicateWholeResource,
+                chapterValueToIndicateWholeBook)
+                .Returns(Task.FromResult(ptSourcePermissions));
+
+            // SUT
+            await env.Service.CheckLinkSharingAsync(User03, Project05, "key12345");
+
+            project = env.GetProject(Project05);
+            Assert.That(project.UserRoles.TryGetValue(User03, out string userRole), Is.True,
+                "user should have been added to project");
+            Assert.That(userRole, Is.EqualTo(SFProjectRole.CommunityChecker));
+            user = env.GetUser(User03);
+            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project05), "user not added to project correctly");
+
+            Assert.That(project.Texts.First().Permissions.ContainsKey(User03), Is.False,
+                "no project permissions should have been specified for user");
+            Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False,
+                "no project permissions should have been specified for user");
+
+            // User03 is not on project project05PTId, but they have access to the source resource. So
+            // UpdatePermissionsAsync() should be inquiring about this and setting permissions as appropriate.
+            env.ParatextService.Received().GetResourcePermissionAsync(Resource01PTId, User03);
+            resource = env.GetProject(Resource01);
+            Assert.That(resource.Texts.First().Permissions[User03], Is.EqualTo(userDBLPermissionForResource),
+                "resource permissions should have been set for joining project user");
+            Assert.That(resource.Texts.First().Chapters.First().Permissions[User03],
+                Is.EqualTo(userDBLPermissionForResource),
+                "resource permissions should have been set for joining project user");
+            Assert.That(resource.UserRoles.TryGetValue(User03, out string resourceUserRole), Is.True,
+                "user should have been added to resource");
+            Assert.That(resourceUserRole, Is.EqualTo(SFProjectRole.Observer),
+                "user role not set correctly on resource");
+            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Resource01),
+                "user not added to resource correctly");
+
+            // With the current implementation, ParatextService.GetPermissionsAsync(for the source resource) should be
+            // called once, but ParatextService.GetPermissionsAsync(for the target project) should be called never. In
+            // a future change to the SUT, it's okay if it is called for the target project, as long as the permissions
+            // don't get applied. But for now, not getting called is a helpful indication of expected operation.
+            // The mocks above regarding env.ParatextService.GetPermissionsAsync(for the target project) are left in
+            // place in case they begin to be used.
+            env.ParatextService.DidNotReceive().GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject sfProject) => sfProject.Id == Project05),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Any<int>());
+            env.ParatextService.Received(1).GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject sfProject) => sfProject.Id == Resource01),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Any<int>());
+
+            // We may not be able to query a book list for the target project without the user having a PT project role.
+            env.ParatextService.DidNotReceive().GetBookList(Arg.Any<UserSecret>(), project05PTId);
+            env.ParatextService.Received(1).GetBookList(Arg.Any<UserSecret>(), Resource01PTId);
+        }
+
+        [Test]
         public async Task IsAlreadyInvitedAsync_BadInput_False()
         {
             var env = new TestEnvironment();
@@ -573,6 +968,344 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
+        public async Task AddUserAsync_PTUserHasPTPermissions()
+        {
+            // If a user connects to an existing project from the Connect Project page, project text permissions should
+            // be updated, so that the connecting user has permissions set that are from PT.
+
+            var env = new TestEnvironment();
+            string project05PTId = "paratext_" + Project05;
+            SFProject project = env.GetProject(Project05);
+            SFProject resource = env.GetProject(Resource01);
+
+            Assert.That(env.UserSecrets.Contains(User03), Is.True, "setup. PT user should have user secrets.");
+            User user = env.GetUser(User03);
+            Assert.That(user.ParatextId, Is.Not.Null, "setup. PT user should have a PT User ID.");
+
+            Assert.That(project.UserRoles.ContainsKey(User03), Is.False,
+                "setup. User should not already be on the project.");
+            Assert.That(project.Texts.First().Permissions.ContainsKey(User03), Is.False,
+                "setup. User should not already have permissions on the project.");
+            Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
+            Assert.That(resource.UserRoles.ContainsKey(User03), Is.False,
+                "setup. User should not already be on the project, for purposes of testing that they are later.");
+            Assert.That(resource.Texts.First().Permissions.ContainsKey(User03), Is.False,
+                "setup. User should not already have permissions.");
+            Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
+
+            string userRoleOnPTProject = SFProjectRole.Translator;
+            env.ParatextService.TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>())
+                .Returns(Task.FromResult(Attempt.Success(userRoleOnPTProject)));
+            string userDBLPermissionForResource = TextInfoPermission.Read;
+            env.ParatextService.GetResourcePermissionAsync(Arg.Any<string>(), User03)
+                .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
+
+            var bookList = new List<int>() { 40, 41 };
+            env.ParatextService.GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(bookList);
+
+            // PT will answer with these permissions.
+            var ptBookPermissions = new Dictionary<string, string>()
+            {
+                { User03, TextInfoPermission.Read },
+                { User01, TextInfoPermission.Read },
+            };
+            var ptChapterPermissions = new Dictionary<string, string>()
+            {
+                { User03, TextInfoPermission.Write },
+                { User01, TextInfoPermission.Read },
+            };
+            var ptSourcePermissions = new Dictionary<string, string>()
+            {
+                { User03, TextInfoPermission.Read },
+                { User01, TextInfoPermission.None },
+            };
+            const int bookValueToIndicateWholeResource = 0;
+            const int chapterValueToIndicateWholeBook = 0;
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), chapterValueToIndicateWholeBook)
+                .Returns(Task.FromResult(ptBookPermissions));
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Is<int>((int arg) => arg > 0))
+                .Returns(Task.FromResult(ptChapterPermissions));
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                bookValueToIndicateWholeResource,
+                chapterValueToIndicateWholeBook)
+                .Returns(Task.FromResult(ptSourcePermissions));
+
+            string projectRoleSpecifiedFromConnectProjectPage = null;
+
+            // SUT
+            await env.Service.AddUserAsync(User03, Project05, projectRoleSpecifiedFromConnectProjectPage);
+
+            project = env.GetProject(Project05);
+            Assert.That(project.UserRoles.TryGetValue(User03, out string userRole), Is.True, "user should be added to project");
+            Assert.That(userRole, Is.EqualTo(userRoleOnPTProject));
+            user = env.GetUser(User03);
+            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project05));
+
+            Assert.That(project.Texts.First().Permissions[User03], Is.EqualTo(TextInfoPermission.Read));
+            Assert.That(project.Texts.First().Chapters.First().Permissions[User03], Is.EqualTo(TextInfoPermission.Write));
+
+            resource = env.GetProject(Resource01);
+            Assert.That(resource.Texts.First().Permissions[User03], Is.EqualTo(userDBLPermissionForResource));
+            Assert.That(resource.Texts.First().Chapters.First().Permissions[User03], Is.EqualTo(userDBLPermissionForResource));
+            Assert.That(resource.UserRoles.TryGetValue(User03, out string resourceUserRole), Is.True, "user should have been added to resource");
+            Assert.That(resourceUserRole, Is.EqualTo(SFProjectRole.Observer), "user role not set correctly on resource");
+            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Resource01), "user not added to resource correctly");
+        }
+
+        [Test]
+        public async Task UpdatePermissionsAsync_SkipsBookNotInDB()
+        {
+            // If a user connects a new project, and we seek to set permissions for the user before actually
+            // synchronizing the Scripture text, then we are missing texts on which to set permissions when running
+            // UpdatePermissionsAsync(). So silently ignore missing books.
+            // It also is conceivable that a race could occur where (1) a book is added in Paratext and SendReceived
+            // to the Paratext servers, (2) a SF user clicks Synchronize in SF, (3) SF RunAsync() gets as far as
+            // running ParatextService.SendReceiveAsync(), but doesn't yet add the new book from PT into the SF DB.
+            // (4) Another SF user joins the SF project, causing UpdatePermissionsAsync() to be called.
+            // (5) UpdatePermissionsAsync() queries for ParatextService.GetBookList(), and then tries to find the
+            // books (including the new book) in the SF project. (6) It doesn't find the new book in SF.
+            // Silently ignoring this situation will prevent a crash from 6. And whether the new user will have
+            // permissions for the new book and its chapters will depend on how smart ParatextSyncRunner's project doc
+            // is.
+
+            string project01PTId = "paratext_" + Project01;
+            var env = new TestEnvironment();
+            SFProject sfProject = env.GetProject(Project01);
+            // The SF DB should only have 2 books
+            Assert.That(sfProject.Texts.Count, Is.LessThan(3), "setup");
+
+            // But PT reports that there are 3 books.
+            env.ParatextService.GetBookList(Arg.Any<UserSecret>(), project01PTId).Returns(new List<int>() { 40, 41, 42 });
+
+            var ptBookPermissions = new Dictionary<string, string>()
+            {
+                { User01, TextInfoPermission.Read },
+                { User02, TextInfoPermission.Write },
+            };
+            var ptChapterPermissions = new Dictionary<string, string>()
+            {
+                { User01, TextInfoPermission.Write },
+                { User02, TextInfoPermission.Read },
+            };
+            const int chapterValueToIndicateWholeBook = 0;
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), chapterValueToIndicateWholeBook)
+                .Returns(Task.FromResult(ptBookPermissions));
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Is<int>((int arg) => arg > 0))
+                .Returns(Task.FromResult(ptChapterPermissions));
+
+            sfProject = env.GetProject(Project01);
+            Assert.That(sfProject.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
+            Assert.That(sfProject.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
+
+            IConnection conn = await env.RealtimeService.ConnectAsync(User01);
+            IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
+
+            // SUT
+            await env.Service.UpdatePermissionsAsync(User01, project01Doc);
+
+            // Permissions were set for the books and chapters that we were able to handle.
+            sfProject = env.GetProject(Project01);
+            Assert.That(sfProject.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
+            Assert.That(sfProject.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Write));
+            Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Write));
+            Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Read));
+
+            // SF should still only have the 2 books.
+            Assert.That(sfProject.Texts.Count, Is.LessThan(3), "surprise");
+        }
+
+        [Test]
+        public async Task UpdatePermissionsAsync_ThrowsIfUserHasNoSecrets()
+        {
+            string project01PTId = "paratext_" + Project01;
+            var env = new TestEnvironment();
+            SFProject sfProject = env.GetProject(Project01);
+            env.ParatextService.GetBookList(Arg.Any<UserSecret>(), project01PTId).Returns(new List<int>() { 40, 41 });
+            Assert.That(env.ProjectSecrets.Contains(User04), Is.False, "setup");
+
+            IConnection conn = await env.RealtimeService.ConnectAsync(User04);
+            IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
+
+            // SUT
+            Assert.ThrowsAsync<DataNotFoundException>(() => env.Service.UpdatePermissionsAsync(User04, project01Doc));
+        }
+
+        [Test]
+        public async Task UpdatePermissionsAsync_SetsBookAndChapterPermissions()
+        {
+            var env = new TestEnvironment();
+            string project01PTId = "paratext_" + Project01;
+
+            SFProject sfProject = env.GetProject(Project01);
+
+            env.ParatextService.GetBookList(Arg.Any<UserSecret>(), project01PTId).Returns(new List<int>() { 40, 41 });
+
+            var ptBookPermissions = new Dictionary<string, string>()
+            {
+                { User01, TextInfoPermission.Read },
+                { User02, TextInfoPermission.Write },
+            };
+            var ptChapterPermissions = new Dictionary<string, string>()
+            {
+                { User01, TextInfoPermission.Write },
+                { User02, TextInfoPermission.Read },
+            };
+            const int chapterValueToIndicateWholeBook = 0;
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), chapterValueToIndicateWholeBook)
+                .Returns(Task.FromResult(ptBookPermissions));
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Is<int>((int arg) => arg > 0))
+                .Returns(Task.FromResult(ptChapterPermissions));
+
+            sfProject = env.GetProject(Project01);
+            Assert.That(sfProject.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
+            Assert.That(sfProject.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
+
+            IConnection conn = await env.RealtimeService.ConnectAsync(User01);
+            IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
+
+            // SUT
+            await env.Service.UpdatePermissionsAsync(User01, project01Doc);
+
+            sfProject = env.GetProject(Project01);
+            Assert.That(sfProject.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
+            Assert.That(sfProject.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Write));
+            Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Write));
+            Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Read));
+        }
+
+
+        [Test]
+        public async Task UpdatePermissionsAsync_UserHasNoChapterPermission()
+        {
+            var env = new TestEnvironment();
+            string project01PTId = "paratext_" + Project01;
+
+            SFProject sfProject = env.GetProject(Project01);
+
+            env.ParatextService.GetBookList(Arg.Any<UserSecret>(), project01PTId).Returns(new List<int>() { 40, 41 });
+
+            var ptBookPermissions = new Dictionary<string, string>()
+            {
+                { User01, TextInfoPermission.Read },
+                { User02, TextInfoPermission.None },
+            };
+            var ptChapterPermissions = new Dictionary<string, string>()
+            {
+                { User01, TextInfoPermission.Read },
+                { User02, TextInfoPermission.None },
+            };
+            const int chapterValueToIndicateWholeBook = 0;
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), chapterValueToIndicateWholeBook)
+                .Returns(Task.FromResult(ptBookPermissions));
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Is<int>((int arg) => arg > 0))
+                .Returns(Task.FromResult(ptChapterPermissions));
+
+            sfProject = env.GetProject(Project01);
+            Assert.That(sfProject.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
+            Assert.That(sfProject.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
+
+            IConnection conn = await env.RealtimeService.ConnectAsync(User01);
+            IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
+
+            // SUT
+            await env.Service.UpdatePermissionsAsync(User01, project01Doc);
+
+            sfProject = env.GetProject(Project01);
+            Assert.That(sfProject.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
+            Assert.That(sfProject.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.None));
+            Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
+            Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User02], Is.EqualTo(TextInfoPermission.None));
+        }
+
+        [Test]
+        public async Task UpdatePermissionsAsync_SetsResourcePermissions()
+        {
+            var env = new TestEnvironment();
+            string project01PTId = "paratext_" + Project01;
+
+            SFProject sfProject = env.GetProject(Project01);
+
+            var bookList = new List<int>() { 40, 41 };
+            env.ParatextService.GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(bookList);
+
+            var ptBookPermissions = new Dictionary<string, string>()
+            {
+                { User01, TextInfoPermission.Write },
+                { User02, TextInfoPermission.Write },
+            };
+            var ptChapterPermissions = new Dictionary<string, string>()
+            {
+                { User01, TextInfoPermission.Write },
+                { User02, TextInfoPermission.Write },
+            };
+            var ptSourcePermissions = new Dictionary<string, string>()
+            {
+                { User01, TextInfoPermission.Read },
+                { User02, TextInfoPermission.None },
+            };
+            const int bookValueToIndicateWholeResource = 0;
+            const int chapterValueToIndicateWholeBook = 0;
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), chapterValueToIndicateWholeBook)
+                .Returns(Task.FromResult(ptBookPermissions));
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Is<int>((int arg) => arg > 0))
+                .Returns(Task.FromResult(ptChapterPermissions));
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), bookValueToIndicateWholeResource, chapterValueToIndicateWholeBook)
+                .Returns(Task.FromResult(ptSourcePermissions));
+
+            sfProject = env.GetProject(Project01);
+            Assert.That(sfProject.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
+            Assert.That(sfProject.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
+
+            SFProject resource = env.GetProject(Resource01);
+            Assert.That(resource.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
+            Assert.That(resource.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
+
+            IConnection conn = await env.RealtimeService.ConnectAsync(User01);
+            IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
+            IDocument<SFProject> resource01Doc = await conn.FetchAsync<SFProject>(Resource01);
+
+            // SUT 1 - Setting target project permissions continues to work as expected.
+            await env.Service.UpdatePermissionsAsync(User01, project01Doc);
+            // SUT 2 - Resource permissions are set.
+            await env.Service.UpdatePermissionsAsync(User01, resource01Doc);
+
+            sfProject = env.GetProject(Project01);
+            resource = env.GetProject(Resource01);
+            Assert.That(sfProject.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Write));
+            Assert.That(sfProject.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Write));
+            Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Write));
+            Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Write));
+            Assert.That(resource.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
+            Assert.That(resource.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.None));
+            Assert.That(resource.Texts.First().Chapters.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
+            Assert.That(resource.Texts.First().Chapters.First().Permissions[User02], Is.EqualTo(TextInfoPermission.None));
+        }
+
+        [Test]
         public void IsSourceProject_TrueWhenProjectIsATranslationSource()
         {
             var env = new TestEnvironment();
@@ -754,6 +1487,109 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
+        public async Task CreateProjectAsync_RequestingPTUserHasPTPermissions()
+        {
+            // If a user connects a project that was not yet in SF via the Connect Project page, project text
+            // permissions should be set so that the connecting user has permissions set that are from PT.
+
+            var env = new TestEnvironment();
+            string targetProjectPTId = PTProjectIdNotYetInSF;
+            string sourceProjectPTId = Resource01PTId;
+            SFProject resource = env.GetProject(Resource01);
+
+            Assert.That(env.UserSecrets.Contains(User03), Is.True, "setup. PT user should have user secrets.");
+            User user = env.GetUser(User03);
+            Assert.That(user.ParatextId, Is.Not.Null, "setup. PT user should have a PT User ID.");
+            Assert.That(env.ContainsProject(targetProjectPTId), Is.False, "setup. No such SF should exist yet.");
+
+            Assert.That(resource.UserRoles.ContainsKey(User03), Is.False,
+                "setup. User should not already be on the project, for purposes of testing that they are later.");
+            Assert.That(resource.Texts.First().Permissions.ContainsKey(User03), Is.False, "setup");
+            Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
+
+            string userRoleOnPTProject = SFProjectRole.Administrator;
+            env.ParatextService.TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>())
+                .Returns(Task.FromResult(Attempt.Success(userRoleOnPTProject)));
+            string userDBLPermissionForResource = TextInfoPermission.Read;
+            env.ParatextService.GetResourcePermissionAsync(Arg.Any<string>(), User03)
+                .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
+
+            var bookList = new List<int>() { 40, 41 };
+            env.ParatextService.GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(bookList);
+
+            // PT will answer with these permissions.
+            // Note that in the case of checking permissions for the target project, SF won't actually get to the
+            // point where it queries for the PT permissions. But leaving these settings here in case
+            // UpdatePermissionsAsync() is later modified and it starts doing that.
+            var ptBookPermissions = new Dictionary<string, string>()
+            {
+                { User03, TextInfoPermission.Read },
+                { User01, TextInfoPermission.Read },
+            };
+            var ptChapterPermissions = new Dictionary<string, string>()
+            {
+                { User03, TextInfoPermission.Write },
+                { User01, TextInfoPermission.Read },
+            };
+            var ptSourcePermissions = new Dictionary<string, string>()
+            {
+                { User03, userDBLPermissionForResource },
+                { User01, TextInfoPermission.None },
+            };
+            const int bookValueToIndicateWholeResource = 0;
+            const int chapterValueToIndicateWholeBook = 0;
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == targetProjectPTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), chapterValueToIndicateWholeBook)
+                .Returns(Task.FromResult(ptBookPermissions));
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == targetProjectPTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Is<int>((int arg) => arg > 0))
+                .Returns(Task.FromResult(ptChapterPermissions));
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == sourceProjectPTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), bookValueToIndicateWholeResource, chapterValueToIndicateWholeBook)
+                .Returns(Task.FromResult(ptSourcePermissions));
+
+            resource = env.GetProject(Resource01);
+            Assert.That(resource.Texts.First().Permissions.Count, Is.EqualTo(0),
+                "setup. User should not have permissions on resource yet.");
+            Assert.That(resource.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
+
+            // SUT
+            string sfProjectId = await env.Service.CreateProjectAsync(User03, new SFProjectCreateSettings()
+            {
+                ParatextId = targetProjectPTId,
+                SourceParatextId = sourceProjectPTId,
+                TranslationSuggestionsEnabled = true,
+            });
+
+            SFProject project = env.GetProject(sfProjectId);
+            Assert.That(project.UserRoles.TryGetValue(User03, out string userRole), Is.True,
+                "user should be added to project");
+            Assert.That(userRole, Is.EqualTo(userRoleOnPTProject));
+            user = env.GetUser(User03);
+            Assert.That(user.Sites[SiteId].Projects, Contains.Item(sfProjectId), "user not added to project correctly");
+
+            // Initially connecting a project should have called Sync, or SF is not going to fetch books and set
+            // permissions on them.
+            env.SyncService.Received().SyncAsync(User03, sfProjectId, Arg.Any<bool>());
+
+            // Don't check that permissions were added to the target project, because we mock the Sync functionality.
+            // But we can show that source resource permissions were set:
+
+            resource = env.GetProject(Resource01);
+            Assert.That(resource.Texts.First().Permissions[User03], Is.EqualTo(userDBLPermissionForResource));
+            Assert.That(resource.Texts.First().Chapters.First().Permissions[User03],
+                Is.EqualTo(userDBLPermissionForResource));
+            Assert.That(resource.UserRoles.TryGetValue(User03, out string resourceUserRole), Is.True,
+                "user should have been added to resource");
+            Assert.That(resourceUserRole, Is.EqualTo(SFProjectRole.Observer),
+                "user role not set correctly on resource");
+            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Resource01), "user not added to resource correctly");
+        }
+
+        [Test]
         public async Task CreateResourceProjectAsync_NotExisting_Created()
         {
             var env = new TestEnvironment();
@@ -822,6 +1658,7 @@ namespace SIL.XForge.Scripture.Services
                     {
                         Id = User01,
                         Email = "user01@example.com",
+                        ParatextId="pt-user01",
                         Sites = new Dictionary<string, Site>
                         {
                             { SiteId, new Site { Projects = { Project01, Project03, DisabledSource } } }
@@ -831,6 +1668,7 @@ namespace SIL.XForge.Scripture.Services
                     {
                         Id = User02,
                         Email = "user02@example.com",
+                        ParatextId="pt-user02",
                         Sites = new Dictionary<string, Site>
                         {
                             { SiteId, new Site { Projects = { Project01, Project02, Project03 } } }
@@ -840,6 +1678,7 @@ namespace SIL.XForge.Scripture.Services
                     {
                         Id = User03,
                         Email = "user03@example.com",
+                        ParatextId="pt-user03",
                         Sites = new Dictionary<string, Site> { { SiteId, new Site() } }
                     },
                     new User
@@ -871,7 +1710,7 @@ namespace SIL.XForge.Scripture.Services
                                 Source = new TranslateSource
                                 {
                                     ProjectRef = Resource01,
-                                    ParatextId = "resid_is_16_char",
+                                    ParatextId = Resource01PTId,
                                     Name = "resource project",
                                     ShortName = "RES",
                                     WritingSystem = new WritingSystem
@@ -915,6 +1754,7 @@ namespace SIL.XForge.Scripture.Services
                             Id = Project02,
                             Name = "project02",
                             ShortName = "P02",
+                            ParatextId = "paratext_" + Project02,
                             CheckingConfig = new CheckingConfig
                             {
                                 ShareEnabled = true,
@@ -930,6 +1770,7 @@ namespace SIL.XForge.Scripture.Services
                             Id = Project03,
                             Name = "project03",
                             ShortName = "P03",
+                            ParatextId = "paratext_" + Project03,
                             CheckingConfig = new CheckingConfig
                             {
                                 ShareEnabled = true,
@@ -953,6 +1794,7 @@ namespace SIL.XForge.Scripture.Services
                         {
                             Id = Project04,
                             Name = "project04",
+                            ParatextId = "paratext_" + Project04,
                             TranslateConfig = new TranslateConfig
                             {
                                 TranslationSuggestionsEnabled = true,
@@ -965,10 +1807,81 @@ namespace SIL.XForge.Scripture.Services
                         },
                         new SFProject
                         {
+                            Id = Project05,
+                            ParatextId = "paratext_" + Project05,
+                            Name = "Project05",
+                            ShortName = "P05",
+                            TranslateConfig = new TranslateConfig
+                            {
+                                TranslationSuggestionsEnabled = true,
+                                Source = new TranslateSource
+                                {
+                                    ProjectRef = Resource01,
+                                    ParatextId = Resource01PTId,
+                                    Name = "resource project",
+                                    ShortName = "RES",
+                                    WritingSystem = new WritingSystem
+                                    {
+                                        Tag = "qaa"
+                                    }
+                                }
+                            },
+                            CheckingConfig = new CheckingConfig
+                            {
+                                ShareEnabled = false
+                            },
+                            UserRoles = new Dictionary<string, string>
+                            {
+                                { User01, SFProjectRole.Administrator },
+                                { User02, SFProjectRole.CommunityChecker }
+                            },
+                            Texts =
+                            {
+                                new TextInfo
+                                {
+                                    BookNum = 40,
+                                    Chapters =
+                                    {
+                                        new Chapter { Number = 1, LastVerse = 3, IsValid = true, Permissions = { } }
+                                    }
+                                },
+                                new TextInfo
+                                {
+                                    BookNum = 41,
+                                    Chapters =
+                                    {
+                                        new Chapter { Number = 1, LastVerse = 3, IsValid = true, Permissions = { } },
+                                        new Chapter { Number = 2, LastVerse = 3, IsValid = true, Permissions = { } }
+                                    }
+                                }
+                            }
+                        },
+                        new SFProject
+                        {
                             Id = Resource01,
-                            ParatextId = "resid_is_16_char",
+                            ParatextId = Resource01PTId,
                             Name = "resource project",
                             ShortName = "RES",
+                            Texts =
+                            {
+                                new TextInfo
+                                {
+                                    BookNum = 40,
+                                    Chapters =
+                                    {
+                                        new Chapter { Number = 1, LastVerse = 3, IsValid = true, Permissions = { } }
+                                    }
+                                },
+                                new TextInfo
+                                {
+                                    BookNum = 41,
+                                    Chapters =
+                                    {
+                                        new Chapter { Number = 1, LastVerse = 3, IsValid = true, Permissions = { } },
+                                        new Chapter { Number = 2, LastVerse = 3, IsValid = true, Permissions = { } }
+                                    }
+                                }
+                            }
                         },
                         new SFProject
                         {
@@ -1002,7 +1915,12 @@ namespace SIL.XForge.Scripture.Services
                 var currentTime = DateTime.Now;
                 ProjectSecrets = new MemoryRepository<SFProjectSecret>(new[]
                 {
-                    new SFProjectSecret { Id = Project01 },
+                    new SFProjectSecret {
+                        Id = Project01,
+                        ShareKeys = new List<ShareKey>
+                        {
+                        }
+                    },
                     new SFProjectSecret
                     {
                         Id = Project02,
@@ -1057,6 +1975,20 @@ namespace SIL.XForge.Scripture.Services
                             }
                         }
                     },
+                    new SFProjectSecret {
+                        Id = Project05,
+                        ShareKeys = new List<ShareKey>
+                        {
+
+                            new ShareKey
+                            {
+                                Email = "user03@example.com",
+                                Key = "key12345",
+                                ExpirationTime = currentTime.AddDays(1),
+                                ProjectRole = SFProjectRole.CommunityChecker
+                            }
+                        }
+                    },
                 });
                 EngineService = Substitute.For<IEngineService>();
                 SyncService = Substitute.For<ISyncService>();
@@ -1074,6 +2006,10 @@ namespace SIL.XForge.Scripture.Services
                     new ParatextProject
                     {
                         ParatextId = GetProject(Project01).ParatextId
+                    },
+                    new ParatextProject
+                    {
+                        ParatextId = PTProjectIdNotYetInSF
                     },
                     new ParatextProject
                     {
@@ -1095,7 +2031,7 @@ namespace SIL.XForge.Scripture.Services
                     }
                 };
                 ParatextService.GetResourcesAsync(Arg.Any<string>()).Returns(ptResources);
-                var userSecrets = new MemoryRepository<UserSecret>(new[]
+                UserSecrets = new MemoryRepository<UserSecret>(new[]
                 {
                     new UserSecret { Id = User01 },
                     new UserSecret { Id = User02 },
@@ -1110,8 +2046,12 @@ namespace SIL.XForge.Scripture.Services
                 SecurityService.GenerateKey().Returns("1234abc");
                 var transceleratorService = Substitute.For<ITransceleratorService>();
 
+                ParatextService.IsResource(Arg.Any<string>()).Returns(callInfo =>
+                    callInfo.ArgAt<string>(0).Length == SFInstallableDblResource.ResourceIdentifierLength
+                );
+
                 Service = new SFProjectService(RealtimeService, siteOptions, audioService, EmailService, ProjectSecrets,
-                    SecurityService, FileSystemService, EngineService, SyncService, ParatextService, userSecrets,
+                    SecurityService, FileSystemService, EngineService, SyncService, ParatextService, UserSecrets,
                     translateMetrics, Localizer, transceleratorService);
             }
 
@@ -1125,6 +2065,7 @@ namespace SIL.XForge.Scripture.Services
             public ISecurityService SecurityService { get; }
             public IParatextService ParatextService { get; }
             public IStringLocalizer<SharedResource> Localizer { get; }
+            public MemoryRepository<UserSecret> UserSecrets { get; }
 
             public SFProject GetProject(string id)
             {


### PR DESCRIPTION
- Permissions were being updated in SF, but on Synchronization. This
means a PT user who joins a SF project won't have their expected PT
permissions until the next Synchronization.
- Separate out permissions updating in ParatextSyncRunner, leaving a
separate UpdateDocsAsync() and UpdatePermissionsAsync(). Move it into
SFProjectService, where it is now called both by
ParatextSyncRunner.RunAsync() and by
SFProjectService.AddUserToProjectAsync().
- Users can join a project in a number of ways. This commit handles a
user joining by connecting a project to SF for the first time
(SFProjectService.CreateProjectAsync()), joining a project by a link
(SFProjectService.CheckLinkSharingAsync()), or "connecting" an
already-connected project using the Connect Project page
(ProjectService.AddUserAsync()).
- Users may not only have a PT Role on a PT project, but they may or
may not have permissions to access a DBL resource. There are separate
sources to determine who has what PT project Role or who has DBL
resource access permission.
- SFProjectService.UpdatePermissionsAsync() uses the joining user's PT
username and PT access tokens to fetch permission information. It then
updates permissions in SF for all SF users of a given project. The
joining user must therefore have adequate access to fetch this
information, or AddUserToProjectAsync() will not call
UpdatePermissionsAsync() when the user joins.
- The change of s/paratextId/projectPTId/ and s/projectId/projectPTId/
in ParatextService.cs was done to reduce ambiguity and provide
clarity.

Because this change involved some cut-and-pasting, like extract method and moving chunks of code from ParatextSyncRunner/Tests to SFProjectService/Tests, the work was done as a series of commits to ease parts of code review. If desired to help in code review, these commits are available for now in branch `task/new-user-permissions`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1063)
<!-- Reviewable:end -->
