### PR TITLE
Code tidy-up post note dialog merge

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.spec.ts
@@ -36,7 +36,7 @@ describe('NoteThreadDoc', () => {
     };
     const noteThreadDoc = await env.setupDoc(noteThread);
     const expectedIcon: NoteThreadIcon = {
-      var: '--icon-file: url(/assets/icons/TagIcons/flag02.png);',
+      cssVar: '--icon-file: url(/assets/icons/TagIcons/flag02.png);',
       url: '/assets/icons/TagIcons/flag02.png'
     };
     expect(noteThreadDoc.icon).toEqual(expectedIcon);
@@ -57,7 +57,7 @@ describe('NoteThreadDoc', () => {
     };
     const noteThreadDoc = await env.setupDoc(noteThread);
     const expectedIcon: NoteThreadIcon = {
-      var: '--icon-file: url(/assets/icons/TagIcons/01flag1.png);',
+      cssVar: '--icon-file: url(/assets/icons/TagIcons/01flag1.png);',
       url: '/assets/icons/TagIcons/01flag1.png'
     };
     expect(noteThreadDoc.icon).toEqual(expectedIcon);
@@ -112,7 +112,7 @@ describe('NoteThreadDoc', () => {
     };
     const noteThreadDoc = await env.setupDoc(noteThread);
     const expectedIcon: NoteThreadIcon = {
-      var: '--icon-file: url(/assets/icons/TagIcons/flag3.png);',
+      cssVar: '--icon-file: url(/assets/icons/TagIcons/flag3.png);',
       url: '/assets/icons/TagIcons/flag3.png'
     };
     expect(noteThreadDoc.icon).toEqual(expectedIcon);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
@@ -8,7 +8,7 @@ import { Note } from 'realtime-server/lib/esm/scriptureforge/models/note';
 import { clone } from 'lodash-es';
 
 export interface NoteThreadIcon {
-  var: string;
+  cssVar: string;
   url: string;
 }
 
@@ -18,7 +18,7 @@ export class NoteThreadDoc extends ProjectDataDoc<NoteThread> {
 
   get icon(): NoteThreadIcon {
     if (this.data == null) {
-      return { var: '', url: '' };
+      return { cssVar: '', url: '' };
     }
     const notes: Note[] = clone(this.data.notes).sort((a, b) => Date.parse(a.dateCreated) - Date.parse(b.dateCreated));
     const iconDefinedNotes = notes.filter(n => n.tagIcon != null);
@@ -28,6 +28,6 @@ export class NoteThreadDoc extends ProjectDataDoc<NoteThread> {
       icon = '01flag1';
     }
     const iconUrl = `/assets/icons/TagIcons/${icon}.png`;
-    return { var: `--icon-file: url(${iconUrl});`, url: iconUrl };
+    return { cssVar: `--icon-file: url(${iconUrl});`, url: iconUrl };
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -40,11 +40,11 @@ export function combineVerseRefStrs(startStr?: string, endStr?: string): VerseRe
 
 export function verseRefFromMouseEvent(event: MouseEvent, bookNum: number): VerseRef | undefined {
   const clickSegment = attributeFromMouseEvent(event, 'USX-SEGMENT', 'data-segment');
-  if (clickSegment != null) {
-    const segmentParts = clickSegment.split('_', 3);
-    return new VerseRef(bookNum, segmentParts[1], segmentParts[2]);
+  if (clickSegment == null) {
+    return;
   }
-  return;
+  const segmentParts = clickSegment.split('_', 3);
+  return new VerseRef(bookNum, segmentParts[1], segmentParts[2]);
 }
 
 export function threadIdFromMouseEvent(event: MouseEvent): string | undefined {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1,7 +1,7 @@
-import { MdcDialog, MdcDialogRef } from '@angular-mdc/web';
 import { HttpErrorResponse } from '@angular/common/http';
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, Params } from '@angular/router';
@@ -72,7 +72,7 @@ const mockedBugsnagService = mock(BugsnagService);
 const mockedCookieService = mock(CookieService);
 const mockedPwaService = mock(PwaService);
 const mockedTranslationEngineService = mock(TranslationEngineService);
-const mockedMdcDialog = mock(MdcDialog);
+const mockedMatDialog = mock(MatDialog);
 
 class MockConsole {
   log(val: any) {
@@ -108,7 +108,7 @@ describe('EditorComponent', () => {
       { provide: CookieService, useMock: mockedCookieService },
       { provide: PwaService, useMock: mockedPwaService },
       { provide: TranslationEngineService, useMock: mockedTranslationEngineService },
-      { provide: MdcDialog, useMock: mockedMdcDialog }
+      { provide: MatDialog, useMock: mockedMatDialog }
     ]
   }));
 
@@ -1461,7 +1461,7 @@ describe('EditorComponent', () => {
       expect(note).not.toBeNull();
       note.nativeElement.click();
       env.wait();
-      verify(mockedMdcDialog.open(NoteDialogComponent, anything())).once();
+      verify(mockedMatDialog.open(NoteDialogComponent, anything())).once();
       env.dispose();
     }));
 
@@ -1860,8 +1860,8 @@ class TestEnvironment {
     );
     when(mockedPwaService.isOnline).thenReturn(true);
     when(mockedPwaService.onlineStatus).thenReturn(of(true));
-    const mockedNoteDialogRef = mock<MdcDialogRef<NoteDialogComponent>>(MdcDialogRef);
-    when(mockedMdcDialog.open(NoteDialogComponent, anything())).thenReturn(instance(mockedNoteDialogRef));
+    const mockedNoteDialogRef = mock<MatDialogRef<NoteDialogComponent>>(MatDialogRef);
+    when(mockedMatDialog.open(NoteDialogComponent, anything())).thenReturn(instance(mockedNoteDialogRef));
 
     this.fixture = TestBed.createComponent(EditorComponent);
     this.component = this.fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1,6 +1,6 @@
-import { MdcDialog } from '@angular-mdc/web/dialog';
 import { AfterViewInit, Component, ElementRef, Inject, OnDestroy, ViewChild } from '@angular/core';
 import { MediaObserver } from '@angular/flex-layout';
+import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
 import { translate } from '@ngneat/transloco';
 import {
@@ -119,7 +119,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     private readonly userService: UserService,
     private readonly projectService: SFProjectService,
     noticeService: NoticeService,
-    private readonly dialog: MdcDialog,
+    private readonly dialog: MatDialog,
     private readonly mediaObserver: MediaObserver,
     private readonly pwaService: PwaService,
     private readonly translationEngineService: TranslationEngineService,
@@ -598,8 +598,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     const dialogRef = this.dialog.open<SuggestionsSettingsDialogComponent, SuggestionsSettingsDialogData>(
       SuggestionsSettingsDialogComponent,
       {
-        clickOutsideToClose: true,
-        escapeToClose: true,
         autoFocus: false,
         data: { projectUserConfigDoc: this.projectUserConfigDoc }
       }
@@ -648,8 +646,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   private showNoteThread(threadId: string): void {
     this.dialog.open(NoteDialogComponent, {
-      clickOutsideToClose: true,
-      escapeToClose: true,
       autoFocus: false,
       data: {
         projectId: this.projectDoc!.id,
@@ -762,7 +758,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     if (
       this.projectUserConfigDoc != null &&
       this.projectUserConfigDoc.data != null &&
-      this.text != null &&
       this.projectUserConfigDoc.data.selectedBookNum === this.text.bookNum &&
       this.projectUserConfigDoc.data.selectedChapterNum === this._chapter &&
       this.projectUserConfigDoc.data.selectedSegment !== ''
@@ -1163,7 +1158,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       return;
     }
 
-    const format = { iconsrc: featured.icon.var, preview: featured.preview, threadid: featured.id };
+    const format = { iconsrc: featured.icon.cssVar, preview: featured.preview, threadid: featured.id };
     return this.target.embedElementInline(
       featured.verseRef,
       featured.id,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
@@ -1,31 +1,27 @@
-<mdc-dialog *transloco="let t; read: 'note_dialog'">
-  <mdc-dialog-container>
-    <mdc-dialog-surface>
-      <mdc-dialog-title>
-        <img [src]="flagIcon" /> <span>{{ verseRef }}</span>
-        <button mat-icon-button [matMenuTriggerFor]="menu"><mat-icon>more_vert</mat-icon></button>
-        <mat-menu #menu="matMenu">
-          <button mat-menu-item (click)="toggleSegmentText()">
-            <mat-icon>compare</mat-icon>
-            <span>{{ showSegmentText ? t("hide_changes") : t("show_changes") }}</span>
-          </button>
-        </mat-menu></mdc-dialog-title
-      >
-      <mdc-dialog-content class="content-padding" [ngClass]="{ rtl: isRtl, ltr: !isRtl }">
-        <div class="text">
-          <div class="note-text" [innerHTML]="noteContextText"></div>
-          <div *ngIf="showSegmentText" class="segment-text" [innerHTML]="segmentText"></div>
-        </div>
-        <div class="notes">
-          <div *ngFor="let note of notes" class="note">
-            <div class="content" [innerHTML]="parseNote(note.content)"></div>
-            <app-owner [ownerRef]="note.ownerRef" [dateTime]="note.dateCreated"></app-owner>
-          </div>
-        </div>
-      </mdc-dialog-content>
-      <mdc-dialog-actions>
-        <button mdcDialogButton mdcDialogAction="close" type="button">{{ t("close") }}</button>
-      </mdc-dialog-actions>
-    </mdc-dialog-surface>
-  </mdc-dialog-container>
-</mdc-dialog>
+<ng-container *transloco="let t; read: 'note_dialog'">
+  <h1 mat-dialog-title>
+    <img [src]="flagIcon" alt="" /> <span>{{ verseRef }}</span>
+    <button mat-icon-button [matMenuTriggerFor]="menu"><mat-icon>more_vert</mat-icon></button>
+    <mat-menu #menu="matMenu">
+      <button mat-menu-item (click)="toggleSegmentText()">
+        <mat-icon>compare</mat-icon>
+        <span>{{ showSegmentText ? t("hide_changes") : t("show_changes") }}</span>
+      </button>
+    </mat-menu>
+  </h1>
+  <mat-dialog-content class="content-padding" [ngClass]="{ rtl: isRtl, ltr: !isRtl }">
+    <div class="text">
+      <div class="note-text" [innerHTML]="noteContextText"></div>
+      <div *ngIf="showSegmentText" class="segment-text" [innerHTML]="segmentText"></div>
+    </div>
+    <div class="notes">
+      <div *ngFor="let note of notes" class="note">
+        <div class="content" [innerHTML]="parseNote(note.content)"></div>
+        <app-owner [ownerRef]="note.ownerRef" [dateTime]="note.dateCreated"></app-owner>
+      </div>
+    </div>
+  </mat-dialog-content>
+  <mat-dialog-actions fxLayoutAlign="end">
+    <button mat-button mat-dialog-close>{{ t("close") }}</button>
+  </mat-dialog-actions>
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
@@ -1,10 +1,10 @@
 @import 'src/variables';
 @import 'bootstrap/scss/mixins/breakpoints';
 
-mdc-dialog-title {
+h1 {
   display: flex;
   align-items: center;
-  padding-top: 10px;
+  margin: -10px 0 10px;
 
   span {
     flex: 1;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -1,5 +1,5 @@
-import { MDC_DIALOG_DATA } from '@angular-mdc/web/dialog';
 import { Component, Inject, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { sortBy } from 'lodash-es';
 import { toVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { Note } from 'realtime-server/lib/esm/scriptureforge/models/note';
@@ -28,7 +28,7 @@ export class NoteDialogComponent implements OnInit {
   private textDoc?: TextDoc;
 
   constructor(
-    @Inject(MDC_DIALOG_DATA) private readonly data: NoteDialogData,
+    @Inject(MAT_DIALOG_DATA) private readonly data: NoteDialogData,
     private readonly i18n: I18nService,
     private readonly projectService: SFProjectService
   ) {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
@@ -1,51 +1,41 @@
 <ng-container *transloco="let t; read: 'suggestions_settings_dialog'">
-  <mdc-dialog>
-    <mdc-dialog-container>
-      <mdc-dialog-surface>
-        <mdc-dialog-title>{{ t("translation_suggestions_settings") }}</mdc-dialog-title>
-        <mdc-dialog-content class="content-padding" fxLayout="column" fxLayoutGap="25px">
-          <div class="offline-text" *ngIf="!pwaService.isOnline">{{ t("settings_not_available_offline") }}</div>
-          <mdc-form-field [formGroup]="suggestionsSwitchFormGroup">
-            <mdc-switch
-              id="suggestions-enabled-switch"
-              *ngIf="open"
-              formControlName="suggestionsEnabledSwitch"
-            ></mdc-switch>
-            <label class="switch-label">{{ t("translation_suggestions") }}</label>
-          </mdc-form-field>
-          <mdc-select
-            id="num-suggestions-select"
-            [disabled]="settingsDisabled"
-            [(ngModel)]="numSuggestions"
-            placeholder="{{ t('number_of_suggestions') }}"
-          >
-            <mdc-menu>
-              <mdc-list>
-                <mdc-list-item *ngFor="let value of ['1', '2', '3', '4', '5']" [value]="value">
-                  {{ value }}
-                </mdc-list-item>
-              </mdc-list>
-            </mdc-menu>
-          </mdc-select>
-          <mdc-form-field>
-            <label mdcSubtitle2>{{ t("suggestion_confidence") }}</label>
-            <div class="slider-labels" fxLayout="row" fxLayoutAlign="space-between">
-              <span mdcCaption>{{ t("more") }}</span> <span mdcCaption>{{ confidenceThreshold }}%</span>
-              <span mdcCaption>{{ t("better") }}</span>
-            </div>
-            <mdc-slider
-              #confidenceThresholdSlider
-              [disabled]="settingsDisabled"
-              [min]="0"
-              [max]="100"
-              [(ngModel)]="confidenceThreshold"
-            ></mdc-slider>
-          </mdc-form-field>
-        </mdc-dialog-content>
-        <mdc-dialog-actions>
-          <button mdcDialogButton [default]="true" type="button" mdcDialogAction="close">{{ t("close") }}</button>
-        </mdc-dialog-actions>
-      </mdc-dialog-surface>
-    </mdc-dialog-container>
-  </mdc-dialog>
+  <h1 mat-dialog-title>{{ t("translation_suggestions_settings") }}</h1>
+  <mat-dialog-content class="content-padding" fxLayout="column" fxLayoutGap="25px">
+    <div class="offline-text" *ngIf="!pwaService.isOnline">{{ t("settings_not_available_offline") }}</div>
+    <mdc-form-field [formGroup]="suggestionsSwitchFormGroup">
+      <mdc-switch id="suggestions-enabled-switch" *ngIf="open" formControlName="suggestionsEnabledSwitch"></mdc-switch>
+      <label class="switch-label">{{ t("translation_suggestions") }}</label>
+    </mdc-form-field>
+    <mdc-select
+      id="num-suggestions-select"
+      [disabled]="settingsDisabled"
+      [(ngModel)]="numSuggestions"
+      placeholder="{{ t('number_of_suggestions') }}"
+    >
+      <mdc-menu>
+        <mdc-list>
+          <mdc-list-item *ngFor="let value of ['1', '2', '3', '4', '5']" [value]="value">
+            {{ value }}
+          </mdc-list-item>
+        </mdc-list>
+      </mdc-menu>
+    </mdc-select>
+    <mdc-form-field>
+      <label mdcSubtitle2>{{ t("suggestion_confidence") }}</label>
+      <div class="slider-labels" fxLayout="row" fxLayoutAlign="space-between">
+        <span mdcCaption>{{ t("more") }}</span> <span mdcCaption>{{ confidenceThreshold }}%</span>
+        <span mdcCaption>{{ t("better") }}</span>
+      </div>
+      <mdc-slider
+        #confidenceThresholdSlider
+        [disabled]="settingsDisabled"
+        [min]="0"
+        [max]="100"
+        [(ngModel)]="confidenceThreshold"
+      ></mdc-slider>
+    </mdc-form-field>
+  </mat-dialog-content>
+  <mat-dialog-actions fxLayoutAlign="end">
+    <button mat-button mat-dialog-close>{{ t("close") }}</button>
+  </mat-dialog-actions>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
@@ -6,7 +6,7 @@
   margin-left: 12px;
 }
 
-mdc-dialog-content.content-padding {
+mat-dialog-content.content-padding {
   padding-top: 15px;
   overflow: visible; // prevent mdc-select menu from causing scroll bar
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.ts
@@ -1,7 +1,7 @@
-import { MdcDialogRef, MDC_DIALOG_DATA } from '@angular-mdc/web/dialog';
 import { MdcSlider } from '@angular-mdc/web/slider';
 import { Component, Inject, ViewChild } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { BehaviorSubject } from 'rxjs';
 import { debounceTime, map, skip } from 'rxjs/operators';
 import { PwaService } from 'xforge-common/pwa.service';
@@ -31,8 +31,8 @@ export class SuggestionsSettingsDialogComponent extends SubscriptionDisposable {
   private confidenceThreshold$ = new BehaviorSubject<number>(20);
 
   constructor(
-    dialogRef: MdcDialogRef<SuggestionsSettingsDialogComponent>,
-    @Inject(MDC_DIALOG_DATA) data: SuggestionsSettingsDialogData,
+    dialogRef: MatDialogRef<SuggestionsSettingsDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) data: SuggestionsSettingsDialogData,
     readonly pwaService: PwaService
   ) {
     super();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate.module.ts
@@ -1,7 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { MatIconModule } from '@angular/material/icon';
-import { MatMenuModule } from '@angular/material/menu';
 import { TranslocoModule } from '@ngneat/transloco';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { XForgeCommonModule } from 'xforge-common/xforge-common.module';
@@ -21,15 +19,6 @@ import { TranslateRoutingModule } from './translate-routing.module';
     SuggestionsSettingsDialogComponent,
     NoteDialogComponent
   ],
-  imports: [
-    TranslateRoutingModule,
-    CommonModule,
-    SharedModule,
-    UICommonModule,
-    XForgeCommonModule,
-    TranslocoModule,
-    MatIconModule,
-    MatMenuModule
-  ]
+  imports: [TranslateRoutingModule, CommonModule, SharedModule, UICommonModule, XForgeCommonModule, TranslocoModule]
 })
 export class TranslateModule {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
@@ -124,6 +124,9 @@ as-split.is-disabled > .as-split-gutter .as-split-gutter-icon {
     color: variables.$sf_grey;
   }
 }
+.mat-button {
+  text-transform: uppercase;
+}
 mdc-icon.ngx-mdc-icon--clickable,
 button.mdc-icon-button {
   transition: color 0.15s;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-utils.ts
@@ -67,6 +67,9 @@ export const emptyHammerLoader = {
   useValue: () => new Promise(() => {})
 };
 
+// Just closing the material dialog can leave residue of the overlay backdrop so wait for it to finish closing
+export const matDialogCloseDelay = 701;
+
 export function getAudioBlob(): Blob {
   const base64 =
     'UklGRlgAAFdBVkVmbXQgEAAAAAEAAQBAHwAAPgAAAgAQAGRhdGFYAAAIAAgACAAIAAgACAAIAAgACAAIAAgACAAIAAgACAAIAAg' +

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -28,6 +28,7 @@ import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatOptionModule } from '@angular/material/core';
+import { MatDialogModule } from '@angular/material/dialog';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
@@ -53,6 +54,7 @@ const modules = [
   FormsModule,
   MatAutocompleteModule,
   MatButtonModule,
+  MatDialogModule,
   MatIconModule,
   MatInputModule,
   MatFormFieldModule,


### PR DESCRIPTION
- Switch suggestions and note dialogs over to material
- Removed redundant imports for material modules in translate module
- Renamed property for `NoteThreadIcon`
- Adjusted null return check in `verseRefFromMouseEvent`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1171)
<!-- Reviewable:end -->
