### PR TITLE
SF-1430 - Note icon does not change into default flag icon in SF if note icon deleted in PT

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/note.ts
+++ b/src/RealtimeServer/scriptureforge/models/note.ts
@@ -3,7 +3,7 @@ import { NoteStatus } from './note-thread';
 
 export interface Note extends Comment {
   threadId: string;
-  content: string;
+  content?: string;
   extUserId: string;
   deleted: boolean;
   tagIcon?: string;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
@@ -21,7 +21,7 @@ export class NoteThreadDoc extends ProjectDataDoc<NoteThread> {
   }
 
   get iconResolved(): NoteThreadIcon {
-    let iconTag = this.getResolvedTag(this.getTag());
+    const iconTag = this.getResolvedTag(this.getTag());
     return this.iconProperties(iconTag);
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
@@ -21,11 +21,16 @@ export class NoteThreadDoc extends ProjectDataDoc<NoteThread> {
   }
 
   get iconResolved(): NoteThreadIcon {
-    let iconTag = this.getTag();
-    if (iconTag !== '') {
-      // Resolved tags use 5 in the filename instead of the current number suffix
-      iconTag = iconTag.slice(0, iconTag.length - 1) + '5';
-    }
+    let iconTag = this.getResolvedTag(this.getTag());
+    return this.iconProperties(iconTag);
+  }
+
+  getNoteIcon(note: Note): NoteThreadIcon {
+    return this.iconProperties(note.tagIcon ? note.tagIcon : '');
+  }
+
+  getNoteResolvedIcon(note: Note): NoteThreadIcon {
+    const iconTag = this.getResolvedTag(note.tagIcon ? note.tagIcon : '');
     return this.iconProperties(iconTag);
   }
 
@@ -43,7 +48,18 @@ export class NoteThreadDoc extends ProjectDataDoc<NoteThread> {
     return iconTag;
   }
 
+  private getResolvedTag(iconTag: string = ''): string {
+    if (iconTag !== '') {
+      // Resolved tags use 5 in the filename instead of the current number suffix
+      iconTag = iconTag.slice(0, iconTag.length - 1) + '5';
+    }
+    return iconTag;
+  }
+
   private iconProperties(iconTag: string): NoteThreadIcon {
+    if (iconTag === '') {
+      return { cssVar: '', url: '' };
+    }
     const iconUrl = `/assets/icons/TagIcons/${iconTag}.png`;
     return { cssVar: `--icon-file: url(${iconUrl});`, url: iconUrl };
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -976,7 +976,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     const notes: Note[] = clone(threadDoc.data!.notes).sort(
       (a, b) => Date.parse(a.dateCreated) - Date.parse(b.dateCreated)
     );
-    let preview: string = this.stripXml(notes[0].content.trim());
+    let preview: string = notes[0].content != null ? this.stripXml(notes[0].content.trim()) : '';
     if (notes.length > 1) {
       preview += '\n' + translate('editor.more_notes', { count: notes.length - 1 });
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -66,7 +66,7 @@ describe('NoteDialogComponent', () => {
 
   it('should style notes', fakeAsync(() => {
     env = new TestEnvironment();
-    const tests: { text: string; expected: string }[] = [
+    const tests: { text: string | undefined; expected: string }[] = [
       {
         text: 'turn <bold>text bold</bold>',
         expected: 'turn <b>text bold</b>'
@@ -82,6 +82,14 @@ describe('NoteDialogComponent', () => {
       {
         text: 'check <unknown id="anything">unknown</unknown> <italic>text</italic>',
         expected: 'check unknown <i>text</i>'
+      },
+      {
+        text: '',
+        expected: ''
+      },
+      {
+        text: undefined,
+        expected: ''
       }
     ];
     tests.forEach(test => {
@@ -98,24 +106,34 @@ describe('NoteDialogComponent', () => {
     env = new TestEnvironment();
 
     // To do
-    expect(env.notes[0].nativeElement.querySelector('img').getAttribute('src')).toEqual(
-      '/assets/icons/TagIcons/flag02.png'
-    );
-    expect(env.notes[0].nativeElement.querySelector('img').getAttribute('title')).toEqual('To do');
+    expect(env.notes[0].nativeElement.querySelector('img').getAttribute('src'))
+      .withContext('[n0] to do - src')
+      .toEqual('/assets/icons/TagIcons/flag02.png');
+    expect(env.notes[0].nativeElement.querySelector('img').getAttribute('title'))
+      .withContext('[n0] to do - title')
+      .toEqual('To do');
 
     // Resolved
-    expect(env.notes[1].nativeElement.querySelector('img').getAttribute('src')).toEqual(
-      '/assets/icons/TagIcons/flag05.png'
-    );
-    expect(env.notes[1].nativeElement.querySelector('img').getAttribute('title')).toEqual('Resolved');
-    expect(env.notes[3].nativeElement.querySelector('img').getAttribute('src')).toEqual(
-      '/assets/icons/TagIcons/flag05.png'
-    );
-    expect(env.notes[3].nativeElement.querySelector('img').getAttribute('title')).toEqual('Resolved');
+    expect(env.notes[1].nativeElement.querySelector('img').getAttribute('src'))
+      .withContext('[n1] resolved - src')
+      .toEqual('/assets/icons/TagIcons/flag05.png');
+    expect(env.notes[1].nativeElement.querySelector('img').getAttribute('title'))
+      .withContext('[n1] resolved - title')
+      .toEqual('Resolved');
+    expect(env.notes[3].nativeElement.querySelector('img').getAttribute('src'))
+      .withContext('[n3] resolved - src')
+      .toEqual('/assets/icons/TagIcons/flag05.png');
+    expect(env.notes[3].nativeElement.querySelector('img').getAttribute('title'))
+      .withContext('[n3] resolved - title')
+      .toEqual('Resolved');
 
     // Blank/unspecified
-    expect(env.notes[2].nativeElement.querySelector('img').getAttribute('src')).toEqual('');
-    expect(env.notes[2].nativeElement.querySelector('img').getAttribute('title')).toEqual('');
+    expect(env.notes[2].nativeElement.querySelector('img').getAttribute('src'))
+      .withContext('[n2] blank - src')
+      .toEqual('');
+    expect(env.notes[2].nativeElement.querySelector('img').getAttribute('title'))
+      .withContext('[n2] blank - title')
+      .toEqual('');
   }));
 
   it('should gracefully return when data not ready', fakeAsync(() => {
@@ -223,6 +241,7 @@ class TestEnvironment {
         deleted: false,
         ownerRef: 'user01',
         status: NoteStatus.Todo,
+        tagIcon: 'flag02',
         dateCreated: '',
         dateModified: ''
       },
@@ -234,6 +253,7 @@ class TestEnvironment {
         deleted: false,
         ownerRef: 'user01',
         status: NoteStatus.Resolved,
+        tagIcon: 'flag02',
         dateCreated: '',
         dateModified: ''
       },
@@ -245,6 +265,7 @@ class TestEnvironment {
         deleted: true,
         ownerRef: 'user01',
         status: NoteStatus.Todo,
+        tagIcon: 'flag02',
         dateCreated: '',
         dateModified: ''
       },
@@ -267,6 +288,7 @@ class TestEnvironment {
         deleted: false,
         ownerRef: 'user01',
         status: NoteStatus.Done,
+        tagIcon: 'flag02',
         dateCreated: '',
         dateModified: ''
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -111,13 +111,16 @@ export class NoteDialogComponent implements OnInit {
     return this.data.threadId;
   }
 
-  parseNote(content: string) {
+  parseNote(content: string | undefined) {
+    if (content == null) {
+      return '';
+    }
     const replace = new Map<RegExp, string>();
     replace.set(/<bold>(.*)<\/bold>/gim, '<b>$1</b>'); // Bold style
     replace.set(/<italic>(.*)<\/italic>/gim, '<i>$1</i>'); // Italic style
     replace.set(/<p>(.*)<\/p>/gim, '$1<br />'); // Turn paragraphs into line breaks
     replace.set(/<(?!i|b|br|\/)(.*?>)(.*?)<\/(.*?)>/gim, '$2'); // Strip out any tags that don't match the above replacements
-    replace.forEach((replacement, regEx) => (content = content.replace(regEx, replacement)));
+    replace.forEach((replacement, regEx) => (content = content!.replace(regEx, replacement)));
     return content;
   }
 
@@ -131,12 +134,12 @@ export class NoteDialogComponent implements OnInit {
     }
     switch (note.status) {
       case NoteStatus.Todo:
-        return this.threadDoc.icon.url;
+        return this.threadDoc.getNoteIcon(note).url;
       case NoteStatus.Done:
       case NoteStatus.Resolved:
-        return this.threadDoc.iconResolved.url;
+        return this.threadDoc.getNoteResolvedIcon(note).url;
     }
-    return '';
+    return this.threadDoc.getNoteIcon(note).url;
   }
 
   noteTitle(note: Note) {

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1264,16 +1264,6 @@ namespace SIL.XForge.Scripture.Services
             _hgHelper.Update(clonePath);
         }
 
-        // private CommentTag GetCommentTag(Paratext.Data.ProjectComments.CommentThread thread, CommentTags commentTags)
-        // {
-        //     Paratext.Data.ProjectComments.Comment info = thread.Comments[0];
-        //     int defaultTagId = 1;
-        //         int tagId = info.TagsAdded != null && info.TagsAdded.Length > 0
-        //             ? int.Parse(info.TagsAdded[0])
-        //             : defaultTagId;
-        //         return info.Type == NoteType.Conflict ? CommentTag.ConflictTag : commentTags.Get(tagId);
-        // }
-
         private IEnumerable<CommentThread> GetCommentThreads(UserSecret userSecret, string projectId, int bookNum)
         {
             ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), projectId);

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -774,7 +774,7 @@ namespace SIL.XForge.Scripture.Services
                     if (matchedComment != null)
                     {
                         matchedCommentIds.Add(matchedComment.Id);
-                        CommentTag commentIconTag = this.GetCommentTag(existingThread, matchedComment, commentTags);
+                        CommentTag commentIconTag = GetCommentTag(existingThread, matchedComment, commentTags);
                         ChangeType changeType = GetCommentChangeType(matchedComment, note, commentIconTag);
                         if (changeType != ChangeType.None)
                         {
@@ -1576,7 +1576,7 @@ namespace SIL.XForge.Scripture.Services
             Paratext.Data.ProjectComments.Comment comment, CommentTags commentTags)
         {
             // Use the main to do tag as default
-            CommentTag tagInUse = commentTags.Get(1);
+            CommentTag tagInUse = commentTags.Get(CommentTag.toDoTagId);
             CommentTag lastTodoTagUsed = null;
             List<Paratext.Data.ProjectComments.Comment> threadComments = thread.Comments.ToList();
             foreach (Paratext.Data.ProjectComments.Comment threadComment in threadComments)
@@ -1588,11 +1588,12 @@ namespace SIL.XForge.Scripture.Services
                 }
 
                 // When checking the tag for the thread and a conflict is found then use that
-                if (threadComment.Type == NoteType.Conflict && comment == null)
-                    return CommentTag.ConflictTag;
-
                 if (comment == null)
+                {
+                    if (threadComment.Type == NoteType.Conflict)
+                        return CommentTag.ConflictTag;
                     continue;
+                }
 
                 if (threadComment.Id == comment.Id)
                 {

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -791,7 +791,7 @@ namespace SIL.XForge.Scripture.Services
                     threadChange.Status = existingThread.Status.InternalValue;
                     threadChange.ThreadUpdated = true;
                 }
-                CommentTag defaultThreadIconTag = this.GetCommentTag(existingThread, null, commentTags);
+                CommentTag defaultThreadIconTag = GetCommentTag(existingThread, null, commentTags);
                 if (defaultThreadIconTag?.Icon != threadDoc.Data.TagIcon)
                 {
                     threadChange.TagIcon = defaultThreadIconTag?.Icon;
@@ -805,7 +805,7 @@ namespace SIL.XForge.Scripture.Services
                     Paratext.Data.ProjectComments.Comment comment =
                         existingThread.Comments.Single(c => c.Id == commentId);
                     SyncUser syncUser = FindOrCreateSyncUser(comment.User, syncUsers);
-                    CommentTag commentIconTag = this.GetCommentTag(existingThread, comment, commentTags);
+                    CommentTag commentIconTag = GetCommentTag(existingThread, comment, commentTags);
                     threadChange.AddChange(CreateNoteFromComment(
                         _guidService.NewObjectId(), comment, commentIconTag, syncUser), ChangeType.Added);
                 }
@@ -826,7 +826,7 @@ namespace SIL.XForge.Scripture.Services
             {
                 CommentThread thread = commentThreads.Single(ct => ct.Id == threadId);
                 Paratext.Data.ProjectComments.Comment info = thread.Comments[0];
-                CommentTag initialTag = this.GetCommentTag(thread, null, commentTags);
+                CommentTag initialTag = GetCommentTag(thread, null, commentTags);
                 NoteThreadChange newThread = new NoteThreadChange(threadId, info.VerseRefStr,
                     info.SelectedText, info.ContextBefore, info.ContextAfter, info.Status.InternalValue, initialTag.Icon);
                 newThread.Position = GetCommentTextAnchor(info, chapterDeltas);
@@ -834,7 +834,7 @@ namespace SIL.XForge.Scripture.Services
                 foreach (var comm in thread.Comments)
                 {
                     SyncUser syncUser = FindOrCreateSyncUser(comm.User, syncUsers);
-                    CommentTag commentIconTag = this.GetCommentTag(thread, comm, commentTags);
+                    CommentTag commentIconTag = GetCommentTag(thread, comm, commentTags);
                     newThread.AddChange(CreateNoteFromComment(_guidService.NewObjectId(), comm, commentIconTag, syncUser),
                         ChangeType.Added);
                 }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -782,9 +782,9 @@ namespace SIL.XForge.Scripture.Services
                 if (change.ThreadUpdated)
                 {
                     if (threadDoc.Data.Status != change.Status)
-                    {
                         op.Set(td => td.Status, change.Status);
-                    }
+                    if (threadDoc.Data.TagIcon != change.TagIcon)
+                        op.Set(td => td.TagIcon, change.TagIcon);
                 }
                 // Update content for updated notes
                 foreach (Note updated in change.NotesUpdated)
@@ -796,6 +796,8 @@ namespace SIL.XForge.Scripture.Services
                             op.Set(td => td.Notes[index].Content, updated.Content);
                         if (threadDoc.Data.Notes[index].Status != updated.Status)
                             op.Set(td => td.Notes[index].Status, updated.Status);
+                        if (threadDoc.Data.Notes[index].TagIcon != updated.TagIcon)
+                            op.Set(td => td.Notes[index].TagIcon, updated.TagIcon);
                     }
                     else
                     {

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1155,14 +1155,18 @@ namespace SIL.XForge.Scripture.Services
             await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
 
             NoteThread thread01 = env.GetNoteThread("project01", "thread01");
+            string expectedThreadTagIcon = "tag02";
+            string expectedNoteTagIcon = "tag03";
             string threadExpected =
-                "Context before Scripture text in project context after-Start:0-Length:0-MAT 1:1-icon1";
+                "Context before Scripture text in project context after-Start:0-Length:0-MAT 1:1-" + expectedThreadTagIcon;
             Assert.That(thread01.NoteThreadToString(), Is.EqualTo(threadExpected));
+            Assert.That(thread01.TagIcon, Is.EqualTo(expectedThreadTagIcon));
             env.DeltaUsxMapper.ReceivedWithAnyArgs(2).ToChapterDeltas(default);
             Assert.That(thread01.Notes.Count, Is.EqualTo(3));
             Assert.That(thread01.Notes[0].Content, Is.EqualTo("thread01 added."));
-            string expected = "thread01-syncuser03--thread01 added.-icon1";
+            string expected = "thread01-syncuser03--thread01 added.-" + expectedNoteTagIcon;
             Assert.That(thread01.Notes[0].NoteToString(), Is.EqualTo(expected));
+            Assert.That(thread01.Notes[0].TagIcon, Is.EqualTo(expectedNoteTagIcon));
             Assert.That(thread01.Notes[0].OwnerRef, Is.EqualTo("user03"));
             Assert.That(thread01.Notes[1].Content, Is.EqualTo("thread01 updated."));
             Assert.That(thread01.Notes[2].Deleted, Is.True);
@@ -1780,14 +1784,15 @@ namespace SIL.XForge.Scripture.Services
                 if (fromParatext)
                 {
                     var noteThreadChange = new NoteThreadChange(threadId, verseRef, $"Scripture text in project",
-                        "Context before ", " context after", NoteStatus.Todo.InternalValue);
+                        "Context before ", " context after", NoteStatus.Todo.InternalValue, "tag02");
+                    noteThreadChange.ThreadUpdated = true;
                     noteThreadChange.Position = new TextAnchor { Start = 0, Length = 0 };
                     noteThreadChange.AddChange(
                         GetNote(threadId, "n01", "syncuser01", $"{threadId} updated.", ChangeType.Updated), ChangeType.Updated);
                     noteThreadChange.AddChange(
                         GetNote(threadId, "n02", "syncuser02", $"{threadId} deleted.", ChangeType.Deleted), ChangeType.Deleted);
                     noteThreadChange.AddChange(
-                        GetNote(threadId, "n03", "syncuser03", $"{threadId} added.", ChangeType.Added), ChangeType.Added);
+                        GetNote(threadId, "n03", "syncuser03", $"{threadId} added.", ChangeType.Added, "tag03"), ChangeType.Added);
 
                     ParatextService.GetNoteThreadChanges(Arg.Any<UserSecret>(), "target", 40,
                         Arg.Any<IEnumerable<IDocument<NoteThread>>>(),
@@ -1966,7 +1971,7 @@ namespace SIL.XForge.Scripture.Services
                 return $"<usx version=\"2.5\"><book code=\"{bookId}\" style=\"id\">{paratextId}</book><content version=\"{version}\"/></usx>";
             }
 
-            private Note GetNote(string threadId, string noteId, string user, string content, ChangeType type)
+            private Note GetNote(string threadId, string noteId, string user, string content, ChangeType type, string tagIcon = null)
             {
                 return new Note
                 {
@@ -1977,7 +1982,7 @@ namespace SIL.XForge.Scripture.Services
                     Content = content,
                     DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc),
                     Deleted = type == ChangeType.Deleted,
-                    TagIcon = "icon1"
+                    TagIcon = tagIcon ?? "icon1"
                 };
             }
         }


### PR DESCRIPTION
- Check tag icon change during sync

PR addresses two points:
1. Setting the correct tag icon for a note which covers all the different statuses including resolving and reopening a thread
2. Ensuring the thread icon matches the correct tag icon (last used) in the list of notes

The end result will look similar to this:
![image](https://user-images.githubusercontent.com/17464863/146473016-3aa16233-290e-4aa9-afc5-c1175ecb2491.png)

I also changed the `Note` interface to set `content` as optional which is how the backend is treating it when saving to Mongo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1211)
<!-- Reviewable:end -->
