### PR TITLE
SF-1516b Improve performance by enabling ngZoneEventCoalescing

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/main.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/main.ts
@@ -18,5 +18,5 @@ if (environment.production || environment.pwaTest) {
 ExceptionHandlingService.initBugsnag();
 
 platformBrowserDynamic(providers)
-  .bootstrapModule(AppModule)
+  .bootstrapModule(AppModule, { ngZoneEventCoalescing: true })
   .catch(err => console.log(err));


### PR DESCRIPTION
This is not the road I have been going down for improving performance, but I came across it tonight and it makes a massive difference, likely greater than my more significant changes. So I briefly threw my other changes on the back burner to test this out first. There's still significant slowness in the checking component when there are lots of questions, but it's a lot better.

Essentially we're telling Angular that if an event occurs, and it knows another one is about to fire, to just wait until they've both fired before running change detection (coalescing events).

See this article by Netanel Basal (the guy behind Transloco and a bunch of other helpful Angular articles I've read) for a deeper explanation of what this does: https://netbasal.com/reduce-change-detection-cycles-with-event-coalescing-in-angular-c4037199859f