### PR TITLE
SF-1479a Retry request for Transcelerator questions when network fails

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
@@ -32,12 +32,17 @@
                 mat-flat-button
                 color="primary"
                 (click)="importFromTranscelerator()"
-                [disabled]="showTransceleratorOfflineMsg"
+                [disabled]="transceleratorRequest.status !== 'complete'"
               >
                 {{ t("import_from_transcelerator") }}
               </button>
               <a mat-button [href]="urls.transceleratorImportHelpPage" target="_blank">{{ t("learn_more") }}</a>
-              <mat-error *ngIf="showTransceleratorOfflineMsg">{{ t("no_transcelerator_offline") }}</mat-error>
+              <mat-error *ngIf="transceleratorRequest.status === 'offline'">
+                {{ t("no_transcelerator_offline") }}
+              </mat-error>
+              <mat-error *ngIf="transceleratorRequest.status === 'trying' && transceleratorRequest.failedAttempts > 0">
+                {{ t("network_error_transcelerator", { count: transceleratorRequest.failedAttempts }) }}
+              </mat-error>
             </mat-card-actions>
           </mat-card>
           <mat-card>

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -116,6 +116,7 @@
     "learn_more": "Learn more",
     "loading": "Loading...",
     "must_be_valid_reference": "Must be a valid reference",
+    "network_error_transcelerator": "Network error fetching Transcelerator questions. Retrying ({{ count }}).",
     "no_questions_available": "There are no questions for the books in this project.",
     "no_transcelerator_offline": "Importing from Transcelerator is not available offline.",
     "question_for_verse": "Question for verse {{ number }}",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/retrying-request.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/retrying-request.service.spec.ts
@@ -1,0 +1,127 @@
+import { fakeAsync, tick } from '@angular/core/testing';
+import { BehaviorSubject, Observable, of, Subject, throwError } from 'rxjs';
+import { CommandErrorCode } from './command.service';
+import { RetryingRequest } from './retrying-request.service';
+import { TestingRetryingRequestService } from './testing-retrying-request.service';
+
+const TEST_NETWORK_ERROR = new Error('Test network error');
+TEST_NETWORK_ERROR['code'] = CommandErrorCode.Other;
+
+const TEST_NON_NETWORK_ERROR = new Error('Test non-network error');
+
+const RETRY_DELAY = RetryingRequest.retryMs;
+const NEGLIGIBLE_AMOUNT_OF_TIME = 10;
+
+describe('RetryingRequest', () => {
+  it('makes requests', async () => {
+    const request = TestingRetryingRequestService.createRequest(of('response'));
+
+    expect(request.result).toBeUndefined();
+    expect(request.error).toBeUndefined();
+    expect(request.status).toBe('trying');
+    expect(request.failedAttempts).toBe(0);
+
+    expect(await request.promiseForResult).toBe('response');
+    expect(request.result).toBe('response');
+    expect(request.error).toBeUndefined();
+    expect(request.status).toBe('complete');
+    expect(request.failedAttempts).toBe(0);
+  });
+
+  it('waits for the user to be online before sending requests', fakeAsync(() => {
+    const online$ = new BehaviorSubject(false);
+    const request = TestingRetryingRequestService.createRequest(of('response'), online$);
+
+    tick();
+    expect(request.result).toBeUndefined();
+    expect(request.error).toBeUndefined();
+    expect(request.status).toBe('offline');
+    expect(request.failedAttempts).toBe(0);
+
+    online$.next(true);
+    tick();
+
+    expect(request.result).toBe('response');
+    expect(request.error).toBeUndefined();
+    expect(request.status).toBe('complete');
+    expect(request.failedAttempts).toBe(0);
+  }));
+
+  it('catches network errors and retries but stops trying when the user is offline', fakeAsync(() => {
+    let networkErrors = true;
+    const online$ = new BehaviorSubject(true);
+    const observable = new Observable(subscriber => {
+      if (networkErrors) {
+        subscriber.error(TEST_NETWORK_ERROR);
+      } else {
+        subscriber.next('response');
+        subscriber.complete();
+      }
+    });
+    const request = TestingRetryingRequestService.createRequest(observable, online$);
+
+    tick();
+    expect(request.failedAttempts).toBe(1);
+    expect(request.status).toBe('trying');
+    expect(request.result).toBeUndefined();
+
+    tick(RETRY_DELAY + NEGLIGIBLE_AMOUNT_OF_TIME);
+    expect(request.failedAttempts).toBe(2);
+    expect(request.status).toBe('trying');
+    expect(request.result).toBeUndefined();
+
+    online$.next(false);
+    tick(RETRY_DELAY + NEGLIGIBLE_AMOUNT_OF_TIME);
+    expect(request.failedAttempts).toBe(2);
+    expect(request.status).toBe('offline');
+    expect(request.result).toBeUndefined();
+
+    networkErrors = false;
+    online$.next(true);
+    tick(RETRY_DELAY + NEGLIGIBLE_AMOUNT_OF_TIME);
+    expect(request.failedAttempts).toBe(2);
+    expect(request.status).toBe('complete');
+    expect(request.result).toBe('response');
+  }));
+
+  it('handles non-network errors', fakeAsync(() => {
+    const online$ = new BehaviorSubject(true);
+    const request = TestingRetryingRequestService.createRequest(throwError(TEST_NON_NETWORK_ERROR), online$);
+
+    let rejectedWithError: any;
+    request.promiseForResult.catch(error => (rejectedWithError = error));
+
+    tick();
+    expect(request.failedAttempts).toBe(0);
+    expect(request.status).toBe('complete');
+    expect(request.result).toBeUndefined();
+    expect(request.error).toEqual(TEST_NON_NETWORK_ERROR);
+    expect(rejectedWithError).toEqual(TEST_NON_NETWORK_ERROR);
+  }));
+
+  it('allows canceling the request', fakeAsync(() => {
+    const online$ = new BehaviorSubject(true);
+    const cancel$ = new Subject<void>();
+    const request = TestingRetryingRequestService.createRequest(throwError(TEST_NETWORK_ERROR), online$, cancel$);
+
+    let rejectedWithError: any;
+    request.promiseForResult.catch(error => (rejectedWithError = error));
+
+    tick();
+    expect(request.failedAttempts).toBe(1);
+    expect(request.status).toBe('trying');
+    expect(request.result).toBeUndefined();
+    expect(request.error).toBeUndefined();
+    expect(rejectedWithError).toBeUndefined();
+
+    tick(RETRY_DELAY - NEGLIGIBLE_AMOUNT_OF_TIME);
+    expect(request.failedAttempts).toBe(1);
+
+    cancel$.next();
+    tick(RETRY_DELAY * 10);
+    expect(request.failedAttempts).toBe(1);
+    expect(request.status).toBe('canceled');
+    expect(request.result).toBeUndefined();
+    expect(request.error).toBeUndefined();
+  }));
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/retrying-request.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/retrying-request.service.ts
@@ -1,0 +1,138 @@
+import { Inject, Injectable } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
+import { filter, take } from 'rxjs/operators';
+import { CONSOLE, ConsoleInterface } from './browser-globals';
+import { CommandErrorCode, CommandService } from './command.service';
+import { PwaService } from './pwa.service';
+
+export interface JsonRpcInvocable {
+  onlineInvoke<T>(url: string, method: string, params: any): Promise<T | undefined>;
+}
+
+export interface FetchOptions {
+  url: string;
+  method: string;
+  params: any;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RetryingRequestService {
+  constructor(
+    private readonly pwaService: PwaService,
+    private readonly commandService: CommandService,
+    @Inject(CONSOLE) private readonly console: ConsoleInterface
+  ) {}
+
+  /**
+   * Creates a RetryingRequest.
+   * @param fetchOptions The url, method, and params for the request.
+   * @param cancel$ An Observable that should fire when the request is no longer needed, such as when the component that
+   * sent the request is being destroyed.
+   */
+  invoke<T>(fetchOptions: FetchOptions, cancel$: Subject<void>): RetryingRequest<T> {
+    return new RetryingRequest<T>(
+      this.commandService,
+      this.pwaService.onlineStatus,
+      cancel$,
+      fetchOptions,
+      this.console
+    );
+  }
+}
+
+/**
+ * Utility class for repeating a request until it is successful. Upon creating the RetryingRequest, if the user is
+ * detected to be online, the request is immediately sent.
+ */
+export class RetryingRequest<T> {
+  /**
+   * Promise that will resolve with the result of the request, or reject if an error was returned by the server.
+   * Does not throw on network errors.
+   */
+  promiseForResult: Promise<T | undefined>;
+  /**
+   * Result of the request. This will be undefined until the request has completed. If the network request is successful
+   * but the server responds with an error, this will remain undefined.
+   */
+  result?: T;
+  /**
+   * The server's error response. This is initially undefined. If the network request is successful and the server
+   * responds with an error, this will be set to that error.
+   */
+  error?: any;
+  /**
+   * The number of times the network request has failed. This is useful for indicating to the user how many network
+   * attempts have been made.
+   */
+  failedAttempts = 0;
+  /**
+   * The status of the request. Possible values are:
+   * offline: Requests are not being attempted because the user is believed to not have a working network connection.
+   * trying: Requests are being actively made. As long as the user has a network connection and until a response is
+   * successful the status will remain trying.
+   * complete: The request has succeeded and is no longer being attempted. This does not indicate that the server's
+   * response did not contain an error, only that a request was successfully made.
+   * canceled: The request was canceled because the cancel Observable fired.
+   */
+  status: 'offline' | 'trying' | 'complete' | 'canceled' = 'trying';
+  private canceled = false;
+  static readonly retryMs = 3000;
+
+  constructor(
+    private readonly rpcService: JsonRpcInvocable,
+    private readonly online$: Observable<boolean>,
+    private readonly cancel$: Subject<void>,
+    fetchOptions: FetchOptions,
+    @Inject(CONSOLE) private readonly console: ConsoleInterface
+  ) {
+    this.cancel$.pipe(take(1)).subscribe(() => {
+      this.canceled = true;
+      this.status = 'canceled';
+    });
+    this.promiseForResult = this.invoke(fetchOptions);
+  }
+
+  private async invoke(options: FetchOptions): Promise<T | undefined> {
+    while (!this.canceled && this.status !== 'complete') {
+      const online = await this.online$.pipe(take(1)).toPromise();
+      if (online !== true) {
+        this.status = 'offline';
+        await this.uponOnline();
+      } else {
+        this.status = 'trying';
+
+        try {
+          const result = await this.rpcService.onlineInvoke<T>(options.url, options.method, options.params);
+          this.result = result;
+          this.status = 'complete';
+          return this.result;
+        } catch (e) {
+          if (!this.isNetworkError(e)) {
+            this.error = e;
+            this.status = 'complete';
+            throw this.error;
+          }
+          this.console.error(e);
+          this.failedAttempts++;
+          await new Promise(resolve => setTimeout(resolve, RetryingRequest.retryMs));
+        }
+      }
+    }
+    return;
+  }
+
+  private async uponOnline(): Promise<void> {
+    await this.online$
+      .pipe(
+        filter(isOnline => isOnline),
+        take(1)
+      )
+      .toPromise();
+  }
+
+  private isNetworkError(error: unknown): boolean {
+    return typeof error === 'object' && error?.['code'] === CommandErrorCode.Other;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/subscription-disposable.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/subscription-disposable.ts
@@ -7,7 +7,7 @@ import { takeUntil } from 'rxjs/operators';
 @Directive()
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
 export abstract class SubscriptionDisposable implements OnDestroy {
-  private ngUnsubscribe: Subject<void> = new Subject<void>();
+  protected ngUnsubscribe: Subject<void> = new Subject<void>();
 
   ngOnDestroy(): void {
     this.dispose();

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/testing-retrying-request.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/testing-retrying-request.service.ts
@@ -1,0 +1,20 @@
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import { ConsoleInterface } from './browser-globals';
+import { FetchOptions, JsonRpcInvocable, RetryingRequest } from './retrying-request.service';
+
+/**
+ * Utility class for testing components that use the RetryingRequestService
+ */
+export class TestingRetryingRequestService {
+  static createRequest<T>(
+    invoke: Observable<T>,
+    online: Observable<boolean> = new BehaviorSubject(true),
+    cancel$ = new Subject<void>()
+  ): RetryingRequest<T> {
+    const invocable = {
+      onlineInvoke: (_url: string, _method: string, _params: string) => invoke.toPromise()
+    } as JsonRpcInvocable;
+    const mockConsole = { log: () => {}, error: () => {} } as ConsoleInterface;
+    return new RetryingRequest<T>(invocable, online, cancel$, {} as FetchOptions, mockConsole);
+  }
+}


### PR DESCRIPTION
Previously our strategy for dealing with a lack of a good network connection was to try to detect whether the user was online (using the PwaService), and wait for the user to be online before initiating a request. This works to a degree, but if the request fails we treat it as a hard error and don't retry. The page is then essentially broken. One place where this could happen is in the import questions dialog, which immediately fetches the Transcelerator questions when the dialog opens, so they'll be ready if the user selects to import from Transcelerator.

A much better strategy is to keep trying as long as the error is only a network error. In order to make this as simple as possible for the components that use it, I've created a RetryingRequest class. There are a lot of doc comments for that class, so I would recommend starting there.

The rest of this change is:
- Using the RetryingRequest in the ImportQuestionsDialog
- A TestingRetryingRequestService that creates RetryingRequests that can easily be used in tests. That way components can easily test what happens when different network conditions occur.
- Tests for RetryingRequest and ImportQuestionsDialog
- A change in SubscriptionDisposable to allow subclasses of SubscriptionDisposable (that would be most of our components I think) to access the ngUnsubscribe property, thereby allowing more flexibility in how subcasses perform cleanup. This change allowed the ImportQuestionsDialog to do `projectService.transceleratorQuestions(this.data.projectId, this.ngUnsubscribe)`, where `this.ngUnsubscribe` (a `Subject<void>`) is being used to inform the RetryingRequest when the dialog is being destroyed and the data is no longer needed (and hence it can stop retrying).
 
Here's how part of the import questions dialog looks when the network request is in various states:

Offline | Attempting | Success
--------|------------|--------
![](https://user-images.githubusercontent.com/6140710/151095367-60a58ebd-9f79-4af8-b3cd-ae2ce52dba32.png) | ![](https://user-images.githubusercontent.com/6140710/151095366-ed95232b-d436-4306-8ddd-31e0ea6d8a1e.png) | ![](https://user-images.githubusercontent.com/6140710/151095368-36c75d3b-a75d-4177-a3d9-aa94bd706b40.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1230)
<!-- Reviewable:end -->
