### PR TITLE
Fix sharing invitation language font

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_variables.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_variables.scss
@@ -15,6 +15,7 @@ $likes: $blueMedium;
 $questions: $purpleLight;
 $answers: $greenLight;
 $comments: #ff7300;
+$languageFonts: language_picker, language_picker_fallback, Arial, Helvetica, sans-serif;
 
 $pt-button-green: $greenDark;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -184,7 +184,7 @@ a {
 
 .locale-menu .mdc-list-item {
   white-space: nowrap;
-  font-family: language_picker, language_picker_fallback, Arial, Helvetica, sans-serif;
+  font-family: $languageFonts;
 }
 
 .online-status {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
@@ -44,7 +44,7 @@
           </mat-form-field>
           <mat-form-field id="invitation-language">
             <mat-label>{{ t("invitation_language") }}</mat-label>
-            <mat-select formControlName="locale">
+            <mat-select formControlName="locale" panelClass="locale-fonts">
               <mat-option *ngFor="let locale of i18n.locales" [value]="locale.canonicalTag">
                 {{ locale.localName }}
               </mat-option>

--- a/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
@@ -144,3 +144,7 @@ button.mdc-icon-button {
 .offline-text {
   color: var(--mdc-theme-error);
 }
+
+.locale-fonts mat-option {
+  font-family: $languageFonts;
+}


### PR DESCRIPTION
- Set language options as a variable
- Updated share component to use new language fonts

Styling the material select component required styles added to the global styles file as per their documentation for styling overlaid components.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1197)
<!-- Reviewable:end -->
