### PR TITLE
SF-1357: Translators can now sync

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app-routing.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app-routing.module.ts
@@ -8,7 +8,7 @@ import { ConnectProjectComponent } from './connect-project/connect-project.compo
 import { ProjectComponent } from './project/project.component';
 import { SettingsComponent } from './settings/settings.component';
 import { PageNotFoundComponent } from './shared/page-not-found/page-not-found.component';
-import { SFAdminAuthGuard, SFTranslatorAuthGuard } from './shared/project-router.guard';
+import { SettingsAuthGuard, SyncAuthGuard } from './shared/project-router.guard';
 import { StartComponent } from './start/start.component';
 import { SyncComponent } from './sync/sync.component';
 
@@ -16,8 +16,8 @@ const routes: Routes = [
   { path: 'connect-project', component: ConnectProjectComponent, canActivate: [AuthGuard] },
   { path: 'login', redirectTo: 'projects', pathMatch: 'full' },
   { path: 'migration', component: BetaMigrationComponent, canActivate: [AuthGuard] },
-  { path: 'projects/:projectId/settings', component: SettingsComponent, canActivate: [SFAdminAuthGuard] },
-  { path: 'projects/:projectId/sync', component: SyncComponent, canActivate: [SFTranslatorAuthGuard] },
+  { path: 'projects/:projectId/settings', component: SettingsComponent, canActivate: [SettingsAuthGuard] },
+  { path: 'projects/:projectId/sync', component: SyncComponent, canActivate: [SyncAuthGuard] },
   { path: 'projects/:projectId', component: ProjectComponent, canActivate: [AuthGuard] },
   { path: 'projects', component: StartComponent, canActivate: [AuthGuard] },
   { path: 'system-administration', component: SystemAdministrationComponent, canActivate: [SystemAdminAuthGuard] },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app-routing.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app-routing.module.ts
@@ -17,7 +17,7 @@ const routes: Routes = [
   { path: 'login', redirectTo: 'projects', pathMatch: 'full' },
   { path: 'migration', component: BetaMigrationComponent, canActivate: [AuthGuard] },
   { path: 'projects/:projectId/settings', component: SettingsComponent, canActivate: [SFAdminAuthGuard] },
-  { path: 'projects/:projectId/sync', component: SyncComponent, canActivate: [SFAdminAuthGuard] },
+  { path: 'projects/:projectId/sync', component: SyncComponent, canActivate: [AuthGuard] },
   { path: 'projects/:projectId', component: ProjectComponent, canActivate: [AuthGuard] },
   { path: 'projects', component: StartComponent, canActivate: [AuthGuard] },
   { path: 'system-administration', component: SystemAdministrationComponent, canActivate: [SystemAdminAuthGuard] },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app-routing.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app-routing.module.ts
@@ -8,7 +8,7 @@ import { ConnectProjectComponent } from './connect-project/connect-project.compo
 import { ProjectComponent } from './project/project.component';
 import { SettingsComponent } from './settings/settings.component';
 import { PageNotFoundComponent } from './shared/page-not-found/page-not-found.component';
-import { SFAdminAuthGuard } from './shared/project-router.guard';
+import { SFAdminAuthGuard, SFTranslatorAuthGuard } from './shared/project-router.guard';
 import { StartComponent } from './start/start.component';
 import { SyncComponent } from './sync/sync.component';
 
@@ -17,7 +17,7 @@ const routes: Routes = [
   { path: 'login', redirectTo: 'projects', pathMatch: 'full' },
   { path: 'migration', component: BetaMigrationComponent, canActivate: [AuthGuard] },
   { path: 'projects/:projectId/settings', component: SettingsComponent, canActivate: [SFAdminAuthGuard] },
-  { path: 'projects/:projectId/sync', component: SyncComponent, canActivate: [AuthGuard] },
+  { path: 'projects/:projectId/sync', component: SyncComponent, canActivate: [SFTranslatorAuthGuard] },
   { path: 'projects/:projectId', component: ProjectComponent, canActivate: [AuthGuard] },
   { path: 'projects', component: StartComponent, canActivate: [AuthGuard] },
   { path: 'system-administration', component: SystemAdministrationComponent, canActivate: [SystemAdminAuthGuard] },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -235,15 +235,17 @@
             </mdc-list-item>
           </ng-container>
         </div>
-        <mdc-list-divider *ngIf="isCheckingEnabled"></mdc-list-divider>
-        <mdc-list-item
-          [appRouterLink]="getRouterLink('sync')"
-          [class.list-item-disabled]="!isAppOnline"
-          (selectionChange)="itemSelected()"
-        >
-          <mdc-icon mdcListItemGraphic>sync</mdc-icon>
-          {{ t("synchronize") }}
-        </mdc-list-item>
+        <div *ngIf="isProjectTranslator$ | async">
+          <mdc-list-divider *ngIf="isCheckingEnabled"></mdc-list-divider>
+          <mdc-list-item
+            [appRouterLink]="getRouterLink('sync')"
+            [class.list-item-disabled]="!isAppOnline"
+            (selectionChange)="itemSelected()"
+          >
+            <mdc-icon mdcListItemGraphic>sync</mdc-icon>
+            {{ t("synchronize") }}
+          </mdc-list-item>
+        </div>
         <div *ngIf="isProjectAdmin$ | async">
           <mdc-list-item
             [appRouterLink]="getRouterLink('settings')"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -235,7 +235,7 @@
             </mdc-list-item>
           </ng-container>
         </div>
-        <div *ngIf="isProjectTranslator$ | async">
+        <div *ngIf="canSync$ | async">
           <mdc-list-divider *ngIf="isCheckingEnabled"></mdc-list-divider>
           <mdc-list-item
             [appRouterLink]="getRouterLink('sync')"
@@ -246,7 +246,7 @@
             {{ t("synchronize") }}
           </mdc-list-item>
         </div>
-        <div *ngIf="isProjectAdmin$ | async">
+        <div *ngIf="canSeeSettings$ | async">
           <mdc-list-item
             [appRouterLink]="getRouterLink('settings')"
             [class.list-item-disabled]="!isAppOnline"
@@ -255,6 +255,8 @@
             <mdc-icon mdcListItemGraphic>settings</mdc-icon>
             {{ t("settings") }}
           </mdc-list-item>
+        </div>
+        <div *ngIf="canSeeUsers$ | async">
           <mdc-list-item
             [appRouterLink]="getRouterLink('users')"
             [class.list-item-disabled]="!isAppOnline"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -235,16 +235,16 @@
             </mdc-list-item>
           </ng-container>
         </div>
+        <mdc-list-divider *ngIf="isCheckingEnabled"></mdc-list-divider>
+        <mdc-list-item
+          [appRouterLink]="getRouterLink('sync')"
+          [class.list-item-disabled]="!isAppOnline"
+          (selectionChange)="itemSelected()"
+        >
+          <mdc-icon mdcListItemGraphic>sync</mdc-icon>
+          {{ t("synchronize") }}
+        </mdc-list-item>
         <div *ngIf="isProjectAdmin$ | async">
-          <mdc-list-divider *ngIf="isCheckingEnabled"></mdc-list-divider>
-          <mdc-list-item
-            [appRouterLink]="getRouterLink('sync')"
-            [class.list-item-disabled]="!isAppOnline"
-            (selectionChange)="itemSelected()"
-          >
-            <mdc-icon mdcListItemGraphic>sync</mdc-icon>
-            {{ t("synchronize") }}
-          </mdc-list-item>
           <mdc-list-item
             [appRouterLink]="getRouterLink('settings')"
             [class.list-item-disabled]="!isAppOnline"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -39,7 +39,7 @@ import { SFProjectDoc } from './core/models/sf-project-doc';
 import { canAccessTranslateApp } from './core/models/sf-project-role-info';
 import { SFProjectService } from './core/sf-project.service';
 import { ProjectDeletedDialogComponent } from './project-deleted-dialog/project-deleted-dialog.component';
-import { SFAdminAuthGuard } from './shared/project-router.guard';
+import { SFAdminAuthGuard, SFTranslatorAuthGuard } from './shared/project-router.guard';
 
 declare function gtag(...args: any): void;
 
@@ -65,6 +65,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
 
   projectDocs?: SFProjectDoc[];
   isProjectAdmin$?: Observable<boolean>;
+  isProjectTranslator$?: Observable<boolean>;
   hasUpdate: boolean = false;
 
   private currentUserDoc?: UserDoc;
@@ -85,6 +86,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     private readonly projectService: SFProjectService,
     private readonly route: ActivatedRoute,
     private readonly adminAuthGuard: SFAdminAuthGuard,
+    private readonly translatorAuthGuard: SFTranslatorAuthGuard,
     private readonly dialog: MdcDialog,
     private readonly fileService: FileService,
     private readonly reportingService: ErrorReportingService,
@@ -358,6 +360,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
         distinctUntilChanged(),
         tap(projectId => {
           this.isProjectAdmin$ = this.adminAuthGuard.allowTransition(projectId);
+          this.isProjectTranslator$ = this.translatorAuthGuard.allowTransition(projectId);
           // the project deleted dialog should be closed by now, so we can reset its ref to null
           if (projectId == null) {
             this.projectDeletedDialogRef = null;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -39,7 +39,7 @@ import { SFProjectDoc } from './core/models/sf-project-doc';
 import { canAccessTranslateApp } from './core/models/sf-project-role-info';
 import { SFProjectService } from './core/sf-project.service';
 import { ProjectDeletedDialogComponent } from './project-deleted-dialog/project-deleted-dialog.component';
-import { SFAdminAuthGuard, SFTranslatorAuthGuard } from './shared/project-router.guard';
+import { SettingsAuthGuard, SyncAuthGuard, UsersAuthGuard } from './shared/project-router.guard';
 
 declare function gtag(...args: any): void;
 
@@ -64,8 +64,9 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   checkingVisible: boolean = false;
 
   projectDocs?: SFProjectDoc[];
-  isProjectAdmin$?: Observable<boolean>;
-  isProjectTranslator$?: Observable<boolean>;
+  canSeeSettings$?: Observable<boolean>;
+  canSeeUsers$?: Observable<boolean>;
+  canSync$?: Observable<boolean>;
   hasUpdate: boolean = false;
 
   private currentUserDoc?: UserDoc;
@@ -85,8 +86,9 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     private readonly userService: UserService,
     private readonly projectService: SFProjectService,
     private readonly route: ActivatedRoute,
-    private readonly adminAuthGuard: SFAdminAuthGuard,
-    private readonly translatorAuthGuard: SFTranslatorAuthGuard,
+    private readonly settingsAuthGuard: SettingsAuthGuard,
+    private readonly syncAuthGuard: SyncAuthGuard,
+    private readonly usersAuthGuard: UsersAuthGuard,
     private readonly dialog: MdcDialog,
     private readonly fileService: FileService,
     private readonly reportingService: ErrorReportingService,
@@ -359,8 +361,9 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
         map(r => r.params['projectId'] as string),
         distinctUntilChanged(),
         tap(projectId => {
-          this.isProjectAdmin$ = this.adminAuthGuard.allowTransition(projectId);
-          this.isProjectTranslator$ = this.translatorAuthGuard.allowTransition(projectId);
+          this.canSeeSettings$ = this.settingsAuthGuard.allowTransition(projectId);
+          this.canSeeUsers$ = this.usersAuthGuard.allowTransition(projectId);
+          this.canSync$ = this.syncAuthGuard.allowTransition(projectId);
           // the project deleted dialog should be closed by now, so we can reset its ref to null
           if (projectId == null) {
             this.projectDeletedDialogRef = null;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/project-router.guard.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/project-router.guard.ts
@@ -34,7 +34,7 @@ abstract class RouterGuard implements CanActivate {
 @Injectable({
   providedIn: 'root'
 })
-export class SFAdminAuthGuard extends RouterGuard {
+export class SettingsAuthGuard extends RouterGuard {
   constructor(authGuard: AuthGuard, projectService: SFProjectService, private userService: UserService) {
     super(authGuard, projectService);
   }
@@ -50,7 +50,23 @@ export class SFAdminAuthGuard extends RouterGuard {
 @Injectable({
   providedIn: 'root'
 })
-export class SFTranslatorAuthGuard extends RouterGuard {
+export class UsersAuthGuard extends RouterGuard {
+  constructor(authGuard: AuthGuard, projectService: SFProjectService, private userService: UserService) {
+    super(authGuard, projectService);
+  }
+
+  check(projectDoc: SFProjectDoc): boolean {
+    return (
+      projectDoc.data != null &&
+      projectDoc.data.userRoles[this.userService.currentUserId] === SFProjectRole.ParatextAdministrator
+    );
+  }
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SyncAuthGuard extends RouterGuard {
   constructor(authGuard: AuthGuard, projectService: SFProjectService, private userService: UserService) {
     super(authGuard, projectService);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/project-router.guard.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/project-router.guard.ts
@@ -50,6 +50,23 @@ export class SFAdminAuthGuard extends RouterGuard {
 @Injectable({
   providedIn: 'root'
 })
+export class SFTranslatorAuthGuard extends RouterGuard {
+  constructor(authGuard: AuthGuard, projectService: SFProjectService, private userService: UserService) {
+    super(authGuard, projectService);
+  }
+
+  check(projectDoc: SFProjectDoc): boolean {
+    return (
+      projectDoc.data != null &&
+      (projectDoc.data.userRoles[this.userService.currentUserId] === SFProjectRole.ParatextAdministrator ||
+        projectDoc.data.userRoles[this.userService.currentUserId] === SFProjectRole.ParatextTranslator)
+    );
+  }
+}
+
+@Injectable({
+  providedIn: 'root'
+})
 export class CheckingAuthGuard extends RouterGuard {
   constructor(authGuard: AuthGuard, projectService: SFProjectService, private router: Router) {
     super(authGuard, projectService);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/users-routing.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/users-routing.module.ts
@@ -1,10 +1,10 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { SFAdminAuthGuard } from '../shared/project-router.guard';
+import { UsersAuthGuard } from '../shared/project-router.guard';
 import { UsersComponent } from './users.component';
 
 const routes: Routes = [
-  { path: 'projects/:projectId/users', component: UsersComponent, canActivate: [SFAdminAuthGuard] }
+  { path: 'projects/:projectId/users', component: UsersComponent, canActivate: [UsersAuthGuard] }
 ];
 
 @NgModule({

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -422,7 +422,8 @@ namespace SIL.XForge.Scripture.Services
                 {
                     // The Id is the value from TextData.GetTextDocId()
                     string textId = textDoc.Id;
-                    userId = await _realtimeService.GetLastModifiedUserIdAsync<TextData>(textId);
+                    int version = textDoc.Version;
+                    userId = await _realtimeService.GetLastModifiedUserIdAsync<TextData>(textId, version);
 
                     // Check that this user still has write permissions
                     if (string.IsNullOrEmpty(userId)

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -423,6 +423,15 @@ namespace SIL.XForge.Scripture.Services
                     // The Id is the value from TextData.GetTextDocId()
                     string textId = textDoc.Id;
                     userId = await _realtimeService.GetLastModifiedUserIdAsync<TextData>(textId);
+
+                    // Check that this user still has write permissions
+                    if (string.IsNullOrEmpty(userId)
+                        || !chapter.Permissions.TryGetValue(userId, out string permission)
+                        || permission != TextInfoPermission.Write)
+                    {
+                        // They no longer have write access, so reset the user id, and find it below
+                        userId = null;
+                    }
                 }
 
                 // If we do not have a record of the last user to modify this chapter

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -323,13 +323,6 @@ namespace SIL.XForge.Scripture.Services
 
         public async Task SyncAsync(string curUserId, string projectId)
         {
-            Attempt<SFProject> attempt = await RealtimeService.TryGetSnapshotAsync<SFProject>(projectId);
-            if (!attempt.TryResult(out SFProject project))
-                throw new DataNotFoundException("The project does not exist.");
-
-            if (!IsProjectAdmin(project, curUserId))
-                throw new ForbiddenException();
-
             await _syncService.SyncAsync(curUserId, projectId, false);
         }
 

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -323,6 +323,13 @@ namespace SIL.XForge.Scripture.Services
 
         public async Task SyncAsync(string curUserId, string projectId)
         {
+            Attempt<SFProject> attempt = await RealtimeService.TryGetSnapshotAsync<SFProject>(projectId);
+            if (!attempt.TryResult(out SFProject project))
+                throw new DataNotFoundException("The project does not exist.");
+
+            if (!(IsProjectAdmin(project, curUserId) || IsProjectTranslator(project, curUserId)))
+                throw new ForbiddenException();
+
             await _syncService.SyncAsync(curUserId, projectId, false);
         }
 

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -332,7 +332,7 @@ namespace SIL.XForge.Scripture.Services
             if (!attempt.TryResult(out SFProject project))
                 throw new DataNotFoundException("The project does not exist.");
 
-            if (!IsProjectAdmin(project, curUserId))
+            if (!(IsProjectAdmin(project, curUserId) || IsProjectTranslator(project, curUserId)))
                 throw new ForbiddenException();
 
             await _syncService.CancelSyncAsync(curUserId, projectId);
@@ -762,6 +762,22 @@ namespace SIL.XForge.Scripture.Services
             {
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Determines whether the user is a project translator for the specified project.
+        /// </summary>
+        /// <param name="project">The project.</param>
+        /// <param name="userId">The user identifier.</param>
+        /// <returns>
+        ///   <c>true</c> if a project translator; otherwise, <c>false</c>.
+        /// </returns>
+        /// <remarks>
+        /// This only checks the local project, and is based on <see cref="ProjectService.IsProjectAdmin" />.
+        /// </remarks>
+        private static bool IsProjectTranslator(SFProject project, string userId)
+        {
+            return project.UserRoles.TryGetValue(userId, out string role) && role == SFProjectRole.Translator;
         }
 
         private static void UpdateSetting<T>(Json0OpBuilder<SFProject> builder, Expression<Func<SFProject, T>> field,

--- a/src/SIL.XForge/Realtime/IRealtimeService.cs
+++ b/src/SIL.XForge/Realtime/IRealtimeService.cs
@@ -17,5 +17,7 @@ namespace SIL.XForge.Realtime
 
         Task DeleteProjectAsync(string projectId);
         Task DeleteUserAsync(string userId);
+
+        Task<string> GetLastModifiedUserIdAsync<T>(string id) where T : IIdentifiable;
     }
 }

--- a/src/SIL.XForge/Realtime/IRealtimeService.cs
+++ b/src/SIL.XForge/Realtime/IRealtimeService.cs
@@ -18,6 +18,6 @@ namespace SIL.XForge.Realtime
         Task DeleteProjectAsync(string projectId);
         Task DeleteUserAsync(string userId);
 
-        Task<string> GetLastModifiedUserIdAsync<T>(string id) where T : IIdentifiable;
+        Task<string> GetLastModifiedUserIdAsync<T>(string id, int version) where T : IIdentifiable;
     }
 }

--- a/src/SIL.XForge/Realtime/MemoryRealtimeService.cs
+++ b/src/SIL.XForge/Realtime/MemoryRealtimeService.cs
@@ -42,6 +42,17 @@ namespace SIL.XForge.Realtime
         }
 
         /// <summary>
+        /// Gets or sets the last modified user identifier.
+        /// </summary>
+        /// <value>
+        /// The last modified user identifier.
+        /// </value>
+        /// <remarks>
+        /// This is only for unit test use.
+        /// </remarks>
+        public string LastModifiedUserId { get; set; }
+
+        /// <summary>
         /// Count of calls to DeleteUserAsync(), for tests.
         /// </summary>
         internal int CallCountDeleteUserAsync { get; set; } = 0;
@@ -76,9 +87,18 @@ namespace SIL.XForge.Realtime
             return docConfig.CollectionName;
         }
 
+        /// <summary>
+        /// Gets the last modified user's identifier asynchronously.
+        /// </summary>
+        /// <returns>
+        /// Null.
+        /// </returns>
+        /// <remarks>
+        /// This is overridable for unit tests.
+        /// </remarks>
         public Task<string> GetLastModifiedUserIdAsync<T>(string id) where T : IIdentifiable
         {
-            return Task.FromResult<string>(null);
+            return Task.FromResult<string>(LastModifiedUserId);
         }
 
         public IQueryable<T> QuerySnapshots<T>() where T : IIdentifiable

--- a/src/SIL.XForge/Realtime/MemoryRealtimeService.cs
+++ b/src/SIL.XForge/Realtime/MemoryRealtimeService.cs
@@ -96,9 +96,9 @@ namespace SIL.XForge.Realtime
         /// <remarks>
         /// This is overridable for unit tests.
         /// </remarks>
-        public Task<string> GetLastModifiedUserIdAsync<T>(string id) where T : IIdentifiable
+        public Task<string> GetLastModifiedUserIdAsync<T>(string id, int version) where T : IIdentifiable
         {
-            return Task.FromResult<string>(LastModifiedUserId);
+            return Task.FromResult(LastModifiedUserId);
         }
 
         public IQueryable<T> QuerySnapshots<T>() where T : IIdentifiable

--- a/src/SIL.XForge/Realtime/MemoryRealtimeService.cs
+++ b/src/SIL.XForge/Realtime/MemoryRealtimeService.cs
@@ -76,6 +76,11 @@ namespace SIL.XForge.Realtime
             return docConfig.CollectionName;
         }
 
+        public Task<string> GetLastModifiedUserIdAsync<T>(string id) where T : IIdentifiable
+        {
+            return Task.FromResult<string>(null);
+        }
+
         public IQueryable<T> QuerySnapshots<T>() where T : IIdentifiable
         {
             return GetRepository<T>().Query();

--- a/src/SIL.XForge/Realtime/RealtimeService.cs
+++ b/src/SIL.XForge/Realtime/RealtimeService.cs
@@ -151,15 +151,23 @@ namespace SIL.XForge.Realtime
         /// </summary>
         /// <typeparam name="T">The type in MongoDB</typeparam>
         /// <param name="id">The identifier.</param>
+        /// <param name="version">The version. If 0 or lower, the version is ignored.</param>
         /// <returns>
         /// The user id, or null if unknown.
         /// </returns>
-        public async Task<string> GetLastModifiedUserIdAsync<T>(string id) where T : IIdentifiable
+        public async Task<string> GetLastModifiedUserIdAsync<T>(string id, int version) where T : IIdentifiable
         {
             // Get the collection and definitions
             string collectionName = GetCollectionName<T>();
             IMongoCollection<BsonDocument> opsCollection = _database.GetCollection<BsonDocument>($"o_{collectionName}");
-            FilterDefinition<BsonDocument> filter = Builders<BsonDocument>.Filter.Eq("d", id);
+            FilterDefinitionBuilder<BsonDocument> builder = Builders<BsonDocument>.Filter;
+            FilterDefinition<BsonDocument> filter = builder.Eq("d", id);
+            if (version > 0)
+            {
+                // The version in the Document is always one more than the version in the operations table
+                filter &= builder.Lt("v", version);
+            }
+
             FieldDefinition<BsonDocument> field = "v";
             SortDefinition<BsonDocument> sort = Builders<BsonDocument>.Sort.Descending(field);
 

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -1705,6 +1705,36 @@ namespace SIL.XForge.Scripture.Services
             Assert.ThrowsAsync<ForbiddenException>(() => env.Service.CancelSyncAsync(User03, Project01));
         }
 
+        [Test]
+        public void SyncAsync_AdministratorsCanSync()
+        {
+            // Setup
+            var env = new TestEnvironment();
+
+            // SUT
+            Assert.DoesNotThrowAsync(() => env.Service.SyncAsync(User01, Project01));
+        }
+
+        [Test]
+        public void SyncAsync_TranslatorsCanSync()
+        {
+            // Setup
+            var env = new TestEnvironment();
+
+            // SUT
+            Assert.DoesNotThrowAsync(() => env.Service.SyncAsync(User05, Project01));
+        }
+
+        [Test]
+        public void SyncAsync_ObserversCannotSync()
+        {
+            // Setup
+            var env = new TestEnvironment();
+
+            // SUT
+            Assert.ThrowsAsync<ForbiddenException>(() => env.Service.SyncAsync(User02, Project01));
+        }
+
         private class TestEnvironment
         {
             public TestEnvironment()

--- a/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
@@ -110,6 +110,7 @@ namespace SIL.XForge.Realtime
             // Setup environment
             var env = new TestEnvironment();
             string id = "123456";
+            int version = -1;
             var doc = BsonDocument.Parse("{}");
 
             // Setup MongoDB mock
@@ -122,7 +123,7 @@ namespace SIL.XForge.Realtime
                 .Returns(Task.FromResult(cursorMock));
 
             // SUT
-            string userId = await env.Service.GetLastModifiedUserIdAsync<User>(id);
+            string userId = await env.Service.GetLastModifiedUserIdAsync<User>(id, version);
             Assert.IsNull(userId);
         }
 
@@ -132,6 +133,7 @@ namespace SIL.XForge.Realtime
             // Setup environment
             var env = new TestEnvironment();
             string id = "123456";
+            int version = -1;
             var doc = BsonDocument.Parse("{ m: {} }");
 
             // Setup MongoDB mock
@@ -144,7 +146,7 @@ namespace SIL.XForge.Realtime
                 .Returns(Task.FromResult(cursorMock));
 
             // SUT
-            string userId = await env.Service.GetLastModifiedUserIdAsync<User>(id);
+            string userId = await env.Service.GetLastModifiedUserIdAsync<User>(id, version);
             Assert.IsNull(userId);
         }
 
@@ -154,6 +156,7 @@ namespace SIL.XForge.Realtime
             // Setup environment
             var env = new TestEnvironment();
             string id = "123456";
+            int version = -1;
             var doc = BsonDocument.Parse("{ m: { uId: 'abcdef' } }");
 
             // Setup MongoDB mock
@@ -166,7 +169,7 @@ namespace SIL.XForge.Realtime
                 .Returns(Task.FromResult(cursorMock));
 
             // SUT
-            string userId = await env.Service.GetLastModifiedUserIdAsync<User>(id);
+            string userId = await env.Service.GetLastModifiedUserIdAsync<User>(id, version);
             Assert.AreEqual("abcdef", userId);
         }
 
@@ -176,6 +179,7 @@ namespace SIL.XForge.Realtime
             // Setup environment
             var env = new TestEnvironment();
             string id = "123456";
+            int version = 3;
             var doc1 = BsonDocument.Parse("{ v: 1, m: { uId: 'abcdef' } }");
             var doc2 = BsonDocument.Parse("{ v: 2, m: { uId: 'ghijkl' } }");
 
@@ -189,7 +193,7 @@ namespace SIL.XForge.Realtime
                 .Returns(Task.FromResult(cursorMock));
 
             // SUT
-            string userId = await env.Service.GetLastModifiedUserIdAsync<User>(id);
+            string userId = await env.Service.GetLastModifiedUserIdAsync<User>(id, version);
             Assert.AreEqual("ghijkl", userId);
         }
 


### PR DESCRIPTION
This pull request adds support for translators who are not administrators to sync.

As well as the UI change, the primary change reads the id of the last user to modify a chapter from MongoDB, and uses that user to synchronize the chapter they edited from SF to the local Paratext repo. This means that the correct permissions are employed, as the `ScrText` is used, utilizing the permission user who made the modification rather than the user who is performing the synchronization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1082)
<!-- Reviewable:end -->
