### PR TITLE
SF-1521 Only highlight translate target editor when user can edit

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -78,7 +78,7 @@
             "
             (loaded)="onTextLoaded('target')"
             (focused)="targetFocused = $event"
-            [highlightSegment]="targetFocused"
+            [highlightSegment]="targetFocused && canEdit"
             [markInvalid]="true"
             [isRightToLeft]="isTargetRightToLeft"
           ></app-text>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -977,6 +977,25 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('does not highlight read-only text editor', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setCurrentUser('user02');
+      env.wait();
+      const segmentRange = env.component.target!.getSegmentRange('verse_1_1')!;
+      env.targetEditor.setSelection(segmentRange.index);
+      env.wait();
+      let element: HTMLElement = env.targetTextEditor.nativeElement.querySelector(
+        'usx-segment[data-segment="verse_1_1"]'
+      );
+      expect(element.classList).not.toContain('highlight-segment');
+
+      env.setCurrentUser('user01');
+      env.wait();
+      element = env.targetTextEditor.nativeElement.querySelector('usx-segment[data-segment="verse_1_1"]');
+      expect(element.classList).toContain('highlight-segment');
+      env.dispose();
+    }));
+
     it('backspace and delete disabled for non-text elements and at segment boundaries', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();


### PR DESCRIPTION
When a user clicks on the target editor, the focused event is fired even though the target editor never truly gets focused when it is read only. This fix is a work-around that sets the text component to not add yellow highlight to verses when the editor is read only. This restores the previous behaviour before we regressed this behaviour with another work-around to set the targetFocused field on the editor component.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1284)
<!-- Reviewable:end -->
