### PR TITLE
Fix some npm vulnerabilities

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -94,7 +94,7 @@
         "karma-jasmine-html-reporter": "~1.5.0",
         "karma-teamcity-reporter": "^1.1.0",
         "lint-staged": "^10.5.4",
-        "npm": "^7.19.1",
+        "npm": "^7.22.0",
         "prettier": "^2.3.2",
         "protractor": "~7.0.0",
         "ts-mockito": "^2.6.1",
@@ -11515,9 +11515,9 @@
       }
     },
     "node_modules/jszip": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
-      "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
       "dev": true,
       "dependencies": {
         "lie": "~3.3.0",
@@ -13361,26 +13361,27 @@
       }
     },
     "node_modules/npm": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-7.19.1.tgz",
-      "integrity": "sha512-aN3hZzGkPzKOyhjXtOhnQTGumorFhgpOU6xfuQsF1nJKh4DhsgfOMG4s/SNx56r4xHPvM5m/sk914wzDgKba3A==",
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-7.22.0.tgz",
+      "integrity": "sha512-HJnjTCrGGnacPMCSnrxuHGf2H4VdrY7hwTAK1RwByg0K96KIuTR4QNioFW+bnc/pW0uwpk9lLsDf4BeEQhTv2Q==",
       "bundleDependencies": [
         "@npmcli/arborist",
         "@npmcli/ci-detect",
         "@npmcli/config",
+        "@npmcli/map-workspaces",
         "@npmcli/package-json",
         "@npmcli/run-script",
         "abbrev",
         "ansicolors",
         "ansistyles",
         "archy",
-        "byte-size",
         "cacache",
         "chalk",
         "chownr",
         "cli-columns",
         "cli-table3",
         "columnify",
+        "fastest-levenshtein",
         "glob",
         "graceful-fs",
         "hosted-git-info",
@@ -13388,7 +13389,6 @@
         "init-package-json",
         "is-cidr",
         "json-parse-even-better-errors",
-        "leven",
         "libnpmaccess",
         "libnpmdiff",
         "libnpmexec",
@@ -13436,74 +13436,74 @@
       ],
       "dev": true,
       "dependencies": {
-        "@npmcli/arborist": "^2.6.4",
-        "@npmcli/ci-detect": "^1.2.0",
-        "@npmcli/config": "^2.2.0",
-        "@npmcli/package-json": "^1.0.1",
-        "@npmcli/run-script": "^1.8.5",
-        "abbrev": "~1.1.1",
-        "ansicolors": "~0.3.2",
-        "ansistyles": "~0.1.3",
-        "archy": "~1.0.0",
-        "byte-size": "^7.0.1",
-        "cacache": "^15.2.0",
-        "chalk": "^4.1.0",
-        "chownr": "^2.0.0",
-        "cli-columns": "^3.1.2",
-        "cli-table3": "^0.6.0",
-        "columnify": "~1.5.4",
-        "glob": "^7.1.7",
-        "graceful-fs": "^4.2.6",
-        "hosted-git-info": "^4.0.2",
-        "ini": "^2.0.0",
-        "init-package-json": "^2.0.3",
-        "is-cidr": "^4.0.2",
-        "json-parse-even-better-errors": "^2.3.1",
-        "leven": "^3.1.0",
-        "libnpmaccess": "^4.0.2",
-        "libnpmdiff": "^2.0.4",
-        "libnpmexec": "^2.0.0",
-        "libnpmfund": "^1.1.0",
-        "libnpmhook": "^6.0.2",
-        "libnpmorg": "^2.0.2",
-        "libnpmpack": "^2.0.1",
-        "libnpmpublish": "^4.0.1",
-        "libnpmsearch": "^3.1.1",
-        "libnpmteam": "^2.0.3",
-        "libnpmversion": "^1.2.1",
-        "make-fetch-happen": "^9.0.3",
-        "minipass": "^3.1.3",
-        "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "mkdirp-infer-owner": "^2.0.0",
-        "ms": "^2.1.2",
-        "node-gyp": "^7.1.2",
-        "nopt": "^5.0.0",
-        "npm-audit-report": "^2.1.5",
-        "npm-package-arg": "^8.1.5",
-        "npm-pick-manifest": "^6.1.1",
-        "npm-profile": "^5.0.3",
-        "npm-registry-fetch": "^11.0.0",
-        "npm-user-validate": "^1.0.1",
-        "npmlog": "~4.1.2",
-        "opener": "^1.5.2",
-        "pacote": "^11.3.3",
-        "parse-conflict-json": "^1.1.1",
-        "qrcode-terminal": "^0.12.0",
-        "read": "~1.0.7",
-        "read-package-json": "^3.0.1",
-        "read-package-json-fast": "^2.0.2",
-        "readdir-scoped-modules": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "ssri": "^8.0.1",
-        "tar": "^6.1.0",
-        "text-table": "~0.2.0",
-        "tiny-relative-date": "^1.3.0",
-        "treeverse": "^1.0.4",
-        "validate-npm-package-name": "~3.0.0",
-        "which": "^2.0.2",
-        "write-file-atomic": "^3.0.3"
+        "@npmcli/arborist": "*",
+        "@npmcli/ci-detect": "*",
+        "@npmcli/config": "*",
+        "@npmcli/map-workspaces": "*",
+        "@npmcli/package-json": "*",
+        "@npmcli/run-script": "*",
+        "abbrev": "*",
+        "ansicolors": "*",
+        "ansistyles": "*",
+        "archy": "*",
+        "cacache": "*",
+        "chalk": "*",
+        "chownr": "*",
+        "cli-columns": "*",
+        "cli-table3": "*",
+        "columnify": "*",
+        "fastest-levenshtein": "*",
+        "glob": "*",
+        "graceful-fs": "*",
+        "hosted-git-info": "*",
+        "ini": "*",
+        "init-package-json": "*",
+        "is-cidr": "*",
+        "json-parse-even-better-errors": "*",
+        "libnpmaccess": "*",
+        "libnpmdiff": "*",
+        "libnpmexec": "*",
+        "libnpmfund": "*",
+        "libnpmhook": "*",
+        "libnpmorg": "*",
+        "libnpmpack": "*",
+        "libnpmpublish": "*",
+        "libnpmsearch": "*",
+        "libnpmteam": "*",
+        "libnpmversion": "*",
+        "make-fetch-happen": "*",
+        "minipass": "*",
+        "minipass-pipeline": "*",
+        "mkdirp": "*",
+        "mkdirp-infer-owner": "*",
+        "ms": "*",
+        "node-gyp": "*",
+        "nopt": "*",
+        "npm-audit-report": "*",
+        "npm-package-arg": "*",
+        "npm-pick-manifest": "*",
+        "npm-profile": "*",
+        "npm-registry-fetch": "*",
+        "npm-user-validate": "*",
+        "npmlog": "*",
+        "opener": "*",
+        "pacote": "*",
+        "parse-conflict-json": "*",
+        "qrcode-terminal": "*",
+        "read": "*",
+        "read-package-json": "*",
+        "read-package-json-fast": "*",
+        "readdir-scoped-modules": "*",
+        "rimraf": "*",
+        "semver": "*",
+        "ssri": "*",
+        "tar": "*",
+        "text-table": "*",
+        "tiny-relative-date": "*",
+        "treeverse": "*",
+        "validate-npm-package-name": "*",
+        "which": "*",
+        "write-file-atomic": "*"
       },
       "bin": {
         "npm": "bin/npm-cli.js",
@@ -13614,8 +13614,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/@gar/promisify": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "2.6.4",
+      "version": "2.8.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -13633,20 +13639,22 @@
         "common-ancestor-path": "^1.0.1",
         "json-parse-even-better-errors": "^2.3.1",
         "json-stringify-nice": "^1.1.4",
+        "mkdirp": "^1.0.4",
         "mkdirp-infer-owner": "^2.0.0",
         "npm-install-checks": "^4.0.0",
-        "npm-package-arg": "^8.1.0",
+        "npm-package-arg": "^8.1.5",
         "npm-pick-manifest": "^6.1.0",
         "npm-registry-fetch": "^11.0.0",
-        "pacote": "^11.2.6",
+        "pacote": "^11.3.5",
         "parse-conflict-json": "^1.1.1",
         "proc-log": "^1.0.0",
         "promise-all-reject-late": "^1.0.0",
         "promise-call-limit": "^1.0.1",
         "read-package-json-fast": "^2.0.2",
         "readdir-scoped-modules": "^1.1.0",
+        "rimraf": "^3.0.2",
         "semver": "^7.3.5",
-        "tar": "^6.1.0",
+        "ssri": "^8.0.1",
         "treeverse": "^1.0.4",
         "walk-up-path": "^1.0.0"
       },
@@ -13664,7 +13672,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -13691,8 +13699,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/npm/node_modules/@npmcli/fs": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promisify": "^1.0.1",
+        "semver": "^7.3.5"
+      }
+    },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "2.0.9",
+      "version": "2.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -13724,7 +13742,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -13793,14 +13811,13 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "1.8.5",
+      "version": "1.8.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/node-gyp": "^1.0.2",
         "@npmcli/promise-spawn": "^1.3.2",
-        "infer-owner": "^1.0.4",
         "node-gyp": "^7.1.0",
         "read-package-json-fast": "^2.0.1"
       }
@@ -13924,13 +13941,16 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
-      "version": "1.1.5",
+      "version": "1.1.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/npm/node_modules/asap": {
@@ -14035,21 +14055,13 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/byte-size": {
-      "version": "7.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm/node_modules/cacache": {
-      "version": "15.2.0",
+      "version": "15.3.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@npmcli/fs": "^1.0.0",
         "@npmcli/move-file": "^1.0.1",
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -14079,7 +14091,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/chalk": {
-      "version": "4.1.1",
+      "version": "4.1.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14245,6 +14257,15 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/npm/node_modules/color-support": {
+      "version": "1.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/npm/node_modules/colors": {
       "version": "1.4.0",
       "dev": true,
@@ -14314,7 +14335,7 @@
       }
     },
     "node_modules/npm/node_modules/debug": {
-      "version": "4.3.1",
+      "version": "4.3.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14465,6 +14486,12 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/npm/node_modules/fastest-levenshtein": {
+      "version": "1.0.12",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/forever-agent": {
       "version": "0.6.1",
       "dev": true,
@@ -14499,51 +14526,23 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/gauge": {
-      "version": "2.7.4",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "aproba": "^1.0.3",
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
         "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
         "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "node_modules/npm/node_modules/gauge/node_modules/aproba": {
-      "version": "1.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/gauge/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
+        "string-width": "^1.0.1 || ^2.0.0",
+        "strip-ansi": "^3.0.1 || ^4.0.0",
+        "wide-align": "^1.1.2"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/gauge/node_modules/string-width": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
       }
     },
     "node_modules/npm/node_modules/getpass": {
@@ -14576,7 +14575,7 @@
       }
     },
     "node_modules/npm/node_modules/graceful-fs": {
-      "version": "4.2.6",
+      "version": "4.2.8",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -14771,7 +14770,7 @@
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
-      "version": "2.0.3",
+      "version": "2.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14780,7 +14779,7 @@
         "npm-package-arg": "^8.1.2",
         "promzard": "^0.3.0",
         "read": "~1.0.1",
-        "read-package-json": "^3.0.1",
+        "read-package-json": "^4.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "^3.0.0"
@@ -14817,7 +14816,7 @@
       }
     },
     "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.4.0",
+      "version": "2.6.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14844,12 +14843,6 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/isarray": {
       "version": "1.0.0",
       "dev": true,
       "inBundle": true,
@@ -14941,15 +14934,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/leven": {
-      "version": "3.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "4.0.3",
       "dev": true,
@@ -14985,7 +14969,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -15122,7 +15106,7 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "9.0.3",
+      "version": "9.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -15141,7 +15125,7 @@
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^0.6.2",
         "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^5.0.0",
+        "socks-proxy-agent": "^6.0.0",
         "ssri": "^8.0.0"
       },
       "engines": {
@@ -15149,7 +15133,7 @@
       }
     },
     "node_modules/npm/node_modules/mime-db": {
-      "version": "1.48.0",
+      "version": "1.49.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -15158,12 +15142,12 @@
       }
     },
     "node_modules/npm/node_modules/mime-types": {
-      "version": "2.1.31",
+      "version": "2.1.32",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "mime-db": "1.48.0"
+        "mime-db": "1.49.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -15206,7 +15190,7 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "1.3.3",
+      "version": "1.4.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -15352,6 +15336,66 @@
         "node": ">= 10.12.0"
       }
     },
+    "node_modules/npm/node_modules/node-gyp/node_modules/aproba": {
+      "version": "1.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
+      "version": "2.7.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/npmlog": {
+      "version": "4.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/string-width": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/npm/node_modules/nopt": {
       "version": "5.0.0",
       "dev": true,
@@ -15368,13 +15412,13 @@
       }
     },
     "node_modules/npm/node_modules/normalize-package-data": {
-      "version": "3.0.2",
+      "version": "3.0.3",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^4.0.1",
-        "resolve": "^1.20.0",
+        "is-core-module": "^2.5.0",
         "semver": "^7.3.4",
         "validate-npm-package-license": "^3.0.1"
       },
@@ -15501,15 +15545,28 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/npmlog": {
-      "version": "4.1.2",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npmlog/node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/npm/node_modules/number-is-nan": {
@@ -15573,12 +15630,12 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "11.3.4",
+      "version": "11.3.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^2.0.1",
+        "@npmcli/git": "^2.1.0",
         "@npmcli/installed-package-contents": "^1.0.6",
         "@npmcli/promise-spawn": "^1.2.0",
         "@npmcli/run-script": "^1.8.2",
@@ -15625,12 +15682,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/npm/node_modules/path-parse": {
-      "version": "1.0.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/performance-now": {
       "version": "2.1.0",
       "dev": true,
@@ -15642,12 +15693,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC"
-    },
-    "node_modules/npm/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
@@ -15746,7 +15791,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/read-package-json": {
-      "version": "3.0.1",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -15761,7 +15806,7 @@
       }
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -15774,18 +15819,17 @@
       }
     },
     "node_modules/npm/node_modules/readable-stream": {
-      "version": "2.3.7",
+      "version": "3.6.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/npm/node_modules/readdir-scoped-modules": {
@@ -15858,19 +15902,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/npm/node_modules/resolve": {
-      "version": "1.20.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
       "dev": true,
@@ -15896,8 +15927,22 @@
       }
     },
     "node_modules/npm/node_modules/safe-buffer": {
-      "version": "5.1.2",
+      "version": "5.2.1",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "inBundle": true,
       "license": "MIT"
     },
@@ -15935,7 +15980,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/smart-buffer": {
-      "version": "4.1.0",
+      "version": "4.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -15959,17 +16004,17 @@
       }
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
-      "version": "5.0.0",
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
-        "debug": "4",
-        "socks": "^2.3.3"
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.1",
+        "socks": "^2.6.1"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/npm/node_modules/spdx-correct": {
@@ -15999,7 +16044,7 @@
       }
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.9",
+      "version": "3.0.10",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
@@ -16020,6 +16065,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16037,12 +16087,12 @@
       }
     },
     "node_modules/npm/node_modules/string_decoder": {
-      "version": "1.1.1",
+      "version": "1.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/npm/node_modules/string-width": {
@@ -16110,7 +16160,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "6.1.0",
+      "version": "6.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -21337,9 +21387,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",
@@ -22142,9 +22192,9 @@
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "node_modules/url-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "dev": true,
       "dependencies": {
         "querystringify": "^2.1.1",
@@ -33720,9 +33770,9 @@
       }
     },
     "jszip": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
-      "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
       "dev": true,
       "requires": {
         "lie": "~3.3.0",
@@ -35204,83 +35254,88 @@
       "dev": true
     },
     "npm": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-7.19.1.tgz",
-      "integrity": "sha512-aN3hZzGkPzKOyhjXtOhnQTGumorFhgpOU6xfuQsF1nJKh4DhsgfOMG4s/SNx56r4xHPvM5m/sk914wzDgKba3A==",
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-7.22.0.tgz",
+      "integrity": "sha512-HJnjTCrGGnacPMCSnrxuHGf2H4VdrY7hwTAK1RwByg0K96KIuTR4QNioFW+bnc/pW0uwpk9lLsDf4BeEQhTv2Q==",
       "dev": true,
       "requires": {
-        "@npmcli/arborist": "^2.6.4",
-        "@npmcli/ci-detect": "^1.2.0",
-        "@npmcli/config": "^2.2.0",
-        "@npmcli/package-json": "^1.0.1",
-        "@npmcli/run-script": "^1.8.5",
-        "abbrev": "~1.1.1",
-        "ansicolors": "~0.3.2",
-        "ansistyles": "~0.1.3",
-        "archy": "~1.0.0",
-        "byte-size": "^7.0.1",
-        "cacache": "^15.2.0",
-        "chalk": "^4.1.0",
-        "chownr": "^2.0.0",
-        "cli-columns": "^3.1.2",
-        "cli-table3": "^0.6.0",
-        "columnify": "~1.5.4",
-        "glob": "^7.1.7",
-        "graceful-fs": "^4.2.6",
-        "hosted-git-info": "^4.0.2",
-        "ini": "^2.0.0",
-        "init-package-json": "^2.0.3",
-        "is-cidr": "^4.0.2",
-        "json-parse-even-better-errors": "^2.3.1",
-        "leven": "^3.1.0",
-        "libnpmaccess": "^4.0.2",
-        "libnpmdiff": "^2.0.4",
-        "libnpmexec": "^2.0.0",
-        "libnpmfund": "^1.1.0",
-        "libnpmhook": "^6.0.2",
-        "libnpmorg": "^2.0.2",
-        "libnpmpack": "^2.0.1",
-        "libnpmpublish": "^4.0.1",
-        "libnpmsearch": "^3.1.1",
-        "libnpmteam": "^2.0.3",
-        "libnpmversion": "^1.2.1",
-        "make-fetch-happen": "^9.0.3",
-        "minipass": "^3.1.3",
-        "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "mkdirp-infer-owner": "^2.0.0",
-        "ms": "^2.1.2",
-        "node-gyp": "^7.1.2",
-        "nopt": "^5.0.0",
-        "npm-audit-report": "^2.1.5",
-        "npm-package-arg": "^8.1.5",
-        "npm-pick-manifest": "^6.1.1",
-        "npm-profile": "^5.0.3",
-        "npm-registry-fetch": "^11.0.0",
-        "npm-user-validate": "^1.0.1",
-        "npmlog": "~4.1.2",
-        "opener": "^1.5.2",
-        "pacote": "^11.3.3",
-        "parse-conflict-json": "^1.1.1",
-        "qrcode-terminal": "^0.12.0",
-        "read": "~1.0.7",
-        "read-package-json": "^3.0.1",
-        "read-package-json-fast": "^2.0.2",
-        "readdir-scoped-modules": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "ssri": "^8.0.1",
-        "tar": "^6.1.0",
-        "text-table": "~0.2.0",
-        "tiny-relative-date": "^1.3.0",
-        "treeverse": "^1.0.4",
-        "validate-npm-package-name": "~3.0.0",
-        "which": "^2.0.2",
-        "write-file-atomic": "^3.0.3"
+        "@npmcli/arborist": "*",
+        "@npmcli/ci-detect": "*",
+        "@npmcli/config": "*",
+        "@npmcli/map-workspaces": "*",
+        "@npmcli/package-json": "*",
+        "@npmcli/run-script": "*",
+        "abbrev": "*",
+        "ansicolors": "*",
+        "ansistyles": "*",
+        "archy": "*",
+        "cacache": "*",
+        "chalk": "*",
+        "chownr": "*",
+        "cli-columns": "*",
+        "cli-table3": "*",
+        "columnify": "*",
+        "fastest-levenshtein": "*",
+        "glob": "*",
+        "graceful-fs": "*",
+        "hosted-git-info": "*",
+        "ini": "*",
+        "init-package-json": "*",
+        "is-cidr": "*",
+        "json-parse-even-better-errors": "*",
+        "libnpmaccess": "*",
+        "libnpmdiff": "*",
+        "libnpmexec": "*",
+        "libnpmfund": "*",
+        "libnpmhook": "*",
+        "libnpmorg": "*",
+        "libnpmpack": "*",
+        "libnpmpublish": "*",
+        "libnpmsearch": "*",
+        "libnpmteam": "*",
+        "libnpmversion": "*",
+        "make-fetch-happen": "*",
+        "minipass": "*",
+        "minipass-pipeline": "*",
+        "mkdirp": "*",
+        "mkdirp-infer-owner": "*",
+        "ms": "*",
+        "node-gyp": "*",
+        "nopt": "*",
+        "npm-audit-report": "*",
+        "npm-package-arg": "*",
+        "npm-pick-manifest": "*",
+        "npm-profile": "*",
+        "npm-registry-fetch": "*",
+        "npm-user-validate": "*",
+        "npmlog": "*",
+        "opener": "*",
+        "pacote": "*",
+        "parse-conflict-json": "*",
+        "qrcode-terminal": "*",
+        "read": "*",
+        "read-package-json": "*",
+        "read-package-json-fast": "*",
+        "readdir-scoped-modules": "*",
+        "rimraf": "*",
+        "semver": "*",
+        "ssri": "*",
+        "tar": "*",
+        "text-table": "*",
+        "tiny-relative-date": "*",
+        "treeverse": "*",
+        "validate-npm-package-name": "*",
+        "which": "*",
+        "write-file-atomic": "*"
       },
       "dependencies": {
+        "@gar/promisify": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
         "@npmcli/arborist": {
-          "version": "2.6.4",
+          "version": "2.8.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -35297,20 +35352,22 @@
             "common-ancestor-path": "^1.0.1",
             "json-parse-even-better-errors": "^2.3.1",
             "json-stringify-nice": "^1.1.4",
+            "mkdirp": "^1.0.4",
             "mkdirp-infer-owner": "^2.0.0",
             "npm-install-checks": "^4.0.0",
-            "npm-package-arg": "^8.1.0",
+            "npm-package-arg": "^8.1.5",
             "npm-pick-manifest": "^6.1.0",
             "npm-registry-fetch": "^11.0.0",
-            "pacote": "^11.2.6",
+            "pacote": "^11.3.5",
             "parse-conflict-json": "^1.1.1",
             "proc-log": "^1.0.0",
             "promise-all-reject-late": "^1.0.0",
             "promise-call-limit": "^1.0.1",
             "read-package-json-fast": "^2.0.2",
             "readdir-scoped-modules": "^1.1.0",
+            "rimraf": "^3.0.2",
             "semver": "^7.3.5",
-            "tar": "^6.1.0",
+            "ssri": "^8.0.1",
             "treeverse": "^1.0.4",
             "walk-up-path": "^1.0.0"
           }
@@ -35321,7 +35378,7 @@
           "dev": true
         },
         "@npmcli/config": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -35340,8 +35397,17 @@
             "ansi-styles": "^4.3.0"
           }
         },
+        "@npmcli/fs": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@gar/promisify": "^1.0.1",
+            "semver": "^7.3.5"
+          }
+        },
         "@npmcli/git": {
-          "version": "2.0.9",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -35365,7 +35431,7 @@
           }
         },
         "@npmcli/map-workspaces": {
-          "version": "1.0.3",
+          "version": "1.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -35421,13 +35487,12 @@
           }
         },
         "@npmcli/run-script": {
-          "version": "1.8.5",
+          "version": "1.8.6",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/node-gyp": "^1.0.2",
             "@npmcli/promise-spawn": "^1.3.2",
-            "infer-owner": "^1.0.4",
             "node-gyp": "^7.1.0",
             "read-package-json-fast": "^2.0.1"
           }
@@ -35514,12 +35579,12 @@
           "dev": true
         },
         "are-we-there-yet": {
-          "version": "1.1.5",
+          "version": "1.1.6",
           "bundled": true,
           "dev": true,
           "requires": {
             "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "readable-stream": "^3.6.0"
           }
         },
         "asap": {
@@ -35600,16 +35665,12 @@
           "bundled": true,
           "dev": true
         },
-        "byte-size": {
-          "version": "7.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "cacache": {
-          "version": "15.2.0",
+          "version": "15.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@npmcli/fs": "^1.0.0",
             "@npmcli/move-file": "^1.0.1",
             "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
@@ -35635,7 +35696,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "4.1.1",
+          "version": "4.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -35741,6 +35802,11 @@
           "bundled": true,
           "dev": true
         },
+        "color-support": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true
+        },
         "colors": {
           "version": "1.4.0",
           "bundled": true,
@@ -35793,7 +35859,7 @@
           }
         },
         "debug": {
-          "version": "4.3.1",
+          "version": "4.3.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -35902,6 +35968,11 @@
           "bundled": true,
           "dev": true
         },
+        "fastest-levenshtein": {
+          "version": "1.0.12",
+          "bundled": true,
+          "dev": true
+        },
         "forever-agent": {
           "version": "0.6.1",
           "bundled": true,
@@ -35926,43 +35997,19 @@
           "dev": true
         },
         "gauge": {
-          "version": "2.7.4",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "^1.0.3",
+            "aproba": "^1.0.3 || ^2.0.0",
+            "color-support": "^1.1.2",
             "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
+            "has-unicode": "^2.0.1",
+            "object-assign": "^4.1.1",
             "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
+            "string-width": "^1.0.1 || ^2.0.0",
+            "strip-ansi": "^3.0.1 || ^4.0.0",
+            "wide-align": "^1.1.2"
           }
         },
         "getpass": {
@@ -35987,7 +36034,7 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.6",
+          "version": "4.2.8",
           "bundled": true,
           "dev": true
         },
@@ -36125,7 +36172,7 @@
           "dev": true
         },
         "init-package-json": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -36133,7 +36180,7 @@
             "npm-package-arg": "^8.1.2",
             "promzard": "^0.3.0",
             "read": "~1.0.1",
-            "read-package-json": "^3.0.1",
+            "read-package-json": "^4.0.0",
             "semver": "^7.3.5",
             "validate-npm-package-license": "^3.0.4",
             "validate-npm-package-name": "^3.0.0"
@@ -36158,7 +36205,7 @@
           }
         },
         "is-core-module": {
-          "version": "2.4.0",
+          "version": "2.6.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -36176,11 +36223,6 @@
           "dev": true
         },
         "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isarray": {
           "version": "1.0.0",
           "bundled": true,
           "dev": true
@@ -36251,11 +36293,6 @@
           "bundled": true,
           "dev": true
         },
-        "leven": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true
-        },
         "libnpmaccess": {
           "version": "4.0.3",
           "bundled": true,
@@ -36283,7 +36320,7 @@
           }
         },
         "libnpmexec": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -36386,7 +36423,7 @@
           }
         },
         "make-fetch-happen": {
-          "version": "9.0.3",
+          "version": "9.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -36404,21 +36441,21 @@
             "minipass-pipeline": "^1.2.4",
             "negotiator": "^0.6.2",
             "promise-retry": "^2.0.1",
-            "socks-proxy-agent": "^5.0.0",
+            "socks-proxy-agent": "^6.0.0",
             "ssri": "^8.0.0"
           }
         },
         "mime-db": {
-          "version": "1.48.0",
+          "version": "1.49.0",
           "bundled": true,
           "dev": true
         },
         "mime-types": {
-          "version": "2.1.31",
+          "version": "2.1.32",
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "1.48.0"
+            "mime-db": "1.49.0"
           }
         },
         "minimatch": {
@@ -36446,7 +36483,7 @@
           }
         },
         "minipass-fetch": {
-          "version": "1.3.3",
+          "version": "1.4.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -36543,6 +36580,57 @@
             "semver": "^7.3.2",
             "tar": "^6.0.2",
             "which": "^2.0.2"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
           }
         },
         "nopt": {
@@ -36554,12 +36642,12 @@
           }
         },
         "normalize-package-data": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "^4.0.1",
-            "resolve": "^1.20.0",
+            "is-core-module": "^2.5.0",
             "semver": "^7.3.4",
             "validate-npm-package-license": "^3.0.1"
           }
@@ -36652,14 +36740,25 @@
           "dev": true
         },
         "npmlog": {
-          "version": "4.1.2",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "^2.0.0",
+            "console-control-strings": "^1.1.0",
+            "gauge": "^3.0.0",
+            "set-blocking": "^2.0.0"
+          },
+          "dependencies": {
+            "are-we-there-yet": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^3.6.0"
+              }
+            }
           }
         },
         "number-is-nan": {
@@ -36699,11 +36798,11 @@
           }
         },
         "pacote": {
-          "version": "11.3.4",
+          "version": "11.3.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/git": "^2.0.1",
+            "@npmcli/git": "^2.1.0",
             "@npmcli/installed-package-contents": "^1.0.6",
             "@npmcli/promise-spawn": "^1.2.0",
             "@npmcli/run-script": "^1.8.2",
@@ -36739,11 +36838,6 @@
           "bundled": true,
           "dev": true
         },
-        "path-parse": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
         "performance-now": {
           "version": "2.1.0",
           "bundled": true,
@@ -36751,11 +36845,6 @@
         },
         "proc-log": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
           "bundled": true,
           "dev": true
         },
@@ -36825,7 +36914,7 @@
           "dev": true
         },
         "read-package-json": {
-          "version": "3.0.1",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -36836,7 +36925,7 @@
           }
         },
         "read-package-json-fast": {
-          "version": "2.0.2",
+          "version": "2.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -36845,17 +36934,13 @@
           }
         },
         "readable-stream": {
-          "version": "2.3.7",
+          "version": "3.6.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
         "readdir-scoped-modules": {
@@ -36917,15 +37002,6 @@
             }
           }
         },
-        "resolve": {
-          "version": "1.20.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
-          }
-        },
         "retry": {
           "version": "0.12.0",
           "bundled": true,
@@ -36940,7 +37016,7 @@
           }
         },
         "safe-buffer": {
-          "version": "5.1.2",
+          "version": "5.2.1",
           "bundled": true,
           "dev": true
         },
@@ -36968,7 +37044,7 @@
           "dev": true
         },
         "smart-buffer": {
-          "version": "4.1.0",
+          "version": "4.2.0",
           "bundled": true,
           "dev": true
         },
@@ -36982,13 +37058,13 @@
           }
         },
         "socks-proxy-agent": {
-          "version": "5.0.0",
+          "version": "6.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "6",
-            "debug": "4",
-            "socks": "^2.3.3"
+            "agent-base": "^6.0.2",
+            "debug": "^4.3.1",
+            "socks": "^2.6.1"
           }
         },
         "spdx-correct": {
@@ -37015,7 +37091,7 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.9",
+          "version": "3.0.10",
           "bundled": true,
           "dev": true
         },
@@ -37044,11 +37120,11 @@
           }
         },
         "string_decoder": {
-          "version": "1.1.1",
+          "version": "1.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "~5.2.0"
           }
         },
         "string-width": {
@@ -37097,7 +37173,7 @@
           }
         },
         "tar": {
-          "version": "6.1.0",
+          "version": "6.1.11",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -41254,9 +41330,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",
@@ -41898,9 +41974,9 @@
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "url-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "dev": true,
       "requires": {
         "querystringify": "^2.1.1",

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -106,7 +106,7 @@
     "karma-jasmine-html-reporter": "~1.5.0",
     "karma-teamcity-reporter": "^1.1.0",
     "lint-staged": "^10.5.4",
-    "npm": "^7.19.1",
+    "npm": "^7.22.0",
     "prettier": "^2.3.2",
     "protractor": "~7.0.0",
     "ts-mockito": "^2.6.1",


### PR DESCRIPTION
- `npm audit fix` (this fixes high severity `tar`) and update npm
- that just leaves `glob-parent` (which is a devDependency only, maybe NG12 update will fix) and `quill`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1136)
<!-- Reviewable:end -->
