### PR TITLE
SF-1406 - Sync date comparison failing with alternative date formats

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
@@ -51,7 +51,7 @@
           >
             {{ t("cancel") }}
           </button>
-          <span *ngIf="!syncActive" [title]="lastSyncDate" id="date-last-sync" class="sync-info">
+          <span *ngIf="!syncActive" [title]="lastSyncDisplayDate" id="date-last-sync" class="sync-info">
             {{ lastSyncNotice }}
           </span>
         </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
@@ -92,7 +92,7 @@ describe('SyncComponent', () => {
 
   it('should sync project when the button is clicked', fakeAsync(() => {
     const env = new TestEnvironment();
-    const previousLastSyncDate = new Date(env.component.lastSyncDate);
+    const previousLastSyncDate = env.component.lastSyncDate;
     verify(mockedProjectService.get(env.projectId)).once();
 
     env.clickElement(env.syncButton);
@@ -104,7 +104,7 @@ describe('SyncComponent', () => {
     expect(env.logInButton).toBeNull();
     expect(env.syncButton).toBeNull();
     env.emitSyncComplete(true, env.projectId);
-    expect(new Date(env.component.lastSyncDate).getTime()).toBeGreaterThan(previousLastSyncDate.getTime());
+    expect(env.component.lastSyncDate!.getTime()).toBeGreaterThan(previousLastSyncDate!.getTime());
     verify(mockedNoticeService.show('Successfully synchronized Sync Test Project with Paratext.')).once();
   }));
 
@@ -147,7 +147,7 @@ describe('SyncComponent', () => {
 
   it('should not report if sync was cancelled', fakeAsync(() => {
     const env = new TestEnvironment();
-    const previousLastSyncDate = new Date(env.component.lastSyncDate);
+    const previousLastSyncDate = env.component.lastSyncDate;
     verify(mockedProjectService.get(env.projectId)).once();
     env.clickElement(env.syncButton);
     verify(mockedProjectService.onlineSync(env.projectId)).once();
@@ -159,7 +159,7 @@ describe('SyncComponent', () => {
     env.emitSyncComplete(false, env.projectId);
 
     expect(env.component.syncActive).toBe(false);
-    expect(new Date(env.component.lastSyncDate)).toEqual(previousLastSyncDate);
+    expect(env.component.lastSyncDate).toEqual(previousLastSyncDate);
     verify(mockedNoticeService.show(anything())).never();
     verify(mockedNoticeService.showMessageDialog(anything())).never();
   }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
@@ -56,21 +56,14 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
   }
 
   get lastSyncDate(): Date | undefined {
-    if (
-      this.projectDoc == null ||
-      this.projectDoc.data == null ||
-      this.projectDoc.data.sync.dateLastSuccessfulSync == null
-    ) {
+    if (this.projectDoc?.data?.sync.dateLastSuccessfulSync == null) {
       return undefined;
     }
     return new Date(this.projectDoc.data.sync.dateLastSuccessfulSync);
   }
 
   get lastSyncDisplayDate() {
-    if (this.lastSyncDate == null) {
-      return '';
-    }
-    return this.lastSyncDate.toLocaleString();
+    return this.lastSyncDate?.toLocaleString() || '';
   }
 
   get projectName(): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
@@ -55,16 +55,22 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
     }
   }
 
-  get lastSyncDate(): string {
+  get lastSyncDate(): Date | undefined {
     if (
       this.projectDoc == null ||
       this.projectDoc.data == null ||
       this.projectDoc.data.sync.dateLastSuccessfulSync == null
     ) {
+      return undefined;
+    }
+    return new Date(this.projectDoc.data.sync.dateLastSuccessfulSync);
+  }
+
+  get lastSyncDisplayDate() {
+    if (this.lastSyncDate == null) {
       return '';
     }
-    const date = new Date(this.projectDoc.data.sync.dateLastSuccessfulSync);
-    return date.toLocaleString();
+    return this.lastSyncDate.toLocaleString();
   }
 
   get projectName(): string {
@@ -81,12 +87,13 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
       if (
         !(
           this.isSyncCancelled &&
-          (this.previousLastSyncDate == null || new Date(this.lastSyncDate) <= this.previousLastSyncDate)
+          (this.previousLastSyncDate == null ||
+            (this.lastSyncDate != null && this.lastSyncDate <= this.previousLastSyncDate))
         )
       ) {
         if (this.projectDoc.data.sync.lastSyncSuccessful) {
           this.noticeService.show(translate('sync.successfully_synchronized_with_paratext', { projectName }));
-          this.previousLastSyncDate = new Date(this.lastSyncDate);
+          this.previousLastSyncDate = this.lastSyncDate;
         } else {
           this.noticeService.showMessageDialog(() =>
             translate('sync.something_went_wrong_synchronizing_this_project', { projectName })
@@ -166,7 +173,7 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
     }
     this._syncActive = this.projectDoc.data.sync.queuedCount > 0;
     if (this.projectDoc.data.sync.lastSyncSuccessful) {
-      this.previousLastSyncDate = new Date(this.lastSyncDate);
+      this.previousLastSyncDate = this.lastSyncDate;
     }
   }
 }


### PR DESCRIPTION
- Refactored sync component lastSyncDate to return a date object
- Added new method to get toLocaleString()

This resolves an issue when toLocaleString() returns a format that then can't be fed back in to new Date() as it returns an invalid date error. i.e. `dd/mm/yyyy hh:mm:ss`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1156)
<!-- Reviewable:end -->
