### PR TITLE
SF-1367: Improved sync error checking and added auto-unlock

### DIFF
--- a/src/SIL.XForge.Scripture/Services/IInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/IInternetSharedRepositorySource.cs
@@ -10,6 +10,7 @@ namespace SIL.XForge.Scripture.Services
         IEnumerable<ProjectMetadata> GetProjectsMetaData();
         string[] Pull(string repository, SharedRepository pullRepo);
         void RefreshToken(string jwtToken);
+        void UnlockRemoteRepository(SharedRepository sharedRepo);
         /// <summary> Access as a particular class. </summary>
         InternetSharedRepositorySource AsInternetSharedRepositorySource();
     }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -200,13 +200,23 @@ namespace SIL.XForge.Scripture.Services
                 sharedProj.Permissions = sharedProj.ScrText.Permissions;
                 List<SharedProject> sharedPtProjectsToSr = new List<SharedProject> { sharedProj };
 
+                // Unlock the repo before we begin
+                try
+                {
+                    source.UnlockRemoteRepository(sharedProj.Repository);
+                }
+                catch (HttpException)
+                {
+                    // A 403 error will be thrown if the repo is not locked
+                }
+
                 // TODO report results
                 List<SendReceiveResult> results = Enumerable.Empty<SendReceiveResult>().ToList();
                 bool success = false;
                 bool noErrors = SharingLogicWrapper.HandleErrors(() => success = SharingLogicWrapper
                     .ShareChanges(sharedPtProjectsToSr, source.AsInternetSharedRepositorySource(),
                     out results, sharedPtProjectsToSr));
-                if (!noErrors || !success)
+                if (!noErrors || !success || results.Any(r => r.Result == SendReceiveResultEnum.Failed))
                     throw new InvalidOperationException(
                         "Failed: Errors occurred while performing the sync with the Paratext Server.");
             }


### PR DESCRIPTION
This pull request makes the following changes:

**When a project is synchronized, an attempt is always made to unlock the repo**
If the connection between the SF server and the PT server is interrupted on sync, the lock can remain on the PT server for around 15 minutes. This change makes it so that before a sync, an unlock is performed. Nearly every time, this will return an error (as project is not locked). However, if the project was locked, it will be unlocked, and the sync will run successfully. This is done this way, as there is no accurate way to see if a sync failed because of a lock, except by reviewing the logs.
https://github.com/sillsdev/web-xforge/blob/a700ac6fc0324a2f8099ba9908bb1d4c31c1c19a/src/SIL.XForge.Scripture/Services/ParatextService.cs#L203-L211

**The ShareChanges results list is now checked for errors**
When a repo is locked (and potentially for other errors), the success return value is set to true, but the `SendReceiveResult` object in the results list is has its `Result` property set to `SendReceiveResultEnum.Failed`. This change, now checks the results collection for this value.
https://github.com/sillsdev/web-xforge/blob/a700ac6fc0324a2f8099ba9908bb1d4c31c1c19a/src/SIL.XForge.Scripture/Services/ParatextService.cs#L219

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1096)
<!-- Reviewable:end -->
