### PR TITLE
SF1372: Restored changesets are now marked as public

### DIFF
--- a/src/SIL.XForge.Scripture/Services/HgWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/HgWrapper.cs
@@ -42,13 +42,10 @@ namespace SIL.XForge.Scripture.Services
         /// Get the most recent revision id of the commit from the last push or pull with the PT send/receive server.
         /// </summary>
         /// <param name="repository">The full path to the repository directory.</param>
-        /// <param name="allowEmptyIfRestoredFromBackup">
-        /// If set to <c>true</c>, allow an empty revision if this is a restored backup.
-        /// </param>
         /// <returns>
         /// The Mercurial revision identifier.
         /// </returns>
-        public string GetLastPublicRevision(string repository, bool allowEmptyIfRestoredFromBackup)
+        public string GetLastPublicRevision(string repository)
         {
             string ids = RunCommand(repository, "log --rev \"public()\" --template \"{node}\n\"");
             string revision = ids.Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries).LastOrDefault()?.Trim();

--- a/src/SIL.XForge.Scripture/Services/IHgWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/IHgWrapper.cs
@@ -10,5 +10,6 @@ namespace SIL.XForge.Scripture.Services
         void BackupRepository(string repository, string backupFile);
         void RestoreRepository(string destination, string backupFile);
         string GetLastPublicRevision(string repository, bool allowEmptyIfRestoredFromBackup);
+        void MarkSharedChangeSetsPublic(string repository);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/IHgWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/IHgWrapper.cs
@@ -9,7 +9,7 @@ namespace SIL.XForge.Scripture.Services
         void Update(string repository);
         void BackupRepository(string repository, string backupFile);
         void RestoreRepository(string destination, string backupFile);
-        string GetLastPublicRevision(string repository, bool allowEmptyIfRestoredFromBackup);
+        string GetLastPublicRevision(string repository);
         void MarkSharedChangeSetsPublic(string repository);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
@@ -42,7 +42,7 @@ namespace SIL.XForge.Scripture.Services
         /// </summary>
         public override string[] Pull(string repository, SharedRepository pullRepo)
         {
-            string baseRev = GetBaseRevision(repository);
+            string baseRev = _hgWrapper.GetLastPublicRevision(repository);
 
             // Get bundle
             string guid = Guid.NewGuid().ToString();
@@ -73,7 +73,7 @@ namespace SIL.XForge.Scripture.Services
         /// </summary>
         public override void Push(string repository, SharedRepository pushRepo)
         {
-            string baseRev = GetBaseRevision(repository);
+            string baseRev = _hgWrapper.GetLastPublicRevision(repository);
 
             // Create bundle
             byte[] bundle = HgWrapper.Bundle(repository, baseRev);
@@ -148,12 +148,6 @@ namespace SIL.XForge.Scripture.Services
             // RestClient only uses the jwtToken if authentication is null;
             ReflectionHelperLite.SetField(client, "authentication", null);
             _registryClient.JwtToken = jwtToken;
-        }
-
-        /// <summary> Get the latest public revision. </summary>
-        private string GetBaseRevision(string repository)
-        {
-            return _hgWrapper.GetLastPublicRevision(repository, allowEmptyIfRestoredFromBackup: true);
         }
     }
 }

--- a/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
@@ -63,7 +63,7 @@ namespace SIL.XForge.Scripture.Services
             // Use bundle
             string[] changeSets = HgWrapper.Pull(repository, bundle);
 
-            MarkSharedChangeSetsPublic(repository);
+            _hgWrapper.MarkSharedChangeSetsPublic(repository);
             return changeSets;
         }
 
@@ -73,8 +73,6 @@ namespace SIL.XForge.Scripture.Services
         /// </summary>
         public override void Push(string repository, SharedRepository pushRepo)
         {
-            // TODO: Because of how restoring a backup works, if no changes were made in Paratext that were merged
-            // into scripture forge, this push will silently fail to push SF changes to PT.
             string baseRev = GetBaseRevision(repository);
 
             // Create bundle
@@ -87,7 +85,7 @@ namespace SIL.XForge.Scripture.Services
             client.PostStreaming(bundle, "pushbundle", "guid", guid, "proj", pushRepo.ScrTextName, "projid",
                 pushRepo.SendReceiveId.Id, "registered", "yes", "userschanged", "no");
 
-            MarkSharedChangeSetsPublic(repository);
+            _hgWrapper.MarkSharedChangeSetsPublic(repository);
         }
 
         /// <summary>
@@ -156,12 +154,6 @@ namespace SIL.XForge.Scripture.Services
         private string GetBaseRevision(string repository)
         {
             return _hgWrapper.GetLastPublicRevision(repository, allowEmptyIfRestoredFromBackup: true);
-        }
-
-        /// <summary> Mark all changesets available on the PT server public. </summary>
-        private void MarkSharedChangeSetsPublic(string repository)
-        {
-            HgWrapper.RunCommand(repository, "phase -p -r 'tip'");
         }
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -941,9 +941,18 @@ namespace SIL.XForge.Scripture.Services
                         _fileSystemService.MoveDirectory(source, destination);
                     }
 
-                    // Restore the Mercurial database, and move it to the repository
+                    // Restore the Mercurial repository to a temporary destination
                     _hgHelper.RestoreRepository(restoredDestination, backupPath);
+
+                    // Although the bundle stores phase information, this is compared against the repo the bundle is
+                    // restored to. As the repo is new, the changesets from the bundle will be marked draft. Because
+                    // the bundle contains changesets from the Paratext server, we can just mark the changesets public,
+                    // as we do when pulling from the repo.
+                    _hgHelper.MarkSharedChangeSetsPublic(restoredDestination);
+
+                    // Now that it is ready, move it to the repository location
                     _fileSystemService.MoveDirectory(restoredDestination, source);
+
                     return true;
                 }
                 catch (Exception e)

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -797,7 +797,7 @@ namespace SIL.XForge.Scripture.Services
             using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
             if (scrText != null)
             {
-                return _hgHelper.GetLastPublicRevision(scrText.Directory, allowEmptyIfRestoredFromBackup: false);
+                return _hgHelper.GetLastPublicRevision(scrText.Directory);
             }
             else
             {

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -920,7 +920,7 @@ namespace SIL.XForge.Scripture.Services
             string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
             ScrText scrText = env.GetScrText(associatedPtUser, ptProjectId);
             string lastPublicRevision = "abc123";
-            env.MockHgWrapper.GetLastPublicRevision(scrText.Directory, allowEmptyIfRestoredFromBackup: false)
+            env.MockHgWrapper.GetLastPublicRevision(scrText.Directory)
                 .Returns(lastPublicRevision);
 
             // SUT
@@ -946,7 +946,7 @@ namespace SIL.XForge.Scripture.Services
                 "DBL resources do not have hg repositories to have a last pushed or pulled hg commit id.");
             // Wouldn't have ended up trying to find a ScrText or querying hg.
             env.MockScrTextCollection.DidNotReceiveWithAnyArgs().FindById(default, default);
-            env.MockHgWrapper.DidNotReceiveWithAnyArgs().GetLastPublicRevision(default, default);
+            env.MockHgWrapper.DidNotReceiveWithAnyArgs().GetLastPublicRevision(default);
         }
 
         [Test]

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -1055,6 +1055,8 @@ namespace SIL.XForge.Scripture.Services
             // SUT
             bool result = env.Service.RestoreRepository(user01Secret, ptProjectId);
             Assert.IsFalse(result);
+            env.MockHgWrapper.DidNotReceiveWithAnyArgs().RestoreRepository(default, default);
+            env.MockHgWrapper.DidNotReceiveWithAnyArgs().MarkSharedChangeSetsPublic(default);
         }
 
         [Test]
@@ -1071,6 +1073,8 @@ namespace SIL.XForge.Scripture.Services
             // SUT
             bool result = env.Service.RestoreRepository(user01Secret, ptProjectId);
             Assert.IsFalse(result);
+            env.MockHgWrapper.DidNotReceiveWithAnyArgs().RestoreRepository(default, default);
+            env.MockHgWrapper.DidNotReceiveWithAnyArgs().MarkSharedChangeSetsPublic(default);
         }
 
         [Test]
@@ -1087,6 +1091,8 @@ namespace SIL.XForge.Scripture.Services
             // SUT
             bool result = env.Service.RestoreRepository(user01Secret, ptProjectId);
             Assert.IsTrue(result);
+            env.MockHgWrapper.ReceivedWithAnyArgs().RestoreRepository(default, default);
+            env.MockHgWrapper.ReceivedWithAnyArgs().MarkSharedChangeSetsPublic(default);
         }
 
         private class TestEnvironment


### PR DESCRIPTION
When a bundle is restored into an initialized repository, the stage for all of the commits is marked as draft. As the commits in a backup are already on the repo server, these should be marked public.

This pull request moves `MarkSharedChangeSetsPublic` from `JwtInternetSharedRepositorySource` to `HgWrapper`, and calls this method when a backup is restored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1117)
<!-- Reviewable:end -->
