### PR TITLE
SF-1348 Ignore cid object property on char nodes when comparing text deltas

### DIFF
--- a/test/SIL.XForge.Tests/Realtime/RichText/DeltaTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/RichText/DeltaTests.cs
@@ -613,6 +613,37 @@ namespace SIL.XForge.Realtime.RichText
             Assert.That(JToken.DeepEquals(resultToken[0], expectedObj));
         }
 
+        [Test]
+        public void GetLength_ReturnsOpLength()
+        {
+            var del = Delta.New();
+            Assert.That(del.GetLength(), Is.EqualTo(0));
+            del.Insert("A");
+            Assert.That(del.GetLength(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void DeepEquals_ExaminesEquality()
+        {
+            var a = Delta.New().Insert("A");
+            var b = Delta.New().Insert("A").Insert("B");
+            Assert.That(a.DeepEquals(b), Is.False);
+            a.Insert("B", new { color = "red" });
+            Assert.That(a.DeepEquals(b), Is.False);
+            Delta c = b.Compose(Delta.New().Retain(1).Retain(1, new { color = "red" }));
+            Assert.That(a.DeepEquals(c), Is.True);
+        }
+
+        [Test]
+        public void ToString_ReturnsString()
+        {
+            var del = Delta.New().Insert("A").Insert("B", new { color = "red" });
+            string str = del.ToString();
+            Assert.That(str.Contains("\"insert\": \"A\""));
+            Assert.That(str.Contains("\"insert\": \"B\""));
+            Assert.That(str.Contains("\"color\": \"red\""));
+        }
+
         private static IEnumerable<JObject> Objs(params object[] objs)
         {
             return objs.Select(Obj);


### PR DESCRIPTION
Char nodes in the text delta appear when words in a text have special meaning or formatting like a footnote.
![MAT_21_footnote](https://user-images.githubusercontent.com/17931130/124995603-d2705400-e004-11eb-97b7-32057a7be597.png)
This specific type of formatting is represented in the text docs as an op like this.
![Embedded Char CID](https://user-images.githubusercontent.com/17931130/124995713-fcc21180-e004-11eb-97a6-f5b29a7802c2.png)

The cid property of a char node is generated and stored in our text docs, but are not stored in Paratext. So it can be safely ignored when processing delta diffs.

To test this, you can use a project with footnotes (the more embedded the better). The text doc for the book and chapter containing the footnote will increment the text doc version for every sync, even when there is no text changes. Then after this change, the text doc version number will not change for every sync.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1090)
<!-- Reviewable:end -->
