### PR TITLE
SF-1374 Include short name when selecting or searching for a resource

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
@@ -102,7 +102,7 @@ describe('ConnectProjectComponent', () => {
     expect(env.selectableSourceProjectsAndResources.projects.length).toEqual(3);
     expect(env.selectableSourceProjectsAndResources.resources.length).toEqual(3);
     expect(env.selectableSourceProjectsAndResources.projects[2]).toBe('THA - Thai');
-    expect(env.selectableSourceProjectsAndResources.resources[0]).toBe('Sob Jonah and Luke');
+    expect(env.selectableSourceProjectsAndResources.resources[0]).toBe('SJL - Sob Jonah and Luke');
     expect(env.component.connectProjectForm.valid).toBe(true);
     env.clickElement(env.submitButton);
   }));
@@ -599,9 +599,13 @@ class TestEnvironment {
           }
         ],
         [
-          { paratextId: 'e01f11e9b4b8e338', name: 'Sob Jonah and Luke' },
-          { paratextId: '5e51f89e89947acb', name: 'Aruamu New Testament [msy] Papua New Guinea 2004 DBL' },
-          { paratextId: '9bb76cd3e5a7f9b4', name: 'Revised Version with Apocrypha 1885, 1895' }
+          { paratextId: 'e01f11e9b4b8e338', name: 'Sob Jonah and Luke', shortName: 'SJL' },
+          {
+            paratextId: '5e51f89e89947acb',
+            name: 'Aruamu New Testament [msy] Papua New Guinea 2004 DBL',
+            shortName: 'ANT'
+          },
+          { paratextId: '9bb76cd3e5a7f9b4', name: 'Revised Version with Apocrypha 1885, 1895', shortName: 'RVA' }
         ]
       ])
     );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.ts
@@ -7,7 +7,7 @@ import { ParatextProject } from './models/paratext-project';
 
 export interface SelectableProject {
   name: string;
-  shortName?: string;
+  shortName: string;
   paratextId: string;
 }
 
@@ -43,8 +43,18 @@ export class ParatextService {
 
   private getResources(): Promise<SelectableProject[] | undefined> {
     return this.http
-      .get<{ [key: string]: string }[]>('paratext-api/resources', { headers: this.getHeaders() })
-      .pipe(map(r => (r ? Object.keys(r).map(key => ({ paratextId: key, name: r[key] })) : undefined)))
+      .get<any[]>('paratext-api/resources', { headers: this.getHeaders() })
+      .pipe(
+        map(result => {
+          return result == null
+            ? undefined
+            : Object.entries(result).map(entry => ({
+                paratextId: entry[0],
+                shortName: entry[1][0],
+                name: entry[1][1]
+              }));
+        })
+      )
       .toPromise();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.html
@@ -14,7 +14,7 @@
     </mat-error>
     <mat-autocomplete
       #auto="matAutocomplete"
-      [displayWith]="projectDisplayText"
+      [displayWith]="projectLabel"
       (opened)="autocompleteOpened()"
       class="project-select"
     >
@@ -22,7 +22,9 @@
         <mat-option *ngFor="let project of projects$ | async" [value]="project">{{ projectLabel(project) }}</mat-option>
       </mat-optgroup>
       <mat-optgroup label="{{ t('resources') }}" *ngIf="nullableLength(resources$ | async) > 0">
-        <mat-option *ngFor="let resource of resources$ | async" [value]="resource">{{ resource.name }}</mat-option>
+        <mat-option *ngFor="let resource of resources$ | async" [value]="resource">{{
+          projectLabel(resource)
+        }}</mat-option>
       </mat-optgroup>
     </mat-autocomplete>
   </mat-form-field>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.spec.ts
@@ -18,7 +18,7 @@ describe('ProjectSelectComponent', () => {
     expect(env.groupLabels[0]).toBe('Projects');
     expect(env.groupLabels[1]).toBe('Resources');
     expect(env.optionsText(0)).toEqual(['P1 - Project 1', 'P3 - Project 3']);
-    expect(env.optionsText(1)).toEqual(['Resource 1', 'Resource 2']);
+    expect(env.optionsText(1)).toEqual(['R1 - Resource 1', 'R2 - Resource 2']);
   }));
 
   it('it only lists groups with menu items', fakeAsync(() => {
@@ -72,11 +72,15 @@ describe('ProjectSelectComponent', () => {
   }));
 
   it('adds list items as the user scrolls the list', fakeAsync(() => {
-    const resources = [...Array(100).keys()].map(key => ({ paratextId: 'r' + key, name: 'Resource ' + (key + 1) }));
+    const resources = [...Array(100).keys()].map(key => ({
+      paratextId: 'r' + key,
+      name: 'Resource ' + (key + 1),
+      shortName: 'R' + key
+    }));
     const env = new TestEnvironment('p03', undefined, resources);
     env.clickInput();
     expect(env.optGroups.length).toBe(2);
-    expect(env.optionsText(0)).toEqual(['P1 - Project 1', 'Project 2']);
+    expect(env.optionsText(0)).toEqual(['P1 - Project 1', 'P2 - Project 2']);
     expect(env.options(1).length).toBe(25);
     env.scrollMenu(2500);
     expect(env.options(1).length).toBe(50);
@@ -128,12 +132,12 @@ class HostComponent {
 
   projects: SelectableProject[] = [
     { name: 'Project 1', paratextId: 'p01', shortName: 'P1' },
-    { name: 'Project 2', paratextId: 'p02' },
+    { name: 'Project 2', paratextId: 'p02', shortName: 'P2' },
     { name: 'Project 3', paratextId: 'p03', shortName: 'P3' }
   ];
   resources: SelectableProject[] = [
-    { name: 'Resource 1', paratextId: 'r01' },
-    { name: 'Resource 2', paratextId: 'r02' }
+    { name: 'Resource 1', paratextId: 'r01', shortName: 'R1' },
+    { name: 'Resource 2', paratextId: 'r02', shortName: 'R2' }
   ];
   nonSelectableProjects: SelectableProject[] = [{ name: 'Project 1', paratextId: 'p01', shortName: 'P1' }];
   hideProjectId: string = '';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
@@ -133,10 +133,6 @@ export class ProjectSelectComponent extends SubscriptionDisposable implements Co
     this.subscribe(this.valueChange, fn);
   }
 
-  projectDisplayText(project?: SelectableProject): string {
-    return project?.name || '';
-  }
-
   autocompleteOpened() {
     setTimeout(() => {
       if (this.autocomplete && this.autocomplete.panel && this.autocompleteTrigger) {
@@ -172,10 +168,18 @@ export class ProjectSelectComponent extends SubscriptionDisposable implements Co
     collection: SelectableProject[],
     limit?: number
   ): SelectableProject[] {
-    const valueLower = typeof value === 'string' ? value.toLowerCase() : '';
+    const valueLower = typeof value === 'string' ? value.trim().toLowerCase() : '';
     return collection
-      .filter(project => project.name.toLowerCase().includes(valueLower) && project.paratextId !== this.hideProjectId)
-      .sort((a, b) => a.name.toLowerCase().indexOf(valueLower) - b.name.toLowerCase().indexOf(valueLower))
+      .filter(p => p.paratextId !== this.hideProjectId && this.projectIndexOf(p, valueLower) < Infinity)
+      .sort((a, b) => this.projectIndexOf(a, valueLower) - this.projectIndexOf(b, valueLower))
       .slice(0, limit);
+  }
+
+  /** valueLower is assumed to already be converted to lower case */
+  private projectIndexOf(project: SelectableProject, valueLower: string): number {
+    const a = project.shortName.toLowerCase().indexOf(valueLower);
+    const b = project.name.toLowerCase().indexOf(valueLower);
+    const i = a === -1 || b === -1 ? Math.max(a, b) : Math.min(a, b);
+    return i === -1 ? Infinity : i;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -518,9 +518,13 @@ class TestEnvironment {
           }
         ],
         [
-          { paratextId: 'e01f11e9b4b8e338', name: 'Sob Jonah and Luke' },
-          { paratextId: '5e51f89e89947acb', name: 'Aruamu New Testament [msy] Papua New Guinea 2004 DBL' },
-          { paratextId: '9bb76cd3e5a7f9b4', name: 'Revised Version with Apocrypha 1885, 1895' }
+          { paratextId: 'e01f11e9b4b8e338', name: 'Sob Jonah and Luke', shortName: 'SJL' },
+          {
+            paratextId: '5e51f89e89947acb',
+            name: 'Aruamu New Testament [msy] Papua New Guinea 2004 DBL',
+            shortName: 'ANT'
+          },
+          { paratextId: '9bb76cd3e5a7f9b4', name: 'Revised Version with Apocrypha 1885, 1895', shortName: 'RVA' }
         ]
       ])
     );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -336,7 +336,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
       (this.projects?.find(p => p.paratextId === source.paratextId) ||
         this.resources?.find(r => r.paratextId === source.paratextId)) == null
     ) {
-      this.nonSelectableProjects = [{ paratextId: source.paratextId, name: source.name }];
+      this.nonSelectableProjects = [{ paratextId: source.paratextId, shortName: source.shortName, name: source.name }];
     } else {
       this.nonSelectableProjects = [];
     }

--- a/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
@@ -59,12 +59,12 @@ namespace SIL.XForge.Scripture.Controllers
         /// so we just return the base class <see cref="ParatextProject" />.
         /// </remarks>
         [HttpGet("resources")]
-        public async Task<ActionResult<Dictionary<string, string>>> ResourcesAsync()
+        public async Task<ActionResult<Dictionary<string, string[]>>> ResourcesAsync()
         {
             try
             {
                 var resources = await _paratextService.GetResourcesAsync(_userAccessor.UserId);
-                return Ok(resources.ToDictionary(r => r.ParatextId, r => r.Name));
+                return Ok(resources.ToDictionary(r => r.ParatextId, r => new string[] { r.ShortName, r.Name }));
             }
             catch (DataNotFoundException)
             {


### PR DESCRIPTION
- When searching for a project or resource, typing the short name should find the project
- Resources should be shown with their respective short names
- When selecting a based-on project/resource, the field showing what is selected should include the short name

This applies to both the settings page and the connect project page, but they both use the same component, so it only needed to be changed in one place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1120)
<!-- Reviewable:end -->
