### PR TITLE
Fix incorrect message saying no import questions are available

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -30,6 +30,7 @@ import { BehaviorSubject, of } from 'rxjs';
 import { anything, instance, mock, resetCalls, verify, when } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
 import { BugsnagService } from 'xforge-common/bugsnag.service';
+import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { NoticeService } from 'xforge-common/notice.service';
 import { PwaService } from 'xforge-common/pwa.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
@@ -272,6 +273,22 @@ describe('CheckingOverviewComponent', () => {
       expect(env.importButton).toBeNull();
       when(mockedProjectService.hasTransceleratorQuestions('project01')).thenResolve(true);
       env.onlineStatus = true;
+      expect(env.importButton).not.toBeNull();
+    }));
+
+    it('should not show import questions button until list of texts have loaded', fakeAsync(() => {
+      const env = new TestEnvironment();
+      when(mockedProjectService.hasTransceleratorQuestions('project01')).thenResolve(true);
+      let setQueryQuestions!: (value: Promise<RealtimeQuery<QuestionDoc>>) => void;
+      when(mockedProjectService.queryQuestions(anything())).thenReturn(
+        new Promise(resolve => (setQueryQuestions = resolve))
+      );
+
+      env.waitForQuestions();
+      expect(env.component.showImportButton).toBe(false);
+      setQueryQuestions(env.realtimeService.subscribeQuery(QuestionDoc.COLLECTION, {}));
+      env.waitForQuestions();
+      expect(env.component.showImportButton).toBe(true);
       expect(env.importButton).not.toBeNull();
     }));
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -43,7 +43,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
 
   private _hasTransceleratorQuestions = false;
   private questionDocs = new Map<string, QuestionDoc[]>();
-  private textsByBookId: TextsByBookId = {};
+  private textsByBookId?: TextsByBookId;
   private projectDoc?: SFProjectDoc;
   private dataChangesSub?: Subscription;
   private projectUserConfigDoc?: SFProjectUserConfigDoc;
@@ -121,7 +121,13 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
   }
 
   get showImportButton(): boolean {
-    return this._hasTransceleratorQuestions && this.pwaService.isOnline;
+    return (
+      this._hasTransceleratorQuestions &&
+      this.pwaService.isOnline &&
+      this.projectDoc != null &&
+      this.textsByBookId != null &&
+      Object.keys(this.textsByBookId).length > 0
+    );
   }
 
   get canCreateQuestion(): boolean {
@@ -357,7 +363,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
   }
 
   async questionDialog(questionDoc?: QuestionDoc): Promise<void> {
-    if (this.projectDoc == null) {
+    if (this.projectDoc == null || this.textsByBookId == null) {
       return;
     }
     if (questionDoc != null && questionDoc.data != null) {
@@ -381,7 +387,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
   }
 
   importDialog(): void {
-    if (this.projectDoc == null) {
+    if (this.projectDoc == null || this.textsByBookId == null) {
       return;
     }
     const data: ImportQuestionsDialogData = {


### PR DESCRIPTION
If the user clicks the import button before the list of books has been loaded, then the dialog will incorrectly state that no questions are available for import. This is because we only list questions that are for books that are available in the project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1134)
<!-- Reviewable:end -->
