### PR TITLE
SF-1404 Use GET requests to check permissions from DBL

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,7 @@
     "caniuse",
     "cdnjs",
     "dropdown",
+    "ethnologue",
     "flexbox",
     "gtag",
     "helphero",

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -306,17 +306,12 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
 
-            // Set up mock REST client to return a successful HEAD request
+            // Set up mock REST client to return a successful GET request
             ISFRestClientFactory mockRestClientFactory = env.SetRestClientFactory(user01Secret);
-            ISFRestClient successMockClient = Substitute.For<ISFRestClient>();
-            successMockClient.Head(Arg.Any<string>()).Returns(string.Empty);
-            mockRestClientFactory
-                .Create(Arg.Any<string>(), Arg.Is<UserSecret>(s => s.Id == env.User01))
-                .Returns(successMockClient);
 
-            // Set up mock REST client to return an unsuccessful HEAD request
+            // Set up mock REST client to return an unsuccessful GET request
             ISFRestClient failureMockClient = Substitute.For<ISFRestClient>();
-            failureMockClient.Head(Arg.Any<string>()).Throws<WebException>();
+            failureMockClient.Get(Arg.Any<string>()).Returns(string.Empty);
             mockRestClientFactory
                 .Create(Arg.Any<string>(), Arg.Is<UserSecret>(s => s.Id == env.User02))
                 .Returns(failureMockClient);
@@ -324,7 +319,7 @@ namespace SIL.XForge.Scripture.Services
             // Set up mock project
             var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
             var project = projects.First();
-            project.ParatextId = "resid_is_16_char";
+            project.ParatextId = env.Resource2Id;
             var ptUsernameMapping = new Dictionary<string, string>()
                 {
                     { env.User01, env.Username01 },
@@ -344,13 +339,8 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
 
-            // Set up mock REST client to return a successful HEAD request
+            // Set up mock REST client to return a successful GET request
             ISFRestClientFactory mockRestClientFactory = env.SetRestClientFactory(user01Secret);
-            ISFRestClient mockClient = Substitute.For<ISFRestClient>();
-            mockClient.Head(Arg.Any<string>()).Throws<WebException>();
-            mockRestClientFactory
-                .Create(Arg.Any<string>(), Arg.Any<UserSecret>())
-                .Returns(mockClient);
 
             var paratextId = "resid_is_16_char";
             var permission = await env.Service.GetResourcePermissionAsync(paratextId, env.User01, CancellationToken.None);
@@ -363,17 +353,8 @@ namespace SIL.XForge.Scripture.Services
             // Set up environment
             var env = new TestEnvironment();
             UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            // Set up mock REST client to return a successful HEAD request
-            ISFRestClientFactory mockRestClientFactory = env.SetRestClientFactory(user01Secret);
-            ISFRestClient mockClient = Substitute.For<ISFRestClient>();
-            mockClient.Head(Arg.Any<string>()).Returns(string.Empty);
-            mockRestClientFactory
-                .Create(Arg.Any<string>(), Arg.Any<UserSecret>())
-                .Returns(mockClient);
-
-            var paratextId = "resid_is_16_char";
-
+            env.SetRestClientFactory(user01Secret);
+            var paratextId = env.Resource2Id;
             var permission = await env.Service.GetResourcePermissionAsync(paratextId, env.User01, CancellationToken.None);
             Assert.That(permission, Is.EqualTo(TextInfoPermission.Read));
         }
@@ -829,7 +810,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSuccessfulSendReceive();
             env.SetRestClientFactory(user01Secret);
             ScrTextCollection.Initialize("/srv/scriptureforge/projects");
-            string resourceId = "9bb76cd3e5a7f9b4"; // See the XML in SetRestClientFactory for this
+            string resourceId = env.Resource3Id; // See the XML in SetRestClientFactory for this
             await env.Service.SendReceiveAsync(user01Secret, ptProjectId);
             await env.Service.SendReceiveAsync(user01Secret, resourceId);
         }
@@ -1104,6 +1085,9 @@ namespace SIL.XForge.Scripture.Services
             public readonly string Project02 = "project02";
             public readonly string Project03 = "project03";
             public readonly string Project04 = "project04";
+            public readonly string Resource1Id = "e01f11e9b4b8e338";
+            public readonly string Resource2Id = "5e51f89e89947acb";
+            public readonly string Resource3Id = "9bb76cd3e5a7f9b4";
             public readonly Dictionary<string, HexId> PTProjectIds = new Dictionary<string, HexId>();
             public readonly string User01 = "user01";
             public readonly string User02 = "user02";
@@ -1238,7 +1222,7 @@ namespace SIL.XForge.Scripture.Services
             ""fullname"": ""Sob Jonah and Luke"",
             ""name"": ""SobP15"",
             ""permissions-checksum"": ""1ab119321b305f99"",
-            ""id"": ""e01f11e9b4b8e338"",
+            ""id"": """ + this.Resource1Id + @""",
             ""relevance"": {
                 ""basic_permissions"": [
                     ""allow_any_user""
@@ -1256,7 +1240,7 @@ namespace SIL.XForge.Scripture.Services
             ""fullname"": ""Aruamu New Testament [msy] Papua New Guinea 2004 DBL"",
             ""name"": ""AruNT04"",
             ""permissions-checksum"": ""1ab119321b305f99"",
-            ""id"": ""5e51f89e89947acb"",
+            ""id"": """ + this.Resource2Id + @""",
             ""relevance"": {
                 ""basic_permissions"": [
                     ""allow_any_user""
@@ -1274,7 +1258,7 @@ namespace SIL.XForge.Scripture.Services
             ""fullname"": ""Revised Version with Apocrypha 1885, 1895"",
             ""name"": ""RV1895"",
             ""permissions-checksum"": ""1ab119321b305f99"",
-            ""id"": ""9bb76cd3e5a7f9b4"",
+            ""id"": """ + this.Resource3Id + @""",
             ""relevance"": {
                 ""basic_permissions"": [
                     ""allow_any_user""


### PR DESCRIPTION
- HEAD requests we previously used to check permissions for a resource are no longer working properly on the DBL QA server, and soon will not work on the live DBL server.
- The `/resources` endpoint on the DBL server is adding an `id` filter query so it is possible to fetch the metadata of just one resource.

So instead of a HEAD request to `server_address/api/resource_entries/the_resource_id`, a GET request is sent to `server_address/api/resource_entries?id=the_resource_id`. At present the live server does not recognize the `id` query and just ignores it, resulting in a large payload. This is inefficient. However, it *will* work because we look at the data that is returned and see if it includes the resource id we were looking for. Once this is deployed the DBL server can be updated and the `resource_entries` endpoint with an `id` query parameter will start to only return the data for that one resource.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1168)
<!-- Reviewable:end -->
