### PR TITLE
notes: don't remove the wrong closing tag

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -82,6 +82,10 @@ describe('NoteDialogComponent', () => {
         expected: 'turn <i>text italic</i>'
       },
       {
+        text: 'Alpha <unknown><bold>Bravo</bold></unknown> Charlie',
+        expected: 'Alpha <b>Bravo</b> Charlie'
+      },
+      {
         text: '<p>this is a paragraph</p>',
         expected: 'this is a paragraph<br />'
       },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -133,7 +133,8 @@ export class NoteDialogComponent implements OnInit {
     replace.set(/<bold>(.*)<\/bold>/gim, '<b>$1</b>'); // Bold style
     replace.set(/<italic>(.*)<\/italic>/gim, '<i>$1</i>'); // Italic style
     replace.set(/<p>(.*)<\/p>/gim, '$1<br />'); // Turn paragraphs into line breaks
-    replace.set(/<(?!i|b|br|\/)(.*?>)(.*?)<\/(.*?)>/gim, '$2'); // Strip out any tags that don't match the above replacements
+    // Strip out any tags that don't match the above replacements
+    replace.set(/<((?!(\/?)(i|b|br|span)))(.*?)>/gim, '');
     replace.forEach((replacement, regEx) => (content = content?.replace(regEx, replacement)));
     return content ?? '';
   }


### PR DESCRIPTION
- The wrong closing tag can be removed. We may find success removing a
closing tag that matches an opening tag, but we can just remove all
unknown opening and closing tags, as with this change.

commit-id:ce153c40

---

**Stack**:
- #1311
- #1308
- #1307
- #1306
- #1305
- #1304
- #1303 ⮜


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*