### PR TITLE
SF-1536 - Focus is lost in the verse box when closing the close dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2179,7 +2179,7 @@ describe('EditorComponent', () => {
       const segmentRef = 'verse_1_3';
       const segmentRange = env.component.target!.getSegmentRange(segmentRef)!;
       env.targetEditor.setSelection(segmentRange.index);
-      expect(document.activeElement?.classList).toContain('ql-editor');
+      expect(env.activeElementClasses).toContain('ql-editor');
       const iconElement: HTMLElement = env.getNoteThreadIconElement(segmentRef, 'thread02')!;
       iconElement.click();
       const element = env.targetTextEditor.nativeElement.querySelector(
@@ -2187,10 +2187,9 @@ describe('EditorComponent', () => {
       );
       verify(mockedMatDialog.open(NoteDialogComponent, anything())).once();
       env.wait();
-      expect(document.activeElement?.tagName).toBe('INPUT');
+      expect(env.activeElementTagName).toBe('INPUT');
       expect(element.classList).withContext('dialog opened').toContain('highlight-segment');
       mockedMatDialog.closeAll();
-      env.wait();
       expect(element.classList).withContext('dialog closed').toContain('highlight-segment');
       env.dispose();
     }));
@@ -2586,6 +2585,13 @@ class TestEnvironment {
 
     this.fixture = TestBed.createComponent(EditorComponent);
     this.component = this.fixture.componentInstance;
+  }
+
+  get activeElementClasses(): DOMTokenList | undefined {
+    return document.activeElement?.classList;
+  }
+  get activeElementTagName(): string | undefined {
+    return document.activeElement?.tagName;
   }
 
   get bookName(): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -82,7 +82,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   trainingMessage: string = '';
   showTrainingProgress: boolean = false;
   textHeight: string = '';
-  targetFocused = false;
 
   @ViewChild('targetContainer') targetContainer?: ElementRef;
   @ViewChild('source') source?: TextComponent;
@@ -106,6 +105,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   private sourceProjectDoc?: SFProjectProfileDoc;
   private sourceLoaded: boolean = false;
   private targetLoaded: boolean = false;
+  private _targetFocused: boolean = false;
   private _chapter?: number;
   private lastShownSuggestions: Suggestion[] = [];
   private readonly segmentUpdated$: Subject<void>;
@@ -147,6 +147,15 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       this.projectDoc.data.translateConfig.source == null
       ? ''
       : this.projectDoc.data.translateConfig.source.shortName;
+  }
+
+  get targetFocused(): boolean {
+    return this._targetFocused;
+  }
+
+  set targetFocused(event: boolean) {
+    event = this.dialog.openDialogs.length > 0 ? true : event;
+    this._targetFocused = event;
   }
 
   get targetLabel(): string {
@@ -684,13 +693,18 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   private showNoteThread(threadId: string): void {
-    this.dialog.open(NoteDialogComponent, {
+    const dialogRef = this.dialog.open(NoteDialogComponent, {
       autoFocus: false,
       width: '600px',
       data: {
         projectId: this.projectDoc!.id,
         threadId: threadId
       } as NoteDialogData
+    });
+    dialogRef.afterClosed().subscribe(() => {
+      // Ensure cursor selection remains at the position of the note in case the focus was lost when the dialog was open
+      const selectIndex = this.target!.segment!.range.index;
+      this.target!.editor!.setSelection(selectIndex, 0, 'user');
     });
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -153,9 +153,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     return this._targetFocused;
   }
 
-  set targetFocused(event: boolean) {
-    event = this.dialog.openDialogs.length > 0 ? true : event;
-    this._targetFocused = event;
+  set targetFocused(focused: boolean) {
+    focused = this.dialog.openDialogs.length > 0 ? true : focused;
+    this._targetFocused = focused;
   }
 
   get targetLabel(): string {
@@ -704,7 +704,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     dialogRef.afterClosed().subscribe(() => {
       // Ensure cursor selection remains at the position of the note in case the focus was lost when the dialog was open
       const selectIndex = this.target!.segment!.range.index;
-      this.target!.editor!.setSelection(selectIndex, 0, 'user');
+      this.target!.editor!.setSelection(selectIndex, 0, 'silent');
     });
   }
 


### PR DESCRIPTION
- Always set the target to focused if there is an open dialog
- Ensure the segment of a note is selected again after a note dialog is closed

The last point isn't being tested as the event trigger that causes the issue for this is actually part of the text component and it was starting to get a bit messy - probably better suited for a E2E test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1312)
<!-- Reviewable:end -->
