### PR TITLE
SF-1445 Highlight unread note threads

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/sf-project-user-config.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project-user-config.ts
@@ -21,4 +21,5 @@ export interface SFProjectUserConfig extends ProjectData {
   questionRefsRead: string[];
   answerRefsRead: string[];
   commentRefsRead: string[];
+  noteRefsRead: string[];
 }

--- a/src/RealtimeServer/scriptureforge/services/question-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/question-service.spec.ts
@@ -114,7 +114,8 @@ class TestEnvironment {
         selectedSegment: '',
         questionRefsRead: ['question01'],
         answerRefsRead: ['answer01'],
-        commentRefsRead: ['comment01']
+        commentRefsRead: ['comment01'],
+        noteRefsRead: []
       }
     );
 
@@ -143,7 +144,8 @@ class TestEnvironment {
         selectedSegment: '',
         questionRefsRead: ['question01'],
         answerRefsRead: ['answer01'],
-        commentRefsRead: ['comment01']
+        commentRefsRead: ['comment01'],
+        noteRefsRead: []
       }
     );
 

--- a/src/RealtimeServer/scriptureforge/services/sf-project-user-config-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-user-config-migrations.ts
@@ -17,4 +17,22 @@ class SFProjectUserConfigMigration1 implements Migration {
   }
 }
 
-export const SF_PROJECT_USER_CONFIG_MIGRATIONS: MigrationConstructor[] = [SFProjectUserConfigMigration1];
+class SFProjectUserConfigMigration2 implements Migration {
+  static readonly VERSION = 2;
+
+  async migrateDoc(doc: Doc): Promise<void> {
+    if (doc.data.noteRefsRead === undefined) {
+      const op: ObjectInsertOp = { p: ['noteRefsRead'], oi: [] };
+      await submitMigrationOp(SFProjectUserConfigMigration1.VERSION, doc, [op]);
+    }
+  }
+
+  migrateOp(_op: RawOp): void {
+    // do nothing
+  }
+}
+
+export const SF_PROJECT_USER_CONFIG_MIGRATIONS: MigrationConstructor[] = [
+  SFProjectUserConfigMigration1,
+  SFProjectUserConfigMigration2
+];

--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -116,11 +116,12 @@ quill-editor.rtl {
       display: inline-block;
       text-indent: 0;
       background: var(--icon-file) no-repeat;
+      margin-left: 0.25em;
+      border: solid 1px transparent;
     }
     &.note-thread-highlight {
       &:before {
         border: solid 1px #a9ca25;
-        margin-left: 0.25em;
       }
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -114,7 +114,6 @@ quill-editor.rtl {
       width: 1.25em;
       height: 1.25em;
       display: inline-block;
-      text-indent: 0;
       background: var(--icon-file) no-repeat;
       margin-left: 0.25em;
       border: solid 1px transparent;

--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -111,13 +111,17 @@ quill-editor.rtl {
     &:before {
       cursor: pointer;
       content: '';
-      width: 1em;
-      height: 1em;
+      width: 1.25em;
+      height: 1.25em;
       display: inline-block;
-      color: #fff;
       text-indent: 0;
-      margin: 0em 0.5em;
       background: var(--icon-file) no-repeat;
+    }
+    &.note-thread-highlight {
+      &:before {
+        border: solid 1px #a9ca25;
+        margin-left: 0.25em;
+      }
     }
   }
   & display-text-anchor {

--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -115,7 +115,7 @@ quill-editor.rtl {
       height: 1.25em;
       display: inline-block;
       background: var(--icon-file) no-repeat;
-      margin-left: 0.25em;
+      margin: 0 0.1em;
       border: solid 1px transparent;
     }
     &.note-thread-highlight {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -476,7 +476,8 @@ class TestEnvironment {
     selectedSegment: '',
     questionRefsRead: [],
     answerRefsRead: [],
-    commentRefsRead: []
+    commentRefsRead: [],
+    noteRefsRead: []
   };
   private reviewerProjectUserConfig: SFProjectUserConfig = {
     ownerRef: this.checkerUser.id,
@@ -488,7 +489,8 @@ class TestEnvironment {
     selectedSegment: '',
     questionRefsRead: ['q1Id', 'q2Id', 'q3Id'],
     answerRefsRead: [],
-    commentRefsRead: []
+    commentRefsRead: [],
+    noteRefsRead: []
   };
   private translatorProjectUserConfig: SFProjectUserConfig = {
     ownerRef: this.translatorUser.id,
@@ -500,7 +502,8 @@ class TestEnvironment {
     selectedSegment: '',
     questionRefsRead: [],
     answerRefsRead: [],
-    commentRefsRead: []
+    commentRefsRead: [],
+    noteRefsRead: []
   };
   private testProject: SFProject = {
     name: 'Project 01',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1477,7 +1477,8 @@ class TestEnvironment {
     selectedSegment: '',
     questionRefsRead: [],
     answerRefsRead: [],
-    commentRefsRead: []
+    commentRefsRead: [],
+    noteRefsRead: []
   };
 
   private readonly checkerProjectUserConfig: SFProjectUserConfig = {
@@ -1491,7 +1492,8 @@ class TestEnvironment {
     selectedQuestionRef: 'project01:q5Id',
     questionRefsRead: [],
     answerRefsRead: ['a0Id', 'a1Id'],
-    commentRefsRead: []
+    commentRefsRead: [],
+    noteRefsRead: []
   };
 
   private readonly cleanCheckerProjectUserConfig: SFProjectUserConfig = {
@@ -1504,7 +1506,8 @@ class TestEnvironment {
     selectedSegment: '',
     questionRefsRead: [],
     answerRefsRead: [],
-    commentRefsRead: []
+    commentRefsRead: [],
+    noteRefsRead: []
   };
 
   private readonly observerProjectUserConfig: SFProjectUserConfig = {
@@ -1518,7 +1521,8 @@ class TestEnvironment {
     selectedSegment: '',
     questionRefsRead: [],
     answerRefsRead: [],
-    commentRefsRead: []
+    commentRefsRead: [],
+    noteRefsRead: []
   };
 
   private projectBookRoute: string = 'JHN';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
@@ -314,7 +314,8 @@ class TestEnvironment {
           selectedSegment: '',
           questionRefsRead: [],
           answerRefsRead: [],
-          commentRefsRead: []
+          commentRefsRead: [],
+          noteRefsRead: []
         }
       });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -40,6 +40,7 @@ interface NoteThread {
   iconsrc: string;
   preview: string;
   threadid: string;
+  highlight?: boolean;
 }
 
 interface Verse extends UsxStyle {
@@ -285,6 +286,9 @@ export function registerScripture(): string[] {
       node.setAttribute('style', value.iconsrc);
       node.setAttribute('title', value.preview);
       node.setAttribute(customAttributeName('thread-id'), value.threadid);
+      if (value.highlight) {
+        node.classList.add('note-thread-highlight');
+      }
       return node;
     }
 
@@ -304,9 +308,7 @@ export function registerScripture(): string[] {
       if (name === NoteThreadEmbed.blotName && value != null) {
         const ref = value as NoteThread;
         const elem = this.domNode as HTMLElement;
-        elem.setAttribute('style', ref.iconsrc);
-        elem.setAttribute('title', ref.preview);
-        elem.setAttribute(customAttributeName('thread-id'), ref.threadid);
+        ref.highlight ? elem.classList.add('note-thread-highlight') : elem.classList.remove('note-thread-highlight');
       } else {
         super.format(name, value);
       }
@@ -584,6 +586,10 @@ export function registerScripture(): string[] {
     scope: Parchment.Scope.INLINE
   });
   formats.push(NoteThreadSegmentClass);
+  const NoteThreadHighlightClass = new ClassAttributor('note-thread-highlight', 'note-thread-highlight', {
+    scope: Parchment.Scope.INLINE
+  });
+  formats.push(NoteThreadHighlightClass);
 
   const NoteThreadCountAttribute = new QuillParchment.Attributor.Attribute(
     'note-thread-count',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -71,6 +71,7 @@ export interface FeaturedVerseRefInfo {
   textAnchor?: TextAnchor;
   icon: NoteThreadIcon;
   preview?: string;
+  highlight?: boolean;
 }
 
 /** View of an editable text document. Used for displaying Scripture. */
@@ -555,6 +556,13 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     this.editor.formatText(embedInsertPos, formatLength, 'text-anchor', 'true', 'api');
     this.updateSegment();
     return embedSegmentRef;
+  }
+
+  formatEmbed(embedId: string, embedName: string, format: any) {
+    const position: number | undefined = this.embeddedElements.get(embedId);
+    if (position != null && this.editor != null) {
+      this.editor.formatText(position, 1, embedName, format, 'api');
+    }
   }
 
   /** Respond to text changes in the quill editor. */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1266,13 +1266,22 @@ describe('EditorComponent', () => {
       expect(puc.data!.noteRefsRead).not.toContain('thread01_note1');
       expect(puc.data!.noteRefsRead).not.toContain('thread01_note2');
 
-      const element: HTMLElement = env.getNoteThreadIconElement('verse_1_1', 'thread01')!;
-      element.click();
+      let iconElement: HTMLElement = env.getNoteThreadIconElement('verse_1_1', 'thread01')!;
+      iconElement.click();
       env.wait();
       puc = env.getProjectUserConfigDoc('user01');
       expect(puc.data!.noteRefsRead).toContain('thread01_note1');
       expect(puc.data!.noteRefsRead).toContain('thread01_note2');
       expect(env.isNoteIconHighlighted('thread01')).toBe(false);
+
+      expect(puc.data!.noteRefsRead).toContain('thread02_note0');
+      iconElement = env.getNoteThreadIconElement('verse_1_3', 'thread02')!;
+      iconElement.click();
+      env.wait();
+      puc = env.getProjectUserConfigDoc('user01');
+      expect(puc.data!.noteRefsRead).toContain('thread02_note0');
+      expect(puc.data!.noteRefsRead.filter(ref => ref === 'thread02_note0').length).toEqual(1);
+      expect(env.isNoteIconHighlighted('thread02')).toBe(false);
       env.dispose();
     }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1251,6 +1251,31 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('shows highlights note icons when new content is unread', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig({ noteRefsRead: ['thread01_note0', 'thread02_note0'] });
+      env.wait();
+
+      expect(env.isNoteIconHighlighted('thread01')).toBe(true);
+      expect(env.isNoteIconHighlighted('thread02')).toBe(false);
+      expect(env.isNoteIconHighlighted('thread03')).toBe(true);
+      expect(env.isNoteIconHighlighted('thread04')).toBe(true);
+      expect(env.isNoteIconHighlighted('thread05')).toBe(true);
+
+      let puc: SFProjectUserConfigDoc = env.getProjectUserConfigDoc('user01');
+      expect(puc.data!.noteRefsRead).not.toContain('thread01_note1');
+      expect(puc.data!.noteRefsRead).not.toContain('thread01_note2');
+
+      const element: HTMLElement = env.getNoteThreadIconElement('verse_1_1', 'thread01')!;
+      element.click();
+      env.wait();
+      puc = env.getProjectUserConfigDoc('user01');
+      expect(puc.data!.noteRefsRead).toContain('thread01_note1');
+      expect(puc.data!.noteRefsRead).toContain('thread01_note2');
+      expect(env.isNoteIconHighlighted('thread01')).toBe(false);
+      env.dispose();
+    }));
+
     it('should update note position when inserting text', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig({ selectedBookNum: 40, selectedChapterNum: 1, selectedSegment: 'verse_1_1' });
@@ -2401,6 +2426,7 @@ class TestEnvironment {
   }
 
   setProjectUserConfig(userConfig: Partial<SFProjectUserConfig> = {}): void {
+    userConfig.noteRefsRead = userConfig.noteRefsRead ?? [];
     const user1Config = cloneDeep(userConfig);
     user1Config.ownerRef = 'user01';
     this.addProjectUserConfig(user1Config as SFProjectUserConfig);
@@ -2451,6 +2477,12 @@ class TestEnvironment {
     return this.realtimeService.get<NoteThreadDoc>(NoteThreadDoc.COLLECTION, docId);
   }
 
+  getNoteThreadIconElement(segmentRef: string, threadId: string): HTMLElement | null {
+    return this.fixture.nativeElement.querySelector(
+      `usx-segment[data-segment=${segmentRef}] display-note[data-thread-id=${threadId}]`
+    );
+  }
+
   /** Editor position of note thread. */
   getNoteThreadEditorPosition(threadId: string): number {
     return this.component.target!.embeddedElements.get(threadId)!;
@@ -2458,6 +2490,13 @@ class TestEnvironment {
 
   getRemoteEditPosition(notePosition: number, positionAfter: number, noteCount: number): number {
     return notePosition + 1 + positionAfter - noteCount;
+  }
+
+  isNoteIconHighlighted(threadId: string): boolean {
+    const thread: HTMLElement | null = this.targetTextEditor.nativeElement.querySelector(
+      'usx-segment display-note[data-thread-id="' + threadId + '"].note-thread-highlight'
+    );
+    return thread != null;
   }
 
   setDataInSync(projectId: string, isInSync: boolean): void {
@@ -2623,7 +2662,7 @@ class TestEnvironment {
       const note: Note = {
         threadId: threadId,
         ownerRef: id,
-        dataId: `thread01_note${id}`,
+        dataId: `${threadId}_note${i}`,
         dateCreated: date.toJSON(),
         dateModified: date.toJSON(),
         content: `<p><bold>Note from ${id}</bold></p>`,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2503,7 +2503,7 @@ class TestEnvironment {
 
   isNoteIconHighlighted(threadId: string): boolean {
     const thread: HTMLElement | null = this.targetTextEditor.nativeElement.querySelector(
-      'usx-segment display-note[data-thread-id="' + threadId + '"].note-thread-highlight'
+      `usx-segment display-note[data-thread-id="${threadId}"].note-thread-highlight`
     );
     return thread != null;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -660,6 +660,29 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     });
   }
 
+  private updateReadNotes(threadId: string) {
+    const noteThread: NoteThreadDoc | undefined = this.noteThreadQuery?.docs.find(
+      d => d.data != null && d.data.dataId == threadId
+    );
+    if (noteThread?.data != null && this.projectUserConfigDoc?.data != null) {
+      const notesRead: string[] = [];
+      for (const note of noteThread.data.notes) {
+        if (!this.projectUserConfigDoc.data.noteRefsRead.includes(note.dataId)) {
+          notesRead.push(note.dataId);
+        }
+      }
+
+      if (notesRead.length == 0) {
+        return;
+      }
+      this.projectUserConfigDoc.submitJson0Op(op => {
+        for (const noteId of notesRead) {
+          op.insert(puc => puc.noteRefsRead, 0, noteId);
+        }
+      });
+    }
+  }
+
   private setupTranslationEngine(): void {
     if (this.trainingSub != null) {
       this.trainingSub.unsubscribe();
@@ -944,6 +967,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
             const threadId = threadIdFromMouseEvent(event);
             if (threadId != null) {
               this.showNoteThread(threadId);
+              this.target?.formatEmbed(threadId, 'note-thread-embed', { ['highlight']: false });
+              this.updateReadNotes(threadId);
             }
           })
         );
@@ -985,13 +1010,15 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     if (threadDoc.data == null || verseRef == null) {
       return;
     }
+    const hasNewContent: boolean = this.hasNewContent(threadDoc);
 
     return {
       verseRef,
       id: threadDoc.data.dataId,
       preview,
       icon: threadDoc.icon,
-      textAnchor: threadDoc.data.position
+      textAnchor: threadDoc.data.position,
+      highlight: hasNewContent
     };
   }
 
@@ -1249,6 +1276,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
 
     const format = { iconsrc: featured.icon.cssVar, preview: featured.preview, threadid: featured.id };
+    if (featured.highlight) {
+      format['highlight'] = featured.highlight;
+    }
     return this.target.embedElementInline(
       featured.verseRef,
       featured.id,
@@ -1256,6 +1286,14 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       'note-thread-embed',
       format
     );
+  }
+
+  private hasNewContent(thread: NoteThreadDoc): boolean {
+    const noteId: string | undefined = thread.data?.notes[thread.data?.notes.length - 1].dataId;
+    if (noteId == null || this.projectUserConfigDoc?.data == null) {
+      return false;
+    }
+    return !this.projectUserConfigDoc.data.noteRefsRead.includes(noteId);
   }
 
   private syncScroll(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -677,7 +677,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       }
       this.projectUserConfigDoc.submitJson0Op(op => {
         for (const noteId of notesRead) {
-          op.insert(puc => puc.noteRefsRead, 0, noteId);
+          op.add(puc => puc.noteRefsRead, noteId);
         }
       });
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -661,9 +661,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   private updateReadNotes(threadId: string) {
-    const noteThread: NoteThreadDoc | undefined = this.noteThreadQuery?.docs.find(
-      d => d.data != null && d.data.dataId == threadId
-    );
+    const noteThread: NoteThreadDoc | undefined = this.noteThreadQuery?.docs.find(d => d.data?.dataId === threadId);
     if (noteThread?.data != null && this.projectUserConfigDoc?.data != null) {
       const notesRead: string[] = [];
       for (const note of noteThread.data.notes) {

--- a/src/SIL.XForge.Scripture/Models/SFProjectUserConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectUserConfig.cs
@@ -27,5 +27,6 @@ namespace SIL.XForge.Scripture.Models
         public List<string> AnswerRefsRead { get; set; } = new List<string>();
         public List<string> CommentRefsRead { get; set; } = new List<string>();
         public string SelectedQuestionRef { get; set; }
+        public List<string> NoteRefsRead { get; set; } = new List<string>();
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -825,7 +825,7 @@ namespace SIL.XForge.Scripture.Services
                     if (username != null)
                         usernamesToUserIds.TryGetValue(username, out ownerRef);
                     added.OwnerRef = string.IsNullOrEmpty(ownerRef) ? _userSecret.Id : ownerRef;
-                    op.Insert(td => td.Notes, 0, added);
+                    op.Add(td => td.Notes, added);
                 }
 
                 // Permanently removes a note

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1163,13 +1163,13 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(thread01.TagIcon, Is.EqualTo(expectedThreadTagIcon));
             env.DeltaUsxMapper.ReceivedWithAnyArgs(2).ToChapterDeltas(default);
             Assert.That(thread01.Notes.Count, Is.EqualTo(3));
-            Assert.That(thread01.Notes[0].Content, Is.EqualTo("thread01 added."));
+            Assert.That(thread01.Notes[0].Content, Is.EqualTo("thread01 updated."));
+            Assert.That(thread01.Notes[1].Deleted, Is.True);
+            Assert.That(thread01.Notes[2].Content, Is.EqualTo("thread01 added."));
             string expected = "thread01-syncuser03--thread01 added.-" + expectedNoteTagIcon;
-            Assert.That(thread01.Notes[0].NoteToString(), Is.EqualTo(expected));
-            Assert.That(thread01.Notes[0].TagIcon, Is.EqualTo(expectedNoteTagIcon));
-            Assert.That(thread01.Notes[0].OwnerRef, Is.EqualTo("user03"));
-            Assert.That(thread01.Notes[1].Content, Is.EqualTo("thread01 updated."));
-            Assert.That(thread01.Notes[2].Deleted, Is.True);
+            Assert.That(thread01.Notes[2].NoteToString(), Is.EqualTo(expected));
+            Assert.That(thread01.Notes[2].TagIcon, Is.EqualTo(expectedNoteTagIcon));
+            Assert.That(thread01.Notes[2].OwnerRef, Is.EqualTo("user03"));
 
             SFProjectSecret projectSecret = env.GetProjectSecret();
             // User 3 was added as a sync user


### PR DESCRIPTION
* add highlight class to unread note thread embeds
* record notes read in project user config doc

Unread note threads in Paratext appear with a border and a highlight colour behind the note icon. I chose to use only a border to identify an unread note thread, but I am open to suggestions on how to make it look clean in our app.
![image](https://user-images.githubusercontent.com/17931130/148297823-17d07cc1-b675-44dc-9133-cc7c40e37901.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1219)
<!-- Reviewable:end -->
