### PR TITLE
Fail sooner and with more explanation

### DIFF
--- a/src/SIL.XForge.Scripture/Services/InternetSharedRepositorySourceProvider.cs
+++ b/src/SIL.XForge.Scripture/Services/InternetSharedRepositorySourceProvider.cs
@@ -33,6 +33,10 @@ namespace SIL.XForge.Scripture.Services
             }
 
             string ptUsername = _jwtTokenHelper.GetParatextUsername(userSecret);
+            if (string.IsNullOrEmpty(ptUsername))
+            {
+                throw new Exception($"Failed to get a PT username for userSecret id {userSecret.Id}.");
+            }
             var ptUser = new SFParatextUser(ptUsername);
             JwtRestClient jwtClient = GenerateParatextRegistryJwtClient(userSecret, registryServerUri);
             IInternetSharedRepositorySource source =

--- a/src/SIL.XForge.Scripture/Services/JwtTokenHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtTokenHelper.cs
@@ -25,7 +25,9 @@ namespace SIL.XForge.Scripture.Services
         /// <summary> Get the Paratext username from the access token stored in the UserSecret. </summary>
         public string GetParatextUsername(UserSecret userSecret)
         {
-            if (userSecret.ParatextTokens == null || userSecret.ParatextTokens.AccessToken == null)
+            if (userSecret == null
+                || userSecret.ParatextTokens == null
+                || userSecret.ParatextTokens.AccessToken == null)
             {
                 return null;
             }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -286,6 +286,10 @@ namespace SIL.XForge.Scripture.Services
         public async Task<Attempt<string>> TryGetProjectRoleAsync(UserSecret userSecret, string paratextId,
             CancellationToken token)
         {
+            if (userSecret == null || string.IsNullOrEmpty(paratextId))
+            {
+                return Attempt.Failure((string)null);
+            }
             // Ensure the user has the paratext access tokens, and this is not a resource
             if (userSecret.ParatextTokens == null || IsResource(paratextId))
             {

--- a/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
+++ b/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
@@ -172,6 +172,10 @@ namespace SIL.XForge.Scripture.Services
                         if (name != null)
                         {
                             string userName = this._jwtTokenHelper.GetParatextUsername(this._userSecret);
+                            if (userName == null)
+                            {
+                                throw new Exception($"Failed to get a PT username for userSecret id {_userSecret.Id}.");
+                            }
                             var ptUser = new SFParatextUser(userName);
                             var passwordProvider = new ParatextZippedResourcePasswordProvider(this._paratextOptions);
                             existingScrText = new ResourceScrText(name, ptUser, passwordProvider);

--- a/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
@@ -42,6 +42,23 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(source, Is.Not.Null);
         }
 
+        [Test]
+        public void GetSource_TroubleWithFetchingUsername()
+        {
+            var env = new TestEnvironment();
+            var userSecret = new UserSecret
+            {
+                Id = "user01",
+                ParatextTokens = new Tokens
+                {
+                    AccessToken = TokenHelper.CreateNewAccessToken(),
+                    RefreshToken = "refresh_token01"
+                }
+            };
+            env.MockJwtTokenHelper.GetParatextUsername(Arg.Any<UserSecret>()).Returns((string)null);
+            Assert.Throws<Exception>(() => env.Provider.GetSource(userSecret, "srServer", "regServer"));
+        }
+
         private class TestEnvironment
         {
             public IJwtTokenHelper MockJwtTokenHelper;
@@ -51,6 +68,7 @@ namespace SIL.XForge.Scripture.Services
             {
                 MockJwtTokenHelper = Substitute.For<IJwtTokenHelper>();
                 MockJwtTokenHelper.GetJwtTokenFromUserSecret(Arg.Any<UserSecret>()).Returns("token_1234");
+                MockJwtTokenHelper.GetParatextUsername(Arg.Any<UserSecret>()).Returns("ptUsernameHere");
                 RegistryU.Implementation = new DotNetCoreRegistry();
                 InternetAccess.RawStatus = InternetUse.Enabled;
                 var siteOptions = Substitute.For<IOptions<SiteOptions>>();

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -816,6 +816,20 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
+        public async Task TryGetProjectRoleAsync_BadArguments()
+        {
+            var env = new TestEnvironment();
+            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+            var attempt = await env.Service.TryGetProjectRoleAsync(null, "paratextIdHere", CancellationToken.None);
+            Assert.That(attempt.Success, Is.False);
+            Assert.That(attempt.Result, Is.Null);
+
+            attempt = await env.Service.TryGetProjectRoleAsync(userSecret, null, CancellationToken.None);
+            Assert.That(attempt.Success, Is.False);
+            Assert.That(attempt.Result, Is.Null);
+        }
+
+        [Test]
         public async Task TryGetProjectRoleAsync_UsesTheRepositoryForUnregisteredProjects()
         {
             var env = new TestEnvironment();


### PR DESCRIPTION
- To help diagnose sync problems more quickly.
- And adjust behaviour to return null rather than crash on
  JwtTokenHelper.GetParatextUsername(null).

===

Here are some changes that I made in response to some of what we were investigating today. 