### PR TITLE
Clarify areas around PT anchoring

### DIFF
--- a/src/SIL.XForge.Scripture/Models/NoteThreadChange.cs
+++ b/src/SIL.XForge.Scripture/Models/NoteThreadChange.cs
@@ -10,6 +10,9 @@ namespace SIL.XForge.Scripture.Models
         None
     }
 
+    /// <summary>
+    /// Represents changes in a Paratext CommentThread.
+    /// </summary>
     public class NoteThreadChange
     {
         public string ThreadId { get; set; }

--- a/src/SIL.XForge.Scripture/Models/TextAnchor.cs
+++ b/src/SIL.XForge.Scripture/Models/TextAnchor.cs
@@ -1,5 +1,18 @@
 namespace SIL.XForge.Scripture.Models
 {
+    /// <summary>
+    /// Text-only position of a series of characters relative to the start of a verse. The position uses zero-based
+    /// indexing, and should correspond to the SF DB "insert" strings of a given verse.
+    /// The position does not take into account quill editor text between segments, quill embeds, USFM markup, or other
+    /// formatting.
+    /// For example, in the following USFM verse:
+    ///     \v 1 Praise the \nd Lord\nd*, all you nations:
+    ///     \q2 laud him, all you peoples.
+    ///     \q
+    /// (1) "Praise" has Start 0 and Length 6.
+    /// (2) "all you peoples" has Start 43 and Length 15. (43 == "Praise the ".Length + "Lord".Length + ", 
+    ///     all you nations:".Length + "laud him, ".Length)
+    /// </summary>
     public class TextAnchor
     {
         public int Start { get; set; } = 0;

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1594,9 +1594,9 @@ namespace SIL.XForge.Scripture.Services
             string verse = GetVerseText(chapterDelta.Delta, comment.VerseRef);
             int startPos = 0;
             PtxUtils.StringUtils.MatchContexts(verse, comment.ContextBefore, comment.SelectedText,
-                comment.ContextAfter, null, ref startPos, out int endPos);
+                comment.ContextAfter, null, ref startPos, out int posJustPastLastCharacter);
             // The text anchor is relative to the text in the verse
-            return new TextAnchor { Start = startPos, Length = endPos - startPos };
+            return new TextAnchor { Start = startPos, Length = posJustPastLastCharacter - startPos };
         }
 
         private SyncUser FindOrCreateSyncUser(string paratextUsername, Dictionary<string, SyncUser> syncUsers)

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -300,7 +300,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, false, false, new Book("MAT", 2), new Book("MRK", 2));
             env.SetupPTData(new Book("MAT", 3), new Book("MRK", 1));
             env.AddParatextNoteThreadData(new Book("MRK", 2));
-            Assert.That(env.ContainsNote("MRK", 2), Is.True);
+            Assert.That(env.ContainsNote(2), Is.True);
 
             await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
             await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
@@ -317,7 +317,7 @@ namespace SIL.XForge.Scripture.Services
 
             Assert.That(env.ContainsQuestion("MAT", 2), Is.True);
             Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
-            Assert.That(env.ContainsNote("MRK", 2), Is.False);
+            Assert.That(env.ContainsNote(2), Is.False);
             env.VerifyProjectSync(true);
         }
 
@@ -347,7 +347,7 @@ namespace SIL.XForge.Scripture.Services
             // Need to make sure we have notes BEFORE the sync
             env.AddParatextNoteThreadData(new Book("MRK", 2));
 
-            Assert.That(env.ContainsNote("MRK", 2), Is.True);
+            Assert.That(env.ContainsNote(2), Is.True);
             await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
             await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
@@ -366,7 +366,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsQuestion("MAT", 1), Is.True);
             Assert.That(env.ContainsQuestion("MAT", 2), Is.True);
 
-            Assert.That(env.ContainsNote("MRK", 2), Is.False);
+            Assert.That(env.ContainsNote(2), Is.False);
             env.VerifyProjectSync(true);
         }
 
@@ -1366,7 +1366,7 @@ namespace SIL.XForge.Scripture.Services
                 return RealtimeService.GetRepository<Question>().Contains($"project01:question{bookId}{chapter}");
             }
 
-            public bool ContainsNote(string bookId, int chapter)
+            public bool ContainsNote(int chapter)
             {
                 return RealtimeService.GetRepository<NoteThread>().Contains($"project01:thread0{chapter}");
             }


### PR DESCRIPTION
- When I examined code about PT anchoring, it took me a bit to catch
on to some concepts and terminology. In this commit I have some
changes that I think will make some of these concepts more quickly
evident, such as by comments and renamed methods and variables.

editor.component.ts:
- I recognize that in getUpdatedTextAnchor(), the `embedIndex`
variable comes from `const [threadId, embedIndex] of
oldSegmentEmbeds.entries()` in updateSegmentNoteThreadAnchors(), and
therefore we won't expect `oldVerseEmbedPositions.values()` not to
contain it. But I propose that we have a warning for the exceptional
unexpected case of embedIndex not being in the set, at least for now,
as we get this positioning working.

ParatextServiceTests.cs:
- I think "related verse" can be a misleading string for the text of a
segment that is related to the base segment of a verse, and adjusted
the string.

ParatextSyncRunnerTests.cs:
- Accepting parameter "bookId" in `ContainsNote()` gives the wrong
idea that the method is limiting the lookup to only notes of that
book. Be evident that the book is not in the consideration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1162)
<!-- Reviewable:end -->
