### PR TITLE
SF-1527 Trim out unproductive ops when deleting duplicate notes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -10,7 +10,7 @@ import {
   ViewChild
 } from '@angular/core';
 import { TranslocoService } from '@ngneat/transloco';
-import { clone } from 'lodash-es';
+import { clone, cloneDeep } from 'lodash-es';
 import isEqual from 'lodash-es/isEqual';
 import merge from 'lodash-es/merge';
 import Quill, { DeltaOperation, DeltaStatic, RangeStatic, Sources } from 'quill';
@@ -967,10 +967,14 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     }
     // Delta for the removal of notes that were re-created
     let notesDeletionDelta: DeltaStatic | undefined;
-    for (const op of delta.ops) {
+    const productiveOps = this.trimUnproductiveOps(delta);
+    if (productiveOps.ops == null) {
+      return;
+    }
+    for (const op of productiveOps.ops) {
       if (op.insert != null && op.insert['note-thread-embed'] != null) {
         const embedId: string = op.insert['note-thread-embed']['threadid'];
-        let deletePosition = this.embeddedElements.get(embedId);
+        const deletePosition = this.embeddedElements.get(embedId);
         if (deletePosition != null) {
           const noteDeleteOps: DeltaOperation[] = [{ retain: deletePosition }, { delete: 1 }];
           const noteDeleteOpDelta = new Delta(noteDeleteOps);
@@ -987,6 +991,42 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
         this.editor?.updateContents(deleteDelta, 'api');
       });
     }
+  }
+
+  /**
+   * Trims out the unproductive ops from a delta emitted by Quill's onContentChanged event.
+   */
+  private trimUnproductiveOps(delta: DeltaStatic): DeltaStatic {
+    // The quill way of determining changes applied to its content doesn't work perfectly on non-text objects
+    // and the result in the delta is a series of object inserts followed by a delete op that removes
+    // the original object inserts. This trims out those ops from this delta so the delta is a true representation
+    // of the changes applied to the text.
+    // For example, a delta may contain [ retain: 10, insert: blank, insert: verse, insert: note, delete: 2 ]
+    // where the delete: 2 op deletes the original verse and note inserts that get replaced in this delta
+    const productiveOps: DeltaStatic = cloneDeep(delta);
+    if (productiveOps.ops == null || productiveOps.ops.length < 2) {
+      return delta;
+    }
+    const opCount: number = productiveOps.ops.length;
+    // find the trailing delete op
+    const lastDeleteOp: number | undefined = productiveOps.ops[opCount - 1].delete;
+    let deleteCount: number = lastDeleteOp == null ? 0 : lastDeleteOp;
+    if (deleteCount === 0) {
+      return delta;
+    }
+
+    for (let i = 0; i < deleteCount; i++) {
+      const curIndex: number = opCount - i - 2;
+      const insertObj = productiveOps.ops[curIndex].insert;
+      if (insertObj != null && typeof insertObj !== 'string') {
+        // the object insert may be a false op
+        continue;
+      }
+      // the op is productive, so keep the entire delta
+      return delta;
+    }
+    productiveOps.ops.splice(opCount - 1 - deleteCount);
+    return productiveOps;
   }
 
   private setHighlightMarkerPosition(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1972,6 +1972,30 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('can backspace the last character in a segment', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.wait();
+
+      const range: RangeStatic = env.component.target!.getSegmentRange('verse_1_2')!;
+      env.targetEditor.setSelection(range.index);
+      env.wait();
+      env.typeCharacters('t');
+      let contents: DeltaStatic = env.targetEditor.getContents(range.index, 3);
+      expect(contents.length()).toEqual(3);
+      expect(contents.ops![0].insert).toEqual('t');
+      expect(contents.ops![1].insert['verse']).toBeDefined();
+      expect(contents.ops![2].insert['note-thread-embed']).toBeDefined();
+
+      env.backspace();
+      contents = env.targetEditor.getContents(range.index, 3);
+      expect(contents.length()).toEqual(3);
+      expect(contents.ops![0].insert.blank).toBeDefined();
+      expect(contents.ops![1].insert['verse']).toBeDefined();
+      expect(contents.ops![2].insert['note-thread-embed']).toBeDefined();
+      env.dispose();
+    }));
+
     it('undo delete-a-note-icon removes the duplicate recreated icon', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();


### PR DESCRIPTION
Sometimes a delta with a note insert means that the user is undoing previously deleting a note icon. Since the note gets recreated when deleted, the recreated note is marked for deletion. However, if a user deletes the final character of a segment, any note immediately following the next verse embed gets marked for deletion because Quill diff mechanism doesn't accurately represent the change applied to the text.

For instance, if the true delta applied to a text is [ retain: 10, insert: blank ], then the delta emitted by the Quill.onContentChanged will be [ retain: 10, insert: blank, insert: verse, insert: note, delete: 2 ]. This change trims the unproductive false ops from the delta and uses that to determine if a note needs to be marked for deletion.