### PR TITLE
SF-1033 localize PT login

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -30,7 +30,7 @@
         "angular-file": "^3.4.0",
         "angular-split": "^4.0.0",
         "arraydiff": "^0.1.3",
-        "auth0-js": "^9.14.3",
+        "auth0-js": "^9.16.2",
         "bootstrap": "^4.6.0",
         "bowser": "^2.11.0",
         "bson-objectid": "^1.3.1",
@@ -11593,12 +11593,13 @@
       }
     },
     "node_modules/auth0-js": {
-      "version": "9.14.3",
-      "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-9.14.3.tgz",
-      "integrity": "sha512-UO/fGv9641PUpYjz2nkPaUHzzrhNaJKupJOqt8blj1pD6wBgpZtxUSXBox6Y8md3eTBzpxeWxV+6RKzzERvr1g==",
+      "version": "9.16.2",
+      "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-9.16.2.tgz",
+      "integrity": "sha512-cF1nRjmMDezmhJ+ZwwYp23F0gPqU0zNmF/VvTpcwvCrEMl9lAvkCd4iburN1I7G8SYaaIYEfcGedCphpDZw6OQ==",
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.0",
-        "idtoken-verifier": "^2.0.3",
+        "idtoken-verifier": "^2.1.2",
         "js-cookie": "^2.2.0",
         "qs": "^6.7.0",
         "superagent": "^5.3.1",
@@ -16235,12 +16236,12 @@
       }
     },
     "node_modules/idtoken-verifier": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/idtoken-verifier/-/idtoken-verifier-2.1.0.tgz",
-      "integrity": "sha512-X0423UM4Rc5bFb39Ai0YHr35rcexlu4oakKdYzSGZxtoPy84P86hhAbzlpgbgomcLOFRgzgKRvhY7YjO5g8OPA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/idtoken-verifier/-/idtoken-verifier-2.1.2.tgz",
+      "integrity": "sha512-YMHiP9zAMjB+pWreV4EHnIj3XCQ168+InWirVRFeRtlsMQIK61S+LLnyLGI8EL0wtlk/v7ya69Gjfio3P9/7Gw==",
       "dependencies": {
         "base64-js": "^1.3.0",
-        "crypto-js": "^3.2.1",
+        "crypto-js": "3.3.0",
         "es6-promise": "^4.2.8",
         "jsbn": "^1.1.0",
         "unfetch": "^4.1.0",
@@ -34112,12 +34113,12 @@
       "dev": true
     },
     "auth0-js": {
-      "version": "9.14.3",
-      "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-9.14.3.tgz",
-      "integrity": "sha512-UO/fGv9641PUpYjz2nkPaUHzzrhNaJKupJOqt8blj1pD6wBgpZtxUSXBox6Y8md3eTBzpxeWxV+6RKzzERvr1g==",
+      "version": "9.16.2",
+      "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-9.16.2.tgz",
+      "integrity": "sha512-cF1nRjmMDezmhJ+ZwwYp23F0gPqU0zNmF/VvTpcwvCrEMl9lAvkCd4iburN1I7G8SYaaIYEfcGedCphpDZw6OQ==",
       "requires": {
         "base64-js": "^1.3.0",
-        "idtoken-verifier": "^2.0.3",
+        "idtoken-verifier": "^2.1.2",
         "js-cookie": "^2.2.0",
         "qs": "^6.7.0",
         "superagent": "^5.3.1",
@@ -38023,12 +38024,12 @@
       }
     },
     "idtoken-verifier": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/idtoken-verifier/-/idtoken-verifier-2.1.0.tgz",
-      "integrity": "sha512-X0423UM4Rc5bFb39Ai0YHr35rcexlu4oakKdYzSGZxtoPy84P86hhAbzlpgbgomcLOFRgzgKRvhY7YjO5g8OPA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/idtoken-verifier/-/idtoken-verifier-2.1.2.tgz",
+      "integrity": "sha512-YMHiP9zAMjB+pWreV4EHnIj3XCQ168+InWirVRFeRtlsMQIK61S+LLnyLGI8EL0wtlk/v7ya69Gjfio3P9/7Gw==",
       "requires": {
         "base64-js": "^1.3.0",
-        "crypto-js": "^3.2.1",
+        "crypto-js": "3.3.0",
         "es6-promise": "^4.2.8",
         "jsbn": "^1.1.0",
         "unfetch": "^4.1.0",

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -44,7 +44,7 @@
     "angular-file": "^3.4.0",
     "angular-split": "^4.0.0",
     "arraydiff": "^0.1.3",
-    "auth0-js": "^9.14.3",
+    "auth0-js": "^9.16.2",
     "bootstrap": "^4.6.0",
     "bowser": "^2.11.0",
     "bson-objectid": "^1.3.1",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.guard.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.guard.spec.ts
@@ -1,0 +1,112 @@
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { anything, instance, mock, resetCalls, verify, when } from 'ts-mockito';
+import { AuthGuard } from './auth.guard';
+import { AuthService } from './auth.service';
+import { LocationService } from './location.service';
+
+const mockedAuthService = mock(AuthService);
+const mockedLocationService = mock(LocationService);
+const mockedActivatedRouteSnapshot = mock(ActivatedRouteSnapshot);
+const mockedRouterStateSnapshot = mock(RouterStateSnapshot);
+
+describe('AuthGuard', () => {
+  beforeEach(() => {
+    resetCalls(mockedAuthService);
+  });
+
+  it('should do nothing if already logged in', (done: DoneFn) => {
+    // url test pattern: https://scriptureforge.org/projects/<projectId>
+    const authGuard = new AuthGuard(instance(mockedAuthService), instance(mockedLocationService));
+    expect(authGuard).toBeDefined();
+    when(mockedAuthService.isLoggedIn).thenResolve(true);
+    when(mockedActivatedRouteSnapshot.queryParams).thenReturn({});
+
+    const canActivate$ = authGuard.canActivate(
+      instance(mockedActivatedRouteSnapshot),
+      instance(mockedRouterStateSnapshot)
+    );
+
+    canActivate$.subscribe(canActivate => {
+      expect(canActivate).toBe(true);
+      verify(mockedAuthService.logIn(anything(), anything(), anything())).never();
+      done();
+    });
+  });
+
+  it('should call logIn when not logged in', (done: DoneFn) => {
+    // url test pattern: https://scriptureforge.org/projects/<projectId>
+    const authGuard = new AuthGuard(instance(mockedAuthService), instance(mockedLocationService));
+    expect(authGuard).toBeDefined();
+    when(mockedAuthService.isLoggedIn).thenResolve(false);
+    when(mockedActivatedRouteSnapshot.queryParams).thenReturn({});
+
+    const canActivate$ = authGuard.canActivate(
+      instance(mockedActivatedRouteSnapshot),
+      instance(mockedRouterStateSnapshot)
+    );
+
+    canActivate$.subscribe(canActivate => {
+      expect(canActivate).toBe(false);
+      verify(mockedAuthService.logIn(anything(), false, undefined)).once();
+      done();
+    });
+  });
+
+  it('should call logIn when not logged in and sharing', (done: DoneFn) => {
+    // url test pattern: https://scriptureforge.org/projects/<projectId>?sharing=true&shareKey=<shareKey>
+    const authGuard = new AuthGuard(instance(mockedAuthService), instance(mockedLocationService));
+    expect(authGuard).toBeDefined();
+    when(mockedAuthService.isLoggedIn).thenResolve(false);
+    when(mockedActivatedRouteSnapshot.queryParams).thenReturn({ sharing: 'true', 'sign-up': 'false' });
+
+    const canActivate$ = authGuard.canActivate(
+      instance(mockedActivatedRouteSnapshot),
+      instance(mockedRouterStateSnapshot)
+    );
+
+    canActivate$.subscribe(canActivate => {
+      expect(canActivate).toBe(false);
+      verify(mockedAuthService.logIn(anything(), true, undefined)).once();
+      done();
+    });
+  });
+
+  it('should call logIn when not logged in and signing up', (done: DoneFn) => {
+    // url test pattern: https://scriptureforge.org/projects/<projectId>?sign-up=true
+    const authGuard = new AuthGuard(instance(mockedAuthService), instance(mockedLocationService));
+    expect(authGuard).toBeDefined();
+    when(mockedAuthService.isLoggedIn).thenResolve(false);
+    when(mockedActivatedRouteSnapshot.queryParams).thenReturn({ sharing: '', 'sign-up': 'true' });
+
+    const canActivate$ = authGuard.canActivate(
+      instance(mockedActivatedRouteSnapshot),
+      instance(mockedRouterStateSnapshot)
+    );
+
+    canActivate$.subscribe(canActivate => {
+      expect(canActivate).toBe(false);
+      verify(mockedAuthService.logIn(anything(), true, undefined)).once();
+      done();
+    });
+  });
+
+  it('should call logIn when not logged in with locale', (done: DoneFn) => {
+    // url test pattern: https://scriptureforge.org/projects/<projectId>?locale=es
+    const authGuard = new AuthGuard(instance(mockedAuthService), instance(mockedLocationService));
+    expect(authGuard).toBeDefined();
+    when(mockedAuthService.isLoggedIn).thenResolve(false);
+    const locale = 'es';
+    when(mockedActivatedRouteSnapshot.queryParams).thenReturn({ locale });
+
+    const canActivate$ = authGuard.canActivate(
+      instance(mockedActivatedRouteSnapshot),
+      instance(mockedRouterStateSnapshot)
+    );
+
+    canActivate$.subscribe(canActivate => {
+      expect(canActivate).toBe(false);
+      verify(mockedAuthService.logIn(anything(), false, locale)).once();
+      done();
+    });
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.guard.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.guard.ts
@@ -16,7 +16,8 @@ export class AuthGuard implements CanActivate {
       tap(isLoggedIn => {
         if (!isLoggedIn) {
           const signUp = next.queryParams['sharing'] === 'true' || next.queryParams['sign-up'] === 'true';
-          this.authService.logIn(this.locationService.pathname + this.locationService.search, signUp);
+          const locale = next.queryParams['locale'];
+          this.authService.logIn(this.locationService.pathname + this.locationService.search, signUp, locale);
         }
       })
     );

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.guard.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.guard.ts
@@ -11,12 +11,12 @@ import { LocationService } from './location.service';
 export class AuthGuard implements CanActivate {
   constructor(private readonly authService: AuthService, private readonly locationService: LocationService) {}
 
-  canActivate(next: ActivatedRouteSnapshot, _state: RouterStateSnapshot): Observable<boolean> {
+  canActivate(route: ActivatedRouteSnapshot, _state: RouterStateSnapshot): Observable<boolean> {
     return this.allowTransition().pipe(
       tap(isLoggedIn => {
         if (!isLoggedIn) {
-          const signUp = next.queryParams['sharing'] === 'true' || next.queryParams['sign-up'] === 'true';
-          const locale = next.queryParams['locale'];
+          const signUp = route.queryParams['sharing'] === 'true' || route.queryParams['sign-up'] === 'true';
+          const locale: string = route.queryParams['locale'];
           this.authService.logIn(this.locationService.pathname + this.locationService.search, signUp, locale);
         }
       })

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
@@ -1,0 +1,138 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { WebAuth } from 'auth0-js';
+import { CookieService } from 'ngx-cookie-service';
+import { of } from 'rxjs';
+import { anyString, anything, capture, instance, mock, resetCalls, verify, when } from 'ts-mockito';
+import { AuthService } from './auth.service';
+import { Auth0Service } from './auth0.service';
+import { BugsnagService } from './bugsnag.service';
+import { CommandService } from './command.service';
+import { ErrorReportingService } from './error-reporting.service';
+import { LocalSettingsService } from './local-settings.service';
+import { LocationService } from './location.service';
+import { NoticeService } from './notice.service';
+import { OfflineStore } from './offline-store';
+import { PwaService } from './pwa.service';
+import { SharedbRealtimeRemoteStore } from './sharedb-realtime-remote-store';
+import { configureTestingModule } from './test-utils';
+import { aspCultureCookieValue } from './utils';
+
+const mockedAuth0Service = mock(Auth0Service);
+const mockedSharedbRealtimeRemoteStore = mock(SharedbRealtimeRemoteStore);
+const mockedOfflineStore = mock(OfflineStore);
+const mockedLocationService = mock(LocationService);
+const mockedCommandService = mock(CommandService);
+const mockedBugsnagService = mock(BugsnagService);
+const mockedCookieService = mock(CookieService);
+const mockedRouter = mock(Router);
+const mockedLocalSettingsService = mock(LocalSettingsService);
+const mockedPwaService = mock(PwaService);
+const mockedNoticeService = mock(NoticeService);
+const mockedErrorReportingService = mock(ErrorReportingService);
+const mockedWebAuth = mock(WebAuth);
+
+describe('AuthService', () => {
+  configureTestingModule(() => ({
+    imports: [RouterTestingModule],
+    providers: [
+      AuthService,
+      { provide: Auth0Service, useMock: mockedAuth0Service },
+      { provide: SharedbRealtimeRemoteStore, useMock: mockedSharedbRealtimeRemoteStore },
+      { provide: OfflineStore, useMock: mockedOfflineStore },
+      { provide: LocationService, useMock: mockedLocationService },
+      { provide: CommandService, useMock: mockedCommandService },
+      { provide: BugsnagService, useMock: mockedBugsnagService },
+      { provide: CookieService, useMock: mockedCookieService },
+      { provide: Router, useMock: mockedRouter },
+      { provide: LocalSettingsService, useMock: mockedLocalSettingsService },
+      { provide: PwaService, useMock: mockedPwaService },
+      { provide: NoticeService, useMock: mockedNoticeService },
+      { provide: ErrorReportingService, useMock: mockedErrorReportingService }
+    ]
+  }));
+
+  it('should login', () => {
+    const env = new TestEnvironment();
+    const returnUrl = 'test-returnUrl';
+
+    env.service.logIn(returnUrl);
+
+    verify(mockedWebAuth.authorize(anything())).once();
+    const [authOptions] = capture(mockedWebAuth.authorize).last();
+    expect(authOptions).toBeDefined();
+    if (authOptions != null) {
+      expect(authOptions.state).toEqual(`{"returnUrl":"${returnUrl}"}`);
+      expect(authOptions.language).toEqual(env.language);
+      expect(authOptions.login_hint).toEqual(env.language);
+      expect(authOptions.mode).toBeUndefined();
+    }
+  });
+
+  it('should login without signup', () => {
+    const env = new TestEnvironment();
+    const returnUrl = 'test-returnUrl';
+    const signUp = false;
+
+    env.service.logIn(returnUrl, signUp);
+
+    verify(mockedWebAuth.authorize(anything())).once();
+    const [authOptions] = capture(mockedWebAuth.authorize).last();
+    expect(authOptions).toBeDefined();
+    if (authOptions != null) {
+      expect(authOptions.language).toEqual(env.language);
+      expect(authOptions.login_hint).toEqual(env.language);
+      expect(authOptions.mode).toBeUndefined();
+    }
+  });
+
+  it('should login with signup', () => {
+    const env = new TestEnvironment();
+    const returnUrl = 'test-returnUrl';
+    const signUp = true;
+
+    env.service.logIn(returnUrl, signUp);
+
+    verify(mockedWebAuth.authorize(anything())).once();
+    const [authOptions] = capture(mockedWebAuth.authorize).last();
+    expect(authOptions).toBeDefined();
+    if (authOptions != null) {
+      expect(authOptions.language).toEqual(env.language);
+      expect(authOptions.login_hint).toEqual(env.language);
+      expect(authOptions.mode).toEqual('signUp');
+    }
+  });
+
+  it('should login with signup and locale', () => {
+    const env = new TestEnvironment();
+    const returnUrl = 'test-returnUrl';
+    const signUp = true;
+    const locale = 'es';
+    expect(locale).not.toEqual(env.language, 'setup');
+
+    env.service.logIn(returnUrl, signUp, locale);
+
+    verify(mockedWebAuth.authorize(anything())).once();
+    const [authOptions] = capture(mockedWebAuth.authorize).last();
+    expect(authOptions).toBeDefined();
+    if (authOptions != null) {
+      expect(authOptions.language).toEqual(env.language);
+      expect(authOptions.login_hint).toEqual(locale);
+      expect(authOptions.mode).toEqual('signUp');
+    }
+  });
+});
+
+class TestEnvironment {
+  readonly service: AuthService;
+  readonly language = 'fr';
+
+  constructor() {
+    resetCalls(mockedWebAuth);
+    when(mockedAuth0Service.init(anything())).thenReturn(instance(mockedWebAuth));
+    when(mockedLocalSettingsService.remoteChanges$).thenReturn(of());
+    when(mockedCookieService.get(anyString())).thenReturn(aspCultureCookieValue(this.language));
+    this.service = TestBed.inject(AuthService);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -20,7 +20,7 @@ import { NoticeService } from './notice.service';
 import { OfflineStore } from './offline-store';
 import { SharedbRealtimeRemoteStore } from './sharedb-realtime-remote-store';
 import { USERS_URL } from './url-constants';
-import { ASP_CULTURE_COOKIE_NAME, getAspCultureCookieLanguage, getI18nLocales } from './utils';
+import { ASP_CULTURE_COOKIE_NAME, getAspCultureCookieLanguage } from './utils';
 
 const XF_USER_ID_CLAIM = 'http://xforge.org/userid';
 const XF_ROLE_CLAIM = 'http://xforge.org/role';
@@ -162,21 +162,14 @@ export class AuthService {
     return true;
   }
 
-  logIn(returnUrl: string, signUp?: boolean): void {
+  logIn(returnUrl: string, signUp?: boolean, locale?: string): void {
     const state: AuthState = { returnUrl };
-    const tag = getAspCultureCookieLanguage(this.cookieService.get(ASP_CULTURE_COOKIE_NAME));
-    const i18nLocales = getI18nLocales();
-    const locales = environment.production ? i18nLocales.filter(locale => locale.production) : i18nLocales;
-    const options: LanguageOption[] = locales.map(locale => {
-      const result = { value: locale.canonicalTag, label: locale.localName };
-      if (!environment.production && !locale.production) {
-        result.label += ' *';
-      }
-      return result;
-    });
-    const authOptions: AuthorizeOptions = { state: JSON.stringify(state), language: JSON.stringify({ tag, options }) };
+    const language: string = getAspCultureCookieLanguage(this.cookieService.get(ASP_CULTURE_COOKIE_NAME));
+    const ui_locales: string = language;
+    const authOptions: AuthorizeOptions = { state: JSON.stringify(state), language, login_hint: ui_locales };
     if (signUp) {
-      authOptions.login_hint = 'signUp';
+      authOptions.mode = 'signUp';
+      authOptions.login_hint = locale ?? ui_locales;
     }
     if (environment.beta) {
       window.parent.postMessage(<BetaMigrationMessage>{ message: 'login_required' }, environment.masterUrl);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { translate } from '@ngneat/transloco';
-import { Auth0DecodedHash, AuthorizeOptions, WebAuth } from 'auth0-js';
+import { Auth0DecodedHash, AuthorizeOptions } from 'auth0-js';
 import jwtDecode from 'jwt-decode';
 import { clone } from 'lodash-es';
 import { CookieService } from 'ngx-cookie-service';
@@ -11,6 +11,7 @@ import { filter, mergeMap } from 'rxjs/operators';
 import { BetaMigrationMessage } from 'xforge-common/beta-migration/beta-migration.component';
 import { PwaService } from 'xforge-common/pwa.service';
 import { environment } from '../environments/environment';
+import { Auth0Service } from './auth0.service';
 import { BugsnagService } from './bugsnag.service';
 import { CommandError, CommandService } from './command.service';
 import { ErrorReportingService } from './error-reporting.service';
@@ -36,11 +37,6 @@ interface AuthState {
   linking?: boolean;
 }
 
-interface LanguageOption {
-  value: string;
-  label?: string;
-}
-
 interface LoginResult {
   loggedIn: boolean;
   newlyLoggedIn: boolean;
@@ -56,7 +52,7 @@ export class AuthService {
   private renewTokenPromise?: Promise<void>;
   private checkSessionPromise?: Promise<Auth0DecodedHash | null>;
 
-  private readonly auth0 = new WebAuth({
+  private readonly auth0 = this.auth0Service.init({
     clientID: environment.authClientId,
     domain: environment.authDomain,
     responseType: 'token id_token',
@@ -70,6 +66,7 @@ export class AuthService {
   );
 
   constructor(
+    private readonly auth0Service: Auth0Service,
     private readonly remoteStore: SharedbRealtimeRemoteStore,
     private readonly offlineStore: OfflineStore,
     private readonly locationService: LocationService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth0.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth0.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { AuthOptions, WebAuth } from 'auth0-js';
+
+/**
+ * Wrapper around WebAuth. This injectable service can be mocked to make dependencies of it testable.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class Auth0Service {
+  init(options: AuthOptions): WebAuth {
+    return new WebAuth(options);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
@@ -204,7 +204,7 @@ class TestEnvironment {
   } as UserDoc;
 
   constructor() {
-    this.service = TestBed.get(ExceptionHandlingService);
+    this.service = TestBed.inject(ExceptionHandlingService);
     this.fixture = TestBed.createComponent(HostComponent);
     this.fixture.detectChanges();
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.spec.ts
@@ -13,7 +13,6 @@ import { createDeletionFileData, createStorageFileData, FileOfflineData, FileTyp
 import { ProjectDataDoc } from './models/project-data-doc';
 import { NoticeService } from './notice.service';
 import { PwaService } from './pwa.service';
-import { RealtimeService } from './realtime.service';
 import { TestRealtimeModule } from './test-realtime.module';
 import { TestRealtimeService } from './test-realtime.service';
 import { TypeRegistry } from './type-registry';

--- a/src/SIL.XForge.Scripture/Pages/Index.cshtml
+++ b/src/SIL.XForge.Scripture/Pages/Index.cshtml
@@ -4,23 +4,23 @@
 @inject IHtmlLocalizer<SharedResource> SharedLocalizer
 @model IndexModel
 @section scripts {
-    <script src="https://cdn.auth0.com/js/auth0/9.10/auth0.min.js"></script>
-    <script type="text/javascript">
-        var webAuth = new auth0.WebAuth({
-            clientID: '@ViewData["ClientId"]',
-            domain: '@ViewData["Domain"]',
-            responseType: 'token id_token',
-            redirectUri: window.location.origin + '/projects',
-            scope: 'openid profile email @ViewData["Scope"]',
-            audience: '@ViewData["Audience"]'
-        });
-        webAuth.checkSession({}, function (err, authResult) {
-            if (!err) {
-                var options = { state: JSON.stringify({}) };
-                webAuth.authorize(options);
-            }
-        });
-    </script>
+<script src="https://cdn.auth0.com/js/auth0/9.16/auth0.min.js"></script>
+<script type="text/javascript">
+    var webAuth = new auth0.WebAuth({
+        clientID: '@ViewData["ClientId"]',
+        domain: '@ViewData["Domain"]',
+        responseType: 'token id_token',
+        redirectUri: window.location.origin + '/projects',
+        scope: 'openid profile email @ViewData["Scope"]',
+        audience: '@ViewData["Audience"]'
+    });
+    webAuth.checkSession({}, function (err, authResult) {
+        if (!err) {
+            var options = { state: JSON.stringify({}) };
+            webAuth.authorize(options);
+        }
+    });
+</script>
 }
 
 <section id="hero">
@@ -76,17 +76,20 @@
                     <div class="about-feature">
                         <img src="~/images/logo-paratext.svg" loading="lazy" alt="Paratext">
                         <span>@Localizer["AboutParatext"]</span>
-                        <p>@(Html.Raw(Model.Localizer["AboutParatextDescription", "<span class=\"highlight\">", "</span>"]))</p>
+                        <p>@(Html.Raw(Model.Localizer["AboutParatextDescription", "<span class=\"highlight\">",
+                            "</span>"]))</p>
                     </div>
                     <div class="about-feature">
                         <i class="material-icons">shuffle</i>
                         <span>@Localizer["AboutFlexible"]</span>
-                        <p>@(Html.Raw(Model.Localizer["AboutFlexibleDescription", "<span class=\"highlight\">", "</span>"]))</p>
+                        <p>@(Html.Raw(Model.Localizer["AboutFlexibleDescription", "<span class=\"highlight\">",
+                            "</span>"]))</p>
                     </div>
                     <div class="about-feature">
                         <i class="material-icons">group</i>
                         <span>@Localizer["AboutUserEngagement"]</span>
-                        <p>@(Html.Raw(Model.Localizer["AboutUserEngagementDescription", "<span class=\"highlight\">", "</span>"]))</p>
+                        <p>@(Html.Raw(Model.Localizer["AboutUserEngagementDescription", "<span class=\"highlight\">",
+                            "</span>"]))</p>
                     </div>
                 </div>
             </div>
@@ -119,8 +122,10 @@
                     @Localizer["Statement"]
                 </div>
                 <div class="statement-buttons flex justify-content-center">
-                    <a asp-page="LearnMore" class="mdl-button mdl-button--raised mdl-button--colored button-lg">@SharedLocalizer[SharedResource.Keys.LearnMore]</a>
-                    <a class="mdl-button mdl-button--raised mdl-button--accent button-lg" href="/login?sign-up=true">@SharedLocalizer[SharedResource.Keys.SignUp]</a>
+                    <a asp-page="LearnMore"
+                        class="mdl-button mdl-button--raised mdl-button--colored button-lg">@SharedLocalizer[SharedResource.Keys.LearnMore]</a>
+                    <a class="mdl-button mdl-button--raised mdl-button--accent button-lg"
+                        href="/login?sign-up=true">@SharedLocalizer[SharedResource.Keys.SignUp]</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- pass language through Auth0 so PT login is localized
- stop using Auth0 language picker
- also fixes using the locale from an invite link

This is a draft waiting on a dependent change. Please first review https://github.com/sillsdev/auth0-configs/pull/100. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1074)
<!-- Reviewable:end -->
