### PR TITLE
SF-1546 Get sync to succeed with duplicate project notes

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1545,7 +1545,7 @@ namespace SIL.XForge.Scripture.Services
             // store a username to a note in SF we construct the intended Comment id at runtime.
             string commentId = string.Format("{0}/{1}/{2}", note.ThreadId, ptUser.Username, date);
             Paratext.Data.ProjectComments.Comment matchingComment =
-                thread.Comments.SingleOrDefault(c => c.Id == commentId);
+                thread.Comments.LastOrDefault(c => c.Id == commentId);
             if (matchingComment != null)
                 return matchingComment;
 
@@ -1553,7 +1553,7 @@ namespace SIL.XForge.Scripture.Services
             DateTime noteTime = note.DateCreated.ToUniversalTime();
             return thread.Comments
                 .Where(c => DateTime.Equals(noteTime, DateTime.Parse(c.Date, null, DateTimeStyles.AdjustToUniversal)))
-                .SingleOrDefault(c => c.User == ptUser.Username);
+                .LastOrDefault(c => c.User == ptUser.Username);
         }
 
         /// <summary>


### PR DESCRIPTION
When a project has duplicate project notes in a thread, the sync with Paratext fails because ParatextService assumed that all project notes are unique. This change fixes that assumption and uses the last comment in the thread as the authoritative comment if multiple comments with the same ID exists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1318)
<!-- Reviewable:end -->
