### PR TITLE
rts: guard when doc object has no keys

### DIFF
--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -61,7 +61,7 @@ export class SFProjectService extends ProjectService<SFProject> {
   }
 
   protected allowRead(docId: string, doc: SFProject, session: ConnectSession): boolean {
-    if (session.isServer || session.role === SystemRole.SystemAdmin) {
+    if (session.isServer || session.role === SystemRole.SystemAdmin || Object.keys(doc).length === 0) {
       return true;
     }
     if (this.hasRight(session.userId, doc, Operation.View)) {


### PR DESCRIPTION
**Stack**:
- #1270
- #1269
- #1268
- #1267
- #1266
- #1274 ⮜


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1274)
<!-- Reviewable:end -->
