### PR TITLE
SF-1531 - The error appears when opening the note icon if a note is created inside the special characters

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -329,7 +329,8 @@ usx-segment:first-child usx-blank {
 }
 
 usx-char {
-  &[data-style='it'] {
+  &[data-style='it'],
+  &[data-style='em'] {
     font-style: italic;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -509,7 +509,10 @@ export function registerScripture(): string[] {
   }
   formats.push(TextAnchorInline);
 
+  // Lower index means deeper in the DOM tree i.e. text-anchor will be nested inside of char. If char doesn't exist
+  // then it will nest inside the next available element higher up the DOM
   (Inline as any).order.push('text-anchor');
+  (Inline as any).order.push('char');
   (Inline as any).order.push('segment');
   (Inline as any).order.push('para-contents');
 


### PR DESCRIPTION
- Adjust the order of quill inlines to ensure text-anchor is deeper than char
- Added styling for usx-char `em` style

The issue was how Quill ordered elements in the DOM and it placed the `<display-text-anchor>` above `<usx-char>` elements:
![image](https://user-images.githubusercontent.com/17464863/162354075-f3ec6850-da06-4cff-a3de-f2b9000af551.png)

After adjusting the order it now appears correctly and the `usx-char` can be styled correctly as well:
![image](https://user-images.githubusercontent.com/17464863/162354193-443ab7fe-c9cc-4c6f-bde9-c17cb104eae7.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1299)
<!-- Reviewable:end -->
