### PR TITLE
SF-1455 Communicate editor focus change via events

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
@@ -19,5 +19,7 @@
   [dir]="$any(textDirection)"
   [lang]="lang"
   [attr.data-browser-engine]="browserEngine"
+  (onBlur)="focused.next(false)"
+  (onFocus)="focused.next(true)"
 >
 </quill-editor>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -87,6 +87,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   @Output() updated = new EventEmitter<TextUpdatedEvent>(true);
   @Output() segmentRefChange = new EventEmitter<string>();
   @Output() loaded = new EventEmitter(true);
+  @Output() focused = new EventEmitter<boolean>(true);
   lang: string = '';
   // only use USX formats and not default Quill formats
   readonly allowedFormats: string[] = USX_FORMATS;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -34,7 +34,7 @@
           <app-text
             #source
             [isReadOnly]="true"
-            [highlightSegment]="target.hasFocus"
+            [highlightSegment]="targetFocused"
             (loaded)="onTextLoaded('source')"
             (updated)="onSourceUpdated($event.delta != null)"
             [isRightToLeft]="isSourceRightToLeft"
@@ -68,7 +68,8 @@
               )
             "
             (loaded)="onTextLoaded('target')"
-            [highlightSegment]="target.hasFocus"
+            (focused)="targetFocused = $event"
+            [highlightSegment]="targetFocused"
             [markInvalid]="true"
             [isRightToLeft]="isTargetRightToLeft"
           ></app-text>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -78,6 +78,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   trainingMessage: string = '';
   showTrainingProgress: boolean = false;
   textHeight: string = '';
+  targetFocused = false;
 
   @ViewChild('targetContainer') targetContainer?: ElementRef;
   @ViewChild('source') source?: TextComponent;
@@ -735,12 +736,12 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     const bounds = elem.getBoundingClientRect();
     // add bottom padding
     const top = bounds.top + (this.mediaObserver.isActive('xs') ? 0 : 14);
-    if (this.target.editor != null && this.target.hasFocus) {
+    if (this.target.editor != null && this.targetFocused) {
       // reset scroll position
       this.target.editor.scrollingContainer.scrollTop = 0;
     }
     this.textHeight = `calc(100vh - ${top}px)`;
-    if (this.target.hasFocus) {
+    if (this.targetFocused) {
       setTimeout(() => {
         // reset focus, which causes Quill to scroll to the selection
         this.target!.blur();
@@ -1266,7 +1267,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       this.target == null ||
       this.target.segment == null ||
       this.target.editor == null ||
-      !this.target.hasFocus
+      !this.targetFocused
     ) {
       return;
     }


### PR DESCRIPTION
Avoids ExpressionChangedAfterItHasBeenCheckedError when double clicking a note icon.

After our call I also went through and updated the other locations in the editor component where we access `target.hasFocus` and swapped it out for the value ascertained from the events. I think this is desirable, as it means the entire component has one single variable it relies on for determining whether the editor has focus.