### PR TITLE
Fix project select for long project names

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -37,7 +37,8 @@
           margin: 0;
           border-radius: 0;
           padding: 0 16px;
-          height: 48px;
+          height: unset;
+          min-height: 48px;
         }
         .mdc-list-divider {
           margin: 8px 0;


### PR DESCRIPTION
Before | After
---------|--------
![](https://user-images.githubusercontent.com/6140710/127939957-8a86500d-83a9-47bc-8c4e-fcc68e357e51.png) | ![](https://user-images.githubusercontent.com/6140710/127939960-16d3a1c0-3c6e-461a-bbc1-c784b1fe8b56.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1114)
<!-- Reviewable:end -->
