### PR TITLE
SF-1373 Disable autofill in project delete dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.html
@@ -18,6 +18,7 @@
               id="project-entry"
               label="{{ t('project_name') }}"
               [formControl]="projectNameEntry"
+              autocomplete="off"
             ></mdc-text-field>
           </mdc-form-field>
         </mdc-dialog-content>


### PR DESCRIPTION
Autofilling the project name in the delete dialog doesn't make sense and can cause weird UI issues (see screenshot in issue).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1115)
<!-- Reviewable:end -->
