### PR TITLE
SF-1529 - Note icon does not appear when the user reattached a new txt and then selects a new icon

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -158,16 +158,27 @@ describe('NoteDialogComponent', () => {
   }));
 
   it('reattached note with content', fakeAsync(() => {
-    const content: string = 'Reattached content text.';
+    let content: string = 'Reattached content text.';
     env = new TestEnvironment({ reattachedContent: content });
+
+    // Check note with status set
     const verseText = 'before selection reattached text after selection';
-    const expectedSrc = '/assets/icons/TagIcons/flag02.png';
-    const reattachNote = env.notes[4].nativeElement as HTMLElement;
+    let expectedSrc = '/assets/icons/TagIcons/flag02.png';
+    let reattachNote = env.notes[4].nativeElement as HTMLElement;
     expect(reattachNote.querySelector('.content .text')!.textContent).toContain(verseText);
     expect(reattachNote.querySelector('.content .verse-reattached')!.textContent).toContain('Matthew 1:4');
     expect(reattachNote.querySelector('.content .note-content')!.textContent).toContain(content);
     expect(reattachNote.querySelector('img')?.getAttribute('src')).toEqual(expectedSrc);
     expect(reattachNote.querySelector('img')?.getAttribute('title')).toEqual('To do');
+
+    // Check note with no status set
+    content = 'reattached02';
+    expectedSrc = '/assets/icons/TagIcons/flag03.png';
+    reattachNote = env.notes[5].nativeElement as HTMLElement;
+    expect(reattachNote.querySelector('.content .verse-reattached')!.textContent).toContain('Matthew 1:4');
+    expect(reattachNote.querySelector('.content .note-content')!.textContent).toContain(content);
+    expect(reattachNote.querySelector('img')?.getAttribute('src')).toEqual(expectedSrc);
+    expect(reattachNote.querySelector('img')?.getAttribute('title')).toEqual('Note reattached');
   }));
 
   it('shows assigned user', fakeAsync(() => {
@@ -372,6 +383,19 @@ class TestEnvironment {
         ownerRef: 'user01',
         status: reattachedContent === '' ? NoteStatus.Unspecified : NoteStatus.Todo,
         tagIcon: reattachedContent === '' ? undefined : 'flag02',
+        dateCreated: '',
+        dateModified: '',
+        reattached: TestEnvironment.reattached
+      });
+      noteThread.notes.push({
+        dataId: 'reattached02',
+        threadId: 'thread01',
+        content: 'reattached02',
+        extUserId: 'user01',
+        deleted: false,
+        ownerRef: 'user01',
+        status: NoteStatus.Unspecified,
+        tagIcon: 'flag03',
         dateCreated: '',
         dateModified: '',
         reattached: TestEnvironment.reattached

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -154,7 +154,8 @@ export class NoteDialogComponent implements OnInit {
       case NoteStatus.Resolved:
         return this.threadDoc.getNoteResolvedIcon(note).url;
     }
-    return note.reattached != null ? this.threadDoc.iconReattached.url : this.threadDoc.getNoteIcon(note).url;
+    const noteIcon: string = this.threadDoc.getNoteIcon(note).url;
+    return note.reattached != null && noteIcon == '' ? this.threadDoc.iconReattached.url : noteIcon;
   }
 
   noteTitle(note: Note) {


### PR DESCRIPTION
- Adjusted output of note icons to use any icon if specifically set on the note otherwise use the re-attached icon

Output should look like this
![image](https://user-images.githubusercontent.com/17464863/161475519-f5c107fd-12a2-40d8-8205-18960bdfb9e8.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1296)
<!-- Reviewable:end -->
