### PR TITLE
Hotfix: Skip updating Paratext comment thread with notes

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -186,10 +186,11 @@ namespace SIL.XForge.Scripture.Services
                     if (isDataInSync)
                     {
                         await UpdateParatextNotesAsync(text, questionDocs);
-                        IEnumerable<IDocument<NoteThread>> noteThreadDocs =
-                            (await FetchNoteThreadDocsAsync(text.BookNum)).Values;
-                        await _paratextService.UpdateParatextCommentsAsync(_userSecret, targetParatextId, text.BookNum,
-                            noteThreadDocs, _currentPtSyncUsers);
+                        // TODO: Sync Note changes back to Paratext
+                        // IEnumerable<IDocument<NoteThread>> noteThreadDocs =
+                        //     (await FetchNoteThreadDocsAsync(text.BookNum)).Values;
+                        // await _paratextService.UpdateParatextCommentsAsync(_userSecret, targetParatextId, text.BookNum,
+                        //     noteThreadDocs, _currentPtSyncUsers);
                     }
                 }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1207,6 +1207,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
+        [Ignore("Not ready to sync notes back to paratext.")]
         public async Task SyncAsync_UpdatesParatextComments()
         {
             var env = new TestEnvironment();


### PR DESCRIPTION
It looks like at least one project has all their notes duplicated for the user who initiated the sync. Synchronizing notes threads back to paratext comment threads is not ready, so we need to disable it for the time being.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1319)
<!-- Reviewable:end -->
