### PR TITLE
Add script to find projects that have docs marked invalid

### DIFF
--- a/mongodb/Projects/ProjectsWithInvalidDocs.mongodb
+++ b/mongodb/Projects/ProjectsWithInvalidDocs.mongodb
@@ -1,0 +1,10 @@
+// Find projects that have a text doc that is "invalid" (not the same as corrupted)
+use("xforge");
+
+const invalidProjects = db.sf_projects.countDocuments({
+  texts: { $elemMatch: { chapters: { $elemMatch: { isValid: false } } } }
+});
+
+const totalProjects = db.sf_projects.countDocuments();
+
+console.log(`${invalidProjects} of ${totalProjects} projects have at least one doc that is marked invalid.`);


### PR DESCRIPTION
This is not that important of a script, but today when some problems were reported with some projects and it wasn't clear to me what the issue was, I wondered whether it might have something to do with a text being marked invalid and therefore not editable. Hence I wrote this script, which may be useful in the future.

Currently the output when run against live is:
```
176 of 238 projects have at least one doc that is marked invalid.
```
That's 74% of projects, which I found surprisingly high.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1259)
<!-- Reviewable:end -->
