### PR TITLE
SF-1509 Skip pushing book text if project is not editable

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/sf-project.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project.ts
@@ -17,4 +17,5 @@ export interface SFProject extends Project {
   checkingConfig: CheckingConfig;
   texts: TextInfo[];
   sync: Sync;
+  editable: boolean;
 }

--- a/src/RealtimeServer/scriptureforge/services/question-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/question-service.spec.ts
@@ -165,6 +165,7 @@ class TestEnvironment {
       },
       texts: [],
       sync: { queuedCount: 0 },
+      editable: true,
       userRoles: {
         projectAdmin: SFProjectRole.ParatextAdministrator,
         checker: SFProjectRole.CommunityChecker

--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.spec.ts
@@ -134,6 +134,21 @@ describe('SFProjectMigrations', () => {
       expect(projectDoc.data.translateConfig.shareLevel).toBe('specific');
     });
   });
+
+  describe('version 6', () => {
+    it('adds editable property', async () => {
+      const env = new TestEnvironment(5);
+      const conn = env.server.connect();
+      await createDoc(conn, SF_PROJECTS_COLLECTION, 'project01', {});
+      let projectDoc = await fetchDoc(conn, SF_PROJECTS_COLLECTION, 'project01');
+      expect(projectDoc.data.editable).not.toBeDefined();
+
+      await env.server.migrateIfNecessary();
+
+      projectDoc = await fetchDoc(conn, SF_PROJECTS_COLLECTION, 'project01');
+      expect(projectDoc.data.editable).toBe(true);
+    });
+  });
 });
 
 class TestEnvironment {

--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
@@ -129,10 +129,27 @@ class SFProjectMigration5 implements Migration {
   }
 }
 
+class SFProjectMigration6 implements Migration {
+  static readonly VERSION = 6;
+
+  async migrateDoc(doc: Doc): Promise<void> {
+    const ops = [];
+    if (doc.data.editable == null) {
+      ops.push({ p: ['editable'], oi: true });
+    }
+    await submitMigrationOp(SFProjectMigration6.VERSION, doc, ops);
+  }
+
+  migrateOp(_op: RawOp): void {
+    //do nothing
+  }
+}
+
 export const SF_PROJECT_MIGRATIONS: MigrationConstructor[] = [
   SFProjectMigration1,
   SFProjectMigration2,
   SFProjectMigration3,
   SFProjectMigration4,
-  SFProjectMigration5
+  SFProjectMigration5,
+  SFProjectMigration6
 ];

--- a/src/RealtimeServer/scriptureforge/services/text-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/text-service.spec.ts
@@ -128,6 +128,7 @@ class TestEnvironment {
       },
       texts: [],
       sync: { queuedCount: 0 },
+      editable: true,
       userRoles: {
         translator: SFProjectRole.ParatextTranslator,
         observer: SFProjectRole.ParatextObserver

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -946,6 +946,7 @@ class TestEnvironment {
           usersSeeEachOthersResponses: true
         },
         sync: { queuedCount: 0 },
+        editable: true,
         userRoles,
         userPermissions: {},
         texts

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -523,6 +523,7 @@ class TestEnvironment {
       shareLevel: TranslateShareLevel.Specific
     },
     sync: { queuedCount: 0 },
+    editable: true,
     texts: [
       {
         bookNum: 40,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1551,6 +1551,7 @@ class TestEnvironment {
         writingSystem: { tag: 'qaa' }
       }
     },
+    editable: true,
     texts: [
       {
         bookNum: 43,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.spec.ts
@@ -192,6 +192,7 @@ class TestEnvironment {
     },
     texts: [this.matthewText],
     sync: { queuedCount: 0 },
+    editable: true,
     userRoles: {
       [this.adminUser.id]: this.adminUser.role
     },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
@@ -431,6 +431,7 @@ class TestEnvironment {
           usersSeeEachOthersResponses: true
         },
         sync: { queuedCount: 1 },
+        editable: true,
         texts: [],
         userRoles: {
           user01: SFProjectRole.ParatextAdministrator

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
@@ -339,6 +339,7 @@ class TestEnvironment {
             shareLevel: CheckingShareLevel.Specific
           },
           sync: { queuedCount: 0 },
+          editable: true,
           texts:
             args.hasTexts == null || args.hasTexts
               ? [

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -752,6 +752,7 @@ class TestEnvironment {
         translateConfig,
         checkingConfig,
         sync: { queuedCount: 0 },
+        editable: true,
         texts: [],
         userRoles: {},
         userPermissions: {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
@@ -65,6 +65,7 @@ export function getSFProject(id: string): SFProject {
       shareLevel: CheckingShareLevel.Specific
     },
     sync: { queuedCount: 0 },
+    editable: true,
     texts: [
       {
         bookNum: 40,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.spec.ts
@@ -159,6 +159,7 @@ class TestEnvironment {
           lastSyncSuccessful: true,
           dateLastSuccessfulSync: date.toJSON()
         },
+        editable: true,
         texts: [],
         userRoles: this.userRoleTarget,
         userPermissions: {}
@@ -191,6 +192,7 @@ class TestEnvironment {
             lastSyncSuccessful: true,
             dateLastSuccessfulSync: date.toJSON()
           },
+          editable: true,
           texts: [],
           userRoles: this.userRoleSource,
           userPermissions: {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
@@ -236,6 +236,7 @@ class TestEnvironment {
           dateLastSuccessfulSync: date.toJSON()
         },
         syncDisabled: isSyncDisabled,
+        editable: true,
         texts: [],
         userRoles: {},
         userPermissions: {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
@@ -391,6 +391,7 @@ class TestEnvironment {
     },
     texts: [TestEnvironment.matthewText],
     sync: { queuedCount: 0 },
+    editable: true,
     userRoles: {
       user01: SFProjectRole.ParatextAdministrator
     },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -58,6 +58,9 @@
             <mdc-icon>error</mdc-icon> {{ t("text_doc_corrupted") }}
             <span [innerHTML]="t('to_report_issue_email', { issueEmailLink: issueEmailLink })"></span>
           </div>
+          <div *ngIf="projectTextNotEditable" class="project-text-not-editable">
+            {{ t("project_text_not_editable") }}
+          </div>
         </ng-container>
         <div #targetContainer class="text-container" [style.height]="textHeight">
           <app-text

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -113,7 +113,8 @@ app-text {
 
 .formatting-invalid-warning,
 .out-of-sync-warning,
-.doc-corrupted-warning {
+.doc-corrupted-warning,
+.project-text-not-editable {
   color: #ff4118;
   border: 1px solid $border-color;
   padding: 5px 10px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -841,6 +841,19 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('user cannot edit a text that is not editable', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setupProject({ editable: false });
+      env.setProjectUserConfig();
+      // env.updateParams({ projectId: 'notEditableProj', bookId: 'GEN' });
+      env.wait();
+
+      expect(env.bookName).toEqual('Matthew');
+      expect(env.component.projectTextNotEditable).toBe(true);
+      expect(env.component.canEdit).toBe(false);
+      env.dispose();
+    }));
+
     it('user has no resource access', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setupProject({
@@ -1274,6 +1287,7 @@ class TestEnvironment {
       shareLevel: CheckingShareLevel.Specific
     },
     sync: { queuedCount: 0, dataInSync: true },
+    editable: true,
     texts: [
       {
         bookNum: 40,
@@ -1573,6 +1587,9 @@ class TestEnvironment {
     }
     if (data.isRightToLeft != null) {
       projectData.isRightToLeft = data.isRightToLeft;
+    }
+    if (data.editable != null) {
+      projectData.editable = data.editable;
     }
     this.realtimeService.addSnapshot<SFProject>(SFProjectDoc.COLLECTION, {
       id: 'project01',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -845,12 +845,12 @@ describe('EditorComponent', () => {
       const env = new TestEnvironment();
       env.setupProject({ editable: false });
       env.setProjectUserConfig();
-      // env.updateParams({ projectId: 'notEditableProj', bookId: 'GEN' });
       env.wait();
 
       expect(env.bookName).toEqual('Matthew');
       expect(env.component.projectTextNotEditable).toBe(true);
       expect(env.component.canEdit).toBe(false);
+      expect(env.fixture.debugElement.query(By.css('.text-area .project-text-not-editable'))).not.toBeNull();
       env.dispose();
     }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -245,11 +245,21 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   get canEdit(): boolean {
-    return this.isUsfmValid && this.hasEditRight && this.dataInSync && !this.target?.areOpsCorrupted;
+    return (
+      this.isUsfmValid &&
+      this.hasEditRight &&
+      this.dataInSync &&
+      !this.target?.areOpsCorrupted &&
+      !this.projectTextNotEditable
+    );
   }
 
   get canShare(): boolean {
     return this.isProjectAdmin || this.projectDoc?.data?.translateConfig.shareEnabled === true;
+  }
+
+  get projectTextNotEditable(): boolean {
+    return this.projectDoc?.data?.editable === false;
   }
 
   get isSourceRightToLeft(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
@@ -277,6 +277,7 @@ class TestEnvironment {
           shareLevel: CheckingShareLevel.Specific
         },
         sync: { queuedCount: 0 },
+        editable: true,
         userRoles: {
           user01: SFProjectRole.ParatextTranslator,
           user02: SFProjectRole.ParatextConsultant

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
@@ -662,6 +662,7 @@ class TestEnvironment {
         shareEnabled: false,
         shareLevel: CheckingShareLevel.Specific
       },
+      editable: true,
       userRoles,
       userPermissions: {}
     };

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -81,6 +81,7 @@
     "cannot_edit_chapter_formatting_invalid": "This chapter cannot be edited because the formatting is invalid. Please fix the formatting in Paratext.",
     "completed_successfully": "Completed successfully",
     "configure_translation_suggestions": "Configure translation suggestions",
+    "project_text_not_editable": "Text in this project is not editable. This setting can be changed in Paratext.",
     "project_data_out_of_sync": "Your project data is out of sync. Please synchronize your project to edit this text.",
     "swap_source_and_target": "Swap source and target",
     "text_doc_corrupted": "This chapter cannot be edited because the data has become corrupted.",

--- a/src/SIL.XForge.Scripture/Models/ParatextSettings.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextSettings.cs
@@ -1,0 +1,12 @@
+namespace SIL.XForge.Scripture.Models
+{
+    public class ParatextSettings
+    {
+        /// <summary> The full name of the project from the local repository. </summary>
+        public string FullName { get; set; }
+        /// <summary> Whether a specific project is in a right to left language. </summary>
+        public bool IsRightToLeft { get; set; }
+        /// <summary> Indicates if the text in the project is editable. </summary>
+        public bool Editable { get; set; }
+    }
+}

--- a/src/SIL.XForge.Scripture/Models/SFProject.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProject.cs
@@ -14,5 +14,6 @@ namespace SIL.XForge.Scripture.Models
         public CheckingConfig CheckingConfig { get; set; } = new CheckingConfig();
         public List<TextInfo> Texts { get; set; } = new List<TextInfo>();
         public Sync Sync { get; set; } = new Sync();
+        public bool Editable { get; set; } = true;
     }
 }

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -16,8 +16,7 @@ namespace SIL.XForge.Scripture.Services
         Task<Attempt<string>> TryGetProjectRoleAsync(UserSecret userSecret, string paratextId, CancellationToken token);
         Task<IReadOnlyDictionary<string, string>> GetProjectRolesAsync(UserSecret userSecret, SFProject project,
             CancellationToken token);
-        bool IsProjectLanguageRightToLeft(UserSecret userSecret, string paratextId);
-        string GetProjectFullName(UserSecret userSecret, string paratextId);
+        ParatextSettings GetParatextSettings(UserSecret userSecret, string paratextId);
 
         Task<IReadOnlyList<ParatextResource>> GetResourcesAsync(string userId);
         bool IsResource(string paratextId);

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -608,25 +608,16 @@ namespace SIL.XForge.Scripture.Services
             }
         }
 
-        /// <summary> Determine if a specific project is in a right to left language. </summary>
-        public bool IsProjectLanguageRightToLeft(UserSecret userSecret, string paratextId)
+        /// <summary> Gets basic settings for a Paratext project. </summary>
+        public ParatextSettings GetParatextSettings(UserSecret userSecret, string paratextId)
         {
             using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
-            return scrText == null ? false : scrText.RightToLeft;
-        }
-
-        /// <summary>
-        /// Gets the full name of the project from the local repository.
-        /// </summary>
-        /// <param name="userSecret">The user secret.</param>
-        /// <param name="paratextId">The paratext identifier.</param>
-        /// <returns>
-        /// The full name of the project.
-        /// </returns>
-        public string GetProjectFullName(UserSecret userSecret, string paratextId)
-        {
-            using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
-            return scrText?.FullName;
+            return new ParatextSettings
+            {
+                FullName = scrText.FullName,
+                IsRightToLeft = scrText?.RightToLeft ?? false,
+                Editable = scrText.Settings.Editable
+            };
         }
 
         /// <summary> Get list of book numbers in PT project. </summary>
@@ -657,6 +648,11 @@ namespace SIL.XForge.Scripture.Services
             {
                 string username = GetParatextUsername(userSecret);
                 ScrText scrText = ScrTextCollection.FindById(username, projectId);
+                if (!scrText.Settings.Editable)
+                {
+                    // do not push changes if the project is not editable
+                    return;
+                }
 
                 // We add this here so we can dispose in the finally
                 scrTexts.Add(userSecret.Id, scrText);

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -609,9 +609,12 @@ namespace SIL.XForge.Scripture.Services
         }
 
         /// <summary> Gets basic settings for a Paratext project. </summary>
+        /// <returns> The Paratext project settings, or null if the project repository does not exist locally </returns>
         public ParatextSettings GetParatextSettings(UserSecret userSecret, string paratextId)
         {
             using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
+            if (scrText == null)
+                return null;
             return new ParatextSettings
             {
                 FullName = scrText?.FullName,

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -614,9 +614,9 @@ namespace SIL.XForge.Scripture.Services
             using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
             return new ParatextSettings
             {
-                FullName = scrText.FullName,
+                FullName = scrText?.FullName,
                 IsRightToLeft = scrText?.RightToLeft ?? false,
-                Editable = scrText.Settings.Editable
+                Editable = scrText?.Settings.Editable ?? true
             };
         }
 
@@ -647,12 +647,7 @@ namespace SIL.XForge.Scripture.Services
             try
             {
                 string username = GetParatextUsername(userSecret);
-                ScrText scrText = ScrTextCollection.FindById(username, projectId);
-                if (!scrText.Settings.Editable)
-                {
-                    // do not push changes if the project is not editable
-                    return;
-                }
+                using ScrText scrText = ScrTextCollection.FindById(username, projectId);
 
                 // We add this here so we can dispose in the finally
                 scrTexts.Add(userSecret.Id, scrText);

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -617,9 +617,9 @@ namespace SIL.XForge.Scripture.Services
                 return null;
             return new ParatextSettings
             {
-                FullName = scrText?.FullName,
-                IsRightToLeft = scrText?.RightToLeft ?? false,
-                Editable = scrText?.Settings.Editable ?? true
+                FullName = scrText.FullName,
+                IsRightToLeft = scrText.RightToLeft,
+                Editable = scrText.Settings.Editable
             };
         }
 

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -640,6 +640,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         /// <summary> Write up-to-date book text from mongo database to Paratext project folder. </summary>
+        /// <remarks> It is up to the caller to determine whether the project text is editable. </remarks>
         public async Task PutBookText(UserSecret userSecret, string projectId, int bookNum, string usx,
             Dictionary<int, string> chapterAuthors = null)
         {

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -824,24 +824,25 @@ namespace SIL.XForge.Scripture.Services
                     }
                 }
 
+                ParatextSettings settings =
+                    _paratextService.GetParatextSettings(_userSecret, _projectDoc.Data.ParatextId);
                 // See if the full name of the project needs updating
-                string fullName = _paratextService.GetProjectFullName(_userSecret, _projectDoc.Data.ParatextId);
-                if (!string.IsNullOrEmpty(fullName))
+                if (!string.IsNullOrEmpty(settings.FullName))
                 {
-                    op.Set(pd => pd.Name, fullName);
+                    op.Set(pd => pd.Name, settings.FullName);
                 }
 
                 // Set the right-to-left language flag
-                bool isRtl = _paratextService.IsProjectLanguageRightToLeft(_userSecret, _projectDoc.Data.ParatextId);
-                op.Set(pd => pd.IsRightToLeft, isRtl);
+                op.Set(pd => pd.IsRightToLeft, settings.IsRightToLeft);
+                op.Set(pd => pd.Editable, settings.Editable);
 
                 // The source can be null if there was an error getting a resource from the DBL
                 if (TranslationSuggestionsEnabled
                     && _projectDoc.Data.TranslateConfig.Source != null)
                 {
-                    bool sourceIsRtl = _paratextService
-                        .IsProjectLanguageRightToLeft(_userSecret, _projectDoc.Data.TranslateConfig.Source.ParatextId);
-                    op.Set(pd => pd.TranslateConfig.Source.IsRightToLeft, sourceIsRtl);
+                    ParatextSettings sourceSettings = _paratextService.GetParatextSettings(_userSecret,
+                        _projectDoc.Data.TranslateConfig.Source.ParatextId);
+                    op.Set(pd => pd.TranslateConfig.Source.IsRightToLeft, sourceSettings.IsRightToLeft);
                 }
             });
             foreach (var userId in userIdsToRemove)

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -164,15 +164,15 @@ namespace SIL.XForge.Scripture.Services
 
                 ParatextSettings settings =
                     _paratextService.GetParatextSettings(_userSecret, _projectDoc.Data.ParatextId);
-                if (settings == null && _projectDoc.Data.Texts.Count > 0)
-                {
-                    Log($"FAILED: Attempting to write to a project repository that does not exist.");
-                    await CompleteSync(false, canRollbackParatext, token);
-                    return;
-                }
                 // update target Paratext books and notes
                 foreach (TextInfo text in _projectDoc.Data.Texts)
                 {
+                    if (settings == null)
+                    {
+                        Log($"FAILED: Attempting to write to a project repository that does not exist.");
+                        await CompleteSync(false, canRollbackParatext, token);
+                        return;
+                    }
                     SortedList<int, IDocument<TextData>> targetTextDocs = await FetchTextDocsAsync(text);
                     targetTextDocsByBook[text.BookNum] = targetTextDocs;
                     if (isDataInSync && settings.Editable)

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -162,12 +162,14 @@ namespace SIL.XForge.Scripture.Services
                     Log($"RunAsync: Considering that data is not in sync. The local PT repo last shared revision is '{lastSharedVersion}'. The SF DB project Sync.SyncedToRepositoryVersion is '{_projectDoc.Data.Sync.SyncedToRepositoryVersion}'. canRollbackParatext is '{canRollbackParatext}'.");
                 }
 
+                ParatextSettings settings =
+                    _paratextService.GetParatextSettings(_userSecret, _projectDoc.Data.ParatextId);
                 // update target Paratext books and notes
                 foreach (TextInfo text in _projectDoc.Data.Texts)
                 {
                     SortedList<int, IDocument<TextData>> targetTextDocs = await FetchTextDocsAsync(text);
                     targetTextDocsByBook[text.BookNum] = targetTextDocs;
-                    if (isDataInSync)
+                    if (isDataInSync && settings.Editable)
                         await UpdateParatextBook(text, targetParatextId, targetTextDocs);
 
                     IReadOnlyList<IDocument<Question>> questionDocs = await FetchQuestionDocsAsync(text);

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -534,37 +534,6 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task PutBookText_SkipsUpdatingReadonlyText()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            // should be able to edit the book text even if the admin user does not have permission
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser, false, false);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            int ruthBookNum = 8;
-            string ruthBookUsx = "<usx version=\"3.0\">\r\n  <book code=\"RUT\" style=\"id\">- ProjectNameHere" +
-                "</book>\r\n  <chapter number=\"1\" style=\"c\" />\r\n  <verse number=\"1\" style=\"v\" />" +
-                "Verse 1 here. <verse number=\"2\" style=\"v\" />Verse 2 here.</usx>";
-            var chapterAuthors = new Dictionary<int, string>
-            {
-                { 1, env.User01 },
-                { 2, env.User01 },
-            };
-
-            // SUT
-            await env.Service.PutBookText(userSecret, ptProjectId, ruthBookNum, ruthBookUsx, chapterAuthors);
-
-            // Make sure only one ScrText was loaded
-            env.MockScrTextCollection.Received(1).FindById(env.Username01, ptProjectId);
-
-            // See if there is a message for the user updating the book
-            string logMessage = string.Format("{0} updated {1} in {2}.", env.User01,
-                    Canon.BookNumberToEnglishName(ruthBookNum), env.ProjectScrText.Name);
-            env.MockLogger.AssertNoEvent((LogEvent logEvent) => logEvent != null);
-        }
-
-        [Test]
         public void GetNotes_RetrievesNotes()
         {
             int ruthBookNum = 8;
@@ -1508,11 +1477,10 @@ namespace SIL.XForge.Scripture.Services
                 return notesElem.ToString();
             }
 
-            public string SetupProject(string baseId, ParatextUser associatedPtUser, bool hasEditPermission = true,
-                bool editable = true)
+            public string SetupProject(string baseId, ParatextUser associatedPtUser, bool hasEditPermission = true)
             {
                 string ptProjectId = PTProjectIds[baseId].Id;
-                ProjectScrText = GetScrText(associatedPtUser, ptProjectId, hasEditPermission, editable);
+                ProjectScrText = GetScrText(associatedPtUser, ptProjectId, hasEditPermission);
 
                 // We set the file manager her so we can track file manager operations after
                 // the ScrText object has been disposed in ParatextService.
@@ -1526,7 +1494,7 @@ namespace SIL.XForge.Scripture.Services
             }
 
             public MockScrText GetScrText(ParatextUser associatedPtUser, string projectId,
-                bool hasEditPermission = true, bool editable = true)
+                bool hasEditPermission = true)
             {
                 string scrtextDir = Path.Combine(SyncDir, projectId, "target");
                 ProjectName projectName = new ProjectName() { ProjectPath = scrtextDir, ShortName = "Proj" };
@@ -1537,8 +1505,6 @@ namespace SIL.XForge.Scripture.Services
                 scrText.Settings.BooksPresentSet = new BookSet("RUT");
                 if (!hasEditPermission)
                     scrText.Permissions.SetPermission(null, 8, PermissionSet.Manual, false);
-                if (!editable)
-                    scrText.Settings.Editable = editable;
                 return scrText;
             }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -409,7 +409,7 @@ namespace SIL.XForge.Scripture.Services
         {
             var env = new TestEnvironment();
             Book[] books = { new Book("MAT", 1) };
-            env.SetupSFData(true, true, false, books);
+            env.SetupSFData(true, true, true, books);
             env.SetupPTData(books);
             SFProject project = env.GetProject("project01");
             Assert.That(project.Editable, Is.True, "setup");
@@ -426,6 +426,8 @@ namespace SIL.XForge.Scripture.Services
 
             // SUT
             await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.ParatextService.DidNotReceiveWithAnyArgs()
+                .PutBookText(default, default, default, default, default);
             project = env.VerifyProjectSync(true);
             Assert.That(project.Editable, Is.False);
         }


### PR DESCRIPTION
* prevent pushing changes if project is not editable
* add the editable property to SFProject
* prevent users from editing projects that are not editable
* check and update editable property on sync
* also consolidate project settings access methods like full name and is left to right

![Editor project text not editable](https://user-images.githubusercontent.com/17931130/158259284-1b82958e-1f41-4f79-9bb5-ffd406a237c4.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1264)
<!-- Reviewable:end -->
