### PR TITLE
Fix resource query incorrectly implemented in #1154

### DIFF
--- a/mongodb/Projects/UnusedResources.mongodb
+++ b/mongodb/Projects/UnusedResources.mongodb
@@ -4,7 +4,7 @@
 use('xforge');
 
 // Find projects with a Paratext ID that is 16 characters long, indicating a resource
-const resources = db.sf_projects.find({paratextId: {$regex: '^.{16,16}$'}}, {_id: 1, shortName: 1})
+const resources = db.sf_projects.find({paratextId: {$regex: '^.{16,16}$'}}, {_id: 1, shortName: 1, name: 1})
   .toArray();
 
 const projectsBasedOnOthers = db.sf_projects.find(
@@ -12,5 +12,5 @@ const projectsBasedOnOthers = db.sf_projects.find(
 ).toArray();
 
 resources.filter(
-  resource => !projectsBasedOnOthers.some(project => project.translateConfig.source.projectRef === resource)
+  resource => !projectsBasedOnOthers.some(project => project.translateConfig.source.projectRef === resource._id)
 );


### PR DESCRIPTION
Also include resource name so it can be searched for on system administration page

The way I originally wrote the script worked, but then I modified the first query (line 7) to fetch objects, rather than an array of string ids. That broke line 15. Unfortunately I didn't catch that until after it was merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1155)
<!-- Reviewable:end -->
