### PR TITLE
Bump Microsoft.AspNetCore.Authentication.JwtBearer from 3.1.2 to 3.1.18

### DIFF
--- a/src/SIL.XForge/SIL.XForge.csproj
+++ b/src/SIL.XForge/SIL.XForge.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Hangfire.Mongo" Version="0.6.6" />
     <PackageReference Include="IdentityModel" Version="3.9.0" />
     <PackageReference Include="Jering.Javascript.NodeJS" Version="5.3.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="3.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.2" />
     <PackageReference Include="MongoDB.Driver" Version="2.9.3" />


### PR DESCRIPTION
Opening this PR because a build won't happen when Dependabot opens a PR.

I've tried to determine what the actual security vulnerability is. All I've found is
> An information disclosure vulnerability exists in .NET 5.0, .NET Core 3.1 and .NET Core 2.1 where a JWT token is logged if it cannot be parsed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1130)
<!-- Reviewable:end -->
