### PR TITLE
Optimize importing of questions

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
@@ -224,7 +224,7 @@ describe('ImportQuestionsDialogComponent', () => {
     env.click(env.importFromTransceleratorButton);
     env.selectQuestion(env.questionRows[0]);
     env.click(env.importSelectedQuestionsButton);
-    verify(mockedProjectService.createQuestion('project01', anything(), undefined, undefined)).once();
+    verify(mockedProjectService.createQuestion('project01', anything(), undefined, undefined, true)).once();
     const question = capture(mockedProjectService.createQuestion).last()[1];
     expect(question.projectRef).toBe('project01');
     expect(question.text).toBe('Transcelerator question 1:1');
@@ -242,7 +242,7 @@ describe('ImportQuestionsDialogComponent', () => {
     env.click(env.importFromTransceleratorButton);
     env.selectQuestion(env.questionRows[1]);
     env.click(env.importSelectedQuestionsButton);
-    verify(mockedProjectService.createQuestion('project01', anything(), undefined, undefined)).once();
+    verify(mockedProjectService.createQuestion('project01', anything(), undefined, undefined, true)).once();
     const question = capture(mockedProjectService.createQuestion).last()[1];
     expect(question.verseRef).toEqual({
       bookNum: 40,
@@ -282,13 +282,13 @@ describe('ImportQuestionsDialogComponent', () => {
     expect(env.importSelectedQuestionsButton.textContent).toContain('1');
 
     env.click(env.importSelectedQuestionsButton);
-    verify(mockedProjectService.createQuestion('project01', anything(), undefined, undefined)).once();
+    verify(mockedProjectService.createQuestion('project01', anything(), undefined, undefined, true)).once();
   }));
 
   it('allows canceling the import of questions', fakeAsync(() => {
     const env = new TestEnvironment();
     env.click(env.importFromTransceleratorButton);
-    when(mockedProjectService.createQuestion('project01', anything(), undefined, undefined)).thenCall(
+    when(mockedProjectService.createQuestion('project01', anything(), undefined, undefined, true)).thenCall(
       () => new Promise(resolve => setTimeout(resolve, 5000))
     );
     expect(env.questionRows.length).toBe(2);
@@ -300,12 +300,12 @@ describe('ImportQuestionsDialogComponent', () => {
     env.importSelectedQuestionsButton.click();
 
     tick(4000);
-    verify(mockedProjectService.createQuestion('project01', anything(), undefined, undefined)).once();
+    verify(mockedProjectService.createQuestion('project01', anything(), undefined, undefined, true)).once();
 
     // cancel while the first question is still being imported
     env.cancelButton.click();
     tick(12000);
-    verify(mockedProjectService.createQuestion('project01', anything(), undefined, undefined)).once();
+    verify(mockedProjectService.createQuestion('project01', anything(), undefined, undefined, true)).once();
   }));
 
   it('can import from a CSV file', fakeAsync(() => {
@@ -526,7 +526,7 @@ class TestEnvironment {
         this.mockedImportQuestionsConfirmationMdcDialogRef
       )
     );
-    when(mockedProjectService.createQuestion(anything(), anything(), anything(), anything())).thenResolve();
+    when(mockedProjectService.createQuestion(anything(), anything(), anything(), anything(), anything())).thenResolve();
     this.fixture.detectChanges();
     tick();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -334,14 +334,17 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable {
           transceleratorQuestionId: listItem.question.id
         };
         await this.zone.runOutsideAngular(() =>
-          this.projectService.createQuestion(this.data.projectId, newQuestion, undefined, undefined)
+          this.projectService.createQuestion(this.data.projectId, newQuestion, undefined, undefined, true)
         );
       } else if (this.questionsDiffer(listItem)) {
-        await listItem.sfVersionOfQuestion.submitJson0Op(op =>
-          op
-            .set(q => q.text!, listItem.question.text)
-            .set(q => q.verseRef, verseRefData)
-            .set(q => q.dateModified, currentDate)
+        await listItem.sfVersionOfQuestion.submitJson0Op(
+          op =>
+            op
+              .set(q => q.text!, listItem.question.text)
+              .set(q => q.verseRef, verseRefData)
+              .set(q => q.dateModified, currentDate),
+          true,
+          true
         );
       }
       this.importedCount++;
@@ -349,6 +352,8 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable {
         break;
       }
     }
+
+    await this.projectService.completeBulkQuestionUpdate();
 
     this.dialogRef.close();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -90,7 +90,8 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
     id: string,
     question: Question,
     audioFileName?: string,
-    audioBlob?: Blob
+    audioBlob?: Blob,
+    bulk: boolean = false
   ): Promise<QuestionDoc | undefined> {
     const docId = getQuestionDocId(id, question.dataId);
     if (audioFileName != null && audioBlob != null) {
@@ -109,7 +110,11 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
       }
       question.audioUrl = audioUrl;
     }
-    return this.realtimeService.create<QuestionDoc>(QuestionDoc.COLLECTION, docId, question);
+    return this.realtimeService.create<QuestionDoc>(QuestionDoc.COLLECTION, docId, question, bulk);
+  }
+
+  async completeBulkQuestionUpdate(): Promise<void> {
+    return this.realtimeService.onLocalDocUpdate(QuestionDoc.COLLECTION);
   }
 
   onlineSync(id: string): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/indexeddb-offline-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/indexeddb-offline-store.ts
@@ -12,18 +12,9 @@ function getAllFromCursor<T extends OfflineData>(
   query?: IDBValidKey | IDBKeyRange
 ): Promise<T[]> {
   return new Promise<T[]>((resolve, reject) => {
-    const results: T[] = [];
-    const request = store.openCursor(query);
+    const request = store.getAll(query);
     request.onerror = () => reject(request.error);
-    request.onsuccess = () => {
-      const cursor = request.result;
-      if (cursor != null) {
-        results.push(cursor.value);
-        cursor.continue();
-      } else {
-        resolve(results);
-      }
-    };
+    request.onsuccess = () => resolve(request.result);
   });
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/json-realtime-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/json-realtime-doc.ts
@@ -11,15 +11,21 @@ export abstract class JsonRealtimeDoc<T = any> extends RealtimeDoc<T, OtJson0Op[
    *
    * @param {(op: Json0OpBuilder<T>) => void} build The function to build the operation.
    * @param {*} [source] The source.
+   * @param {boolean} [bulk=false] Indicates that ops are being submitted in bulk. If true, it is the responsibility of
+   * caller to call RealtimeService.onLocalDocUpdate() once the bulk operation is completed.
    */
-  async submitJson0Op(build: (op: Json0OpBuilder<T>) => void, source: any = true): Promise<boolean> {
+  async submitJson0Op(
+    build: (op: Json0OpBuilder<T>) => void,
+    source: any = true,
+    bulk: boolean = false
+  ): Promise<boolean> {
     if (this.data == null) {
       return false;
     }
     const builder = new Json0OpBuilder(this.data);
     build(builder);
     if (builder.op.length > 0) {
-      await this.submit(builder.op, source);
+      await this.submit(builder.op, source, bulk);
       return true;
     }
     return false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.ts
@@ -90,11 +90,13 @@ export class RealtimeService {
    * @param {string} collection The collection name.
    * @param {string} id The id.
    * @param {*} data The initial data.
+   * @param {boolean} [bulk=false] Indicates that docs are being created in bulk. If true, it is the responsibility of
+   * caller to call RealtimeService.onLocalDocUpdate() once the bulk operation is completed.
    * @returns {Promise<T>} The newly created real-time doc.
    */
-  async create<T extends RealtimeDoc>(collection: string, id: string, data: any): Promise<T> {
+  async create<T extends RealtimeDoc>(collection: string, id: string, data: any, bulk: boolean = false): Promise<T> {
     const doc = this.get<T>(collection, id);
-    await doc.create(data);
+    await doc.create(data, bulk);
     return doc;
   }
 
@@ -146,8 +148,8 @@ export class RealtimeService {
     }
   }
 
-  async onLocalDocUpdate(doc: RealtimeDoc): Promise<void> {
-    const collectionQueries = this.subscribeQueries.get(doc.collection);
+  async onLocalDocUpdate(collection: string): Promise<void> {
+    const collectionQueries = this.subscribeQueries.get(collection);
     if (collectionQueries != null) {
       const promises: Promise<void>[] = [];
       for (const query of collectionQueries) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -21,7 +21,7 @@ export function supportedBrowser(): boolean {
   const isSupportedBrowser = BROWSER.satisfies({
     chrome: '>=58',
     chromium: '>=58',
-    edge: '>=76',
+    edge: '>=79',
     firefox: '>=51',
     safari: '>=11.1',
 


### PR DESCRIPTION
There are three commits here, the first by Damien, and the second by me.

First commit:
Creates a way to speed up import by skipping the local update until after the last question is imported.

Second commit:
Changes Edge required version to 79 because the IndexedDB getAll method is not supported below version 79. Since Edge is now Chromium based, I would imagine Edge 79 is fairly outdated (and likely broken for other reasons?). But we know below version 79 it will be broken, so it seems best to bump the requirement.

Third commit:
Fixes assertions in tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1220)
<!-- Reviewable:end -->
