### PR TITLE
SF-1381 Sync error when backup is restored but not used

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -960,6 +960,11 @@ namespace SIL.XForge.Scripture.Services
 
                 try
                 {
+                    if (_fileSystemService.DirectoryExists(restoredDestination))
+                    {
+                        _fileSystemService.DeleteDirectory(restoredDestination);
+                    }
+
                     // Remove the backup destination, if it exists
                     if (_fileSystemService.DirectoryExists(destination))
                     {


### PR DESCRIPTION
Looking SF-1381 it seems that the reason the testers saw errors was because of an existing "_Restored" directory that prevented hg from restoring the backup. This ensures that any existing directories that need to be deleted are before attempting to restore the backup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1252)
<!-- Reviewable:end -->
