### PR TITLE
Exclude dataInSync from sync transaction

### DIFF
--- a/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
@@ -42,16 +42,16 @@ namespace SIL.XForge.Scripture.Services
         /// </summary>
         public override string[] Pull(string repository, SharedRepository pullRepo)
         {
-            string tip = GetBaseRevision(repository);
+            string baseRev = GetBaseRevision(repository);
 
             // Get bundle
             string guid = Guid.NewGuid().ToString();
             List<string> query = new List<string> { "guid", guid, "proj", pullRepo.ScrTextName, "projid",
                         pullRepo.SendReceiveId.Id, "type", "zstd-v2" };
-            if (tip != null)
+            if (baseRev != null)
             {
                 query.Add("base1");
-                query.Add(tip);
+                query.Add(baseRev);
             }
 
             byte[] bundle = client.GetStreaming("pullbundle", query.ToArray());
@@ -73,10 +73,12 @@ namespace SIL.XForge.Scripture.Services
         /// </summary>
         public override void Push(string repository, SharedRepository pushRepo)
         {
-            string tip = GetBaseRevision(repository);
+            // TODO: Because of how restoring a backup works, if no changes were made in Paratext that were merged
+            // into scripture forge, this push will silently fail to push SF changes to PT.
+            string baseRev = GetBaseRevision(repository);
 
             // Create bundle
-            byte[] bundle = HgWrapper.Bundle(repository, tip);
+            byte[] bundle = HgWrapper.Bundle(repository, baseRev);
             if (bundle.Length == 0)
                 return;
 

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -765,9 +765,7 @@ namespace SIL.XForge.Scripture.Services
                 if (canRollbackParatext)
                 {
                     // If the restore is successful, then dataInSync will always be set to true because
-                    // the restored repo is not guaranteed to be at the version that is recorded in the project doc.
-                    // In these cases, the backup is expected to be ahead of what is recorded in the project doc
-                    // and future synchronizations can be performed safely.
+                    // the restored repo can be assumed to be at the revision recorded in the project doc.
                     restoreSucceeded = _paratextService.RestoreRepository(_userSecret, _projectDoc.Data.ParatextId);
                 }
                 Log($"CompleteSync: Sync was not successful. {(restoreSucceeded ? "Rolled back" : "Failed to roll back")} local PT repo.");

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -382,6 +382,7 @@ namespace SIL.XForge.Scripture.Services
             _conn.BeginTransaction();
             _conn.ExcludePropertyFromTransaction<SFProject>(op => op.Sync.PercentCompleted);
             _conn.ExcludePropertyFromTransaction<SFProject>(op => op.Sync.QueuedCount);
+            _conn.ExcludePropertyFromTransaction<SFProject>(op => op.Sync.DataInSync);
             _projectDoc = await _conn.FetchAsync<SFProject>(projectSFId);
             if (!_projectDoc.IsLoaded)
             {


### PR DESCRIPTION
This fix ensures that the DataInSync property is always written to the project doc outside of any transaction.

The second commit introduces a fix where a backup is restored at a revision that does not match our record in the project doc. In these cases, we mark that the data is in sync and the next time synchronized a full sync is done to save local edits.

A drawing of the scenarios can be found here. https://docs.google.com/drawings/d/1pCSxW-97I-iy0OFfR6ad7er6QpI8ePz3Sy27D11cNI8/edit

Acceptance tests:
Scenario 1
Bad scenario
1. Checkout branch SF-1371-a-bad and run command dotnet run.
2. Make a change to book text
3. Synchronize the project.
4. Go to book and observe that the book CAN be edited. Edit the book.
5. Checkout master branch and run command dotnet run.
6. Edit the book.
7. Synchronize the project. Observe that the edited text is lost.

Good scenario
1. Checkout branch SF-1371-a-fix and run command dotnet run.
2. Make a change to book text.
3. Synchronize the project.
4. Go to book and observe that the book CANNOT be edited.

Scenario 2
Setup
1. Checkout SF-1371-b and run command dotnet run
2. Make some text change and synchronize the project.
3. Checkout SF-1371-c and run command dotnet run.
4. Make some text changes.
5. Synchronize the project.

Bad scenario
1. Checkout master branch and run command dotnet run.
2. Synchronize the project.
3. Observe that the second text changes are lost.

Good scenario
1. Checkout fix/restore-fail-data-loss branch and run command dotnet run.
2. Synchronize the project.
3. Observe that the second text changes are still there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1108)
<!-- Reviewable:end -->
