### PR TITLE
Ensure a blank in the first segment is smaller than other blanks

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -324,6 +324,10 @@ usx-blank {
   }
 }
 
+usx-segment:first-child usx-blank {
+  width: 5px;
+}
+
 usx-char {
   &[data-style='it'] {
     font-style: italic;


### PR DESCRIPTION
Resolves an issue where a `usx-blank` in at the start of a paragraph is larger than what it was intended to be.
Introduced via #1088 

Before:
![image](https://user-images.githubusercontent.com/17464863/133544948-8df68d1c-82f0-4427-a71c-b9e4c0b7713e.png)

After:
![image](https://user-images.githubusercontent.com/17464863/133544961-a5dd6439-9aa1-45d4-b363-61e37599a40d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1146)
<!-- Reviewable:end -->
