### PR TITLE
SF-1519 check  ws origin

### DIFF
--- a/src/RealtimeServer/common/index.ts
+++ b/src/RealtimeServer/common/index.ts
@@ -22,6 +22,7 @@ interface RealtimeServerOptions {
   audience: string;
   scope: string;
   authority: string;
+  origin: string;
   bugsnagApiKey: string;
   releaseStage: string;
   migrationsDisabled: boolean;
@@ -68,6 +69,7 @@ async function startServer(options: RealtimeServerOptions): Promise<void> {
       options.scope,
       options.authority,
       options.port,
+      options.origin,
       exceptionReporter
     );
     streamListener.listen(server);

--- a/src/RealtimeServer/common/web-socket-stream-listener.ts
+++ b/src/RealtimeServer/common/web-socket-stream-listener.ts
@@ -48,14 +48,8 @@ export class WebSocketStreamListener {
     });
 
     wss.on('connection', (webSocket: WebSocket, req: http.IncomingMessage) => {
-      this.verifyToken(req, (res: boolean, code = 200, message?: string) => {
-        if (res) {
-          const stream = new WebSocketJSONStream(webSocket);
-          backend.listen(stream, req);
-        } else {
-          webSocket.close(4000 + code, message);
-        }
-      });
+      const stream = new WebSocketJSONStream(webSocket);
+      backend.listen(stream, req);
     });
   }
 

--- a/src/RealtimeServer/common/web-socket-stream-listener.ts
+++ b/src/RealtimeServer/common/web-socket-stream-listener.ts
@@ -8,7 +8,7 @@ import ws from 'ws';
 import { ExceptionReporter } from './exception-reporter';
 
 function isLocalRequest(request: http.IncomingMessage): boolean {
-  const addr = request.connection.remoteAddress;
+  const addr = request.socket.remoteAddress;
   return addr === '127.0.0.1' || addr === '::ffff:127.0.0.1' || addr === '::1';
 }
 
@@ -21,6 +21,7 @@ export class WebSocketStreamListener {
     private readonly scope: string,
     authority: string,
     private readonly port: number,
+    private readonly origin: string,
     private exceptionReporter: ExceptionReporter
   ) {
     // Create web servers to serve files and listen to WebSocket connections
@@ -42,7 +43,8 @@ export class WebSocketStreamListener {
   listen(backend: ShareDB): void {
     // Connect any incoming WebSocket connection to ShareDB
     const wss = new ws.Server({
-      server: this.httpServer
+      server: this.httpServer,
+      verifyClient: this.verifyClient
     });
 
     wss.on('connection', (webSocket: WebSocket, req: http.IncomingMessage) => {
@@ -118,4 +120,15 @@ export class WebSocketStreamListener {
       .then(key => done(null, key.getPublicKey()))
       .catch(done);
   }
+
+  private verifyClient: ws.VerifyClientCallbackAsync = (
+    info: { origin: string; secure: boolean; req: http.IncomingMessage },
+    callback: (res: boolean, code?: number, message?: string, headers?: http.OutgoingHttpHeaders) => void
+  ): void => {
+    if (info.origin !== this.origin) {
+      callback(false, 401, 'Unauthorized');
+    } else {
+      this.verifyToken(info.req, callback);
+    }
+  };
 }

--- a/src/SIL.XForge/Realtime/RealtimeService.cs
+++ b/src/SIL.XForge/Realtime/RealtimeService.cs
@@ -232,6 +232,7 @@ namespace SIL.XForge.Realtime
                 Authority = $"https://{_authOptions.Value.Domain}/",
                 Audience = _authOptions.Value.Audience,
                 Scope = _authOptions.Value.Scope,
+                Origin = this._configuration.GetValue<string>("Site:Origin"),
                 BugsnagApiKey = this._configuration.GetValue<string>("Bugsnag:ApiKey"),
                 ReleaseStage = this._configuration.GetValue<string>("Bugsnag:ReleaseStage"),
                 MigrationsDisabled = this._realtimeOptions.Value.MigrationsDisabled,


### PR DESCRIPTION
- to prevent CSWSH Cross-Site WebSocket Hijacking
- its better to verify the token before a connection is even established. Establishing a websocket connection is a bit expensive anyway. So you don’t want unauthorized people hogging connections.
- no longer verify token inside the ws

- also change deprecated request.connection to request.socket

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1276)
<!-- Reviewable:end -->
