### PR TITLE
Update invitee role when user is re-invited

### DIFF
--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -373,6 +373,7 @@ namespace SIL.XForge.Scripture.Services
                 await ProjectSecrets.UpdateAsync(
                     p => p.Id == projectId && p.ShareKeys.Any(sk => sk.Email == email),
                     update => update.Set(p => p.ShareKeys[index].ExpirationTime, expTime)
+                                    .Set(p => p.ShareKeys[index].ProjectRole, role)
                 );
             }
             string key = projectSecret.ShareKeys.Single(sk => sk.Email == email).Key;


### PR DESCRIPTION
When a user is re-invited with a different role the invitation role should be updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1069)
<!-- Reviewable:end -->
