### PR TITLE
sync: log when unexpected QueuedCount

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1024,6 +1024,7 @@ namespace SIL.XForge.Scripture.Services
                 }
                 else
                 {
+                    Log($"CompleteSync: Warning: SF project id {_projectDoc.Id} QueuedCount is unexpectedly {_projectDoc.Data.Sync.QueuedCount}. Setting to 0 instead of decrementing.");
                     op.Set(pd => pd.Sync.QueuedCount, 0);
                 }
 


### PR DESCRIPTION
- Sometimes the QueuedCount is >1, or <0. Syncs can be cancelled. They
can be re-enqueued manually. Multiple syncs could be requested around
the same time.
- When setting the QueuedCount, also log a warning if the QueuedCount
is an unusual value, to assist in investigations.

commit-id:88b403db