### PR TITLE
SF-1428 Duplicate notes detected and cleaned up

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -622,6 +622,8 @@ export class TextViewModel {
         if (cloneOp.delete < 1) {
           cloneOp = undefined;
         }
+      } else if (cloneOp.insert != null && cloneOp.insert['note-thread-embed'] != null) {
+        cloneOp = undefined;
       }
 
       if (cloneOp != null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -13,7 +13,7 @@ import { TranslocoService } from '@ngneat/transloco';
 import { clone } from 'lodash-es';
 import isEqual from 'lodash-es/isEqual';
 import merge from 'lodash-es/merge';
-import Quill, { DeltaStatic, RangeStatic, Sources } from 'quill';
+import Quill, { DeltaOperation, DeltaStatic, RangeStatic, Sources } from 'quill';
 import { TextAnchor } from 'realtime-server/lib/esm/scriptureforge/models/text-anchor';
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
 import { fromEvent } from 'rxjs';
@@ -558,6 +558,9 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
 
   /** Respond to text changes in the quill editor. */
   onContentChanged(delta: DeltaStatic, source: string): void {
+    if ((source as Sources) === 'user') {
+      this.deleteDuplicateNoteIcons(delta);
+    }
     this.viewModel.update(delta, source as Sources);
     this.updatePlaceholderText();
     // skip updating when only formatting changes occurred
@@ -930,6 +933,38 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   private getEmbedCountInRange(editorStartPos: number, length: number): number {
     const embedPositions: number[] = Array.from(this.embeddedElements.values());
     return embedPositions.filter((pos: number) => pos >= editorStartPos && pos < editorStartPos + length).length;
+  }
+
+  /**
+   * Delete existing notes in the quill editor when the delta includes inserting a note.
+   * i.e. The user triggers an undo after deleting a note.
+   */
+  private deleteDuplicateNoteIcons(delta: DeltaStatic): void {
+    if (this.editor == null || delta.ops == null) {
+      return;
+    }
+    // Delta for the removal of notes that were re-created
+    let notesDeletionDelta: DeltaStatic | undefined;
+    for (const op of delta.ops) {
+      if (op.insert != null && op.insert['note-thread-embed'] != null) {
+        const embedId: string = op.insert['note-thread-embed']['threadid'];
+        let deletePosition = this.embeddedElements.get(embedId);
+        if (deletePosition != null) {
+          const noteDeleteOpDelta = new Delta();
+          (noteDeleteOpDelta as any).push({ retain: deletePosition } as DeltaOperation);
+          (noteDeleteOpDelta as any).push({ delete: 1 } as DeltaOperation);
+          notesDeletionDelta =
+            notesDeletionDelta == null ? noteDeleteOpDelta : noteDeleteOpDelta.compose(notesDeletionDelta);
+        }
+      }
+    }
+
+    if (notesDeletionDelta != null) {
+      notesDeletionDelta.chop();
+      Promise.resolve(notesDeletionDelta).then(del => {
+        this.editor?.updateContents(del, 'api');
+      });
+    }
   }
 
   private setHighlightMarkerPosition(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1789,8 +1789,8 @@ describe('EditorComponent', () => {
       // undo deleting multiple notes
       const noteThread3: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread03');
       const noteThread4: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread04');
-      const noteThread3Anchor: TextAnchor = { start: 19, length: 7 };
-      const noteThread4Anchor: TextAnchor = { start: 19, length: 5 };
+      const noteThread3Anchor: TextAnchor = { start: 20, length: 7 };
+      const noteThread4Anchor: TextAnchor = { start: 20, length: 5 };
       expect(noteThread3.data!.position).toEqual(noteThread3Anchor);
       expect(noteThread4.data!.position).toEqual(noteThread4Anchor);
       const note3Position: number = env.getNoteThreadEditorPosition('thread03');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1724,7 +1724,7 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('undo deleting a note icon removes the duplicate recreated icon', fakeAsync(() => {
+    it('undo delete-a-note-icon removes the duplicate recreated icon', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
       const noteThread6Anchor: TextAnchor = { start: 19, length: 5 };
@@ -1735,6 +1735,8 @@ describe('EditorComponent', () => {
       const noteThread1: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread01');
       const noteThread1Anchor: TextAnchor = { start: 8, length: 9 };
       expect(noteThread1.data!.position).toEqual(noteThread1Anchor);
+      const textDoc: TextDoc = env.getTextDoc(new TextDocId('project01', 40, 1));
+      expect(textDoc.data!.ops![3].insert).toEqual('target: chapter 1, verse 1.');
       const note1Position: number = env.getNoteThreadEditorPosition('thread01');
       // target: |->$<-|chapter 1, $verse 1.
       env.targetEditor.setSelection(note1Position, 1, 'user');
@@ -1785,6 +1787,7 @@ describe('EditorComponent', () => {
       expect(env.getNoteThreadEditorPosition('thread06')).toEqual(note6Position);
       expect(noteThread6.data!.position).toEqual(noteThread6Anchor);
       expect(noteThread1.data!.position).toEqual(noteThread1Anchor);
+      expect(textDoc.data!.ops![3].insert).toEqual('target: chapter 1, verse 1.');
 
       // undo deleting multiple notes
       const noteThread3: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread03');
@@ -1793,6 +1796,7 @@ describe('EditorComponent', () => {
       const noteThread4Anchor: TextAnchor = { start: 20, length: 5 };
       expect(noteThread3.data!.position).toEqual(noteThread3Anchor);
       expect(noteThread4.data!.position).toEqual(noteThread4Anchor);
+      expect(textDoc.data!.ops![8].insert).toEqual('target: chapter 1, verse 3.');
       const note3Position: number = env.getNoteThreadEditorPosition('thread03');
       const note4Position: number = env.getNoteThreadEditorPosition('thread04');
       deleteLength = 6;
@@ -1809,6 +1813,7 @@ describe('EditorComponent', () => {
       expect(env.getNoteThreadEditorPosition('thread04')).toEqual(note4Position);
       expect(noteThread3.data!.position).toEqual(noteThread3Anchor);
       expect(noteThread4.data!.position).toEqual(noteThread4Anchor);
+      expect(textDoc.data!.ops![8].insert).toEqual('target: chapter 1, verse 3.');
       env.dispose();
     }));
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1723,6 +1723,94 @@ describe('EditorComponent', () => {
       expect(noteThread1Doc.data!.position).toEqual(originalNoteThread1TextPos);
       env.dispose();
     }));
+
+    it('undo deleting a note icon removes the duplicate recreated icon', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      const noteThread6Anchor: TextAnchor = { start: 19, length: 5 };
+      env.addParatextNoteThread(6, 'MAT 1:1', 'verse', noteThread6Anchor, ['user01']);
+      env.wait();
+
+      // undo deleting just the note
+      const noteThread1: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread01');
+      const noteThread1Anchor: TextAnchor = { start: 8, length: 9 };
+      expect(noteThread1.data!.position).toEqual(noteThread1Anchor);
+      const note1Position: number = env.getNoteThreadEditorPosition('thread01');
+      // target: |->$<-|chapter 1, $verse 1.
+      env.targetEditor.setSelection(note1Position, 1, 'user');
+      env.deleteCharacters();
+      const positionAfterDelete: number = env.getNoteThreadEditorPosition('thread01');
+      expect(positionAfterDelete).toEqual(note1Position);
+      env.triggerUndo();
+      expect(env.getNoteThreadEditorPosition('thread01')).toEqual(note1Position);
+      expect(env.component.target!.getSegmentText('verse_1_1')).toBe('target: chapter 1, verse 1.');
+      expect(noteThread1.data!.position).toEqual(noteThread1Anchor);
+
+      // undo deleting note and context
+      let deleteLength: number = 5;
+      let beforeNoteLength: number = 2;
+      // target|->: $ch<-|apter 1, $verse 1.
+      env.targetEditor.setSelection(note1Position - beforeNoteLength, deleteLength, 'user');
+      env.deleteCharacters();
+      let newNotePosition: number = env.getNoteThreadEditorPosition('thread01');
+      expect(newNotePosition).toEqual(note1Position - beforeNoteLength);
+      env.triggerUndo();
+      expect(env.getNoteThreadEditorPosition('thread01')).toEqual(note1Position);
+      expect(noteThread1.data!.position).toEqual(noteThread1Anchor);
+
+      // undo deleting note and entire selection
+      const embedLength = 1;
+      deleteLength = beforeNoteLength + embedLength + noteThread1.data!.position.length;
+      // target|->: $chapter<-| 1: $verse 1.
+      env.targetEditor.setSelection(note1Position - beforeNoteLength, deleteLength, 'user');
+      env.deleteCharacters();
+      newNotePosition = env.getNoteThreadEditorPosition('thread01');
+      const range = env.component.target!.getSegmentRange('verse_1_1')!;
+      // note moves to the beginning of the verse
+      expect(newNotePosition).toEqual(range.index);
+      env.triggerUndo();
+      expect(noteThread1.data!.position).toEqual({ start: 8, length: 9 });
+
+      // undo deleting a second note in verse does not affect first note
+      const note6Position: number = env.getNoteThreadEditorPosition('thread06');
+      const noteThread6: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread06');
+      deleteLength = 3;
+      const text = 'abc';
+      // target: $chapter 1, |->$ve<-|rse 1.
+      env.targetEditor.setSelection(note6Position, deleteLength, 'api');
+      env.typeCharacters(text);
+      newNotePosition = env.getNoteThreadEditorPosition('thread06');
+      expect(newNotePosition).toEqual(note6Position + text.length);
+      env.triggerUndo();
+      expect(env.getNoteThreadEditorPosition('thread06')).toEqual(note6Position);
+      expect(noteThread6.data!.position).toEqual(noteThread6Anchor);
+      expect(noteThread1.data!.position).toEqual(noteThread1Anchor);
+
+      // undo deleting multiple notes
+      const noteThread3: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread03');
+      const noteThread4: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread04');
+      const noteThread3Anchor: TextAnchor = { start: 19, length: 7 };
+      const noteThread4Anchor: TextAnchor = { start: 19, length: 5 };
+      expect(noteThread3.data!.position).toEqual(noteThread3Anchor);
+      expect(noteThread4.data!.position).toEqual(noteThread4Anchor);
+      const note3Position: number = env.getNoteThreadEditorPosition('thread03');
+      const note4Position: number = env.getNoteThreadEditorPosition('thread04');
+      deleteLength = 6;
+      // $target: chapter 1|->, $$ve<-|rse 3.
+      env.targetEditor.setSelection(note4Position - beforeNoteLength, deleteLength, 'api');
+      env.deleteCharacters();
+      newNotePosition = env.getNoteThreadEditorPosition('thread03');
+      expect(newNotePosition).toEqual(note3Position - beforeNoteLength);
+      newNotePosition = env.getNoteThreadEditorPosition('thread04');
+      expect(newNotePosition).toEqual(note4Position - beforeNoteLength);
+      env.triggerUndo();
+      env.wait();
+      expect(env.getNoteThreadEditorPosition('thread03')).toEqual(note3Position);
+      expect(env.getNoteThreadEditorPosition('thread04')).toEqual(note4Position);
+      expect(noteThread3.data!.position).toEqual(noteThread3Anchor);
+      expect(noteThread4.data!.position).toEqual(noteThread4Anchor);
+      env.dispose();
+    }));
   });
 
   describe('Translation Suggestions disabled', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/typings/sharedb.d.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/typings/sharedb.d.ts
@@ -52,6 +52,12 @@ declare module 'sharedb/lib/client' {
       options?: any,
       callback?: (err: Error, results: Doc[]) => void
     ): Query;
+    fetchSnapshot(
+      collectionName: string,
+      documentID: string,
+      version: number | null,
+      callback?: (err: Error, snapshot: Snapshot) => void
+    ): Snapshot;
     close(): void;
   }
 
@@ -111,6 +117,7 @@ declare module 'sharedb/lib/client' {
     whenNothingPending(callback: Callback): void;
     hasWritePending(): boolean;
     flush(): void;
+    previousSnapshot(): Snapshot;
   }
 
   export interface Query extends EventEmitter {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/memory-realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/memory-realtime-remote-store.ts
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash-es';
 import isEqual from 'lodash-es/isEqual';
 import * as OTJson0 from 'ot-json0';
 import { EMPTY, Subject } from 'rxjs';
@@ -66,6 +67,7 @@ export class MemoryRealtimeDocAdapter implements RealtimeDocAdapter {
   readonly create$ = new Subject<void>();
   readonly delete$ = new Subject<void>();
   readonly idle$ = EMPTY;
+  private _previousSnapshot: Snapshot;
 
   constructor(
     public readonly collection: string,
@@ -79,6 +81,7 @@ export class MemoryRealtimeDocAdapter implements RealtimeDocAdapter {
     } else if (this.data != null) {
       this.version = 0;
     }
+    this._previousSnapshot = cloneDeep(this) as any as Snapshot;
   }
 
   create(data: any, type: string = OTJson0.type.name): Promise<void> {
@@ -106,6 +109,7 @@ export class MemoryRealtimeDocAdapter implements RealtimeDocAdapter {
     if (this.type == null) {
       throw new Error('The doc has not been loaded.');
     }
+    this._previousSnapshot = cloneDeep(this) as any as Snapshot;
 
     if (op != null && this.type.normalize != null) {
       op = this.type.normalize(op);
@@ -116,6 +120,10 @@ export class MemoryRealtimeDocAdapter implements RealtimeDocAdapter {
       this.emitRemoteChange(op);
     }
     return Promise.resolve();
+  }
+
+  previousSnapshot(): Promise<Snapshot> {
+    return Promise.resolve(this._previousSnapshot);
   }
 
   exists(): Promise<boolean> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
@@ -1,6 +1,7 @@
 import { merge, Observable, Subject, Subscription } from 'rxjs';
 import { RealtimeService } from 'xforge-common/realtime.service';
 import { RealtimeDocAdapter } from '../realtime-remote-store';
+import { Snapshot } from './snapshot';
 import { RealtimeOfflineData } from './realtime-offline-data';
 
 export interface RealtimeDocConstructor {
@@ -138,6 +139,10 @@ export abstract class RealtimeDoc<T = any, Ops = any> {
     if (this.isLoaded) {
       this.checkExists();
     }
+  }
+
+  previousSnapshot(): Promise<Snapshot<T>> {
+    return this.adapter.previousSnapshot();
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime-remote-store.ts
@@ -42,6 +42,7 @@ export interface RealtimeDocAdapter {
   exists(): Promise<boolean>;
   delete(): Promise<void>;
   updatePendingOps(ops: any[]): void;
+  previousSnapshot(): Promise<Snapshot>;
 
   destroy(): Promise<void>;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
@@ -6,6 +6,7 @@ import { fromEvent, Observable, Subject } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 import { Connection, Doc, OTType, Query, Snapshot, types } from 'sharedb/lib/client';
 import { PwaService } from 'xforge-common/pwa.service';
+import { Snapshot as DataSnapshot } from 'xforge-common/models/snapshot';
 import { environment } from '../environments/environment';
 import { LocationService } from './location.service';
 import { QueryParameters } from './query-parameters';
@@ -233,6 +234,23 @@ export class SharedbRealtimeDocAdapter implements RealtimeDocAdapter {
   updatePendingOps(ops: any[]): void {
     this.doc.pendingOps.push(...ops.map(component => ({ op: component, type: this.doc.type, callbacks: [] })));
     this.doc.flush();
+  }
+
+  previousSnapshot(): Promise<DataSnapshot> {
+    return new Promise((resolve, reject) => {
+      this.doc.connection.fetchSnapshot(
+        this.doc.collection,
+        this.doc.id,
+        Math.min(0, this.doc.version - 1),
+        (err, snapshot) => {
+          if (err) {
+            reject();
+          } else {
+            resolve(snapshot as DataSnapshot);
+          }
+        }
+      );
+    });
   }
 
   destroy(): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
@@ -241,7 +241,7 @@ export class SharedbRealtimeDocAdapter implements RealtimeDocAdapter {
       this.doc.connection.fetchSnapshot(
         this.doc.collection,
         this.doc.id,
-        Math.min(0, this.doc.version - 1),
+        Math.max(0, this.doc.version - 1),
         (err, snapshot) => {
           if (err) {
             reject();


### PR DESCRIPTION
When a note icon is deleted by the user in SF, the note icon's position will be recalculated and will reappear as it does in Paratext. When a user triggers an undo, the recreated note must be deleted so the previous note can be reinserted. The change performs two steps: (1) deleting the note that was recreated when the user first deleted a note. (2) reverts the position of the text anchor for the reinserted note and for all notes affected by the undo operation.

This change also refactors how we update a note's text anchor. The update method now accepts the update delta and uses it to calculate the note's updated position.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1198)
<!-- Reviewable:end -->
