### PR TITLE
SF-1526b notes: add conflict properties to model

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/note-thread.ts
+++ b/src/RealtimeServer/scriptureforge/models/note-thread.ts
@@ -7,6 +7,7 @@ export const NOTE_THREAD_COLLECTION = 'note_threads';
 export const NOTE_THREAD_INDEX_PATHS = PROJECT_DATA_INDEX_PATHS;
 
 /**
+ * Note status, mimicking PT CommentList.cs.
  * Paratext used to record notes as deleted when completed but then changed to display them as resolved.
  * Done is also a backwards compatible status that could also be treated as deleted/resolved.
  */
@@ -15,6 +16,32 @@ export enum NoteStatus {
   Todo = 'todo',
   Done = 'done',
   Resolved = 'deleted'
+}
+
+/** Note type, mimicking PT CommentList.cs.
+ *  Note that this enum does not list Unspecified, since the PT API says that is for use in filters and that notes
+ * should never be created with that type.
+ */
+export enum NoteType {
+  Normal = '',
+  Conflict = 'conflict'
+}
+
+/** Type of conflict from a merge, mimicking PT CommentList.cs. Note that in PT, an additional item is `None`, which
+ * is null. Also note that the default value is "unknownConflictType", which is present in Note XML files when the note
+ * is not a conflict note. */
+export enum NoteConflictType {
+  VerseTextConflict = 'verseText',
+  InvalidVerses = 'invalidVerses',
+  VerseBridgeDifferences = 'verseBridge',
+  DuplicateVerses = 'duplicateVerses',
+  ReadError = 'readError',
+  VerseOrderError = 'verseOrder',
+  StudyBibleChangeConflict = 'studyBibleChangeConflict',
+  StudyBibleOverlappingChanges = 'studyBibleOverlappingChanges',
+  StudyBibleChangeDeleteConflict = 'studyBibleChangeDeleteConflict',
+  /** This is not part of the PT enum, but is the default value. */
+  DefaultValue = 'unknownConflictType'
 }
 
 export function getNoteThreadDocId(projectId: string, noteThreadId: string): string {

--- a/src/RealtimeServer/scriptureforge/models/note.ts
+++ b/src/RealtimeServer/scriptureforge/models/note.ts
@@ -5,11 +5,14 @@ export const REATTACH_SEPARATOR = '\uFFFC';
 
 export interface Note extends Comment {
   threadId: string;
-  content?: string;
+  type: string;
+  conflictType: string;
   extUserId: string;
   deleted: boolean;
-  tagIcon?: string;
   status: NoteStatus;
+  tagIcon?: string;
   reattached?: string;
   assignment?: string;
+  content?: string;
+  acceptedChangeXml?: string;
 }

--- a/src/RealtimeServer/scriptureforge/services/note-thread-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-service.spec.ts
@@ -24,7 +24,14 @@ import {
   SFProjectUserConfig,
   SF_PROJECT_USER_CONFIGS_COLLECTION
 } from '../models/sf-project-user-config';
-import { getNoteThreadDocId, NoteThread, NOTE_THREAD_COLLECTION, NoteStatus } from '../models/note-thread';
+import {
+  getNoteThreadDocId,
+  NoteThread,
+  NOTE_THREAD_COLLECTION,
+  NoteStatus,
+  NoteType,
+  NoteConflictType
+} from '../models/note-thread';
 import { Note } from '../models/note';
 import { VerseRefData } from '../models/verse-ref-data';
 import { TextAnchor } from '../models/text-anchor';
@@ -255,6 +262,8 @@ class TestEnvironment {
     };
     const position: TextAnchor = { start: 0, length: 0 };
     const status: NoteStatus = NoteStatus.Todo;
+    const type: NoteType = NoteType.Normal;
+    const conflictType: NoteConflictType = NoteConflictType.DefaultValue;
     await createDoc<NoteThread>(conn, NOTE_THREAD_COLLECTION, getNoteThreadDocId('project01', 'noteThread01'), {
       projectRef: 'project01',
       ownerRef: 'some-owner',
@@ -263,6 +272,8 @@ class TestEnvironment {
       notes: [
         {
           dataId: 'noteThread01note01',
+          type,
+          conflictType,
           threadId: 'noteThread01',
           extUserId: 'some-ext-user-id',
           deleted: false,
@@ -273,6 +284,8 @@ class TestEnvironment {
         },
         {
           dataId: 'noteThread01note02',
+          type,
+          conflictType,
           threadId: 'noteThread01',
           extUserId: 'some-ext-user-id',
           deleted: false,
@@ -283,6 +296,8 @@ class TestEnvironment {
         },
         {
           dataId: 'noteThread01note03',
+          type,
+          conflictType,
           threadId: 'noteThread01',
           extUserId: 'some-ext-user-id',
           deleted: false,
@@ -293,6 +308,8 @@ class TestEnvironment {
         },
         {
           dataId: 'noteThread01note04',
+          type,
+          conflictType,
           threadId: 'noteThread01',
           extUserId: 'some-ext-user-id',
           deleted: false,
@@ -318,6 +335,8 @@ class TestEnvironment {
       notes: [
         {
           dataId: 'noteThread02note01',
+          type,
+          conflictType,
           threadId: 'noteThread02',
           extUserId: 'some-ext-user-id',
           deleted: false,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.spec.ts
@@ -1,6 +1,11 @@
 import { mock } from 'ts-mockito';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
-import { NoteStatus, NoteThread } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
+import {
+  NoteConflictType,
+  NoteStatus,
+  NoteThread,
+  NoteType
+} from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { TestBed } from '@angular/core/testing';
 import { configureTestingModule } from 'xforge-common/test-utils';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
@@ -72,9 +77,14 @@ describe('NoteThreadDoc', () => {
   });
 
   it('should use the last icon specified in a threads note list based on date ', async () => {
+    const type: NoteType = NoteType.Normal;
+    const conflictType: NoteConflictType = NoteConflictType.DefaultValue;
+
     const notes = [
       {
         dataId: 'note01',
+        type,
+        conflictType,
         threadId: 'thread01',
         content: 'note content',
         deleted: false,
@@ -87,6 +97,8 @@ describe('NoteThreadDoc', () => {
       },
       {
         dataId: 'note03',
+        type,
+        conflictType,
         threadId: 'thread01',
         content: 'note content',
         deleted: false,
@@ -99,6 +111,8 @@ describe('NoteThreadDoc', () => {
       },
       {
         dataId: 'note02',
+        type,
+        conflictType,
         threadId: 'thread01',
         content: 'note content',
         deleted: false,
@@ -123,9 +137,13 @@ describe('NoteThreadDoc', () => {
   it('reports the reattached verse reference', async () => {
     const reattachParts: string[] = ['MAT 1:2', 'reattached selected text', '0', '', ''];
     const reattached: string = reattachParts.join(REATTACH_SEPARATOR);
+    const type: NoteType = NoteType.Normal;
+    const conflictType: NoteConflictType = NoteConflictType.DefaultValue;
     const notes = [
       {
         dataId: 'note01',
+        type,
+        conflictType,
         threadId: 'thread01',
         content: 'note content',
         deleted: false,
@@ -138,6 +156,8 @@ describe('NoteThreadDoc', () => {
       },
       {
         dataId: 'reattach01',
+        type,
+        conflictType,
         threadId: 'thread01',
         content: '',
         deleted: false,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -23,7 +23,13 @@ import { User } from 'realtime-server/lib/esm/common/models/user';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { CheckingShareLevel } from 'realtime-server/lib/esm/scriptureforge/models/checking-config';
 import { Note, REATTACH_SEPARATOR } from 'realtime-server/lib/esm/scriptureforge/models/note';
-import { AssignedUsers, NoteStatus, NoteThread } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
+import {
+  AssignedUsers,
+  NoteConflictType,
+  NoteStatus,
+  NoteThread,
+  NoteType
+} from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { SFProject, SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { hasParatextRole, SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import {
@@ -2953,8 +2959,12 @@ class TestEnvironment {
       const id = userIds[i];
       const date = new Date('2021-03-01T12:00:00');
       date.setHours(date.getHours() + i);
+      const type: NoteType = NoteType.Normal;
+      const conflictType: NoteConflictType = NoteConflictType.DefaultValue;
       const note: Note = {
         threadId: threadId,
+        type,
+        conflictType,
         ownerRef: id,
         dataId: `${threadId}_note${i}`,
         dateCreated: date.toJSON(),
@@ -2996,8 +3006,12 @@ class TestEnvironment {
     const contextAfter: string = ` ${verseRef.verseNum}.`;
     const reattachParts: string[] = [verseStr, 'verse', position.start.toString(), 'target: chapter 1, ', contextAfter];
     const reattached: string = reattachParts.join(REATTACH_SEPARATOR);
+    const type: NoteType = NoteType.Normal;
+    const conflictType: NoteConflictType = NoteConflictType.DefaultValue;
     const note: Note = {
       dataId: 'reattach01',
+      type,
+      conflictType,
       threadId: template.threadId,
       content: template.content,
       deleted: false,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -19,7 +19,13 @@ import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule, matDialogCloseDelay, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { AssignedUsers, NoteStatus, NoteThread } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
+import {
+  AssignedUsers,
+  NoteConflictType,
+  NoteStatus,
+  NoteThread,
+  NoteType
+} from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { TranslateShareLevel } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { REATTACH_SEPARATOR } from 'realtime-server/lib/esm/scriptureforge/models/note';
 import { UserService } from 'xforge-common/user.service';
@@ -317,6 +323,8 @@ class TestEnvironment {
     REATTACH_SEPARATOR
   );
   static getNoteThread(reattachedContent?: string): NoteThread {
+    const type: NoteType = NoteType.Normal;
+    const conflictType: NoteConflictType = NoteConflictType.DefaultValue;
     const noteThread: NoteThread = {
       originalContextBefore: 'before selection ',
       originalContextAfter: ' after selection',
@@ -332,6 +340,8 @@ class TestEnvironment {
       notes: [
         {
           dataId: 'note01',
+          type,
+          conflictType,
           threadId: 'thread01',
           content: 'note',
           extUserId: 'user01',
@@ -345,6 +355,8 @@ class TestEnvironment {
         },
         {
           dataId: 'note02',
+          type,
+          conflictType,
           threadId: 'thread01',
           content: 'note02',
           extUserId: 'user01',
@@ -358,6 +370,8 @@ class TestEnvironment {
         },
         {
           dataId: 'note03',
+          type,
+          conflictType,
           threadId: 'thread01',
           content: 'note03',
           extUserId: 'user01',
@@ -370,6 +384,8 @@ class TestEnvironment {
         },
         {
           dataId: 'note04',
+          type,
+          conflictType,
           threadId: 'thread01',
           content: 'note04',
           extUserId: 'user01',
@@ -381,6 +397,8 @@ class TestEnvironment {
         },
         {
           dataId: 'note05',
+          type,
+          conflictType,
           threadId: 'thread01',
           content: 'note05',
           extUserId: 'user01',
@@ -396,6 +414,8 @@ class TestEnvironment {
     if (reattachedContent != null) {
       noteThread.notes.push({
         dataId: 'reattached01',
+        type,
+        conflictType,
         threadId: 'thread01',
         content: reattachedContent,
         extUserId: 'user01',
@@ -409,6 +429,8 @@ class TestEnvironment {
       });
       noteThread.notes.push({
         dataId: 'reattached02',
+        type,
+        conflictType,
         threadId: 'thread01',
         content: 'reattached02',
         extUserId: 'user01',

--- a/src/SIL.XForge.Scripture/Models/Note.cs
+++ b/src/SIL.XForge.Scripture/Models/Note.cs
@@ -1,9 +1,16 @@
 namespace SIL.XForge.Scripture.Models
 {
+    /// <summary>Represents a project note.</summary>
     public class Note : Comment
     {
         public string ThreadId { get; set; }
-        public string Content { get; set; }
+        /// <summary>Type of note, such as "" for a normal note, or "conflict" for a conflict note.</summary>
+        public string Type { get; set; }
+        /// <summary>
+        /// Type of conflict, if a conflict note. For example, "verseText". If it is not a conflict note, this
+        /// may read "unknownConflictType".
+        /// </summary>
+        public string ConflictType { get; set; }
         public string ExtUserId { get; set; }
         public bool Deleted { get; set; }
         public string Status { get; set; }
@@ -14,5 +21,20 @@ namespace SIL.XForge.Scripture.Models
         /// or a category such as team or unassigned.
         /// </summary>
         public string Assignment { get; set; }
+        /// <summary>
+        /// Content of note. Contains XML. Corresponds to `Contents` element, which is not always present in the
+        /// Notes XML file.
+        /// </summary>
+        public string Content { get; set; }
+        /// <summary>
+        /// Change difference accepted from a conflict, if any. Contains encoded XML. Not always present, in
+        /// Notes XML file.
+        /// </summary>
+        public string AcceptedChangeXml { get; set; }
+
+        /// <summary>The default value for ConflictType in Paratext is "unknownConflictType", which is present
+        /// in Note XML files when the note is not a conflict note. However, this is not one of the values of
+        /// the NoteConflictType enum.</summary>
+        public readonly static string NoConflictType = "unknownConflictType";
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1641,10 +1641,19 @@ namespace SIL.XForge.Scripture.Services
                 return ChangeType.Deleted;
             // Check if fields have been updated in Paratext
             bool statusChanged = comment.Status.InternalValue != note.Status;
+            bool typeChanged = comment.Type.InternalValue != note.Type;
+            bool conflictTypeChanged = comment.ConflictType.InternalValue != note.ConflictType;
+            bool acceptedChangeXmlChanged = comment.AcceptedChangeXmlStr != note.AcceptedChangeXml;
             bool contentChanged = comment.Contents?.InnerXml != note.Content;
             bool tagChanged = commentTag?.Icon != note.TagIcon;
             bool assignedUserChanged = GetAssignedUserRef(comment.AssignedUser, ptProjectUsers) != note.Assignment;
-            if (contentChanged || statusChanged || tagChanged || assignedUserChanged)
+            if (contentChanged ||
+                statusChanged ||
+                tagChanged ||
+                typeChanged ||
+                conflictTypeChanged ||
+                assignedUserChanged ||
+                acceptedChangeXmlChanged)
                 return ChangeType.Updated;
             return ChangeType.None;
         }
@@ -1675,11 +1684,14 @@ namespace SIL.XForge.Scripture.Services
             {
                 DataId = noteId,
                 ThreadId = comment.Thread,
+                Type = comment.Type.InternalValue,
+                ConflictType = comment.ConflictType.InternalValue,
                 ExtUserId = comment.ExternalUser,
                 // The owner is unknown at this point and is determined when submitting the ops to the note thread docs
                 OwnerRef = "",
                 SyncUserRef = FindOrCreateParatextUser(comment.User, ptProjectUsers)?.OpaqueUserId,
                 Content = comment.Contents?.InnerXml,
+                AcceptedChangeXml = comment.AcceptedChangeXmlStr,
                 DateCreated = DateTime.Parse(comment.Date),
                 DateModified = DateTime.Parse(comment.Date),
                 Deleted = comment.Deleted,

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -802,10 +802,16 @@ namespace SIL.XForge.Scripture.Services
                             op.Set(td => td.Notes[index].Content, updated.Content);
                         if (threadDoc.Data.Notes[index].Status != updated.Status)
                             op.Set(td => td.Notes[index].Status, updated.Status);
+                        if (threadDoc.Data.Notes[index].Type != updated.Type)
+                            op.Set(td => td.Notes[index].Type, updated.Type);
+                        if (threadDoc.Data.Notes[index].ConflictType != updated.ConflictType)
+                            op.Set(td => td.Notes[index].ConflictType, updated.ConflictType);
                         if (threadDoc.Data.Notes[index].TagIcon != updated.TagIcon)
                             op.Set(td => td.Notes[index].TagIcon, updated.TagIcon);
                         if (threadDoc.Data.Notes[index].Assignment != updated.Assignment)
                             op.Set(td => td.Notes[index].Assignment, updated.Assignment);
+                        if (threadDoc.Data.Notes[index].AcceptedChangeXml != updated.AcceptedChangeXml)
+                            op.Set(td => td.Notes[index].AcceptedChangeXml, updated.AcceptedChangeXml);
                     }
                     else
                     {


### PR DESCRIPTION
Adds to Note:
- Type
- ConflictType
- AcceptedChangeXml

Adds types:
- NoteType
- NoteConflictType

ParatextService.cs: Detect and compose incoming Note changes of Type,
ConflictType, and AcceptedChangeXml.

ParatxtSyncRunner.cs: Writing Notes to the SF DB should include the
new properties.

commit-id:84774793

---

**Stack**:
- #1311
- #1308
- #1307
- #1306 ⮜


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*