### PR TITLE
debug: Revise targets, add attaches

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,30 +2,71 @@
   "version": "0.2.0",
   "compounds": [
     {
-      "name": "Full App (SF)",
-      "configurations": [".NET Core (SF)", "Chrome (SF)"]
+      "name": "Launch Chromium, run and debug frontend and backend",
+      "configurations": ["Run and debug backend", "Launch Chromium and debug the running frontend"]
     }
   ],
   "configurations": [
+
     {
-      "type": "node",
+      // Attach to Chromium and debug the running frontend.
+      // This also works with Edge. Type doesn't seem to need to be "pwa-msedge" to attach with Edge.
+      // First you need to launch Chromium/Chrome or Edge with --remote-debugging-port=9977. The SF frontend must also be running/accessible.
+      "name": "Attach to frontend (in a running Chromium)",
+      "port": 9977,
       "request": "attach",
-      "name": "Node",
-      "port": 9230
+      "type": "pwa-chrome",
+      "webRoot": "${workspaceRoot}/src/SIL.XForge.Scripture/ClientApp",
     },
     {
-      "type": "chrome",
+      // Attach to and debug the running backend
+      "name": "Attach to backend",
+      "type": "coreclr",
+      "request": "attach",
+      "processName": "SIL.XForge.Scripture"
+    },
+    {
+      // Attach to Chromium and debug the running frontend tests
+      // First you need to launch the test runner, such as by: cd ClientApp && npm test -- --include src/app/shared/text/text.component.spec.ts
+      "name": "Attach to frontend tests (via Karma in Chromium)",
+      "port": 9988,
+      "request": "attach",
+      "type": "pwa-chrome",
+      "webRoot": "${workspaceFolder}/src/SIL.XForge.Scripture/ClientApp",
+      "sourceMaps": true,
+      "pathMapping": {
+        "/_karma_webpack_": "${workspaceFolder}/src/SIL.XForge.Scripture/ClientApp"
+      },
+    },
+    {
+      "name": "Launch Chromium and debug the running frontend",
+      "type": "pwa-chrome",
       "request": "launch",
-      "preLaunchTask": "npm start (SF)",
-      "name": "Chrome (SF)",
       "url": "http://localhost:5000",
       "webRoot": "${workspaceRoot}/src/SIL.XForge.Scripture/ClientApp",
       "linux": {
+        "name": "",
+        "type": "pwa-chrome",
+        "request": "launch",
         "runtimeExecutable": "/usr/bin/chromium-browser"
       }
     },
     {
-      "name": ".NET Core - npm start (SF)",
+      "name": "Run and debug backend",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "dotnet build",
+      "program": "${workspaceRoot}/src/SIL.XForge.Scripture/bin/Debug/netcoreapp3.1/SIL.XForge.Scripture.dll",
+      "args": ["--start-ng-serve=listen"],
+      "cwd": "${workspaceRoot}/src/SIL.XForge.Scripture/",
+      "stopAtEntry": false,
+      "console": "integratedTerminal",
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    {
+      "name": "Run frontend, run and debug backend",
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "dotnet build",
@@ -39,82 +80,27 @@
       }
     },
     {
-      "name": ".NET Core - npm start (SF) - Beta",
-      "type": "coreclr",
+      // VSCode may complain about startup errors, but you may be successful to Debug Anyway.
+      "name": "Launch Chrome and run and debug frontend",
+      "type": "pwa-chrome",
       "request": "launch",
-      "preLaunchTask": "dotnet build",
-      "program": "${workspaceRoot}/src/SIL.XForge.Scripture/bin/Debug/netcoreapp3.1/SIL.XForge.Scripture.dll",
-      "args": ["--start-ng-serve=yes", "--enable-beta-realtime-server=yes"],
-      "cwd": "${workspaceRoot}/src/SIL.XForge.Scripture/",
-      "stopAtEntry": false,
-      "console": "integratedTerminal",
-      "env": {
-        "ASPNETCORE_ENVIRONMENT": "DevelopmentBeta"
-      }
-    },
-    {
-      "name": ".NET Core (SF)",
-      "type": "coreclr",
-      "request": "launch",
-      "preLaunchTask": "dotnet build",
-      "program": "${workspaceRoot}/src/SIL.XForge.Scripture/bin/Debug/netcoreapp3.1/SIL.XForge.Scripture.dll",
-      "args": ["--start-ng-serve=listen"],
-      "cwd": "${workspaceRoot}/src/SIL.XForge.Scripture/",
-      "stopAtEntry": false,
-      "console": "integratedTerminal",
-      "env": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    {
-      "name": "Migration PtdaSyncAll",
-      "type": "coreclr",
-      "request": "launch",
-      "preLaunchTask": "build-migrator-ptdaSyncAll",
-      "program": "${workspaceRoot}/src/Migrations/PtdaSyncAll/bin/Debug/netcoreapp3.1/PtdaSyncAll.dll",
-      "cwd": "${workspaceRoot}/src/Migrations/PtdaSyncAll",
-      "stopAtEntry": false,
-      "console": "integratedTerminal",
-      "args": ["--start-ng-serve=listen"],
-      "env": {
-        // "SYNC_SET": "sfProject2 sfProject3",
-        // "SF_PROJECT_ADMINS": "sfProject1:sfUserA sfProject2:sfUserB",
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "PTDASYNCALL_MODE": "NOTsync",
-        "SKIPSYNCBOOK": "NOTskip"
-      }
-    },
-    {
-      "name": "Migrations PTDDCloneAll",
-      "type": "coreclr",
-      "request": "launch",
-      "preLaunchTask": "build-migrator-PTDDCloneAll",
-      "program": "${workspaceRoot}/src/Migrations/PTDDCloneAll/bin/Debug/netcoreapp3.1/PTDDCloneAll.dll",
-      "cwd": "${workspaceRoot}/src/Migrations/PTDDCloneAll",
-      "stopAtEntry": false,
-      "console": "integratedTerminal",
-      "env": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    {
-      "name": "Migration SyncCancel",
-      "type": "coreclr",
-      "request": "launch",
-      "preLaunchTask": "build-migrator-ptdaSyncCancelAll",
-      "program": "${workspaceRoot}/src/Migrations/SyncCancel/bin/Debug/netcoreapp3.1/SyncCancel.dll",
-      "cwd": "${workspaceRoot}/src/Migrations/SyncCancel",
-      "stopAtEntry": false,
-      "console": "integratedTerminal",
-      "args": ["--start-ng-serve=listen"],
-      "env": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+      "preLaunchTask": "npm start (SF)",
+      "url": "http://localhost:5000",
+      "webRoot": "${workspaceRoot}/src/SIL.XForge.Scripture/ClientApp",
+      "linux": {
+        "runtimeExecutable": "/usr/bin/chromium-browser"
       }
     },
     {
       "type": "node",
-      "request": "launch",
+      "request": "attach",
+      "name": "Node",
+      "port": 9230
+    },
+    {
       "name": "vscode-jest-tests",
+      "type": "node",
+      "request": "launch",
       "program": "${workspaceFolder}/src/RealtimeServer/node_modules/.bin/jest",
       "args": ["--runInBand"],
       "console": "integratedTerminal",
@@ -126,7 +112,7 @@
       }
     },
     {
-      "name": "Karma active spec (SF)",
+      "name": "Launch Chromium and run and debug current spec",
       "type": "chrome",
       "request": "launch",
       "preLaunchTask": "npm test active spec (SF)",
@@ -140,6 +126,20 @@
       "linux": {
         "runtimeExecutable": "/usr/bin/chromium-browser"
       }
-    }
+    },
+    // {
+    //   "name": "Migration Foo",
+    //   "type": "coreclr",
+    //   "request": "launch",
+    //   "preLaunchTask": "build-migrator-foo",
+    //   "program": "${workspaceRoot}/src/Migrations/Foo/bin/Debug/netcoreapp3.1/Foo.dll",
+    //   "cwd": "${workspaceRoot}/src/Migrations/Foo",
+    //   "stopAtEntry": false,
+    //   "console": "integratedTerminal",
+    //   "args": ["--start-ng-serve=listen"],
+    //   "env": {
+    //     "ASPNETCORE_ENVIRONMENT": "Development"
+    //   }
+    // },
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,39 +21,6 @@
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "build-migrator-ptdaSyncAll",
-      "command": "dotnet",
-      "args": ["build", "/property:GenerateFullPaths=true"],
-      "type": "shell",
-      "group": "build",
-      "options": {
-        "cwd": "${workspaceRoot}/src/Migrations/PtdaSyncAll"
-      },
-      "problemMatcher": "$msCompile"
-    },
-    {
-      "label": "build-migrator-PTDDCloneAll",
-      "command": "dotnet",
-      "args": ["build", "/property:GenerateFullPaths=true"],
-      "type": "shell",
-      "group": "build",
-      "options": {
-        "cwd": "${workspaceRoot}/src/Migrations/PTDDCloneAll"
-      },
-      "problemMatcher": "$msCompile"
-    },
-    {
-      "label": "build-migrator-syncCancel",
-      "command": "dotnet",
-      "args": ["build", "/property:GenerateFullPaths=true"],
-      "type": "shell",
-      "group": "build",
-      "options": {
-        "cwd": "${workspaceRoot}/src/Migrations/SyncCancel"
-      },
-      "problemMatcher": "$msCompile"
-    },
-    {
       "label": "npm start (SF)",
       "command": "npm start",
       "type": "shell",
@@ -151,6 +118,17 @@
         "cwd": "${workspaceRoot}/src/SIL.XForge.Scripture"
       },
       "problemMatcher": "$msCompile"
-    }
+    },
+    // {
+    //   "label": "build-migrator-foo",
+    //   "command": "dotnet",
+    //   "args": ["build", "/property:GenerateFullPaths=true"],
+    //   "type": "shell",
+    //   "group": "build",
+    //   "options": {
+    //     "cwd": "${workspaceRoot}/src/Migrations/Foo"
+    //   },
+    //   "problemMatcher": "$msCompile"
+    // },
   ]
 }

--- a/README.md
+++ b/README.md
@@ -381,7 +381,8 @@ The best way to debug Angular unit tests is with Chrome/Chromium.
 - Run `npm test` (which will include source maps, `ng test` does not)
 - When the Chrome/Chromium window appears, press _F12_
 - Click the Sources tab
-- Files might show up under `webpack://` or `context/localhost:dddd/src` or elsewhere, but you can always press _CTRL-P_ and type the name of a file to get there faster.
+- Files might show up under `webpack://` or `context/localhost:dddd/src` or elsewhere, but you can always press Ctrl+P
+  and type the name of a file to get there faster.
 
 [This video](https://youtu.be/NVqplMyOZTM) has a live demo of the process.
 
@@ -389,11 +390,12 @@ It is also possible to debug Angular unit tests in VS Code.
 
 - Open the spec file that you want to debug in VS Code.
 - Set a breakpoint.
-- Navigate to the Debug view.
-- Select `Karma active spec` from the debug dropdown.
-- Click the `Start Debugging` button.
+- Navigate to the **Run and Debug** view.
+- Select **Launch Chromium and run and debug current spec** from the debug dropdown.
+- Click the **Start Debugging** button.
 
-This will run `ng test` on the active spec file, open Chrome, and attach the VS Code debugger. You can refresh the page by clicking the `Restart` button in the Debug toolbar.
+This will run `ng test` on the active spec file, open Chrome, and attach the VS Code debugger. You can refresh the page
+by clicking the `Restart` button in the Debug toolbar.
 
 #### Filtering Unit Tests
 
@@ -526,7 +528,60 @@ If a model change is made, then a corresponding data migration should be impleme
 
 ## Debugging
 
-In Visual Studio Code, in the debug sidebar, choose **Full App (SF)** to debug the front-end and back-end at the same time, or **Launch Chrome (SF)** or **.NET Core (SF)** to just debug the front-end or back-end.
+Run the frontend, such as with the following in its own Terminal tab. It will automatically re-compile when the code
+is changed.
+
+```bash
+cd src/SIL.XForge.Scripture/ClientApp && ng serve
+```
+
+Run the backend, such as with the following in its own Terminal tab. It will automatically re-compile when the code is
+changed. (Running the frontend and backend separately allow them to be independently restarted.)
+
+```bash
+cd src/SIL.XForge.Scripture && dotnet watch run --start-ng-serve=listen
+```
+
+Run frontend tests on desired specs, such as with the following in its own Terminal tab. It will automatically
+re-compile and re-run the tests when the code is changed. It will also open a browser window where you can watch the
+tests run, and inspect the DOM. Modify the `--include` arguments in the example below by replacing them with spec
+files you wish to test.
+
+```bash
+cd src/SIL.XForge.Scripture/ClientApp &&
+  npm test -- --include src/app/shared/text/text.component.spec.ts --include src/app/translate/editor/editor.component.spec.ts
+```
+
+Launch Chromium/Chrome or Edge with `--remote-debugging-port=9977`, and go to http://localhost:5000/ . For example, in
+Linux run:
+
+```bash
+chromium-browser --remote-debugging-port=9977
+```
+
+Or in Windows:
+  - Navigate to Chrome.exe.
+  - Right-click Chrome.exe and create a desktop shortcut.
+  - Right-click the new desktop shortcut, and modify its properties.
+  - Append ` --remote-debugging-port=9977` to the command.
+  - Double-click the desktop shortcut to launch Chrome.
+
+Note that your Chromium window for testing the frontend and your Chromium window for running unit tests will be
+different windows.
+
+In Visual Studio Code, go to the **Run and Debug** view. Choose one or more of the following and click
+**Start Debugging**.
+  - **Attach to frontend**
+  - **Attach to backend**
+  - **Attach to frontend tests**
+
+When you are finished debugging, click **Disconnect**. The processes will continue running until you press Ctrl+C
+to end them in the Terminal.
+
+To debug backend tests, open a C# Tests file. In the code above the test, click **Debug Test**, or above the class,
+click **Debug All Tests**.
+
+Other debugging targets are available as well, such as targets that start running the frontend and/or backend.
 
 ## Database
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/karma.conf.js
+++ b/src/SIL.XForge.Scripture/ClientApp/src/karma.conf.js
@@ -61,7 +61,8 @@ module.exports = function (config) {
           '--disable-extensions',
           '--use-fake-device-for-media-stream',
           '--use-fake-ui-for-media-stream',
-          '--autoplay-policy=no-user-gesture-required'
+          '--autoplay-policy=no-user-gesture-required',
+          '--remote-debugging-port=9988'
         ]
       },
       xForgeChromeHeadless: {
@@ -71,7 +72,8 @@ module.exports = function (config) {
           '--disable-extensions',
           '--use-fake-device-for-media-stream',
           '--use-fake-ui-for-media-stream',
-          '--autoplay-policy=no-user-gesture-required'
+          '--autoplay-policy=no-user-gesture-required',
+          '--remote-debugging-port=9988'
         ]
       },
       xForgeChrome: {
@@ -79,7 +81,8 @@ module.exports = function (config) {
         flags: [
           '--use-fake-ui-for-media-stream',
           '--use-fake-device-for-media-stream',
-          '--autoplay-policy=no-user-gesture-required'
+          '--autoplay-policy=no-user-gesture-required',
+          '--remote-debugging-port=9988'
         ]
       }
     },


### PR DESCRIPTION
- It's not necessary to specifically stop and re-run the frontend or
backend 'in the debugger'. Rather, one can separately attach and
detach from  dotnet, ng, or Chromium without needing to restart them.
This can be a simpler experience.
- This patch gives explanatory names to the debug targets, and adds
attach targets for the frontend, backend, and frontend tests.
- Explain in README a process that can be followed to do this.
- Add item to launch Chromium and debug, but without also running the
frontend.
- Modify launcher names to be descriptive about whether they are
running the frontend.
- Modify launchers to use the newer type "pwa-chrome".
- Remove old Beta.
- Remove Migration launchers. Leave a commented out example to quickly
make one next time. Similar for tasks.json.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1177)
<!-- Reviewable:end -->
