### PR TITLE
Update note icon click subscriptions for all icons in the verse

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -672,16 +672,13 @@ export function registerScripture(): string[] {
     if (delta.ops != null) {
       for (const op of delta.ops) {
         const modelOp: DeltaOperation = cloneDeep(op);
-        let attrs = modelOp.attributes;
+        const attrs = modelOp.attributes;
         if (attrs != null && attrs['segment'] != null && attrs['highlight-segment'] == null) {
           attrs['highlight-segment'] = false;
         }
-        if (
-          modelOp.insert != null &&
-          typeof modelOp.insert === 'object' &&
-          modelOp.insert['note-thread-embed'] != null
-        ) {
-          attrs = undefined;
+        if (typeof modelOp.insert === 'object') {
+          // clear the formatting attributes on embeds to prevent dom elements from being corrupted
+          modelOp.attributes = undefined;
         }
         (updatedDelta as any).push(modelOp);
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -656,7 +656,7 @@ export function registerScripture(): string[] {
       this.lastRecorded = 0;
       this.ignoreChange = true;
       // during undo/redo, segments can be incorrectly highlighted, so explicitly remove incorrect highlighting
-      this.quill.updateContents(removeSegmentHighlight(delta[source]), 'user');
+      this.quill.updateContents(removeObsoleteSegmentAttrs(delta[source]), 'user');
       this.ignoreChange = false;
       const index = getLastChangeIndex(delta[source]);
       this.quill.setSelection(index);
@@ -665,15 +665,23 @@ export function registerScripture(): string[] {
 
   /**
    * Updates delta to remove segment highlights from segments that are not explicitly highlighted
+   * and strips off formatting from note thread embeds.
    */
-  function removeSegmentHighlight(delta: DeltaStatic): DeltaStatic {
+  function removeObsoleteSegmentAttrs(delta: DeltaStatic): DeltaStatic {
     const updatedDelta = new Delta();
     if (delta.ops != null) {
       for (const op of delta.ops) {
         const modelOp: DeltaOperation = cloneDeep(op);
-        const attrs = modelOp.attributes;
+        let attrs = modelOp.attributes;
         if (attrs != null && attrs['segment'] != null && attrs['highlight-segment'] == null) {
           attrs['highlight-segment'] = false;
+        }
+        if (
+          modelOp.insert != null &&
+          typeof modelOp.insert === 'object' &&
+          modelOp.insert['note-thread-embed'] != null
+        ) {
+          attrs = undefined;
         }
         (updatedDelta as any).push(modelOp);
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -479,7 +479,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       if (count != null) {
         formats[formatCount] = value ? count : false;
       }
-      this.editor.formatText(range.index, range.length, formats, 'silent');
+      this.editor.formatText(range.index, range.length, formats, 'api');
     }
     return segments;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1858,6 +1858,13 @@ describe('EditorComponent', () => {
       expect(env.getNoteThreadEditorPosition('thread01')).toEqual(note1Position);
       expect(noteThread1.data!.position).toEqual(noteThread1Anchor);
 
+      // undo deleting just the note when note thread doc has history
+      // target: |->$<-|chapter 1, $verse 1.
+      env.targetEditor.setSelection(note1Position, 1, 'user');
+      env.deleteCharacters();
+      env.triggerUndo();
+      expect(noteThread1.data!.position).toEqual(noteThread1Anchor);
+
       // undo deleting note and entire selection
       const embedLength = 1;
       deleteLength = beforeNoteLength + embedLength + noteThread1.data!.position.length;
@@ -1912,6 +1919,29 @@ describe('EditorComponent', () => {
       expect(noteThread3.data!.position).toEqual(noteThread3Anchor);
       expect(noteThread4.data!.position).toEqual(noteThread4Anchor);
       expect(textDoc.data!.ops![8].insert).toEqual('target: chapter 1, verse 3.');
+      env.dispose();
+    }));
+
+    it('note dialog appears after undo delete-a-note', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.wait();
+      let element: HTMLElement = env.getNoteThreadIconElement('verse_1_1', 'thread01')!;
+      element.click();
+      verify(mockedMatDialog.open(NoteDialogComponent, anything())).once();
+
+      const notePosition: number = env.getNoteThreadEditorPosition('thread01');
+      const selectionIndex: number = notePosition - 2;
+      const length: number = 5;
+      env.targetEditor.setSelection(selectionIndex, length, 'user');
+      env.wait();
+      env.deleteCharacters();
+      env.triggerUndo();
+      element = env.getNoteThreadIconElement('verse_1_1', 'thread01')!;
+      element.click();
+      env.wait();
+      verify(mockedMatDialog.open(NoteDialogComponent, anything())).twice();
+      expect().nothing();
       env.dispose();
     }));
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1926,22 +1926,31 @@ describe('EditorComponent', () => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
       env.wait();
-      let element: HTMLElement = env.getNoteThreadIconElement('verse_1_1', 'thread01')!;
-      element.click();
+      let iconElement02: HTMLElement = env.getNoteThreadIconElement('verse_1_3', 'thread02')!;
+      iconElement02.click();
       verify(mockedMatDialog.open(NoteDialogComponent, anything())).once();
-
-      const notePosition: number = env.getNoteThreadEditorPosition('thread01');
-      const selectionIndex: number = notePosition - 2;
-      const length: number = 5;
-      env.targetEditor.setSelection(selectionIndex, length, 'user');
-      env.wait();
-      env.deleteCharacters();
-      env.triggerUndo();
-      element = env.getNoteThreadIconElement('verse_1_1', 'thread01')!;
-      element.click();
-      env.wait();
+      let iconElement03: HTMLElement = env.getNoteThreadIconElement('verse_1_3', 'thread03')!;
+      iconElement03.click();
       verify(mockedMatDialog.open(NoteDialogComponent, anything())).twice();
-      expect().nothing();
+
+      const notePosition: number = env.getNoteThreadEditorPosition('thread02');
+      const selectionIndex: number = notePosition + 1;
+      env.targetEditor.setSelection(selectionIndex, 'user');
+      env.wait();
+      env.backspace();
+
+      // SUT
+      env.triggerUndo();
+      iconElement02 = env.getNoteThreadIconElement('verse_1_3', 'thread02')!;
+      iconElement02.click();
+      env.wait();
+      verify(mockedMatDialog.open(NoteDialogComponent, anything())).thrice();
+      expect(iconElement02.parentElement!.tagName.toLowerCase()).toBe('display-text-anchor');
+      iconElement03 = env.getNoteThreadIconElement('verse_1_3', 'thread03')!;
+      iconElement03.click();
+      env.wait();
+      // ensure that clicking subsequent notes in a verse still works
+      verify(mockedMatDialog.open(NoteDialogComponent, anything())).times(4);
       env.dispose();
     }));
   });
@@ -2620,6 +2629,13 @@ class TestEnvironment {
       this.wait();
     }
     return selectionIndex;
+  }
+
+  backspace(): void {
+    const selection = this.targetEditor.getSelection()!;
+    const delta = new Delta([{ retain: selection.index - 1 }, { delete: 1 }]);
+    this.targetEditor.updateContents(delta, 'user');
+    this.wait();
   }
 
   deleteCharacters(): number {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -108,7 +108,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   private projectDataChangesSub?: Subscription;
   private trainingProgressClosed: boolean = false;
   private trainingCompletedTimeout: any;
-  private clickSubs: Subscription[] = [];
+  private clickSubs: Map<string, Subscription[]> = new Map<string, Subscription[]>();
   private noteThreadQuery?: RealtimeQuery<NoteThreadDoc>;
   private toggleNoteThreadVerseRefs$: BehaviorSubject<void> = new BehaviorSubject<void>(undefined);
   private toggleNoteThreadSub?: Subscription;
@@ -507,6 +507,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     if (delta != null) {
       // only recreate note embeds if the delta has productive edits
       this.recreateDeletedNoteThreadEmbeds();
+      if (segment != null) {
+        this.subscribeClickEvents([segment.ref]);
+      }
     }
   }
 
@@ -619,8 +622,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     this.shouldNoteThreadsRespondToEdits = false;
     this.target?.removeEmbeddedElements();
     // Un-subscribe from all segment click events as these all get setup again
-    for (const event of this.clickSubs) {
-      event.unsubscribe();
+    for (const segmentEvents of this.clickSubs.values()) {
+      for (const event of segmentEvents) {
+        event.unsubscribe();
+      }
     }
   }
 
@@ -639,10 +644,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     const noteThreadVerseRefs: VerseRef[] = featureVerseRefInfo.map(f => f.verseRef);
 
     if (value) {
+      const segments: string[] = this.target.toggleFeaturedVerseRefs(value, noteThreadVerseRefs, 'note-thread');
       for (const featured of featureVerseRefInfo) {
         this.embedNoteThread(featured);
       }
-      const segments: string[] = this.target.toggleFeaturedVerseRefs(value, noteThreadVerseRefs, 'note-thread');
       this.subscribeClickEvents(segments);
     } else {
       this.removeEmbeddedElements();
@@ -956,8 +961,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       if (elements == null) {
         continue;
       }
-      Array.from(elements).map((element: Element) => {
-        this.clickSubs.push(
+      this.clickSubs.get(segment)?.forEach(s => s.unsubscribe());
+      this.clickSubs.set(
+        segment,
+        Array.from(elements).map((element: Element) =>
           this.subscribe(fromEvent<MouseEvent>(element, 'click'), event => {
             if (this.bookNum == null) {
               return;
@@ -969,8 +976,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
               this.updateReadNotes(threadId);
             }
           })
-        );
-      });
+        )
+      );
     }
   }
 
@@ -1041,12 +1048,17 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
 
     // a user initiated delta with ops that include inserting a note embed can only be undo deleting a note icon
-    const reinsertedNotes: DeltaOperation[] = delta.ops.filter(
+    const reinsertedNotes: DeltaOperation[] = delta.filter(
       op => op.insert != null && op.insert['note-thread-embed'] != null
     );
     const duplicateNoteIds: string[] = reinsertedNotes.map(op =>
       op.attributes == null ? null : op.attributes['threadid']
     );
+    const textInsertOps: DeltaOperation[] = delta.filter(
+      ops => ops.insert != null && ops.insert['note-thread-embed'] == null
+    );
+    const textDeleteOps: DeltaOperation[] = delta.filter(ops => ops.delete != null);
+    const hasTextEditOp: boolean = textInsertOps.length > 0 || textDeleteOps.length > 0;
     for (const [threadId, noteIndex] of oldVerseEmbeds.entries()) {
       const noteThreadDoc: NoteThreadDoc | undefined = this.noteThreadQuery.docs.find(n => n.data?.dataId === threadId);
       if (noteThreadDoc?.data == null) {
@@ -1059,11 +1071,11 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         noteThreadDoc.data.position.length
       );
       const noteAnchorEndIndex: number = noteIndex + noteThreadDoc.data.position.length + noteCountInTextAnchor;
-      // A note is only affected by the undo operation if the delta includes inserting a note with the specified
-      // thread id, or if the edit op occurs before the note text anchor last character
+      // A note anchor is only affected by the undo operation if the delta includes inserting the note embed, or
+      // if the edit op occurs before the note text anchor last character
       // i.e. note anchors are unaffected if the edit index comes after the note and anchor
       const noteIsAffected: boolean = noteAnchorEndIndex >= editOpIndex || duplicateNoteIds.includes(threadId);
-      if (reinsertedNotes.length > 0 && noteIsAffected) {
+      if (reinsertedNotes.length > 0 && noteIsAffected && hasTextEditOp) {
         updatePromises.push(
           noteThreadDoc
             .previousSnapshot()


### PR DESCRIPTION
The click subscriptions were not being updated correctly when a user deletes a note, and then they undo the deletion. This change records the note icon click subscription and refreshes all of the subscriptions when a note is deleted, and then the user undoes the deletion. In order to get it to work, it was also necessary to strip away the formatting on the note thread embed that gets re-embedded so that it wouldn't cause our formatting in quill to be in a bad state.
There was another bug where undo deleting-a-note would revert the position to a previous position even when it should not. So now it checks that there was a measurable text edit in addition to the note deletion before performing the undo and reverting the note thread position.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1217)
<!-- Reviewable:end -->
