### PR TITLE
Improve question import speed by using NgZone.runOutsideAngular

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
@@ -509,6 +509,7 @@ class TestEnvironment {
         this.mockedImportQuestionsConfirmationMdcDialogRef
       )
     );
+    when(mockedProjectService.createQuestion(anything(), anything(), anything(), anything())).thenResolve();
     this.fixture.detectChanges();
     if (options.fakeAsync !== false) {
       tick();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -1,5 +1,5 @@
 import { MdcDialog, MdcDialogConfig, MdcDialogRef } from '@angular-mdc/web';
-import { Component, ElementRef, Inject, ViewChild } from '@angular/core';
+import { Component, ElementRef, Inject, NgZone, ViewChild } from '@angular/core';
 import { AbstractControl, FormControl, FormGroup } from '@angular/forms';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
@@ -107,6 +107,7 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable {
     private readonly transloco: TranslocoService,
     private readonly mdcDialog: MdcDialog,
     private readonly pwaService: PwaService,
+    private readonly zone: NgZone,
     readonly i18n: I18nService,
     readonly urls: ExternalUrlService
   ) {
@@ -331,7 +332,9 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable {
           dateModified: currentDate,
           transceleratorQuestionId: listItem.question.id
         };
-        await this.projectService.createQuestion(this.data.projectId, newQuestion, undefined, undefined);
+        await this.zone.runOutsideAngular(() =>
+          this.projectService.createQuestion(this.data.projectId, newQuestion, undefined, undefined)
+        );
       } else if (this.questionsDiffer(listItem)) {
         await listItem.sfVersionOfQuestion.submitJson0Op(op =>
           op


### PR DESCRIPTION
This dramatically improves import speed, though it still gets slower over time. That should be improved in a future PR.

The total width of the chart is about 919 questions. The red line goes to about 162 questions. The two instances didn't take the same amount of time or import the same number of questions. 

![](https://user-images.githubusercontent.com/6140710/147141402-3007e1a9-f280-4a9d-9eaf-7a7c64e33965.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1214)
<!-- Reviewable:end -->
