### PR TITLE
Re-add HasTransceleratorQuestions API endpoint

### DIFF
--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -362,7 +362,7 @@ namespace SIL.XForge.Scripture.Controllers
             }
         }
 
-        /// To be removed soon. Only here for clients still running a front end that still calls it.
+        [Obsolete("To be removed soon. Only here for clients still running a front end that still calls it.")]
         public async Task<IRpcMethodResult> HasTransceleratorQuestions(string projectId)
         {
             try

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -362,6 +362,23 @@ namespace SIL.XForge.Scripture.Controllers
             }
         }
 
+        /// To be removed soon. Only here for clients still running a front end that still calls it.
+        public async Task<IRpcMethodResult> HasTransceleratorQuestions(string projectId)
+        {
+            try
+            {
+                return Ok(await _projectService.HasTransceleratorQuestions(UserId, projectId));
+            }
+            catch (ForbiddenException)
+            {
+                return ForbiddenError();
+            }
+            catch (DataNotFoundException dnfe)
+            {
+                return NotFoundError(dnfe.Message);
+            }
+        }
+
         public async Task<IRpcMethodResult> SetUserProjectPermissions(string projectId, string userId, string[] permissions)
         {
             try

--- a/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,6 +25,8 @@ namespace SIL.XForge.Scripture.Services
         Task<IReadOnlyList<InviteeStatus>> InvitedUsersAsync(string curUserId, string projectId);
         bool IsSourceProject(string projectId);
         Task<IEnumerable<TransceleratorQuestion>> TransceleratorQuestions(string curUserId, string projectId);
+        [Obsolete("Only here for clients still running a front end that still calls it")]
+        Task<bool> HasTransceleratorQuestions(string curUserId, string projectId);
         Task UpdatePermissionsAsync(string curUserId, IDocument<SFProject> projectDoc, CancellationToken token);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ITransceleratorService.cs
+++ b/src/SIL.XForge.Scripture/Services/ITransceleratorService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using SIL.XForge.Scripture.Models;
 
@@ -6,5 +7,7 @@ namespace SIL.XForge.Scripture.Services
     public interface ITransceleratorService
     {
         IEnumerable<TransceleratorQuestion> Questions(string paratextId);
+        [Obsolete("Only here for clients still running a front end that still calls it")]
+        bool HasQuestions(string paratextId);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -591,6 +591,7 @@ namespace SIL.XForge.Scripture.Services
             }
         }
 
+        [Obsolete("Only here for clients still running a front end that still calls it")]
         public async Task<bool> HasTransceleratorQuestions(string curUserId, string projectId)
         {
             using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -591,6 +591,21 @@ namespace SIL.XForge.Scripture.Services
             }
         }
 
+        public async Task<bool> HasTransceleratorQuestions(string curUserId, string projectId)
+        {
+            using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
+            {
+                IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
+                if (!projectDoc.IsLoaded)
+                    throw new DataNotFoundException("The project does not exist.");
+                // TODO Checking whether the permissions contains a particular string is not a very robust way to check
+                // permissions. A rights service needs to be created in C# land.
+                if (!IsProjectAdmin(projectDoc.Data, curUserId) && !projectDoc.Data.UserPermissions[curUserId].Contains("questions.create"))
+                    throw new ForbiddenException();
+                return _transceleratorService.HasQuestions(projectDoc.Data.ParatextId);
+            }
+        }
+
         protected override async Task AddUserToProjectAsync(IConnection conn, IDocument<SFProject> projectDoc,
             IDocument<User> userDoc, string projectRole, bool removeShareKeys = true)
         {

--- a/src/SIL.XForge.Scripture/Services/TransceleratorService.cs
+++ b/src/SIL.XForge.Scripture/Services/TransceleratorService.cs
@@ -20,6 +20,11 @@ namespace SIL.XForge.Scripture.Services
             _siteOptions = siteOptions;
         }
 
+        public bool HasQuestions(string paratextId)
+        {
+            return QuestionFiles(paratextId).Count() > 0;
+        }
+
         public IEnumerable<TransceleratorQuestion> Questions(string paratextId)
         {
             IEnumerable<XmlElement> docs = QuestionFiles(paratextId).Select(file => ReadFileAsXml(file).DocumentElement);

--- a/test/SIL.XForge.Scripture.Tests/Services/TransceleratorServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/TransceleratorServiceTests.cs
@@ -13,6 +13,22 @@ namespace SIL.XForge.Scripture.Services
         private const string Project01 = "project01";
 
         [Test]
+        public void TransceleratorService_HasQuestions()
+        {
+            var env = new TestEnvironment();
+            env.FileSystemService.DirectoryExists(Arg.Any<string>()).Returns(true);
+            env.FileSystemService.EnumerateFiles(Arg.Any<string>()).Returns(
+                new string[] { "Just some file.xml" }
+            );
+            Assert.False(env.Service.HasQuestions(Project01));
+
+            env.FileSystemService.EnumerateFiles(Arg.Any<string>()).Returns(
+                new string[] { "Just some file.xml", "Translated Checking Questions for MAT.xml" }
+            );
+            Assert.True(env.Service.HasQuestions(Project01));
+        }
+
+        [Test]
         public void TransceleratorService_Questions()
         {
             var env = new TestEnvironment();


### PR DESCRIPTION
This was prematurely removed in #1182. We don't need it anymore, but existing clients call it, so we shouldn't remove it until #1182 is live on nearly all clients.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1199)
<!-- Reviewable:end -->
