### PR TITLE
sync: Add operational logging messages

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -835,6 +835,10 @@ namespace SIL.XForge.Scripture.Services
             // We do not back up resources
             if (paratextId == null || paratextId.Length == SFInstallableDblResource.ResourceIdentifierLength)
             {
+                if (paratextId == null)
+                {
+                    _logger.LogInformation("Not backing up local PT repo for null paratextId.");
+                }
                 return false;
             }
 
@@ -844,6 +848,7 @@ namespace SIL.XForge.Scripture.Services
             // If we do not have a scripture text, do not back up
             if (scrText == null)
             {
+                _logger.LogInformation($"Not backing up local PT repo since no scrText for PTId '{paratextId}'.");
                 return false;
             }
 
@@ -869,8 +874,9 @@ namespace SIL.XForge.Scripture.Services
                 _fileSystemService.MoveFile(tempPath, path);
                 return true;
             }
-            catch (Exception)
+            catch (Exception e)
             {
+                _logger.LogError(e, $"Problem backing up local PT repo for PTId '{paratextId}'.");
                 // An error has occurred, so the backup was not created
                 return false;
             }
@@ -881,6 +887,15 @@ namespace SIL.XForge.Scripture.Services
             // We do not back up resources
             if (paratextId == null || paratextId.Length == SFInstallableDblResource.ResourceIdentifierLength)
             {
+                if (paratextId == null)
+                {
+                    _logger.LogInformation("Not restoring local PT repo for null paratextId.");
+                }
+                else if (paratextId.Length == SFInstallableDblResource.ResourceIdentifierLength)
+                {
+                    _logger.LogInformation("Not restoring a DBL resource.");
+                }
+
                 return false;
             }
 
@@ -890,6 +905,7 @@ namespace SIL.XForge.Scripture.Services
             // If we do not have a scripture text, do not back up
             if (scrText == null)
             {
+                _logger.LogInformation($"Not restoring local PT repo since no scrText for PTId '{paratextId}'.");
                 return false;
             }
 
@@ -926,14 +942,19 @@ namespace SIL.XForge.Scripture.Services
                     _fileSystemService.MoveDirectory(restoredDestination, source);
                     return true;
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
+                    _logger.LogError(e, $"Problem restoring local PT repo for PTId '{paratextId}'.");
                     // On error, move the backup destination back to the repository folder
                     if (!_fileSystemService.DirectoryExists(source))
                     {
                         _fileSystemService.MoveDirectory(destination, source);
                     }
                 }
+            }
+            else
+            {
+                _logger.LogInformation($"Not restoring local PT repo for PTId '{paratextId}' since no backup exists.");
             }
 
             // An error occurred, or the backup does not exist
@@ -982,9 +1003,10 @@ namespace SIL.XForge.Scripture.Services
                     Path.Combine(Paratext.Data.ScrTextCollection.SettingsDirectory, "_Backups", $"{scrText.Guid}.bndl");
                 return _fileSystemService.FileExists(path);
             }
-            catch (Exception)
+            catch (Exception e)
             {
                 // An error occurred
+                _logger.LogError(e, $"Problem when checking if a local PT repo backup exists for scrText id '{scrText.Guid}'.");
                 return false;
             }
         }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -81,8 +81,14 @@ namespace SIL.XForge.Scripture.Services
         private bool TranslationSuggestionsEnabled => _projectDoc.Data.TranslateConfig.TranslationSuggestionsEnabled;
         private bool CheckingEnabled => _projectDoc.Data.CheckingConfig.CheckingEnabled;
 
-        // Do not allow multiple sync jobs to run in parallel on the same project by creating a mutex on the projectId
-        // parameter, i.e. "{0}"
+        /// <summary>
+        /// Synchronize content and user permissions in SF DB with Paratext SendReceive servers and PT Registry, for
+        /// a project.
+        /// </summary>
+        /// <remarks>
+        /// Do not allow multiple sync jobs to run in parallel on the same project by creating a hangfire mutex on the
+        /// <param name="projectId"/> parameter, i.e. "{0}".
+        /// </remarks>
         [Mutex("{0}")]
         public async Task RunAsync(string projectId, string userId, bool trainEngine, CancellationToken token)
         {
@@ -99,6 +105,7 @@ namespace SIL.XForge.Scripture.Services
                 string targetParatextId = _projectDoc.Data.ParatextId;
                 string sourceParatextId = _projectDoc.Data.TranslateConfig.Source?.ParatextId;
                 string sourceProjectRef = _projectDoc.Data.TranslateConfig.Source?.ProjectRef;
+                Log($"RunAsync: Starting. Target PTID '{targetParatextId}', source PTID '{sourceParatextId}'.");
 
                 // Determine if we can rollback Paratext
                 canRollbackParatext = _paratextService.BackupExists(_userSecret, targetParatextId);
@@ -106,6 +113,14 @@ namespace SIL.XForge.Scripture.Services
                 {
                     // Attempt to create a backup if we cannot rollback
                     canRollbackParatext = _paratextService.BackupRepository(_userSecret, targetParatextId);
+                    if (canRollbackParatext)
+                    {
+                        Log($"RunAsync: There wasn't already a local PT repo backup, so we made one.");
+                    }
+                    else
+                    {
+                        Log($"RunAsync: There wasn't already a local PT repo backup, so we tried to make one but failed.");
+                    }
                 }
 
                 var targetTextDocsByBook = new Dictionary<int, SortedList<int, IDocument<TextData>>>();
@@ -118,12 +133,14 @@ namespace SIL.XForge.Scripture.Services
                     // The hg repository has no pushed or pulled commit. Maybe we are only just getting set up with a
                     // project. Maybe it is a resource and not a project and has no hg repo directory.
                     isDataInSync = true;
+                    Log($"RunAsync: The local PT repo has no last shared revision. Considering that data is in sync.");
                 }
                 if (lastSharedVersion == _projectDoc.Data.Sync.SyncedToRepositoryVersion)
                 {
                     // The recent hg repository pushed or pulled commit id matches what we recorded as being the last
                     // place where SF and PT last synced.
                     isDataInSync = true;
+                    Log($"RunAsync: The local PT repo last shared rev matches the SF DB SyncedToRepositoryVersion of '{lastSharedVersion}'. Is in sync.");
                 }
                 if (_projectDoc.Data.Sync.SyncedToRepositoryVersion == null && _projectDoc.Data.Sync.DataInSync == null)
                 {
@@ -138,6 +155,11 @@ namespace SIL.XForge.Scripture.Services
                     // There is also a special case where SyncedToRepositoryVersion may be absent, but DataInSync may
                     // be present (and true), which may indicate that the initial Connect project failed to hg clone.
                     isDataInSync = true;
+                    Log($"RunAsync: The SF DB project has no settings for Sync.SyncedToRepositoryVersion or Sync.DataInSync. Considering that data is in sync.");
+                }
+                if (!isDataInSync)
+                {
+                    Log($"RunAsync: Considering that data is not in sync. The local PT repo last shared revision is '{lastSharedVersion}'. The SF DB project Sync.SyncedToRepositoryVersion is '{_projectDoc.Data.Sync.SyncedToRepositoryVersion}'. canRollbackParatext is '{canRollbackParatext}'.");
                 }
 
                 // update target Paratext books and notes
@@ -168,8 +190,10 @@ namespace SIL.XForge.Scripture.Services
                     // Create the handler
                     progress.ProgressUpdated += SyncProgress_ProgressUpdated;
 
+                    Log($"RunAsync: Going to do ParatextData SendReceive.");
                     // perform Paratext send/receive
                     await _paratextService.SendReceiveAsync(_userSecret, targetParatextId, progress, token);
+                    Log($"RunAsync: ParatextData SendReceive finished without throwing.");
                 }
                 finally
                 {
@@ -203,6 +227,7 @@ namespace SIL.XForge.Scripture.Services
                 // delete all data for removed books
                 if (targetBooksToDelete.Count > 0)
                 {
+                    Log($"RunAsync: Going to delete texts and questions,comments,answers for {targetBooksToDelete.Count} books.");
                     // delete target books
                     foreach (int bookNum in targetBooksToDelete)
                     {
@@ -245,9 +270,10 @@ namespace SIL.XForge.Scripture.Services
                             {
                                 await _projectService.AddUserAsync(uid, sourceProjectRef);
                             }
-                            catch (ForbiddenException)
+                            catch (ForbiddenException e)
                             {
                                 // The user does not have Paratext access
+                                Log($"RunAsync: Error attempting to add a user to the resource access list: {e}");
                             }
                         }
 
@@ -350,21 +376,30 @@ namespace SIL.XForge.Scripture.Services
             }
         }
 
-        internal async Task<bool> InitAsync(string projectId, string userId, CancellationToken token)
+        internal async Task<bool> InitAsync(string projectSFId, string userId, CancellationToken token)
         {
             _conn = await _realtimeService.ConnectAsync();
             _conn.BeginTransaction();
             _conn.ExcludePropertyFromTransaction<SFProject>(op => op.Sync.PercentCompleted);
             _conn.ExcludePropertyFromTransaction<SFProject>(op => op.Sync.QueuedCount);
-            _projectDoc = await _conn.FetchAsync<SFProject>(projectId);
+            _projectDoc = await _conn.FetchAsync<SFProject>(projectSFId);
             if (!_projectDoc.IsLoaded)
+            {
+                Log($"Project doc was not loaded.", projectSFId, userId);
                 return false;
+            }
 
-            if (!(await _projectSecrets.TryGetAsync(projectId)).TryResult(out _projectSecret))
+            if (!(await _projectSecrets.TryGetAsync(projectSFId)).TryResult(out _projectSecret))
+            {
+                Log($"Could not find project secret.", projectSFId, userId);
                 return false;
+            }
 
             if (!(await _userSecrets.TryGetAsync(userId)).TryResult(out _userSecret))
+            {
+                Log($"Could not find user secret.", projectSFId, userId);
                 return false;
+            }
 
             List<User> paratextUsers = await _realtimeService.QuerySnapshots<User>()
                 .Where(u => _projectDoc.Data.UserRoles.Keys.Contains(u.Id) && u.ParatextId != null)
@@ -669,8 +704,13 @@ namespace SIL.XForge.Scripture.Services
 
         private async Task CompleteSync(bool successful, bool canRollbackParatext, CancellationToken token)
         {
+            if (token.IsCancellationRequested)
+            {
+                Log($"CompleteSync: There was a cancellation request.");
+            }
             if (_projectDoc == null || _projectSecret == null)
             {
+                Log("CompleteSync: _projectDoc or _projectSecret are null. Rolling back SF DB transaction.");
                 _conn.RollbackTransaction();
                 return;
             }
@@ -695,6 +735,7 @@ namespace SIL.XForge.Scripture.Services
                 {
                     if (ex is HttpRequestException || ex is OperationCanceledException)
                     {
+                        Log($"CompleteSync: Problem fetching project roles. Maybe the user does not have access to the project or cancelled the sync. ({ex})");
                         // This throws a 404 if the user does not have access to the project
                         // A task cancelled exception will be thrown if the user cancels the task
                         // Note: OperationCanceledException includes TaskCanceledException
@@ -703,6 +744,7 @@ namespace SIL.XForge.Scripture.Services
                     }
                     else
                     {
+                        Log($"CompleteSync: Problem fetching project roles. Rethrowing: ({ex})");
                         throw;
                     }
                 }
@@ -717,7 +759,8 @@ namespace SIL.XForge.Scripture.Services
             // If we have failed, restore the repository, if we can
             if (!successful && canRollbackParatext)
             {
-                _paratextService.RestoreRepository(_userSecret, _projectDoc.Data.ParatextId);
+                bool rollbackOutcome = _paratextService.RestoreRepository(_userSecret, _projectDoc.Data.ParatextId);
+                Log($"CompleteSync: Sync was not successful. {(rollbackOutcome ? "Rolled back" : "Failed to roll back")} local PT repo.");
             }
 
             // NOTE: This is executed outside of the transaction because it modifies "Sync.PercentCompleted"
@@ -733,12 +776,16 @@ namespace SIL.XForge.Scripture.Services
 
                 if (successful)
                 {
+                    Log($"CompleteSync: Successfully synchronized to PT repo commit id '{repoVersion}'.");
                     op.Set(pd => pd.Sync.DateLastSuccessfulSync, DateTime.UtcNow);
                     op.Set(pd => pd.Sync.SyncedToRepositoryVersion, repoVersion);
                     op.Set(pd => pd.Sync.DataInSync, true);
                 }
                 else
+                {
+                    Log($"CompleteSync: Failed to synchronize. PT repo latest shared version is '{repoVersion}'. SF DB project SyncedToRepositoryVersion is '{_projectDoc.Data.Sync.SyncedToRepositoryVersion}'.");
                     op.Set(pd => pd.Sync.DataInSync, repoVersion == _projectDoc.Data.Sync.SyncedToRepositoryVersion);
+                }
                 // the frontend checks the queued count to determine if the sync is complete. The ShareDB client emits
                 // an event for each individual op even if they are applied as a batch, so this needs to be set last,
                 // otherwise the info about the sync won't be set yet when the frontend determines that the sync is
@@ -821,7 +868,11 @@ namespace SIL.XForge.Scripture.Services
                 // Backup the repository
                 if (_projectDoc.Data.ParatextId.Length != SFInstallableDblResource.ResourceIdentifierLength)
                 {
-                    _paratextService.BackupRepository(_userSecret, _projectDoc.Data.ParatextId);
+                    bool backupOutcome = _paratextService.BackupRepository(_userSecret, _projectDoc.Data.ParatextId);
+                    if (!backupOutcome)
+                    {
+                        Log($"CompleteSync: Failure backing up local PT repo.");
+                    }
                 }
             }
             else
@@ -829,6 +880,7 @@ namespace SIL.XForge.Scripture.Services
                 // Rollback the operations (the repository was restored above)
                 _conn.RollbackTransaction();
             }
+            Log($"CompleteSync: Finished. Sync was {(successful ? "successful" : "unsuccessful")}.");
         }
 
         private IDocument<TextData> GetTextDoc(TextInfo text, int chapter)
@@ -876,6 +928,13 @@ namespace SIL.XForge.Scripture.Services
                 code = code * 31 + obj.IsValid.GetHashCode();
                 return code;
             }
+        }
+
+        private void Log(string message, string projectSFId = null, string userId = null)
+        {
+            projectSFId = projectSFId ?? _projectDoc?.Id ?? "unknown";
+            userId = userId ?? _userSecret?.Id ?? "unknown";
+            _logger.LogInformation($"SyncLog ({projectSFId},{userId}): {message}");
         }
     }
 }

--- a/src/SIL.XForge.Scripture/appsettings.json
+++ b/src/SIL.XForge.Scripture/appsettings.json
@@ -3,7 +3,9 @@
     "LogLevel": {
       "Default": "Warning",
       "Microsoft.AspNetCore.Localization": "Error",
-      "SIL": "Information"
+      "SIL": "Information",
+      "SIL.Machine.WebApi.Services.EngineRuntime": "Information",
+      "SIL.XForge.Scripture.Services.ParatextSyncRunner": "Information"
     }
   },
   "AllowedHosts": "*",

--- a/test/SIL.XForge.Scripture.Tests/Services/MockLogger.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockLogger.cs
@@ -1,18 +1,42 @@
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using System;
+using NUnit.Framework;
+using System.Linq;
 
 namespace SIL.XForge.Scripture.Services
 {
     /// <summary>
-    /// Mock for ILogger since it's difficult to mock with NSubstitute.
+    /// An occurrence of something being logged. For use by unit tests.
+    /// </summary>
+    public class LogEvent
+    {
+        public LogLevel LogLevel { get; set; }
+        public EventId EventId { get; set; }
+        public object State { get; set; }
+        public Exception Exception { get; set; }
+        public string Message { get { return State.ToString(); } }
+
+        public override string ToString()
+        {
+            string summary = $"LogEvent {EventId} {LogLevel}: {Message}";
+            if (Exception != null)
+            {
+                summary += $" ({Exception})";
+            }
+            return summary;
+        }
+    }
+
+    /// <summary>
+    /// Mock for ILogger since it's difficult to mock with NSubstitute. To help with unit tests.
     /// </summary>
     public class MockLogger<T> : ILogger<T>
     {
         /// <summary>
-        /// Stores logged messages.
+        /// Stores logged events.
         /// </summary>
-        public readonly List<string> Messages = new List<string>();
+        public readonly List<LogEvent> LogEvents = new List<LogEvent>();
 
         public MockLogger()
         {
@@ -32,7 +56,63 @@ namespace SIL.XForge.Scripture.Services
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
             Func<TState, Exception, string> formatter)
         {
-            Messages.Add(((object)state).ToString());
+            LogEvents.Add(new LogEvent
+            {
+                LogLevel = logLevel,
+                EventId = eventId,
+                State = state,
+                Exception = exception
+            });
+        }
+
+        /// <summary>
+        /// Assert that at least one event was logged that matches <param name="predicate"/>.
+        /// </summary>
+        public void AssertHasEvent(Func<LogEvent, bool> predicate, string explanation = null)
+        {
+            bool has = LogEvents.Any<LogEvent>(predicate);
+            if (!has)
+            {
+                if (LogEvents.Count == 0)
+                {
+                    Console.WriteLine("Event log is empty.");
+                }
+                else
+                {
+                    Console.WriteLine("Event log contains:");
+                    LogEvents.ForEach(Console.WriteLine);
+                }
+            }
+            Assert.That(has, Is.True, explanation);
+        }
+
+        /// <summary>
+        /// Assert that no event was logged that matches <param name="predicate"/>.
+        /// </summary>
+        public void AssertNoEvent(Func<LogEvent, bool> predicate, string explanation = null)
+        {
+            AssertEventCount(predicate, 0, explanation);
+        }
+
+        /// <summary>
+        /// Assert that exactly <param name="expectedCount"/> events were logged that match <param name="predicate"/>.
+        /// </summary>
+        public void AssertEventCount(Func<LogEvent, bool> predicate, int expectedCount, string explanation = null)
+        {
+            int actualCount = LogEvents.Count<LogEvent>(predicate);
+            if (expectedCount != actualCount)
+            {
+                if (LogEvents.Count == 0)
+                {
+                    Console.WriteLine("Event log is empty.");
+                }
+                else
+                {
+                    Console.WriteLine("Event log contains:");
+                    LogEvents.ForEach(Console.WriteLine);
+                }
+            }
+            Assert.That(actualCount, Is.EqualTo(expectedCount), explanation);
         }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -459,7 +459,7 @@ namespace SIL.XForge.Scripture.Services
                 .WriteFileCreatingBackup(Arg.Any<string>(), Arg.Any<Action<string>>());
 
             // PT username is not written to server logs
-            Assert.That(env.MockLogger.Messages.Any((string message) => message.Contains(env.Username01)), Is.False);
+            env.MockLogger.AssertNoEvent((LogEvent logEvent) => logEvent.Message.Contains(env.Username01));
         }
 
         [Test]
@@ -485,7 +485,7 @@ namespace SIL.XForge.Scripture.Services
             // See if there is a message for the user updating the book
             string logMessage = string.Format("{0} updated {1} in {2}.", env.User01,
                     Canon.BookNumberToEnglishName(ruthBookNum), env.ProjectScrText.Name);
-            Assert.That(env.MockLogger.Messages.Any((string message) => message == logMessage), Is.True);
+            env.MockLogger.AssertHasEvent((LogEvent logEvent) => logEvent.Message == logMessage);
         }
 
         [Test]
@@ -516,7 +516,7 @@ namespace SIL.XForge.Scripture.Services
             // See if there is a message for the user updating the book
             string logMessage = string.Format("{0} updated {1} in {2}.", env.User01,
                     Canon.BookNumberToEnglishName(ruthBookNum), env.ProjectScrText.Name);
-            Assert.That(env.MockLogger.Messages.Any((string message) => message == logMessage), Is.True);
+            env.MockLogger.AssertHasEvent((LogEvent logEvent) => logEvent.Message == logMessage);
         }
 
         [Test]
@@ -549,7 +549,7 @@ namespace SIL.XForge.Scripture.Services
             // See if there is a message for the user updating the chapter
             string logMessage = string.Format("{0} updated chapter {1} of {2} in {3}.", env.User01, 1,
                     Canon.BookNumberToEnglishName(ruthBookNum), env.ProjectScrText.Name);
-            Assert.That(env.MockLogger.Messages.Any((string message) => message == logMessage), Is.True);
+            env.MockLogger.AssertHasEvent((LogEvent logEvent) => logEvent.Message == logMessage);
         }
 
         [Test]
@@ -608,7 +608,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(comment.Deleted, Is.True, "Comment should be marked deleted");
 
             // PT username is not written to server logs
-            Assert.That(env.MockLogger.Messages.Any((string message) => message.Contains(env.Username01)), Is.False);
+            env.MockLogger.AssertNoEvent((LogEvent logEvent) => logEvent.Message.Contains(env.Username01));
         }
 
         [Test]


### PR DESCRIPTION
- To help diagnose the events that lead to problem situations.
- We can trim this down if needed.
- Output information about swallowed exceptions.
- The Log() method gets the project SF Id and user SF Id from the
object instance. But it can also be passed Ids to use (which is useful
in InitAsync(), where _projectDoc and _userSecret may not be set yet.
Otherwise it can fall back to "unknown", such as if we weren't given a
valid user id.
- Specifically specify the ParatextSyncRunner and EngineRuntime as
allowed for "Information" logging. This is redundant with "SIL" on the
line above, but if we remove "SIL" then (1) this makes it clear what
was something that was intended to be logged, and (2) it will be easy
to retain the logging of these.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1106)
<!-- Reviewable:end -->
