### PR TITLE
Add SyncUser migration tool

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -127,6 +127,22 @@
         "runtimeExecutable": "/usr/bin/chromium-browser"
       }
     },
+    {
+      "name": "Migration Sync User",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build-migrator-sync-user-to-pt-user",
+      "program": "${workspaceRoot}/src/Migrations/SyncUserToPTUser/bin/Debug/netcoreapp3.1/SyncUserToPTUser.dll",
+      "cwd": "${workspaceRoot}/src/Migrations/SyncUserToPTUser",
+      "stopAtEntry": false,
+      "console": "integratedTerminal",
+      "args": ["--start-ng-serve=listen"],
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "SYNC_USER_PROJECT_IDS": "6201831c0e13de5c38e0ed7d",
+        "SYNC_USER_MODE_RUN": "true"
+      }
+    }
     // {
     //   "name": "Migration Foo",
     //   "type": "coreclr",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -119,6 +119,17 @@
       },
       "problemMatcher": "$msCompile"
     },
+    {
+      "label": "build-migrator-sync-user-to-pt-user",
+      "command": "dotnet",
+      "args": ["build", "/property:GenerateFullPaths=true"],
+      "type": "shell",
+      "group": "build",
+      "options": {
+        "cwd": "${workspaceRoot}/src/Migrations/SyncUserToPTUser"
+      },
+      "problemMatcher": "$msCompile"
+    }
     // {
     //   "label": "build-migrator-foo",
     //   "command": "dotnet",

--- a/src/Migrations/SyncUserToPTUser/IProgramLogger.cs
+++ b/src/Migrations/SyncUserToPTUser/IProgramLogger.cs
@@ -1,0 +1,10 @@
+namespace SyncUserToPTUser
+{
+    /// <summary>
+    /// Expected interface, to allow mocking.
+    /// </summary>
+    public interface IProgramLogger
+    {
+        void Log(string message, bool finalNewline = true);
+    }
+}

--- a/src/Migrations/SyncUserToPTUser/ISyncUserToPTUserService.cs
+++ b/src/Migrations/SyncUserToPTUser/ISyncUserToPTUserService.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SyncUserToPTUser
+{
+    interface ISyncUserToPTUserService
+    {
+        Task MoveSyncUsersToProject(bool dryRun, ISet<string> sfProjectIdsToUpdate);
+    }
+}

--- a/src/Migrations/SyncUserToPTUser/Program.cs
+++ b/src/Migrations/SyncUserToPTUser/Program.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using SIL.XForge.Scripture.Services;
+
+namespace SyncUserToPTUser
+{
+    /// <summary>
+    /// Moves paratext users on a project synced with notes from the project secrets to the sf-project model
+    /// Fails to run if SF server is running, with error
+    /// > System.Net.Http.HttpRequestException: An error occurred while sending the request.
+    /// >  ---> System.IO.IOException: The response ended prematurely.
+    /// </summary>
+    public class Program
+    {
+        public static readonly char Bullet1 = '>';
+        public static readonly char Bullet2 = '*';
+        public static readonly char Bullet3 = '-';
+        public static IProgramLogger Logger;
+
+        public static async Task Main(string[] args)
+        {
+            string sfAppDir = Environment.GetEnvironmentVariable("SF_APP_DIR") ?? "../../SIL.XForge.Scripture";
+            Directory.SetCurrentDirectory(sfAppDir);
+            IWebHostBuilder builder = CreateWebHostBuilder(args);
+            IWebHost webHost = builder.Build();
+            Logger = webHost.Services.GetService<IProgramLogger>();
+            Logger.Log($"Starting.");
+
+            try
+            {
+                await webHost.StartAsync();
+            }
+            catch (HttpRequestException)
+            {
+                Logger.Log("There was an error starting the program before getting to the inspection or migration. "
+                    + "Maybe the SF server is running on this machine and needs shut down? Rethrowing.");
+                throw;
+            }
+            ISyncUserToPTUserService tool = webHost.Services.GetService<ISyncUserToPTUserService>();
+            string projectIds = Environment.GetEnvironmentVariable("SYNC_USER_PROJECT_IDS");
+            bool runMode = Environment.GetEnvironmentVariable("SYNC_USER_MODE_RUN") == "true";
+            var syncUserProjectIds = string.IsNullOrEmpty(projectIds) ? null : new HashSet<string>(projectIds.Split(' '));
+            await tool.MoveSyncUsersToProject(!runMode, syncUserProjectIds);
+            await webHost.StopAsync();
+            Logger.Log("Done.");
+        }
+
+        /// <summary>
+        /// This was copied and modified from `SIL.XForge.Scripture/Program.cs`.
+        /// </summary>
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args)
+        {
+            IWebHostBuilder builder = WebHost.CreateDefaultBuilder(args);
+
+            // Secrets to connect to PT web API are associated with the SIL.XForge.Scripture assembly.
+            Assembly sfAssembly = Assembly.GetAssembly(typeof(ParatextService));
+
+            IConfigurationRoot configuration = new ConfigurationBuilder()
+                .AddUserSecrets(sfAssembly)
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .Build();
+
+            return builder
+                .ConfigureAppConfiguration((context, config) =>
+                    {
+                        IWebHostEnvironment env = context.HostingEnvironment;
+                        if (env.IsDevelopment() || env.IsEnvironment("Testing"))
+                            config.AddJsonFile("appsettings.user.json", true);
+                        else
+                            config.AddJsonFile("secrets.json", true, true);
+                        if (env.IsEnvironment("Testing"))
+                        {
+                            var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
+                            if (appAssembly != null)
+                                config.AddUserSecrets(appAssembly, true);
+                        }
+                        config.AddEnvironmentVariables();
+                    })
+                .UseConfiguration(configuration)
+                .UseStartup<Startup>();
+        }
+    }
+}

--- a/src/Migrations/SyncUserToPTUser/ProgramLogger.cs
+++ b/src/Migrations/SyncUserToPTUser/ProgramLogger.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace SyncUserToPTUser
+{
+    /// <summary>
+    /// Simple logger functionality, that can be mocked.
+    /// </summary>
+    public class ProgramLogger : IProgramLogger
+    {
+        private readonly int _processId;
+        public ProgramLogger(int processId)
+        {
+            _processId = processId;
+        }
+        /// <summary>
+        /// Write message to standard output, prefixed by time and program name.
+        /// </summary>
+        public void Log(string message, bool finalNewline = true)
+        {
+            string when = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+            string programName = "SyncUserToPTUser";
+            string output = $"{when} {programName}[{_processId}]: {message}";
+            if (finalNewline)
+            {
+                Console.WriteLine(output);
+            }
+            else
+            {
+                Console.Write(output);
+            }
+        }
+    }
+}

--- a/src/Migrations/SyncUserToPTUser/Startup.cs
+++ b/src/Migrations/SyncUserToPTUser/Startup.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Autofac;
+using Autofac.Extensions.DependencyInjection;
+using SIL.XForge;
+using SIL.XForge.Configuration;
+using SIL.XForge.Scripture;
+using SIL.XForge.Scripture.Services;
+using System.Diagnostics;
+
+namespace SyncUserToPTUser
+{
+    /// <summary>
+    /// SyncUserToPTUser app configuration to get needed services available.
+    /// This was copied and modified from `SIL.XForge.Scripture/Startup.cs`.
+    /// </summary>
+    public class Startup
+    {
+        public Startup(IConfiguration configuration, IWebHostEnvironment env, ILoggerFactory loggerFactory)
+        {
+            Configuration = configuration;
+            Environment = env;
+            LoggerFactory = loggerFactory;
+        }
+
+        public IConfiguration Configuration { get; }
+        public IWebHostEnvironment Environment { get; }
+        public ILoggerFactory LoggerFactory { get; }
+        public IContainer ApplicationContainer { get; private set; }
+
+        private bool IsDevelopment => Environment.IsDevelopment() || Environment.IsEnvironment("Testing");
+
+        public IServiceProvider ConfigureServices(IServiceCollection services)
+        {
+            var containerBuilder = new ContainerBuilder();
+
+            services.AddExceptionReporting(Configuration);
+
+            services.AddConfiguration(Configuration);
+
+            services.AddSFRealtimeServer(LoggerFactory, Configuration, IsDevelopment);
+
+            services.AddSFServices();
+
+            services.AddSFDataAccess(Configuration);
+
+            services.AddLocalization(options => options.ResourcesPath = "Resources");
+
+            services.AddSFMachine(Configuration);
+
+            services.AddTransient<IParatextSyncRunner, ParatextSyncRunner>();
+            services.AddSingleton<IProgramLogger>((IServiceProvider serviceProvider) =>
+            {
+                using (Process thisProcess = Process.GetCurrentProcess())
+                {
+                    return new ProgramLogger(thisProcess.Id);
+                }
+            });
+            services.AddSingleton<ISyncUserToPTUserService, SyncUserToPTUserService>();
+
+            services.Configure<RequestLocalizationOptions>(
+                opts =>
+                {
+                    var supportedCultures = new List<CultureInfo>();
+                    foreach (var culture in SharedResource.Cultures)
+                    {
+                        supportedCultures.Add(new CultureInfo(culture.Key));
+                    }
+
+                    opts.DefaultRequestCulture = new RequestCulture("en");
+                    // Formatting numbers, dates, etc.
+                    opts.SupportedCultures = supportedCultures;
+                    // UI strings that we have localized.
+                    opts.SupportedUICultures = supportedCultures;
+                });
+
+            containerBuilder.Populate(services);
+            ApplicationContainer = containerBuilder.Build();
+            return new AutofacServiceProvider(ApplicationContainer);
+        }
+
+        public void Configure(IApplicationBuilder app, IHostApplicationLifetime appLifetime,
+            IExceptionHandler exceptionHandler)
+        {
+            // Set a custom realtime port using the Realtime__Port environment variable
+            string realtimePort = Configuration["Realtime:Port"];
+            Console.WriteLine($"Realtime:Port : {realtimePort}");
+            app.UseRealtimeServer();
+            app.UseSFDataAccess(false);
+            appLifetime.ApplicationStopped.Register(() => ApplicationContainer.Dispose());
+        }
+    }
+}

--- a/src/Migrations/SyncUserToPTUser/SyncUserToPTUser.csproj
+++ b/src/Migrations/SyncUserToPTUser/SyncUserToPTUser.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\SIL.XForge.Scripture\SIL.XForge.Scripture.csproj" />
+    <ProjectReference Include="..\..\SIL.XForge\SIL.XForge.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Migrations/SyncUserToPTUser/SyncUserToPTUserService.cs
+++ b/src/Migrations/SyncUserToPTUser/SyncUserToPTUserService.cs
@@ -80,12 +80,6 @@ namespace SyncUserToPTUser
                         }
                         if (projectDoc.Data.ParatextUsers == null)
                             op.Set(pd => pd.ParatextUsers, ptUsers);
-                        else
-                        {
-                            _logger.Log($"      {Program.Bullet3} Some Paratext users already exist. Adding to the list.");
-                            foreach (ParatextUserProfile user in ptUsers)
-                                op.Add(pd => pd.ParatextUsers, user);
-                        }
                     });
                     await _projectSecretRepo.UpdateAsync(projectSecret.Id, u =>
                     {

--- a/src/Migrations/SyncUserToPTUser/SyncUserToPTUserService.cs
+++ b/src/Migrations/SyncUserToPTUser/SyncUserToPTUserService.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
+using Autofac;
+using MongoDB.Driver;
+using SIL.XForge.DataAccess;
+using SIL.XForge.Models;
+using SIL.XForge.Realtime;
+using SIL.XForge.Realtime.Json0;
+using SIL.XForge.Scripture.Models;
+using SIL.XForge.Scripture.Services;
+
+namespace SyncUserToPTUser
+{
+    /// <summary> Code to move sync users to the sf-project model. </summary>
+    public class SyncUserToPTUserService : ISyncUserToPTUserService
+    {
+        private readonly IRealtimeService _realtimeService;
+        private readonly IParatextService _paratextService;
+        private readonly IRepository<SFProjectSecret> _projectSecretRepo;
+        private IConnection _realtimeServiceConnection;
+
+        private readonly IProgramLogger _logger;
+
+        public SyncUserToPTUserService(IRealtimeService realtimeService, IParatextService paratextService,
+            IRepository<SFProjectSecret> projectSecretRepo, IProgramLogger logger)
+        {
+            _realtimeService = realtimeService;
+            _paratextService = paratextService;
+            _projectSecretRepo = projectSecretRepo;
+            _logger = logger;
+        }
+
+        /// <summary> Move sync users to the SF project model. </summary>
+        public async Task MoveSyncUsersToProject(bool dryRun, ISet<string> sfProjectIdsToUpdate = null)
+        {
+            List<SFProject> sfProjects = _realtimeService.QuerySnapshots<SFProject>().ToList<SFProject>();
+            if (sfProjectIdsToUpdate != null)
+            {
+                sfProjects.RemoveAll((SFProject sfProject) => !sfProjectIdsToUpdate.Contains(sfProject.Id));
+                string ids = string.Join(' ', sfProjects.Select((SFProject sfProject) => sfProject.Id));
+                int count = sfProjects.Count;
+                _logger.Log($"Only working on the subset of projects (count {count}) with these SF project ids: {ids}");
+            }
+            _realtimeServiceConnection = await _realtimeService.ConnectAsync();
+
+            _logger.Log($"{Program.Bullet1} Report on projects to move sync users:");
+            foreach (SFProject sfProject in sfProjects)
+            {
+                try
+                {
+                    IDocument<SFProject> projectDoc = await _realtimeServiceConnection.FetchAsync<SFProject>(sfProject.Id);
+                    if (!(await _projectSecretRepo.TryGetAsync(sfProject.Id)).TryResult(out SFProjectSecret projectSecret))
+                    {
+                        _logger.Log($"Could not find project secret for project {sfProject.Id}.");
+                        continue;
+                    }
+                    if (dryRun)
+                    {
+                        int syncUserCount = projectSecret.SyncUsers.Count;
+                        _logger.Log($"  {Program.Bullet2} Dry Run Mode: Expected to move {syncUserCount} sync users on project: {sfProject.Id}");
+                        continue;
+                    }
+                    List<ParatextUserProfile> ptUsers = new List<ParatextUserProfile>();
+                    await projectDoc.SubmitJson0OpAsync(op =>
+                    {
+                        foreach (SyncUser syncUser in projectSecret.SyncUsers)
+                        {
+                            var paratextUser = new ParatextUserProfile
+                            {
+                                Username = syncUser.ParatextUsername,
+                                OpaqueUserId = syncUser.Id,
+                            };
+                            ptUsers.Add(paratextUser);
+                        }
+                        op.Set(pd => pd.ParatextUsers, ptUsers);
+                    });
+                    await _projectSecretRepo.UpdateAsync(projectSecret.Id, u =>
+                    {
+                        u.Unset(projectSecret => projectSecret.SyncUsers);
+                    });
+                    _logger.Log($"  {Program.Bullet2} Sync users moved to SF project {sfProject.Name} {sfProject.Id}.");
+                }
+                catch (Exception e)
+                {
+                    // We probably won't get here. But just in case.
+                    _logger.Log($"  {Program.Bullet2} There was a problem moving sync users - projectId: {sfProject.Id}");
+                    _logger.Log($"  {Program.Bullet2} Exception was {e.Message}");
+                }
+            }
+            _realtimeServiceConnection?.Dispose();
+        }
+    }
+}

--- a/src/Migrations/SyncUserToPTUser/build-dev
+++ b/src/Migrations/SyncUserToPTUser/build-dev
@@ -1,0 +1,2 @@
+#!/bin/bash
+ASPNETCORE_ENVIRONMENT=Development dotnet watch build

--- a/src/Migrations/SyncUserToPTUser/build-production
+++ b/src/Migrations/SyncUserToPTUser/build-production
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Build for running on another computer.
+# This is turning into a bit of a kludge, in order for the product filename to contain the date,
+# the contents to be contained within a top-level folder, and not leave old intermediate production
+# files laying around. But it works.
+#
+# Usage: ./build-production
+#
+# To run product on another computer:
+# Set ASPNETCORE_ENVIRONMENT to Development on a workstation, Staging for QA, or omit it for Live.
+# Set SYNC_USER_PROJECT_IDS to "<project_1_ID> <project_2_ID> ... <project_N_ID>" to limit projects
+# Set SYNC_USER_MODE_RUN to "true" to perform the migration, or omit to do a dry run
+# Extract program:
+#   tar xf sync-user-to-pt-user-*.tar.xz
+# Run:
+#   ASPNETCORE_ENVIRONMENT=Development SF_APP_DIR="/path/to/sf/app" sync-user-to-pt-user-*/SyncUserToPtUser
+
+set -ue -o pipefail
+
+outputProductName="sync-user-to-pt-user-$(date '+%Y%m%d%H%M%S')"
+outputDir="bin/${outputProductName}"
+dotnet publish --runtime "linux-x64" -o "${outputDir}"
+package="$(mktemp -d)/${outputProductName}.tar.xz"
+cd "${outputDir}/.."
+tar cfJ "${package}" ${outputProductName}
+cd -
+rm -rf "${outputDir}"
+echo Product: ${package}


### PR DESCRIPTION
To hide pt usernames from users that should not have access, the sf-project model had the ParatextUsers property added, but this will be projected away for users who do not have access. Since SyncUsers in the SFProjectSecret model essentially shared the same purpose of mapping paratext usernames to an id used to mark notes, it made sense to merge the PT sync users from the SFProjectSecret model into the SFProject in the ParatextUsers property.

This tool can be run on the QA and Live servers to move the SyncUsers of each project secret to the corresponding project. The link to the run sheet can be found [here](https://docs.google.com/document/d/1sTk0Du8XxebFNbAlqVH-BHbyHGwqpAPTcmIDPPEBBC8/edit?usp=sharing)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1240)
<!-- Reviewable:end -->
