### PR TITLE
Add script to delete doc and restore to past version

### DIFF
--- a/scripts/db_tools/revert-doc.js
+++ b/scripts/db_tools/revert-doc.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+// Delete a doc (though it still exists in the DB), then recreate it in a state that it was in at a
+// previous version
+
+const utils = require('./utils.js');
+const RichText = utils.requireFromRealTimeServer('rich-text');
+const ShareDB = utils.requireFromRealTimeServer('sharedb/lib/client');
+const WebSocket = utils.requireFromRealTimeServer('ws');
+
+// Edit these settings to specify which doc to revert
+const docId = '';
+const connectionConfig = utils.devConfig;
+const resetToVersion = 0;
+const collection = 'texts';
+const dryRun = true;
+
+ShareDB.types.register(RichText.type);
+
+async function run() {
+  const ws = new WebSocket(connectionConfig.wsConnectionString);
+  const conn = new ShareDB.Connection(ws);
+  try {
+    const doc = conn.get(collection, docId);
+    await utils.fetchDoc(doc);
+
+    const revertToSnapshot = await utils.fetchSnapshotByVersion(conn, collection, docId, resetToVersion);
+
+    if (!dryRun) {
+      await utils.deleteDoc(doc);
+      console.log('deleted doc');
+    }
+
+    if (dryRun) {
+      console.log('would reset doc to:');
+      console.log(revertToSnapshot.data.ops);
+    } else {
+      await utils.createDoc(doc, revertToSnapshot.data.ops, RichText.type.name);
+      console.log('recreated doc');
+    }
+  } finally {
+    conn.close();
+  }
+}
+
+run();

--- a/scripts/db_tools/utils.js
+++ b/scripts/db_tools/utils.js
@@ -2,6 +2,54 @@ function requireFromRealTimeServer(package) {
   return require('../../src/RealtimeServer/node_modules/' + package);
 }
 
+function fetchDoc(doc) {
+  return new Promise((resolve, reject) => {
+    doc.fetch(err => {
+      if (err != null) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+function submitDocOp(doc, components) {
+  return new Promise((resolve, reject) => {
+    doc.submitOp(components, undefined, err => {
+      if (err != null) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+function deleteDoc(doc) {
+  return new Promise((resolve, reject) => {
+    doc.del(undefined, err => {
+      if (err != null) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+function createDoc(doc, data, type) {
+  return new Promise((resolve, reject) => {
+    doc.create(data, type, undefined, err => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
 function fetchSnapshotByVersion(conn, collection, docId, version) {
   return new Promise((resolve, reject) => {
     conn.fetchSnapshot(collection, docId, version, (err, snapshot) => (err != null ? reject(err) : resolve(snapshot)));
@@ -19,7 +67,9 @@ function fetchSnapshotByTimestamp(conn, collection, docId, time) {
 function visualizeOps(ops) {
   const result = ops
     .map(op => {
-      if (typeof op.insert === 'string') {
+      if (typeof op.insert === 'undefined') {
+        return '[ invalid op ' + JSON.stringify(op) + ' ]';
+      } else if (typeof op.insert === 'string') {
         return op.insert;
       } else if (op.insert.verse) {
         return op.insert.verse.number + ' ';
@@ -48,6 +98,10 @@ const liveConfig = {
 
 module.exports = {
   requireFromRealTimeServer,
+  fetchDoc,
+  submitDocOp,
+  deleteDoc,
+  createDoc,
   fetchSnapshotByVersion,
   fetchSnapshotByTimestamp,
   visualizeOps,


### PR DESCRIPTION
This script was tested locally and then used to fix the data corruption on live.

The utils file provides supporting code for multiple scripts. Some of the changes to the utils file aren't really relevant to this particular commit, but it seemed pointless to try to revert those specific portions before committing. There will probably be future PRs where I add scripts that rely on some of these changes.