### PR TITLE
SF-1323 - Hide note thread when a thread is resolved

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/note-thread.ts
+++ b/src/RealtimeServer/scriptureforge/models/note-thread.ts
@@ -14,5 +14,6 @@ export interface NoteThread extends ProjectData {
   originalContextBefore: string;
   originalContextAfter: string;
   position: TextAnchor;
+  resolved: boolean;
   tagIcon: string;
 }

--- a/src/RealtimeServer/scriptureforge/models/note-thread.ts
+++ b/src/RealtimeServer/scriptureforge/models/note-thread.ts
@@ -6,6 +6,17 @@ import { VerseRefData } from './verse-ref-data';
 export const NOTE_THREAD_COLLECTION = 'note_threads';
 export const NOTE_THREAD_INDEX_PATHS = PROJECT_DATA_INDEX_PATHS;
 
+/**
+ * Paratext used to record notes as deleted when completed but then changed to display them as resolved
+ * Done is also a backwards compatible status that could also be treated as deleted/resolved
+ */
+export enum NoteStatus {
+  Unspecified = '',
+  Todo = 'todo',
+  Done = 'done',
+  Resolved = 'deleted'
+}
+
 export interface NoteThread extends ProjectData {
   dataId: string;
   verseRef: VerseRefData;
@@ -14,6 +25,6 @@ export interface NoteThread extends ProjectData {
   originalContextBefore: string;
   originalContextAfter: string;
   position: TextAnchor;
-  resolved: boolean;
+  status: NoteStatus;
   tagIcon: string;
 }

--- a/src/RealtimeServer/scriptureforge/models/note.ts
+++ b/src/RealtimeServer/scriptureforge/models/note.ts
@@ -1,4 +1,5 @@
 import { Comment } from './comment';
+import { NoteStatus } from './note-thread';
 
 export interface Note extends Comment {
   threadId: string;
@@ -6,4 +7,5 @@ export interface Note extends Comment {
   extUserId: string;
   deleted: boolean;
   tagIcon?: string;
+  status: NoteStatus;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.spec.ts
@@ -1,6 +1,6 @@
 import { mock } from 'ts-mockito';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
-import { NoteThread } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
+import { NoteStatus, NoteThread } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { TestBed } from '@angular/core/testing';
 import { configureTestingModule } from 'xforge-common/test-utils';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
@@ -21,7 +21,7 @@ describe('NoteThreadDoc', () => {
     env = new TestEnvironment();
   });
 
-  it('produce valid alternative note icon', async () => {
+  it('should use specified icon instead of default', async () => {
     const noteThread: NoteThread = {
       originalContextBefore: '',
       originalContextAfter: '',
@@ -32,7 +32,7 @@ describe('NoteThreadDoc', () => {
       ownerRef: 'user01',
       projectRef: 'project01',
       tagIcon: 'flag02',
-      resolved: false,
+      status: NoteStatus.Todo,
       verseRef: { bookNum: 40, chapterNum: 1, verseNum: 1 }
     };
     const noteThreadDoc = await env.setupDoc(noteThread);
@@ -43,7 +43,7 @@ describe('NoteThreadDoc', () => {
     expect(noteThreadDoc.icon).toEqual(expectedIcon);
   });
 
-  it('produce valid alternative note icon', async () => {
+  it('should use default to do icon if none specified', async () => {
     const noteThread: NoteThread = {
       originalContextBefore: '',
       originalContextAfter: '',
@@ -54,7 +54,7 @@ describe('NoteThreadDoc', () => {
       ownerRef: 'user01',
       projectRef: 'project01',
       tagIcon: '',
-      resolved: false,
+      status: NoteStatus.Todo,
       verseRef: { bookNum: 40, chapterNum: 1, verseNum: 1 }
     };
     const noteThreadDoc = await env.setupDoc(noteThread);
@@ -65,7 +65,34 @@ describe('NoteThreadDoc', () => {
     expect(noteThreadDoc.icon).toEqual(expectedIcon);
   });
 
-  it('produce valid alternative note icon', async () => {
+  it('should use resolved icon', async () => {
+    const noteThread: NoteThread = {
+      originalContextBefore: '',
+      originalContextAfter: '',
+      originalSelectedText: '',
+      position: { start: 0, length: 1 },
+      dataId: 'thread01',
+      notes: [],
+      ownerRef: 'user01',
+      projectRef: 'project01',
+      tagIcon: '',
+      status: NoteStatus.Todo,
+      verseRef: { bookNum: 40, chapterNum: 1, verseNum: 1 }
+    };
+    const noteThreadDoc = await env.setupDoc(noteThread);
+    const expectedIcon: NoteThreadIcon = {
+      cssVar: '--icon-file: url(/assets/icons/TagIcons/01flag1.png);',
+      url: '/assets/icons/TagIcons/01flag1.png'
+    };
+    const expectedIconResolved: NoteThreadIcon = {
+      cssVar: '--icon-file: url(/assets/icons/TagIcons/01flag5.png);',
+      url: '/assets/icons/TagIcons/01flag5.png'
+    };
+    expect(noteThreadDoc.icon).toEqual(expectedIcon);
+    expect(noteThreadDoc.iconResolved).toEqual(expectedIconResolved);
+  });
+
+  it('should use the last icon specified in a threads note list based on date ', async () => {
     const noteThread: NoteThread = {
       originalContextBefore: '',
       originalContextAfter: '',
@@ -73,7 +100,7 @@ describe('NoteThreadDoc', () => {
       ownerRef: 'user01',
       projectRef: 'project01',
       tagIcon: '',
-      resolved: false,
+      status: NoteStatus.Todo,
       verseRef: { bookNum: 40, chapterNum: 1, verseNum: 1 },
       position: { start: 0, length: 1 },
       dataId: 'thread01',
@@ -84,6 +111,7 @@ describe('NoteThreadDoc', () => {
           content: 'note content',
           deleted: false,
           tagIcon: 'flag2',
+          status: NoteStatus.Todo,
           ownerRef: 'user01',
           extUserId: 'user01',
           dateCreated: '2021-11-10T12:00:00',
@@ -95,6 +123,7 @@ describe('NoteThreadDoc', () => {
           content: 'note content',
           deleted: false,
           tagIcon: 'flag3',
+          status: NoteStatus.Todo,
           ownerRef: 'user01',
           extUserId: 'user01',
           dateCreated: '2021-11-10T13:00:00', // Note out of order to test it still renders last
@@ -106,6 +135,7 @@ describe('NoteThreadDoc', () => {
           content: 'note content',
           deleted: false,
           tagIcon: 'flag4',
+          status: NoteStatus.Todo,
           ownerRef: 'user01',
           extUserId: 'user01',
           dateCreated: '2021-11-10T12:30:00',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.spec.ts
@@ -32,6 +32,7 @@ describe('NoteThreadDoc', () => {
       ownerRef: 'user01',
       projectRef: 'project01',
       tagIcon: 'flag02',
+      resolved: false,
       verseRef: { bookNum: 40, chapterNum: 1, verseNum: 1 }
     };
     const noteThreadDoc = await env.setupDoc(noteThread);
@@ -53,6 +54,7 @@ describe('NoteThreadDoc', () => {
       ownerRef: 'user01',
       projectRef: 'project01',
       tagIcon: '',
+      resolved: false,
       verseRef: { bookNum: 40, chapterNum: 1, verseNum: 1 }
     };
     const noteThreadDoc = await env.setupDoc(noteThread);
@@ -71,6 +73,7 @@ describe('NoteThreadDoc', () => {
       ownerRef: 'user01',
       projectRef: 'project01',
       tagIcon: '',
+      resolved: false,
       verseRef: { bookNum: 40, chapterNum: 1, verseNum: 1 },
       position: { start: 0, length: 1 },
       dataId: 'thread01',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
@@ -17,17 +17,34 @@ export class NoteThreadDoc extends ProjectDataDoc<NoteThread> {
   static readonly INDEX_PATHS = NOTE_THREAD_INDEX_PATHS;
 
   get icon(): NoteThreadIcon {
+    return this.iconProperties(this.getTag());
+  }
+
+  get iconResolved(): NoteThreadIcon {
+    let iconTag = this.getTag();
+    if (iconTag !== '') {
+      // Resolved tags use 5 in the filename instead of the current number suffix
+      iconTag = iconTag.slice(0, iconTag.length - 1) + '5';
+    }
+    return this.iconProperties(iconTag);
+  }
+
+  private getTag(): string {
     if (this.data == null) {
-      return { cssVar: '', url: '' };
+      return '';
     }
     const notes: Note[] = clone(this.data.notes).sort((a, b) => Date.parse(a.dateCreated) - Date.parse(b.dateCreated));
     const iconDefinedNotes = notes.filter(n => n.tagIcon != null);
-    let icon: string =
+    let iconTag: string =
       iconDefinedNotes.length === 0 ? this.data.tagIcon : iconDefinedNotes[iconDefinedNotes.length - 1].tagIcon!;
-    if (icon === '') {
-      icon = '01flag1';
+    if (iconTag === '') {
+      iconTag = '01flag1';
     }
-    const iconUrl = `/assets/icons/TagIcons/${icon}.png`;
+    return iconTag;
+  }
+
+  private iconProperties(iconTag: string): NoteThreadIcon {
+    const iconUrl = `/assets/icons/TagIcons/${iconTag}.png`;
     return { cssVar: `--icon-file: url(${iconUrl});`, url: iconUrl };
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -119,7 +119,10 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
   }
 
   queryNoteThreads(id: string): Promise<RealtimeQuery<NoteThreadDoc>> {
-    const queryParams: QueryParameters = { [obj<NoteThread>().pathStr(t => t.projectRef)]: id };
+    const queryParams: QueryParameters = {
+      [obj<NoteThread>().pathStr(t => t.projectRef)]: id,
+      [obj<ParatextNoteThread>().pathStr(t => t.resolved)]: false
+    };
     return this.realtimeService.subscribeQuery(NoteThreadDoc.COLLECTION, queryParams);
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -121,7 +121,7 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
   queryNoteThreads(id: string): Promise<RealtimeQuery<NoteThreadDoc>> {
     const queryParams: QueryParameters = {
       [obj<NoteThread>().pathStr(t => t.projectRef)]: id,
-      [obj<ParatextNoteThread>().pathStr(t => t.resolved)]: false
+      [obj<NoteThread>().pathStr(t => t.resolved)]: false
     };
     return this.realtimeService.subscribeQuery(NoteThreadDoc.COLLECTION, queryParams);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
-import { NoteThread } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
+import { NoteThread, NoteStatus } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { getQuestionDocId, Question } from 'realtime-server/lib/esm/scriptureforge/models/question';
 import { SFProject, SF_PROJECTS_COLLECTION } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
@@ -121,7 +121,7 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
   queryNoteThreads(id: string): Promise<RealtimeQuery<NoteThreadDoc>> {
     const queryParams: QueryParameters = {
       [obj<NoteThread>().pathStr(t => t.projectRef)]: id,
-      [obj<NoteThread>().pathStr(t => t.resolved)]: false
+      [obj<NoteThread>().pathStr(t => t.status)]: NoteStatus.Todo
     };
     return this.realtimeService.subscribeQuery(NoteThreadDoc.COLLECTION, queryParams);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1012,64 +1012,6 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('adds display-note tag to element', fakeAsync(() => {
-      const env = new TestEnvironment();
-      env.setProjectUserConfig();
-      env.wait();
-      const segment: HTMLElement = env.targetTextEditor.nativeElement.querySelector(
-        'usx-segment[data-segment=verse_1_1]'
-      )!;
-      expect(segment).not.toBeNull();
-      expect(segment.hasAttribute('data-note-thread-count')).toBe(true);
-      expect(segment.getAttribute('data-note-thread-count')).toBe('1');
-      const note = segment.querySelector('display-note')! as HTMLElement;
-      expect(note).not.toBeNull();
-      expect(note.hasAttribute('style')).toBe(true);
-      expect(note.getAttribute('style')).toEqual('--icon-file: url(/assets/icons/TagIcons/01flag3.png);');
-      expect(note.hasAttribute('title')).toBe(true);
-      expect(note.getAttribute('title')).toEqual('Note from user01\n--- 2 more note(s) ---');
-      expect(note.innerText).toEqual('chapter 1');
-
-      const blankSegmentNote = env.targetTextEditor.nativeElement.querySelector(
-        'usx-segment[data-segment="verse_1_4/p_1"] display-note'
-      )! as HTMLElement;
-      expect(blankSegmentNote).not.toBeNull();
-      expect(blankSegmentNote.hasAttribute('style')).toBe(true);
-      expect(blankSegmentNote.getAttribute('style')).toEqual('--icon-file: url(/assets/icons/TagIcons/01flag1.png);');
-      expect(blankSegmentNote.hasAttribute('title')).toBe(true);
-      expect(blankSegmentNote.getAttribute('title')).toEqual('Note from user01');
-      env.dispose();
-    }));
-
-    it('adds display-note tag to element', fakeAsync(() => {
-      const env = new TestEnvironment();
-      env.setProjectUserConfig();
-      env.wait();
-      const segment: HTMLElement = env.targetTextEditor.nativeElement.querySelector(
-        'usx-segment[data-segment=verse_1_1]'
-      )!;
-      expect(segment).not.toBeNull();
-      expect(segment.hasAttribute('data-note-thread-count')).toBe(true);
-      expect(segment.getAttribute('data-note-thread-count')).toBe('1');
-      const note = segment.querySelector('display-note')! as HTMLElement;
-      expect(note).not.toBeNull();
-      expect(note.hasAttribute('style')).toBe(true);
-      expect(note.getAttribute('style')).toEqual('--icon-file: url(/assets/icons/TagIcons/01flag3.png);');
-      expect(note.hasAttribute('title')).toBe(true);
-      expect(note.getAttribute('title')).toEqual('Note from user01\n--- 2 more note(s) ---');
-      expect(note.innerText).toEqual('chapter 1');
-
-      const blankSegmentNote = env.targetTextEditor.nativeElement.querySelector(
-        'usx-segment[data-segment="verse_1_4/p_1"] display-note'
-      )! as HTMLElement;
-      expect(blankSegmentNote).not.toBeNull();
-      expect(blankSegmentNote.hasAttribute('style')).toBe(true);
-      expect(blankSegmentNote.getAttribute('style')).toEqual('--icon-file: url(/assets/icons/TagIcons/01flag1.png);');
-      expect(blankSegmentNote.hasAttribute('title')).toBe(true);
-      expect(blankSegmentNote.getAttribute('title')).toEqual('Note from user01');
-      env.dispose();
-    }));
-
     it('ensure resolved notes do not appear', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
@@ -2053,7 +1995,7 @@ class TestEnvironment {
     this.addParatextNoteThread(3, 'MAT 1:3', 'verse 3', { start: 19, length: 7 }, ['user01']);
     this.addParatextNoteThread(4, 'MAT 1:3', 'verse', { start: 19, length: 5 }, ['user01']);
     this.addParatextNoteThread(5, 'MAT 1:4', 'Paragraph', { start: 27, length: 9 }, ['user01']);
-    this.addParatextNoteThread(5, 'resolved note', ['user01'], true);
+    this.addParatextNoteThread(6, 'MAT 1:5', 'resolved note', { start: 0, length: 0 }, ['user01'], true);
     when(this.mockedRemoteTranslationEngine.getWordGraph(anything())).thenCall(segment =>
       Promise.resolve(this.createWordGraph(segment))
     );
@@ -2085,7 +2027,7 @@ class TestEnvironment {
     when(mockedSFProjectService.queryNoteThreads('project01')).thenCall(id =>
       this.realtimeService.subscribeQuery(NoteThreadDoc.COLLECTION, {
         [obj<NoteThread>().pathStr(t => t.projectRef)]: id,
-        [obj<ParatextNoteThread>().pathStr(t => t.resolved)]: false
+        [obj<NoteThread>().pathStr(t => t.resolved)]: false
       })
     );
     when(mockedPwaService.isOnline).thenReturn(true);
@@ -2464,7 +2406,6 @@ class TestEnvironment {
     verseStr: string,
     selectedText: string,
     position: TextAnchor,
-
     userIds: string[],
     resolved: boolean = false
   ): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -23,7 +23,7 @@ import { User } from 'realtime-server/lib/esm/common/models/user';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { CheckingShareLevel } from 'realtime-server/lib/esm/scriptureforge/models/checking-config';
 import { Note } from 'realtime-server/lib/esm/scriptureforge/models/note';
-import { NoteThread } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
+import { NoteStatus, NoteThread } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import {
@@ -1995,7 +1995,7 @@ class TestEnvironment {
     this.addParatextNoteThread(3, 'MAT 1:3', 'verse 3', { start: 19, length: 7 }, ['user01']);
     this.addParatextNoteThread(4, 'MAT 1:3', 'verse', { start: 19, length: 5 }, ['user01']);
     this.addParatextNoteThread(5, 'MAT 1:4', 'Paragraph', { start: 27, length: 9 }, ['user01']);
-    this.addParatextNoteThread(6, 'MAT 1:5', 'resolved note', { start: 0, length: 0 }, ['user01'], true);
+    this.addParatextNoteThread(6, 'MAT 1:5', 'resolved note', { start: 0, length: 0 }, ['user01'], NoteStatus.Resolved);
     when(this.mockedRemoteTranslationEngine.getWordGraph(anything())).thenCall(segment =>
       Promise.resolve(this.createWordGraph(segment))
     );
@@ -2027,7 +2027,7 @@ class TestEnvironment {
     when(mockedSFProjectService.queryNoteThreads('project01')).thenCall(id =>
       this.realtimeService.subscribeQuery(NoteThreadDoc.COLLECTION, {
         [obj<NoteThread>().pathStr(t => t.projectRef)]: id,
-        [obj<NoteThread>().pathStr(t => t.resolved)]: false
+        [obj<NoteThread>().pathStr(t => t.status)]: NoteStatus.Todo
       })
     );
     when(mockedPwaService.isOnline).thenReturn(true);
@@ -2407,7 +2407,7 @@ class TestEnvironment {
     selectedText: string,
     position: TextAnchor,
     userIds: string[],
-    resolved: boolean = false
+    status: NoteStatus = NoteStatus.Todo
   ): void {
     const threadId: string = `thread0${threadNum}`;
     const notes: Note[] = [];
@@ -2424,6 +2424,7 @@ class TestEnvironment {
         content: `<p><bold>Note from ${id}</bold></p>`,
         extUserId: id,
         deleted: false,
+        status: NoteStatus.Todo,
         tagIcon: `01flag${i + 1}`
       };
       notes.push(note);
@@ -2443,7 +2444,7 @@ class TestEnvironment {
         originalContextBefore: '\\v 1 target: ',
         originalContextAfter: ', verse 1.',
         position,
-        resolved: resolved
+        status: status
       }
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1012,6 +1012,77 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('adds display-note tag to element', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.wait();
+      const segment: HTMLElement = env.targetTextEditor.nativeElement.querySelector(
+        'usx-segment[data-segment=verse_1_1]'
+      )!;
+      expect(segment).not.toBeNull();
+      expect(segment.hasAttribute('data-note-thread-count')).toBe(true);
+      expect(segment.getAttribute('data-note-thread-count')).toBe('1');
+      const note = segment.querySelector('display-note')! as HTMLElement;
+      expect(note).not.toBeNull();
+      expect(note.hasAttribute('style')).toBe(true);
+      expect(note.getAttribute('style')).toEqual('--icon-file: url(/assets/icons/TagIcons/01flag3.png);');
+      expect(note.hasAttribute('title')).toBe(true);
+      expect(note.getAttribute('title')).toEqual('Note from user01\n--- 2 more note(s) ---');
+      expect(note.innerText).toEqual('chapter 1');
+
+      const blankSegmentNote = env.targetTextEditor.nativeElement.querySelector(
+        'usx-segment[data-segment="verse_1_4/p_1"] display-note'
+      )! as HTMLElement;
+      expect(blankSegmentNote).not.toBeNull();
+      expect(blankSegmentNote.hasAttribute('style')).toBe(true);
+      expect(blankSegmentNote.getAttribute('style')).toEqual('--icon-file: url(/assets/icons/TagIcons/01flag1.png);');
+      expect(blankSegmentNote.hasAttribute('title')).toBe(true);
+      expect(blankSegmentNote.getAttribute('title')).toEqual('Note from user01');
+      env.dispose();
+    }));
+
+    it('adds display-note tag to element', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.wait();
+      const segment: HTMLElement = env.targetTextEditor.nativeElement.querySelector(
+        'usx-segment[data-segment=verse_1_1]'
+      )!;
+      expect(segment).not.toBeNull();
+      expect(segment.hasAttribute('data-note-thread-count')).toBe(true);
+      expect(segment.getAttribute('data-note-thread-count')).toBe('1');
+      const note = segment.querySelector('display-note')! as HTMLElement;
+      expect(note).not.toBeNull();
+      expect(note.hasAttribute('style')).toBe(true);
+      expect(note.getAttribute('style')).toEqual('--icon-file: url(/assets/icons/TagIcons/01flag3.png);');
+      expect(note.hasAttribute('title')).toBe(true);
+      expect(note.getAttribute('title')).toEqual('Note from user01\n--- 2 more note(s) ---');
+      expect(note.innerText).toEqual('chapter 1');
+
+      const blankSegmentNote = env.targetTextEditor.nativeElement.querySelector(
+        'usx-segment[data-segment="verse_1_4/p_1"] display-note'
+      )! as HTMLElement;
+      expect(blankSegmentNote).not.toBeNull();
+      expect(blankSegmentNote.hasAttribute('style')).toBe(true);
+      expect(blankSegmentNote.getAttribute('style')).toEqual('--icon-file: url(/assets/icons/TagIcons/01flag1.png);');
+      expect(blankSegmentNote.hasAttribute('title')).toBe(true);
+      expect(blankSegmentNote.getAttribute('title')).toEqual('Note from user01');
+      env.dispose();
+    }));
+
+    it('ensure resolved notes do not appear', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.wait();
+      const segment: HTMLElement = env.targetTextEditor.nativeElement.querySelector(
+        'usx-segment[data-segment=verse_1_5]'
+      )!;
+      expect(segment).not.toBeNull();
+      const note = segment.querySelector('display-note')! as HTMLElement;
+      expect(note).toBeNull();
+      env.dispose();
+    }));
+
     it('ensure inserting in a blank segment only produces required delta ops', fakeAsync(() => {
       const env = new TestEnvironment();
       env.wait();
@@ -1982,6 +2053,7 @@ class TestEnvironment {
     this.addParatextNoteThread(3, 'MAT 1:3', 'verse 3', { start: 19, length: 7 }, ['user01']);
     this.addParatextNoteThread(4, 'MAT 1:3', 'verse', { start: 19, length: 5 }, ['user01']);
     this.addParatextNoteThread(5, 'MAT 1:4', 'Paragraph', { start: 27, length: 9 }, ['user01']);
+    this.addParatextNoteThread(5, 'resolved note', ['user01'], true);
     when(this.mockedRemoteTranslationEngine.getWordGraph(anything())).thenCall(segment =>
       Promise.resolve(this.createWordGraph(segment))
     );
@@ -2012,7 +2084,8 @@ class TestEnvironment {
     when(mockedSFProjectService.isProjectAdmin('project01', 'user04')).thenResolve(true);
     when(mockedSFProjectService.queryNoteThreads('project01')).thenCall(id =>
       this.realtimeService.subscribeQuery(NoteThreadDoc.COLLECTION, {
-        [obj<NoteThread>().pathStr(t => t.projectRef)]: id
+        [obj<NoteThread>().pathStr(t => t.projectRef)]: id,
+        [obj<ParatextNoteThread>().pathStr(t => t.resolved)]: false
       })
     );
     when(mockedPwaService.isOnline).thenReturn(true);
@@ -2391,7 +2464,9 @@ class TestEnvironment {
     verseStr: string,
     selectedText: string,
     position: TextAnchor,
-    userIds: string[]
+
+    userIds: string[],
+    resolved: boolean = false
   ): void {
     const threadId: string = `thread0${threadNum}`;
     const notes: Note[] = [];
@@ -2426,7 +2501,8 @@ class TestEnvironment {
         tagIcon: '01flag1',
         originalContextBefore: '\\v 1 target: ',
         originalContextAfter: ', verse 1.',
-        position
+        position,
+        resolved: resolved
       }
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -648,6 +648,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   private showNoteThread(threadId: string): void {
     this.dialog.open(NoteDialogComponent, {
       autoFocus: false,
+      width: '600px',
       data: {
         projectId: this.projectDoc!.id,
         threadId: threadId

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
@@ -17,6 +17,7 @@
     <div class="notes">
       <div *ngFor="let note of notes" class="note">
         <div class="content" [innerHTML]="parseNote(note.content)"></div>
+        <img [src]="noteIcon(note)" alt="" [title]="noteTitle(note)" />
         <app-owner [ownerRef]="note.ownerRef" [dateTime]="note.dateCreated"></app-owner>
       </div>
     </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
@@ -30,8 +30,11 @@ h1 {
 .notes {
   .note {
     padding: 20px 0;
+    display: flex;
+    flex-wrap: wrap;
     .content {
       color: #000;
+      flex: 1 1 100%;
     }
     &:first-child {
       padding-top: 10px;
@@ -41,7 +44,10 @@ h1 {
     }
     app-owner {
       display: block;
-      margin-top: 5px;
+      margin: 5px;
+    }
+    img {
+      align-self: center;
     }
   }
 }
@@ -52,7 +58,7 @@ h1 {
   }
 }
 .ltr {
-  app-owner {
-    text-align: right;
+  .note {
+    flex-direction: row-reverse;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -19,7 +19,7 @@ import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule, matDialogCloseDelay, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { NoteThread } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
+import { NoteStatus, NoteThread } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { TranslateShareLevel } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { SFProjectDoc } from '../../../core/models/sf-project-doc';
 import { SF_TYPE_REGISTRY } from '../../../core/models/sf-type-registry';
@@ -163,7 +163,7 @@ class TestEnvironment {
     projectRef: TestEnvironment.PROJECT01,
     tagIcon: 'flag02',
     verseRef: { bookNum: 40, chapterNum: 1, verseNum: 7 },
-    resolved: false,
+    status: NoteStatus.Todo,
     notes: [
       {
         dataId: 'note01',
@@ -172,6 +172,7 @@ class TestEnvironment {
         extUserId: 'user01',
         deleted: false,
         ownerRef: 'user01',
+        status: NoteStatus.Todo,
         dateCreated: '',
         dateModified: ''
       },
@@ -182,6 +183,7 @@ class TestEnvironment {
         extUserId: 'user01',
         deleted: false,
         ownerRef: 'user01',
+        status: NoteStatus.Todo,
         dateCreated: '',
         dateModified: ''
       },
@@ -192,6 +194,7 @@ class TestEnvironment {
         extUserId: 'user01',
         deleted: true,
         ownerRef: 'user01',
+        status: NoteStatus.Todo,
         dateCreated: '',
         dateModified: ''
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -61,7 +61,7 @@ describe('NoteDialogComponent', () => {
 
   it('should not show deleted notes', fakeAsync(() => {
     env = new TestEnvironment();
-    expect(env.notes.length).toBe(2);
+    expect(env.notes.length).toBe(3);
   }));
 
   it('should style notes', fakeAsync(() => {
@@ -92,6 +92,26 @@ describe('NoteDialogComponent', () => {
   it('produce correct default note icon', fakeAsync(() => {
     env = new TestEnvironment();
     expect(env.component.flagIcon).toEqual('/assets/icons/TagIcons/flag02.png');
+  }));
+
+  it('should show correct icon', fakeAsync(() => {
+    env = new TestEnvironment();
+
+    // To do
+    expect(env.notes[0].nativeElement.querySelector('img').getAttribute('src')).toEqual(
+      '/assets/icons/TagIcons/flag02.png'
+    );
+    expect(env.notes[0].nativeElement.querySelector('img').getAttribute('title')).toEqual('To do');
+
+    // Resolved
+    expect(env.notes[1].nativeElement.querySelector('img').getAttribute('src')).toEqual(
+      '/assets/icons/TagIcons/flag05.png'
+    );
+    expect(env.notes[1].nativeElement.querySelector('img').getAttribute('title')).toEqual('Resolved');
+
+    // Blank/unspecified
+    expect(env.notes[2].nativeElement.querySelector('img').getAttribute('src')).toEqual('');
+    expect(env.notes[2].nativeElement.querySelector('img').getAttribute('title')).toEqual('');
   }));
 });
 
@@ -183,7 +203,7 @@ class TestEnvironment {
         extUserId: 'user01',
         deleted: false,
         ownerRef: 'user01',
-        status: NoteStatus.Todo,
+        status: NoteStatus.Resolved,
         dateCreated: '',
         dateModified: ''
       },
@@ -195,6 +215,17 @@ class TestEnvironment {
         deleted: true,
         ownerRef: 'user01',
         status: NoteStatus.Todo,
+        dateCreated: '',
+        dateModified: ''
+      },
+      {
+        dataId: 'note03',
+        threadId: 'thread01',
+        content: 'note03',
+        extUserId: 'user01',
+        deleted: false,
+        ownerRef: 'user01',
+        status: NoteStatus.Unspecified,
         dateCreated: '',
         dateModified: ''
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -61,7 +61,7 @@ describe('NoteDialogComponent', () => {
 
   it('should not show deleted notes', fakeAsync(() => {
     env = new TestEnvironment();
-    expect(env.notes.length).toBe(3);
+    expect(env.notes.length).toBe(4);
   }));
 
   it('should style notes', fakeAsync(() => {
@@ -108,10 +108,20 @@ describe('NoteDialogComponent', () => {
       '/assets/icons/TagIcons/flag05.png'
     );
     expect(env.notes[1].nativeElement.querySelector('img').getAttribute('title')).toEqual('Resolved');
+    expect(env.notes[3].nativeElement.querySelector('img').getAttribute('src')).toEqual(
+      '/assets/icons/TagIcons/flag05.png'
+    );
+    expect(env.notes[3].nativeElement.querySelector('img').getAttribute('title')).toEqual('Resolved');
 
     // Blank/unspecified
     expect(env.notes[2].nativeElement.querySelector('img').getAttribute('src')).toEqual('');
     expect(env.notes[2].nativeElement.querySelector('img').getAttribute('title')).toEqual('');
+  }));
+
+  it('should gracefully return when data not ready', fakeAsync(() => {
+    env = new TestEnvironment({ includeSnapshots: false });
+    expect(env.component.segmentText).toEqual('');
+    expect(env.component.noteIcon(TestEnvironment.noteThread[0])).toEqual('');
   }));
 });
 
@@ -138,6 +148,10 @@ class ChildViewContainerComponent {
   exports: [ViewContainerDirective, ChildViewContainerComponent, NoteDialogComponent]
 })
 class DialogTestModule {}
+
+interface TestEnvironmentConstructorArgs {
+  includeSnapshots?: boolean;
+}
 
 class TestEnvironment {
   static PROJECT01: string = 'project01';
@@ -228,6 +242,17 @@ class TestEnvironment {
         status: NoteStatus.Unspecified,
         dateCreated: '',
         dateModified: ''
+      },
+      {
+        dataId: 'note05',
+        threadId: 'thread01',
+        content: 'note05',
+        extUserId: 'user01',
+        deleted: false,
+        ownerRef: 'user01',
+        status: NoteStatus.Done,
+        dateCreated: '',
+        dateModified: ''
       }
     ]
   };
@@ -238,7 +263,7 @@ class TestEnvironment {
   readonly dialogRef: MatDialogRef<NoteDialogComponent>;
   readonly mockedNoteMdcDialogRef = mock(MatDialogRef);
 
-  constructor() {
+  constructor({ includeSnapshots = true }: TestEnvironmentConstructorArgs = {}) {
     this.fixture = TestBed.createComponent(ChildViewContainerComponent);
     const configData: NoteDialogData = {
       projectId: TestEnvironment.PROJECT01,
@@ -248,20 +273,22 @@ class TestEnvironment {
     this.component = this.dialogRef.componentInstance;
     tick();
 
-    this.realtimeService.addSnapshot<SFProject>(SFProjectDoc.COLLECTION, {
-      id: configData.projectId,
-      data: TestEnvironment.testProject
-    });
-    const textDocId = new TextDocId(TestEnvironment.PROJECT01, 40, 1);
-    this.realtimeService.addSnapshot<TextData>(TextDoc.COLLECTION, {
-      id: textDocId.toString(),
-      data: getTextDoc(textDocId),
-      type: RichText.type.name
-    });
-    this.realtimeService.addSnapshot<NoteThread>(NoteThreadDoc.COLLECTION, {
-      id: [TestEnvironment.PROJECT01, TestEnvironment.noteThread.dataId].join(':'),
-      data: TestEnvironment.noteThread
-    });
+    if (includeSnapshots) {
+      this.realtimeService.addSnapshot<SFProject>(SFProjectDoc.COLLECTION, {
+        id: configData.projectId,
+        data: TestEnvironment.testProject
+      });
+      const textDocId = new TextDocId(TestEnvironment.PROJECT01, 40, 1);
+      this.realtimeService.addSnapshot<TextData>(TextDoc.COLLECTION, {
+        id: textDocId.toString(),
+        data: getTextDoc(textDocId),
+        type: RichText.type.name
+      });
+      this.realtimeService.addSnapshot<NoteThread>(NoteThreadDoc.COLLECTION, {
+        id: [TestEnvironment.PROJECT01, TestEnvironment.noteThread.dataId].join(':'),
+        data: TestEnvironment.noteThread
+      });
+    }
 
     when(mockedProjectService.getNoteThread(anything())).thenCall(id =>
       this.realtimeService.subscribe(NoteThreadDoc.COLLECTION, id)

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -219,9 +219,9 @@ class TestEnvironment {
         dateModified: ''
       },
       {
-        dataId: 'note03',
+        dataId: 'note04',
         threadId: 'thread01',
-        content: 'note03',
+        content: 'note04',
         extUserId: 'user01',
         deleted: false,
         ownerRef: 'user01',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -163,6 +163,7 @@ class TestEnvironment {
     projectRef: TestEnvironment.PROJECT01,
     tagIcon: 'flag02',
     verseRef: { bookNum: 40, chapterNum: 1, verseNum: 7 },
+    resolved: false,
     notes: [
       {
         dataId: 'note01',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -112,9 +112,6 @@ export class NoteDialogComponent implements OnInit {
   }
 
   parseNote(content: string) {
-    if (content == null) {
-      return '';
-    }
     const replace = new Map<RegExp, string>();
     replace.set(/<bold>(.*)<\/bold>/gim, '<b>$1</b>'); // Bold style
     replace.set(/<italic>(.*)<\/italic>/gim, '<i>$1</i>'); // Italic style

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -4,6 +4,8 @@ import { sortBy } from 'lodash-es';
 import { toVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { Note } from 'realtime-server/lib/esm/scriptureforge/models/note';
 import { I18nService } from 'xforge-common/i18n.service';
+import { NoteStatus } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
+import { translate } from '@ngneat/transloco';
 import { SFProjectDoc } from '../../../core/models/sf-project-doc';
 import { TextDoc, TextDocId } from '../../../core/models/text-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
@@ -124,5 +126,30 @@ export class NoteDialogComponent implements OnInit {
 
   toggleSegmentText(): void {
     this.showSegmentText = !this.showSegmentText;
+  }
+
+  noteIcon(note: Note) {
+    if (this.threadDoc?.data == null) {
+      return '';
+    }
+    switch (note.status) {
+      case NoteStatus.Todo:
+        return this.threadDoc.icon.url;
+      case NoteStatus.Done:
+      case NoteStatus.Resolved:
+        return this.threadDoc.iconResolved.url;
+    }
+    return '';
+  }
+
+  noteTitle(note: Note) {
+    switch (note.status) {
+      case NoteStatus.Todo:
+        return translate('note_dialog.status_to_do');
+      case NoteStatus.Done:
+      case NoteStatus.Resolved:
+        return translate('note_dialog.status_resolved');
+    }
+    return '';
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -119,7 +119,9 @@
   "note_dialog": {
     "close": "Close",
     "hide_changes": "Hide changes",
-    "show_changes": "Show changes"
+    "show_changes": "Show changes",
+    "status_resolved": "Resolved",
+    "status_to_do": "To do"
   },
   "paginator": {
     "items_per_page": "Items per page",

--- a/src/SIL.XForge.Scripture/Models/Note.cs
+++ b/src/SIL.XForge.Scripture/Models/Note.cs
@@ -6,6 +6,7 @@ namespace SIL.XForge.Scripture.Models
         public string Content { get; set; }
         public string ExtUserId { get; set; }
         public bool Deleted { get; set; }
+        public string Status { get; set; }
         public string TagIcon { get; set; }
     }
 }

--- a/src/SIL.XForge.Scripture/Models/NoteThread.cs
+++ b/src/SIL.XForge.Scripture/Models/NoteThread.cs
@@ -14,5 +14,6 @@ namespace SIL.XForge.Scripture.Models
         public TextAnchor Position { get; set; }
         public string ParatextUser { get; set; }
         public string TagIcon { get; set; }
+        public bool Resolved { get; set; } = false;
     }
 }

--- a/src/SIL.XForge.Scripture/Models/NoteThread.cs
+++ b/src/SIL.XForge.Scripture/Models/NoteThread.cs
@@ -14,6 +14,6 @@ namespace SIL.XForge.Scripture.Models
         public TextAnchor Position { get; set; }
         public string ParatextUser { get; set; }
         public string TagIcon { get; set; }
-        public bool Resolved { get; set; } = false;
+        public bool? Resolved { get; set; }
     }
 }

--- a/src/SIL.XForge.Scripture/Models/NoteThread.cs
+++ b/src/SIL.XForge.Scripture/Models/NoteThread.cs
@@ -14,6 +14,6 @@ namespace SIL.XForge.Scripture.Models
         public TextAnchor Position { get; set; }
         public string ParatextUser { get; set; }
         public string TagIcon { get; set; }
-        public bool? Resolved { get; set; }
+        public string Status { get; set; }
     }
 }

--- a/src/SIL.XForge.Scripture/Models/NoteThreadChange.cs
+++ b/src/SIL.XForge.Scripture/Models/NoteThreadChange.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using Paratext.Data.ProjectComments;
+using PtxUtils;
 
 namespace SIL.XForge.Scripture.Models
 {
@@ -22,7 +24,7 @@ namespace SIL.XForge.Scripture.Models
         public string ContextAfter { get; set; }
         public TextAnchor Position { get; set; }
         public string TagIcon { get; set; }
-        public bool Resolved { get; set; }
+        public string Status { get; set; }
         /// <summary> True if the thread has been permanently removed. </summary>
         public bool ThreadRemoved { get; set; }
         public bool ThreadUpdated { get; set; }
@@ -42,7 +44,7 @@ namespace SIL.XForge.Scripture.Models
         }
 
         public NoteThreadChange(string threadId, string verseRef, string selectedText, string contextBefore,
-            string contextAfter, string tagIcon = null, bool resolved = false)
+            string contextAfter, string status, string tagIcon = null)
         {
             ThreadId = threadId;
             VerseRefStr = verseRef;
@@ -50,7 +52,7 @@ namespace SIL.XForge.Scripture.Models
             ContextBefore = contextBefore;
             ContextAfter = contextAfter;
             TagIcon = tagIcon;
-            Resolved = resolved;
+            Status = status;
         }
 
         public void AddChange(Note changedNote, ChangeType type)

--- a/src/SIL.XForge.Scripture/Models/NoteThreadChange.cs
+++ b/src/SIL.XForge.Scripture/Models/NoteThreadChange.cs
@@ -22,8 +22,10 @@ namespace SIL.XForge.Scripture.Models
         public string ContextAfter { get; set; }
         public TextAnchor Position { get; set; }
         public string TagIcon { get; set; }
+        public bool Resolved { get; set; }
         /// <summary> True if the thread has been permanently removed. </summary>
         public bool ThreadRemoved { get; set; }
+        public bool ThreadUpdated { get; set; }
         public List<Note> NotesAdded { get; set; } = new List<Note>();
         public List<Note> NotesUpdated { get; set; } = new List<Note>();
         public List<Note> NotesDeleted { get; set; } = new List<Note>();
@@ -35,12 +37,12 @@ namespace SIL.XForge.Scripture.Models
             get
             {
                 return NotesAdded.Count > 0 || NotesUpdated.Count > 0 || NotesDeleted.Count > 0 ||
-                    NoteIdsRemoved.Count > 0 || ThreadRemoved || Position != null;
+                    NoteIdsRemoved.Count > 0 || ThreadRemoved || ThreadUpdated || Position != null;
             }
         }
 
         public NoteThreadChange(string threadId, string verseRef, string selectedText, string contextBefore,
-            string contextAfter, string tagIcon = null)
+            string contextAfter, string tagIcon = null, bool resolved = false)
         {
             ThreadId = threadId;
             VerseRefStr = verseRef;
@@ -48,6 +50,7 @@ namespace SIL.XForge.Scripture.Models
             ContextBefore = contextBefore;
             ContextAfter = contextAfter;
             TagIcon = tagIcon;
+            Resolved = resolved;
         }
 
         public void AddChange(Note changedNote, ChangeType type)

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -756,7 +756,7 @@ namespace SIL.XForge.Scripture.Services
                 List<string> matchedCommentIds = new List<string>();
                 NoteThreadChange threadChange = new NoteThreadChange(threadDoc.Data.DataId,
                     threadDoc.Data.VerseRef.ToString(), threadDoc.Data.OriginalSelectedText, threadDoc.Data.OriginalContextBefore,
-                    threadDoc.Data.OriginalContextAfter);
+                    threadDoc.Data.OriginalContextAfter, threadDoc.Data.Status);
                 // Find the corresponding comment thread
                 var existingThread = commentThreads.SingleOrDefault(ct => ct.Id == threadDoc.Data.DataId);
                 if (existingThread == null)
@@ -785,15 +785,9 @@ namespace SIL.XForge.Scripture.Services
                     else
                         threadChange.NoteIdsRemoved.Add(note.DataId);
                 }
-                // Make thread resolved if status has changed to deleted
-                if (existingThread.Status == NoteStatus.Deleted && (threadDoc.Data.Resolved == false || threadDoc.Data.Resolved == null))
+                if (existingThread.Status.InternalValue != threadDoc.Data.Status)
                 {
-                    threadChange.Resolved = true;
-                    threadChange.ThreadUpdated = true;
-                }
-                else if (existingThread.Status == NoteStatus.Todo && (threadDoc.Data.Resolved == true || threadDoc.Data.Resolved == null))
-                {
-                    threadChange.Resolved = false;
+                    threadChange.Status = existingThread.Status.InternalValue;
                     threadChange.ThreadUpdated = true;
                 }
                 // Add new Comments to note thread change
@@ -829,11 +823,9 @@ namespace SIL.XForge.Scripture.Services
                 int tagId = info.TagsAdded != null && info.TagsAdded.Length > 0
                     ? int.Parse(info.TagsAdded[0])
                     : defaultTagId;
-                // Make thread resolved if status has changed to deleted
-                bool resolved = (thread.Status == NoteStatus.Deleted);
                 CommentTag initialTag = info.Type == NoteType.Conflict ? CommentTag.ConflictTag : commentTags.Get(tagId);
                 NoteThreadChange newThread = new NoteThreadChange(threadId, info.VerseRefStr,
-                    info.SelectedText, info.ContextBefore, info.ContextAfter, initialTag.Icon, resolved);
+                    info.SelectedText, info.ContextBefore, info.ContextAfter, info.Status.InternalValue, initialTag.Icon);
                 newThread.Position = GetCommentTextAnchor(info, chapterDeltas);
                 foreach (var comm in thread.Comments)
                 {
@@ -1530,8 +1522,8 @@ namespace SIL.XForge.Scripture.Services
         {
             if (comment.Deleted != note.Deleted)
                 return ChangeType.Deleted;
-            // If the content does not match it has been updated in Paratext
-            if (comment.Contents?.InnerXml != note.Content)
+            // Check if fields have been updated in Paratext
+            if (comment.Contents?.InnerXml != note.Content || comment.Status.InternalValue != note.Status)
                 return ChangeType.Updated;
             return ChangeType.None;
         }
@@ -1573,6 +1565,7 @@ namespace SIL.XForge.Scripture.Services
                 DateCreated = DateTime.Parse(comment.Date),
                 DateModified = DateTime.Parse(comment.Date),
                 Deleted = comment.Deleted,
+                Status = comment.Status.InternalValue,
                 TagIcon = tag?.Icon
             };
         }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -785,6 +785,17 @@ namespace SIL.XForge.Scripture.Services
                     else
                         threadChange.NoteIdsRemoved.Add(note.DataId);
                 }
+                // Make thread resolved if status has changed to deleted
+                if (existingThread.Status == NoteStatus.Deleted && threadDoc.Data.Resolved == false)
+                {
+                    threadChange.Resolved = true;
+                    threadChange.ThreadUpdated = true;
+                }
+                else if (existingThread.Status == NoteStatus.Todo && threadDoc.Data.Resolved == true)
+                {
+                    threadChange.Resolved = false;
+                    threadChange.ThreadUpdated = true;
+                }
                 // Add new Comments to note thread change
                 IEnumerable<string> ptCommentIds = existingThread.Comments.Select(c => c.Id);
                 IEnumerable<string> newCommentIds = ptCommentIds.Except(matchedCommentIds);
@@ -818,11 +829,12 @@ namespace SIL.XForge.Scripture.Services
                 int tagId = info.TagsAdded != null && info.TagsAdded.Length > 0
                     ? int.Parse(info.TagsAdded[0])
                     : defaultTagId;
+                // Make thread resolved if status has changed to deleted
+                bool resolved = (thread.Status == NoteStatus.Deleted);
                 CommentTag initialTag = info.Type == NoteType.Conflict ? CommentTag.ConflictTag : commentTags.Get(tagId);
                 NoteThreadChange newThread = new NoteThreadChange(threadId, info.VerseRefStr,
-                    info.SelectedText, info.ContextBefore, info.ContextAfter, initialTag.Icon);
+                    info.SelectedText, info.ContextBefore, info.ContextAfter, initialTag.Icon, resolved);
                 newThread.Position = GetCommentTextAnchor(info, chapterDeltas);
-
                 foreach (var comm in thread.Comments)
                 {
                     SyncUser syncUser = FindOrCreateSyncUser(comm.User, syncUsers);

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -827,6 +827,7 @@ namespace SIL.XForge.Scripture.Services
                 NoteThreadChange newThread = new NoteThreadChange(threadId, info.VerseRefStr,
                     info.SelectedText, info.ContextBefore, info.ContextAfter, info.Status.InternalValue, initialTag.Icon);
                 newThread.Position = GetCommentTextAnchor(info, chapterDeltas);
+                newThread.Status = thread.Status.InternalValue;
                 foreach (var comm in thread.Comments)
                 {
                     SyncUser syncUser = FindOrCreateSyncUser(comm.User, syncUsers);

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -786,12 +786,12 @@ namespace SIL.XForge.Scripture.Services
                         threadChange.NoteIdsRemoved.Add(note.DataId);
                 }
                 // Make thread resolved if status has changed to deleted
-                if (existingThread.Status == NoteStatus.Deleted && threadDoc.Data.Resolved == false)
+                if (existingThread.Status == NoteStatus.Deleted && (threadDoc.Data.Resolved == false || threadDoc.Data.Resolved == null))
                 {
                     threadChange.Resolved = true;
                     threadChange.ThreadUpdated = true;
                 }
-                else if (existingThread.Status == NoteStatus.Todo && threadDoc.Data.Resolved == true)
+                else if (existingThread.Status == NoteStatus.Todo && (threadDoc.Data.Resolved == true || threadDoc.Data.Resolved == null))
                 {
                     threadChange.Resolved = false;
                     threadChange.ThreadUpdated = true;

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -670,7 +670,8 @@ namespace SIL.XForge.Scripture.Services
                             OriginalContextBefore = change.ContextBefore,
                             OriginalContextAfter = change.ContextAfter,
                             TagIcon = change.TagIcon,
-                            Position = change.Position
+                            Position = change.Position,
+                            Resolved = change.Resolved
                         });
                         await SubmitChangesOnNoteThreadDocAsync(doc, change, usernamesToUserIds);
                     }
@@ -777,6 +778,14 @@ namespace SIL.XForge.Scripture.Services
 
             await threadDoc.SubmitJson0OpAsync(op =>
             {
+                // Update thread details
+                if (change.ThreadUpdated)
+                {
+                    if (threadDoc.Data.Resolved != change.Resolved)
+                    {
+                        op.Set(td => td.Resolved, change.Resolved);
+                    }
+                }
                 // Update content for updated notes
                 foreach (Note updated in change.NotesUpdated)
                 {

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -671,7 +671,7 @@ namespace SIL.XForge.Scripture.Services
                             OriginalContextAfter = change.ContextAfter,
                             TagIcon = change.TagIcon,
                             Position = change.Position,
-                            Resolved = change.Resolved
+                            Status = change.Status
                         });
                         await SubmitChangesOnNoteThreadDocAsync(doc, change, usernamesToUserIds);
                     }
@@ -781,9 +781,9 @@ namespace SIL.XForge.Scripture.Services
                 // Update thread details
                 if (change.ThreadUpdated)
                 {
-                    if (threadDoc.Data.Resolved != change.Resolved)
+                    if (threadDoc.Data.Status != change.Status)
                     {
-                        op.Set(td => td.Resolved, change.Resolved);
+                        op.Set(td => td.Status, change.Status);
                     }
                 }
                 // Update content for updated notes
@@ -791,9 +791,16 @@ namespace SIL.XForge.Scripture.Services
                 {
                     int index = threadDoc.Data.Notes.FindIndex(n => n.DataId == updated.DataId);
                     if (index >= 0)
-                        op.Set(td => td.Notes[index].Content, updated.Content);
+                    {
+                        if (threadDoc.Data.Notes[index].Content != updated.Content)
+                            op.Set(td => td.Notes[index].Content, updated.Content);
+                        if (threadDoc.Data.Notes[index].Status != updated.Status)
+                            op.Set(td => td.Notes[index].Status, updated.Status);
+                    }
                     else
+                    {
                         _logger.LogWarning("Unable to update note in database with id: " + updated.DataId);
+                    }
                 }
                 // Delete notes
                 foreach (Note deleted in change.NotesDeleted)

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -1805,7 +1805,8 @@ namespace SIL.XForge.Scripture.Services
                         Position = comp.appliesToVerse
                             ? new TextAnchor()
                             : new TextAnchor { Start = before.Length, Length = text.Length },
-                        OriginalContextAfter = comp.appliesToVerse ? "" : after
+                        OriginalContextAfter = comp.appliesToVerse ? "" : after,
+                        Status = NoteStatus.Todo.InternalValue
                     };
                     List<Note> notes = new List<Note>();
                     for (int i = 1; i <= comp.noteCount; i++)
@@ -1820,7 +1821,8 @@ namespace SIL.XForge.Scripture.Services
                             SyncUserRef = comp.isNew ? null : "syncuser01",
                             DateCreated = new DateTime(2019, 1, i, 8, 0, 0, DateTimeKind.Utc),
                             TagIcon = $"icon{comp.threadNum}",
-                            Deleted = comp.isDeleted
+                            Deleted = comp.isDeleted,
+                            Status = NoteStatus.Todo.InternalValue
                         });
                     }
                     noteThread.Notes = notes;
@@ -1936,6 +1938,7 @@ namespace SIL.XForge.Scripture.Services
                             Contents = content,
                             Date = date,
                             Deleted = comp.isDeleted,
+                            Status = NoteStatus.Todo,
                             ExternalUser = "user02",
                             TagsAdded = comp.isConflict ? null : new[] { comp.threadNum.ToString() },
                             Type = comp.isConflict ? NoteType.Conflict : NoteType.Normal

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1238,7 +1238,7 @@ namespace SIL.XForge.Scripture.Services
             await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             // Default resolved status is false
-            ParatextNoteThread thread02 = env.GetNoteThread("project01", "thread02");
+            NoteThread thread02 = env.GetNoteThread("project01", "thread02");
             Assert.That(thread02.VerseRef.ToString(), Is.EqualTo("MAT 1:1"));
             Assert.That(thread02.Resolved, Is.EqualTo(false));
 
@@ -1817,11 +1817,12 @@ namespace SIL.XForge.Scripture.Services
 
             public void SetupNoteStatusChange(string threadId, bool resolved, string verseRef = "MAT 1:1")
             {
-                var noteThreadChange = new ParatextNoteThreadChange(threadId, verseRef, $"{threadId} selected text.",
-                    "Context before ", " context after", 17, "icon1", resolved);
+                var noteThreadChange = new NoteThreadChange(threadId, verseRef, $"{threadId} selected text.",
+                    "Context before ", " context after", "icon1", resolved);
                 noteThreadChange.ThreadUpdated = true;
                 ParatextService.GetNoteThreadChanges(Arg.Any<UserSecret>(), "target", 40,
-                    Arg.Any<IEnumerable<IDocument<ParatextNoteThread>>>(), Arg.Any<Dictionary<string, SyncUser>>())
+                    Arg.Any<IEnumerable<IDocument<NoteThread>>>(),
+                    Arg.Any<Dictionary<int, ChapterDelta>>(), Arg.Any<Dictionary<string, SyncUser>>())
                     .Returns(new[] { noteThreadChange });
             }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1830,7 +1830,7 @@ namespace SIL.XForge.Scripture.Services
             public void SetupNewNoteThreadChange(string threadId, string syncUserId, string verseRef = "MAT 1:1")
             {
                 var noteThreadChange = new NoteThreadChange(threadId, verseRef, $"Scripture text in project",
-                    "Context before ", " context after", "todo", "icon1");
+                    "Context before ", " context after", NoteStatus.Todo.InternalValue, "icon1");
                 noteThreadChange.Position = new TextAnchor { Start = 0, Length = 0 };
                 noteThreadChange.AddChange(
                     GetNote(threadId, "n01", syncUserId, $"New {threadId} added.", ChangeType.Added), ChangeType.Added);
@@ -1843,7 +1843,7 @@ namespace SIL.XForge.Scripture.Services
             public void SetupNoteRemovedChange(string threadId, string noteId, string verseRef = "MAT 1:1")
             {
                 var noteThreadChange = new NoteThreadChange(threadId, verseRef, $"{threadId} selected text.",
-                    "Context before ", " context after", "deleted", "icon1");
+                    "Context before ", " context after", NoteStatus.Deleted.InternalValue, "icon1");
                 if (noteId == null)
                     noteThreadChange.ThreadRemoved = true;
                 else


### PR DESCRIPTION
- Sync note/comment status as well as thread status
- Hide resolved threads from translate app
- Show relevant note icon if one is set on the note
- Force a maximum width on note dialog

Existing notes may need to be deleted before a sync - I had hit this issue but it may have just been a bug that I fixed afterwards. I had concluded that this was fine as, once rolled out, no one would have had notes in the first place so it isn't an issue.

This is one of my first real PRs for working in the backend so please be gentle with your replies for changes :) Do let me know if there are much better ways in C# to tackle anything. One thing I wanted to do but couldn't figure out is have an array/list of strings that I iterate through to compare changes from a document to a PT comment. We appear to use the same names so it made sense. What I've currently done is copy & paste more or less the same IF statement when checking for updates - you'll see what I mean during the review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1189)
<!-- Reviewable:end -->
