### PR TITLE
SF-1278 - Text lost, verse numbers duplicated, from multiple devices coming online

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -318,8 +318,10 @@ quill-editor.rtl {
 
 usx-blank {
   width: 35px;
-  font-size: 0;
   display: inline-block;
+  span {
+    font-size: 0;
+  }
 }
 
 usx-char {

--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -316,6 +316,11 @@ quill-editor.rtl {
   }
 }
 
+usx-blank {
+  width: 35px;
+  display: inline-block;
+}
+
 usx-char {
   &[data-style='it'] {
     font-style: italic;

--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -318,6 +318,7 @@ quill-editor.rtl {
 
 usx-blank {
   width: 35px;
+  font-size: 0;
   display: inline-block;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -125,9 +125,7 @@ export function registerScripture(): string[] {
     static tagName = 'usx-blank';
 
     static create(value: boolean): Node {
-      const node = super.create(value) as HTMLElement;
-      node.innerText = NBSP.repeat(8);
-      return node;
+      return super.create(value) as HTMLElement;
     }
 
     static value(_node: HTMLElement): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -125,7 +125,9 @@ export function registerScripture(): string[] {
     static tagName = 'usx-blank';
 
     static create(value: boolean): Node {
-      return super.create(value) as HTMLElement;
+      const node = super.create(value) as HTMLElement;
+      node.innerText = NBSP.repeat(8);
+      return node;
     }
 
     static value(_node: HTMLElement): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -476,10 +476,7 @@ export class TextViewModel {
       fixOffset++;
     } else if (segment.containsBlank && segment.length > 1) {
       // delete blank
-      const delta = new Delta()
-        .retain(segment.index + fixOffset)
-        .retain(segment.length - 1, { segment: segment.ref, 'para-contents': true, 'direction-segment': 'auto' })
-        .delete(1);
+      const delta = new Delta().retain(segment.index + fixOffset).delete(1);
       fixDelta = fixDelta.compose(delta);
       fixOffset--;
       const sel = editor.getSelection();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -302,11 +302,11 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   }
 
   get isSelectionAtSegmentEnd(): boolean {
-    return this.getSelectionAtSegmentPosition(true);
+    return this.isSelectionAtSegmentPosition(true);
   }
 
   get isSelectionAtSegmentStart(): boolean {
-    return this.getSelectionAtSegmentPosition(false);
+    return this.isSelectionAtSegmentPosition(false);
   }
 
   get readOnlyEnabled(): boolean {
@@ -471,7 +471,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     this.applyEditorStyles();
   }
 
-  private getSelectionAtSegmentPosition(end: boolean) {
+  private isSelectionAtSegmentPosition(end: boolean): boolean {
     if (this.editor == null || this.segment == null) {
       return false;
     }


### PR DESCRIPTION
- Change usx-blank into an inline-block with a fixed width
- Move position of cursor to appear after usx-blank in order to keep it inside the usx-segment element
- Adjusted quill left/right handlers to work with new cursor position with usx-blank

**Please note that this fix is just related to data loss from going offline to online. If a bug other than that is found then check Jira as there may be a separate ticket for it.**

## Acceptance Tests
1. Load a project and navigate to a book in the translate app which has lots of blank segments
2. Load the same page in another browser or profile
3. Go offline (shutdown dotnet)
4. Insert text in to any of the segments across both browsers
5. Close down the tab in one of the browsers
6. Go online
7. OBSERVE: The browser that was left open should go online as normal
8. Load the tab again in the other browser
9. OBSERVE: The data in the other browser is synced and now text from both browsers are showing correctly in the correct segments with no missing data

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1088)
<!-- Reviewable:end -->
