### PR TITLE
SF-1471a Remove have-read note refs when remove note

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/note-thread.ts
+++ b/src/RealtimeServer/scriptureforge/models/note-thread.ts
@@ -7,14 +7,18 @@ export const NOTE_THREAD_COLLECTION = 'note_threads';
 export const NOTE_THREAD_INDEX_PATHS = PROJECT_DATA_INDEX_PATHS;
 
 /**
- * Paratext used to record notes as deleted when completed but then changed to display them as resolved
- * Done is also a backwards compatible status that could also be treated as deleted/resolved
+ * Paratext used to record notes as deleted when completed but then changed to display them as resolved.
+ * Done is also a backwards compatible status that could also be treated as deleted/resolved.
  */
 export enum NoteStatus {
   Unspecified = '',
   Todo = 'todo',
   Done = 'done',
   Resolved = 'deleted'
+}
+
+export function getNoteThreadDocId(projectId: string, noteThreadId: string): string {
+  return `${projectId}:${noteThreadId}`;
 }
 
 export enum AssignedUsers {

--- a/src/RealtimeServer/scriptureforge/services/note-thread-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-service.spec.ts
@@ -1,0 +1,325 @@
+import ShareDB from 'sharedb';
+import ShareDBMingo from 'sharedb-mingo-memory';
+import { instance, mock } from 'ts-mockito';
+import { Connection } from 'sharedb/lib/client';
+import { TranslateShareLevel } from '../models/translate-config';
+import { SystemRole } from '../../common/models/system-role';
+import { User, USERS_COLLECTION } from '../../common/models/user';
+import { RealtimeServer } from '../../common/realtime-server';
+import { SchemaVersionRepository } from '../../common/schema-version-repository';
+import { allowAll, clientConnect, createDoc, flushPromises, submitJson0Op } from '../../common/utils/test-utils';
+import { CheckingShareLevel } from '../models/checking-config';
+import { SFProject, SF_PROJECTS_COLLECTION } from '../models/sf-project';
+import { SFProjectRole } from '../models/sf-project-role';
+import {
+  getSFProjectUserConfigDocId,
+  SFProjectUserConfig,
+  SF_PROJECT_USER_CONFIGS_COLLECTION
+} from '../models/sf-project-user-config';
+import { getNoteThreadDocId, NoteThread, NOTE_THREAD_COLLECTION, NoteStatus } from '../models/note-thread';
+import { Note } from '../models/note';
+import { VerseRefData } from '../models/verse-ref-data';
+import { TextAnchor } from '../models/text-anchor';
+
+import { NoteThreadService } from './note-thread-service';
+
+describe('NoteThreadService', () => {
+  it('the model builds an id as expected', () => {
+    expect(getNoteThreadDocId('myProjectId', 'myNoteThreadId')).toEqual('myProjectId:myNoteThreadId');
+  });
+
+  it('removes read refs when note deleted', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+    const conn: Connection = clientConnect(env.server, 'projectAdmin');
+    await env.setHaveReadNoteRefs(conn);
+
+    // Assert that data is set up as expected for testing.
+    const noteThread01: NoteThread =
+      env.db.docs[NOTE_THREAD_COLLECTION][getNoteThreadDocId('project01', 'noteThread01')].data;
+    const noteThread01noteIds: string[] = noteThread01.notes.map((note: Note) => note.dataId);
+    expect(noteThread01noteIds).toContain('noteThread01note01');
+    expect(noteThread01noteIds).toContain('noteThread01note02');
+    expect(noteThread01noteIds).toContain('noteThread01note03');
+    expect(noteThread01noteIds).toContain('noteThread01note04');
+    const noteThread02: NoteThread =
+      env.db.docs[NOTE_THREAD_COLLECTION][getNoteThreadDocId('project01', 'noteThread02')].data;
+    const noteThread02noteIds: string[] = noteThread02.notes.map((note: Note) => note.dataId);
+    expect(noteThread02noteIds).toContain('noteThread02note01');
+
+    let adminProjectUserConfig: SFProjectUserConfig =
+      env.db.docs[SF_PROJECT_USER_CONFIGS_COLLECTION][getSFProjectUserConfigDocId('project01', 'projectAdmin')].data;
+    expect(adminProjectUserConfig.noteRefsRead).toContain('noteThread01note01');
+    expect(adminProjectUserConfig.noteRefsRead).not.toContain('noteThread01note02');
+    expect(adminProjectUserConfig.noteRefsRead).toContain('noteThread01note03');
+    expect(adminProjectUserConfig.noteRefsRead).toContain('noteThread01note04');
+    expect(adminProjectUserConfig.noteRefsRead).toContain('noteThread02note01');
+    let checkerProjectUserConfig: SFProjectUserConfig =
+      env.db.docs[SF_PROJECT_USER_CONFIGS_COLLECTION][getSFProjectUserConfigDocId('project01', 'checker')].data;
+    expect(checkerProjectUserConfig.noteRefsRead).toContain('noteThread01note03');
+    expect(checkerProjectUserConfig.noteRefsRead).toContain('noteThread01note04');
+
+    const nt01n01index = (noteThread01.notes as Note[]).findIndex((note: Note) => note.dataId === 'noteThread01note01');
+    const nt01n02index = (noteThread01.notes as Note[]).findIndex((note: Note) => note.dataId === 'noteThread01note02');
+    const nt01n03index = (noteThread01.notes as Note[]).findIndex((note: Note) => note.dataId === 'noteThread01note03');
+
+    // SUT
+    await submitJson0Op<NoteThread>(
+      conn,
+      NOTE_THREAD_COLLECTION,
+      getNoteThreadDocId('project01', 'noteThread01'),
+      ops => {
+        ops.remove((noteThread: NoteThread) => noteThread.notes, nt01n03index);
+        ops.remove((noteThread: NoteThread) => noteThread.notes, nt01n02index);
+        ops.remove((noteThread: NoteThread) => noteThread.notes, nt01n01index);
+      }
+    );
+    await flushPromises();
+
+    adminProjectUserConfig = env.db.docs[SF_PROJECT_USER_CONFIGS_COLLECTION][
+      getSFProjectUserConfigDocId('project01', 'projectAdmin')
+    ].data as SFProjectUserConfig;
+    // This have-read should be gone since the corresponding note was removed.
+    expect(adminProjectUserConfig.noteRefsRead).not.toContain('noteThread01note01');
+    // User still does not have this have-read item, and importantly, nothing crashed as a result.
+    expect(adminProjectUserConfig.noteRefsRead).not.toContain('noteThread01note02');
+    // This have-read should be gone since the corresponding note was removed.
+    expect(adminProjectUserConfig.noteRefsRead).not.toContain('noteThread01note03');
+    // This have-read should not have been removed because the note was not removed.
+    expect(adminProjectUserConfig.noteRefsRead).toContain('noteThread01note04');
+    // this have-read should not have been removed. It regards a note in another notethread that was not touched.
+    expect(adminProjectUserConfig.noteRefsRead).toContain('noteThread02note01');
+    checkerProjectUserConfig = env.db.docs[SF_PROJECT_USER_CONFIGS_COLLECTION][
+      getSFProjectUserConfigDocId('project01', 'checker')
+    ].data as SFProjectUserConfig;
+    // This have-read should be gone since the corresponding note was removed.
+    expect(checkerProjectUserConfig.noteRefsRead).not.toContain('noteThread01note03');
+    // This have-read should not have been removed because the note was not removed.
+    expect(checkerProjectUserConfig.noteRefsRead).toContain('noteThread01note04');
+  });
+});
+
+class TestEnvironment {
+  readonly service: NoteThreadService;
+  readonly server: RealtimeServer;
+  readonly db: ShareDBMingo;
+  readonly mockedSchemaVersionRepository = mock(SchemaVersionRepository);
+
+  constructor() {
+    this.service = new NoteThreadService();
+    const ShareDBMingoType = ShareDBMingo.extendMemoryDB(ShareDB.MemoryDB);
+    this.db = new ShareDBMingoType();
+    this.server = new RealtimeServer(
+      'TEST',
+      false,
+      [this.service],
+      SF_PROJECTS_COLLECTION,
+      this.db,
+      instance(this.mockedSchemaVersionRepository)
+    );
+    allowAll(this.server, USERS_COLLECTION);
+    allowAll(this.server, SF_PROJECTS_COLLECTION);
+    allowAll(this.server, SF_PROJECT_USER_CONFIGS_COLLECTION);
+  }
+
+  async createData(): Promise<void> {
+    const conn = this.server.connect();
+    await createDoc<User>(conn, USERS_COLLECTION, 'projectAdmin', {
+      name: 'User 01',
+      email: 'user01@example.com',
+      role: SystemRole.User,
+      isDisplayNameConfirmed: true,
+      authId: 'auth01',
+      displayName: 'User 01',
+      avatarUrl: '',
+      sites: {}
+    });
+
+    await createDoc<SFProjectUserConfig>(
+      conn,
+      SF_PROJECT_USER_CONFIGS_COLLECTION,
+      getSFProjectUserConfigDocId('project01', 'projectAdmin'),
+      {
+        projectRef: 'project01',
+        ownerRef: 'projectAdmin',
+        isTargetTextRight: false,
+        confidenceThreshold: 0.2,
+        translationSuggestionsEnabled: true,
+        numSuggestions: 1,
+        selectedSegment: '',
+        questionRefsRead: ['question01'],
+        answerRefsRead: ['answer01'],
+        commentRefsRead: ['comment01'],
+        noteRefsRead: []
+      }
+    );
+
+    await createDoc<User>(conn, USERS_COLLECTION, 'checker', {
+      name: 'User 02',
+      email: 'user02@example.com',
+      role: SystemRole.User,
+      isDisplayNameConfirmed: true,
+      authId: 'auth02',
+      displayName: 'User 02',
+      avatarUrl: '',
+      sites: {}
+    });
+
+    await createDoc<SFProjectUserConfig>(
+      conn,
+      SF_PROJECT_USER_CONFIGS_COLLECTION,
+      getSFProjectUserConfigDocId('project01', 'checker'),
+      {
+        projectRef: 'project01',
+        ownerRef: 'checker',
+        isTargetTextRight: false,
+        confidenceThreshold: 0.2,
+        translationSuggestionsEnabled: true,
+        numSuggestions: 1,
+        selectedSegment: '',
+        questionRefsRead: ['question01'],
+        answerRefsRead: ['answer01'],
+        commentRefsRead: ['comment01'],
+        noteRefsRead: []
+      }
+    );
+
+    await createDoc<SFProject>(conn, SF_PROJECTS_COLLECTION, 'project01', {
+      name: 'Project 01',
+      shortName: 'PT01',
+      paratextId: 'pt01',
+      writingSystem: { tag: 'qaa' },
+      translateConfig: {
+        translationSuggestionsEnabled: false,
+        shareEnabled: true,
+        shareLevel: TranslateShareLevel.Specific
+      },
+      checkingConfig: {
+        checkingEnabled: false,
+        usersSeeEachOthersResponses: true,
+        shareEnabled: true,
+        shareLevel: CheckingShareLevel.Specific
+      },
+      texts: [],
+      sync: { queuedCount: 0 },
+      userRoles: {
+        projectAdmin: SFProjectRole.ParatextAdministrator,
+        checker: SFProjectRole.CommunityChecker
+      },
+      userPermissions: {},
+      paratextUsers: []
+    });
+
+    const verseRef: VerseRefData = {
+      bookNum: 40,
+      chapterNum: 1,
+      verseNum: 1
+    };
+    const position: TextAnchor = { start: 0, length: 0 };
+    const status: NoteStatus = NoteStatus.Todo;
+    await createDoc<NoteThread>(conn, NOTE_THREAD_COLLECTION, getNoteThreadDocId('project01', 'noteThread01'), {
+      projectRef: 'project01',
+      ownerRef: 'some-owner',
+      dataId: 'noteThread01',
+      verseRef,
+      notes: [
+        {
+          dataId: 'noteThread01note01',
+          threadId: 'noteThread01',
+          extUserId: 'some-ext-user-id',
+          deleted: false,
+          status,
+          dateModified: '',
+          dateCreated: '',
+          ownerRef: 'some-owner-id'
+        },
+        {
+          dataId: 'noteThread01note02',
+          threadId: 'noteThread01',
+          extUserId: 'some-ext-user-id',
+          deleted: false,
+          status,
+          dateModified: '',
+          dateCreated: '',
+          ownerRef: 'some-owner-id'
+        },
+        {
+          dataId: 'noteThread01note03',
+          threadId: 'noteThread01',
+          extUserId: 'some-ext-user-id',
+          deleted: false,
+          status,
+          dateModified: '',
+          dateCreated: '',
+          ownerRef: 'some-owner-id'
+        },
+        {
+          dataId: 'noteThread01note04',
+          threadId: 'noteThread01',
+          extUserId: 'some-ext-user-id',
+          deleted: false,
+          status,
+          dateModified: '',
+          dateCreated: '',
+          ownerRef: 'some-owner-id'
+        }
+      ],
+      originalSelectedText: '',
+      originalContextBefore: '',
+      originalContextAfter: '',
+      position,
+      status,
+      tagIcon: ''
+    });
+
+    await createDoc<NoteThread>(conn, NOTE_THREAD_COLLECTION, getNoteThreadDocId('project01', 'noteThread02'), {
+      projectRef: 'project01',
+      ownerRef: 'some-owner',
+      dataId: 'noteThread02',
+      verseRef,
+      notes: [
+        {
+          dataId: 'noteThread02note01',
+          threadId: 'noteThread02',
+          extUserId: 'some-ext-user-id',
+          deleted: false,
+          status,
+          dateModified: '',
+          dateCreated: '',
+          ownerRef: 'some-owner-id'
+        }
+      ],
+      originalSelectedText: '',
+      originalContextBefore: '',
+      originalContextAfter: '',
+      position,
+      status,
+      tagIcon: ''
+    });
+  }
+
+  /** Set have-read indications for specific notes. */
+  async setHaveReadNoteRefs(conn: Connection): Promise<void> {
+    submitJson0Op<SFProjectUserConfig>(
+      conn,
+      SF_PROJECT_USER_CONFIGS_COLLECTION,
+      getSFProjectUserConfigDocId('project01', 'projectAdmin'),
+      ops => {
+        ops.add((puc: SFProjectUserConfig) => puc.noteRefsRead, 'noteThread01note01');
+        ops.add((puc: SFProjectUserConfig) => puc.noteRefsRead, 'noteThread01note03');
+        ops.add((puc: SFProjectUserConfig) => puc.noteRefsRead, 'noteThread01note04');
+        ops.add((puc: SFProjectUserConfig) => puc.noteRefsRead, 'noteThread02note01');
+      }
+    );
+    submitJson0Op<SFProjectUserConfig>(
+      conn,
+      SF_PROJECT_USER_CONFIGS_COLLECTION,
+      getSFProjectUserConfigDocId('project01', 'checker'),
+      ops => {
+        ops.add((puc: SFProjectUserConfig) => puc.noteRefsRead, 'noteThread01note03');
+        ops.add((puc: SFProjectUserConfig) => puc.noteRefsRead, 'noteThread01note04');
+      }
+    );
+    await flushPromises();
+  }
+}

--- a/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
@@ -1,7 +1,12 @@
+import { Connection, Doc } from 'sharedb/lib/client';
+import { createFetchQuery, docSubmitJson0Op } from '../../common/utils/sharedb-utils';
+import { OwnedData } from '../../common/models/owned-data';
 import { ProjectDomainConfig } from '../../common/services/project-data-service';
 import { ANY_INDEX } from '../../common/utils/obj-path';
 import { NoteThread, NOTE_THREAD_COLLECTION, NOTE_THREAD_INDEX_PATHS } from '../models/note-thread';
 import { SFProjectDomain } from '../models/sf-project-rights';
+import { SFProjectUserConfig, SF_PROJECT_USER_CONFIGS_COLLECTION } from '../models/sf-project-user-config';
+import { Note } from '../models/note';
 import { NOTE_THREAD_MIGRATIONS } from './note-thread-migrations';
 import { SFProjectDataService } from './sf-project-data-service';
 
@@ -36,5 +41,41 @@ export class NoteThreadService extends SFProjectDataService<NoteThread> {
         pathTemplate: this.pathTemplate(t => t.notes[ANY_INDEX])
       }
     ];
+  }
+  protected onDelete(userId: string, docId: string, projectDomain: string, entity: OwnedData): Promise<void> {
+    if (projectDomain === SFProjectDomain.Notes) {
+      this.removeEntityHaveReadRefs(userId, docId, projectDomain, entity);
+    }
+    return Promise.resolve();
+  }
+
+  private async removeEntityHaveReadRefs(
+    userId: string,
+    docId: string,
+    projectDomain: SFProjectDomain,
+    entity: OwnedData
+  ): Promise<void> {
+    if (this.server == null) {
+      throw Error('Null server');
+    }
+    const parts: string[] = docId.split(':');
+    const projectId: string = parts[0];
+    const conn: Connection = this.server.connect(userId);
+    const pucDocs: Doc[] = (await createFetchQuery(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, { projectRef: projectId }))
+      .results;
+    const promises: Promise<boolean>[] = [];
+    for (const doc of pucDocs) {
+      promises.push(this.removeNoteHaveReadRefs(doc, entity as Note));
+    }
+    await Promise.all(promises);
+  }
+  private removeNoteHaveReadRefs(sfProjectUserConfigDoc: Doc, note: Note): Promise<boolean> {
+    return docSubmitJson0Op<SFProjectUserConfig>(sfProjectUserConfigDoc, ops => {
+      const data: SFProjectUserConfig = sfProjectUserConfigDoc.data;
+      const index: number = data.noteRefsRead.indexOf(note.dataId);
+      if (index !== -1) {
+        ops.remove(puc => puc.noteRefsRead, index);
+      }
+    });
   }
 }


### PR DESCRIPTION
- When a note is removed, also remove refs to it from
project-user-config docs' have-read note refs lists,
to not needlessly build up orphaned refs there.

- This does not take into account notes being removed while a user is
offline, where they could still read a note and add its ref to their
have-read list, even even tho that note had already been removed from
the server.

- This was based on question-service.ts and
question-service.spec.ts.

---

**Stack**:
- #1270
- #1269
- #1268
- #1267 ⮜


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*