### PR TITLE
SF-1524 Apply relevant attributes when applying remote text changes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -757,11 +757,13 @@ export class TextViewModel {
 
   private getAttributesAtPosition(editorPosition: number): StringMap {
     const editor: Quill = this.checkEditor();
-    // The format of the insertion point lacks some properties that we have to get from the following editor position
+    // The format of the insertion point may only contain the block level formatting,
+    // the format classes and other information we get from the character following the insertion point
     const insertionFormat: StringMap = editor.getFormat(editorPosition);
     const characterFormat: StringMap = editor.getFormat(editorPosition, 1);
     if (characterFormat['segment'] != null) {
       for (const key of Object.keys(characterFormat)) {
+        // we ignore text anchor formatting because we cannot depend on the character format to tell us if it is needed
         if (key !== 'text-anchor') {
           insertionFormat[key] = characterFormat[key];
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -755,8 +755,18 @@ export class TextViewModel {
     return embeddedElementsCount;
   }
 
-  private getAttributesAtPosition(editorPosition: number) {
+  private getAttributesAtPosition(editorPosition: number): StringMap {
     const editor: Quill = this.checkEditor();
-    return editor.getFormat(editorPosition);
+    // The format of the insertion point lacks some properties that we have to get from the following editor position
+    const insertionFormat: StringMap = editor.getFormat(editorPosition);
+    const characterFormat: StringMap = editor.getFormat(editorPosition, 1);
+    if (characterFormat['segment'] != null) {
+      for (const key of Object.keys(characterFormat)) {
+        if (key !== 'text-anchor') {
+          insertionFormat[key] = characterFormat[key];
+        }
+      }
+    }
+    return insertionFormat;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2002,6 +2002,7 @@ describe('EditorComponent', () => {
       expect(contents.ops![0].insert.blank).toBeDefined();
       expect(contents.ops![1].insert['verse']).toBeDefined();
       expect(contents.ops![2].insert['note-thread-embed']).toBeDefined();
+      env.dispose();
     }));
 
     it('remote edits next to note on verse applied correctly', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2002,6 +2002,40 @@ describe('EditorComponent', () => {
       expect(contents.ops![0].insert.blank).toBeDefined();
       expect(contents.ops![1].insert['verse']).toBeDefined();
       expect(contents.ops![2].insert['note-thread-embed']).toBeDefined();
+    }));
+
+    it('remote edits next to note on verse applied correctly', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.wait();
+
+      let verse3Element: HTMLElement = env.getSegmentElement('verse_1_3')!;
+      let noteThreadIcon = verse3Element.querySelector('.note-thread-segment display-note');
+      expect(noteThreadIcon).not.toBeNull();
+      // Insert text next to thread02 icon
+      const notePosition: number = env.getNoteThreadEditorPosition('thread02');
+      const remoteEditPositionAfterNote: number = 0;
+      const noteCountBeforePosition = 2;
+      // $|*target: chapter 1, $$verse 3.
+      const remoteEditTextPos: number = env.getRemoteEditPosition(
+        notePosition,
+        remoteEditPositionAfterNote,
+        noteCountBeforePosition
+      );
+      const insert: string = 'abc';
+      const deltaOps: DeltaOperation[] = [{ retain: remoteEditTextPos }, { insert: insert }];
+      const textDoc: TextDoc = env.getTextDoc(new TextDocId('project01', 40, 1));
+      textDoc.submit(new Delta(deltaOps));
+
+      env.wait();
+      expect(env.getNoteThreadEditorPosition('thread02')).toEqual(notePosition);
+      verse3Element = env.getSegmentElement('verse_1_3')!;
+      noteThreadIcon = verse3Element.querySelector('.note-thread-segment display-note');
+      expect(noteThreadIcon).not.toBeNull();
+      // check that the note thread underline does not get applied
+      const insertTextDelta = env.targetEditor.getContents(notePosition + 1, 3);
+      expect(insertTextDelta.ops![0].insert).toEqual('abc');
+      expect(insertTextDelta.ops![0].attributes!['text-anchor']).toBeUndefined();
       env.dispose();
     }));
 


### PR DESCRIPTION
There appears to be a difference in the result of a text editor position getFormat and calling getFormat on a string of text. This results in the remote inserts being applied with insufficient format attributes. This improves on that situation by grabbing all formatting of a character and adding it onto the formatting retrieved from a text editor position (excluding the text-anchoring info that appears to be working correctly).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1292)
<!-- Reviewable:end -->
