### PR TITLE
SF-1451b Fix infinite loading indicator when importing offline

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
@@ -14,7 +14,7 @@ import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-inf
 import { fromVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { Canon } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/canon';
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
-import { BehaviorSubject, Observable, of, throwError } from 'rxjs';
+import { BehaviorSubject, of, throwError } from 'rxjs';
 import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
 import { CsvService } from 'xforge-common/csv-service.service';
@@ -38,6 +38,7 @@ const mockedAuthService = mock(AuthService);
 const mockedCookieService = mock(CookieService);
 const mockedMdcDialog = mock(MdcDialog);
 const mockedCsvService = mock(CsvService);
+const mockedRealtimeQuery = mock(RealtimeQuery);
 
 describe('ImportQuestionsDialogComponent', () => {
   configureTestingModule(() => ({
@@ -709,12 +710,7 @@ class TestEnvironment {
         TestingRetryingRequestService.createRequest(of(this.questions), this.online$)
       );
     }
-    when(mockedProjectService.queryQuestions('project01')).thenResolve({
-      ready$: new Observable<void>(subscriber => {
-        setTimeout(() => subscriber.next(), 0);
-      }),
-      dispose: () => {},
-      docs: this.existingQuestions as Readonly<QuestionDoc[]>
-    } as RealtimeQuery<QuestionDoc>);
+    when(mockedRealtimeQuery.docs).thenReturn(this.existingQuestions);
+    when(mockedProjectService.queryQuestions('project01')).thenResolve(instance(mockedRealtimeQuery));
   }
 }


### PR DESCRIPTION
Previously the front end was trying to make sure it had a completely up to date list of existing questions before starting the import. This isn't possible while offline, so it never completed.

The root problem was a wrong assumption by me about what a realtime query's `ready$` really does (caused in turn by a lack of documentation). Hence the change to the test; I was mocking my wrong assumption into the test. It would have taken an actual e2e test to properly test this without my wrong assumption getting in the way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1242)
<!-- Reviewable:end -->
