### PR TITLE
Log unexpected problem looking up project role

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -595,7 +595,15 @@ namespace SIL.XForge.Scripture.Services
                 IEnumerable<SharedRepository> remotePtProjects =
                     GetRepositories(ptRepoSource, $"For {moreInformation}");
                 SharedRepository remotePtProject =
-                    remotePtProjects.Single(p => p.SendReceiveId.Id == project.ParatextId);
+                    remotePtProjects.SingleOrDefault(p => p.SendReceiveId.Id == project.ParatextId);
+                if (remotePtProject == null)
+                {
+                    string projects = string.Join(",", remotePtProjects
+                        .Select((SharedRepository r) => r.SendReceiveId.Id));
+                    string message = $"Failed to find project, when looking in permissible set of repositories "
+                        + $"of PT ids '{projects}', for {moreInformation}";
+                    throw new ForbiddenException(message);
+                }
 
                 // Build a dictionary of user IDs mapped to roles using the user secrets
                 var userMapping = new Dictionary<string, string>();

--- a/src/SIL.XForge/Services/ForbiddenException.cs
+++ b/src/SIL.XForge/Services/ForbiddenException.cs
@@ -7,5 +7,10 @@ namespace SIL.XForge.Services
             : base("The user does not have permission to perform this operation.")
         {
         }
+
+        public ForbiddenException(string message)
+            : base($"The user does not have permission to perform this operation. {message}")
+        {
+        }
     }
 }


### PR DESCRIPTION
Looking in the list of projects was recently associated with an
InvalidOperationException, where `remotePtProjects.Single()` failed to
find the expected PT project id. Log more information when this
happens to assist in investigation.

---

**Stack**:
- #1297
- #1289
- #1288
- #1287 ⮜


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1287)
<!-- Reviewable:end -->
