### PR TITLE
SF-1471b Remove have-read note refs when remove noteThread

### DIFF
--- a/src/RealtimeServer/common/utils/test-utils.ts
+++ b/src/RealtimeServer/common/utils/test-utils.ts
@@ -14,6 +14,12 @@ export async function fetchDoc(conn: Connection, collection: string, id: string)
   return doc;
 }
 
+export async function hasDoc(conn: Connection, collection: string, id: string): Promise<boolean> {
+  const doc = conn.get(collection, id);
+  await docFetch(doc);
+  return doc.data != null;
+}
+
 export function createDoc<T>(conn: Connection, collection: string, id: string, data: T, type?: OTType): Promise<void> {
   return docCreate(conn.get(collection, id), data, type);
 }


### PR DESCRIPTION
Respond to a noteThread deletion just before it happens, so we still
have access to the noteThread's notes list.

---

**Stack**:
- #1270
- #1269
- #1268 ⮜
- #1267


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*