### PR TITLE
SF-1505 Fix permission error removing user during sync

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -285,8 +285,7 @@ namespace SIL.XForge.Scripture.Services
                                 await _paratextService.GetResourcePermissionAsync(sourceParatextId, uid, token);
                             if (permission == TextInfoPermission.None)
                             {
-                                // As resource projects don't have administrators, connect as the user we are to remove
-                                await _projectService.RemoveUserAsync(uid, sourceProjectRef, uid);
+                                await _projectService.RemoveUserWithoutPermissionsCheckAsync(uid, sourceProjectRef, uid);
                             }
                         }
                     }
@@ -846,7 +845,7 @@ namespace SIL.XForge.Scripture.Services
                 }
             });
             foreach (var userId in userIdsToRemove)
-                await _projectService.RemoveUserAsync(_userSecret.Id, _projectDoc.Id, userId);
+                await _projectService.RemoveUserWithoutPermissionsCheckAsync(_userSecret.Id, _projectDoc.Id, userId);
             if (_notesMapper.NewSyncUsers.Count > 0)
             {
                 await _projectSecrets.UpdateAsync(_projectSecret.Id, u =>

--- a/src/SIL.XForge/Services/IProjectService.cs
+++ b/src/SIL.XForge/Services/IProjectService.cs
@@ -8,6 +8,7 @@ namespace SIL.XForge.Services
     {
         Task AddUserAsync(string curUserId, string projectId, string projectRole = null);
         Task RemoveUserAsync(string curUserId, string projectId, string projectUserId);
+        Task RemoveUserWithoutPermissionsCheckAsync(string curUserId, string projectId, string projectUserId);
         Task<string> GetProjectRoleAsync(string curUserId, string projectId);
         Task UpdateRoleAsync(string curUserId, string systemRole, string projectId, string projectRole);
         Task<Uri> SaveAudioAsync(string curUserId, string projectId, string dataId, string extension,

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -90,21 +90,6 @@ namespace SIL.XForge.Services
             }
         }
 
-        public async Task<string> GetProjectRoleAsync(string curUserId, string projectId)
-        {
-            TModel project;
-            try
-            {
-                project = await GetProjectAsync(projectId);
-            }
-            catch (DataNotFoundException)
-            {
-                return null;
-            }
-            Attempt<string> attempt = await TryGetProjectRoleAsync(project, curUserId);
-            return attempt.Result;
-        }
-
         /// <summary>
         /// Disassociate user projectUserId from project projectId, without checking permissions.
         /// </summary>
@@ -141,6 +126,21 @@ namespace SIL.XForge.Services
                     await task;
                 }
             }
+        }
+
+        public async Task<string> GetProjectRoleAsync(string curUserId, string projectId)
+        {
+            TModel project;
+            try
+            {
+                project = await GetProjectAsync(projectId);
+            }
+            catch (DataNotFoundException)
+            {
+                return null;
+            }
+            Attempt<string> attempt = await TryGetProjectRoleAsync(project, curUserId);
+            return attempt.Result;
         }
 
         public async Task UpdateRoleAsync(string curUserId, string systemRole, string projectId, string projectRole)

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -75,6 +75,21 @@ namespace SIL.XForge.Services
             }
         }
 
+        /// <summary>
+        /// Disassociate user projectUserId from project projectId. No permissions check is performed.
+        /// </summary>
+        public async Task RemoveUserWithoutPermissionsCheckAsync(string curUserId, string projectId, string projectUserId)
+        {
+            if (curUserId == null || projectId == null || projectUserId == null)
+            {
+                throw new ArgumentNullException();
+            }
+            using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
+            {
+                await RemoveUserCoreAsync(conn, curUserId, projectId, projectUserId);
+            }
+        }
+
         public async Task<string> GetProjectRoleAsync(string curUserId, string projectId)
         {
             TModel project;

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -377,7 +377,7 @@ namespace SIL.XForge.Scripture.Services
 
             SFProject project = env.VerifyProjectSync(true);
             Assert.That(project.UserRoles["user01"], Is.EqualTo(SFProjectRole.Translator));
-            await env.SFProjectService.Received().RemoveUserAsync("user01", "project01", "user02");
+            await env.SFProjectService.Received().RemoveUserWithoutPermissionsCheckAsync("user01", "project01", "user02");
         }
 
         [Test]


### PR DESCRIPTION
Here's what the problem appears to be:
- Project B is based on Project A
- User 1 is on Project A as an observer, and Project B as an admin
- A user is removed from Project A in Paratext
- User 1 does a sync of Project B, which also syncs Project A
- The sync of Project A involves removing the user from the project that was removed already in Paratext
- The removal of the user fails, because the user is only an observer and doesn't have permission to remove a user

The solution is to just not check permissions when removing the user. If the user has permission to sync, and the project had a user removed, then the user can effectuate the removal of the user from the Scripture Forge project. The user isn't actually making a decision to remove a user from the project, only to update Scripture Forge with what is already in Paratext.

There's another simpler way this issue could probably manifest:
- Project A exists, and has User 1 as a translator
- An admin removes a user from Project A in Paratext
- User 1 syncs Project A
- When the sync process attempts to remove the user, this will fail, since the user is only a translator on the project and not an admin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1257)
<!-- Reviewable:end -->
