### PR TITLE
SF-1508 Handle creating a shared project for derived projects

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ISharingLogicWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/ISharingLogicWrapper.cs
@@ -8,8 +8,6 @@ namespace SIL.XForge.Scripture.Services
     {
         bool ShareChanges(List<SharedProject> sharedProjects, SharedRepositorySource source,
             out List<SendReceiveResult> results, IList<SharedProject> reviewProjects);
-        SharedProject CreateSharedProject(string projId, string proj, SharedRepositorySource source,
-            IEnumerable<SharedRepository> sourceRepositories);
         bool HandleErrors(Action action, bool throwExceptions = false);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/SharingLogicWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/SharingLogicWrapper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using Paratext.Data;
 using Paratext.Data.Repository;
@@ -14,12 +15,6 @@ namespace SIL.XForge.Scripture.Services
             out List<SendReceiveResult> results, IList<SharedProject> reviewProjects)
         {
             return SharingLogic.ShareChanges(sharedProjects, source, out results, reviewProjects);
-        }
-
-        public SharedProject CreateSharedProject(string projId, string proj, SharedRepositorySource source,
-            IEnumerable<SharedRepository> sourceRepositories)
-        {
-            return SharingLogic.CreateSharedProject(HexId.FromStr(projId), proj, source, sourceRepositories);
         }
 
         public bool HandleErrors(Action action, bool throwExceptions = false)

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -630,6 +630,22 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
+        public void SendReceiveAsync_NoMatchingSourceRepository_Throws()
+        {
+            var env = new TestEnvironment();
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            string projectId = env.SetupProject(env.Project01, associatedPtUser);
+            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+            IInternetSharedRepositorySource mockSource =
+                env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
+
+            ArgumentException ex = Assert.ThrowsAsync<ArgumentException>(() =>
+                env.Service.SendReceiveAsync(user01Secret, "badProjectId", null));
+            Assert.That(ex.Message, Does.Contain("PT projects with the following PT ids were requested"));
+        }
+
+        [Test]
         public void SendReceiveAsync_ShareChangesErrors_InResultsOnly()
         {
             var env = new TestEnvironment();
@@ -1510,16 +1526,6 @@ namespace SIL.XForge.Scripture.Services
 
             public void SetupSuccessfulSendReceive()
             {
-                MockSharingLogicWrapper.CreateSharedProject(Arg.Any<string>(), Arg.Any<string>(),
-                    Arg.Any<SharedRepositorySource>(), Arg.Any<IEnumerable<SharedRepository>>())
-                    .Returns(callInfo => new SharedProject()
-                    {
-                        SendReceiveId = HexId.FromStr(callInfo.ArgAt<string>(0)),
-                        Repository = new SharedRepository
-                        {
-                            SendReceiveId = HexId.FromStr(callInfo.ArgAt<string>(0)),
-                        },
-                    });
                 MockSharingLogicWrapper.ShareChanges(Arg.Any<List<SharedProject>>(), Arg.Any<SharedRepositorySource>(),
                     out Arg.Any<List<SendReceiveResult>>(), Arg.Any<List<SharedProject>>()).Returns(true);
                 // Have the HandleErrors method run its first argument, which would be the ShareChanges() call.


### PR DESCRIPTION
* throw early if paratext id is not available to the user
* remove obselete null shared project logs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1272)
<!-- Reviewable:end -->
