### PR TITLE
SF-1451 Fix exception when import dialog is opened offline

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
@@ -28,10 +28,16 @@
               </ol>
             </mat-card-content>
             <mat-card-actions>
-              <button mat-flat-button color="primary" (click)="importFromTranscelerator()">
+              <button
+                mat-flat-button
+                color="primary"
+                (click)="importFromTranscelerator()"
+                [disabled]="showTransceleratorOfflineMsg"
+              >
                 {{ t("import_from_transcelerator") }}
               </button>
               <a mat-button [href]="urls.transceleratorImportHelpPage" target="_blank">{{ t("learn_more") }}</a>
+              <mat-error *ngIf="showTransceleratorOfflineMsg">{{ t("no_transcelerator_offline") }}</mat-error>
             </mat-card-actions>
           </mat-card>
           <mat-card>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.scss
@@ -63,6 +63,10 @@
       padding: 0 0.5em;
     }
   }
+
+  mat-error {
+    display: block;
+  }
 }
 
 .support-message {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -117,6 +117,7 @@
     "loading": "Loading...",
     "must_be_valid_reference": "Must be a valid reference",
     "no_questions_available": "There are no questions for the books in this project.",
+    "no_transcelerator_offline": "Importing from Transcelerator is not available offline.",
     "question_for_verse": "Question for verse {{ number }}",
     "question": "Question",
     "reference_from": "Reference from",


### PR DESCRIPTION
In order to import Transcelerator questions a request needs to be sent to the back end. If offline, that causes an error (`Error invoking transceleratorQuestions: Http failure response for command-api/projects`).

Here's how it looks now:

![](https://user-images.githubusercontent.com/6140710/146074568-79b1feec-c21f-4caf-a7dc-b726110fd82e.png)

This PR prevents such requests if we're known to be offline. That part was pretty simple. The tests required some significant changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1209)
<!-- Reviewable:end -->
