### PR TITLE
drop: expect and hide console logs in tests (#1234)

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -68,6 +68,7 @@
         "@angular/compiler": "~11.2.14",
         "@angular/compiler-cli": "~11.2.14",
         "@angular/language-service": "~11.2.14",
+        "@triviality/logger": "^1.1.6",
         "@types/auth0-js": "^9.14.5",
         "@types/jasmine": "~3.10.3",
         "@types/jasminewd2": "~2.0.10",
@@ -3793,6 +3794,29 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@triviality/core": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@triviality/core/-/core-1.2.5.tgz",
+      "integrity": "sha512-gON9hw952+91mmHS5WKLsa0iGiyAV1t/1rPVAVIgeIu/QzuQ3/Jpk+8Wac963x0mnCWJ89BDg3xiNcEm2weGOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "^4.14.149",
+        "@types/ramda": "0",
+        "lodash": "^4.17.15",
+        "ramda": "0"
+      }
+    },
+    "node_modules/@triviality/logger": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@triviality/logger/-/logger-1.1.6.tgz",
+      "integrity": "sha512-eImRpBT4auMklBiCbUCLnzRiuf1gTYCj7zsRKircN4T6DjnA/mCLoBqLyUaO9ldtBsMNoCFp4lRZZxfc4VzBaw==",
+      "dev": true,
+      "dependencies": {
+        "@triviality/core": "^1.2.5",
+        "moment": "2",
+        "ts-log": "2"
+      }
+    },
     "node_modules/@trysound/sax": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.1.1.tgz",
@@ -3923,6 +3947,15 @@
       "dev": true,
       "dependencies": {
         "parchment": "^1.1.2"
+      }
+    },
+    "node_modules/@types/ramda": {
+      "version": "0.27.64",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.64.tgz",
+      "integrity": "sha512-EDf++ss/JoMiDpvT1MuA8oi88OwpvmqVE+o8Ojm5v/5bdJEPZ6eIQd/XYAeQ0imlwG6Tf0Npfq4Z9w3hAKBk9Q==",
+      "dev": true,
+      "dependencies": {
+        "ts-toolbelt": "^6.15.1"
       }
     },
     "node_modules/@types/selenium-webdriver": {
@@ -13068,6 +13101,15 @@
         "obliterator": "^1.5.0"
       }
     },
+    "node_modules/moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -16207,11 +16249,6 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18618,6 +18655,16 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
       "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo="
+    },
+    "node_modules/ramda": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
+      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -21925,6 +21972,12 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/ts-log": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.4.tgz",
+      "integrity": "sha512-DEQrfv6l7IvN2jlzc/VTdZJYsWUnQNCsueYjMkC/iXoEoi5fNan6MjeDqkvhfzbmHgdz9UxDUluX3V5HdjTydQ==",
+      "dev": true
+    },
     "node_modules/ts-md5": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-1.2.9.tgz",
@@ -21977,6 +22030,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/ts-toolbelt": {
+      "version": "6.15.5",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
+      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==",
+      "dev": true
     },
     "node_modules/tsconfig-paths": {
       "version": "3.9.0",
@@ -27833,6 +27892,29 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@triviality/core": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@triviality/core/-/core-1.2.5.tgz",
+      "integrity": "sha512-gON9hw952+91mmHS5WKLsa0iGiyAV1t/1rPVAVIgeIu/QzuQ3/Jpk+8Wac963x0mnCWJ89BDg3xiNcEm2weGOg==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "^4.14.149",
+        "@types/ramda": "0",
+        "lodash": "^4.17.15",
+        "ramda": "0"
+      }
+    },
+    "@triviality/logger": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@triviality/logger/-/logger-1.1.6.tgz",
+      "integrity": "sha512-eImRpBT4auMklBiCbUCLnzRiuf1gTYCj7zsRKircN4T6DjnA/mCLoBqLyUaO9ldtBsMNoCFp4lRZZxfc4VzBaw==",
+      "dev": true,
+      "requires": {
+        "@triviality/core": "^1.2.5",
+        "moment": "2",
+        "ts-log": "2"
+      }
+    },
     "@trysound/sax": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.1.1.tgz",
@@ -27960,6 +28042,15 @@
       "dev": true,
       "requires": {
         "parchment": "^1.1.2"
+      }
+    },
+    "@types/ramda": {
+      "version": "0.27.64",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.64.tgz",
+      "integrity": "sha512-EDf++ss/JoMiDpvT1MuA8oi88OwpvmqVE+o8Ojm5v/5bdJEPZ6eIQd/XYAeQ0imlwG6Tf0Npfq4Z9w3hAKBk9Q==",
+      "dev": true,
+      "requires": {
+        "ts-toolbelt": "^6.15.1"
       }
     },
     "@types/selenium-webdriver": {
@@ -35174,6 +35265,12 @@
         "obliterator": "^1.5.0"
       }
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "dev": true
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -39259,6 +39356,12 @@
         "fast-diff": "1.1.2"
       }
     },
+    "ramda": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
+      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
+      "dev": true
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -41912,6 +42015,12 @@
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
+    "ts-log": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.4.tgz",
+      "integrity": "sha512-DEQrfv6l7IvN2jlzc/VTdZJYsWUnQNCsueYjMkC/iXoEoi5fNan6MjeDqkvhfzbmHgdz9UxDUluX3V5HdjTydQ==",
+      "dev": true
+    },
     "ts-md5": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-1.2.9.tgz",
@@ -41943,6 +42052,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
+      "dev": true
+    },
+    "ts-toolbelt": {
+      "version": "6.15.5",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
+      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==",
       "dev": true
     },
     "tsconfig-paths": {

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -79,6 +79,7 @@
     "@angular/compiler": "~11.2.14",
     "@angular/compiler-cli": "~11.2.14",
     "@angular/language-service": "~11.2.14",
+    "@triviality/logger": "^1.1.6",
     "@types/auth0-js": "^9.14.5",
     "@types/jasmine": "~3.10.3",
     "@types/jasminewd2": "~2.0.10",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/mock-console.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/mock-console.ts
@@ -1,0 +1,159 @@
+import { AbstractFunctionLogger, LogLevel } from '@triviality/logger';
+
+/** Record of a log item. */
+class LogItem {
+  constructor(public readonly logLevel: LogLevel, public readonly message?: any, public readonly params?: any[]) {}
+}
+
+/** Implementation of LoggerInterface that keeps a record of each log usage, for later examination.
+ *
+ * This class might be used as:
+ * ```
+ * expectedMessage = /record not found/;
+ * mockedConsole.muteFor(expectedMessage);
+ * ...SUT...
+ * mockedConsole.assertHasOnly(expectedMessage);
+ * ```
+ * Or as:
+ * ```
+ * mockedConsole.expectAndHideOnly(/record not found/);
+ * ...SUT...
+ * mockedConsole.verify();
+ * ```
+ */
+export class MockConsole extends AbstractFunctionLogger {
+  /** Create a new instance and install it as the global console. */
+  static install(): MockConsole {
+    const instance: MockConsole = new this();
+    (console as any) = instance;
+    return instance;
+  }
+
+  public logs: LogItem[] = [];
+  private hushes: RegExp[] = [];
+  private expectations: { message: RegExp; context: string; count?: number }[] = [];
+
+  constructor(private readonly originalConsole: Console = console) {
+    super();
+  }
+
+  trace(message?: any, ...optionalParams: any[]): void {
+    this.logs.push(new LogItem(LogLevel.trace, message, optionalParams));
+    if (this.hushes.filter((husher: RegExp) => husher.test(message)).length === 0) {
+      this.originalConsole.trace(message, optionalParams);
+    }
+  }
+
+  debug(message?: any, ...optionalParams: any[]): void {
+    this.logs.push(new LogItem(LogLevel.debug, message, optionalParams));
+    if (this.hushes.filter((husher: RegExp) => husher.test(message)).length === 0) {
+      this.originalConsole.debug(message, optionalParams);
+    }
+  }
+
+  info(message?: any, ...optionalParams: any[]): void {
+    this.logs.push(new LogItem(LogLevel.info, message, optionalParams));
+    if (this.hushes.filter((husher: RegExp) => husher.test(message)).length === 0) {
+      this.originalConsole.info(message, optionalParams);
+    }
+  }
+
+  warn(message?: any, ...optionalParams: any[]): void {
+    this.logs.push(new LogItem(LogLevel.warn, message, optionalParams));
+    if (this.hushes.filter((husher: RegExp) => husher.test(message)).length === 0) {
+      this.originalConsole.warn(message, optionalParams);
+    }
+  }
+
+  error(message?: any, ...optionalParams: any[]): void {
+    this.logs.push(new LogItem(LogLevel.error, message, optionalParams));
+    if (this.hushes.filter((husher: RegExp) => husher.test(message)).length === 0) {
+      this.originalConsole.error(message, optionalParams);
+    }
+  }
+
+  log(message?: any, ...optionalParams: any[]): void {
+    this.info(message, optionalParams);
+  }
+
+  reset() {
+    this.logs = [];
+    this.hushes = [];
+    this.expectations = [];
+  }
+
+  /** When a message is logged with this regexp, log the event but don't print the message. */
+  muteFor(regex: RegExp) {
+    this.hushes.push(regex);
+  }
+
+  /** Assert that a message was logged, matching a regex. */
+  assertHasLog(message: RegExp, context: string = 'should have contained expected log item') {
+    const has: boolean = this.logs.filter((logItem: LogItem) => message.test(logItem.message)).length > 0;
+    if (!has) {
+      if (this.logs.length === 0) {
+        this.originalConsole.log('Nothing was logged.');
+      } else {
+        this.originalConsole.log('The following was logged:');
+        this.logs.forEach(this.originalConsole.log);
+      }
+    }
+    expect(has).withContext(context).toBeTrue();
+  }
+
+  /** Assert that a message was logged, and no other messages were logged. */
+  assertHasOnlyLog(message: RegExp, moreContext: string = '') {
+    const hits: number = this.logs.filter((logItem: LogItem) => message.test(logItem.message)).length;
+    const has: boolean = hits > 0;
+    const logCount: number = this.logs.length;
+    if (!has) {
+      if (this.logs.length === 0) {
+        this.originalConsole.log('Nothing was logged.');
+      } else {
+        this.originalConsole.log('The following was logged:');
+        this.logs.forEach(this.originalConsole.log);
+      }
+      fail(`should have contained expected log item matching regex ${message}. ${moreContext}`);
+    } else {
+      if (logCount > 1) {
+        this.originalConsole.log('The following was logged:');
+        this.logs.forEach(this.originalConsole.log);
+        fail(`item was logged matching regex ${message}, but not alone. ${moreContext}`);
+      }
+    }
+  }
+
+  /** Specify a log message to mute and later check for when verifying. */
+  expectAndHide(message: RegExp, context: string = ''): void {
+    this.expectations.push({ message, context });
+    this.muteFor(message);
+  }
+
+  /** Specify a log message to mute and later check when verifying that it was the only log message. */
+  expectAndHideOnly(message: RegExp, context: string = ''): void {
+    if (this.expectations.length > 0) {
+      throw new Error('Can not expect a single log item in addition to other log items.');
+    }
+    this.expectations.push({ message, context, count: 1 });
+    this.muteFor(message);
+  }
+
+  /** Assert that the expected log messages occurred. */
+  verify(): void {
+    this.expectations.forEach(expectation => {
+      if (expectation.count != null && expectation.count === 1) {
+        this.assertHasOnlyLog(expectation.message, expectation.context);
+      } else {
+        this.assertHasLog(expectation.message, expectation.context);
+      }
+    });
+  }
+
+  assertNoLogs(context: string = 'should not have log messages') {
+    if (this.logs.length !== 0) {
+      this.originalConsole.log('The following was logged:');
+      this.logs.forEach(this.originalConsole.log);
+    }
+    expect(this.logs.length).withContext(context).toEqual(0);
+  }
+}


### PR DESCRIPTION
- @triviality/logger is not here used in a way that requires it in
production, and so it is added only to the development set of
dependencies.

(cherry picked from commit 2cdf489f41ca7d437e40cfccaf322a52a80ca113)

---

**Stack**:
- #1308
- #1307
- #1306
- #1305
- #1304
- #1303
- #1302 ⮜


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1302)
<!-- Reviewable:end -->
