### PR TITLE
SF-1516a Use IndexedDB getAll instead of looping

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/indexeddb-offline-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/indexeddb-offline-store.ts
@@ -12,18 +12,9 @@ function getAllFromCursor<T extends OfflineData>(
   query?: IDBValidKey | IDBKeyRange
 ): Promise<T[]> {
   return new Promise<T[]>((resolve, reject) => {
-    const results: T[] = [];
-    const request = store.openCursor(query);
+    const request = store.getAll(query);
     request.onerror = () => reject(request.error);
-    request.onsuccess = () => {
-      const cursor = request.result;
-      if (cursor != null) {
-        results.push(cursor.value);
-        cursor.continue();
-      } else {
-        resolve(results);
-      }
-    };
+    request.onsuccess = () => resolve(request.result);
   });
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -21,7 +21,7 @@ export function supportedBrowser(): boolean {
   const isSupportedBrowser = BROWSER.satisfies({
     chrome: '>=58',
     chromium: '>=58',
-    edge: '>=76',
+    edge: '>=79',
     firefox: '>=51',
     safari: '>=11.1',
 


### PR DESCRIPTION
This is an initial fix to improve performance. The change was originally suggested by Damien when we were investigating slow question import, but didn't get made at the time. As I've been investigating slowness in community checking, my attention was directed to this method by the debugger (if you pause the debugger when the page is slow, it often shows this method in the stack, which made it look like almost all of the time was being spent here).

Manual testing shows when you load a page from scratch, the time to first paint for 1500 questions is about 85% of what it was before this change. That's not massive, though for a change this small, it's surprising it makes even that much of a difference.

Here's my testing data (time for questions to show on screen, after entering URL in new tab, listed in seconds).

Test # | Before | After
-------|--------|------
1 | 42.5 | 35.9
2 | 42.7 | 36.96
3 | 42.6 | 35.54
4 | 42.95 | 35.85
5 | 42.34 | 36.08

Again, it's not a huge change, but it certainly seems to make a difference. I've found ways of affecting performance way more significantly than this, but this is low hanging fruit and I wanted to get it out of the way.

I also updated the browser version requirements. The getAll method is not available in older IndexedDB implementations. Sources for this are [MDN](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/getAll) and [Can I Use](https://caniuse.com/indexeddb2).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1282)
<!-- Reviewable:end -->
