### PR TITLE
SF-1048c: Fix cancel sync bugs

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
@@ -48,7 +48,7 @@ describe('SyncComponent', () => {
     ]
   }));
 
-  it('should display log in to paratext', fakeAsync(() => {
+  it('should display Log In to Paratext', fakeAsync(() => {
     const env = new TestEnvironment();
     expect(env.title.textContent).toContain('Synchronize Sync Test Project with Paratext');
     expect(env.logInButton.nativeElement.textContent).toContain('Log in to Paratext');
@@ -59,9 +59,11 @@ describe('SyncComponent', () => {
     expect(env.logInButton).toBeNull();
   }));
 
-  it('should redirect the user to log in to paratext', fakeAsync(() => {
+  it('should redirect the user to Log In to Paratext', fakeAsync(() => {
     const env = new TestEnvironment();
+
     env.clickElement(env.logInButton);
+
     verify(mockedParatextService.linkParatext(anything())).once();
     expect().nothing();
   }));
@@ -80,21 +82,28 @@ describe('SyncComponent', () => {
     expect(env.syncButton.nativeElement.disabled).toBe(true);
     expect(env.lastSyncDate.textContent).toContain('Last synced on');
     expect(env.offlineMessage).not.toBeNull();
+
     env.onlineStatus = true;
+
     expect(env.syncButton.nativeElement.disabled).toBe(false);
     expect(env.offlineMessage).toBeNull();
   }));
 
   it('should sync project when the button is clicked', fakeAsync(() => {
     const env = new TestEnvironment(true);
+    const previousLastSyncDate = new Date(env.component.lastSyncDate);
     verify(mockedProjectService.get('testProject01')).once();
+
     env.clickElement(env.syncButton);
+
     verify(mockedProjectService.onlineSync('testProject01')).once();
     expect(env.component.syncActive).toBe(true);
     expect(env.progressBar).not.toBeNull();
+    expect(env.cancelButton).not.toBeNull();
     expect(env.logInButton).toBeNull();
     expect(env.syncButton).toBeNull();
     env.emitSyncComplete(true, 'testProject01');
+    expect(new Date(env.component.lastSyncDate).getTime()).toBeGreaterThan(previousLastSyncDate.getTime());
     verify(mockedNoticeService.show('Successfully synchronized Sync Test Project with Paratext.')).once();
   }));
 
@@ -107,8 +116,10 @@ describe('SyncComponent', () => {
     expect(env.progressBar).not.toBeNull();
     // Simulate sync in progress
     env.emitSyncProgress(0.25, 'testProject01');
+
     // Simulate sync error
     env.emitSyncComplete(false, 'testProject01');
+
     expect(env.component.syncActive).toBe(false);
     verify(mockedNoticeService.showMessageDialog(anything())).once();
   }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
@@ -78,7 +78,10 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
   set syncActive(isActive: boolean) {
     if (this._syncActive && !isActive && this.projectDoc?.data != null) {
       const projectName: string = this.projectDoc.data.name;
-      if (this.isSyncCancelled && new Date(this.lastSyncDate) <= this.previousLastSyncDate!) {
+      if (
+        this.isSyncCancelled &&
+        (this.previousLastSyncDate == null || new Date(this.lastSyncDate) <= this.previousLastSyncDate)
+      ) {
         this.noticeService.show(translate('sync.synchronize_was_cancelled', { projectName }));
       } else {
         if (this.projectDoc.data.sync.lastSyncSuccessful) {
@@ -162,6 +165,8 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
       this.syncDisabled = this.projectDoc.data.syncDisabled;
     }
     this._syncActive = this.projectDoc.data.sync.queuedCount > 0;
-    this.previousLastSyncDate = new Date(this.lastSyncDate);
+    if (this.projectDoc.data.sync.lastSyncSuccessful) {
+      this.previousLastSyncDate = new Date(this.lastSyncDate);
+    }
   }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -351,6 +351,7 @@ namespace SIL.XForge.Scripture.Services
             _conn = await _realtimeService.ConnectAsync();
             _conn.BeginTransaction();
             _conn.ExcludePropertyFromTransaction<SFProject>(op => op.Sync.PercentCompleted);
+            _conn.ExcludePropertyFromTransaction<SFProject>(op => op.Sync.QueuedCount);
             _projectDoc = await _conn.FetchAsync<SFProject>(projectId);
             if (!_projectDoc.IsLoaded)
                 return false;

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -286,7 +286,11 @@ namespace SIL.XForge.Scripture.Services
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "Error occurred while executing Paratext sync for project '{Project}'", projectId);
+                if (!(e is TaskCanceledException))
+                {
+                    _logger.LogError(e, "Error occurred while executing Paratext sync for project '{Project}'", projectId);
+                }
+
                 await CompleteSync(false, canRollbackParatext, token);
             }
             finally


### PR DESCRIPTION
This pull request fixes the following bugs found when using the cancel sync feature:

 - Updates to the cancellation message (commit 8ffd282)
 - When a sync is cancelled, the status was not being correctly updated in some cases (commit de70969)
 - A TaskCancelledException is no longer logged when a CancellationToken request is caught in third party code (commit 278348e)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1084)
<!-- Reviewable:end -->
