### PR TITLE
SF-1447 Correctly show remote edits following a note

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -71,6 +71,16 @@ function removeAttribute(op: DeltaOperation, name: string): void {
   }
 }
 
+/** Provides information about a range of text that includes the embedded elements */
+export interface EditorRange {
+  startEditorPosition: number;
+  endEditorPosition: number;
+  embedsWithinRange: number;
+  leadingEmbedCount: number;
+  // not counted in embedsWithinRange
+  trailingEmbedCount: number;
+}
+
 class SegmentInfo {
   length: number = 0;
   origRef?: string;
@@ -381,22 +391,40 @@ export class TextViewModel {
     return undefined;
   }
 
-  /** Returns the editor position that corresponds to a text position past an editor position. */
-  getEditorPositionPlusTextPosition(startingEditorPos: number, textPosPast: number): number {
-    let textCharactersFound = 0;
-    let resultingEditorPos = startingEditorPos;
+  /** Returns editor range information that corresponds to a text position past an editor position. */
+  getEditorContentRange(startEditorPosition: number, textPosPast: number): EditorRange {
     const embedEditorPositions = Array.from(this.embeddedElements.values());
+    const leadingEmbedCount = this.countEmbedsAtPosition(startEditorPosition);
+    let resultingEditorPos = startEditorPosition + leadingEmbedCount;
+    let textCharactersFound = 0;
+    let embedsWithinRange = leadingEmbedCount;
     while (textCharactersFound < textPosPast) {
       if (!embedEditorPositions.includes(resultingEditorPos)) {
         textCharactersFound++;
+      } else {
+        embedsWithinRange++;
       }
       resultingEditorPos++;
     }
-    // if the position ends on an embed, include it in the final editor position i.e. make this greedy
-    while (embedEditorPositions.includes(resultingEditorPos)) {
-      resultingEditorPos++;
+    // trailing embeds do not count towards embedsWithinRange
+    const trailingEmbedCount: number = this.countEmbedsAtPosition(resultingEditorPos);
+    return {
+      startEditorPosition,
+      endEditorPosition: resultingEditorPos,
+      embedsWithinRange,
+      leadingEmbedCount,
+      trailingEmbedCount
+    };
+  }
+
+  private countEmbedsAtPosition(startEditorPosition: number): number {
+    const embedEditorPositions = Array.from(this.embeddedElements.values());
+    // add up the leading embeds
+    let leadingEmbedCount = 0;
+    while (embedEditorPositions.includes(startEditorPosition + leadingEmbedCount)) {
+      leadingEmbedCount++;
     }
-    return resultingEditorPos;
+    return leadingEmbedCount;
   }
 
   private viewToData(delta: DeltaStatic): DeltaStatic {
@@ -657,32 +685,45 @@ export class TextViewModel {
     const adjustedDelta = new Delta();
     let curIndex: number = 0;
     let embedsUpToIndex: number = 0;
+    let previousOp: 'retain' | 'insert' | 'delete' | undefined;
+    let editorStartPos: number = 0;
     for (const op of modelDelta.ops) {
-      let cloneOp: DeltaOperation | undefined = cloneDeep(op);
-      const editorStartPos: number = curIndex + embedsUpToIndex;
+      let cloneOp: DeltaOperation = cloneDeep(op);
+      editorStartPos = curIndex + embedsUpToIndex;
       if (cloneOp.retain != null) {
         // editorStartPos must be the current index plus the number of embeds previous
-        const embedsInRange: number = this.calculateEmbedsInTextRange(editorStartPos, cloneOp.retain);
-        embedsUpToIndex += embedsInRange;
+        const editorRange: EditorRange = this.getEditorContentRange(editorStartPos, cloneOp.retain);
+        embedsUpToIndex += editorRange.embedsWithinRange;
         curIndex += cloneOp.retain;
-        // add to the retain op the number of embedded elements contained in its content
-        cloneOp.retain += embedsInRange;
-      } else if (cloneOp.delete != null) {
-        const embedsInRange: number = this.calculateEmbedsInTextRange(editorStartPos, cloneOp.delete);
-        curIndex += cloneOp.delete;
-        embedsUpToIndex += embedsInRange;
-        // add to the delete op the number of embedded elements contained in its content
-        cloneOp.delete += embedsInRange;
-        if (cloneOp.delete < 1) {
-          cloneOp = undefined;
+        // remove any embeds subsequent to the previous insert so they can be redrawn
+        if (editorRange.leadingEmbedCount > 0 && editorStartPos > 0 && previousOp === 'insert') {
+          (adjustedDelta as any).push({ delete: editorRange.leadingEmbedCount } as DeltaOperation);
         }
+        // add to the retain op the number of embedded elements contained in its content
+        cloneOp.retain += editorRange.embedsWithinRange - editorRange.leadingEmbedCount;
+        previousOp = 'retain';
+      } else if (cloneOp.delete != null) {
+        const editorRange: EditorRange = this.getEditorContentRange(editorStartPos, cloneOp.delete);
+        curIndex += cloneOp.delete;
+        embedsUpToIndex += editorRange.embedsWithinRange;
+        // add to the delete op the number of embedded elements contained in its content
+        cloneOp.delete += editorRange.embedsWithinRange;
+        if (cloneOp.delete < 1) {
+          continue;
+        }
+        previousOp = 'delete';
       } else if (cloneOp.insert != null) {
         cloneOp.attributes = this.getAttributesAtPosition(editorStartPos);
+        previousOp = 'insert';
       }
+      (adjustedDelta as any).push(cloneOp);
+    }
 
-      if (cloneOp != null) {
-        (adjustedDelta as any).push(cloneOp);
-      }
+    editorStartPos = curIndex + embedsUpToIndex;
+    // remove any embeds subsequent the previous insert so they can be redrawn
+    const embedsAfterLastEdit = this.countEmbedsAtPosition(editorStartPos);
+    if (embedsAfterLastEdit > 0 && previousOp === 'insert') {
+      (adjustedDelta as any).push({ delete: embedsAfterLastEdit } as DeltaOperation);
     }
 
     return adjustedDelta;
@@ -703,14 +744,6 @@ export class TextViewModel {
       }
     }
     return embeddedElementsCount;
-  }
-
-  /** Get the number of embeds displayed in the quill editor for a given range of text data. */
-  private calculateEmbedsInTextRange(editorStartPos: number, length: number): number {
-    const editorEndPos: number = this.getEditorPositionPlusTextPosition(editorStartPos, length);
-    const lengthWithEmbeds: number = editorEndPos - editorStartPos;
-    const embedCount: number = lengthWithEmbeds - length;
-    return embedCount;
   }
 
   private getAttributesAtPosition(editorPosition: number) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -392,6 +392,10 @@ export class TextViewModel {
       }
       resultingEditorPos++;
     }
+    // if the position ends on an embed, include it in the final editor position i.e. make this greedy
+    while (embedEditorPositions.includes(resultingEditorPos)) {
+      resultingEditorPos++;
+    }
     return resultingEditorPos;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -137,7 +137,7 @@ export class TextViewModel {
     if (subscribeToUpdates) {
       this.remoteChangesSub = this.textDoc.remoteChanges$.subscribe(ops => {
         const deltaWithEmbeds: DeltaStatic = this.addEmbeddedElementsToDelta(ops as DeltaStatic);
-        editor.updateContents(deltaWithEmbeds);
+        editor.updateContents(deltaWithEmbeds, 'api');
       });
     }
     this.onCreateSub = this.textDoc.create$.subscribe(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -74,6 +74,12 @@ export interface FeaturedVerseRefInfo {
   highlight?: boolean;
 }
 
+/** Information about an embed and its associated formatting. */
+export interface EmbedFormat {
+  id: string;
+  formatLength: number;
+}
+
 /** View of an editable text document. Used for displaying Scripture. */
 @Component({
   selector: 'app-text',
@@ -612,18 +618,24 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     }
   }
 
-  removeEmbeddedElements(embedIdsWithLength?: [string, number][]): void {
+  /** Remove embedded elements that are not part of the text data. This may be necessary to preserve the cursor
+   * location when switching between texts. This is also helpful if a particular embed needs to be redrawn.
+   * @param embedFormats An array of the ids and format lengths for each embed to remove. The embed is removed
+   * along with the corresponding length for formatting associated with the embed.
+   * Set to undefined to remove all embeds.
+   */
+  removeEmbeddedElements(embedFormats?: EmbedFormat[]): void {
     if (this.editor == null) {
       return;
     }
     let embedIndicesWithLength: [number, number][] = [];
-    if (embedIdsWithLength == null) {
+    if (embedFormats == null) {
       embedIndicesWithLength = Array.from(this.viewModel.embeddedElements.values()).map(e => [e, 0]);
     } else {
-      for (const [embedId, length] of embedIdsWithLength) {
-        const index: number | undefined = this.viewModel.embeddedElements.get(embedId);
+      for (const embed of embedFormats) {
+        const index: number | undefined = this.viewModel.embeddedElements.get(embed.id);
         if (index != null) {
-          embedIndicesWithLength.push([index, length]);
+          embedIndicesWithLength.push([index, embed.formatLength]);
         }
       }
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -484,7 +484,8 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     return segments;
   }
 
-  /** Embeds an element, with the specified format, into the editor, at the editor position that corresponds to
+  /**
+   * Embeds an element, with the specified format, into the editor, at an editor position that corresponds to
    * the beginning of textAnchor.
    */
   embedElementInline(
@@ -544,15 +545,12 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       editorPosOfSegmentToModify.index,
       startTextPosInVerse
     );
-    const embedInsertPos: number = editorRange.endEditorPosition + editorRange.trailingEmbedCount;
+    const embedInsertPos: number =
+      editorRange.startEditorPosition + editorRange.editorLength + editorRange.trailingEmbedCount;
 
     this.editor.insertEmbed(embedInsertPos, formatName, format, 'api');
-    const endPosition: number = this.viewModel.getEditorContentRange(
-      embedInsertPos,
-      textAnchor.length
-    ).endEditorPosition;
-    // add one to include the embed to underline
-    const formatLength: number = endPosition - embedInsertPos;
+    const textAnchorRange = this.viewModel.getEditorContentRange(embedInsertPos, textAnchor.length);
+    const formatLength: number = textAnchorRange.editorLength;
     this.editor.formatText(embedInsertPos, formatLength, 'text-anchor', 'true', 'api');
     this.updateSegment();
     return embedSegmentRef;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -67,7 +67,7 @@
                 $event.isLocalUpdate
               )
             "
-            (loaded)="onTextLoaded('target', $event)"
+            (loaded)="onTextLoaded('target')"
             (focused)="targetFocused = $event"
             [highlightSegment]="targetFocused"
             [markInvalid]="true"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -67,7 +67,7 @@
                 $event.isLocalUpdate
               )
             "
-            (loaded)="onTextLoaded('target')"
+            (loaded)="onTextLoaded('target', $event)"
             (focused)="targetFocused = $event"
             [highlightSegment]="targetFocused"
             [markInvalid]="true"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2699,6 +2699,7 @@ class TestEnvironment {
   }
 
   dispose(): void {
+    this.wait();
     this.component.metricsSession!.dispose();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1227,8 +1227,8 @@ describe('EditorComponent', () => {
       env.wait();
 
       const note7Position = env.getNoteThreadEditorPosition('thread07');
-      const adjacentNoteLength = 1;
-      expect(note7Position).toEqual(env.component.target!.getSegmentRange('verse_1_4/p_1')!.index + adjacentNoteLength);
+      const note4EmbedLength = 1;
+      expect(note7Position).toEqual(env.component.target!.getSegmentRange('verse_1_4/p_1')!.index + note4EmbedLength);
       env.dispose();
     }));
 
@@ -1777,11 +1777,11 @@ describe('EditorComponent', () => {
       env.wait();
 
       const noteThread1Doc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread01');
-      const noteThread3Doc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread04');
+      const noteThread4Doc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread04');
       const originalNoteThread1TextPos: TextAnchor = noteThread1Doc.data!.position;
-      const originalNoteThread3TextPos: TextAnchor = noteThread3Doc.data!.position;
+      const originalNoteThread4TextPos: TextAnchor = noteThread4Doc.data!.position;
       expect(originalNoteThread1TextPos).toEqual({ start: 8, length: 9 });
-      expect(originalNoteThread3TextPos).toEqual({ start: 20, length: 5 });
+      expect(originalNoteThread4TextPos).toEqual({ start: 20, length: 5 });
 
       // simulate text changes at current segment
       let notePosition: number = env.getNoteThreadEditorPosition('thread04');
@@ -1804,7 +1804,7 @@ describe('EditorComponent', () => {
       // SUT 1
       env.wait();
       expect(env.component.target!.getSegmentText('verse_1_3')).toEqual('target: chapter 1, v' + insert + 'erse 3.');
-      expect(noteThread3Doc.data!.position).toEqual(originalNoteThread3TextPos);
+      expect(noteThread4Doc.data!.position).toEqual(originalNoteThread4TextPos);
 
       // simulate text changes at a different segment
       notePosition = env.getNoteThreadEditorPosition('thread01');
@@ -1820,6 +1820,7 @@ describe('EditorComponent', () => {
       env.wait();
       expect(env.component.target!.getSegmentText('verse_1_1')).toEqual('target: c' + insert + 'hapter 1, verse 1.');
       expect(noteThread1Doc.data!.position).toEqual(originalNoteThread1TextPos);
+      expect(noteThread4Doc.data!.position).toEqual(originalNoteThread4TextPos);
 
       // simulate text changes just before a note embed
       remoteEditPositionAfterNote = -1;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1209,12 +1209,12 @@ describe('EditorComponent', () => {
       expect(contents.ops![1].insert).toEqual({ note: { caller: '*' } });
       const note2Position = env.getNoteThreadEditorPosition('thread02');
       expect(range.index).toEqual(note2Position);
-      const noteThreadDoc4 = env.getNoteThreadDoc('project01', 'thread04');
-      const noteThread4StartPosition = 20;
-      expect(noteThreadDoc4.data!.position).toEqual({ start: noteThread4StartPosition, length: 5 });
-      const note4Position = env.getNoteThreadEditorPosition('thread04');
+      const noteThreadDoc3 = env.getNoteThreadDoc('project01', 'thread03');
+      const noteThread3StartPosition = 20;
+      expect(noteThreadDoc3.data!.position).toEqual({ start: noteThread3StartPosition, length: 7 });
+      const note3Position = env.getNoteThreadEditorPosition('thread03');
       // plus 1 for the note icon embed at the beginning of the verse
-      expect(range.index + noteThread4StartPosition + 1).toEqual(note4Position);
+      expect(range.index + noteThread3StartPosition + 1).toEqual(note3Position);
       env.dispose();
     }));
 
@@ -1226,8 +1226,9 @@ describe('EditorComponent', () => {
       env.setProjectUserConfig();
       env.wait();
 
-      const index = env.getNoteThreadEditorPosition('thread07');
-      expect(index).toEqual(env.component.target!.getSegmentRange('verse_1_4/p_1')!.index);
+      const note7Position = env.getNoteThreadEditorPosition('thread07');
+      const adjacentNoteLength = 1;
+      expect(note7Position).toEqual(env.component.target!.getSegmentRange('verse_1_4/p_1')!.index + adjacentNoteLength);
       env.dispose();
     }));
 
@@ -1559,37 +1560,37 @@ describe('EditorComponent', () => {
       env.setProjectUserConfig({ selectedBookNum: 40, selectedChapterNum: 1, selectedSegment: 'verse_1_1' });
       env.wait();
 
-      const thread4Doc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread04');
+      const thread3Doc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread03');
       const thread3AnchorLength = 7;
       const thread4AnchorLength = 5;
-      expect(thread4Doc.data!.position).toEqual({ start: 20, length: thread4AnchorLength });
-      const otherNoteThreadDoc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread03');
-      expect(otherNoteThreadDoc.data!.position).toEqual({ start: 20, length: thread3AnchorLength });
+      expect(thread3Doc.data!.position).toEqual({ start: 20, length: thread3AnchorLength });
+      const otherNoteThreadDoc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread04');
+      expect(otherNoteThreadDoc.data!.position).toEqual({ start: 20, length: thread4AnchorLength });
       const verseNoteThreadDoc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread02');
       expect(verseNoteThreadDoc.data!.position).toEqual({ start: 0, length: 0 });
       // edit before paratext note
-      let thread4Position = env.getNoteThreadEditorPosition('thread04');
-      env.targetEditor.setSelection(thread4Position, 0, 'user');
+      let thread3Position = env.getNoteThreadEditorPosition('thread03');
+      env.targetEditor.setSelection(thread3Position, 0, 'user');
       env.wait();
       const textBeforeNote = 'add text before ';
       const length1 = textBeforeNote.length;
       env.typeCharacters(textBeforeNote);
-      expect(thread4Doc.data!.position).toEqual({ start: 20 + length1, length: thread4AnchorLength });
-      expect(otherNoteThreadDoc.data!.position).toEqual({ start: 20 + length1, length: thread3AnchorLength });
+      expect(thread3Doc.data!.position).toEqual({ start: 20 + length1, length: thread3AnchorLength });
+      expect(otherNoteThreadDoc.data!.position).toEqual({ start: 20 + length1, length: thread4AnchorLength });
 
       // edit within note selection start
-      thread4Position = env.getNoteThreadEditorPosition('thread04');
-      env.targetEditor.setSelection(thread4Position + 1, 0, 'user');
+      thread3Position = env.getNoteThreadEditorPosition('thread03');
+      env.targetEditor.setSelection(thread3Position + 1, 0, 'user');
       env.wait();
       const textWithinNote = 'edit within note ';
       const length2 = textWithinNote.length;
       env.typeCharacters(textWithinNote);
       env.wait();
       let lengthChange: number = length2;
-      expect(thread4Doc.data!.position).toEqual({ start: 20 + length1, length: thread4AnchorLength + lengthChange });
+      expect(thread3Doc.data!.position).toEqual({ start: 20 + length1, length: thread3AnchorLength + lengthChange });
       expect(otherNoteThreadDoc.data!.position).toEqual({
         start: 20 + length1,
-        length: thread3AnchorLength + lengthChange
+        length: thread4AnchorLength + lengthChange
       });
 
       // edit within note selection end
@@ -1600,35 +1601,35 @@ describe('EditorComponent', () => {
       env.targetEditor.setSelection(editorPosImmediatelyFollowingThread4Anchoring, 0, 'user');
       env.typeCharacters(textWithinNote);
       lengthChange += length2;
-      expect(thread4Doc.data!.position).toEqual({ start: 20 + length1, length: thread4AnchorLength + lengthChange });
+      expect(thread3Doc.data!.position).toEqual({ start: 20 + length1, length: thread3AnchorLength + lengthChange });
       expect(otherNoteThreadDoc.data!.position).toEqual({
         start: 20 + length1,
-        length: thread3AnchorLength + lengthChange
+        length: thread4AnchorLength + lengthChange
       });
 
       // delete text within note selection
-      thread4Position = env.getNoteThreadEditorPosition('thread04');
+      thread3Position = env.getNoteThreadEditorPosition('thread03');
       const deleteLength = 5;
       const lengthAfterNote = 2;
-      env.targetEditor.setSelection(thread4Position + lengthAfterNote, deleteLength, 'user');
+      env.targetEditor.setSelection(thread3Position + lengthAfterNote, deleteLength, 'user');
       env.wait();
       env.typeCharacters('');
       lengthChange -= deleteLength;
-      expect(thread4Doc.data!.position).toEqual({ start: 20 + length1, length: thread4AnchorLength + lengthChange });
+      expect(thread3Doc.data!.position).toEqual({ start: 20 + length1, length: thread3AnchorLength + lengthChange });
       expect(otherNoteThreadDoc.data!.position).toEqual({
         start: 20 + length1,
-        length: thread3AnchorLength + lengthChange
+        length: thread4AnchorLength + lengthChange
       });
       // the verse note thread position never changes
       expect(verseNoteThreadDoc.data!.position).toEqual({ start: 0, length: 0 });
 
       // delete text at the end of a note anchor
-      const thread3IconLength = 1;
-      const lastTextAnchorPosition: number = thread4Position + thread3IconLength + thread4AnchorLength + lengthChange;
+      const thread4IconLength = 1;
+      const lastTextAnchorPosition: number = thread3Position + thread4IconLength + thread3AnchorLength + lengthChange;
       env.targetEditor.setSelection(lastTextAnchorPosition, 1, 'user');
       env.deleteCharacters();
       lengthChange--;
-      expect(thread4Doc.data!.position).toEqual({ start: 20 + length1, length: thread4AnchorLength + lengthChange });
+      expect(thread3Doc.data!.position).toEqual({ start: 20 + length1, length: thread3AnchorLength + lengthChange });
       env.dispose();
     }));
 
@@ -1763,9 +1764,9 @@ describe('EditorComponent', () => {
       const verse3Index: number = env.component.target!.getSegmentRange('verse_1_3')!.index;
       // The note is re-embedded at the position in the note thread doc.
       // Applying remote changes must not affect text anchors
-      let notesBefore: number = 2;
+      let notesBefore: number = 1;
       expect(env.getNoteThreadEditorPosition('thread03')).toEqual(verse3Index + originalNotePosInVerse + notesBefore);
-      notesBefore = 1;
+      notesBefore = 2;
       expect(env.getNoteThreadEditorPosition('thread04')).toEqual(verse3Index + originalNotePosInVerse + notesBefore);
       env.dispose();
     }));
@@ -1776,14 +1777,14 @@ describe('EditorComponent', () => {
       env.wait();
 
       const noteThread1Doc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread01');
-      const noteThread3Doc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread03');
+      const noteThread3Doc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread04');
       const originalNoteThread1TextPos: TextAnchor = noteThread1Doc.data!.position;
       const originalNoteThread3TextPos: TextAnchor = noteThread3Doc.data!.position;
       expect(originalNoteThread1TextPos).toEqual({ start: 8, length: 9 });
-      expect(originalNoteThread3TextPos).toEqual({ start: 20, length: 7 });
+      expect(originalNoteThread3TextPos).toEqual({ start: 20, length: 5 });
 
       // simulate text changes at current segment
-      let notePosition: number = env.getNoteThreadEditorPosition('thread03');
+      let notePosition: number = env.getNoteThreadEditorPosition('thread04');
       let remoteEditPositionAfterNote: number = 1;
       // 1 note in verse 1, and 3 in verse 3
       let noteCountBeforePosition: number = 4;
@@ -1794,16 +1795,15 @@ describe('EditorComponent', () => {
         noteCountBeforePosition
       );
       env.targetEditor.setSelection(notePosition + remoteEditPositionAfterNote);
-
-      const inSegmentDelta = new Delta();
-      (inSegmentDelta as any).push({ retain: remoteEditTextPos } as DeltaOperation);
-      (inSegmentDelta as any).push({ insert: 'abc' } as DeltaOperation);
+      let insert = 'abc';
+      let deltaOps: DeltaOperation[] = [{ retain: remoteEditTextPos }, { insert: insert }];
+      const inSegmentDelta = new Delta(deltaOps);
       const textDoc: TextDoc = env.getTextDoc(new TextDocId('project01', 40, 1));
       textDoc.submit(inSegmentDelta);
 
       // SUT 1
       env.wait();
-      expect(env.component.target!.getSegmentText('verse_1_3')).toEqual('target: chapter 1, v' + 'abc' + 'erse 3.');
+      expect(env.component.target!.getSegmentText('verse_1_3')).toEqual('target: chapter 1, v' + insert + 'erse 3.');
       expect(noteThread3Doc.data!.position).toEqual(originalNoteThread3TextPos);
 
       // simulate text changes at a different segment
@@ -1811,9 +1811,9 @@ describe('EditorComponent', () => {
       noteCountBeforePosition = 1;
       // target: $c|hapter 1, verse 1.
       remoteEditTextPos = env.getRemoteEditPosition(notePosition, remoteEditPositionAfterNote, noteCountBeforePosition);
-      const outOfSegmentDelta = new Delta();
-      (outOfSegmentDelta as any).push({ retain: remoteEditTextPos });
-      (outOfSegmentDelta as any).push({ insert: 'def' });
+      insert = 'def';
+      deltaOps = [{ retain: remoteEditTextPos }, { insert: insert }];
+      const outOfSegmentDelta = new Delta(deltaOps);
       textDoc.submit(outOfSegmentDelta);
 
       // SUT 2
@@ -1907,7 +1907,7 @@ describe('EditorComponent', () => {
       const note4Position: number = env.getNoteThreadEditorPosition('thread04');
       deleteLength = 6;
       // $target: chapter 1|->, $$ve<-|rse 3.
-      env.targetEditor.setSelection(note4Position - beforeNoteLength, deleteLength, 'api');
+      env.targetEditor.setSelection(note3Position - beforeNoteLength, deleteLength, 'api');
       env.deleteCharacters();
       newNotePosition = env.getNoteThreadEditorPosition('thread03');
       expect(newNotePosition).toEqual(note3Position - beforeNoteLength);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -43,7 +43,7 @@ import { NoteThreadDoc } from '../../core/models/note-thread-doc';
 import { SFProjectDoc } from '../../core/models/sf-project-doc';
 import { SF_DEFAULT_TRANSLATE_SHARE_ROLE } from '../../core/models/sf-project-role-info';
 import { SFProjectUserConfigDoc } from '../../core/models/sf-project-user-config-doc';
-import { Delta } from '../../core/models/text-doc';
+import { Delta, TextDoc } from '../../core/models/text-doc';
 import { TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
@@ -105,6 +105,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   private lastShownSuggestions: Suggestion[] = [];
   private readonly segmentUpdated$: Subject<void>;
   private trainingSub?: Subscription;
+  private remoteChangeSub?: Subscription;
   private projectDataChangesSub?: Subscription;
   private trainingProgressClosed: boolean = false;
   private trainingCompletedTimeout: any;
@@ -412,6 +413,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     if (this.projectDataChangesSub != null) {
       this.projectDataChangesSub.unsubscribe();
     }
+    if (this.remoteChangeSub != null) {
+      this.remoteChangeSub.unsubscribe();
+    }
     if (this.metricsSession != null) {
       this.metricsSession.dispose();
     }
@@ -533,7 +537,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
   }
 
-  onTextLoaded(textType: TextType): void {
+  onTextLoaded(textType: TextType, textDoc?: TextDoc): void {
     switch (textType) {
       case 'source':
         this.sourceLoaded = true;
@@ -542,6 +546,12 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         this.targetLoaded = true;
         this.toggleNoteThreadVerseRefs$.next();
         this.shouldNoteThreadsRespondToEdits = true;
+        this.remoteChangeSub?.unsubscribe();
+        if (textDoc != null) {
+          this.remoteChangeSub = this.subscribe(textDoc.remoteChanges$, ops =>
+            Promise.resolve().then(() => this.refreshNoteEmbedPositions(ops as DeltaStatic))
+          );
+        }
         break;
     }
     if ((!this.hasSource || this.sourceLoaded) && this.targetLoaded) {
@@ -1265,6 +1275,38 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         nt.data.verseRef.chapterNum === this.chapter &&
         nt.data.notes.length > 0
     );
+  }
+
+  private refreshNoteEmbedPositions(delta: DeltaStatic): void {
+    if (delta.ops == null || this.target == null || this.noteThreadQuery?.docs == null) {
+      return;
+    }
+
+    const embedsToRefresh: string[] = [];
+    let insertLength: number = 0;
+    for (const op of delta.ops) {
+      let insertionPos = 0;
+      if (op.retain != null) {
+        insertionPos = op.retain;
+        // Find all embeds that exist at the insertion point
+        for (const [embedId, pos] of this.target.embeddedElements.entries()) {
+          if (insertionPos > pos) {
+            // an embed exists before the insertion position, so the true position of the insertion is incremented
+          } else if (insertionPos == pos) {
+            embedsToRefresh.push(embedId);
+          } else {
+            break;
+          }
+          insertionPos++;
+        }
+      } else if (op.insert != null) {
+        insertLength = typeof op.insert === 'string' ? op.insert.length : 1;
+      }
+    }
+    // remove and redraw embeds only if the remote user has inserted something
+    if (insertLength > 0) {
+      this.target.removeEmbeddedElements(embedsToRefresh.map(e => [e, insertLength]));
+    }
   }
 
   /** Re-create any note embeds that have been deleted by the user. */


### PR DESCRIPTION
Previously when a user inserts text, remote users see the text update in real-time. Unfortunately, if text is inserted just after a note embed, remote users see the text inserted immediately before the note embed. The first commit changes the behaviour so that remote edits will always be inserted after the note icon if the edit occurs right at the icon's position. The second change listens the the textDoc's remote changes observable, and redraws the note icon based on the note thread's position data. It would be ideal to review the 2 commits separately.
The majority of the first change makes adjustments to the spec, where thread03 used to follow thread04. Because of this change, now thread04 follows thread03.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1206)
<!-- Reviewable:end -->
