### PR TITLE
Update ProjectsWhereLastSyncFailed script to show when sync failed

### DIFF
--- a/mongodb/Projects/ProjectsWhereLastSyncFailed.mongodb
+++ b/mongodb/Projects/ProjectsWhereLastSyncFailed.mongodb
@@ -3,8 +3,33 @@
 // This script is designed to be run either by mongosh on the command line (logging results), or by the MongoDB VS Code
 // extension (showing projects in the results pane).
 
-use('xforge')
+use("xforge");
 
-const projects = db.sf_projects.find({'sync.lastSyncSuccessful': false}, {texts: 0}).toArray();
-console.log(projects.map(project => project.shortName).join('\n'));
-projects
+function projectLastSyncTime(projectId) {
+  const syncFinishOp = db.o_sf_projects
+    .find({
+      d: projectId,
+      op: {
+        $elemMatch: {
+          p: ["sync", "percentCompleted"],
+          od: { $exists: true }
+        }
+      }
+    })
+    .sort({ v: -1 })
+    .limit(1)
+    .toArray()[0];
+  return syncFinishOp.m.ts;
+}
+
+const projects = db.sf_projects.find({ "sync.lastSyncSuccessful": false }, { texts: 0 }).toArray();
+for (const project of projects) {
+  project.lastSyncTime = projectLastSyncTime(project._id);
+}
+projects.sort((a, b) => b.lastSyncTime - a.lastSyncTime);
+
+console.log(projects.length + " projects:");
+for (const project of projects) {
+  console.log(new Date(project.lastSyncTime).toUTCString() + ' ' + project.shortName)
+}
+projects;

--- a/scripts/db_tools/find-problems.sh
+++ b/scripts/db_tools/find-problems.sh
@@ -31,7 +31,7 @@ function runChecks() {
   # mongosh is the replacement for the deprecated mongo shell
   mongosh --port "$1" --file ../../mongodb/Projects/ProjectsInSyncState.mongodb --quiet
   echo
-  echo PROJECTS WERE LAST SYNC FAILED
+  echo PROJECTS WHERE LAST SYNC FAILED
   mongosh --port "$1" --file ../../mongodb/Projects/ProjectsWhereLastSyncFailed.mongodb --quiet
   echo
   echo CORRUPTED TEXTS


### PR DESCRIPTION
Previously the output would just list the short names of projects that failed the last sync. While useful, it doesn't indicate when the failed, so it's hard to notice when a project starts having trouble syncing.

Before:
```
AAA
BBB
CCC
```
After:
```
3 projects:
Thu, 10 Mar 2022 01:01:01 GMT AAA
Tue, 01 Mar 2022 02:02:02 GMT BBB
Wed, 26 Jan 2022 03:03:03 GMT CCC
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1271)
<!-- Reviewable:end -->
