### PR TITLE
Include additional step for manual development setup on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ Although this setup is specifically written for **Windows**, the steps could be 
 On Windows, just put these off your root drive, e.g. `C:\var\lib\...`
 
 10. Add developer secrets. Ask another developer how to get these.
-11. In `src/SIL.XForge.Scripture/`, run `dotnet run`. Browse to `http://localhost:5000`.
+11. Copy `/deploy/files/InternetSettings.xml` to `%localappdata%/Paratext92` or `~/.local/share/Paratext92/` on other systems. If you have installed Paratext 9.2, and completed the initial setup on first run, then this step will be taken care of for you.
+12. In `src/SIL.XForge.Scripture/`, run `dotnet run`. Browse to `http://localhost:5000`.
 
 ### Development Process
 


### PR DESCRIPTION
After doing a recent manual install on Windows I received an error trying to connect to any Paratext project. Nathanial also hit the same issue on his new machine after doing a manual install (on Linux). 

This step is already included in ansible setup so this PR adds the missing step to the manual process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1202)
<!-- Reviewable:end -->
