### PR TITLE
sync: Remove backslash from backup path

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -781,7 +781,7 @@ namespace SIL.XForge.Scripture.Services
             {
                 string source = scrText.Directory;
                 string destination =
-                    Path.Combine(Paratext.Data.ScrTextCollection.SettingsDirectory, "_Backups\\", scrText.Guid.ToString());
+                    Path.Combine(Paratext.Data.ScrTextCollection.SettingsDirectory, "_Backups", scrText.Guid.ToString());
                 string restoredDestination = destination + "_Restored";
                 string backupPath = destination + ".bndl";
 
@@ -838,7 +838,7 @@ namespace SIL.XForge.Scripture.Services
             try
             {
                 string path =
-                    Path.Combine(Paratext.Data.ScrTextCollection.SettingsDirectory, "_Backups\\", $"{scrText.Guid}.bndl");
+                    Path.Combine(Paratext.Data.ScrTextCollection.SettingsDirectory, "_Backups", $"{scrText.Guid}.bndl");
                 return _fileSystemService.FileExists(path);
             }
             catch (Exception)


### PR DESCRIPTION
- To look for the directory where we intend to.
- Note that on Windows it was not causing a problem, but on Linux it
was including the backslash as part of the path segment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1105)
<!-- Reviewable:end -->
