### PR TITLE
Improve tests by making CSV parsing mockable

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -10,11 +10,11 @@ import { first } from 'rxjs/operators';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { objectId } from 'xforge-common/utils';
-import Papa from 'papaparse';
 import { TranslocoService } from '@ngneat/transloco';
 import { I18nService } from 'xforge-common/i18n.service';
 import { ExternalUrlService } from 'xforge-common/external-url.service';
 import { PwaService } from 'xforge-common/pwa.service';
+import { CsvService } from 'xforge-common/csv-service.service';
 import { environment } from '../../../environments/environment';
 import { QuestionDoc } from '../../core/models/question-doc';
 import { TextsByBookId } from '../../core/models/texts-by-book-id';
@@ -108,6 +108,7 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable {
     private readonly mdcDialog: MdcDialog,
     private readonly pwaService: PwaService,
     private readonly zone: NgZone,
+    private readonly csvService: CsvService,
     readonly i18n: I18nService,
     readonly urls: ExternalUrlService
   ) {
@@ -381,12 +382,12 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable {
   async fileSelected(file: File) {
     this.loading = true;
 
-    const result = await new Promise<Papa.ParseResult<string[]>>(resolve => Papa.parse(file, { complete: resolve }));
+    const result = await this.csvService.parse(file);
 
     let invalidRows: string[][] = [];
     const questions: SourceQuestion[] = [];
 
-    for (const [index, row] of result.data.entries()) {
+    for (const [index, row] of result.entries()) {
       // skip rows where every cell is the empty string
       if (!row.some(cell => cell !== '')) {
         continue;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/csv-service.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/csv-service.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import Papa from 'papaparse';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CsvService {
+  parse(file: File): Promise<string[][]> {
+    return new Promise(resolve => Papa.parse(file, { complete: result => resolve(result.data as string[][]) }));
+  }
+}


### PR DESCRIPTION
One of the tests for the question import dialog couldn't use `fakeAsync` because Jasmine doesn't redefine FileReader, so reading files can't be controlled using `tick()` and `flush()` (you can `tick()` and `flush()`, but the FileReader doesn't fire its event handlers).

What I've done in this PR is pull the file parsing out into a separate service so it can be more easily mocked in the tests. Now a File object isn't actually needed in the tests, and `tick()` and `flush()` work.

I'm making this change because I'm going to need to write another test, and I couldn't figure out how to get it to work. It should be a lot easier after this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1213)
<!-- Reviewable:end -->
