### PR TITLE
SF-1309 Reduce logging

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -131,9 +131,13 @@ namespace SIL.XForge.Scripture.Services
         /// <summary> Prepare access to Paratext.Data library, authenticate, and prepare Mercurial. </summary>
         public void Init()
         {
-            // Uncomment to output more info from ParatextData.dll for investigating.
-            // Trace.Listeners.Add(new TextWriterTraceListener(Console.Out));
-            // Trace.AutoFlush = true;
+            // Uncomment to output more info to the Terminal from ParatextData.dll for investigating. Note that without Clear()ing, the output would show in Debug Console while debugging.
+            // The output is using System.Diagnostics.Trace and so is not managed by the ILogging LogLevel filtering settings.
+            // System.Diagnostics.Trace.Listeners.Add(new System.Diagnostics.TextWriterTraceListener(Console.Out));
+            // System.Diagnostics.Trace.AutoFlush = true;
+
+            // Stop ParatextData.dll Trace output from appearing on the server.
+            System.Diagnostics.Trace.Listeners.Clear();
 
             SyncDir = Path.Combine(_siteOptions.Value.SiteDir, "sync");
             if (!_fileSystemService.DirectoryExists(SyncDir))

--- a/src/SIL.XForge.Scripture/appsettings.Development.json
+++ b/src/SIL.XForge.Scripture/appsettings.Development.json
@@ -1,7 +1,13 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information"
+      "Default": "Information",
+      "Microsoft.AspNetCore.Localization": "Error",
+      "Hangfire": "Warning",
+      "SIL.XForge.Services.EmailService": "Information",
+      "SIL.XForge.Scripture.Services.ParatextService": "Information",
+      "SIL.Machine.WebApi.Services.EngineRuntime": "Information",
+      "SIL.XForge.Scripture.Services.ParatextSyncRunner": "Information"
     }
   },
   "Site": {

--- a/src/SIL.XForge.Scripture/appsettings.json
+++ b/src/SIL.XForge.Scripture/appsettings.json
@@ -3,7 +3,9 @@
     "LogLevel": {
       "Default": "Warning",
       "Microsoft.AspNetCore.Localization": "Error",
-      "SIL": "Information",
+      "Hangfire": "Warning",
+      "SIL.XForge.Services.EmailService": "Warning",
+      "SIL.XForge.Scripture.Services.ParatextService": "Warning",
       "SIL.Machine.WebApi.Services.EngineRuntime": "Information",
       "SIL.XForge.Scripture.Services.ParatextSyncRunner": "Information"
     }


### PR DESCRIPTION
- Clear trace listeners to stop showing ParatextData and hg output
  during sync.
- Set log level filtering to show less on production server.
  - Hiding email sends, some ParatextService messages.
  - Showing info from sync or training engine.
- Set log level filtering to specifically show certain logging items
  in development. These can be changed to Trace to see more
  information.
  - Show (faked) email sends.
  - Show ParatextService messages.
  - Hide most hangfire messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1110)
<!-- Reviewable:end -->
