### PR TITLE
SF-1467 Note can attach to text outside of verse reference

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
@@ -47,6 +47,12 @@ export function getCombinedVerseTextDoc(id: TextDocId): TextData {
   delta.insert({ verse: { number: '2-3', style: 'v' } });
   delta.insert(`${id.textType}: chapter ${id.chapterNum}, verse 2-3.`, { segment: `verse_${id.chapterNum}_2-3` });
   delta.insert('\n', { para: { style: 'p' } });
+  delta.insert('Text in section heading', { segment: 's_2' });
+  delta.insert('\n', { para: { style: 's' } });
+  delta.insert({ blank: true }, { segment: 'p_2' });
+  delta.insert({ verse: { number: '4', style: 'v' } });
+  delta.insert(`${id.textType}: chapter ${id.chapterNum}, verse 4.`, { segment: `verse_${id.chapterNum}_4` });
+  delta.insert('\n', { para: { style: 'p' } });
   return delta;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -287,6 +287,11 @@ export class TextViewModel {
     return Array.from(this._segments.keys()).filter(r => r.indexOf(ref + '/') === 0);
   }
 
+  /** Get the segments that fall within a given verse reference. A segment is considered
+   * to be in the reference if its ref is (or the first preceding segment with a ref) of the
+   * format verse_c_v falls within the given verse reference.
+   * For example, the result for MAT 1:1 can be as follows: [verse_1_1, verse_1_1/p_1, s_1]
+   */
   getVerseSegments(verseRef?: VerseRef): string[] {
     const segmentsInVerseRef: string[] = [];
     if (verseRef == null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -288,8 +288,9 @@ export class TextViewModel {
   }
 
   /** Get the segments that fall within a given verse reference. A segment is considered
-   * to be in the reference if its ref is (or the first preceding segment with a ref) of the
-   * format verse_c_v falls within the given verse reference.
+   * to be in the reference if (1) its ref is in the format verse_c_v or verse_c_v-w, and that
+   * ref is within the given verse reference, or (2) its ref is not in that format, but the
+   * first preceding segment with a ref in that format is within the given verse reference.
    * For example, the result for MAT 1:1 can be as follows: [verse_1_1, verse_1_1/p_1, s_1]
    */
   getVerseSegments(verseRef?: VerseRef): string[] {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -295,14 +295,16 @@ export class TextViewModel {
     const verses: VerseRef[] = verseRef.allVerses();
     const startVerseNum: number = verses[0].verseNum;
     const lastVerseNum: number = verses[verses.length - 1].verseNum;
+    let matchStartNum = 0;
+    let matchLastNum = 0;
     for (const segment of this._segments.keys()) {
       const match: RegExpExecArray | null = VERSE_FROM_SEGMENT_REF_REGEX.exec(segment);
-      if (match == null) {
-        continue;
+      if (match != null) {
+        // update numbers for the new verse
+        const verseParts: string[] = match[1].split('-');
+        matchStartNum = +verseParts[0];
+        matchLastNum = +verseParts[verseParts.length - 1];
       }
-      const verseParts: string[] = match[1].split('-');
-      const matchStartNum: number = +verseParts[0];
-      const matchLastNum: number = +verseParts[verseParts.length - 1];
       const matchStartsWithin = matchStartNum >= startVerseNum && matchStartNum <= lastVerseNum;
       const matchEndsWithin = matchLastNum >= startVerseNum && matchLastNum <= lastVerseNum;
       if (matchStartsWithin || matchEndsWithin) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1074,43 +1074,44 @@ describe('EditorComponent', () => {
     it('embeds note on verse segments', fakeAsync(() => {
       const env = new TestEnvironment();
       env.addParatextNoteThread(6, 'MAT 1:2', '', { start: 0, length: 0 }, ['user01']);
-      env.addParatextNoteThread(7, 'LUK 1:2-3', '', { start: 0, length: 0 }, ['user01']);
+      env.addParatextNoteThread(7, 'LUK 1:0', 'for chapter', { start: 6, length: 11 }, ['user01']);
+      env.addParatextNoteThread(8, 'LUK 1:2-3', '', { start: 0, length: 0 }, ['user01']);
+      env.addParatextNoteThread(9, 'LUK 1:2-3', 'section heading', { start: 37, length: 15 }, ['user01']);
       env.setProjectUserConfig();
       env.wait();
-      const segment: HTMLElement = env.targetTextEditor.nativeElement.querySelector(
-        'usx-segment[data-segment=verse_1_1]'
-      )!;
-      expect(segment).not.toBeNull();
-
-      const note = segment.querySelector('display-note')! as HTMLElement;
-      expect(note).not.toBeNull();
-      expect(note.getAttribute('style')).toEqual('--icon-file: url(/assets/icons/TagIcons/01flag3.png);');
-      expect(note.getAttribute('title')).toEqual('Note from user01\n--- 2 more note(s) ---');
-      const contents = env.targetEditor.getContents();
+      const verse1Segment: HTMLElement = env.getSegmentElement('verse_1_1')!;
+      const verse1Note = verse1Segment.querySelector('display-note') as HTMLElement;
+      expect(verse1Note).not.toBeNull();
+      expect(verse1Note.getAttribute('style')).toEqual('--icon-file: url(/assets/icons/TagIcons/01flag3.png);');
+      expect(verse1Note.getAttribute('title')).toEqual('Note from user01\n--- 2 more note(s) ---');
+      let contents = env.targetEditor.getContents();
       expect(contents.ops![3].insert).toEqual('target: ');
       expect(contents.ops![4].attributes!['iconsrc']).toEqual('--icon-file: url(/assets/icons/TagIcons/01flag3.png);');
 
       // three notes in the segment on verse 3
-      const noteVerse3: HTMLElement[] = env.targetTextEditor.nativeElement.querySelectorAll(
-        'usx-segment[data-segment="verse_1_3"] display-note'
-      )!;
+      const noteVerse3: NodeListOf<Element> = env.getSegmentElement('verse_1_3')!.querySelectorAll('display-note')!;
       expect(noteVerse3.length).toEqual(3);
 
-      const blankSegmentNote = env.targetTextEditor.nativeElement.querySelector(
-        'usx-segment[data-segment="verse_1_2"] display-note'
-      )! as HTMLElement;
-      expect(blankSegmentNote).not.toBeNull();
+      const blankSegmentNote = env.getSegmentElement('verse_1_2')!.querySelector('display-note') as HTMLElement;
       expect(blankSegmentNote.getAttribute('style')).toEqual('--icon-file: url(/assets/icons/TagIcons/01flag1.png);');
       expect(blankSegmentNote.getAttribute('title')).toEqual('Note from user01');
 
       env.updateParams({ projectId: 'project01', bookId: 'LUK' });
       env.wait();
-      const combinedVerseUsxSegment: HTMLElement = env.targetTextEditor.nativeElement.querySelector(
-        'usx-segment[data-segment="verse_1_2-3"]'
-      );
+      const titleUsxSegment: HTMLElement = env.getSegmentElement('s_1')!;
+      expect(titleUsxSegment.classList).toContain('note-thread-segment');
+      const titleUsxNote: HTMLElement | null = titleUsxSegment.querySelector('display-note');
+      expect(titleUsxNote).not.toBeNull();
+
+      const combinedVerseUsxSegment: HTMLElement = env.getSegmentElement('verse_1_2-3')!;
       expect(combinedVerseUsxSegment.classList).toContain('note-thread-segment');
       const verse2and3CombinedNote: HTMLElement | null = combinedVerseUsxSegment.querySelector('display-note');
       expect(verse2and3CombinedNote).not.toBeNull();
+
+      const sectionHeadingUsxSegment: HTMLElement = env.getSegmentElement('s_2')!;
+      expect(sectionHeadingUsxSegment.classList).toContain('note-thread-segment');
+      const sectionHeadingNote: HTMLElement | null = sectionHeadingUsxSegment.querySelector('display-note');
+      expect(sectionHeadingNote).not.toBeNull();
       env.dispose();
     }));
 

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1630,15 +1630,7 @@ namespace SIL.XForge.Scripture.Services
         private string GetVerseText(Delta delta, VerseRef verseRef)
         {
             string vref = string.IsNullOrEmpty(verseRef.Verse) ? verseRef.VerseNum.ToString() : verseRef.Verse;
-            string segment = $"verse_{verseRef.ChapterNum}_{vref}";
-            bool segmentFilter(JToken op)
-            {
-                return op.Type == JTokenType.Object &&
-                    op["attributes"] != null && op["attributes"]["segment"] != null &&
-                    (((string)op["attributes"]["segment"]) == segment ||
-                    ((string)op["attributes"]["segment"]).StartsWith(segment + "/"));
-            };
-            return delta.TryConcatenateInserts(out string verseText, segmentFilter) ? verseText : string.Empty;
+            return delta.TryConcatenateInserts(out string verseText, vref) ? verseText : string.Empty;
         }
 
         private TextAnchor GetThreadTextAnchor(CommentThread thread, Dictionary<int, ChapterDelta> chapterDeltas)

--- a/src/SIL.XForge/Realtime/RichText/Delta.cs
+++ b/src/SIL.XForge/Realtime/RichText/Delta.cs
@@ -223,10 +223,18 @@ namespace SIL.XForge.Realtime.RichText
             return array.ToString();
         }
 
-        public bool TryConcatenateInserts(out string opStr, string verse)
+        /// <summary>
+        /// Concatenate all the text belonging to a given verse, including section headings. If the verse string
+        /// given is 0, this returns all the text previous to the first verse in the text.
+        /// </summary>
+        /// <param name="opStr">The string of text belonging to a verse.</param>
+        /// <param name="verseRef">
+        /// The reference to the verse. For example: "1". If the verses in the text data is combined, "1-2".
+        /// </param>
+        public bool TryConcatenateInserts(out string opStr, string verseRef)
         {
             List<JToken> verseOps = new List<JToken>();
-            bool isTargetVerse = verse == "0";
+            bool isTargetVerse = verseRef == "0";
             foreach (JToken op in this.Ops)
             {
                 if (op[InsertType]?.Type == JTokenType.Object)
@@ -236,7 +244,7 @@ namespace SIL.XForge.Realtime.RichText
                         JProperty numberToken =
                             ((JObject)((JObject)op[InsertType]).Property("verse").Value).Property("number");
                         // update target verse so we know what verse we are in
-                        isTargetVerse = numberToken.Value.Type == JTokenType.String && (string)numberToken.Value == verse;
+                        isTargetVerse = numberToken.Value.Type == JTokenType.String && (string)numberToken.Value == verseRef;
                         continue;
                     }
                     else if (((JObject)op[InsertType]).Property("chapter")?.Value.Type == JTokenType.Object)

--- a/src/SIL.XForge/Realtime/RichText/Delta.cs
+++ b/src/SIL.XForge/Realtime/RichText/Delta.cs
@@ -226,19 +226,24 @@ namespace SIL.XForge.Realtime.RichText
         public bool TryConcatenateInserts(out string opStr, string verse)
         {
             List<JToken> verseOps = new List<JToken>();
-            bool targetVerse = false;
+            bool isTargetVerse = verse == "0";
             foreach (JToken op in this.Ops)
             {
-                if (op[InsertType]?.Type == JTokenType.Object &&
-                    ((JObject)op[InsertType]).Property("verse")?.Value.Type == JTokenType.Object)
+                if (op[InsertType]?.Type == JTokenType.Object)
                 {
-                    JProperty numberToken =
-                        ((JObject)((JObject)op[InsertType]).Property("verse").Value).Property("number");
-                    // update target verse so we know what verse we are in
-                    targetVerse = numberToken.Value.Type == JTokenType.String && (string)numberToken.Value == verse;
-                    continue;
+                    if (((JObject)op[InsertType]).Property("verse")?.Value.Type == JTokenType.Object)
+                    {
+                        JProperty numberToken =
+                            ((JObject)((JObject)op[InsertType]).Property("verse").Value).Property("number");
+                        // update target verse so we know what verse we are in
+                        isTargetVerse = numberToken.Value.Type == JTokenType.String && (string)numberToken.Value == verse;
+                        continue;
+                    }
+                    else if (((JObject)op[InsertType]).Property("chapter")?.Value.Type == JTokenType.Object)
+                        continue;
                 }
-                if (targetVerse)
+                bool isNewLine = op[InsertType]?.Type == JTokenType.String && (string)op[InsertType] == "\n";
+                if (isTargetVerse && !isNewLine)
                     verseOps.Add(op);
             }
             Delta verseDeltaOps = new Delta(verseOps);

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -2134,7 +2134,7 @@ namespace SIL.XForge.Scripture.Services
                         content.InnerXml = comp.isEdited ? $"<p>{threadId} note {i}: EDITED.</p>" : $"<p>{threadId} note {i}.</p>";
                         if (comp.alternateText == SelectionType.RelatedVerse)
                         {
-                            // The alternate text is in a proceeding paragraph with a footnote represented by '*'
+                            // The alternate text is in a subsequent paragraph with a footnote represented by '*'
                             before = before + text + after + "\n*";
                             after = "";
                             selectedText = "other text in verse";
@@ -2145,7 +2145,11 @@ namespace SIL.XForge.Scripture.Services
                             after = "";
                             selectedText = "Section heading text";
                         }
-                        ThreadNoteComponents note = new ThreadNoteComponents { status = NoteStatus.Todo, tagsAdded = new[] { comp.threadNum.ToString() } };
+                        ThreadNoteComponents note = new ThreadNoteComponents
+                        {
+                            status = NoteStatus.Todo,
+                            tagsAdded = new[] { comp.threadNum.ToString() }
+                        };
                         if (comp.notes != null)
                             note = comp.notes[i - 1];
                         ProjectCommentManager.AddComment(new Paratext.Data.ProjectComments.Comment(associatedPtUser)

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -2134,6 +2134,7 @@ namespace SIL.XForge.Scripture.Services
                         content.InnerXml = comp.isEdited ? $"<p>{threadId} note {i}: EDITED.</p>" : $"<p>{threadId} note {i}.</p>";
                         if (comp.alternateText == SelectionType.RelatedVerse)
                         {
+                            // The alternate text is in a proceeding paragraph with a footnote represented by '*'
                             before = before + text + after + "\n*";
                             after = "";
                             selectedText = "other text in verse";

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -865,8 +865,9 @@ namespace SIL.XForge.Scripture.Services
 
             env.AddParatextComments(new[]
             {
-                new ThreadComponents { threadNum = 1, noteCount = 1, username = env.Username01, relatedVerseSelection = true },
-                new ThreadComponents { threadNum = 10, noteCount = 1, username = env.Username01, relatedVerseSelection = true }
+                new ThreadComponents { threadNum = 1, noteCount = 1, username = env.Username01, alternateText = SelectionType.RelatedVerse },
+                new ThreadComponents { threadNum = 8, noteCount = 1, username = env.Username01, alternateText = SelectionType.Section },
+                new ThreadComponents { threadNum = 10, noteCount = 1, username = env.Username01, alternateText = SelectionType.RelatedVerse }
             });
 
             using (IConnection conn = await env.RealtimeService.ConnectAsync())
@@ -879,7 +880,7 @@ namespace SIL.XForge.Scripture.Services
                 IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(userSecret, ptProjectId, 40,
                     new IDocument<NoteThread>[0], deltas, syncUsers);
 
-                Assert.That(changes.Count, Is.EqualTo(2));
+                Assert.That(changes.Count, Is.EqualTo(3));
                 NoteThreadChange thread1Change = changes.Single(c => c.ThreadId == "thread1");
                 // The full matching text of thread1Change.SelectedText is not found. The best match is a substring.
                 // This test also verifies that fetching verse text for verse 1 will fetch text from segment
@@ -889,13 +890,19 @@ namespace SIL.XForge.Scripture.Services
                 Assert.That(thread1Change.SelectedText, Is.EqualTo("other text in verse"), "setup");
                 Assert.That(thread1Change.Position.Length, Is.LessThan("other text in verse".Length));
 
+                NoteThreadChange thread8Change = changes.Single(c => c.ThreadId == "thread8");
+                string textBefore8 = "Context before Text selected thread8 context after.\n";
+                int thread8AnchoringLength = "Section heading text\n".Length;
+                TextAnchor expected8 = new TextAnchor { Start = textBefore8.Length, Length = thread8AnchoringLength };
+                Assert.That(thread8Change.Position, Is.EqualTo(expected8));
+
                 NoteThreadChange thread10Change = changes.Single(c => c.ThreadId == "thread10");
-                string textBefore = "Context before Text selected thread10 context after *";
+                string textBefore10 = "Context before Text selected thread10 context after.\n*";
                 int thread10AnchoringLength = "other text in verse".Length;
-                TextAnchor expected2 = new TextAnchor { Start = textBefore.Length, Length = thread10AnchoringLength };
+                TextAnchor expected10 = new TextAnchor { Start = textBefore10.Length, Length = thread10AnchoringLength };
                 // This test also verifies that fetching verse text for verse 10 will fetch text from both segments
                 // "verse_1_10" and "verse_1_10/p_1".
-                Assert.That(thread10Change.Position, Is.EqualTo(expected2));
+                Assert.That(thread10Change.Position, Is.EqualTo(expected10));
             }
         }
 
@@ -1390,13 +1397,20 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(mapping.Count, Is.EqualTo(0));
         }
 
+        enum SelectionType
+        {
+            Standard,
+            RelatedVerse,
+            Section
+        }
+
         struct ThreadComponents
         {
             public int threadNum;
             public int noteCount;
             public ThreadNoteComponents[] notes;
             public string username;
-            public bool relatedVerseSelection;
+            public SelectionType alternateText;
             public bool isNew;
             public bool isEdited;
             public bool isDeleted;
@@ -2118,11 +2132,17 @@ namespace SIL.XForge.Scripture.Services
                         string date = $"2019-01-0{i}T08:00:00.0000000+00:00";
                         XmlElement content = doc.CreateElement("Contents");
                         content.InnerXml = comp.isEdited ? $"<p>{threadId} note {i}: EDITED.</p>" : $"<p>{threadId} note {i}.</p>";
-                        if (comp.relatedVerseSelection)
+                        if (comp.alternateText == SelectionType.RelatedVerse)
+                        {
+                            before = before + text + after + "\n*";
+                            after = "";
+                            selectedText = "other text in verse";
+                        }
+                        else if (comp.alternateText == SelectionType.Section)
                         {
                             before = before + text + after;
                             after = "";
-                            selectedText = "other text in verse";
+                            selectedText = "Section heading text";
                         }
                         ThreadNoteComponents note = new ThreadNoteComponents { status = NoteStatus.Todo, tagsAdded = new[] { comp.threadNum.ToString() } };
                         if (comp.notes != null)
@@ -2253,6 +2273,15 @@ namespace SIL.XForge.Scripture.Services
                         "{ \"insert\": { \"verse\": { \"number\": \"" + i + "\" } }}, " +
                         "{ \"insert\": \"" + before + noteSelectedText + after + "\", " +
                         "\"attributes\": { \"segment\": \"verse_" + chapterNum + "_" + i + "\" } }";
+                    if (i == 8)
+                    {
+                        // create a new section heading after verse 8
+                        chapterText = chapterText + " ," +
+                            "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"p\" } }}, " +
+                            "{ \"insert\": \"Section heading text\", \"attributes\": { \"segment\": \"s_1\" } }, " +
+                            "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"s\" } }}, " +
+                            "{ \"insert\": { \"blank\": true }, \"attributes\": { \"segment\": \"p_1\" } }";
+                    }
                 }
                 if (includeExtraLastVerseSegment)
                 {

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -891,13 +891,13 @@ namespace SIL.XForge.Scripture.Services
                 Assert.That(thread1Change.Position.Length, Is.LessThan("other text in verse".Length));
 
                 NoteThreadChange thread8Change = changes.Single(c => c.ThreadId == "thread8");
-                string textBefore8 = "Context before Text selected thread8 context after.\n";
-                int thread8AnchoringLength = "Section heading text\n".Length;
+                string textBefore8 = "Context before Text selected thread8 context after.";
+                int thread8AnchoringLength = "Section heading text".Length;
                 TextAnchor expected8 = new TextAnchor { Start = textBefore8.Length, Length = thread8AnchoringLength };
                 Assert.That(thread8Change.Position, Is.EqualTo(expected8));
 
                 NoteThreadChange thread10Change = changes.Single(c => c.ThreadId == "thread10");
-                string textBefore10 = "Context before Text selected thread10 context after.\n*";
+                string textBefore10 = "Context before Text selected thread10 context after.*";
                 int thread10AnchoringLength = "other text in verse".Length;
                 TextAnchor expected10 = new TextAnchor { Start = textBefore10.Length, Length = thread10AnchoringLength };
                 // This test also verifies that fetching verse text for verse 10 will fetch text from both segments


### PR DESCRIPTION
* GetVerseText gets the texts in the delta that also includes section headings
* determine note anchoring position using all text belonging to a verse
* handle anchoring notes to verse text on the front end

![Section heading notes](https://user-images.githubusercontent.com/17931130/149019973-7cf269b9-a4d1-445c-9856-b499afc63cd4.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1224)
<!-- Reviewable:end -->
