### PR TITLE
SF-1322 Support multiple note threads in a segment

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -38,6 +38,7 @@ interface Chapter extends UsxStyle {
 interface NoteThread {
   iconsrc: string;
   preview: string;
+  embedid: string;
 }
 
 interface Verse extends UsxStyle {
@@ -274,6 +275,44 @@ export function registerScripture(): string[] {
   }
   formats.push(NoteEmbed);
 
+  class NoteThreadEmbed extends Embed {
+    static blotName = 'note-thread-embed';
+    static tagName = 'display-note';
+
+    static create(value: NoteThread) {
+      const node = super.create(value) as HTMLElement;
+      node.setAttribute('style', value.iconsrc);
+      node.setAttribute('title', value.preview);
+      node.setAttribute('embed-id', value.embedid);
+      return node;
+    }
+
+    static formats(node: HTMLElement): NoteThread {
+      return NoteThreadEmbed.value(node);
+    }
+
+    static value(node: HTMLElement): NoteThread {
+      return {
+        iconsrc: node.getAttribute('style')!,
+        preview: node.getAttribute('title')!,
+        embedid: node.getAttribute('embed-id')!
+      };
+    }
+
+    format(name: string, value: any): void {
+      if (name === NoteThreadEmbed.blotName && value != null) {
+        const ref = value as NoteThread;
+        const elem = this.domNode as HTMLElement;
+        elem.setAttribute('style', ref.iconsrc);
+        elem.setAttribute('title', ref.preview);
+        elem.setAttribute('embed-id', ref.embedid);
+      } else {
+        super.format(name, value);
+      }
+    }
+  }
+  formats.push(NoteThreadEmbed);
+
   class OptBreakEmbed extends Embed {
     static blotName = 'optbreak';
     static tagName = 'usx-optbreak';
@@ -474,42 +513,6 @@ export function registerScripture(): string[] {
     }
   }
   formats.push(ChapterEmbed);
-
-  class NoteThreadInline extends Inline {
-    static blotName = 'note-thread';
-    static tagName = 'display-note';
-
-    static create(value: NoteThread) {
-      const node = super.create(value) as HTMLElement;
-      node.setAttribute('style', value.iconsrc);
-      node.setAttribute('title', value.preview);
-      return node;
-    }
-
-    static formats(node: HTMLElement): NoteThread {
-      return NoteThreadInline.value(node);
-    }
-
-    static value(node: HTMLElement): NoteThread {
-      return {
-        iconsrc: node.getAttribute('style')!,
-        preview: node.getAttribute('title')!
-      };
-    }
-
-    format(name: string, value: any): void {
-      if (name === NoteThreadInline.blotName && value != null) {
-        const ref = value as NoteThread;
-        const elem = this.domNode as HTMLElement;
-        elem.setAttribute('style', ref.iconsrc);
-        elem.setAttribute('title', ref.preview);
-      } else {
-        super.format(name, value);
-      }
-    }
-  }
-  formats.push(NoteThreadInline);
-
   Scroll.allowedChildren.push(ParaBlock);
   Scroll.allowedChildren.push(ChapterEmbed);
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -38,7 +38,7 @@ interface Chapter extends UsxStyle {
 interface NoteThread {
   iconsrc: string;
   preview: string;
-  embedid: string;
+  threadid: string;
 }
 
 interface Verse extends UsxStyle {
@@ -283,7 +283,7 @@ export function registerScripture(): string[] {
       const node = super.create(value) as HTMLElement;
       node.setAttribute('style', value.iconsrc);
       node.setAttribute('title', value.preview);
-      node.setAttribute('embed-id', value.embedid);
+      node.setAttribute('thread-id', value.threadid);
       return node;
     }
 
@@ -295,7 +295,7 @@ export function registerScripture(): string[] {
       return {
         iconsrc: node.getAttribute('style')!,
         preview: node.getAttribute('title')!,
-        embedid: node.getAttribute('embed-id')!
+        threadid: node.getAttribute('thread-id')!
       };
     }
 
@@ -305,7 +305,7 @@ export function registerScripture(): string[] {
         const elem = this.domNode as HTMLElement;
         elem.setAttribute('style', ref.iconsrc);
         elem.setAttribute('title', ref.preview);
-        elem.setAttribute('embed-id', ref.embedid);
+        elem.setAttribute('thread-id', ref.threadid);
       } else {
         super.format(name, value);
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -283,7 +283,7 @@ export function registerScripture(): string[] {
       const node = super.create(value) as HTMLElement;
       node.setAttribute('style', value.iconsrc);
       node.setAttribute('title', value.preview);
-      node.setAttribute('thread-id', value.threadid);
+      node.setAttribute(customAttributeName('thread-id'), value.threadid);
       return node;
     }
 
@@ -295,7 +295,7 @@ export function registerScripture(): string[] {
       return {
         iconsrc: node.getAttribute('style')!,
         preview: node.getAttribute('title')!,
-        threadid: node.getAttribute('thread-id')!
+        threadid: node.getAttribute(customAttributeName('thread-id'))!
       };
     }
 
@@ -305,7 +305,7 @@ export function registerScripture(): string[] {
         const elem = this.domNode as HTMLElement;
         elem.setAttribute('style', ref.iconsrc);
         elem.setAttribute('title', ref.preview);
-        elem.setAttribute('thread-id', ref.threadid);
+        elem.setAttribute(customAttributeName('thread-id'), ref.threadid);
       } else {
         super.format(name, value);
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -170,8 +170,6 @@ export class TextViewModel {
     if (source === 'user' && editor.isEnabled()) {
       const modelDelta = this.viewToData(delta);
       if (modelDelta.ops != null && modelDelta.ops.length > 0) {
-        console.log('ops submitted');
-        console.log(modelDelta);
         this.textDoc.submit(modelDelta, this.editor);
       }
     }
@@ -341,9 +339,6 @@ export class TextViewModel {
           'question-count',
           'note-thread-segment',
           'note-thread-count',
-          'note-thread',
-          'note-icon-source',
-          'note-preview',
           'initial',
           'direction-segment',
           'direction-block',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -465,7 +465,7 @@ export class TextViewModel {
             } else if (op.insert['note-thread-embed'] != null) {
               // record the presence of an embedded note in the segment
               const id = op.attributes != null && op.attributes['threadid'];
-              this._embeddedElements.set(id, curIndex + curSegment.length);
+              this._embeddedElements.set(id, curIndex + curSegment.length - 1);
               curSegment.notesCount++;
             }
           }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -706,18 +706,17 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
         this.segment.text === '' &&
         delta?.ops != null &&
         delta.ops.length > 2 &&
-        delta.ops[0].retain != null
+        delta.ops[0].retain != null &&
+        delta.ops[1].insert['note-thread-embed'] != null
       ) {
-        if (delta.ops[1].insert['note-thread-embed'] != null) {
-          // Embedding notes into quill makes quill emit deltas when it registers that content has changed
-          // but quill incorrectly interprets the change when the selection is within the updated segment.
-          // Content coming after the selection gets moved before the selection. This moves the selection back.
-          const curSegmentRange = this.segment.range;
-          const insertionPoint = delta.ops[0].retain;
-          const segmentEndPoint = curSegmentRange.index + curSegmentRange.length - 1;
-          if (insertionPoint >= curSegmentRange.index && insertionPoint <= segmentEndPoint) {
-            this._editor.setSelection(segmentEndPoint);
-          }
+        // Embedding notes into quill makes quill emit deltas when it registers that content has changed
+        // but quill incorrectly interprets the change when the selection is within the updated segment.
+        // Content coming after the selection gets moved before the selection. This moves the selection back.
+        const curSegmentRange: RangeStatic = this.segment.range;
+        const insertionPoint: number = delta.ops[0].retain;
+        const segmentEndPoint: number = curSegmentRange.index + curSegmentRange.length - 1;
+        if (insertionPoint >= curSegmentRange.index && insertionPoint <= segmentEndPoint) {
+          this._editor.setSelection(segmentEndPoint);
         }
       }
       // get currently selected segment ref
@@ -822,8 +821,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     let newSel: RangeStatic | undefined;
     if (this._segment.text === '') {
       // always select at the end of blank so the cursor is inside the segment and not between the segment and verse
-      const notesCount = this._segment.range.length - 1;
-      newSel = { index: this._segment.range.index + notesCount + 1, length: 0 };
+      newSel = { index: this._segment.range.index + this._segment.range.length, length: 0 };
     } else if (!this.multiSegmentSelection) {
       // selections outside of the text chooser dialog are not permitted to extend across segments
       const newStart = Math.max(sel.index, this._segment.range.index);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -329,10 +329,6 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     return 'auto';
   }
 
-  get embeddedNotes(): Map<string, number> {
-    return this.viewModel.embeddedElements;
-  }
-
   private get contentShowing(): boolean {
     return this.id != null && this.viewModel.isLoaded && !this.viewModel.isEmpty;
   }
@@ -575,10 +571,10 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     if (this.editor == null) {
       return;
     }
-    let previousEmbedIndex = 0;
+    let previousEmbedIndex = -1;
     const deleteDelta = new Delta();
     for (const [_, embedIndex] of this.viewModel.embeddedElements.entries()) {
-      // check that there are elements other than notes between the previous and current embed
+      // retain elements other than notes between the previous and current embed
       if (embedIndex > previousEmbedIndex + 1) {
         deleteDelta.retain(embedIndex - (previousEmbedIndex + 1));
       }
@@ -707,6 +703,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
         delta?.ops != null &&
         delta.ops.length > 2 &&
         delta.ops[0].retain != null &&
+        delta.ops[1].insert != null &&
         delta.ops[1].insert['note-thread-embed'] != null
       ) {
         // Embedding notes into quill makes quill emit deltas when it registers that content has changed

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -18,7 +18,7 @@ import { fromEvent } from 'rxjs';
 import { PwaService } from 'xforge-common/pwa.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { getBrowserEngine, verseSlug } from 'xforge-common/utils';
-import { TextDocId } from '../../core/models/text-doc';
+import { Delta, TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { registerScripture } from './quill-scripture';
 import { Segment } from './segment';
@@ -57,6 +57,7 @@ export interface TextUpdatedEvent {
 
 export interface FeaturedVerseRefInfo {
   verseRef: VerseRef;
+  id: string;
   iconName?: string;
   selectedText?: string;
   preview?: string;
@@ -185,6 +186,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   private highlightMarkerHeight: number = 0;
   private _placeholder?: string;
   private displayMessage: string = '';
+  private _toggleVerseElement: boolean = false;
 
   constructor(
     private readonly projectService: SFProjectService,
@@ -328,6 +330,10 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     return 'auto';
   }
 
+  get embeddedNotes(): Map<string, number> {
+    return this.viewModel.embeddedElements;
+  }
+
   private get contentShowing(): boolean {
     return this.id != null && this.viewModel.isLoaded && !this.viewModel.isEmpty;
   }
@@ -383,6 +389,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       this.initialSegmentFocus = focus;
       return true;
     }
+
     const prevSegment = this.segment;
     if (this.tryChangeSegment(segmentRef, checksum, focus, end)) {
       this.updated.emit({ prevSegment, segment: this._segment });
@@ -474,11 +481,11 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       }
       this.editor.formatText(range.index, range.length, formats, 'silent');
     }
-
+    this._toggleVerseElement = value;
     return segments;
   }
 
-  toggleInlineFormat(verseRef: VerseRef, selectedText: string, formatName: string, format: any): void {
+  embedElementInline(verseRef: VerseRef, id: string, selectedText: string, formatName: string, format: any): void {
     if (this.editor == null) {
       return;
     }
@@ -487,7 +494,10 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     const verseSegments: string[] = this.getVerseSegments(verseRef);
     let noteRange: RangeStatic | undefined = this.getSegmentRange(verseSegments[0]);
     let startPosition = 0;
-    let selectionLength = 0;
+    if (Array.from(this.viewModel.embeddedElements.keys()).includes(id)) {
+      return;
+    }
+
     for (const vs of verseSegments) {
       const text: string = this.getSegmentText(vs);
       const range: RangeStatic | undefined = this.getSegmentRange(vs);
@@ -506,7 +516,6 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
           // TODO: Find a better way to match a note to its selected text
           startPosition = start;
           noteRange = range;
-          selectionLength = selectedText.length;
           break;
         }
       }
@@ -515,10 +524,10 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     if (noteRange == null) {
       return;
     }
-    if (selectionLength === 0) {
-      selectionLength = noteRange.length;
-    }
-    this.editor.formatText(noteRange.index + startPosition, selectionLength, formatName, format, 'silent');
+
+    const noteInsertIndex: number = noteRange.index + startPosition;
+    this.editor.insertEmbed(noteInsertIndex, formatName, format, 'api');
+    this.updateSegment();
   }
 
   onContentChanged(delta: DeltaStatic, source: string): void {
@@ -564,6 +573,26 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     }
   }
 
+  removeEmbeddedElements(): void {
+    if (this.editor == null) {
+      return;
+    }
+    let previousEmbedIndex = 0;
+    const deleteDelta = new Delta();
+    for (const [_, embedIndex] of this.viewModel.embeddedElements.entries()) {
+      // check that there are elements other than notes between the previous and current embed
+      if (embedIndex > previousEmbedIndex + 1) {
+        deleteDelta.retain(embedIndex - (previousEmbedIndex + 1));
+      }
+      deleteDelta.delete(1);
+      previousEmbedIndex = embedIndex;
+    }
+    deleteDelta.chop();
+    if (deleteDelta.ops != null && deleteDelta.ops.length > 0) {
+      this.editor.updateContents(deleteDelta, 'api');
+    }
+  }
+
   private applyEditorStyles() {
     if (this._editor != null) {
       const container = this._editor.container as HTMLElement;
@@ -577,6 +606,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
 
   private async bindQuill(): Promise<void> {
     this.viewModel.unbind();
+    this._toggleVerseElement = false;
     if (this._id == null) {
       return;
     }
@@ -676,7 +706,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     if (this._editor != null && segmentRef == null) {
       // get currently selected segment ref
       const selection = this._editor.getSelection();
-      if (selection != null) {
+      if (this._toggleVerseElement && selection != null) {
         segmentRef = this.viewModel.getSegmentRef(selection);
       }
     }
@@ -776,7 +806,8 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     let newSel: RangeStatic | undefined;
     if (this._segment.text === '') {
       // always select at the end of blank so the cursor is inside the segment and not between the segment and verse
-      newSel = { index: this._segment.range.index + 1, length: 0 };
+      const notesCount = this._segment.range.length - 1;
+      newSel = { index: this._segment.range.index + notesCount + 1, length: 0 };
     } else if (!this.multiSegmentSelection) {
       // selections outside of the text chooser dialog are not permitted to extend across segments
       const newStart = Math.max(sel.index, this._segment.range.index);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -256,7 +256,7 @@ describe('EditorComponent', () => {
         'note-thread-embed': {
           iconsrc: '--icon-file: url(/assets/icons/TagIcons/01flag1.png);',
           preview: 'Note from user01',
-          embedid: 'thread04'
+          threadid: 'thread04'
         }
       });
       op = segmentContents.ops![1];
@@ -273,7 +273,7 @@ describe('EditorComponent', () => {
         'note-thread-embed': {
           iconsrc: '--icon-file: url(/assets/icons/TagIcons/01flag1.png);',
           preview: 'Note from user01',
-          embedid: 'thread04'
+          threadid: 'thread04'
         }
       });
       op = segmentContents.ops![1];
@@ -291,7 +291,7 @@ describe('EditorComponent', () => {
         'note-thread-embed': {
           iconsrc: '--icon-file: url(/assets/icons/TagIcons/01flag1.png);',
           preview: 'Note from user01',
-          embedid: 'thread04'
+          threadid: 'thread04'
         }
       });
       op = segmentContents.ops![1];
@@ -574,7 +574,6 @@ describe('EditorComponent', () => {
       expect(env.bookName).toEqual('Matthew');
       expect(env.component.target!.segmentRef).toEqual('verse_1_1');
       verify(env.mockedRemoteTranslationEngine.getWordGraph(anything())).once();
-      console.log(env.targetEditor.getSelection());
 
       resetCalls(env.mockedRemoteTranslationEngine);
       env.updateParams({ projectId: 'project01', bookId: 'MRK' });
@@ -995,9 +994,7 @@ describe('EditorComponent', () => {
 
       const note = segment.querySelector('display-note')! as HTMLElement;
       expect(note).not.toBeNull();
-      expect(note.hasAttribute('style')).toBe(true);
       expect(note.getAttribute('style')).toEqual('--icon-file: url(/assets/icons/TagIcons/01flag3.png);');
-      expect(note.hasAttribute('title')).toBe(true);
       expect(note.getAttribute('title')).toEqual('Note from user01\n--- 2 more note(s) ---');
       const contents = env.targetEditor.getContents();
       expect(contents.ops![3].insert).toEqual('target: ');
@@ -1013,9 +1010,7 @@ describe('EditorComponent', () => {
         'usx-segment[data-segment="verse_1_4/p_1"] display-note'
       )! as HTMLElement;
       expect(blankSegmentNote).not.toBeNull();
-      expect(blankSegmentNote.hasAttribute('style')).toBe(true);
       expect(blankSegmentNote.getAttribute('style')).toEqual('--icon-file: url(/assets/icons/TagIcons/01flag1.png);');
-      expect(blankSegmentNote.hasAttribute('title')).toBe(true);
       expect(blankSegmentNote.getAttribute('title')).toEqual('Note from user01');
       env.dispose();
     }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1041,6 +1041,29 @@ describe('EditorComponent', () => {
       expect(contents.ops![7]!.insert).toBe('t');
       env.dispose();
     }));
+
+    it('correctly removes embedded elements', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.wait();
+
+      let contents = env.targetEditor.getContents();
+      expect(contents.ops![3].insert).toBe('target: ');
+      expect(contents.ops![4].insert['note-thread-embed']).not.toBeNull();
+      expect(contents.ops![5].insert).toBe('chapter 1, verse 1.');
+      expect(contents.ops![9].insert['note-thread-embed']).not.toBeNull();
+      expect(contents.ops![10].insert).toBe('target: chapter 1,');
+      expect(contents.ops![11].insert['note-thread-embed']).not.toBeNull();
+      expect(contents.ops![12].insert).toBe(' verse 3.');
+
+      env.component.target!.removeEmbeddedElements();
+      contents = env.targetEditor.getContents();
+      expect(contents.ops![3].insert).toBe('target: chapter 1, verse 1.');
+      expect(contents.ops![7].insert).toBe('target: chapter 1, verse 3.');
+
+      env.wait();
+      env.dispose();
+    }));
   });
 
   describe('Translation Suggestions disabled', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -38,7 +38,6 @@ import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { PwaService } from 'xforge-common/pwa.service';
 import { UserService } from 'xforge-common/user.service';
-import { verseSlug } from 'xforge-common/utils';
 import XRegExp from 'xregexp';
 import { environment } from '../../../environments/environment';
 import { ParatextNoteThreadDoc } from '../../core/models/paratext-note-thread-doc';
@@ -623,7 +622,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         }
         const iconName: string = featured.iconName ?? '01flag1';
         const nodeProp: string = iconSourceProp(iconName);
-        const format = value ? { iconsrc: nodeProp, preview: featured.preview, embedid: featured.id } : {};
+        const format = { iconsrc: nodeProp, preview: featured.preview, threadid: featured.id };
         this.target.embedElementInline(
           featured.verseRef,
           featured.id,
@@ -632,14 +631,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
           format
         );
       }
-    } else {
-      this.target.removeEmbeddedElements();
-    }
-    const segments: string[] = this.target.toggleFeaturedVerseRefs(value, noteThreadVerseRefs, 'note-thread');
-
-    if (value) {
+      const segments: string[] = this.target.toggleFeaturedVerseRefs(value, noteThreadVerseRefs, 'note-thread');
       this.subscribeClickEvents(segments);
     } else {
+      this.target.removeEmbeddedElements();
       // Un-subscribe from all segment click events as these all get setup again
       for (const event of this.clickSubs) {
         event.unsubscribe();


### PR DESCRIPTION
* remove the obselete note in line format from quill
* introduce note thread embed format to quill
* record embedded paratext note thread positions in text-view-model
* account for embedded note threads when sending ops to text doc
* account for note threads embedded into blank segments
* strip away note threads when switching texts

![image](https://user-images.githubusercontent.com/17931130/128943346-746027de-5939-4a30-9392-11473ca88adb.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1122)
<!-- Reviewable:end -->
