### PR TITLE
SF-1364b Fix error calling isAlreadyInvited when checking has sharing disabled

### DIFF
--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -484,7 +484,9 @@ namespace SIL.XForge.Scripture.Services
         public async Task<bool> IsAlreadyInvitedAsync(string curUserId, string projectId, string email)
         {
             SFProject project = await GetProjectAsync(projectId);
-            if (!IsProjectAdmin(project, curUserId) && !project.CheckingConfig.ShareEnabled)
+            bool sharingEnabled = project.TranslateConfig.ShareEnabled ||
+                (project.CheckingConfig.CheckingEnabled && project.CheckingConfig.ShareEnabled);
+            if (!IsProjectAdmin(project, curUserId) && !(IsOnProject(project, curUserId) && sharingEnabled))
                 throw new ForbiddenException();
 
             if (email == null)


### PR DESCRIPTION
The condition where the error would occur is:
- Checking sharing is disabled
- Translate sharing is enabled
- User opens share dialog and types email to invite

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1125)
<!-- Reviewable:end -->
