### PR TITLE
SF-1417c Account for text in display-text-anchor when drop

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/drag-and-drop.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/drag-and-drop.ts
@@ -170,10 +170,24 @@ export class DragAndDrop {
       // Add up the length of text and embeds that are previous nodes in the usx-segment
       while (node.previousSibling != null) {
         node = node.previousSibling;
-        if (node.nodeType === textNodeType && node.nodeValue != null) {
-          startPositionInSegment += node.nodeValue.length;
-        } else if (node.nodeType !== textNodeType) {
-          startPositionInSegment++;
+        if (node.nodeType === textNodeType) {
+          if (node.nodeValue != null) {
+            startPositionInSegment += node.nodeValue.length;
+          } else {
+            console.warn(`Warning: Unexpected situation of null text node value`);
+          }
+        } else {
+          if (node.nodeName.toLowerCase() === 'display-text-anchor') {
+            const anchoredTextOfNote: string = node.lastChild?.nodeValue ?? '';
+            startPositionInSegment += anchoredTextOfNote.length;
+            const lengthOfEmbed = 1;
+            startPositionInSegment += lengthOfEmbed;
+          } else {
+            console.warn(
+              `Warning: drag-and-drop is assuming length 1 for unknown element: ${node.nodeName.toLowerCase()}`
+            );
+            startPositionInSegment++;
+          }
         }
       }
       startPositionInSegment += startPositionInTextNode;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -223,7 +223,7 @@ describe('TextComponent', () => {
       expect(resultingSelection.length).toEqual(desiredSelectionLength);
     }));
 
-    it('inserts externally introduced data in the right place with embeds minus formatting', fakeAsync(() => {
+    it('inserts externally introduced data in the right place, accounting for embeds', fakeAsync(() => {
       const env = new TestEnvironment();
       env.fixture.detectChanges();
       env.id = new TextDocId('project01', 40, 1);
@@ -231,6 +231,7 @@ describe('TextComponent', () => {
       env.embedNoteAtVerse(4);
       tick();
       const initialTextInDoc = 'target: chapter 1, verse 4.';
+      //       This part is anchored to ^^^^^^^
       //                                           ^ insert here
       const textToDropIn = 'Hello';
       const expectedFinalText = 'target: chapter 1, Helloverse 4.';
@@ -251,8 +252,11 @@ describe('TextComponent', () => {
       dragEvent.setTarget(targetElement);
 
       const startContainer: Node = targetElement!.childNodes[2] as Node;
+      // The text in the text node that is dropped into, leading up to the place of insertion. This text node is
+      // after the text spanned by the note anchor.
+      const dropTextNodeBeginningText: string = ` 1, `;
       // The length into this text node that will be returned by caretRangeFromPoint
-      const textNodeIndex: number = 'chapter 1, '.length;
+      const textNodeIndex: number = dropTextNodeBeginningText.length;
       document.caretRangeFromPoint = (_x: number, _y: number) =>
         ({ startOffset: textNodeIndex, startContainer } as Range);
 
@@ -278,7 +282,7 @@ describe('TextComponent', () => {
       expect(resultingSelection.length).toEqual(desiredSelectionLength);
     }));
 
-    it('also works in Firefox', fakeAsync(() => {
+    it('also works in Firefox: inserts externally introduced data in the right place, without formatting or line breaks', fakeAsync(() => {
       const env = new TestEnvironment();
       env.fixture.detectChanges();
       env.id = new TextDocId('project01', 40, 1);
@@ -333,7 +337,7 @@ describe('TextComponent', () => {
       expect(resultingSelection.length).toEqual(desiredSelectionLength);
     }));
 
-    it('also works for segment embeds in Firefox', fakeAsync(() => {
+    it('also works for Firefox: inserts externally introduced data in the right place, accounting for embeds', fakeAsync(() => {
       const env = new TestEnvironment();
       env.fixture.detectChanges();
       env.id = new TextDocId('project01', 40, 1);
@@ -359,7 +363,11 @@ describe('TextComponent', () => {
       });
       dragEvent.setTarget(targetElement);
 
-      const textNodeIndex = 'chapter 1, '.length;
+      // The text in the text node that is dropped into, leading up to the place of insertion. This text node is
+      // after the text spanned by the note anchor.
+      const dropTextNodeBeginningText: string = ` 1, `;
+      // The length into this text node that will be returned by the browser.
+      const textNodeIndex: number = dropTextNodeBeginningText.length;
       // Override the Firefox point-to-index method behaviour to simulate actually pointing to a location
       // when dropping.
       const offsetNode: Node = targetElement!.childNodes[2] as Node;
@@ -1153,7 +1161,7 @@ class TestEnvironment {
   embedNoteAtVerse(verse: number): void {
     const verseRef: VerseRef = VerseRef.parse(`MAT 1:${verse}`);
     const id: string = `embedid${verse}`;
-    const textAnchor: TextAnchor = { start: 8, length: 9 };
+    const textAnchor: TextAnchor = { start: 8, length: 7 };
     const iconSource: string = '--icon-file: url(/assets/icons/TagIcons/01flag1.png)';
     const text: string = `text message on ${id}`;
     const format = { iconsrc: iconSource, preview: text, threadid: id };


### PR DESCRIPTION
- When dragging to a segment with note embeds, the display-text-anchor
    element isn't just a length 1 item to include in the calculation for
    insertion position. It also contains the text that is anchored to.
    Account for this, and adjust Chromium and Firefox tests to behave like
    the browsers in this regard.
- text.component.spec.ts: Set `textAnchor` `length` to 7 to span the
text 'chapter'.

====

This was fixed on the way to addressing the actual SF-1417 issue.

This PR was previously described as "SF-1417b ...", and contained some refactoring. That refactoring was split out and applied onto master, which was then merged to develop, and this PR was rebased on top of the refactoring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1179)
<!-- Reviewable:end -->
