### PR TITLE
SF-1471 Delete have-read note refs when rm note

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/sf-project-user-config.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project-user-config.ts
@@ -18,8 +18,8 @@ export interface SFProjectUserConfig extends ProjectData {
   numSuggestions: number;
   selectedSegment: string;
   selectedSegmentChecksum?: number;
+  noteRefsRead: string[];
   questionRefsRead: string[];
   answerRefsRead: string[];
   commentRefsRead: string[];
-  noteRefsRead: string[];
 }

--- a/src/SIL.XForge.Scripture/Models/NoteThread.cs
+++ b/src/SIL.XForge.Scripture/Models/NoteThread.cs
@@ -5,6 +5,12 @@ namespace SIL.XForge.Scripture.Models
 {
     public class NoteThread : ProjectData
     {
+        public static string GetDocId(string sfProjectId, string threadId)
+        {
+            return $"{sfProjectId}:{threadId}";
+        }
+
+        /// <summary>Thread id. Not to be confused with the doc id.</summary>
         public string DataId { get; set; }
         public VerseRefData VerseRef { get; set; }
         public List<Note> Notes { get; set; } = new List<Note>();

--- a/src/SIL.XForge.Scripture/Models/SFProjectUserConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectUserConfig.cs
@@ -21,12 +21,13 @@ namespace SIL.XForge.Scripture.Models
         public bool TranslationSuggestionsEnabled { get; set; } = true;
         public string SelectedSegment { get; set; } = "";
         public int? SelectedSegmentChecksum { get; set; }
+        /// <summary>Ids of notes (not threads) which the user has read.</summary>
+        public List<string> NoteRefsRead { get; set; } = new List<string>();
 
         // checking
         public List<string> QuestionRefsRead { get; set; } = new List<string>();
         public List<string> AnswerRefsRead { get; set; } = new List<string>();
         public List<string> CommentRefsRead { get; set; } = new List<string>();
         public string SelectedQuestionRef { get; set; }
-        public List<string> NoteRefsRead { get; set; } = new List<string>();
     }
 }

--- a/src/SIL.XForge/Models/Project.cs
+++ b/src/SIL.XForge/Models/Project.cs
@@ -5,6 +5,7 @@ namespace SIL.XForge.Models
     public abstract class Project : Json0Snapshot
     {
         public string Name { get; set; }
+        /// <summary>Dictionary of SF user id to project role</summary>
         public Dictionary<string, string> UserRoles { get; set; } = new Dictionary<string, string>();
         public Dictionary<string, string[]> UserPermissions { get; set; } = new Dictionary<string, string[]>();
         public bool SyncDisabled { get; set; }


### PR DESCRIPTION
- At sync time, when a note is removed, also remove refs to it from
project-user-config docs' have-read note refs lists, to not needlessly
build up orphaned refs there.
- In the SFProjectUserConfig model, move NoteRefsRead out of the
Checking area.
- This does not take into account notes being removed while a user is
offline, where they could still read a note and add its ref to their
have-read list, even even tho that note had already been removed from
the server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1249)
<!-- Reviewable:end -->
