### PR TITLE
SF-1456 Remove excessive space in import question dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
@@ -157,13 +157,13 @@
     </div>
 
     <div *ngIf="status === 'filter'" class="dialog-content-footer">
-      <mat-error [class.hidden]="!(importClicked && selectedCount < 1)">
+      <mat-error *ngIf="importClicked && selectedCount < 1">
         {{ t("select_questions") }}
       </mat-error>
-      <div *ngIf="questionSource === 'transcelerator'" [class.hidden]="!showDuplicateImportNote">
+      <div *ngIf="showDuplicateImportNote && questionSource === 'transcelerator'">
         {{ t("transcelerator_some_questions_already_imported") }}
       </div>
-      <div *ngIf="questionSource === 'csv_file'" [class.hidden]="!showDuplicateImportNote">
+      <div *ngIf="showDuplicateImportNote && questionSource === 'csv_file'">
         {{ t("csv_questions_duplicates") }}
       </div>
     </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.scss
@@ -136,10 +136,6 @@ mdc-text-field ::ng-deep {
   white-space: initial;
 }
 
-.hidden {
-  visibility: hidden;
-}
-
 .mat-error {
   margin-top: 10px;
   font-size: 14px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
@@ -249,14 +249,14 @@ describe('ImportQuestionsDialogComponent', () => {
   it('should show validation error when form is submitted with no questions selected', fakeAsync(() => {
     const env = new TestEnvironment();
     env.click(env.importFromTransceleratorButton);
-    expect(env.noQuestionsError.classList).toContain('hidden');
+    expect(env.errorMessages).toEqual([]);
     env.click(env.importSelectedQuestionsButton);
-    expect(env.noQuestionsError.classList).not.toContain('hidden');
+    expect(env.errorMessages).toEqual(['Select questions to import']);
 
     env.selectQuestion(env.questionRows[1]);
-    expect(env.noQuestionsError.classList).toContain('hidden');
+    expect(env.errorMessages).toEqual([]);
     env.selectQuestion(env.questionRows[1]);
-    expect(env.noQuestionsError.classList).not.toContain('hidden');
+    expect(env.errorMessages).toEqual(['Select questions to import']);
 
     // Make valid and cleanup dialog
     env.selectQuestion(env.questionRows[1]);
@@ -524,8 +524,10 @@ class TestEnvironment {
     return this.dialogContentBody.textContent || '';
   }
 
-  get noQuestionsError(): HTMLElement {
-    return this.overlayContainerElement.querySelector('mat-error') as HTMLElement;
+  get errorMessages(): string[] {
+    return Array.from(this.overlayContainerElement.querySelectorAll('mat-error')).map(node =>
+      (node.textContent || '').trim()
+    );
   }
 
   get importSelectedQuestionsButton(): HTMLButtonElement {


### PR DESCRIPTION
There are several possible messages that can be shown at the bottom of the import questions dialog. Originally they were styled `visibility: hidden` until shown so the layout would not change at all once they were revealed. However, this is not great on mobile where screen space is very limited. For that reason this PR changes from using `visibility: hidden` to using `*ngIf`. This required changes to the tests. The changes to the UI are shown in the screenshots below. It is assumed at least one of the questions has already been imported (otherwise this message wouldn't show at all).
 
Description | Before this change | After this change
------------|--------------------|------------------
Initial dialog screen | ![](https://user-images.githubusercontent.com/6140710/145847414-7e7f825a-cb38-46a2-b4b4-0861132caa50.png) | ![](https://user-images.githubusercontent.com/6140710/145847525-f9c2f66b-0d5a-4fce-8fae-b04305b88ca1.png)
After selecting questions | ![](https://user-images.githubusercontent.com/6140710/145847670-3f952ec4-2856-489f-8599-72ecbe33ddbd.png) | ![](https://user-images.githubusercontent.com/6140710/145847708-6fae5c3b-a4e1-4a92-b981-fbc8ce814f5c.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1208)
<!-- Reviewable:end -->
