### PR TITLE
SF-1419 Get note threads to appear on combined verses

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
@@ -36,6 +36,20 @@ export function getTextDoc(id: TextDocId): TextData {
   return delta;
 }
 
+export function getCombinedVerseTextDoc(id: TextDocId): TextData {
+  const delta = new Delta();
+  delta.insert(`Title for chapter ${id.chapterNum}`, { segment: 's_1' });
+  delta.insert('\n', { para: { style: 's' } });
+  delta.insert({ chapter: { number: id.chapterNum.toString(), style: 'c' } });
+  delta.insert({ blank: true }, { segment: 'p_1' });
+  delta.insert({ verse: { number: '1', style: 'v' } });
+  delta.insert(`${id.textType}: chapter ${id.chapterNum}, verse 1.`, { segment: `verse_${id.chapterNum}_1` });
+  delta.insert({ verse: { number: '2-3', style: 'v' } });
+  delta.insert(`${id.textType}: chapter ${id.chapterNum}, verse 2-3.`, { segment: `verse_${id.chapterNum}_2-3` });
+  delta.insert('\n', { para: { style: 'p' } });
+  return delta;
+}
+
 export function getSFProject(id: string): SFProject {
   return {
     name: `${id} name`,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -2,8 +2,8 @@ import cloneDeep from 'lodash-es/cloneDeep';
 import Quill, { DeltaOperation, DeltaStatic, RangeStatic, Sources, StringMap } from 'quill';
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
 import { Subscription } from 'rxjs';
-import { VERSE_FROM_SEGMENT_REF_REGEX } from 'xforge-common/utils';
 import { Delta, TextDoc } from '../../core/models/text-doc';
+import { VERSE_FROM_SEGMENT_REF_REGEX } from '../utils';
 import { USFM_STYLE_DESCRIPTIONS } from './usfm-style-descriptions';
 
 const PARA_STYLES: Set<string> = new Set<string>([
@@ -292,8 +292,7 @@ export class TextViewModel {
     const verses: VerseRef[] = verseRef.allVerses();
     const startVerseNum: number = verses[0].verseNum;
     const lastVerseNum: number = verses[verses.length - 1].verseNum;
-    const textSegments = Array.from(this._segments.keys());
-    for (const segment of textSegments) {
+    for (const segment of this._segments.keys()) {
       const match: RegExpExecArray | null = VERSE_FROM_SEGMENT_REF_REGEX.exec(segment);
       if (match == null) {
         continue;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -19,10 +19,11 @@ import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils
 import { fromEvent } from 'rxjs';
 import { PwaService } from 'xforge-common/pwa.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
-import { getBrowserEngine, VERSE_REGEX } from 'xforge-common/utils';
+import { getBrowserEngine } from 'xforge-common/utils';
 import { Delta, TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { NoteThreadIcon } from '../../core/models/note-thread-doc';
+import { VERSE_REGEX } from '../utils';
 import { registerScripture } from './quill-scripture';
 import { Segment } from './segment';
 import { TextViewModel } from './text-view-model';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -19,7 +19,7 @@ import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils
 import { fromEvent } from 'rxjs';
 import { PwaService } from 'xforge-common/pwa.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
-import { getBrowserEngine, verseSlug } from 'xforge-common/utils';
+import { getBrowserEngine, VERSE_REGEX } from 'xforge-common/utils';
 import { Delta, TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { NoteThreadIcon } from '../../core/models/note-thread-doc';
@@ -48,9 +48,6 @@ function onNativeSelectionChanged(): void {
     }
   }
 }
-
-// Regular expression for the verse segment ref of scripture content
-const VERSE_REGEX = /verse_[0-9]+_[0-9]+/;
 
 const USX_FORMATS = registerScripture();
 window.document.addEventListener('selectionchange', onNativeSelectionChanged);
@@ -430,24 +427,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   }
 
   getVerseSegments(verseRef?: VerseRef): string[] {
-    if (verseRef == null) {
-      return [];
-    }
-    const segments: string[] = [];
-    let segment = '';
-    for (const verseInRange of verseRef.allVerses()) {
-      segment = verseSlug(verseInRange);
-      if (!segments.includes(segment)) {
-        segments.push(segment);
-      }
-      // Check for related segments like this verse i.e. verse_1_2/q1
-      for (const relatedSegment of this.getRelatedSegmentRefs(segment)) {
-        if (!segments.includes(relatedSegment)) {
-          segments.push(relatedSegment);
-        }
-      }
-    }
-    return segments;
+    return this.viewModel.getVerseSegments(verseRef);
   }
 
   getSegmentElement(segment: string): Element | null {
@@ -459,22 +439,23 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     featureVerseRefs: VerseRef[],
     featureName: 'question' | 'note-thread'
   ): string[] {
-    if (this.editor == null) {
+    if (this.editor == null || this.id == null) {
       return [];
     }
     const segments: string[] = [];
     const verseFeatureCount = new Map<string, number>();
-    for (const verseRef of featureVerseRefs) {
-      const referenceSegments = this.getVerseSegments(verseRef);
-      if (referenceSegments.length > 0) {
-        const featureStartSegment = referenceSegments[0];
-        const count: number = verseFeatureCount.get(featureStartSegment) ?? 0;
-        verseFeatureCount.set(featureStartSegment, count + 1);
-
-        for (const segment of referenceSegments) {
-          if (!segments.includes(segment)) {
-            segments.push(segment);
-          }
+    const chapterFeaturedVerseRefs: VerseRef[] = featureVerseRefs.filter(fvr => fvr.chapterNum === this.id!.chapterNum);
+    for (const verseRef of chapterFeaturedVerseRefs) {
+      const featuredVerseSegments: string[] = this.viewModel.getVerseSegments(verseRef);
+      if (featuredVerseSegments.length === 0) {
+        continue;
+      }
+      const featureStartSegmentRef: string = featuredVerseSegments[0];
+      const count: number = verseFeatureCount.get(featureStartSegmentRef) ?? 0;
+      verseFeatureCount.set(featureStartSegmentRef, count + 1);
+      for (const segment of featuredVerseSegments) {
+        if (!segments.includes(segment)) {
+          segments.push(segment);
         }
       }
     }
@@ -514,9 +495,11 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     }
 
     // A single verse can be associated with multiple segments (e.g verse_1_1, verse_1_1/p_1)
-    const ref: string = verseSlug(verseRef);
-    const verseSegments: string[] = [ref].concat(this.getRelatedSegmentRefs(ref));
-    let editorPosOfSegmentToModify: RangeStatic | undefined = this.getSegmentRange(ref);
+    const verseSegments: string[] = this.viewModel.getVerseSegments(verseRef);
+    if (verseSegments.length === 0) {
+      return;
+    }
+    let editorPosOfSegmentToModify: RangeStatic | undefined = this.getSegmentRange(verseSegments[0]);
     let startTextPosInVerse: number = textAnchor.start;
     if (Array.from(this.viewModel.embeddedElements.keys()).includes(id)) {
       return;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -514,8 +514,9 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     }
 
     // A single verse can be associated with multiple segments (e.g verse_1_1, verse_1_1/p_1)
-    const verseSegments: string[] = this.getVerseSegments(verseRef);
-    let editorPosOfSegmentToModify: RangeStatic | undefined = this.getSegmentRange(verseSegments[0]);
+    const ref: string = verseSlug(verseRef);
+    const verseSegments: string[] = [ref].concat(this.getRelatedSegmentRefs(ref));
+    let editorPosOfSegmentToModify: RangeStatic | undefined = this.getSegmentRange(ref);
     let startTextPosInVerse: number = textAnchor.start;
     if (Array.from(this.viewModel.embeddedElements.keys()).includes(id)) {
       return;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -1,6 +1,11 @@
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
 import { SelectableProject } from '../core/paratext.service';
 
+// Regular expression for getting the verse from a segment ref
+export const VERSE_FROM_SEGMENT_REF_REGEX = /verse_[0-9]+_([0-9]+)[-/]*/;
+// Regular expression for the verse segment ref of scripture content
+export const VERSE_REGEX = /verse_[0-9]+_[0-9]+/;
+
 export function combineVerseRefStrs(startStr?: string, endStr?: string): VerseRef | undefined {
   if (!startStr) {
     // no start ref
@@ -36,6 +41,13 @@ export function combineVerseRefStrs(startStr?: string, endStr?: string): VerseRe
     return undefined;
   }
   return range.verseRef;
+}
+
+export function verseSlug(verse: VerseRef) {
+  if (verse.verse != null) {
+    return 'verse_' + verse.chapterNum + '_' + verse.verse;
+  }
+  return 'verse_' + verse.chapterNum + '_' + verse.verseNum;
 }
 
 export function verseRefFromMouseEvent(event: MouseEvent, bookNum: number): VerseRef | undefined {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -59,6 +59,7 @@ import { Delta, TextDoc, TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
 import { SharedModule } from '../../shared/shared.module';
+import { getCombinedVerseTextDoc } from '../../shared/test-utils';
 import { EditorComponent, UPDATE_SUGGESTIONS_TIMEOUT } from './editor.component';
 import { NoteDialogComponent } from './note-dialog/note-dialog.component';
 import { SuggestionsComponent } from './suggestions.component';
@@ -807,7 +808,7 @@ describe('EditorComponent', () => {
       expect(env.component.targetLabel).toEqual('TRG');
       expect(env.component.target!.segmentRef).toEqual('verse_1_1');
       const selection = env.targetEditor.getSelection();
-      expect(selection!.index).toBe(30);
+      expect(selection!.index).toBe(50);
       expect(selection!.length).toBe(0);
       verify(env.mockedRemoteTranslationEngine.getWordGraph(anything())).never();
       expect(env.component.showSuggestions).toBe(false);
@@ -1557,7 +1558,7 @@ describe('EditorComponent', () => {
       expect(env.component.chapter).toBe(2);
       expect(env.component.target!.segmentRef).toEqual('verse_2_1');
       const selection = env.targetEditor.getSelection();
-      expect(selection!.index).toBe(30);
+      expect(selection!.index).toBe(50);
       expect(selection!.length).toBe(0);
       verify(env.mockedRemoteTranslationEngine.getWordGraph(anything())).never();
       expect(env.component.showSuggestions).toBe(false);
@@ -2301,6 +2302,14 @@ class TestEnvironment {
     return noteEmbedCount;
   }
 
+  private addCombinedVerseTextDoc(id: TextDocId): void {
+    this.realtimeService.addSnapshot(TextDoc.COLLECTION, {
+      id: id.toString(),
+      type: RichText.type.name,
+      data: getCombinedVerseTextDoc(id)
+    });
+  }
+
   private addProjectUserConfig(userConfig: SFProjectUserConfig): void {
     if (userConfig.translationSuggestionsEnabled == null) {
       userConfig.translationSuggestionsEnabled = true;
@@ -2314,22 +2323,6 @@ class TestEnvironment {
     this.realtimeService.addSnapshot<SFProjectUserConfig>(SFProjectUserConfigDoc.COLLECTION, {
       id: getSFProjectUserConfigDocId('project01', userConfig.ownerRef),
       data: userConfig
-    });
-  }
-
-  private addCombinedVerseTextDoc(id: TextDocId): void {
-    const delta = new Delta();
-    delta.insert({ chapter: { number: id.chapterNum.toString(), style: 'c' } });
-    delta.insert({ blank: true }, { segment: 'p_1' });
-    delta.insert({ verse: { number: '1', style: 'v' } });
-    delta.insert(`${id.textType}: chapter ${id.chapterNum}, verse 1.`, { segment: `verse_${id.chapterNum}_1` });
-    delta.insert({ verse: { number: '2-3', style: 'v' } });
-    delta.insert(`${id.textType}: chapter ${id.chapterNum}, verse 2-3.`, { segment: `verse_${id.chapterNum}_2-3` });
-    delta.insert('\n', { para: { style: 'p' } });
-    this.realtimeService.addSnapshot(TextDoc.COLLECTION, {
-      id: id.toString(),
-      type: RichText.type.name,
-      data: delta
     });
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -629,10 +629,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
     if (value) {
       for (const featured of featureVerseRefInfo) {
-        const verseSegments = this.target.getVerseSegments(featured.verseRef);
-        if (verseSegments.length === 0) {
-          continue;
-        }
         this.embedNoteThread(featured);
       }
       const segments: string[] = this.target.toggleFeaturedVerseRefs(value, noteThreadVerseRefs, 'note-thread');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -617,7 +617,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
     const chapterNoteThreadDocs: NoteThreadDoc[] = this.noteThreadQuery.docs.filter(
       nt =>
-        nt.data != null && nt.data.verseRef.bookNum === this.bookNum && nt.data.verseRef.chapterNum === this._chapter
+        nt.data != null &&
+        nt.data.verseRef.bookNum === this.bookNum &&
+        nt.data.verseRef.chapterNum === this._chapter &&
+        nt.data.notes.length > 0
     );
     const noteThreadVerseRefs: VerseRef[] = chapterNoteThreadDocs.map(nt => toVerseRef(nt.data!.verseRef));
     const featureVerseRefInfo: FeaturedVerseRefInfo[] = chapterNoteThreadDocs.map(nt =>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -1,18 +1,12 @@
 import { translate } from '@ngneat/transloco';
 import Bowser from 'bowser';
 import ObjectID from 'bson-objectid';
-import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
 import locales from '../../../locales.json';
 import { version } from '../../../version.json';
 import { environment } from '../environments/environment';
 import { Locale } from './models/i18n-locale';
 
 const BROWSER = Bowser.getParser(window.navigator.userAgent);
-
-// Regular expression for getting the verse from a segment ref
-export const VERSE_FROM_SEGMENT_REF_REGEX = /verse_[0-9]+_([0-9]+)[-/]*/;
-// Regular expression for the verse segment ref of scripture content
-export const VERSE_REGEX = /verse_[0-9]+_[0-9]+/;
 
 export function nameof<T>(name: Extract<keyof T, string>): string {
   return name;
@@ -75,13 +69,6 @@ export function parseJSON(str: string): any | undefined {
   } catch (err) {
     return undefined;
   }
-}
-
-export function verseSlug(verse: VerseRef) {
-  if (verse.verse != null) {
-    return 'verse_' + verse.chapterNum + '_' + verse.verse;
-  }
-  return 'verse_' + verse.chapterNum + '_' + verse.verseNum;
 }
 
 export const ASP_CULTURE_COOKIE_NAME = '.AspNetCore.Culture';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -9,6 +9,11 @@ import { Locale } from './models/i18n-locale';
 
 const BROWSER = Bowser.getParser(window.navigator.userAgent);
 
+// Regular expression for getting the verse from a segment ref
+export const VERSE_FROM_SEGMENT_REF_REGEX = /verse_[0-9]+_([0-9]+)[-/]*/;
+// Regular expression for the verse segment ref of scripture content
+export const VERSE_REGEX = /verse_[0-9]+_[0-9]+/;
+
 export function nameof<T>(name: Extract<keyof T, string>): string {
   return name;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -73,6 +73,9 @@ export function parseJSON(str: string): any | undefined {
 }
 
 export function verseSlug(verse: VerseRef) {
+  if (verse.verse != null) {
+    return 'verse_' + verse.chapterNum + '_' + verse.verse;
+  }
   return 'verse_' + verse.chapterNum + '_' + verse.verseNum;
 }
 


### PR DESCRIPTION
Verses that are combined have a verse segment ref that looks like `verse_1_2-3`. This change takes into consideration this format for a verse segment of a combined verse so that notes can be correctly embedded.

![Verse range note](https://user-images.githubusercontent.com/17931130/139339713-0648cf9d-f776-4677-98a0-d78b115d0f33.png)
.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1176)
<!-- Reviewable:end -->
