### PR TITLE
SF-1420 Note dialog RTL verse markup and content

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
@@ -56,6 +56,12 @@ h1 {
   .text {
     text-align: right;
   }
+  .text {
+    direction: rtl;
+  }
+  .note .content {
+    direction: rtl;
+  }
 }
 .ltr {
   .note {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -123,6 +123,21 @@ describe('NoteDialogComponent', () => {
     expect(env.component.segmentText).toEqual('');
     expect(env.component.noteIcon(TestEnvironment.noteThread[0])).toEqual('');
   }));
+
+  it('uses rtl direction with rtl project', fakeAsync(() => {
+    env = new TestEnvironment({ isRightToLeftProject: true });
+    expect(env.component.isRtl).withContext('setup').toBeTrue();
+    // RTL is detected and applied.
+    expect(env.dialogContentArea.classes.rtl).toBeTrue();
+    expect(env.dialogContentArea.classes.ltr).toBeUndefined();
+  }));
+
+  it('uses ltr direction with ltr project', fakeAsync(() => {
+    env = new TestEnvironment();
+    expect(env.component.isRtl).withContext('setup').toBeFalse();
+    expect(env.dialogContentArea.classes.rtl).toBeUndefined();
+    expect(env.dialogContentArea.classes.ltr).toBeTrue();
+  }));
 });
 
 @Directive({
@@ -151,6 +166,7 @@ class DialogTestModule {}
 
 interface TestEnvironmentConstructorArgs {
   includeSnapshots?: boolean;
+  isRightToLeftProject?: boolean;
 }
 
 class TestEnvironment {
@@ -263,12 +279,13 @@ class TestEnvironment {
   readonly dialogRef: MatDialogRef<NoteDialogComponent>;
   readonly mockedNoteMdcDialogRef = mock(MatDialogRef);
 
-  constructor({ includeSnapshots = true }: TestEnvironmentConstructorArgs = {}) {
+  constructor({ includeSnapshots = true, isRightToLeftProject }: TestEnvironmentConstructorArgs = {}) {
     this.fixture = TestBed.createComponent(ChildViewContainerComponent);
     const configData: NoteDialogData = {
       projectId: TestEnvironment.PROJECT01,
       threadId: TestEnvironment.noteThread.dataId
     };
+    TestEnvironment.testProject.isRightToLeft = isRightToLeftProject;
     this.dialogRef = TestBed.inject(MatDialog).open(NoteDialogComponent, { data: configData });
     this.component = this.dialogRef.componentInstance;
     tick();
@@ -322,6 +339,10 @@ class TestEnvironment {
 
   get segmentText(): DebugElement {
     return this.overlayContainerElement.query(By.css('.segment-text'));
+  }
+
+  get dialogContentArea(): DebugElement {
+    return this.overlayContainerElement.query(By.css('mat-dialog-content'));
   }
 
   private get overlayContainerElement(): DebugElement {


### PR DESCRIPTION
- In the Note dialog, like Paratext for an RTL project, show the verse
USFM marker on the right side, and display the note content RTL.
- The two added tests check existing behaviour.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1203)
<!-- Reviewable:end -->
