### PR TITLE
Gracefully abort handling of HttpRequest intercepts when not authenticated

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.spec.ts
@@ -1,0 +1,154 @@
+import { HTTP_INTERCEPTORS, HttpClient, HttpErrorResponse, HttpRequest } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { mock, verify, when } from 'ts-mockito';
+import { AuthService } from 'xforge-common/auth.service';
+import { AUTH_APIS, AuthHttpInterceptor } from 'xforge-common/auth-http-interceptor';
+import { CommandErrorCode, JsonRpcResponse } from 'xforge-common/command.service';
+import { configureTestingModule } from 'xforge-common/test-utils';
+import { COMMAND_API_NAMESPACE, PROJECTS_URL, USERS_URL } from 'xforge-common/url-constants';
+
+const mockedAuthService = mock(AuthService);
+
+describe('AuthHttpInterceptor', () => {
+  configureTestingModule(() => ({
+    imports: [HttpClientTestingModule],
+    providers: [
+      { provide: HTTP_INTERCEPTORS, useClass: AuthHttpInterceptor, multi: true },
+      { provide: AuthService, useMock: mockedAuthService }
+    ]
+  }));
+
+  it('Sets authorization bearer only for valid auth apis', fakeAsync(() => {
+    const env = new TestEnvironment({ isAuthenticated: true });
+    const tests: { url: string; authorizationRequired: boolean }[] = [USERS_URL, PROJECTS_URL]
+      .map(url => ({
+        url,
+        authorizationRequired: false
+      }))
+      .concat(AUTH_APIS.map(url => ({ url, authorizationRequired: true })));
+    tests.forEach(test => {
+      env.httpClient.get(test.url).toPromise();
+      tick();
+      env.httpMock.expectOne((request: HttpRequest<any>) => {
+        expect(request.url).toEqual(test.url);
+        if (test.authorizationRequired) {
+          expect(request.headers.get('authorization'))
+            .withContext(test.url)
+            .toEqual(`Bearer ${TestEnvironment.accessToken}`);
+        } else {
+          expect(request.headers.get('authorization')).withContext(test.url).toBeNull();
+        }
+        return true;
+      });
+    });
+    env.httpMock.verify();
+  }));
+
+  it('Converts JSON RPC errors to normal http response error and attempts to authenticate again with auth0', fakeAsync(() => {
+    const env = new TestEnvironment({ isAuthenticated: true });
+    const apiUrl = COMMAND_API_NAMESPACE;
+    let result: any | undefined;
+    env.httpClient
+      .get(apiUrl)
+      .toPromise()
+      .then(r => (result = r));
+    tick();
+    const request = env.httpMock.expectOne((request: HttpRequest<any>) => {
+      expect(request.url).toEqual(apiUrl);
+      expect(request.headers.get('authorization')).toEqual(`Bearer ${TestEnvironment.accessToken}`);
+      return true;
+    });
+    // JSON RPC response are returned via a 200 response but containing the error
+    // The interceptor identifies this and throws a new error with the JSON error code and message
+    // requiring the interceptor to parse the correct error and attempt authentication again
+    const jsonRpcResponse: JsonRpcResponse<string> = {
+      jsonrpc: '2.0',
+      error: { code: CommandErrorCode.InvalidRequest, message: 'Unauthorized' },
+      id: '1'
+    };
+    request.flush(jsonRpcResponse);
+    tick();
+    expect(result).toBeUndefined();
+    verify(mockedAuthService.expireToken()).once();
+    verify(mockedAuthService.isAuthenticated()).twice();
+    // This is because a second call is made when the JSON response is handled and it needs to be flushed
+    env.httpMock.expectOne({ url: apiUrl });
+    env.httpMock.verify();
+  }));
+
+  it('Handles a 401 response and redirects to auth0 to login if unable to authenticate silently', fakeAsync(() => {
+    const env = new TestEnvironment();
+    const apiUrl = COMMAND_API_NAMESPACE;
+    env.httpClient.get(apiUrl).toPromise();
+    tick();
+    verify(mockedAuthService.isAuthenticated()).once();
+    // None should be available as it never completes due to isAuthenticated failing and auth0 redirecting
+    env.httpMock.expectNone({ url: apiUrl });
+    env.httpMock.verify();
+    expect().nothing();
+  }));
+
+  it('Handles a normal error and throws it', fakeAsync(() => {
+    const env = new TestEnvironment({ isAuthenticated: true });
+    const apiUrl = COMMAND_API_NAMESPACE;
+    let result: HttpErrorResponse | undefined;
+    env.httpClient
+      .get(apiUrl)
+      .toPromise()
+      .catch(r => (result = r));
+    tick();
+    const request = env.httpMock.expectOne((request: HttpRequest<any>) => {
+      expect(request.url).toEqual(apiUrl);
+      expect(request.headers.get('authorization')).toEqual(`Bearer ${TestEnvironment.accessToken}`);
+      return true;
+    });
+    request.error(new ErrorEvent('Error', { message: 'An error occurred' }));
+    tick();
+    expect(result!.error.message).toBe('An error occurred');
+    env.httpMock.verify();
+  }));
+
+  it('Handle a normal JSON RPC response without throwing an error', fakeAsync(() => {
+    const env = new TestEnvironment({ isAuthenticated: true });
+    const apiUrl = COMMAND_API_NAMESPACE;
+    let result: any | undefined;
+    env.httpClient
+      .get(apiUrl)
+      .toPromise()
+      .then(r => (result = r));
+    tick();
+    const request = env.httpMock.expectOne((request: HttpRequest<any>) => {
+      expect(request.url).toEqual(apiUrl);
+      expect(request.headers.get('authorization')).toEqual(`Bearer ${TestEnvironment.accessToken}`);
+      return true;
+    });
+    const jsonRpcResponse: JsonRpcResponse<string> = {
+      jsonrpc: '2.0',
+      result: 'ok',
+      id: '1'
+    };
+    request.flush(jsonRpcResponse);
+    tick();
+    expect(result).toBe(jsonRpcResponse);
+    env.httpMock.verify();
+  }));
+});
+
+interface TestEnvironmentConstructorArgs {
+  isAuthenticated?: boolean;
+}
+
+class TestEnvironment {
+  static accessToken = 'validAccessToken';
+  readonly httpMock: HttpTestingController;
+  readonly httpClient: HttpClient;
+
+  constructor({ isAuthenticated = false }: TestEnvironmentConstructorArgs = {}) {
+    this.httpMock = TestBed.inject(HttpTestingController);
+    this.httpClient = TestBed.inject(HttpClient);
+
+    when(mockedAuthService.isAuthenticated()).thenResolve(isAuthenticated);
+    when(mockedAuthService.accessToken).thenReturn(isAuthenticated === true ? TestEnvironment.accessToken : '');
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.ts
@@ -12,7 +12,7 @@ import { catchError, map } from 'rxjs/operators';
 import { CommandErrorCode } from 'xforge-common/command.service';
 import { AuthService } from './auth.service';
 
-const AUTH_APIS = ['paratext-api', 'machine-api', 'command-api'];
+export const AUTH_APIS = ['paratext-api', 'machine-api', 'command-api'];
 
 @Injectable()
 export class AuthHttpInterceptor implements HttpInterceptor {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.ts
@@ -7,7 +7,7 @@ import {
   HttpResponse
 } from '@angular/common/http';
 import { Injectable, Injector } from '@angular/core';
-import { from, Observable, throwError } from 'rxjs';
+import { from, NEVER, Observable, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { CommandErrorCode } from 'xforge-common/command.service';
 import { AuthService } from './auth.service';
@@ -26,7 +26,10 @@ export class AuthHttpInterceptor implements HttpInterceptor {
     }
     // Make sure the user is authenticated with a valid access token
     if (!(await this.authService.isAuthenticated())) {
-      return await throwError('User not authenticated - login required').toPromise();
+      // When authentication fails auth0 is already in the process of redirecting to the login screen
+      // Using NEVER is a graceful way of waiting for the browser to complete the redirection
+      // without triggering any other errors from an incomplete http request
+      return NEVER.toPromise();
     }
     // Add access token to the request header
     const authReq = req.clone({


### PR DESCRIPTION
This addresses a problem that would occur when auth0 issued a login required error either by the session expiring or from 3rd party cookies being blocked. If this instance occurred as well as the access token expiry (captured on first login and stored in local storage) also expiring AND the app first loaded OR the app loaded while offline and then came online an error dialog would occur due to the `checkUserNeedsMigrating` check that is run when the app first loads. 

This issue was minimized in a recent update that ensured if the access token had expired, and the user was online, it would check immediately and the user would be redirected to auth0 before the main app would ever need to run `checkUserNeedsMigrating`.

This is the most common scenario but the same dialog could have occurred when other checks with the backend are taking place and a 401 response comes back.

The dialog would only ever appear for a couple of seconds because when auth0 responds with a login required error the app immediately starts redirecting but while waiting for the redirect to occur SF continues with the reset of its execution and displays the error.

This fix in the http interceptor simple keeps the request in limbo using `EMPTY` which means the observable never confirms to any subscriptions that it completes resulting in the app sitting and waiting patiently for the redirect to occur.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1191)
<!-- Reviewable:end -->

Currently on `master` we have the auth0 tenant to force a login after 2 minutes or 1 minute of no activity with auth0. There is another setting that only expires our access token after 5 minutes which makes it a little tricky to test. The best way to replicate is to:
1. Build PWA
2. Login
3. Go offline
4. Wait 1 minute
5. Edit local storage and change `expires_at` to something low - just deleting one of the numbers is enough
6. Refresh the page making the PWA reload the app in offline mode
7. Go online

Current `master` will show the dialog whereas this branch will take you to auth0 without showing an error dialog.