### PR TITLE
Clean up test output and stop showing Prettier errors

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/.eslintrc.json
+++ b/src/SIL.XForge.Scripture/ClientApp/.eslintrc.json
@@ -41,11 +41,11 @@
           "error",
           {
             "ignorePattern": "^import ",
+            "ignoreStrings": true,
             "code": 120
           }
         ],
-        "no-underscore-dangle": "off",
-        "prettier/prettier": "error"
+        "no-underscore-dangle": "off"
       }
     },
     {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
@@ -182,7 +182,6 @@ describe('ImportQuestionsDialogComponent', () => {
   it('should inform the user when Transcelerator version is unsupported', fakeAsync(() => {
     const env = new TestEnvironment(false, true);
     expect(env.statusMessage).toEqual(
-      // eslint-disable-next-line max-len
       'The version of Transcelerator used in this project is not supported. Please update to at least Transcelerator version 1.5.3.'
     );
     env.click(env.cancelButton);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
@@ -34,8 +34,15 @@ class MockConsole {
   }
   error(val: any) {
     if (
-      !['', 'Test error', 'Original error'].includes(val.message) &&
-      !(val.message != null && val.message.startsWith('Unknown error'))
+      ![
+        '',
+        'Test error',
+        'Original error',
+        'Http failure response for (unknown url): 400 Bad Request',
+        'Http failure response for http://localhost:5000/command-api/some-end-point: 504 Gateway Timeout',
+        'Http failure response for http://localhost:5000/machine-api/translation/engines/some-end-point: 504 Gateway Timeout'
+      ].includes(val.message) &&
+      !val.message?.startsWith('Unknown error')
     ) {
       console.error(val);
     }


### PR DESCRIPTION
Also disable max-len ESLint errors for lines with strings

A pre-commit hook still makes sure files are formatted according to Prettier rules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1139)
<!-- Reviewable:end -->
