### PR TITLE
SF-1320b: Sync rollback support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -65,6 +65,7 @@
     "transcelerator",
     "transloco",
     "uncheck",
+    "unelevated",
     "uninvite",
     "unsynchronized",
     "usfm",

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -116,6 +116,10 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
     return this.onlineInvoke('sync', { projectId: id });
   }
 
+  onlineCancelSync(id: string): Promise<void> {
+    return this.onlineInvoke('cancelSync', { projectId: id });
+  }
+
   onlineUpdateSettings(id: string, settings: SFProjectSettings): Promise<void> {
     return this.onlineInvoke('updateSettings', { projectId: id, settings });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
@@ -40,6 +40,17 @@
             [projectDoc]="projectDoc"
             (inProgress)="syncActive = $event"
           ></app-sync-progress>
+          <button
+            *ngIf="syncActive"
+            class="action-button"
+            mdc-button
+            type="button"
+            (click)="cancelSync()"
+            [disabled]="isLoading || !isAppOnline || syncDisabled"
+            id="btn-cancel-sync"
+          >
+            {{ t("cancel") }}
+          </button>
           <span *ngIf="!syncActive" [title]="lastSyncDate" id="date-last-sync" class="sync-info">
             {{ lastSyncNotice }}
           </span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
@@ -20,7 +20,8 @@ h2 {
   align-self: center;
 }
 
-#btn-sync {
+#btn-sync,
+.progress-bar {
   margin-bottom: 1rem;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
@@ -106,7 +106,7 @@ describe('SyncComponent', () => {
     expect(env.component.syncActive).toBe(true);
     expect(env.progressBar).not.toBeNull();
     // Simulate sync in progress
-    env.emitSyncProgress(0, 'testProject01');
+    env.emitSyncProgress(0.25, 'testProject01');
     // Simulate sync error
     env.emitSyncComplete(false, 'testProject01');
     expect(env.component.syncActive).toBe(false);
@@ -131,6 +131,21 @@ describe('SyncComponent', () => {
     const env = new TestEnvironment(true, false, true, false);
     expect(env.syncButton.nativeElement.disabled).toBe(false);
     expect(env.syncDisabledMessage).toBeNull();
+  }));
+
+  it('should report cancelled if sync was cancelled', fakeAsync(() => {
+    const env = new TestEnvironment(true);
+    verify(mockedProjectService.get('testProject01')).once();
+    env.clickElement(env.syncButton);
+    verify(mockedProjectService.onlineSync('testProject01')).once();
+    expect(env.component.syncActive).toBe(true);
+    expect(env.progressBar).not.toBeNull();
+
+    env.clickElement(env.cancelButton);
+    env.emitSyncComplete(false, 'testProject01');
+
+    expect(env.component.syncActive).toBe(false);
+    verify(mockedNoticeService.show('Synchronize for Sync Test Project was cancelled.')).once();
   }));
 });
 
@@ -208,6 +223,10 @@ class TestEnvironment {
 
   get syncButton(): DebugElement {
     return this.fixture.debugElement.query(By.css('#btn-sync'));
+  }
+
+  get cancelButton(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#btn-cancel-sync'));
   }
 
   get progressBar(): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -194,6 +194,7 @@
     "translation_suggestions_settings": "Translation suggestions settings"
   },
   "sync": {
+    "cancel": "Cancel",
     "connect_network_to_synchronize": "Please connect to the internet to synchronize this project",
     "last_synced_time_stamp": "Last synced on {{ timeStamp }}",
     "log_in_to_paratext": "Log in to Paratext",
@@ -201,6 +202,7 @@
     "something_went_wrong_synchronizing_this_project": "Something went wrong while synchronizing {{ projectName }} with Paratext. Please try again.",
     "successfully_synchronized_with_paratext": "Successfully synchronized {{ projectName }} with Paratext.",
     "synchronize": "Synchronize",
+    "synchronize_was_cancelled": "Synchronize for {{ projectName }} was cancelled.",
     "synchronize_project": "Synchronize {{ projectName }} with Paratext",
     "your_project_is_being_synchronized": "Your project is being synchronized...",
     "sync_is_disabled": "Synchronization for this project needed to be disabled, so it is not available at this time. Please contact {{ email }} to discuss what needs to be done so project synchronization can be enabled again."

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -291,6 +291,23 @@ namespace SIL.XForge.Scripture.Controllers
             }
         }
 
+        public async Task<IRpcMethodResult> CancelSync(string projectId)
+        {
+            try
+            {
+                await _projectService.CancelSyncAsync(UserId, projectId);
+                return Ok();
+            }
+            catch (ForbiddenException)
+            {
+                return ForbiddenError();
+            }
+            catch (DataNotFoundException dnfe)
+            {
+                return NotFoundError(dnfe.Message);
+            }
+        }
+
         public async Task<IRpcMethodResult> DeleteAudio(string projectId, string ownerId, string dataId)
         {
             try

--- a/src/SIL.XForge.Scripture/Models/SFProjectSecret.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectSecret.cs
@@ -6,6 +6,17 @@ namespace SIL.XForge.Scripture.Models
     public class SFProjectSecret : ProjectSecret
     {
         /// <summary>
+        /// The queued or active Hangfire Job Ids for the project.
+        /// </summary>
+        /// <value>
+        /// The Hangfire Job Ids.
+        /// </value>
+        /// <remarks>
+        /// The <see cref="List{T}.Count">Count</see> should correspond to <see cref="QueuedCount" />.
+        /// </remarks>
+        public List<string> JobIds { get; set; } = new List<string>();
+
+        /// <summary>
         /// Keeps track of all Paratext usernames that have been used to sync notes with Paratext
         /// </summary>
         public List<SyncUser> SyncUsers { get; set; } = new List<SyncUser>();

--- a/src/SIL.XForge.Scripture/Services/DictionaryComparer.cs
+++ b/src/SIL.XForge.Scripture/Services/DictionaryComparer.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SIL.XForge.Scripture.Services
+{
+    public class DictionaryComparer<TKey, TValue> : IEqualityComparer<Dictionary<TKey, TValue>>
+    {
+        public bool Equals(Dictionary<TKey, TValue> x, Dictionary<TKey, TValue> y)
+        {
+            return (x ?? new Dictionary<TKey, TValue>()).OrderBy(p => p.Key)
+                .SequenceEqual((y ?? new Dictionary<TKey, TValue>()).OrderBy(p => p.Key));
+        }
+
+        public int GetHashCode(Dictionary<TKey, TValue> obj)
+        {
+            int hash = 0;
+            if (obj != null)
+            {
+                foreach (KeyValuePair<TKey, TValue> element in obj)
+                {
+                    hash ^= element.Key.GetHashCode();
+                    hash ^= element.Value.GetHashCode();
+                }
+            }
+
+            return hash;
+        }
+    }
+}

--- a/src/SIL.XForge.Scripture/Services/IHgWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/IHgWrapper.cs
@@ -7,6 +7,8 @@ namespace SIL.XForge.Scripture.Services
         void SetDefault(Hg hgDefault);
         void Init(string repository);
         void Update(string repository);
-        string GetLastPublicRevision(string repository);
+        void BackupRepository(string repository, string backupFile);
+        void RestoreRepository(string destination, string backupFile);
+        string GetLastPublicRevision(string repository, bool allowEmptyIfRestoredFromBackup);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/IJwtTokenHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/IJwtTokenHelper.cs
@@ -1,4 +1,5 @@
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using SIL.XForge.Configuration;
 using SIL.XForge.Models;
@@ -9,6 +10,7 @@ namespace SIL.XForge.Scripture.Services
     {
         string GetParatextUsername(UserSecret userSecret);
         string GetJwtTokenFromUserSecret(UserSecret userSecret);
-        Task<Tokens> RefreshAccessTokenAsync(ParatextOptions options, Tokens paratextTokens, HttpClient client);
+        Task<Tokens> RefreshAccessTokenAsync(ParatextOptions options, Tokens paratextTokens, HttpClient client,
+            CancellationToken token);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/IParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextNotesMapper.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using SIL.XForge.Models;
@@ -12,7 +13,7 @@ namespace SIL.XForge.Scripture.Services
         List<SyncUser> NewSyncUsers { get; }
 
         Task InitAsync(UserSecret currentUserSecret, SFProjectSecret projectSecret, List<User> ptUsers,
-            string paratextProjectId);
+            string paratextProjectId, CancellationToken token);
         Task<XElement> GetNotesChangelistAsync(XElement oldNotesElem, IEnumerable<IDocument<Question>> questionsDocs);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -34,6 +34,9 @@ namespace SIL.XForge.Scripture.Services
         string GetNotes(UserSecret userSecret, string paratextId, int bookNum);
         void PutNotes(UserSecret userSecret, string paratextId, string notesText);
         string GetLatestSharedVersion(UserSecret userSecret, string paratextId);
+        bool BackupExists(UserSecret userSecret, string paratextId);
+        bool BackupRepository(UserSecret userSecret, string paratextId);
+        bool RestoreRepository(UserSecret userSecret, string paratextId);
 
         Task SendReceiveAsync(UserSecret userSecret, string paratextId, IProgress<ProgressState> progress = null,
             CancellationToken token = default);

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using SIL.XForge.Models;
 using SIL.XForge.Scripture.Models;
@@ -12,17 +13,19 @@ namespace SIL.XForge.Scripture.Services
         void Init();
         Task<IReadOnlyList<ParatextProject>> GetProjectsAsync(UserSecret userSecret);
         string GetParatextUsername(UserSecret userSecret);
-        Task<Attempt<string>> TryGetProjectRoleAsync(UserSecret userSecret, string paratextId);
-        Task<IReadOnlyDictionary<string, string>> GetProjectRolesAsync(UserSecret userSecret, string paratextId);
+        Task<Attempt<string>> TryGetProjectRoleAsync(UserSecret userSecret, string paratextId, CancellationToken token);
+        Task<IReadOnlyDictionary<string, string>> GetProjectRolesAsync(UserSecret userSecret, string paratextId,
+            CancellationToken token);
         bool IsProjectLanguageRightToLeft(UserSecret userSecret, string paratextId);
 
         Task<IReadOnlyList<ParatextResource>> GetResourcesAsync(string userId);
         bool IsResource(string paratextId);
-        Task<string> GetResourcePermissionAsync(string paratextId, string userId);
+        Task<string> GetResourcePermissionAsync(string paratextId, string userId, CancellationToken token);
         Task<IReadOnlyDictionary<string, string>> GetParatextUsernameMappingAsync(UserSecret userSecret,
-            string paratextId);
+            string paratextId, CancellationToken token);
         Task<Dictionary<string, string>> GetPermissionsAsync(UserSecret userSecret, SFProject project,
-            IReadOnlyDictionary<string, string> ptUsernameMapping, int book = 0, int chapter = 0);
+            IReadOnlyDictionary<string, string> ptUsernameMapping, int book = 0, int chapter = 0,
+            CancellationToken token = default);
 
         IReadOnlyList<int> GetBookList(UserSecret userSecret, string paratextId);
         string GetBookText(UserSecret userSecret, string paratextId, int bookNum);
@@ -32,6 +35,7 @@ namespace SIL.XForge.Scripture.Services
         void PutNotes(UserSecret userSecret, string paratextId, string notesText);
         string GetLatestSharedVersion(UserSecret userSecret, string paratextId);
 
-        Task SendReceiveAsync(UserSecret userSecret, string paratextId, IProgress<ProgressState> progress = null);
+        Task SendReceiveAsync(UserSecret userSecret, string paratextId, IProgress<ProgressState> progress = null,
+            CancellationToken token = default);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/IParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextSyncRunner.cs
@@ -1,9 +1,10 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SIL.XForge.Scripture.Services
 {
     public interface IParatextSyncRunner
     {
-        Task RunAsync(string projectId, string userId, bool trainEngine);
+        Task RunAsync(string projectId, string userId, bool trainEngine, CancellationToken token);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
@@ -1,8 +1,9 @@
-using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Services;
-using SIL.XForge.Realtime;
 
 namespace SIL.XForge.Scripture.Services
 {
@@ -24,6 +25,6 @@ namespace SIL.XForge.Scripture.Services
         bool IsSourceProject(string projectId);
         Task<IEnumerable<TransceleratorQuestion>> TransceleratorQuestions(string curUserId, string projectId);
         Task<bool> HasTransceleratorQuestions(string curUserId, string projectId);
-        Task UpdatePermissionsAsync(string curUserId, IDocument<SFProject> projectDoc);
+        Task UpdatePermissionsAsync(string curUserId, IDocument<SFProject> projectDoc, CancellationToken token);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
@@ -14,6 +14,7 @@ namespace SIL.XForge.Scripture.Services
         Task UpdateSettingsAsync(string curUserId, string projectId, SFProjectSettings settings);
         Task AddTranslateMetricsAsync(string curUserId, string projectId, TranslateMetrics metrics);
         Task SyncAsync(string curUserId, string projectId);
+        Task CancelSyncAsync(string curUserId, string projectId);
         Task<bool> InviteAsync(string curUserId, string projectId, string email, string locale, string role);
         Task<string> GetLinkSharingKeyAsync(string projectId, string role);
         Task<bool> IsAlreadyInvitedAsync(string curUserId, string projectId, string email);

--- a/src/SIL.XForge.Scripture/Services/ISyncService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISyncService.cs
@@ -5,5 +5,6 @@ namespace SIL.XForge.Scripture.Services
     public interface ISyncService
     {
         Task SyncAsync(string curUserId, string projectId, bool trainEngine);
+        Task CancelSyncAsync(string curUserId, string projectId);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
@@ -153,7 +153,7 @@ namespace SIL.XForge.Scripture.Services
         /// <summary> Get the latest public revision. </summary>
         private string GetBaseRevision(string repository)
         {
-            return _hgWrapper.GetLastPublicRevision(repository);
+            return _hgWrapper.GetLastPublicRevision(repository, allowEmptyIfRestoredFromBackup: true);
         }
 
         /// <summary> Mark all changesets available on the PT server public. </summary>

--- a/src/SIL.XForge.Scripture/Services/JwtTokenHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtTokenHelper.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using SIL.XForge.Configuration;
@@ -44,7 +45,7 @@ namespace SIL.XForge.Scripture.Services
 
         /// <summary> Refresh the Paratext access token if expired with the given HttpClient. </summary>
         public async Task<Tokens> RefreshAccessTokenAsync(ParatextOptions options, Tokens paratextTokens,
-            HttpClient client)
+            HttpClient client, CancellationToken token)
         {
             bool expired = !paratextTokens.ValidateLifetime();
             if (!expired)
@@ -57,7 +58,7 @@ namespace SIL.XForge.Scripture.Services
                     new JProperty("client_secret", options.ClientSecret),
                     new JProperty("refresh_token", paratextTokens.RefreshToken));
                 request.Content = new StringContent(requestObj.ToString(), Encoding.Default, "application/json");
-                HttpResponseMessage response = await client.SendAsync(request);
+                HttpResponseMessage response = await client.SendAsync(request, token);
                 await _exceptionHandler.EnsureSuccessStatusCode(response);
 
                 string responseJson = await response.Content.ReadAsStringAsync();

--- a/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Extensions.Localization;
@@ -49,7 +50,7 @@ namespace SIL.XForge.Scripture.Services
         public List<SyncUser> NewSyncUsers { get; } = new List<SyncUser>();
 
         public async Task InitAsync(UserSecret currentUserSecret, SFProjectSecret projectSecret, List<User> ptUsers,
-            string paratextProjectId)
+            string paratextProjectId, CancellationToken token)
         {
             _currentUserSecret = currentUserSecret;
             _currentParatextUsername = _paratextService.GetParatextUsername(currentUserSecret);
@@ -63,7 +64,7 @@ namespace SIL.XForge.Scripture.Services
             }
             _ptProjectUsersWhoCanWriteNotes = new HashSet<string>();
             IReadOnlyDictionary<string, string> roles = await _paratextService.GetProjectRolesAsync(currentUserSecret,
-                paratextProjectId);
+                paratextProjectId, token);
             var ptRolesCanWriteNote = new HashSet<string> { SFProjectRole.Administrator, SFProjectRole.Translator,
                 SFProjectRole.Consultant, SFProjectRole.WriteNote };
             foreach (User user in ptUsers)

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
@@ -85,7 +86,7 @@ namespace SIL.XForge.Scripture.Services
         // Do not allow multiple sync jobs to run in parallel on the same project by creating a mutex on the projectId
         // parameter, i.e. "{0}"
         [Mutex("{0}")]
-        public async Task RunAsync(string projectId, string userId, bool trainEngine)
+        public async Task RunAsync(string projectId, string userId, bool trainEngine, CancellationToken token)
         {
             try
             {

--- a/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
+++ b/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
@@ -11,7 +11,6 @@ using Paratext.Data;
 using Paratext.Data.Archiving;
 using Paratext.Data.Languages;
 using Paratext.Data.ProjectFileAccess;
-using Paratext.Data.RegistryServerAccess;
 using PtxUtils;
 using PtxUtils.Http;
 using SIL.Extensions;
@@ -230,37 +229,51 @@ namespace SIL.XForge.Scripture.Services
             }
             catch (Exception ex)
             {
-                // Normally we would catch the specific WebException,
-                // but something in ParatextData is interfering with it.
-                if (ex.InnerException?.Message.StartsWith("401: ", StringComparison.OrdinalIgnoreCase) ?? false)
+                // Paratext throws an HttpException instead of a WebException
+                // If you need it, the WebException is the InnerException
+                if (ex is HttpException httpException)
                 {
-                    // A 401 error means unauthorized (probably a bad token)
-                    return false;
-                }
-                else if (ex.InnerException?.Message.StartsWith("403: ", StringComparison.OrdinalIgnoreCase) ?? false)
-                {
-                    // A 403 error means no access.
-                    return false;
-                }
-                else if (ex.InnerException?.Message.StartsWith("404: ", StringComparison.OrdinalIgnoreCase) ?? false)
-                {
-                    // A 404 error means that the resource is not on the server
-                    return false;
-                }
-                else if (ex.InnerException?.Message.StartsWith("405: ", StringComparison.OrdinalIgnoreCase) ?? false)
-                {
-                    // A 405 means that HEAD request does not work on the server, so we will use the resource list
-                    // This is slower (although faster than a GET request on the resource), but more reliable
-                    IEnumerable<SFInstallableDblResource> resources =
-                        GetInstallableDblResources(
-                        userSecret,
-                        paratextOptions,
-                        restClientFactory,
-                        fileSystemService,
-                        jwtTokenHelper,
-                        exceptionHandler,
-                        baseUrl);
-                    return resources.Any(r => r.DBLEntryUid.Id == id);
+                    if (httpException.Response.StatusCode == HttpStatusCode.Unauthorized)
+                    {
+                        // A 401 error means unauthorized (probably a bad token)
+                        return false;
+                    }
+                    else if (httpException.Response.StatusCode == HttpStatusCode.Forbidden)
+                    {
+                        // A 403 error means no access.
+                        return false;
+                    }
+                    else if (httpException.Response.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        // A 404 error means that the resource is not on the server
+                        return false;
+                    }
+                    else if (httpException.Response.StatusCode == HttpStatusCode.MethodNotAllowed)
+                    {
+                        // A 405 means that HEAD request does not work on the server, so we will use the resource list
+                        // This is slower (although faster than a GET request on the resource), but more reliable
+                        IEnumerable<SFInstallableDblResource> resources =
+                            GetInstallableDblResources(
+                            userSecret,
+                            paratextOptions,
+                            restClientFactory,
+                            fileSystemService,
+                            jwtTokenHelper,
+                            exceptionHandler,
+                            baseUrl);
+                        return resources.Any(r => r.DBLEntryUid.Id == id);
+                    }
+                    else if (httpException.Response.StatusCode == HttpStatusCode.OK)
+                    {
+                        // A 200 status is success - this should not have triggered an error
+                        // This is only a just in case
+                        return true;
+                    }
+                    else
+                    {
+                        // Unknown status code
+                        throw;
+                    }
                 }
                 else if (ex.Source == "NSubstitute")
                 {

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -27,6 +27,8 @@ namespace SIL.XForge.Scripture.Services
     /// </summary>
     public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFProjectService
     {
+        private static readonly IEqualityComparer<Dictionary<string, string>> _permissionDictionaryEqualityComparer =
+            new DictionaryComparer<string, string>();
         public static readonly string ErrorAlreadyConnectedKey = "error-already-connected";
         private readonly IEngineService _engineService;
         private readonly ISyncService _syncService;
@@ -699,12 +701,13 @@ namespace SIL.XForge.Scripture.Services
                 foreach ((int bookIndex, Dictionary<string, string> bookPermissions) in projectBookPermissions)
                 {
                     op.Set(pd => pd.Texts[bookIndex].Permissions, bookPermissions,
-                        ParatextSyncRunner.PermissionDictionaryEqualityComparer);
+                        _permissionDictionaryEqualityComparer);
                 }
                 foreach ((int bookIndex, int chapterIndex, Dictionary<string, string> chapterPermissions)
                     in projectChapterPermissions)
                 {
-                    op.Set(pd => pd.Texts[bookIndex].Chapters[chapterIndex].Permissions, chapterPermissions);
+                    op.Set(pd => pd.Texts[bookIndex].Chapters[chapterIndex].Permissions, chapterPermissions,
+                        _permissionDictionaryEqualityComparer);
                 }
             });
         }

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -327,6 +327,18 @@ namespace SIL.XForge.Scripture.Services
             await _syncService.SyncAsync(curUserId, projectId, false);
         }
 
+        public async Task CancelSyncAsync(string curUserId, string projectId)
+        {
+            Attempt<SFProject> attempt = await RealtimeService.TryGetSnapshotAsync<SFProject>(projectId);
+            if (!attempt.TryResult(out SFProject project))
+                throw new DataNotFoundException("The project does not exist.");
+
+            if (!IsProjectAdmin(project, curUserId))
+                throw new ForbiddenException();
+
+            await _syncService.CancelSyncAsync(curUserId, projectId);
+        }
+
         public async Task<bool> InviteAsync(string curUserId, string projectId, string email, string locale,
             string role)
         {

--- a/src/SIL.XForge.Scripture/Services/SyncService.cs
+++ b/src/SIL.XForge.Scripture/Services/SyncService.cs
@@ -1,7 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Hangfire;
+using Hangfire.States;
+using SIL.XForge.DataAccess;
 using SIL.XForge.Realtime;
 using SIL.XForge.Realtime.Json0;
 using SIL.XForge.Scripture.Models;
@@ -15,33 +18,38 @@ namespace SIL.XForge.Scripture.Services
     public class SyncService : ISyncService
     {
         private readonly IBackgroundJobClient _backgroundJobClient;
+        private readonly IRepository<SFProjectSecret> _projectSecrets;
         private readonly IRealtimeService _realtimeService;
-        private readonly Dictionary<string, string> _jobIdsByProjectId = new Dictionary<string, string>();
-        private readonly Dictionary<string, string> _sourceJobIdsByProjectId = new Dictionary<string, string>();
 
         public SyncService(
             IBackgroundJobClient backgroundJobClient,
+            IRepository<SFProjectSecret> projectSecrets,
             IRealtimeService realtimeService)
         {
             _backgroundJobClient = backgroundJobClient;
+            _projectSecrets = projectSecrets;
             _realtimeService = realtimeService;
         }
 
         public async Task SyncAsync(string curUserId, string projectId, bool trainEngine)
         {
-            string sourceProjectId = null;
             using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
             {
+                // Load the project document
                 IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
                 if (projectDoc.Data.SyncDisabled)
                 {
                     throw new ForbiddenException();
                 }
 
-                sourceProjectId = projectDoc.Data.TranslateConfig.Source?.ProjectRef;
-                await projectDoc.SubmitJson0OpAsync(op => op.Inc(pd => pd.Sync.QueuedCount));
+                // Load the target project secrets, so we can store the job id
+                if (!(await _projectSecrets.TryGetAsync(projectId)).TryResult(out SFProjectSecret projectSecret))
+                {
+                    throw new ArgumentException("The target project secret cannot be found.");
+                }
 
                 // See if we can sync the source project
+                string sourceProjectId = projectDoc.Data.TranslateConfig.Source?.ProjectRef;
                 if (!string.IsNullOrWhiteSpace(sourceProjectId))
                 {
                     IDocument<SFProject> sourceProjectDoc = await conn.FetchAsync<SFProject>(sourceProjectId);
@@ -51,48 +59,140 @@ namespace SIL.XForge.Scripture.Services
                     }
                     else
                     {
-                        await sourceProjectDoc.SubmitJson0OpAsync(op => op.Inc(pd => pd.Sync.QueuedCount));
+                        // Load the source project secrets, so we can store the job id
+                        if (!(await _projectSecrets.TryGetAsync(sourceProjectId)).TryResult(out SFProjectSecret sourceProjectSecret))
+                        {
+                            throw new ArgumentException("The source project secret cannot be found.");
+                        }
+
+                        // Schedule the sync for 5 minutes to give us enough time to update the project's sync object
+                        // We do this because there is no "draft" status in hangfire - this is close enough
+                        // After we do that, we will enqueue the job. We do it this way because we don't want to start
+                        // the job unless the queued count and job ids have been incremented appropriately.
+                        // We need to sync the source first so that we can link the source texts and train the engine.
+                        string sourceJobId = _backgroundJobClient.Schedule<ParatextSyncRunner>(
+                            r => r.RunAsync(sourceProjectId, curUserId, false, CancellationToken.None),
+                            TimeSpan.FromMinutes(5));
+                        string targetJobId = _backgroundJobClient.ContinueJobWith<ParatextSyncRunner>(sourceJobId,
+                            r => r.RunAsync(projectId, curUserId, trainEngine, CancellationToken.None), null,
+                            JobContinuationOptions.OnAnyFinishedState);
+                        try
+                        {
+                            await sourceProjectDoc.SubmitJson0OpAsync(op =>
+                            {
+                                op.Inc(pd => pd.Sync.QueuedCount);
+                            });
+                            await projectDoc.SubmitJson0OpAsync(op =>
+                            {
+                                op.Inc(pd => pd.Sync.QueuedCount);
+                            });
+
+                            // Store the source job id so we can cancel the job later if needed
+                            await _projectSecrets.UpdateAsync(sourceProjectSecret.Id, u =>
+                            {
+                                u.Add(p => p.JobIds, sourceJobId);
+                            });
+
+                            // Store the target job id so we can cancel the job later if needed
+                            await _projectSecrets.UpdateAsync(projectSecret.Id, u =>
+                            {
+                                u.Add(p => p.JobIds, targetJobId);
+                            });
+
+                            _backgroundJobClient.ChangeState(sourceJobId, new EnqueuedState());
+                        }
+                        catch (Exception)
+                        {
+                            // Delete the jobs on error, and notify the user
+                            _backgroundJobClient.Delete(targetJobId);
+                            _backgroundJobClient.Delete(sourceJobId);
+                            throw;
+                        }
+
+                        // Exit so we don't queue the target again, in the following block
+                        return;
                     }
                 }
-            }
 
-            if (!string.IsNullOrWhiteSpace(sourceProjectId))
-            {
-                // We need to sync the source first so that we can link the source texts and train the engine
-                string sourceJobId = _backgroundJobClient.Enqueue<ParatextSyncRunner>(
-                    r => r.RunAsync(sourceProjectId, curUserId, false, CancellationToken.None));
-                _sourceJobIdsByProjectId[projectId] = sourceJobId;
-                _jobIdsByProjectId[projectId] = _backgroundJobClient.ContinueJobWith<ParatextSyncRunner>(sourceJobId,
-                    r => r.RunAsync(projectId, curUserId, trainEngine, CancellationToken.None));
-            }
-            else
-            {
-                _jobIdsByProjectId[projectId] = _backgroundJobClient.Enqueue<ParatextSyncRunner>(
-                    r => r.RunAsync(projectId, curUserId, trainEngine, CancellationToken.None));
+                // Sync the target project only, as it does not have a source, or the source cannot be synced
+                // See the comments in the block above regarding scheduling for rationale on the process
+                string jobId = _backgroundJobClient.Schedule<ParatextSyncRunner>(
+                    r => r.RunAsync(projectId, curUserId, trainEngine, CancellationToken.None),
+                    TimeSpan.FromMinutes(5));
+                try
+                {
+                    await projectDoc.SubmitJson0OpAsync(op =>
+                    {
+                        op.Inc(pd => pd.Sync.QueuedCount);
+                    });
+
+                    // Store the job id so we can cancel the job later if needed
+                    await _projectSecrets.UpdateAsync(projectSecret.Id, u =>
+                    {
+                        u.Add(p => p.JobIds, jobId);
+                    });
+
+                    _backgroundJobClient.ChangeState(jobId, new EnqueuedState());
+                }
+                catch (Exception)
+                {
+                    // Delete the job on error, and notify the user
+                    _backgroundJobClient.Delete(jobId);
+                    throw;
+                }
             }
         }
 
         public async Task CancelSyncAsync(string curUserId, string projectId)
         {
-            if (_sourceJobIdsByProjectId.TryGetValue(projectId, out string sourceJobId))
-                _backgroundJobClient.Delete(sourceJobId);
-            if (_jobIdsByProjectId.TryGetValue(projectId, out string jobId))
-                _backgroundJobClient.Delete(jobId);
-
             using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
             {
                 IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
-                if (projectDoc.Data.SyncDisabled)
-                {
-                    throw new ForbiddenException();
-                }
                 if (projectDoc.Data.Sync.QueuedCount > 0)
-                    await projectDoc.SubmitJson0OpAsync(op =>
+                {
+                    await CancelProjectDocumentSyncAsync(projectDoc);
+
+                    // Cancel all jobs for the source (if present)
+                    string sourceProjectId = projectDoc.Data.TranslateConfig.Source?.ProjectRef;
+                    if (!string.IsNullOrWhiteSpace(sourceProjectId))
                     {
-                        op.Inc(pd => pd.Sync.QueuedCount, -1);
-                        op.Unset(pd => pd.Sync.PercentCompleted);
-                        op.Set(pd => pd.Sync.LastSyncSuccessful, false);
-                    });
+                        IDocument<SFProject> sourceProjectDoc = await conn.FetchAsync<SFProject>(sourceProjectId);
+                        if (sourceProjectDoc.IsLoaded && !sourceProjectDoc.Data.SyncDisabled)
+                        {
+                            if (sourceProjectDoc.Data.Sync.QueuedCount > 0)
+                            {
+                                await CancelProjectDocumentSyncAsync(sourceProjectDoc);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private async Task CancelProjectDocumentSyncAsync(IDocument<SFProject> projectDoc)
+        {
+            // Load the project secrets, so we can get any job ids
+            if ((await _projectSecrets.TryGetAsync(projectDoc.Data.Id)).TryResult(out SFProjectSecret projectSecret))
+            {
+                // Cancel all jobs for the project
+                foreach (string jobId in projectSecret.JobIds)
+                {
+                    _backgroundJobClient.Delete(jobId);
+                }
+
+                // Remove all job ids from the project secrets
+                await _projectSecrets.UpdateAsync(projectSecret.Id, u =>
+                {
+                    u.Set(p => p.JobIds, new List<string>());
+                });
+
+                // Mark sync as cancelled
+                await projectDoc.SubmitJson0OpAsync(op =>
+                {
+                    op.Set(pd => pd.Sync.QueuedCount, 0);
+                    op.Unset(pd => pd.Sync.PercentCompleted);
+                    op.Set(pd => pd.Sync.LastSyncSuccessful, false);
+                });
             }
         }
     }

--- a/src/SIL.XForge.Scripture/Services/SyncService.cs
+++ b/src/SIL.XForge.Scripture/Services/SyncService.cs
@@ -50,7 +50,8 @@ namespace SIL.XForge.Scripture.Services
 
                 // See if we can sync the source project
                 string sourceProjectId = projectDoc.Data.TranslateConfig.Source?.ProjectRef;
-                if (!string.IsNullOrWhiteSpace(sourceProjectId))
+                if (projectDoc.Data.TranslateConfig.TranslationSuggestionsEnabled
+                    && !string.IsNullOrWhiteSpace(sourceProjectId))
                 {
                     IDocument<SFProject> sourceProjectDoc = await conn.FetchAsync<SFProject>(sourceProjectId);
                     if (!sourceProjectDoc.IsLoaded || sourceProjectDoc.Data.SyncDisabled)

--- a/src/SIL.XForge/DataAccess/IUpdateBuilder.cs
+++ b/src/SIL.XForge/DataAccess/IUpdateBuilder.cs
@@ -18,6 +18,8 @@ namespace SIL.XForge.DataAccess
         IUpdateBuilder<T> RemoveAll<TItem>(Expression<Func<T, IEnumerable<TItem>>> field,
             Expression<Func<TItem, bool>> predicate);
 
+        IUpdateBuilder<T> Remove<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value);
+
         IUpdateBuilder<T> Add<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value);
     }
 }

--- a/src/SIL.XForge/DataAccess/MemoryUpdateBuilder.cs
+++ b/src/SIL.XForge/DataAccess/MemoryUpdateBuilder.cs
@@ -87,6 +87,15 @@ namespace SIL.XForge.DataAccess
             return this;
         }
 
+        public IUpdateBuilder<T> Remove<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value)
+        {
+            Func<T, IEnumerable<TItem>> getCollection = field.Compile();
+            IEnumerable<TItem> collection = getCollection(_entity);
+            MethodInfo addMethod = collection.GetType().GetMethod("Remove");
+            addMethod.Invoke(collection, new object[] { value });
+            return this;
+        }
+
         public IUpdateBuilder<T> Add<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value)
         {
             Func<T, IEnumerable<TItem>> getCollection = field.Compile();

--- a/src/SIL.XForge/DataAccess/MongoUpdateBuilder.cs
+++ b/src/SIL.XForge/DataAccess/MongoUpdateBuilder.cs
@@ -49,6 +49,12 @@ namespace SIL.XForge.DataAccess
             return this;
         }
 
+        public IUpdateBuilder<T> Remove<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value)
+        {
+            _defs.Add(_builder.Pull(ToFieldDefinition(field), value));
+            return this;
+        }
+
         public IUpdateBuilder<T> Add<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value)
         {
             _defs.Add(_builder.Push(ToFieldDefinition(field), value));

--- a/src/SIL.XForge/Models/QueuedAction.cs
+++ b/src/SIL.XForge/Models/QueuedAction.cs
@@ -1,0 +1,20 @@
+namespace SIL.XForge.Models
+{
+    internal enum QueuedAction
+    {
+        /// <summary>
+        /// The <c>createDoc</c> action.
+        /// </summary>
+        Create = 0,
+
+        /// <summary>
+        /// The <c>deleteDoc</c> action.
+        /// </summary>
+        Delete = 1,
+
+        /// <summary>
+        /// The <c>submitOp</c> action.
+        /// </summary>
+        Submit = 2,
+    }
+}

--- a/src/SIL.XForge/Models/QueuedOperation.cs
+++ b/src/SIL.XForge/Models/QueuedOperation.cs
@@ -1,0 +1,90 @@
+namespace SIL.XForge.Models
+{
+    /// <summary>
+    /// A queued operation.
+    /// </summary>
+    /// <remarks>
+    /// This is for use by <see cref="Realtime.QueuedRealtimeServer"/>.
+    /// </remarks>
+    internal class QueuedOperation
+    {
+        /// <summary>
+        /// Gets or sets the action.
+        /// </summary>
+        /// <value>
+        /// The action.
+        /// </value>
+        /// <remarks>
+        /// This corresponds to the function called on the realtime server.
+        /// </remarks>
+        public QueuedAction Action { get; set; }
+
+        /// <summary>
+        /// Gets or sets the collection.
+        /// </summary>
+        /// <value>
+        /// The collection.
+        /// </value>
+        /// <remarks>
+        /// This is specified for all queued operations.
+        /// </remarks>
+        public string Collection { get; set; }
+
+        /// <summary>
+        /// Gets or sets the data.
+        /// </summary>
+        /// <value>
+        /// The data.
+        /// </value>
+        /// <remarks>
+        /// This is required for <see cref="QueuedAction.Create" />.
+        /// </remarks>
+        public object Data { get; set; }
+
+        /// <summary>
+        /// Gets or sets the handle.
+        /// </summary>
+        /// <value>
+        /// The handle.
+        /// </value>
+        /// <remarks>
+        /// This is specified for all queued operations.
+        /// </remarks>
+        public int Handle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier.
+        /// </summary>
+        /// <value>
+        /// The identifier.
+        /// </value>
+        /// <remarks>
+        /// This is specified for all queued operations.
+        /// </remarks>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the operations.
+        /// </summary>
+        /// <value>
+        /// The operations.
+        /// </value>
+        /// <remarks>
+        /// Required for <see cref="QueuedAction.Submit" />.
+        /// This is usually a collection of JSON0 or RichText operations.
+        /// </remarks>
+        public object Op { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the ot type.
+        /// </summary>
+        /// <value>
+        /// The name of the ot type.
+        /// </value>
+        /// <remarks>
+        /// This is required for <see cref="QueuedAction.Create" />.
+        /// See <see cref="Realtime.OTType" /> for allowed values.
+        /// </remarks>
+        public string OtTypeName { get; set; }
+    }
+}

--- a/src/SIL.XForge/Realtime/Connection.cs
+++ b/src/SIL.XForge/Realtime/Connection.cs
@@ -1,8 +1,16 @@
+using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
+using Jering.Javascript.NodeJS;
 using SIL.ObjectModel;
 using SIL.XForge.Configuration;
 using SIL.XForge.Models;
+using SIL.XForge.Realtime.Json0;
+using SIL.XForge.Utils;
 
 namespace SIL.XForge.Realtime
 {
@@ -11,33 +19,348 @@ namespace SIL.XForge.Realtime
     /// </summary>
     public class Connection : DisposableBase, IConnection
     {
-        private readonly RealtimeService _realtimeService;
-        private int _handle;
-
+        /// <summary>
+        /// The documents cache.
+        /// </summary>
         private readonly ConcurrentDictionary<(string, string), object> _documents;
 
+        /// <summary>
+        /// The properties to excluded from the transaction (i.e. to commit immediately).
+        /// </summary>
+        /// <remarks>
+        /// These are in the form "Type.Property.Property", in lower case.
+        /// </remarks>
+        private List<string> _excludedProperties = new List<string>();
+
+        /// <summary>
+        /// The connection handle.
+        /// </summary>
+        private int _handle;
+
+        /// <summary>
+        /// Whether or not this connection is in a transaction state.
+        /// </summary>
+        private bool _isTransaction;
+
+        /// <summary>
+        /// The queued operations.
+        /// </summary>
+        private ConcurrentQueue<QueuedOperation> _queuedOperations = new ConcurrentQueue<QueuedOperation>();
+
+        /// <summary>
+        /// The realtime server to create/modify documents with.
+        /// </summary>
+        private IRealtimeServer _realtimeServer;
+
+        /// <summary>
+        /// The realtime service to use for this connection.
+        /// </summary>
+        private readonly RealtimeService _realtimeService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Connection"/> class.
+        /// </summary>
+        /// <param name="realtimeService">The realtime service.</param>
         internal Connection(RealtimeService realtimeService)
         {
             _realtimeService = realtimeService;
+            _realtimeServer = realtimeService.Server;
             _documents = new ConcurrentDictionary<(string, string), object>();
         }
 
+        /// <summary>
+        /// Gets the excluded properties.
+        /// </summary>
+        /// <value>
+        /// The excluded properties.
+        /// </value>
+        /// <remarks>
+        /// This is for unit test verification or debugging.
+        /// </remarks>
+        internal IReadOnlyCollection<string> ExcludedProperties => _excludedProperties;
+
+        /// <summary>
+        /// Gets the number of queued operations.
+        /// </summary>
+        /// <value>
+        /// The number of operations in the queue.
+        /// </value>
+        /// <remarks>
+        /// This is for unit test verification or debugging.
+        /// </remarks>
+        internal IReadOnlyCollection<QueuedOperation> QueuedOperations => _queuedOperations;
+
+        /// <summary>
+        /// Begins the transaction.
+        /// </summary>
+        /// <exception cref="ArgumentException">The connection is already in a transaction state.</exception>
+        public void BeginTransaction()
+        {
+            // Start the transaction state, if we are not in a transaction state
+            if (!_isTransaction)
+            {
+                _isTransaction = true;
+            }
+            else
+            {
+                // We are already in a transaction state
+                throw new ArgumentException("The connection is already in a transaction state.");
+            }
+        }
+
+        /// <summary>
+        /// Commits the transaction.
+        /// </summary>
+        /// <exception cref="ArgumentException">The connection is not in a transaction state.</exception>
+        public async Task CommitTransactionAsync()
+        {
+            if (_isTransaction)
+            {
+                // Execute the queued operations
+                while (_queuedOperations.TryDequeue(out QueuedOperation queuedOperation))
+                {
+                    switch (queuedOperation.Action)
+                    {
+                        case QueuedAction.Create:
+                            await _realtimeServer.CreateDocAsync(queuedOperation.Handle, queuedOperation.Collection,
+                                queuedOperation.Id, queuedOperation.Data, queuedOperation.OtTypeName);
+                            break;
+                        case QueuedAction.Delete:
+                            await _realtimeServer.DeleteDocAsync(queuedOperation.Handle, queuedOperation.Collection,
+                                queuedOperation.Id);
+                            break;
+                        case QueuedAction.Submit:
+                            await _realtimeServer.SubmitOpAsync<object>(queuedOperation.Handle,
+                                queuedOperation.Collection, queuedOperation.Id, queuedOperation.Op);
+                            break;
+                    }
+                }
+
+                // Clear the excluded operations, and reset the transaction state
+                _excludedProperties.Clear();
+                _isTransaction = false;
+            }
+            else
+            {
+                // We are not in a transaction state
+                throw new ArgumentException("The connection is not in a transaction state.");
+            }
+        }
+
+        /// <summary>
+        /// Creates a document asynchronously.
+        /// </summary>
+        /// <typeparam name="T">The document type.</typeparam>
+        /// <param name="collection">The collection.</param>
+        /// <param name="id">The identifier.</param>
+        /// <param name="data">The data.</param>
+        /// <param name="otTypeName">Name of the OT type.</param>
+        /// <returns>
+        /// A snapshot of the created document from the realtime server.
+        /// </returns>
+        public async Task<Snapshot<T>> CreateDocAsync<T>(string collection, string id, T data, string otTypeName)
+        {
+            if (_isTransaction)
+            {
+                // Queue this operation
+                _queuedOperations.Enqueue(new QueuedOperation
+                {
+                    Action = QueuedAction.Create,
+                    Collection = collection,
+                    Data = data,
+                    Handle = _handle,
+                    Id = id,
+                    OtTypeName = otTypeName,
+                });
+
+                // Return a snapshot
+                return new Snapshot<T>
+                {
+                    Data = data,
+                    Version = 1,
+                };
+            }
+            else
+            {
+                return await _realtimeServer.CreateDocAsync(_handle, collection, id, data, otTypeName);
+            }
+        }
+
+        /// <summary>
+        /// Deletes a document asynchronously.
+        /// </summary>
+        /// <param name="collection">The collection.</param>
+        /// <param name="id">The identifier.</param>
+        /// <returns>The task.</returns>
+        public async Task DeleteDocAsync(string collection, string id)
+        {
+            if (_isTransaction)
+            {
+                // Queue this operation
+                _queuedOperations.Enqueue(new QueuedOperation
+                {
+                    Action = QueuedAction.Delete,
+                    Collection = collection,
+                    Handle = _handle,
+                    Id = id,
+                });
+            }
+            else
+            {
+                await _realtimeServer.DeleteDocAsync(_handle, collection, id);
+            }
+        }
+
+        /// <summary>
+        /// Excludes a property from the transaction.
+        /// </summary>
+        /// <typeparam name="T">The type the field belongs to.</typeparam>
+        /// <param name="field">The property field.</param>
+        /// <exception cref="ArgumentException">The connection is not in a transaction state.</exception>
+        /// <remarks>
+        /// Notes:
+        ///  - When a field is excluded from a transaction, operations to it are committed immediately.
+        ///  - Any operations lists that contain an excluded property will all be committed immediately.
+        ///  - You will need to call this again if you begin a new transaction.
+        ///  - This only applies to JSON0 operations.
+        /// </remarks>
+        public void ExcludePropertyFromTransaction<T>(Expression<Func<T, object>> field)
+        {
+            if (_isTransaction)
+            {
+                // Exclude the property, if we are in a transaction state
+                string excluded =
+                    (typeof(T).Name + "." + string.Join('.', new ObjectPath(field).Items)).ToLowerInvariant();
+                _excludedProperties.Add(excluded);
+            }
+            else
+            {
+                // We are not in a transaction state
+                throw new ArgumentException("The connection is not in a transaction state.");
+            }
+        }
+
+        /// <summary>
+        /// Fetches a document asynchronously.
+        /// </summary>
+        /// <typeparam name="T">The document type.</typeparam>
+        /// <param name="collection">The collection.</param>
+        /// <param name="id">The identifier.</param>
+        /// <returns>
+        /// A snapshot of the fetched document from the realtime server.
+        /// </returns>
+        public async Task<Snapshot<T>> FetchDocAsync<T>(string collection, string id)
+        {
+            return await _realtimeServer.FetchDocAsync<T>(_handle, collection, id);
+        }
+
+        /// <summary>
+        /// Gets the specified document, bound to the current realtime server.
+        /// </summary>
+        /// <typeparam name="T">The document type.</typeparam>
+        /// <param name="id">The identifier.</param>
+        /// <returns>
+        /// The document.
+        /// </returns>
         public IDocument<T> Get<T>(string id) where T : IIdentifiable
         {
             DocConfig docConfig = _realtimeService.GetDocConfig<T>();
             object doc = _documents.GetOrAdd((docConfig.CollectionName, id), key =>
             {
                 string otTypeName = docConfig.OTTypeName;
-                return new Document<T>(_realtimeService.Server, _handle, otTypeName, docConfig.CollectionName, id);
+                return new Document<T>(this, otTypeName, docConfig.CollectionName, id);
             });
             return (Document<T>)doc;
         }
 
+        /// <summary>
+        /// Rolls back the transaction.
+        /// </summary>
+        /// <exception cref="ArgumentException">The connection is not in a transaction state.</exception>
+        public void RollbackTransaction()
+        {
+            if (_isTransaction)
+            {
+                // Clear the operations
+                _excludedProperties.Clear();
+                _queuedOperations.Clear();
+
+                // Reset the transaction state
+                _isTransaction = false;
+            }
+            else
+            {
+                // We are not in a transaction state
+                throw new ArgumentException("The connection is not in a transaction state.");
+            }
+        }
+
+        /// <summary>
+        /// Submits an operation asynchronously.
+        /// </summary>
+        /// <typeparam name="T">The document type.</typeparam>
+        /// <param name="collection">The collection.</param>
+        /// <param name="id">The identifier.</param>
+        /// <param name="op">The operation.</param>
+        /// <param name="currentDoc">The current document (only used when in a transaction).</param>
+        /// <param name="currentVersion">The current version (only used when in a transaction).</param>
+        /// <returns>
+        /// A snapshot of the document with the submitted operation from the realtime server.
+        /// </returns>
+        public async Task<Snapshot<T>> SubmitOpAsync<T>(string collection, string id, object op, T currentDoc,
+            int currentVersion)
+        {
+            if (_isTransaction)
+            {
+                // If we have a collection of JSON0 operations, see if any are to be committed immediately
+                if (_excludedProperties.Any() && op is IEnumerable<Json0Op> jsonOps)
+                {
+                    foreach (Json0Op jsonOp in jsonOps)
+                    {
+                        string path = (typeof(T).Name + "." + string.Join('.', jsonOp.Path)).ToLowerInvariant();
+                        if (_excludedProperties.Contains(path))
+                        {
+                            return await _realtimeServer.SubmitOpAsync<T>(_handle, collection, id, op);
+                        }
+                    }
+                }
+
+                // Queue this operation
+                _queuedOperations.Enqueue(new QueuedOperation
+                {
+                    Action = QueuedAction.Submit,
+                    Collection = collection,
+                    Handle = _handle,
+                    Id = id,
+                    Op = op,
+                });
+
+                // Return the operation applied to the object
+                string otTypeName = op is IEnumerable<Json0Op> || op is Json0Op ? OTType.Json0 : OTType.RichText;
+                return new Snapshot<T>
+                {
+                    Data = await _realtimeServer.ApplyOpAsync(otTypeName, currentDoc, op),
+                    Version = ++currentVersion,
+                };
+            }
+            else
+            {
+                return await _realtimeServer.SubmitOpAsync<T>(_handle, collection, id, op);
+            }
+        }
+
+        /// <summary>
+        /// Starts the realtime server asynchronously.
+        /// </summary>
+        /// <param name="userId">The user identifier.</param>
         internal async Task StartAsync(string userId = null)
         {
             _handle = await _realtimeService.Server.ConnectAsync(userId);
         }
 
+        /// <summary>
+        /// Disposes the managed resources.
+        /// </summary>
         protected override void DisposeManagedResources()
         {
             _realtimeService.Server.Disconnect(_handle);

--- a/src/SIL.XForge/Realtime/IConnection.cs
+++ b/src/SIL.XForge/Realtime/IConnection.cs
@@ -1,10 +1,20 @@
 using System;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
 using SIL.XForge.Models;
 
 namespace SIL.XForge.Realtime
 {
     public interface IConnection : IDisposable
     {
+        void BeginTransaction();
+        Task CommitTransactionAsync();
+        Task<Snapshot<T>> CreateDocAsync<T>(string collection, string id, T data, string otTypeName);
+        Task DeleteDocAsync(string collection, string id);
+        void ExcludePropertyFromTransaction<T>(Expression<Func<T, object>> field);
+        Task<Snapshot<T>> FetchDocAsync<T>(string collection, string id);
         IDocument<T> Get<T>(string id) where T : IIdentifiable;
+        void RollbackTransaction();
+        Task<Snapshot<T>> SubmitOpAsync<T>(string collection, string id, object op, T currentDoc, int currentVersion);
     }
 }

--- a/src/SIL.XForge/Realtime/MemoryConnection.cs
+++ b/src/SIL.XForge/Realtime/MemoryConnection.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
 using SIL.XForge.Configuration;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
@@ -16,6 +19,81 @@ namespace SIL.XForge.Realtime
             _documents = new Dictionary<(string, string), object>();
         }
 
+        /// <summary>
+        /// Begins the transaction.
+        /// </summary>
+        /// <returns>
+        /// A null value.
+        /// </returns>
+        /// <remarks>
+        /// The <see cref="MemoryConnection" /> does not support transactions.
+        /// No exception is thrown for compatibility reasons.
+        /// </remarks>
+        public void BeginTransaction()
+        {
+        }
+
+        /// <summary>
+        /// Commits the transaction.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="MemoryConnection" /> does not support transactions.
+        /// No exception is thrown for compatibility reasons.
+        /// </remarks>
+        public Task CommitTransactionAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Creates a document asynchronously.
+        /// </summary>
+        /// <exception cref="NotImplementedException">
+        /// This is not supported by a <see cref="MemoryConnection" />.
+        /// </exception>
+        public Task<Snapshot<T>> CreateDocAsync<T>(string collection, string id, T data, string otTypeName)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Deletes a document asynchronously.
+        /// </summary>
+        /// <exception cref="NotImplementedException">
+        /// This is not supported by a <see cref="MemoryConnection" />.
+        /// </exception>
+        public Task DeleteDocAsync(string collection, string id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Dispose()
+        {
+        }
+
+        /// <summary>
+        /// Excludes the field from the transaction.
+        /// </summary>
+        /// <typeparam name="T">The type.</typeparam>
+        /// <param name="op">The field.</param>
+        /// <remarks>
+        /// The <see cref="MemoryConnection" /> does not support transactions.
+        /// </remarks>
+        public void ExcludePropertyFromTransaction<T>(Expression<Func<T, object>> field)
+        {
+        }
+
+        /// <summary>
+        /// Fetches a document asynchronously.
+        /// </summary>
+        /// <exception cref="NotImplementedException">
+        /// This is not supported by a <see cref="MemoryConnection" />.
+        /// </exception>
+        public Task<Snapshot<T>> FetchDocAsync<T>(string collection, string id)
+        {
+            throw new NotImplementedException();
+        }
+
         public IDocument<T> Get<T>(string id) where T : IIdentifiable
         {
             DocConfig docConfig = _realtimeService.GetDocConfig<T>();
@@ -28,8 +106,26 @@ namespace SIL.XForge.Realtime
             return doc;
         }
 
-        public void Dispose()
+        /// <summary>
+        /// Rolls back the transaction.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="MemoryConnection" /> does not support transactions.
+        /// </remarks>
+        public void RollbackTransaction()
         {
+        }
+
+        /// <summary>
+        /// Submits an operation asynchronously.
+        /// </summary>
+        /// <exception cref="NotImplementedException">
+        /// This is not supported by a <see cref="MemoryConnection" />.
+        /// </exception>
+        public Task<Snapshot<T>> SubmitOpAsync<T>(string collection, string id, object op, T currentDoc,
+            int currentVersion)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/SIL.XForge/Services/FileSystemService.cs
+++ b/src/SIL.XForge/Services/FileSystemService.cs
@@ -45,6 +45,11 @@ namespace SIL.XForge.Services
             Directory.Move(sourceDirPath, targetDirPath);
         }
 
+        public void MoveFile(string sourceFilePath, string targetFilePath)
+        {
+            File.Move(sourceFilePath, targetFilePath);
+        }
+
         public void DeleteDirectory(string path)
         {
             Directory.Delete(path, true);

--- a/src/SIL.XForge/Services/IFileSystemService.cs
+++ b/src/SIL.XForge/Services/IFileSystemService.cs
@@ -14,6 +14,7 @@ namespace SIL.XForge.Services
         bool DirectoryExists(string path);
         void DeleteDirectory(string path);
         void MoveDirectory(string sourceDirPath, string targetDirPath);
+        void MoveFile(string sourceFilePath, string targetFilePath);
         IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*");
         IEnumerable<string> EnumerateDirectories(string path);
     }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Extensions.Localization;
@@ -418,7 +419,7 @@ namespace SIL.XForge.Scripture.Services
             public async Task InitMapperAsync(bool includeSyncUsers, bool twoPtUsersOnProject)
             {
                 await Mapper.InitAsync(UserSecrets.Get("user01"), ProjectSecret(includeSyncUsers),
-                    ParatextUsersOnProject(twoPtUsersOnProject), "paratextId");
+                    ParatextUsersOnProject(twoPtUsersOnProject), "paratextId", CancellationToken.None);
             }
 
             public void AddData(string answerSyncUserId1, string answerSyncUserId2, string commentSyncUserId1,
@@ -491,7 +492,8 @@ namespace SIL.XForge.Scripture.Services
                 ptUserRoles["ptuser01"] = "pt_administrator";
                 if (twoPtUserOnProject)
                     ptUserRoles["ptuser03"] = "pt_translator";
-                ParatextService.GetProjectRolesAsync(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(ptUserRoles);
+                ParatextService.GetProjectRolesAsync(Arg.Any<UserSecret>(), Arg.Any<string>(),
+                    Arg.Any<CancellationToken>()).Returns(ptUserRoles);
             }
 
             private static SFProjectSecret ProjectSecret(bool includeSyncUsers)

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.Hosting;
@@ -356,7 +357,7 @@ namespace SIL.XForge.Scripture.Services
                 .Returns(mockClient);
 
             var paratextId = "resid_is_16_char";
-            var permission = await env.Service.GetResourcePermissionAsync(paratextId, env.User01);
+            var permission = await env.Service.GetResourcePermissionAsync(paratextId, env.User01, CancellationToken.None);
             Assert.That(permission, Is.EqualTo(TextInfoPermission.None));
         }
 
@@ -377,7 +378,7 @@ namespace SIL.XForge.Scripture.Services
 
             var paratextId = "resid_is_16_char";
 
-            var permission = await env.Service.GetResourcePermissionAsync(paratextId, env.User01);
+            var permission = await env.Service.GetResourcePermissionAsync(paratextId, env.User01, CancellationToken.None);
             Assert.That(permission, Is.EqualTo(TextInfoPermission.Read));
         }
 
@@ -710,12 +711,13 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             const string resourceId = "1234567890abcdef";
             Assert.That(resourceId.Length, Is.EqualTo(SFInstallableDblResource.ResourceIdentifierLength));
-            var mapping = await env.Service.GetParatextUsernameMappingAsync(env.MakeUserSecret(env.User01, env.Username01), resourceId);
+            var mapping = await env.Service.GetParatextUsernameMappingAsync(env.MakeUserSecret(env.User01, env.Username01),
+                resourceId, CancellationToken.None);
             Assert.That(mapping.Count, Is.EqualTo(0));
         }
 
         [Test]
-        public async Task GetLatestSharedVersion_ForPTProject()
+        public void GetLatestSharedVersion_ForPTProject()
         {
             var env = new TestEnvironment();
             var associatedPtUser = new SFParatextUser(env.Username01);
@@ -733,10 +735,9 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task GetLatestSharedVersion_ForDBLResource()
+        public void GetLatestSharedVersion_ForDBLResource()
         {
             var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
             UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01);
 
             string resourcePTId = "1234567890123456";
@@ -833,7 +834,7 @@ namespace SIL.XForge.Scripture.Services
                 MockJwtTokenHelper.GetParatextUsername(Arg.Any<UserSecret>()).Returns(User01);
                 MockJwtTokenHelper.GetJwtTokenFromUserSecret(Arg.Any<UserSecret>()).Returns(accessToken);
                 MockJwtTokenHelper.RefreshAccessTokenAsync(Arg.Any<ParatextOptions>(), Arg.Any<Tokens>(),
-                    Arg.Any<HttpClient>())
+                    Arg.Any<HttpClient>(), Arg.Any<CancellationToken>())
                     .Returns(Task.FromResult(new Tokens
                     {
                         AccessToken = accessToken,

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -726,7 +726,8 @@ namespace SIL.XForge.Scripture.Services
             string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
             ScrText scrText = env.GetScrText(associatedPtUser, ptProjectId);
             string lastPublicRevision = "abc123";
-            env.MockHgWrapper.GetLastPublicRevision(scrText.Directory).Returns(lastPublicRevision);
+            env.MockHgWrapper.GetLastPublicRevision(scrText.Directory, allowEmptyIfRestoredFromBackup: false)
+                .Returns(lastPublicRevision);
 
             // SUT
             string latestSharedVersion = env.Service.GetLatestSharedVersion(user01Secret, ptProjectId);
@@ -751,9 +752,148 @@ namespace SIL.XForge.Scripture.Services
                 "DBL resources do not have hg repositories to have a last pushed or pulled hg commit id.");
             // Wouldn't have ended up trying to find a ScrText or querying hg.
             env.MockScrTextCollection.DidNotReceiveWithAnyArgs().FindById(default, default);
-            env.MockHgWrapper.DidNotReceiveWithAnyArgs().GetLastPublicRevision(default);
+            env.MockHgWrapper.DidNotReceiveWithAnyArgs().GetLastPublicRevision(default, default);
         }
 
+        [Test]
+        public void BackupExists_Failure()
+        {
+            // Setup test environment
+            var env = new TestEnvironment();
+            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01);
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+            env.MockFileSystemService.FileExists(Arg.Any<string>()).Throws(new UnauthorizedAccessException());
+
+            // SUT
+            bool result = env.Service.BackupExists(user01Secret, ptProjectId);
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void BackupExists_Missing()
+        {
+            // Setup test environment
+            var env = new TestEnvironment();
+            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01);
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+            env.MockFileSystemService.FileExists(Arg.Any<string>()).Returns(false);
+
+            // SUT
+            bool result = env.Service.BackupExists(user01Secret, ptProjectId);
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void BackupExists_Success()
+        {
+            // Setup test environment
+            var env = new TestEnvironment();
+            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01);
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+            env.MockFileSystemService.FileExists(Arg.Any<string>()).Returns(true);
+
+            // SUT
+            bool result = env.Service.BackupExists(user01Secret, ptProjectId);
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void BackupRepository_Failure()
+        {
+            // Setup test environment
+            var env = new TestEnvironment();
+            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01);
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+            env.MockFileSystemService.FileExists(Arg.Any<string>()).Throws(new UnauthorizedAccessException());
+
+            // SUT
+            bool result = env.Service.BackupRepository(user01Secret, ptProjectId);
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void BackupRepository_InvalidProject()
+        {
+            // Setup test environment
+            var env = new TestEnvironment();
+            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01);
+            string ptProjectId = "invalid_project";
+
+            // SUT
+            bool result = env.Service.BackupRepository(user01Secret, ptProjectId);
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void BackupRepository_Success()
+        {
+            // Setup test environment
+            var env = new TestEnvironment();
+            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01);
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+
+            // SUT
+            bool result = env.Service.BackupRepository(user01Secret, ptProjectId);
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void RestoreRepository_Failure()
+        {
+            // Setup test environment
+            var env = new TestEnvironment();
+            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01);
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+            env.MockFileSystemService.FileExists(Arg.Any<string>()).Throws(new UnauthorizedAccessException());
+
+            // SUT
+            bool result = env.Service.RestoreRepository(user01Secret, ptProjectId);
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void RestoreRepository_Missing()
+        {
+            // Setup test environment
+            var env = new TestEnvironment();
+            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01);
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+            env.MockFileSystemService.FileExists(Arg.Any<string>()).Returns(false);
+
+            // SUT
+            bool result = env.Service.RestoreRepository(user01Secret, ptProjectId);
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void RestoreRepository_Success()
+        {
+            // Setup test environment
+            var env = new TestEnvironment();
+            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01);
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+            env.MockFileSystemService.FileExists(Arg.Any<string>()).Returns(true);
+
+            // SUT
+            bool result = env.Service.RestoreRepository(user01Secret, ptProjectId);
+            Assert.IsTrue(result);
+        }
 
         private class TestEnvironment
         {
@@ -1104,7 +1244,11 @@ namespace SIL.XForge.Scripture.Services
                     Arg.Any<SharedRepositorySource>(), Arg.Any<IEnumerable<SharedRepository>>())
                     .Returns(callInfo => new SharedProject()
                     {
-                        SendReceiveId = HexId.FromStr(callInfo.ArgAt<string>(0))
+                        SendReceiveId = HexId.FromStr(callInfo.ArgAt<string>(0)),
+                        Repository = new SharedRepository
+                        {
+                            SendReceiveId = HexId.FromStr(callInfo.ArgAt<string>(0)),
+                        },
                     });
                 MockSharingLogicWrapper.ShareChanges(Arg.Any<List<SharedProject>>(), Arg.Any<SharedRepositorySource>(),
                     out Arg.Any<List<SendReceiveResult>>(), Arg.Any<List<SharedProject>>()).Returns(true);

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
@@ -25,7 +26,7 @@ namespace SIL.XForge.Scripture.Services
         {
             var env = new TestEnvironment();
 
-            await env.Runner.RunAsync("project03", "user01", false);
+            await env.Runner.RunAsync("project03", "user01", false, CancellationToken.None);
         }
 
         [Test]
@@ -35,7 +36,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, true);
             env.ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), "target").Returns("beforeSR");
 
-            await env.Runner.RunAsync("project01", "user03", false);
+            await env.Runner.RunAsync("project01", "user03", false, CancellationToken.None);
+
             SFProject project = env.VerifyProjectSync(false);
             Assert.That(project.Sync.DataInSync, Is.True);
         }
@@ -48,7 +50,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
             env.DeltaUsxMapper.When(d => d.ToChapterDeltas(Arg.Any<XDocument>())).Do(x => throw new Exception());
 
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+
             SFProject project = env.VerifyProjectSync(false);
             Assert.That(project.Sync.DataInSync, Is.False);
         }
@@ -60,7 +63,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(false, false, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
 
-            await env.Runner.RunAsync("project01", "user01", true);
+            await env.Runner.RunAsync("project01", "user01", true, CancellationToken.None);
 
             Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
             Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
@@ -88,8 +91,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
 
-            await env.Runner.RunAsync("project02", "user01", true);
-            await env.Runner.RunAsync("project01", "user01", true);
+            await env.Runner.RunAsync("project02", "user01", true, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", true, CancellationToken.None);
 
             Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
             Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
@@ -117,8 +120,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, false, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
 
-            await env.Runner.RunAsync("project02", "user01", true);
-            await env.Runner.RunAsync("project01", "user01", true);
+            await env.Runner.RunAsync("project02", "user01", true, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", true, CancellationToken.None);
 
             Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
             Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
@@ -146,7 +149,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(false, true, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
 
-            await env.Runner.RunAsync("project01", "user01", true);
+            await env.Runner.RunAsync("project01", "user01", true, CancellationToken.None);
 
             Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
             Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
@@ -175,7 +178,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, false, books);
             env.SetupPTData(books);
 
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             await env.ParatextService.DidNotReceive().PutBookText(Arg.Any<UserSecret>(), "target", 40, Arg.Any<string>());
             await env.ParatextService.DidNotReceive().PutBookText(Arg.Any<UserSecret>(), "target", 41, Arg.Any<string>());
@@ -212,8 +215,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, true, books);
             env.SetupPTData(books);
 
-            await env.Runner.RunAsync("project02", "user01", false);
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             await env.ParatextService.Received()
                 .PutBookText(Arg.Any<UserSecret>(), "target", 40, Arg.Any<string>(), Arg.Any<Dictionary<int, string>>());
@@ -251,8 +254,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, false, true, books);
             env.SetupPTData(books);
 
-            await env.Runner.RunAsync("project02", "user01", false);
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             await env.ParatextService.Received()
                 .PutBookText(Arg.Any<UserSecret>(), "target", 40, Arg.Any<string>(), Arg.Any<Dictionary<int, string>>());
@@ -289,8 +292,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, false, new Book("MAT", 2), new Book("MRK", 2));
             env.SetupPTData(new Book("MAT", 3), new Book("MRK", 1));
 
-            await env.Runner.RunAsync("project02", "user01", false);
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             Assert.That(env.ContainsText("project01", "MAT", 3), Is.True);
             Assert.That(env.ContainsText("project01", "MRK", 2), Is.False);
@@ -310,7 +313,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, false, new Book("MAT", 2), new Book("MRK", 2) { InvalidChapters = { 1 } });
             env.SetupPTData(new Book("MAT", 2) { InvalidChapters = { 2 } }, new Book("MRK", 2));
 
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             SFProject project = env.GetProject();
             Assert.That(project.Texts[0].Chapters[0].IsValid, Is.True);
@@ -327,8 +330,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, false, new Book("MAT", 2), new Book("MRK", 2));
             env.SetupPTData(new Book("MAT", 2), new Book("LUK", 2));
 
-            await env.Runner.RunAsync("project02", "user01", false);
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             Assert.That(env.ContainsText("project01", "MRK", 1), Is.False);
             Assert.That(env.ContainsText("project01", "MRK", 2), Is.False);
@@ -361,7 +364,7 @@ namespace SIL.XForge.Scripture.Services
             env.ParatextService.GetProjectRolesAsync(Arg.Any<UserSecret>(), "target")
                 .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
 
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             SFProject project = env.VerifyProjectSync(true);
             Assert.That(project.UserRoles["user01"], Is.EqualTo(SFProjectRole.Translator));
@@ -381,9 +384,100 @@ namespace SIL.XForge.Scripture.Services
             };
             env.ParatextService.GetProjectRolesAsync(Arg.Any<UserSecret>(), "target")
                 .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+            var ptSourcePermissions = new Dictionary<string, string>()
+            {
+                { "user01", TextInfoPermission.Read },
+                { "user02", TextInfoPermission.None },
+            };
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(), Arg.Any<SFProject>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Any<int>())
+                .Returns(Task.FromResult(ptSourcePermissions));
 
-            // SUT
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+
+            SFProject project = env.VerifyProjectSync(true);
+            Assert.That(project.Texts.First().Permissions["user02"], Is.EqualTo(TextInfoPermission.None));
+        }
+
+        [Test]
+        public async Task SyncAsync_UserHasNoChapterPermission()
+        {
+            var env = new TestEnvironment();
+            Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+            env.SetupSFData(true, true, false, books);
+            env.SetupPTData(books);
+            var ptUserRoles = new Dictionary<string, string>
+            {
+                { "pt01", SFProjectRole.Translator }
+            };
+            env.ParatextService.GetProjectRolesAsync(Arg.Any<UserSecret>(), "target")
+                .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+            var ptChapterPermissions = new Dictionary<string, string>()
+            {
+                { "user01", TextInfoPermission.Read },
+                { "user02", TextInfoPermission.None },
+            };
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(), Arg.Any<SFProject>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Any<int>())
+                .Returns(Task.FromResult(ptChapterPermissions));
+
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+
+            SFProject project = env.VerifyProjectSync(true);
+            Assert.That(project.Texts.First().Chapters.First().Permissions["user02"], Is.EqualTo(TextInfoPermission.None));
+        }
+
+        [Test]
+        public async Task SyncAsync_UserHasResourcePermission()
+        {
+            var env = new TestEnvironment();
+            Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+            env.SetupSFData(true, true, false, books);
+            env.SetupPTData(books);
+            var ptUserRoles = new Dictionary<string, string>
+            {
+                { "pt01", SFProjectRole.Translator }
+            };
+            env.ParatextService.GetProjectRolesAsync(Arg.Any<UserSecret>(), "target")
+                .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+            var ptSourcePermissions = new Dictionary<string, string>()
+            {
+                { "user01", TextInfoPermission.Read },
+                { "user02", TextInfoPermission.Read },
+            };
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(), Arg.Any<SFProject>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Any<int>())
+                .Returns(Task.FromResult(ptSourcePermissions));
+
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+
+            SFProject project = env.VerifyProjectSync(true);
+            Assert.That(project.Texts.First().Permissions["user02"], Is.EqualTo(TextInfoPermission.Read));
+        }
+
+        [Test]
+        public async Task SyncAsync_UserHasChapterPermission()
+        {
+            var env = new TestEnvironment();
+            Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+            env.SetupSFData(true, true, false, books);
+            env.SetupPTData(books);
+            var ptUserRoles = new Dictionary<string, string>
+            {
+                { "pt01", SFProjectRole.Translator }
+            };
+            env.ParatextService.GetProjectRolesAsync(Arg.Any<UserSecret>(), "target")
+                .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+            var ptChapterPermissions = new Dictionary<string, string>()
+            {
+                { "user01", TextInfoPermission.Read },
+                { "user02", TextInfoPermission.Read },
+            };
+            env.ParatextService.GetPermissionsAsync(Arg.Any<UserSecret>(), Arg.Any<SFProject>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<int>(), Arg.Any<int>())
+                .Returns(Task.FromResult(ptChapterPermissions));
+
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             env.SFProjectService.Received().UpdatePermissionsAsync("user01",
                 Arg.Is<IDocument<SFProject>>((IDocument<SFProject> sfProjDoc) =>
@@ -407,7 +501,7 @@ namespace SIL.XForge.Scripture.Services
             await env.SetUserRole("user02", SFProjectRole.CommunityChecker);
             SFProject project = env.GetProject();
             Assert.That(project.UserRoles["user02"], Is.EqualTo(SFProjectRole.CommunityChecker));
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             env.VerifyProjectSync(true);
             await env.SFProjectService.DidNotReceiveWithAnyArgs().RemoveUserAsync("user01", "project01", "user02");
@@ -423,7 +517,7 @@ namespace SIL.XForge.Scripture.Services
 
             env.ParatextService.IsProjectLanguageRightToLeft(Arg.Any<UserSecret>(), "target")
                 .Returns(true);
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             SFProject project = env.GetProject();
             env.ParatextService.Received().IsProjectLanguageRightToLeft(Arg.Any<UserSecret>(), "target");
@@ -444,7 +538,7 @@ namespace SIL.XForge.Scripture.Services
                 });
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2), new Book("LUK", 2));
 
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             var delta = Delta.New().InsertText("text");
             Assert.That(env.GetText("project01", "MAT", 1).DeepEquals(delta), Is.True);
@@ -469,8 +563,8 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
 
             // SUT
-            await env.Runner.RunAsync("project02", "user01", false);
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             env.Logger.DidNotReceiveWithAnyArgs().LogError(Arg.Any<Exception>(), default, default);
 
@@ -502,8 +596,8 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsText("project02", "MAT", 3), Is.True);
 
             // SUT
-            await env.Runner.RunAsync("project02", "user01", false);
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             env.Logger.DidNotReceiveWithAnyArgs().LogError(Arg.Any<Exception>(), default, default);
 
@@ -529,7 +623,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
 
             // SUT
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             env.Logger.DidNotReceiveWithAnyArgs().LogError(Arg.Any<Exception>(), default, default);
 
@@ -557,8 +651,8 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsText("project02", "MAT", 3), Is.True);
 
             // SUT
-            await env.Runner.RunAsync("project02", "user01", false);
-            await env.Runner.RunAsync("project01", "user01", false);
+            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             env.Logger.DidNotReceiveWithAnyArgs().LogError(Arg.Any<Exception>(), default, default);
 
@@ -597,7 +691,7 @@ namespace SIL.XForge.Scripture.Services
                     .Returns("1", "2");
 
                 // SUT
-                await env.Runner.RunAsync(projectSFId, userId, false);
+                await env.Runner.RunAsync(projectSFId, userId, false, CancellationToken.None);
 
                 project = env.GetProject(projectSFId);
                 // We should get into UpdateParatextBook() and fetch and perhaps put books.
@@ -644,7 +738,7 @@ namespace SIL.XForge.Scripture.Services
                     .Returns("1", "2");
 
                 // SUT
-                await env.Runner.RunAsync(projectSFId, userId, false);
+                await env.Runner.RunAsync(projectSFId, userId, false, CancellationToken.None);
 
                 project = env.GetProject(projectSFId);
                 // We are in an out-of-sync situation and so should not be writing to PT.

--- a/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
@@ -1,11 +1,14 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
 using NSubstitute;
 using NUnit.Framework;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Scripture.Realtime;
-using Hangfire;
 using SIL.XForge.Services;
 
 namespace SIL.XForge.Scripture.Services
@@ -15,6 +18,118 @@ namespace SIL.XForge.Scripture.Services
     {
         private static readonly string Project01 = "project01";
         private static readonly string Project02 = "project02";
+        private static readonly string Project03 = "project03";
+
+        [Test]
+        public async Task SyncAsync_CancelSourceAndTarget()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project03, false);
+
+            // Verify that the jobs were queued correctly
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
+
+            // Cancel sync
+            await env.Service.CancelSyncAsync("userid", Project03);
+
+            // Verify that the job was cancelled correctly
+            env.BackgroundJobClient.Received(2).ChangeState("jobid", Arg.Any<DeletedState>(), null); // Same as Delete()
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
+        }
+
+        [Test]
+        public async Task SyncAsync_CancelSourceNotTarget()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project03, false);
+
+            // Verify that the jobs were queued correctly
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
+
+            // Cancel sync
+            await env.Service.CancelSyncAsync("userid", Project01);
+
+            // Verify that the job was cancelled correctly
+            env.BackgroundJobClient.Received(1).ChangeState("jobid", Arg.Any<DeletedState>(), null); // Same as Delete()
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
+        }
+
+        [Test]
+        public async Task SyncAsync_CancelTargetWithoutSource()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project01, false);
+
+            // Verify that the job was queued correctly
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
+
+            // Cancel sync
+            await env.Service.CancelSyncAsync("userid", Project01);
+
+            // Verify that the job was cancelled correctly
+            env.BackgroundJobClient.Received(1).ChangeState("jobid", Arg.Any<DeletedState>(), null); // Same as Delete()
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
+        }
 
         [Test]
         public void SyncAsync_Enqueues()
@@ -23,6 +138,50 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).SyncDisabled, Is.False);
             // SUT
             Assert.DoesNotThrowAsync(() => env.Service.SyncAsync("userid", Project01, false));
+        }
+
+        [Test]
+        public async Task SyncAsync_EnqueuesSourceAndTarget()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project03, false);
+
+            // Verify that the jobs were queued correctly
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
+        }
+
+        [Test]
+        public async Task SyncAsync_EnqueuedTargetWithoutSource()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project01, false);
+
+            // Verify that the job was queued correctly
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(0));
+            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
+            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
         }
 
         [Test]
@@ -38,6 +197,12 @@ namespace SIL.XForge.Scripture.Services
             public TestEnvironment()
             {
                 BackgroundJobClient = Substitute.For<IBackgroundJobClient>();
+                ProjectSecrets = new MemoryRepository<SFProjectSecret>(new[]
+                {
+                    new SFProjectSecret { Id = "project01" },
+                    new SFProjectSecret { Id = "project02" },
+                    new SFProjectSecret { Id = "project03" },
+                });
                 RealtimeService = new SFMemoryRealtimeService();
 
                 RealtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(
@@ -70,13 +235,34 @@ namespace SIL.XForge.Scripture.Services
                             },
                             SyncDisabled = true
                         },
+                        new SFProject
+                        {
+                            Id = Project03,
+                            Name = "project03",
+                            ShortName = "P03",
+                            CheckingConfig = new CheckingConfig
+                            {
+                                ShareEnabled = false
+                            },
+                            UserRoles = new Dictionary<string, string>
+                            {
+                            },
+                            TranslateConfig = new TranslateConfig
+                            {
+                                Source = new TranslateSource
+                                {
+                                    ProjectRef = Project01
+                                }
+                            }
+                        }
                 }));
 
-                Service = new SyncService(BackgroundJobClient, RealtimeService);
+                Service = new SyncService(BackgroundJobClient, ProjectSecrets, RealtimeService);
             }
 
             public SyncService Service { get; }
             public IBackgroundJobClient BackgroundJobClient { get; }
+            public MemoryRepository<SFProjectSecret> ProjectSecrets { get; }
             public SFMemoryRealtimeService RealtimeService { get; }
         }
     }

--- a/test/SIL.XForge.Tests/DataAccess/MemoryUpdateBuilderTests.cs
+++ b/test/SIL.XForge.Tests/DataAccess/MemoryUpdateBuilderTests.cs
@@ -1,0 +1,154 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using SIL.XForge.Models;
+
+namespace SIL.XForge.DataAccess
+{
+    [TestFixture]
+    public class MemoryUpdateBuilderTests
+    {
+        [Test]
+        public void MemoryUpdateBuilder_Add()
+        {
+            // Setup environment
+            var env = new TestEnvironment();
+            int oldCount = env.TestEntity.TestChildCollection.Count;
+
+            // Test collection add
+            env.MemoryUpdateBuilder.Add(e => e.TestChildCollection, new TestEntity { Id = "test_id_3" });
+            Assert.AreEqual(oldCount + 1, env.TestEntity.TestChildCollection.Count);
+        }
+
+        [Test]
+        public void MemoryUpdateBuilder_Inc()
+        {
+            var env = new TestEnvironment();
+            int oldValue = env.TestEntity.TestChildCollection.Count;
+
+            // Test increment
+            env.MemoryUpdateBuilder.Inc(e => e.TestNumber, 1);
+            Assert.AreEqual(oldValue + 1, env.TestEntity.TestNumber);
+
+            // Test decrement
+            env.MemoryUpdateBuilder.Inc(e => e.TestNumber, -1);
+            Assert.AreEqual(oldValue, env.TestEntity.TestNumber);
+        }
+
+        [Test]
+        public void MemoryUpdateBuilder_Remove()
+        {
+            // Setup environment
+            var env = new TestEnvironment();
+            int oldCount = env.TestEntity.TestStringCollection.Count;
+
+            // Test string collection remove
+            env.MemoryUpdateBuilder.Remove(e => e.TestStringCollection, "test_value_2");
+            Assert.AreEqual(oldCount - 1, env.TestEntity.TestStringCollection.Count);
+        }
+
+        [Test]
+        public void MemoryUpdateBuilder_RemoveAll()
+        {
+            // Setup environment
+            var env = new TestEnvironment();
+            int oldCount = env.TestEntity.TestChildCollection.Count;
+
+            // Test string collection remove all
+            env.MemoryUpdateBuilder.RemoveAll(e => e.TestChildCollection, e => e.Id == "test_id_2");
+            Assert.AreEqual(oldCount - 1, env.TestEntity.TestChildCollection.Count);
+        }
+
+        [Test]
+        public void MemoryUpdateBuilder_Set()
+        {
+            // Setup environment
+            var env = new TestEnvironment();
+            string oldValue = env.TestEntity.TestStringField;
+            string expected = "updated_test_value";
+
+            // Test string field set
+            Assert.AreNotEqual(expected, env.TestEntity.TestStringField);
+            env.MemoryUpdateBuilder.Set(e => e.TestStringField, expected);
+            Assert.AreEqual(expected, env.TestEntity.TestStringField);
+        }
+
+        [Test]
+        public void MemoryUpdateBuilder_SetOnInsertDisabled()
+        {
+            // Setup environment
+            var env = new TestEnvironment(false);
+            string oldValue = env.TestEntity.TestStringField;
+            string expected = "updated_test_value";
+
+            // Test string field set
+            Assert.AreNotEqual(expected, env.TestEntity.TestStringField);
+            env.MemoryUpdateBuilder.SetOnInsert(e => e.TestStringField, expected);
+            Assert.AreEqual(oldValue, env.TestEntity.TestStringField);
+        }
+
+        [Test]
+        public void MemoryUpdateBuilder_SetOnInsertEnabled()
+        {
+            // Setup environment
+            var env = new TestEnvironment(true);
+            string oldValue = env.TestEntity.TestStringField;
+            string expected = "updated_test_value";
+
+            // Test string field set
+            Assert.AreNotEqual(expected, env.TestEntity.TestStringField);
+            env.MemoryUpdateBuilder.SetOnInsert(e => e.TestStringField, expected);
+            Assert.AreEqual(expected, env.TestEntity.TestStringField);
+        }
+
+        [Test]
+        public void MemoryUpdateBuilder_Unset()
+        {
+            // Setup environment
+            var env = new TestEnvironment();
+            string expected = null;
+
+            // Test string field unset
+            Assert.AreNotEqual(expected, env.TestEntity.TestStringField);
+            env.MemoryUpdateBuilder.Unset(e => e.TestStringField);
+            Assert.AreEqual(expected, env.TestEntity.TestStringField);
+        }
+
+        private class TestEntity : IIdentifiable
+        {
+            public string Id { get; set; }
+            public int TestNumber { get; set; }
+            public List<TestEntity> TestChildCollection { get; set; } = new List<TestEntity>();
+            public List<string> TestStringCollection { get; set; } = new List<string>();
+            public string TestStringField { get; set; }
+        }
+
+        private class TestEnvironment
+        {
+            public TestEnvironment(bool setOnInsert = false)
+            {
+                // Set up the test entity
+                TestEntity = new TestEntity
+                {
+                    Id = "test_id_1",
+                    TestChildCollection = new List<TestEntity>
+                    {
+                        new TestEntity { Id = "test_id_2" },
+                    },
+                    TestNumber = 1,
+                    TestStringCollection = new List<string>
+                    {
+                        "test_value_1",
+                        "test_value_2",
+                    },
+                    TestStringField = "test_value",
+                };
+
+                // Set up the memory update builder for the test entity
+                MemoryUpdateBuilder =
+                    new MemoryUpdateBuilder<TestEntity>(e => e.Id == TestEntity.Id, TestEntity, setOnInsert);
+            }
+            public MemoryUpdateBuilder<TestEntity> MemoryUpdateBuilder { get; }
+            public TestEntity TestEntity { get; }
+        }
+    }
+}

--- a/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
@@ -1,0 +1,446 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using MongoDB.Driver;
+using NSubstitute;
+using NUnit.Framework;
+using SIL.XForge.Configuration;
+using SIL.XForge.Models;
+using SIL.XForge.Realtime.Json0;
+using Options = Microsoft.Extensions.Options.Options;
+
+namespace SIL.XForge.Realtime
+{
+    [TestFixture]
+    public class ConnectionTests
+    {
+        [Test]
+        public async Task CommitTransactionAsync_ClearsExcludedProperties()
+        {
+            // Setup
+            var env = new TestEnvironment();
+            string collection = "test_project";
+            string id = "id1";
+
+            // Set up excluded operations and queue
+            env.Service.BeginTransaction();
+            env.Service.ExcludePropertyFromTransaction<TestProject>(op => op.SyncDisabled);
+            await env.Service.DeleteDocAsync(collection, id);
+
+            // Verify excluded operations and queue
+            Assert.AreEqual(env.Service.ExcludedProperties.Count, 1);
+            Assert.AreEqual(env.Service.QueuedOperations.Count, 1);
+
+            // SUT
+            await env.Service.CommitTransactionAsync();
+
+            // Verify the clear
+            Assert.AreEqual(env.Service.ExcludedProperties.Count, 0);
+            Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
+
+            // Verify that the call was passed to the underlying realtime server
+            await env.RealtimeService.Server.Received(1)
+                .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
+        }
+
+        [Test]
+        public void CommitTransactionAsync_RequiresBeginTransaction()
+        {
+            // Setup
+            var env = new TestEnvironment();
+
+            // SUT
+            Assert.ThrowsAsync<ArgumentException>(() => env.Service.CommitTransactionAsync());
+        }
+
+        [Test]
+        public async Task CommitTransactionAsync_UsesUnderlyingRealtimeServerOnCommit()
+        {
+            // Setup
+            var env = new TestEnvironment();
+            string collection = "test_project";
+            string id = "id1";
+            string otTypeName = OTType.Json0;
+            var snapshot = new Snapshot<TestProject>
+            {
+                Data = new TestProject()
+                {
+                    Id = id,
+                    SyncDisabled = false,
+                },
+                Version = 1,
+            };
+            var builder = new Json0OpBuilder<TestProject>(snapshot.Data);
+            builder.Set(p => p.SyncDisabled, true);
+            List<Json0Op> op = builder.Op;
+            var updatedData = new TestProject()
+            {
+                Id = id,
+                SyncDisabled = true,
+            };
+
+            env.RealtimeService.Server.FetchDocAsync<TestProject>(Arg.Any<int>(), collection, id)
+                .Returns(Task.FromResult(snapshot));
+            env.RealtimeService.Server.ApplyOpAsync(otTypeName, snapshot.Data, op)
+                .Returns(Task.FromResult(updatedData));
+
+            // Setup Queue
+            env.Service.BeginTransaction();
+            await env.Service.CreateDocAsync(collection, id, snapshot.Data, otTypeName);
+            await env.Service.SubmitOpAsync(collection, id, op, snapshot.Data, snapshot.Version);
+            await env.Service.DeleteDocAsync(collection, id);
+
+            // Verify Queue
+            Assert.AreEqual(env.Service.QueuedOperations.First().Action, QueuedAction.Create);
+            Assert.AreEqual(env.Service.QueuedOperations.Skip(1).First().Action, QueuedAction.Submit);
+            Assert.AreEqual(env.Service.QueuedOperations.Last().Action, QueuedAction.Delete);
+
+            // SUT
+            await env.Service.CommitTransactionAsync();
+
+            // Verify Submit Operations
+            await env.RealtimeService.Server.Received(1).CreateDocAsync(Arg.Any<int>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<object>(), Arg.Any<string>());
+            await env.RealtimeService.Server.Received(1).DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(),
+                Arg.Any<string>());
+            await env.RealtimeService.Server.Received(1).SubmitOpAsync<object>(Arg.Any<int>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<object>());
+        }
+
+        [Test]
+        public async Task CreateDocAsync_QueuesAction()
+        {
+            // Setup
+            var env = new TestEnvironment();
+            string collection = "test_project";
+            string id = "id1";
+            var data = new TestProject
+            {
+                Id = id,
+                Name = "Test Project 1",
+            };
+            string otTypeName = OTType.Json0;
+
+            // SUT
+            env.Service.BeginTransaction();
+            var result = await env.Service.CreateDocAsync(collection, id, data, otTypeName);
+
+            // Verify result
+            Assert.AreEqual(result.Version, 1);
+            Assert.AreEqual(result.Data, data);
+
+            // Verify queue
+            Assert.AreEqual(env.Service.QueuedOperations.Count, 1);
+            QueuedOperation queuedOperation = env.Service.QueuedOperations.First();
+            Assert.AreEqual(queuedOperation.Action, QueuedAction.Create);
+            Assert.AreEqual(queuedOperation.Collection, collection);
+            Assert.AreEqual(queuedOperation.Data, data);
+            Assert.AreEqual(queuedOperation.Id, id);
+            Assert.AreEqual(queuedOperation.OtTypeName, otTypeName);
+
+            // Verify that the call was not passed to the underlying realtime server
+            await env.RealtimeService.Server.Received(0).CreateDocAsync(Arg.Any<int>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<object>(), Arg.Any<string>());
+        }
+
+        [Test]
+        public async Task CreateDocAsync_UsesUnderlyingRealtimeServerOutsideOfATransaction()
+        {
+            // Setup
+            var env = new TestEnvironment();
+            string collection = "test_project";
+            string id = "id1";
+            var data = new TestProject
+            {
+                Id = id,
+                Name = "Test Project 1",
+            };
+            string otTypeName = OTType.Json0;
+
+            // SUT
+            await env.Service.CreateDocAsync(collection, id, data, otTypeName);
+
+            // Verify queue is empty
+            Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
+
+            // Verify that the call was not passed to the underlying realtime server
+            await env.RealtimeService.Server.Received(1).CreateDocAsync(Arg.Any<int>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<TestProject>(), Arg.Any<string>());
+        }
+
+        [Test]
+        public async Task DeleteDocAsync_QueuesAction()
+        {
+            // Setup
+            var env = new TestEnvironment();
+            string collection = "test_project";
+            string id = "id1";
+
+            // SUT
+            env.Service.BeginTransaction();
+            await env.Service.DeleteDocAsync(collection, id);
+
+            // Verify queue
+            Assert.AreEqual(env.Service.QueuedOperations.Count, 1);
+            QueuedOperation queuedOperation = env.Service.QueuedOperations.First();
+            Assert.AreEqual(queuedOperation.Action, QueuedAction.Delete);
+            Assert.AreEqual(queuedOperation.Collection, collection);
+            Assert.AreEqual(queuedOperation.Id, id);
+
+            // Verify that the call was not passed to the underlying realtime server
+            await env.RealtimeService.Server.Received(0)
+                .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
+        }
+
+        [Test]
+        public async Task DeleteDocAsync_UsesUnderlyingRealtimeServerOutsideOfATransaction()
+        {
+            // Setup
+            var env = new TestEnvironment();
+            string collection = "test_project";
+            string id = "id1";
+
+            // SUT
+            await env.Service.DeleteDocAsync(collection, id);
+
+            // Verify queue is empty
+            Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
+
+            // Verify that the call was not passed to the underlying realtime server
+            await env.RealtimeService.Server.Received(1)
+                .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
+        }
+
+        [Test]
+        public void ExcludePropertyFromTransaction_DeconstructsTheProperty()
+        {
+            // Setup
+            var env = new TestEnvironment();
+            env.Service.BeginTransaction();
+
+            // SUT
+            env.Service.ExcludePropertyFromTransaction<TestProject>(op => op.SyncDisabled);
+
+            // Verify
+            Assert.AreEqual(env.Service.ExcludedProperties.Count, 1);
+            Assert.AreEqual(env.Service.ExcludedProperties.First(), "testproject.syncdisabled");
+        }
+
+        [Test]
+        public void ExcludePropertyFromTransaction_RequiresBeginTransaction()
+        {
+            // Setup
+            var env = new TestEnvironment();
+
+            // SUT
+            Assert.Throws<ArgumentException>(
+                () => env.Service.ExcludePropertyFromTransaction<TestProject>(op => op.SyncDisabled));
+        }
+
+        [Test]
+        public async Task FetchDocAsync_UsesUnderlyingRealtimeServer()
+        {
+            // Setup
+            var env = new TestEnvironment();
+            string collection = "test_project";
+            string id = "id1";
+
+            // SUT
+            await env.Service.FetchDocAsync<TestProject>(collection, id);
+
+            // Verify
+            await env.RealtimeService.Server.Received(1).FetchDocAsync<TestProject>(Arg.Any<int>(), collection, id);
+        }
+
+        [Test]
+        public async Task RollbackTransaction_ClearsQueuedOperationsAndExcludedProperties()
+        {
+            // Setup
+            var env = new TestEnvironment();
+            string collection = "test_project";
+            string id = "id1";
+
+            // Set up excluded operations and queue
+            env.Service.BeginTransaction();
+            env.Service.ExcludePropertyFromTransaction<TestProject>(op => op.SyncDisabled);
+            await env.Service.DeleteDocAsync(collection, id);
+
+            // Verify excluded operations and queue
+            Assert.AreEqual(env.Service.ExcludedProperties.Count, 1);
+            Assert.AreEqual(env.Service.QueuedOperations.Count, 1);
+
+            // SUT
+            env.Service.RollbackTransaction();
+
+            // Verify the clear
+            Assert.AreEqual(env.Service.ExcludedProperties.Count, 0);
+            Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
+
+            // Verify that the call was not passed to the underlying realtime server
+            await env.RealtimeService.Server.Received(0)
+                .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
+        }
+
+        [Test]
+        public void RollbackTransaction_RequiresBeginTransaction()
+        {
+            // Setup
+            var env = new TestEnvironment();
+
+            // SUT
+            Assert.Throws<ArgumentException>(() => env.Service.RollbackTransaction());
+        }
+
+        [Test]
+        public async Task SubmitOpAsync_ExecutesExcludedAction()
+        {
+            // Setup
+            var env = new TestEnvironment();
+            string collection = "test_project";
+            string id = "id1";
+            var data = new TestProject()
+            {
+                Id = id,
+                SyncDisabled = false,
+            };
+            var snapshot = new Snapshot<TestProject>
+            {
+                Data = new TestProject()
+                {
+                    Id = id,
+                    SyncDisabled = true,
+                },
+                Version = 2,
+            };
+            var builder = new Json0OpBuilder<TestProject>(data);
+            builder.Set(p => p.SyncDisabled, true);
+            List<Json0Op> op = builder.Op;
+            env.RealtimeService.Server.SubmitOpAsync<TestProject>(Arg.Any<int>(), collection, id, op)
+                .Returns(Task.FromResult(snapshot));
+
+            // SUT
+            env.Service.BeginTransaction();
+            env.Service.ExcludePropertyFromTransaction<TestProject>(p => p.SyncDisabled);
+            var result = await env.Service.SubmitOpAsync(collection, id, op, snapshot.Data, snapshot.Version);
+
+            // Verify result
+            Assert.AreEqual(result.Version, snapshot.Version);
+            Assert.AreEqual(result.Data, snapshot.Data);
+
+            // Verify queue
+            Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
+
+            // Verify that the call was passed to the underlying realtime server
+            await env.RealtimeService.Server.Received(1)
+                .SubmitOpAsync<TestProject>(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>());
+        }
+
+        [Test]
+        public async Task SubmitOpAsync_QueuesAction()
+        {
+            // Setup
+            var env = new TestEnvironment();
+            string collection = "test_project";
+            string id = "id1";
+            string otTypeName = OTType.Json0;
+            var snapshot = new Snapshot<TestProject>
+            {
+                Data = new TestProject()
+                {
+                    Id = id,
+                    SyncDisabled = false,
+                },
+                Version = 1,
+            };
+            var builder = new Json0OpBuilder<TestProject>(snapshot.Data);
+            builder.Set(p => p.SyncDisabled, true);
+            List<Json0Op> op = builder.Op;
+            var updatedData = new TestProject()
+            {
+                Id = id,
+                SyncDisabled = true,
+            };
+
+            env.RealtimeService.Server.FetchDocAsync<TestProject>(Arg.Any<int>(), collection, id)
+                .Returns(Task.FromResult(snapshot));
+            env.RealtimeService.Server.ApplyOpAsync(otTypeName, snapshot.Data, op)
+                .Returns(Task.FromResult(updatedData));
+
+            // SUT
+            env.Service.BeginTransaction();
+            var result = await env.Service.SubmitOpAsync(collection, id, op, snapshot.Data, snapshot.Version);
+
+            // Verify result
+            Assert.AreEqual(result.Version, 2);
+            Assert.AreEqual(result.Data, updatedData);
+
+            // Verify queue
+            Assert.AreEqual(env.Service.QueuedOperations.Count, 1);
+            QueuedOperation queuedOperation = env.Service.QueuedOperations.First();
+            Assert.AreEqual(queuedOperation.Action, QueuedAction.Submit);
+            Assert.AreEqual(queuedOperation.Collection, collection);
+            Assert.AreEqual(queuedOperation.Op, op);
+
+            // Verify that the call was not passed to the underlying realtime server
+            await env.RealtimeService.Server.Received(0)
+                .SubmitOpAsync<TestProject>(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>());
+        }
+
+        [Test]
+        public async Task SubmitOpAsync_UsesUnderlyingRealtimeServerOutsideOfATransaction()
+        {
+            // Setup
+            var env = new TestEnvironment();
+            string collection = "test_project";
+            string id = "id1";
+            var snapshot = new Snapshot<TestProject>
+            {
+                Data = new TestProject()
+                {
+                    Id = id,
+                    SyncDisabled = false,
+                },
+                Version = 1,
+            };
+            var builder = new Json0OpBuilder<TestProject>(snapshot.Data);
+            builder.Set(p => p.SyncDisabled, true);
+            List<Json0Op> op = builder.Op;
+
+            // SUT
+            var result = await env.Service.SubmitOpAsync(collection, id, op, snapshot.Data, snapshot.Version);
+
+            // Verify queue
+            Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
+
+            // Verify that the call was not passed to the underlying realtime server
+            await env.RealtimeService.Server.Received(1)
+                .SubmitOpAsync<TestProject>(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>());
+        }
+
+        private class TestEnvironment
+        {
+            public Connection Service = null;
+            public RealtimeService RealtimeService = null;
+            public TestEnvironment()
+            {
+                var realtimeServer = Substitute.For<IRealtimeServer>();
+                var siteOptions = Options.Create(Substitute.For<SiteOptions>());
+                var dataAccessOptions = Options.Create(Substitute.For<DataAccessOptions>());
+                var realtimeOptions = Options.Create(new RealtimeOptions()
+                {
+                    ProjectDoc = new DocConfig("some_projects", typeof(Project)),
+                    ProjectDataDocs = new List<DocConfig>(),
+                    UserDataDocs = new List<DocConfig>(),
+                });
+                var authOptions = Options.Create(Substitute.For<AuthOptions>());
+                var mongoClient = Substitute.For<IMongoClient>();
+                var configuration = Substitute.For<IConfiguration>();
+                RealtimeService = new RealtimeService(realtimeServer, siteOptions, dataAccessOptions, realtimeOptions,
+                    authOptions, mongoClient, configuration);
+                Service = new Connection(RealtimeService);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change implements a "transaction styled" commit/rollback feature for the Realtime Server, and backup/restore support for Paratext repositories (based on Paratext's Backup/Restore). These two features are used by `ParatextSyncRunner` to allow rollback of Realtimeserver and Mercurial changes when a sync is cancelled.

The transaction implementation is accessed via the `Connection`, and properties can be excluded from the transaction (and so committed immediately), meaning that the sync progress is still updated in real time for the user.

**Other Fixes Included**
 - `HgWrapper.GetLastPublicRevision()` now supports repositories without public commits (i.e. restored from backup)
 - Source projects are no longer synced if the target project has translation suggestions disabled (see `SyncService.SyncAsync()`).
 - `ParatextSyncRunner.CompleteSync()` no longer crashes if the source could not be set, due to an issue contacting the DBL (the sync will rollback however)
 - `SFInstallableDblResource.CheckResourcePermission()` checks for the HTTP status codes in a more robust manner that allows for server message differences
 - Permissions were being incorrectly overwritten on sync, so the `ChapterEqualityComparer` no longer checks permissions (as permissions are handled via `SFProjectService`), and `SFProjectService.UpdatePermissionsAsync()` now uses the permission dictionary comparer to stop unnecessary writes to the project permissions collections.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1064)
<!-- Reviewable:end -->
