### PR TITLE
Don't request thread position updates when not changed

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1049,6 +1049,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         editOpIndex,
         delta
       );
+      if (isEqual(oldNotePosition, newSelection)) {
+        continue;
+      }
       updatePromises.push(noteThreadDoc.submitJson0Op(op => op.set(n => n.position, newSelection)));
     }
     await Promise.all(updatePromises);


### PR DESCRIPTION
- Needless.

====
I identified this while working on SF-1417, but am proposing it afterward since it wasn't part of the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1205)
<!-- Reviewable:end -->
