### PR TITLE
Add script to print history of a text doc

### DIFF
--- a/scripts/db_tools/README.md
+++ b/scripts/db_tools/README.md
@@ -1,0 +1,6 @@
+# Usage
+To run one of the scripts:
+- Start the local server or forward ports from a remote server.
+- Edit the connection settings in `utils.js` (`devConfig`, `qaConfig`, or `liveConfig`) to specify where the script should connect.
+- Edit the script you want to run so it uses the right connection config and selects the right document.
+- Run the script.

--- a/scripts/db_tools/text-doc-history.js
+++ b/scripts/db_tools/text-doc-history.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+// The purpose of this script is to visualize the history of a text document by showing who made what edits when.
+// Sequential edits by the same user are grouped together so the size of the history is manageable.
+
+const utils = require('./utils.js');
+const RichText = utils.requireFromRealTimeServer('rich-text');
+const ShareDB = utils.requireFromRealTimeServer('sharedb/lib/client');
+const WebSocket = utils.requireFromRealTimeServer('ws');
+const MongoClient = utils.requireFromRealTimeServer('mongodb');
+const OTJson0 = utils.requireFromRealTimeServer('ot-json0');
+
+// Edit these settings to specify which doc to visualize
+const projectShortName = 'AAA';
+const book = 'GEN';
+const chapter = 1;
+const connectionConfig = utils.devConfig;
+
+ShareDB.types.register(RichText.type);
+ShareDB.types.register(OTJson0.type);
+
+async function run() {
+  const ws = new WebSocket(connectionConfig.wsConnectionString);
+  const conn = new ShareDB.Connection(ws);
+  const client = await MongoClient.connect(connectionConfig.dbLocation, { useUnifiedTopology: true });
+  try {
+    const db = client.db();
+    const projectCollection = db.collection('sf_projects');
+    const usersCollection = db.collection('users');
+    const textOperationCollection = db.collection('o_texts');
+
+    const projectId = (await projectCollection.findOne({ shortName: projectShortName }))._id;
+    const docId = `${projectId}:${book}:${chapter}:target`;
+
+    const docs = await textOperationCollection
+      .find({ d: docId }, { projection: { v: 1, m: 1 }, sort: { v: 1 } })
+      .toArray();
+    let lastLoggedDocIndex = -1;
+    for (let i = 0; i < docs.length; i++) {
+      const doc = docs[i];
+      if (!doc.m.uId) {
+        const snapshot = await utils.fetchSnapshotByVersion(conn, 'texts', docId, doc.v + 1);
+        const project = await utils.fetchSnapshotByTimestamp(conn, 'sf_projects', projectId, doc.m.ts);
+        const user = 'unspecified user (sync was ' + (!project.data.sync.queuedCount ? 'not ' : '') + 'in progress)';
+        logEdit(snapshot, user, 1, doc.m.ts);
+      } else if (docs[i + 1] && docs[i + 1].m.uId === doc.m.uId) {
+        continue;
+      } else {
+        const snapshot = await utils.fetchSnapshotByVersion(conn, 'texts', docId, doc.v + 1);
+        const user = await usersCollection.findOne({ _id: doc.m.uId }, { projection: { displayName: 1 } });
+        const userDescription = `${user.displayName} (${doc.m.uId})`;
+        logEdit(snapshot, userDescription, i - lastLoggedDocIndex, docs[lastLoggedDocIndex + 1].m.ts, doc.m.ts);
+      }
+      lastLoggedDocIndex = i;
+    }
+  } finally {
+    client.close();
+    conn.close();
+  }
+}
+
+function logEdit(snapshot, user, editCount, startTime, endTime) {
+  const time =
+    editCount === 1
+      ? `at ${new Date(startTime).toUTCString()}`
+      : `from ${new Date(startTime).toUTCString()} to ${new Date(endTime).toUTCString()}`;
+
+  console.log(`Modified by ${user} in ${editCount} edits ${time}`);
+  utils.visualizeOps(snapshot.data.ops);
+  console.log();
+}
+
+run();

--- a/scripts/db_tools/utils.js
+++ b/scripts/db_tools/utils.js
@@ -1,0 +1,57 @@
+function requireFromRealTimeServer(package) {
+  return require('../../src/RealtimeServer/node_modules/' + package);
+}
+
+function fetchSnapshotByVersion(conn, collection, docId, version) {
+  return new Promise((resolve, reject) => {
+    conn.fetchSnapshot(collection, docId, version, (err, snapshot) => (err != null ? reject(err) : resolve(snapshot)));
+  });
+}
+
+function fetchSnapshotByTimestamp(conn, collection, docId, time) {
+  return new Promise((resolve, reject) => {
+    conn.fetchSnapshotByTimestamp(collection, docId, time, (err, snapshot) =>
+      err != null ? reject(err) : resolve(snapshot)
+    );
+  });
+}
+
+function visualizeOps(ops) {
+  const result = ops
+    .map(op => {
+      if (typeof op.insert === 'string') {
+        return op.insert;
+      } else if (op.insert.verse) {
+        return op.insert.verse.number + ' ';
+      } else if (op.insert.chapter) {
+        return 'Chapter ' + op.insert.chapter.number + '\n';
+      } else return '';
+    })
+    .join('');
+  console.log(result);
+}
+
+const devConfig = {
+  dbLocation: 'mongodb://localhost:27017/xforge',
+  wsConnectionString: 'ws://127.0.0.1:5003/?server=true'
+};
+
+const qaConfig = {
+  dbLocation: 'mongodb://localhost:4017/xforge',
+  wsConnectionString: 'ws://127.0.0.1:4003/?server=true'
+};
+
+const liveConfig = {
+  dbLocation: 'mongodb://localhost:3017/xforge',
+  wsConnectionString: 'ws://127.0.0.1:3003/?server=true'
+};
+
+module.exports = {
+  requireFromRealTimeServer,
+  fetchSnapshotByVersion,
+  fetchSnapshotByTimestamp,
+  visualizeOps,
+  devConfig,
+  qaConfig,
+  liveConfig
+};


### PR DESCRIPTION
Likely more scripts to follow. Hence the use of a utils file and an attempt to centralize configurations regarding where the connections should be made to. The idea is that it should be very easy to run the scripts against localhost and then switch to running them against qa or live with only minimal changes (experience has shown that constantly having to edit the scripts to specify a different port number is slow and confusing).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1109)
<!-- Reviewable:end -->
