### PR TITLE
Add query for projects that are in syncing state

### DIFF
--- a/mongodb/Projects/projects_in_sync_state.mongodb
+++ b/mongodb/Projects/projects_in_sync_state.mongodb
@@ -1,0 +1,8 @@
+// This script searches for projects that are in the sync state. It is intended to be used for finding projects that
+// are stuck in a perpetual state of syncing. Keep in mind that when things go wrong the project's state may not fully
+// reflect whether a Hangfire job is currently in the queue for this project, so checking the Hangfire dashboard at the
+// same time may be useful.
+
+use('xforge')
+
+db.sf_projects.find({'sync.queuedCount': {$ne: 0}})


### PR DESCRIPTION
This is a trivially simple query, but I think it's worth having in the repo so we can easily check for projects that are in the syncing state without writing the query from scratch every time.

Also, since a query like this is typically (hopefully) going to return no results, it's hard to be confident a query was written correctly, since most incorrect queries don't find any results either (in a case like this I would typically modify the query to something like `{'sync.queuedCount': {$ne: 1}}` and check that it's returning a bunch of projects). Having a known-working version in the repo is therefore simpler than writing it from scratch every time.

In the past I've seen up to six or so projects that were all stuck in a syncing state on live.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1104)
<!-- Reviewable:end -->
