### PR TITLE
Do not show no questions message until questions load

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -110,7 +110,7 @@
     fxLayout="row"
     fxLayoutAlign="space-around"
     class="reviewer-panels"
-    *ngIf="allQuestionsCount === 0"
+    *ngIf="showNoQuestionsMessage"
     id="no-questions-label"
   >
     <p>
@@ -121,6 +121,8 @@
       ></span>
     </p>
   </div>
+
+  <p id="loading-questions-message" *ngIf="showQuestionsLoadingMessage">{{ t("loading_questions") }}</p>
 
   <ng-template #reviewerQuestionPanel>
     <div fxLayout="column" fxLayoutAlign="space-around" class="reviewer-panels" id="reviewer-question-panel">
@@ -256,10 +258,13 @@
       fxLayout="row"
       fxLayoutAlign="space-around"
       class="reviewer-panels"
-      *ngIf="allArchivedQuestionsCount === 0"
+      *ngIf="showNoArchivedQuestionsMessage"
       id="no-archived-questions-label"
     >
       <p>{{ t("no_archived_questions") }}</p>
     </div>
   </div>
+  <p *ngIf="showArchivedQuestionsLoadingMessage" id="loading-archived-questions-message">
+    {{ t("loading_questions") }}
+  </p>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
@@ -38,7 +38,10 @@ app-donut-chart {
 }
 
 #no-questions-label,
-#no-archived-questions-label {
+#no-archived-questions-label,
+#loading-questions-message,
+#loading-archived-questions-message {
+  text-align: center;
   color: var(--mdc-theme-text-hint-on-background);
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -90,11 +90,13 @@ describe('CheckingOverviewComponent', () => {
 
   describe('Add Question', () => {
     it('should display "No question" message', fakeAsync(() => {
-      const env = new TestEnvironment();
+      const env = new TestEnvironment(false);
       env.fixture.detectChanges();
-      expect(env.noQuestionsLabel).not.toBeNull();
-      env.waitForQuestions();
+      expect(env.loadingQuestionsLabel).not.toBeNull();
       expect(env.noQuestionsLabel).toBeNull();
+      env.waitForQuestions();
+      expect(env.loadingQuestionsLabel).toBeNull();
+      expect(env.noQuestionsLabel).not.toBeNull();
     }));
 
     it('should not display "Add question" button for community checker', fakeAsync(() => {
@@ -296,12 +298,14 @@ describe('CheckingOverviewComponent', () => {
 
   describe('for Reviewer', () => {
     it('should display "No question" message', fakeAsync(() => {
-      const env = new TestEnvironment();
+      const env = new TestEnvironment(false);
       env.setCurrentUser(env.checkerUser);
       env.fixture.detectChanges();
-      expect(env.noQuestionsLabel).not.toBeNull();
-      env.waitForQuestions();
+      expect(env.loadingQuestionsLabel).not.toBeNull();
       expect(env.noQuestionsLabel).toBeNull();
+      env.waitForQuestions();
+      expect(env.loadingQuestionsLabel).toBeNull();
+      expect(env.noQuestionsLabel).not.toBeNull();
     }));
 
     it('should not display progress for project admin', fakeAsync(() => {
@@ -385,12 +389,16 @@ describe('CheckingOverviewComponent', () => {
     it('should display "No archived question" message', fakeAsync(() => {
       const env = new TestEnvironment();
       const id = new TextDocId('project01', 40, 1);
+      env.fixture.detectChanges();
+      expect(env.loadingArchivedQuestionsLabel).not.toBeNull();
       env.waitForQuestions();
+      expect(env.loadingArchivedQuestionsLabel).toBeNull();
       expect(env.noArchivedQuestionsLabel).toBeNull();
 
       env.simulateRowClick(0, undefined, true);
       env.simulateRowClick(1, id, true);
       env.clickElement(env.questionPublishButtons[0]);
+      expect(env.loadingArchivedQuestionsLabel).toBeNull();
       expect(env.noArchivedQuestionsLabel).not.toBeNull();
     }));
 
@@ -815,6 +823,10 @@ class TestEnvironment {
     return this.fixture.debugElement.query(By.css('#import-btn'));
   }
 
+  get loadingQuestionsLabel(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#loading-questions-message'));
+  }
+
   get noQuestionsLabel(): DebugElement {
     return this.fixture.debugElement.query(By.css('#no-questions-label'));
   }
@@ -841,6 +853,10 @@ class TestEnvironment {
 
   get questionPublishButtons(): DebugElement[] {
     return this.archivedQuestions.queryAll(By.css('mdc-list-item .publish-btn'));
+  }
+
+  get loadingArchivedQuestionsLabel(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#loading-archived-questions-message'));
   }
 
   get noArchivedQuestionsLabel(): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -62,6 +62,28 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
     super(noticeService);
   }
 
+  get showQuestionsLoadingMessage(): boolean {
+    return this.questionsQuery?.ready !== true && this.allQuestionsCount === 0;
+  }
+
+  get showArchivedQuestionsLoadingMessage(): boolean {
+    return (
+      this.questionsQuery?.ready !== true &&
+      (this.questionsQuery?.docs || []).filter(qd => qd.data?.isArchived).length === 0
+    );
+  }
+
+  get showNoQuestionsMessage(): boolean {
+    return this.questionsQuery?.ready === true && this.allQuestionsCount === 0;
+  }
+
+  get showNoArchivedQuestionsMessage(): boolean {
+    return (
+      this.questionsQuery?.ready === true &&
+      this.questionsQuery?.docs.filter(qd => qd.data != null && qd.data.isArchived).length === 0
+    );
+  }
+
   get allQuestionsCount(): number {
     return this.allPublishedQuestions.length;
   }
@@ -139,13 +161,6 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
     const project = this.projectDoc?.data;
     const userId = this.userService.currentUserId;
     return project != null && SF_PROJECT_RIGHTS.hasRight(project, userId, SFProjectDomain.Questions, Operation.Edit);
-  }
-
-  get allArchivedQuestionsCount(): number {
-    if (this.questionsQuery == null) {
-      return 0;
-    }
-    return this.questionsQuery.docs.filter(qd => qd.data != null && qd.data.isArchived).length;
   }
 
   private get allPublishedQuestions(): QuestionDoc[] {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -216,6 +216,7 @@
     "answers": "Answers",
     "comments": "Comments",
     "likes": "Likes",
+    "loading_questions": "Loading questions...",
     "questions": "Questions",
     "texts_with_questions": "Texts with Questions"
   },


### PR DESCRIPTION
This has been bugging me for a while. It's less noticeable after some recent performance improvements, but definitely still there. And on a slower network it might be even more noticeable.

How checking overview component looks while loading:
Before | After
---------|--------
![](https://user-images.githubusercontent.com/6140710/162367788-f6a9b138-1e96-418b-8ccc-566c07bfb09a.png) | ![](https://user-images.githubusercontent.com/6140710/164784585-a60893c2-cf42-4896-9062-a24012a27261.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1300)
<!-- Reviewable:end -->
