### PR TITLE
SF-1516c Optimize checking questions component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -35,6 +35,7 @@ import { UserService } from 'xforge-common/user.service';
 import { issuesEmailTemplate, supportedBrowser } from 'xforge-common/utils';
 import { version } from '../../../version.json';
 import { environment } from '../environments/environment';
+import { QuestionDoc } from './core/models/question-doc';
 import { SFProjectProfileDoc } from './core/models/sf-project-profile-doc';
 import { canAccessTranslateApp } from './core/models/sf-project-role-info';
 import { SFProjectService } from './core/sf-project.service';
@@ -80,7 +81,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   private selectedProjectDeleteSub?: Subscription;
   private removedFromProjectSub?: Subscription;
   private _isDrawerPermanent: boolean = true;
-  private readonly questionCountQueries = new Map<number, RealtimeQuery>();
+  private readonly questionCountQueries = new Map<number, RealtimeQuery<QuestionDoc>>();
 
   constructor(
     private readonly router: Router,
@@ -533,7 +534,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       );
     }
     await Promise.all(promises);
-    this.questionCountQueries.forEach((query: RealtimeQuery, bookNum: number) => {
+    this.questionCountQueries.forEach((query: RealtimeQuery<QuestionDoc>, bookNum: number) => {
       this.subscribe(merge(query.remoteChanges$, query.localChanges$, query.ready$), () => {
         if (this.selectedProjectDoc == null) {
           return;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -23,8 +23,8 @@
                   (changed)="questionChanged($event)"
                   [visible]="isDrawerPermanent || isExpanded"
                   [projectUserConfigDoc]="projectUserConfigDoc"
-                  [project]="projectDoc?.data"
-                  [questionDocs]="questionDocs"
+                  [projectProfileDoc]="projectDoc"
+                  [questionDocs$]="questionDocs$"
                   [isAllBooksShown]="showAllBooks"
                 ></app-checking-questions>
               </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -15,7 +15,7 @@ import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-inf
 import { toVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { Canon } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/canon';
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
-import { merge, Subscription } from 'rxjs';
+import { merge, NEVER, Observable, Subscription } from 'rxjs';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { I18nService } from 'xforge-common/i18n.service';
 import { FileType } from 'xforge-common/models/file-offline-data';
@@ -172,6 +172,10 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
 
   get questionDocs(): Readonly<QuestionDoc[]> {
     return this.questionsQuery?.docs || [];
+  }
+
+  get questionDocs$(): Observable<Readonly<QuestionDoc[]>> {
+    return this.questionsQuery?.docs$ || NEVER;
   }
 
   get textsByBookId(): TextsByBookId {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/memory-realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/memory-realtime-remote-store.ts
@@ -63,6 +63,7 @@ export class MemoryRealtimeDocAdapter implements RealtimeDocAdapter {
   readonly pendingOps: any[] = [];
   subscribed: boolean = false;
   version: number = -1;
+  readonly changes$ = new Subject<any>();
   readonly remoteChanges$ = new Subject<any>();
   readonly create$ = new Subject<void>();
   readonly delete$ = new Subject<void>();
@@ -116,6 +117,7 @@ export class MemoryRealtimeDocAdapter implements RealtimeDocAdapter {
     }
     this.data = this.type.apply(this.data, op);
     this.version++;
+    this.emitChange(op);
     if (!source) {
       this.emitRemoteChange(op);
     }
@@ -144,6 +146,10 @@ export class MemoryRealtimeDocAdapter implements RealtimeDocAdapter {
 
   destroy(): Promise<void> {
     return Promise.resolve();
+  }
+
+  emitChange(op?: any): void {
+    this.changes$.next(op);
   }
 
   emitRemoteChange(op?: any): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
@@ -80,6 +80,10 @@ export abstract class RealtimeDoc<T = any, Ops = any> {
     return this.adapter.remoteChanges$;
   }
 
+  get changes$(): Observable<Ops> {
+    return this.adapter.changes$;
+  }
+
   /**
    * Subscribes to remote changes for the realtime data.
    * For this record, update the RealtimeDoc cache, if any, from IndexedDB.

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime-remote-store.ts
@@ -32,6 +32,8 @@ export interface RealtimeDocAdapter {
   readonly create$: Observable<void>;
   readonly delete$: Observable<void>;
   /** Fires when there are changes to underlying data. */
+  readonly changes$: Observable<any>;
+  /** Fires when there are changes to underlying data that came from a different client. */
   readonly remoteChanges$: Observable<any>;
 
   create(data: any, type?: string): Promise<void>;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.ts
@@ -130,19 +130,19 @@ export class RealtimeService {
     return query;
   }
 
-  onQuerySubscribe(query: RealtimeQuery): void {
+  onQuerySubscribe<T extends RealtimeDoc>(query: RealtimeQuery<T>): void {
     let collectionQueries = this.subscribeQueries.get(query.collection);
     if (collectionQueries == null) {
       collectionQueries = new Set<RealtimeQuery>();
       this.subscribeQueries.set(query.collection, collectionQueries);
     }
-    collectionQueries.add(query);
+    collectionQueries.add(query as any as RealtimeQuery);
   }
 
-  onQueryUnsubscribe(query: RealtimeQuery): void {
+  onQueryUnsubscribe<T extends RealtimeDoc>(query: RealtimeQuery<T>): void {
     const collectionQueries = this.subscribeQueries.get(query.collection);
     if (collectionQueries != null) {
-      collectionQueries.delete(query);
+      collectionQueries.delete(query as any as RealtimeQuery);
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
@@ -90,12 +90,14 @@ export class SharedbRealtimeDocAdapter implements RealtimeDocAdapter {
   readonly idle$: Observable<void>;
   readonly create$: Observable<void>;
   readonly delete$: Observable<void>;
+  readonly changes$: Observable<any>;
   readonly remoteChanges$: Observable<any>;
 
   constructor(private readonly doc: Doc) {
     this.idle$ = fromEvent(this.doc, 'no write pending');
     this.create$ = fromEvent(this.doc, 'create');
     this.delete$ = fromEvent(this.doc, 'del');
+    this.changes$ = fromEvent<[any, any]>(this.doc, 'op').pipe(map(([ops]) => ops));
     this.remoteChanges$ = fromEvent<[any, any]>(this.doc, 'op').pipe(
       filter(([, source]) => !source),
       map(([ops]) => ops)


### PR DESCRIPTION
The performance improvement is made by using the OnPush change detection strategy in the checking questions component. Since it can list a large number of questions, change detection in that component is particularly expensive, so reducing the number of times it is run speeds things up immensely.

There are two main "supporting changes" (changes that are not directly related to the issue at hand, but were necessary in order to make the main change:
- Add changes$ observable to RealtimeDoc and RealtimeDocAdapter
- Add docs$ observable to RealtimeQuery

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1301)
<!-- Reviewable:end -->
