### PR TITLE
Fix login redirect with 3rd party cookies

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.ts
@@ -25,7 +25,9 @@ export class AuthHttpInterceptor implements HttpInterceptor {
       this.authService = this.injector.get<AuthService>(AuthService);
     }
     // Make sure the user is authenticated with a valid access token
-    await this.authService.isAuthenticated();
+    if (!(await this.authService.isAuthenticated())) {
+      return await throwError('User not authenticated - login required').toPromise();
+    }
     // Add access token to the request header
     const authReq = req.clone({
       headers: req.headers.set('Authorization', 'Bearer ' + this.authService.accessToken)

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
@@ -101,10 +101,7 @@ describe('AuthService', () => {
   }));
 
   it('check session is valid after returning online and login if session has expired', fakeAsync(() => {
-    const env = new TestEnvironment({
-      isOnline: false,
-      isLoggedIn: true
-    });
+    const env = new TestEnvironment({ isOnline: false, isLoggedIn: true });
     expect(env.isAuthenticated).toBe(true);
     verify(mockedWebAuth.authorize(anything())).never();
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -222,7 +222,7 @@ export class AuthService {
       ) {
         return await this.tryOnlineLogIn();
       }
-      await this.handleOfflineAuth();
+      await this.remoteStore.init(() => this.accessToken);
       return { loggedIn: true, newlyLoggedIn: false };
     } catch (error) {
       await this.handleLoginError('tryLogIn', error);
@@ -318,11 +318,6 @@ export class AuthService {
     } else if (this.locationService.hash !== '') {
       this.router.navigateByUrl(this.locationService.pathname, { replaceUrl: true });
     }
-    return true;
-  }
-
-  private async handleOfflineAuth(): Promise<boolean> {
-    await this.remoteStore.init(() => this.accessToken);
     return true;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -137,14 +137,13 @@ export class AuthService {
     });
   }
 
+  /**
+   * Triggered when app first loads and when returning from offline mode
+   * Ensure renewal timer is initiated so tokens can be refreshed when expired
+   */
   async checkOnlineAuth(): Promise<void> {
-    // Only need to check if the app has logged in via an offline state
     if (await this.isLoggedIn) {
-      this.tryOnlineLogIn().then(result => {
-        if (!result.loggedIn) {
-          this.logIn(this.locationService.pathname + this.locationService.search);
-        }
-      });
+      this.scheduleRenewal();
     }
   }
 
@@ -211,7 +210,12 @@ export class AuthService {
   private async tryLogIn(): Promise<LoginResult> {
     try {
       // If we have no valid auth0 data then we have to validate online first
-      if (this.accessToken == null || this.idToken == null || this.expiresAt == null) {
+      if (
+        this.accessToken == null ||
+        this.idToken == null ||
+        this.expiresAt == null ||
+        (this.pwaService.isOnline && (await this.hasExpired()))
+      ) {
         return await this.tryOnlineLogIn();
       }
       await this.handleOfflineAuth();
@@ -324,8 +328,7 @@ export class AuthService {
     const expiresIn$ = of(expiresAt).pipe(
       mergeMap(expAt => {
         const now = Date.now();
-        // Expiry 30 seconds sooner than the actual expiry date to avoid any inflight expiry issues
-        return timer(Math.max(1, expAt - now - 30000));
+        return timer(Math.max(1, expAt - now));
       }),
       filter(() => this.pwaService.isOnline)
     );
@@ -417,7 +420,8 @@ export class AuthService {
       this.localSettings.clear();
     }
 
-    const expiresAt = expiresIn * 1000 + Date.now();
+    // Expiry 30 seconds sooner than the actual expiry date to avoid any inflight expiry issues
+    const expiresAt = (expiresIn - 30) * 1000 + Date.now();
     this.localSettings.set(ACCESS_TOKEN_SETTING, accessToken);
     this.localSettings.set(ID_TOKEN_SETTING, idToken);
     this.localSettings.set(EXPIRES_AT_SETTING, expiresAt);


### PR DESCRIPTION
Based on some recent feedback to the login process around redirect issues with 3rd party cookies, as well as some of the other login redirect related issues, I've reworked some of the login process.

For context, when the app first loads if settings are available in local storage then the user will be logged in "offline". Once the app is fully loaded a background check is made (as long as they're online) with auth0 to get an updated token. When 3rd party cookies are blocked it means any check with auth0 will return "login required" and a redirect to auth0 takes place. 

After doing the recent auth service tests I noticed that the above was the intention but the reality is slightly different. When auth0 returns the user to SF it stores the result of the parsed hash in a promise. From then on any checks with auth0 simply check that result rather than actually checking with auth0 again. If the page was to refresh then the parsed hash would be lost and those with 3rd party cookies blocked would be redirected to auth0 again. Anyone using a browser without 3rd party cookies blocked would be fine as it would do the intended check with auth0 in the background.

Because of the above I felt safe to change our "check with auth0" code once the app loads to simply ensure the token expire scheduler is running. Auth0 provides us an expiry date/time for when the token expires so we really don't need to check with auth0 again until that expires. The proposed changes does just that. This appears to resolve both the redirect issue as well as the refresh issue.

The end goal is still to rework the auth0 flow to remove reliance on 3rd party cookies so this PR is to help cover us until we get there.

Interested in others feedback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1183)
<!-- Reviewable:end -->
