### PR TITLE
Add script to modify doc, even if it's corrupted

### DIFF
--- a/scripts/db_tools/fix-doc.js
+++ b/scripts/db_tools/fix-doc.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+// Delete a doc (though it still exists in the DB), then recreate it in another state. This is useful for when a
+// document has been corrupted in such a way that it cannot be fixed by just applying a operation to it. This script is
+// intended to be edited to be used as needed.
+
+const utils = require('./utils.js');
+const RichText = utils.requireFromRealTimeServer('rich-text');
+const ShareDB = utils.requireFromRealTimeServer('sharedb/lib/client');
+const WebSocket = utils.requireFromRealTimeServer('ws');
+
+// Edit these settings to specify which doc to revert
+const docId = '';
+const connectionConfig = utils.devConfig;
+const collection = 'texts';
+const dryRun = true;
+
+ShareDB.types.register(RichText.type);
+
+async function run() {
+  const ws = new WebSocket(connectionConfig.wsConnectionString);
+  const conn = new ShareDB.Connection(ws);
+  try {
+    const doc = conn.get(collection, docId);
+    await utils.fetchDoc(doc);
+
+    const newOps = cleanupOps(doc.data.ops);
+
+    if (!dryRun) {
+      await utils.deleteDoc(doc);
+      console.log('deleted doc');
+    }
+
+    if (dryRun) {
+      console.log('would set doc to:');
+      utils.visualizeOps(newOps, true);
+    } else {
+      await utils.createDoc(doc, newOps, RichText.type.name);
+      console.log('recreated doc');
+    }
+  } finally {
+    conn.close();
+  }
+}
+
+// Edit this function to modify the ops to whatever state they should be in
+function cleanupOps(ops) {
+  return ops.filter(op => op.insert != null && ['object', 'string'].includes(typeof op.insert));
+}
+
+run();


### PR DESCRIPTION
If a doc is corrupted in such a way that it's not a valid doc, then it's not possible to convert it into a valid doc by applying an op.

This script gets around that problem by deleting the doc and recreating it. It's still the same doc though; the version numbers keep climbing. Basically there's an op that says "delete everything" and then another op that says "create it in this state."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1235)
<!-- Reviewable:end -->
