### PR TITLE
SF-1400 Sort questions in query rather than component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -237,7 +237,7 @@ describe('CheckingComponent', () => {
     it('responds to remote community checking disabled when observer', fakeAsync(() => {
       // User with access to translate app should get redirected there
       const env = new TestEnvironment(OBSERVER_USER, 'ALL');
-      env.selectQuestion(2);
+      env.selectQuestion(1);
       env.setCheckingEnabled(false);
       expect(env.location.path()).toEqual('/projects/project01/translate/JHN');
       expect(env.component.projectDoc).toBeUndefined();
@@ -247,11 +247,6 @@ describe('CheckingComponent', () => {
   });
 
   describe('Questions', () => {
-    it('sorts questions by canonical order', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER, 'ALL');
-      expect(env.component.questionDocs[0].id).toBe('project01:q16Id');
-    }));
-
     it('questions are displaying and audio is cached', fakeAsync(() => {
       const env = new TestEnvironment(CHECKER_USER);
       verify(mockedFileService.findOrUpdateCache(FileType.Audio, QuestionDoc.COLLECTION, anything(), anything())).times(
@@ -271,10 +266,10 @@ describe('CheckingComponent', () => {
       expect(env.component.questionsPanel!.activeQuestionDoc!.data!.dataId).toBe('q5Id');
       // A sixteenth question is archived
       expect(env.questions.length).toEqual(16);
-      let question = env.selectQuestion(2);
+      let question = env.selectQuestion(1);
       expect(env.getQuestionText(question)).toBe('Book 1, Q1 text');
       expect(env.currentBookAndChapter).toBe('John 1');
-      question = env.selectQuestion(1);
+      question = env.selectQuestion(16);
       expect(env.getQuestionText(question)).toBe('Matthew question relating to chapter 1');
       expect(env.currentBookAndChapter).toBe('Matthew 1');
     }));
@@ -425,7 +420,7 @@ describe('CheckingComponent', () => {
       expect(env.isSegmentHighlighted(1, 1)).toBe(false);
       expect(env.isSegmentHighlighted(1, 5)).toBe(true);
       expect(env.segmentHasQuestion(1, 5)).toBe(true);
-      expect(env.component.questionVerseRefs[13]).toEqual(VerseRef.parse('JHN 1:5'));
+      expect(env.component.questionVerseRefs[0]).toEqual(VerseRef.parse('JHN 1:5'));
     }));
 
     it('unread answers badge is only visible when the setting is ON to see other answers', fakeAsync(() => {
@@ -464,7 +459,7 @@ describe('CheckingComponent', () => {
       env.waitForSliderUpdate();
       expect(env.component.questionsPanel!.activeQuestionDoc!.id).toBe(questionId);
       expect(env.questions.length).toEqual(16);
-      question = env.selectQuestion(15);
+      question = env.selectQuestion(16);
       expect(env.getQuestionText(question)).toBe('Admin just added a question.');
     }));
 
@@ -567,7 +562,7 @@ describe('CheckingComponent', () => {
       const projectUserConfigDoc = env.component.projectUserConfigDoc!.data!;
       verify(mockedTranslationEngineService.trainSelectedSegment(anything(), anything())).once();
       expect(projectUserConfigDoc.selectedQuestionRef).toBe('project01:q5Id');
-      env.selectQuestion(5);
+      env.selectQuestion(4);
       expect(projectUserConfigDoc.selectedTask).toBe('checking');
       expect(projectUserConfigDoc.selectedQuestionRef).toBe('project01:q4Id');
       expect(projectUserConfigDoc.selectedBookNum).toBeUndefined();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -2304,7 +2304,8 @@ class TestEnvironment {
         'project01',
         deepEqual({
           bookNum: this.projectBookRoute === 'ALL' ? undefined : Canon.bookIdToNumber(this.projectBookRoute),
-          sort: true
+          sort: true,
+          activeOnly: true
         })
       )
     ).thenCall(() =>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -171,16 +171,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
   }
 
   get questionDocs(): Readonly<QuestionDoc[]> {
-    return (this.questionsQuery?.docs || [])
-      .filter(qd => qd.data != null && qd.data.isArchived === false)
-      .sort((docA, docB) => {
-        const a = docA.data!;
-        const b = docB.data!;
-        const diff =
-          VerseRef.getBBBCCCVVV(a.verseRef.bookNum, a.verseRef.chapterNum, a.verseRef.verseNum) -
-          VerseRef.getBBBCCCVVV(b.verseRef.bookNum, b.verseRef.chapterNum, b.verseRef.verseNum);
-        return diff !== 0 ? diff : Date.parse(a.dateCreated) - Date.parse(b.dateCreated);
-      });
+    return this.questionsQuery?.docs.filter(qd => qd.data?.isArchived === false) || [];
   }
 
   get textsByBookId(): TextsByBookId {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -171,7 +171,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
   }
 
   get questionDocs(): Readonly<QuestionDoc[]> {
-    return this.questionsQuery?.docs.filter(qd => qd.data?.isArchived === false) || [];
+    return this.questionsQuery?.docs || [];
   }
 
   get textsByBookId(): TextsByBookId {
@@ -370,7 +370,8 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
         this.showAllBooks = bookId === 'ALL';
         this.questionsQuery = await this.projectService.queryQuestions(projectId, {
           bookNum: this.showAllBooks ? undefined : bookNum,
-          sort: true
+          sort: true,
+          activeOnly: true
         });
         // TODO: check for remote changes to file data more generically
         if (this.questionsRemoteChangesSub != null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -109,7 +109,12 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
       queryParams[obj<Question>().pathStr(q => q.isArchived)] = false;
     }
     if (options.sort != null) {
-      queryParams.$sort = { [obj<Question>().pathStr(q => q.dateCreated)]: 1 };
+      queryParams.$sort = {
+        [obj<Question>().pathStr(q => q.verseRef.bookNum)]: 1,
+        [obj<Question>().pathStr(q => q.verseRef.chapterNum)]: 1,
+        [obj<Question>().pathStr(q => q.verseRef.verseNum)]: 1,
+        [obj<Question>().pathStr(q => q.dateCreated)]: 1
+      };
     }
     return this.realtimeService.subscribeQuery(QuestionDoc.COLLECTION, queryParams);
   }


### PR DESCRIPTION
While working on improving performance in the Angular app, I discovered that the way I had implemented sorting questions was non-ideal for several reasons. We already had a way to sort questions in a query, and rather than use that, I had rolled my own. Questions would be sorted every time the `get questionDocs()` getter was used, which would be multiple times per round of change detection. This is not ideal, since sorting large numbers of things is slow, and there's no real reason to re-sort them. It also means if another component wanted sorted questions the same sorting logic could not be easily re-used.

Also I was filtering for questions that are not archived, which should have been done in the query itself.

Unfortunately, my original change involved somewhat confusing changes to the tests. So I just reverted that entire commit, and then made my changes afterwards. I think it will be easiest to review by looking at the commits separately. The PR I'm reverting is #1140.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1294)
<!-- Reviewable:end -->
