### PR TITLE
SF-1526a notes: improve conflict diff colouring

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -398,3 +398,13 @@ usx-ref {
 usx-unmatched {
   display: none;
 }
+
+.note-content {
+  .conflict-text-older {
+    background-color: #ffc0cb;
+  }
+  .conflict-text-newer {
+    background-color: #90ee90;
+    font-weight: bold;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -94,6 +94,26 @@ describe('NoteDialogComponent', () => {
         expected: 'check unknown <i>text</i>'
       },
       {
+        text: 'Alpha <strikethrough><color name="red">Bravo</color></strikethrough> Charlie',
+        expected: 'Alpha <span class="conflict-text-older">Bravo</span> Charlie'
+      },
+      {
+        text: 'Alpha <bold><color name="red">Bravo</color></bold> Charlie',
+        expected: 'Alpha <span class="conflict-text-newer">Bravo</span> Charlie'
+      },
+      {
+        // The following is derived from data from Paratext 9.
+        text: '<language name="en">Alpha <strikethrough><color name="red">original </color></strikethrough><bold><color name="red">one-option </color></bold>Bravo</language>',
+        expected:
+          'Alpha <span class="conflict-text-older">original </span><span class="conflict-text-newer">one-option </span>Bravo'
+      },
+      {
+        // The following is derived from data from Paratext 9.
+        text: 'Preamble Before <strikethrough><color name="red">Older text </color></strikethrough><bold><color name="red">Newer text</color></bold><bold><color name="red">\\x - </color></bold><bold><color name="red">\\xo </color></bold><bold><color name="red">3.16 </color></bold><bold><color name="red">\\xt </color></bold><bold><color name="red">cross reference here </color></bold><bold><color name="red">\\x*</color></bold><bold><color name="red"> </color></bold>After ',
+        expected:
+          'Preamble Before <span class="conflict-text-older">Older text </span><span class="conflict-text-newer">Newer text</span><span class="conflict-text-newer">\\x - </span><span class="conflict-text-newer">\\xo </span><span class="conflict-text-newer">3.16 </span><span class="conflict-text-newer">\\xt </span><span class="conflict-text-newer">cross reference here </span><span class="conflict-text-newer">\\x*</span><span class="conflict-text-newer"> </span>After '
+      },
+      {
         text: '',
         expected: ''
       },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -130,6 +130,11 @@ export class NoteDialogComponent implements OnInit {
 
   parseNote(content: string | undefined): string {
     const replace = new Map<RegExp, string>();
+    replace.set(/<bold><color name="red">(.*?)<\/color><\/bold>/gim, '<span class="conflict-text-newer">$1</span>');
+    replace.set(
+      /<strikethrough><color name="red">(.*?)<\/color><\/strikethrough>/gim,
+      '<span class="conflict-text-older">$1</span>'
+    );
     replace.set(/<bold>(.*)<\/bold>/gim, '<b>$1</b>'); // Bold style
     replace.set(/<italic>(.*)<\/italic>/gim, '<i>$1</i>'); // Italic style
     replace.set(/<p>(.*)<\/p>/gim, '$1<br />'); // Turn paragraphs into line breaks


### PR DESCRIPTION
**Stack**:
- #1311
- #1308
- #1307
- #1306
- #1305
- #1304 ⮜


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1304)
<!-- Reviewable:end -->
