### PR TITLE
Show invitee role on users page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
@@ -116,9 +116,9 @@ describe('CollaboratorsComponent', () => {
   it('displays invited users', fakeAsync(() => {
     const env = new TestEnvironment();
     when(mockedProjectService.onlineInvitedUsers(env.project01Id)).thenResolve([
-      { email: 'alice@a.aa', expired: false },
-      { email: 'bob@b.bb', expired: false },
-      { email: 'charles@c.cc', expired: true }
+      { email: 'alice@a.aa', role: 'sf_community_checker', expired: false },
+      { email: 'bob@b.bb', role: 'sf_community_checker', expired: false },
+      { email: 'charles@c.cc', role: 'sf_community_checker', expired: true }
     ]);
 
     env.setupProjectData();
@@ -184,7 +184,7 @@ describe('CollaboratorsComponent', () => {
   it('should refresh user list after inviting a new user', fakeAsync(() => {
     const env = new TestEnvironment();
     when(mockedProjectService.onlineInvitedUsers(env.project01Id)).thenResolve([
-      { email: 'alice@a.aa', expired: false }
+      { email: 'alice@a.aa', role: 'sf_community_checker', expired: false }
     ]);
     env.setupProjectData();
     env.fixture.detectChanges();
@@ -198,8 +198,8 @@ describe('CollaboratorsComponent', () => {
 
     // Simulate invitation event
     when(mockedProjectService.onlineInvitedUsers(env.project01Id)).thenResolve([
-      { email: 'alice@a.aa', expired: false },
-      { email: 'new-invitee@example.com', expired: false }
+      { email: 'alice@a.aa', role: 'sf_community_checker', expired: false },
+      { email: 'new-invitee@example.com', role: 'sf_community_checker', expired: false }
     ]);
     numInvitees++;
     env.component.onInvitationSent();
@@ -214,7 +214,7 @@ describe('CollaboratorsComponent', () => {
     const env = new TestEnvironment();
     when(mockedProjectService.onlineUninviteUser(anything(), anything())).thenResolve();
     when(mockedProjectService.onlineInvitedUsers(env.project01Id)).thenResolve([
-      { email: 'alice@a.aa', expired: false }
+      { email: 'alice@a.aa', role: 'sf_community_checker', expired: false }
     ]);
     env.setupProjectData();
     env.fixture.detectChanges();
@@ -263,7 +263,7 @@ describe('CollaboratorsComponent', () => {
     const env = new TestEnvironment();
     env.setupProjectData();
     when(mockedProjectService.onlineInvitedUsers(env.project01Id)).thenResolve([
-      { email: 'bob@example.com', expired: false }
+      { email: 'bob@example.com', role: 'sf_community_checker', expired: false }
     ]);
     env.fixture.detectChanges();
     tick();
@@ -282,7 +282,7 @@ describe('CollaboratorsComponent', () => {
     expect(env.userRows.length).toEqual(1);
 
     env.setInputValue(env.filterInput, 'Community Checker');
-    expect(env.userRows.length).toEqual(1);
+    expect(env.userRows.length).toEqual(2);
   }));
 
   it('should page', fakeAsync(() => {
@@ -405,7 +405,7 @@ describe('CollaboratorsComponent', () => {
     const env = new TestEnvironment(false);
     env.setupProjectData();
     when(mockedProjectService.onlineInvitedUsers(env.project01Id)).thenResolve([
-      { email: 'alice@a.aa', expired: false }
+      { email: 'alice@a.aa', role: 'sf_community_checker', expired: false }
     ]);
     env.fixture.detectChanges();
     tick();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.ts
@@ -35,6 +35,7 @@ interface Row {
 
 export interface InviteeStatus {
   email: string;
+  role: string;
   expired: boolean;
 }
 
@@ -271,7 +272,7 @@ export class CollaboratorsComponent extends DataLoadingComponent implements OnIn
         return {
           id: '',
           user: { email: invitee.email },
-          role: '',
+          role: invitee.role,
           inviteeStatus: invitee
         } as Row;
       });

--- a/src/SIL.XForge.Scripture/Models/InviteeStatus.cs
+++ b/src/SIL.XForge.Scripture/Models/InviteeStatus.cs
@@ -3,6 +3,7 @@ namespace SIL.XForge.Scripture.Models
     public class InviteeStatus
     {
         public string Email { get; set; }
+        public string Role { get; set; }
         public bool Expired { get; set; }
     }
 }

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -464,7 +464,7 @@ namespace SIL.XForge.Scripture.Services
 
             DateTime now = DateTime.UtcNow;
             return projectSecret.ShareKeys.Where(s => s.Email != null).Select(sk =>
-                new InviteeStatus { Email = sk.Email, Expired = sk.ExpirationTime < now }).ToArray();
+                new InviteeStatus { Email = sk.Email, Role = sk.ProjectRole, Expired = sk.ExpirationTime < now }).ToArray();
         }
 
         /// <summary> Check that a share link is valid for a project and add the user to the project. </summary>


### PR DESCRIPTION
While considering whether SF-1198 is complete (Allow inviting users to view translation) this seemed like something that was missing, as it's not possible to tell what role a user was invited to.

![](https://user-images.githubusercontent.com/6140710/121957115-f99e7300-cd2f-11eb-9f42-b7b829dcddca.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1068)
<!-- Reviewable:end -->
