### PR TITLE
Add trace messages to help track down problems

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/drag-and-drop.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/drag-and-drop.ts
@@ -103,6 +103,9 @@ export class DragAndDrop {
       let newText: string = dragEvent.dataTransfer.getData('text/plain');
       // Replace newlines with a space.
       newText = newText.replace(/(?:\r?\n)+/g, ' ');
+      console.debug(
+        `dnd: inserting into quill ${newText.length} chars in segment ${destinationSegmentRef} at ${startPositionInSegment}.`
+      );
       quill.insertText(insertionPositionInDocument, newText, 'user');
 
       // Identify the selection range, if any, now that we updated the document with an insert. This will be a
@@ -118,6 +121,9 @@ export class DragAndDrop {
         if (dragEvent.dataTransfer.types.includes(DragAndDrop.quillIsSourceToken) && !dragEvent.ctrlKey) {
           // If the drag was started from within quill, then treat the selection as the source data of the drag, and
           // delete the selection. Unless the user was holding the ctrl key to copy text instead of move it.
+          console.debug(
+            `dnd: deleting from quill ${originalSelection.length} chars starting at ${originalSelection.index}.`
+          );
           quill.deleteText(originalSelection.index, originalSelection.length, 'user');
         }
         // Or if the drag was not started from within quill, or the user was holding the ctrl key, then don't delete

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -158,6 +158,7 @@ export class TextViewModel {
   update(delta: DeltaStatic, source: Sources): void {
     const editor = this.checkEditor();
     if (this.textDoc == null) {
+      console.warn(`text-view-model update(): this.textDoc was unexpectedly null.`);
       return;
     }
 
@@ -167,6 +168,8 @@ export class TextViewModel {
       if (modelDelta.ops != null && modelDelta.ops.length > 0) {
         this.textDoc.submit(modelDelta, this.editor);
       }
+    } else {
+      console.debug(`text-view-model update(): Not passing quill editor change on to doc.`);
     }
 
     // Re-compute segment boundaries so the insertion point stays in the right place.

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -402,11 +402,16 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
 
   /** Respond to text changes in the quill editor. */
   onContentChanged(delta: DeltaStatic, source: string): void {
+    console.debug(`TextComponent: Quill content changed: `, delta);
     this.viewModel.update(delta, source as Sources);
     this.updatePlaceholderText();
     // skip updating when only formatting changes occurred
     if (delta.ops != null && delta.ops.some(op => op.insert != null || op.delete != null)) {
       this.update(delta);
+    } else {
+      console.debug(
+        `TextComponent: Quill content changed. Skipping a kind of update since no insert or delete (only formatting changes occurred).`
+      );
     }
   }
 


### PR DESCRIPTION
---

How useful would this kind of thing be, to show up in breadcrumbs?
BTW to see console.debug messages in Chromium you need to show Verbose log messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1148)
<!-- Reviewable:end -->
