### PR TITLE
SF-1470 Do not allow backspace or delete on non-text elements

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -506,8 +506,10 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       const text = this._editor.getText(range.index, range.length);
       return text !== '';
     }
+    const text = this._editor.getText(range.index - 1, 1);
+    const isTextDeletion: boolean = text != null && text.length > 0;
 
-    return this._segment != null && range.index !== this._segment.range.index;
+    return isTextDeletion && this._segment != null && range.index !== this._segment.range.index;
   }
 
   private isDeleteAllowed(range: RangeStatic): boolean {
@@ -519,8 +521,12 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       const text = this._editor.getText(range.index, range.length);
       return text !== '';
     }
+    const text = this._editor.getText(range.index, 1);
+    const isTextDeletion: boolean = text != null && text.length > 0;
 
-    return this._segment != null && range.index !== this._segment.range.index + this._segment.range.length;
+    return (
+      isTextDeletion && this._segment != null && range.index !== this._segment.range.index + this._segment.range.length
+    );
   }
 
   private moveNextSegment(end: boolean = true): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -923,6 +923,8 @@ describe('EditorComponent', () => {
       env.setProjectUserConfig();
       env.wait();
       let range = env.component.target!.getSegmentRange('verse_1_2')!;
+      let contents = env.targetEditor.getContents(range.index, 1);
+      expect(contents.ops![0].insert.blank).toBeDefined();
 
       // set selection on a blank segment
       env.targetEditor.setSelection(range.index, 'user');
@@ -934,6 +936,8 @@ describe('EditorComponent', () => {
       expect(env.targetEditor.history['stack']['undo'].length).toEqual(0);
       env.pressKey('delete');
       expect(env.targetEditor.history['stack']['undo'].length).toEqual(0);
+      contents = env.targetEditor.getContents(range.index, 1);
+      expect(contents.ops![0].insert.blank).toBeDefined();
 
       // set selection at the end of a segment
       range = env.component.target!.getSegmentRange('verse_1_4')!;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -930,6 +930,8 @@ describe('EditorComponent', () => {
       // set selection on a blank segment
       env.targetEditor.setSelection(range.index, 'user');
       env.wait();
+      // the selection is programmatically set to after the blank
+      expect(env.targetEditor.getSelection()!.index).toEqual(range.index + 1);
       expect(env.targetEditor.history['stack']['undo'].length).toEqual(0);
 
       env.pressKey('backspace');


### PR DESCRIPTION
When hitting backspace on a blank segment, the editor history records information on the event but the user does not see any changes. However, if a note is embedded with the blank segment, hitting delete, and then undo will result in duplicate verses. I've put this change on master branch because this change is an improvement on the behaviour of blank segments as a whole.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1225)
<!-- Reviewable:end -->
