### PR TITLE
Consider text footnotes length when calculating text anchor positions on sync

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -515,6 +515,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       }
       const skipBlankSegment: boolean = this.isSegmentBlank(vs) && textAnchor.length > 0;
       if (skipBlankSegment) {
+        startTextPosInVerse--;
         continue;
       }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -17,7 +17,7 @@ import {
 } from '@sillsdev/machine';
 import cloneDeep from 'lodash-es/cloneDeep';
 import { CookieService } from 'ngx-cookie-service';
-import Quill, { DeltaOperation, DeltaStatic, Sources } from 'quill';
+import Quill, { DeltaOperation, DeltaStatic, RangeStatic, Sources } from 'quill';
 import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { User } from 'realtime-server/lib/esm/common/models/user';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
@@ -1191,9 +1191,29 @@ describe('EditorComponent', () => {
       doc = env.getNoteThreadDoc('project01', 'thread05');
       // Add 1 to the position to account for the new line
       const noteStart5 = env.component.target!.getSegmentRange('verse_1_4')!.index + doc.data!.position.start + 1;
-      // positions are 11, 34, 54, 55, 93
+      // positions are 11, 34, 55, 56, 94
       const expected = [noteStart1, noteStart2, noteStart3, noteStart4, noteStart5];
       expect(Array.from(env.component.target!.embeddedElements.values())).toEqual(expected);
+      env.dispose();
+    }));
+
+    it('note position correctly accounts for footnote symbols', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.wait();
+
+      const range: RangeStatic = env.component.target!.getSegmentRange('verse_1_3')!;
+      const contents = env.targetEditor.getContents(range.index, range.length);
+      // The footnote starts after a note thread in the segment
+      expect(contents.ops![1].insert).toEqual({ note: { caller: '*' } });
+      const note2Position = env.getNoteThreadEditorPosition('thread02');
+      expect(range.index).toEqual(note2Position);
+      const noteThreadDoc4 = env.getNoteThreadDoc('project01', 'thread04');
+      const noteThread4StartPosition = 20;
+      expect(noteThreadDoc4.data!.position).toEqual({ start: noteThread4StartPosition, length: 5 });
+      const note4Position = env.getNoteThreadEditorPosition('thread04');
+      // plus 1 for the note icon embed at the beginning of the verse
+      expect(range.index + noteThread4StartPosition + 1).toEqual(note4Position);
       env.dispose();
     }));
 
@@ -1284,12 +1304,12 @@ describe('EditorComponent', () => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
       env.wait();
-      expect(Array.from(env.component.target!.embeddedElements.values())).toEqual([11, 34, 54, 55, 93]);
+      expect(Array.from(env.component.target!.embeddedElements.values())).toEqual([11, 34, 55, 56, 94]);
 
       // deletes just the note icon
       env.targetEditor.setSelection(11, 1, 'user');
       env.deleteCharacters();
-      expect(Array.from(env.component.target!.embeddedElements.values())).toEqual([11, 34, 54, 55, 93]);
+      expect(Array.from(env.component.target!.embeddedElements.values())).toEqual([11, 34, 55, 56, 94]);
       const textDoc = env.getTextDoc(new TextDocId('project01', 40, 1));
       expect(textDoc.data!.ops![3].insert).toBe('target: chapter 1, verse 1.');
 
@@ -1299,7 +1319,7 @@ describe('EditorComponent', () => {
       expect(noteThreadDoc.data!.position).toEqual({ start: 8, length: 9 });
       env.typeCharacters('t');
       // 4 characters deleted and 1 character inserted
-      expect(Array.from(env.component.target!.embeddedElements.values())).toEqual([10, 31, 51, 52, 90]);
+      expect(Array.from(env.component.target!.embeddedElements.values())).toEqual([10, 31, 52, 53, 91]);
       expect(noteThreadDoc.data!.position).toEqual({ start: 7, length: 7 });
       expect(textDoc.data!.ops![3].insert).toBe('targettapter 1, verse 1.');
 
@@ -1310,7 +1330,7 @@ describe('EditorComponent', () => {
 
       env.updateParams({ projectId: 'project01', bookId: 'MAT' });
       env.wait();
-      expect(Array.from(env.component!.target!.embeddedElements.values())).toEqual([10, 31, 51, 52, 90]);
+      expect(Array.from(env.component!.target!.embeddedElements.values())).toEqual([10, 31, 52, 53, 91]);
       env.dispose();
     }));
 
@@ -1340,7 +1360,7 @@ describe('EditorComponent', () => {
 
       const noteThreadDoc = env.getNoteThreadDoc('project01', 'thread05');
       expect(noteThreadDoc.data!.position).toEqual({ start: 27, length: 9 });
-      env.targetEditor.setSelection(85, 0, 'user');
+      env.targetEditor.setSelection(86, 0, 'user');
       const text = ' new text ';
       const length = text.length;
       env.typeCharacters(text);
@@ -1373,7 +1393,7 @@ describe('EditorComponent', () => {
     it('handles insert at the last character position', fakeAsync(() => {
       const env = new TestEnvironment();
       env.addParatextNoteThread(6, 'MAT 1:1', '1', { start: 16, length: 1 }, ['user01']);
-      env.addParatextNoteThread(7, 'MAT 1:3', '.', { start: 26, length: 1 }, ['user01']);
+      env.addParatextNoteThread(7, 'MAT 1:3', '.', { start: 27, length: 1 }, ['user01']);
       env.setProjectUserConfig();
       env.wait();
 
@@ -1398,13 +1418,13 @@ describe('EditorComponent', () => {
 
       // insert in an adjacent text anchor should not be included in the previous note
       const noteThread3Doc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread03');
-      expect(noteThread3Doc.data!.position).toEqual({ start: 19, length: 7 });
+      expect(noteThread3Doc.data!.position).toEqual({ start: 20, length: 7 });
       const index = env.getNoteThreadEditorPosition('thread07');
       env.targetEditor.setSelection(index + 1, 0, 'user');
       env.typeCharacters('c');
-      expect(noteThread3Doc.data!.position).toEqual({ start: 19, length: 7 });
+      expect(noteThread3Doc.data!.position).toEqual({ start: 20, length: 7 });
       const noteThread7Doc: NoteThreadDoc = env.getNoteThreadDoc('project01', `thread07`);
-      expect(noteThread7Doc.data!.position).toEqual({ start: 26, length: 1 + 'c'.length });
+      expect(noteThread7Doc.data!.position).toEqual({ start: 27, length: 1 + 'c'.length });
 
       env.dispose();
     }));
@@ -1426,7 +1446,7 @@ describe('EditorComponent', () => {
 
       // delete text that includes the entire text anchor
       noteThreadDoc = env.getNoteThreadDoc('project01', 'thread03');
-      expect(noteThreadDoc.data!.position).toEqual({ start: 19, length: 7 });
+      expect(noteThreadDoc.data!.position).toEqual({ start: 20, length: 7 });
       notePosition = env.getNoteThreadEditorPosition('thread03');
       length = 8;
       env.targetEditor.setSelection(notePosition + 1, length, 'user');
@@ -1441,9 +1461,9 @@ describe('EditorComponent', () => {
       env.wait();
 
       const thread4Doc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread04');
-      expect(thread4Doc.data!.position).toEqual({ start: 19, length: 5 });
+      expect(thread4Doc.data!.position).toEqual({ start: 20, length: 5 });
       const otherNoteThreadDoc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread03');
-      expect(otherNoteThreadDoc.data!.position).toEqual({ start: 19, length: 7 });
+      expect(otherNoteThreadDoc.data!.position).toEqual({ start: 20, length: 7 });
       const verseNoteThreadDoc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread02');
       expect(verseNoteThreadDoc.data!.position).toEqual({ start: 0, length: 0 });
       // edit before paratext note
@@ -1453,8 +1473,8 @@ describe('EditorComponent', () => {
       const textBeforeNote = 'add text before ';
       const length1 = textBeforeNote.length;
       env.typeCharacters(textBeforeNote);
-      expect(thread4Doc.data!.position).toEqual({ start: 19 + length1, length: 5 });
-      expect(otherNoteThreadDoc.data!.position).toEqual({ start: 19 + length1, length: 7 });
+      expect(thread4Doc.data!.position).toEqual({ start: 20 + length1, length: 5 });
+      expect(otherNoteThreadDoc.data!.position).toEqual({ start: 20 + length1, length: 7 });
 
       // edit within note selection start
       thread4Position = env.getNoteThreadEditorPosition('thread04');
@@ -1464,8 +1484,8 @@ describe('EditorComponent', () => {
       const length2 = textWithinNote.length;
       env.typeCharacters(textWithinNote);
       env.wait();
-      expect(thread4Doc.data!.position).toEqual({ start: 19 + length1, length: 5 + length2 });
-      expect(otherNoteThreadDoc.data!.position).toEqual({ start: 19 + length1, length: 7 + length2 });
+      expect(thread4Doc.data!.position).toEqual({ start: 20 + length1, length: 5 + length2 });
+      expect(otherNoteThreadDoc.data!.position).toEqual({ start: 20 + length1, length: 7 + length2 });
 
       // edit within note selection end
       const verse3Range = env.component.target!.getSegmentRange('verse_1_3')!;
@@ -1474,14 +1494,14 @@ describe('EditorComponent', () => {
       const editorPosImmediatelyFollowingThread4Anchoring = verse3Range.index + verse3Range.length - extraAmount;
       env.targetEditor.setSelection(editorPosImmediatelyFollowingThread4Anchoring, 0, 'user');
       env.typeCharacters(textWithinNote);
-      expect(thread4Doc.data!.position).toEqual({ start: 19 + length1, length: 5 + length2 * 2 });
+      expect(thread4Doc.data!.position).toEqual({ start: 20 + length1, length: 5 + length2 * 2 });
 
       // delete text within note selection
       thread4Position = env.getNoteThreadEditorPosition('thread04');
       env.targetEditor.setSelection(thread4Position + 2, 5, 'user');
       env.wait();
       env.typeCharacters('');
-      const expected = { start: 19 + length1, length: 5 + length2 * 2 - 5 };
+      const expected = { start: 20 + length1, length: 5 + length2 * 2 - 5 };
       expect(thread4Doc.data!.position).toEqual(expected);
       // the verse note thread position never changes
       expect(verseNoteThreadDoc.data!.position).toEqual({ start: 0, length: 0 });
@@ -1520,7 +1540,7 @@ describe('EditorComponent', () => {
       env.wait();
       env.updateParams({ projectId: 'project01', bookId: 'MAT' });
       env.wait();
-      const note5Index: number = env.getNoteThreadEditorPosition('thread05');
+      let note5Index: number = env.getNoteThreadEditorPosition('thread05');
       verse4p1Index = env.component.target!.getSegmentRange('verse_1_4/p_1')!.index;
       expect(note5Index).toEqual(verse4p1Index);
 
@@ -1539,7 +1559,8 @@ describe('EditorComponent', () => {
       env.wait();
       expect(noteThreadDoc.data!.position).toEqual({ start: text.length, length: 9 });
       verse4p1Index = env.component.target!.getSegmentRange('verse_1_4/p_1')!.index;
-      expect(env.getNoteThreadEditorPosition('thread05')).toEqual(verse4p1Index);
+      note5Index = env.getNoteThreadEditorPosition('thread05');
+      expect(note5Index).toEqual(verse4p1Index);
       env.dispose();
     }));
 
@@ -1992,8 +2013,8 @@ class TestEnvironment {
     this.setupProject();
     this.addParatextNoteThread(1, 'MAT 1:1', 'chapter 1', { start: 8, length: 9 }, ['user01', 'user02', 'user03']);
     this.addParatextNoteThread(2, 'MAT 1:3', 'target: chapter 1, verse 3.', { start: 0, length: 0 }, ['user01']);
-    this.addParatextNoteThread(3, 'MAT 1:3', 'verse 3', { start: 19, length: 7 }, ['user01']);
-    this.addParatextNoteThread(4, 'MAT 1:3', 'verse', { start: 19, length: 5 }, ['user01']);
+    this.addParatextNoteThread(3, 'MAT 1:3', 'verse 3', { start: 20, length: 7 }, ['user01']);
+    this.addParatextNoteThread(4, 'MAT 1:3', 'verse', { start: 20, length: 5 }, ['user01']);
     this.addParatextNoteThread(5, 'MAT 1:4', 'Paragraph', { start: 27, length: 9 }, ['user01']);
     this.addParatextNoteThread(6, 'MAT 1:5', 'resolved note', { start: 0, length: 0 }, ['user01'], NoteStatus.Resolved);
     when(this.mockedRemoteTranslationEngine.getWordGraph(anything())).thenCall(segment =>
@@ -2379,6 +2400,7 @@ class TestEnvironment {
         break;
     }
     delta.insert({ verse: { number: '3', style: 'v' } });
+    delta.insert({ note: { caller: '*' } });
     delta.insert(`${id.textType}: chapter ${id.chapterNum}, verse 3.`, { segment: `verse_${id.chapterNum}_3` });
     delta.insert({ verse: { number: '4', style: 'v' } });
     delta.insert(`${id.textType}: chapter ${id.chapterNum}, verse 4.`, { segment: `verse_${id.chapterNum}_4` });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1533,7 +1533,7 @@ describe('EditorComponent', () => {
       const range = env.component.target!.getSegmentRange('verse_1_4')!;
       env.targetEditor.setSelection(range.index, range.length, 'user');
       env.deleteCharacters();
-      expect(noteThreadDoc.data!.position).toEqual({ start: 0, length: 9 });
+      expect(noteThreadDoc.data!.position).toEqual({ start: 1, length: 9 });
 
       // switch to a new book and back
       env.updateParams({ projectId: 'project01', bookId: 'MRK' });
@@ -1604,10 +1604,11 @@ describe('EditorComponent', () => {
       notePosition = env.getNoteThreadEditorPosition('thread02');
       // 1 note from verse 1, and 1 in verse 3 before the selection point
       noteCountBeforePosition = 2;
+      remoteEditPositionAfterNote = 5;
       remoteEditTextPos = env.getRemoteEditPosition(notePosition, remoteEditPositionAfterNote, noteCountBeforePosition);
       const originalNotePosInVerse: number = env.getNoteThreadDoc('project01', 'thread03').data!.position.start;
-      // $targ|->et: cha<-|pter 1, $$verse 3.
-      //         ------- 7 characters get replaced locally by the text 'defgh'
+      // $*targ|->et: cha<-|pter 1, $$verse 3.
+      //          ------- 7 characters get replaced locally by the text 'defgh'
       const selectionLength: number = 'et: cha'.length;
       const insertDeleteDelta: DeltaStatic = new Delta();
       (insertDeleteDelta as any).push({ retain: remoteEditTextPos } as DeltaOperation);
@@ -1620,10 +1621,10 @@ describe('EditorComponent', () => {
       expect(env.component.target!.getSegmentText('verse_1_3')).toEqual('targ' + 'defgh' + 'pter 1, verse 3.');
 
       // The remote user selects and deletes some text that includes a couple note embeds.
-      remoteEditPositionAfterNote = 14;
+      remoteEditPositionAfterNote = 15;
       remoteEditTextPos = env.getRemoteEditPosition(notePosition, remoteEditPositionAfterNote, noteCountBeforePosition);
-      // $targdefghpter |->1, $$v<-|erse 3.
-      //                   ------ editor range deleted
+      // $*targdefghpter |->1, $$v<-|erse 3.
+      //                    ------ editor range deleted
       const deleteDelta: DeltaStatic = new Delta();
       (deleteDelta as any).push({ retain: remoteEditTextPos } as DeltaOperation);
       // the remote edit deletes 4, but locally it is expanded to 6 to include the 2 note embeds
@@ -1655,7 +1656,7 @@ describe('EditorComponent', () => {
       const originalNoteThread1TextPos: TextAnchor = noteThread1Doc.data!.position;
       const originalNoteThread3TextPos: TextAnchor = noteThread3Doc.data!.position;
       expect(originalNoteThread1TextPos).toEqual({ start: 8, length: 9 });
-      expect(originalNoteThread3TextPos).toEqual({ start: 19, length: 7 });
+      expect(originalNoteThread3TextPos).toEqual({ start: 20, length: 7 });
 
       // simulate text changes at current segment
       let notePosition: number = env.getNoteThreadEditorPosition('thread03');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1007,20 +1007,13 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     let insertLength = 0;
     let deleteLength = 0;
     // get the length that was inserted or deleted to apply to the verse text anchors
-    if (delta.ops[1].insert != null && typeof delta.ops[1].insert === 'string') {
-      insertLength = delta.ops[1].insert.length;
+    if (delta.ops[1].insert != null) {
+      insertLength = typeof delta.ops[1].insert === 'string' ? delta.ops[1].insert.length : 1;
       if (delta.ops.length > 2 && delta.ops[2].delete != null) {
         deleteLength = delta.ops[2].delete;
       }
     } else if (delta.ops[1].delete != null) {
-      const selection = this.target.editor?.getSelection();
-      const isBlank: boolean =
-        this.target.segment == null ? false : this.target.isSegmentBlank(this.target.segment.ref);
-      if ((editOpIndex != null && selection?.index === editOpIndex) || isBlank) {
-        // the user triggered the deletion, not editor logic i.e. blank deleted after user inserts text
-        // if the segment is blank, assume that the user triggered the deletion
-        deleteLength = delta.ops[1].delete;
-      }
+      deleteLength = delta.ops[1].delete;
     }
     if (editOpIndex == null || (insertLength === 0 && deleteLength === 0)) {
       return;

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1582,9 +1582,16 @@ namespace SIL.XForge.Scripture.Services
             StringBuilder bldr = new StringBuilder();
             foreach (JObject segmentObj in ops)
             {
-                if (segmentObj["insert"] != null && segmentObj["insert"].Type == JTokenType.String)
+                if (segmentObj["insert"] != null)
                 {
-                    bldr.Append((string)segmentObj["insert"]);
+                    if (segmentObj["insert"].Type == JTokenType.String)
+                    {
+                        bldr.Append((string)segmentObj["insert"]);
+                    }
+                    else if (segmentObj["insert"].Type == JTokenType.Object && segmentObj["insert"]["note"] != null)
+                    {
+                        bldr.Append("*");
+                    }
                 }
             }
             return bldr.ToString();

--- a/src/SIL.XForge/Realtime/RichText/Delta.cs
+++ b/src/SIL.XForge/Realtime/RichText/Delta.cs
@@ -223,6 +223,12 @@ namespace SIL.XForge.Realtime.RichText
             return array.ToString();
         }
 
+        public bool TryConcatenateInserts(out string opStr, Func<JToken, bool> filter = null)
+        {
+            Delta filteredDelta = filter == null ? this : new Delta(this.Ops.Where(op => filter(op)));
+            return TryConcatInserts(filteredDelta, out opStr);
+        }
+
         private Delta Add(JToken newOp)
         {
             int index = Ops.Count;

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -818,7 +818,7 @@ namespace SIL.XForge.Scripture.Services
                 Assert.That(thread1Change.Position.Length, Is.LessThan("other text in verse".Length));
 
                 NoteThreadChange thread10Change = changes.Single(c => c.ThreadId == "thread10");
-                string textBefore = "Context before Text selected thread10 context after ";
+                string textBefore = "Context before Text selected thread10 context after *";
                 int thread10AnchoringLength = "other text in verse".Length;
                 TextAnchor expected2 = new TextAnchor { Start = textBefore.Length, Length = thread10AnchoringLength };
                 // This test also verifies that fetching verse text for verse 10 will fetch text from both segments
@@ -2010,9 +2010,12 @@ namespace SIL.XForge.Scripture.Services
                 if (includeExtraLastVerseSegment)
                 {
                     // Add a second segment in the last verse (Note the segment name ends with "/p_1").
+                    string verseRef = $"verse_{chapterNum}_{verses}";
                     chapterText = chapterText + ", { \"insert\": \"\n\" }," +
+                        "{ \"insert\": { \"note\": { \"caller\": \"*\" } }, " +
+                        "\"attributes\": { \"segment\": \"" + verseRef + "\" } }," +
                         "{ \"insert\": \"other text in verse\", " +
-                        "\"attributes\": { \"segment\": \"verse_" + chapterNum + "_" + verses + "/p_1\" } }";
+                        "\"attributes\": { \"segment\": \"" + verseRef + "/p_1\" } }";
                 }
                 chapterText = chapterText + "]";
                 return new Delta(JToken.Parse(chapterText));


### PR DESCRIPTION
Footnotes, endnotes and cross references appear in the text with a special symbol. The quill editor has been designed to show this symbol as an embed in the editor. The embed takes up a length of 1, which means that on the backend when we synchronize and update our note thread text anchors, the text anchor position should also account for the symbol.

This uses a space "\0" on the backend to represent a non-text insert e.g. blanks, footnote, endnote or cross reference.
![image](https://user-images.githubusercontent.com/17931130/139313269-50b86774-aac1-4df2-86ed-92703e18f816.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1175)
<!-- Reviewable:end -->
