### PR TITLE
Remove XRegExp dependency

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -54,7 +54,6 @@
         "sharedb": "1.0.0-beta.31",
         "tslib": "^2.4.0",
         "uuid": "^8.3.2",
-        "xregexp": "^5.1.0",
         "zone.js": "^0.11.5"
       },
       "devDependencies": {

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -65,7 +65,6 @@
     "sharedb": "1.0.0-beta.31",
     "tslib": "^2.4.0",
     "uuid": "^8.3.2",
-    "xregexp": "^5.1.0",
     "zone.js": "^0.11.5"
   },
   "devDependencies": {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -39,7 +39,6 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { PwaService } from 'xforge-common/pwa.service';
 import { UserService } from 'xforge-common/user.service';
 import { getLinkHTML, issuesEmailTemplate } from 'xforge-common/utils';
-import XRegExp from 'xregexp';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { environment } from '../../../environments/environment';
 import { NoteThreadDoc } from '../../core/models/note-thread-doc';
@@ -63,7 +62,7 @@ import { TranslateMetricsSession } from './translate-metrics-session';
 
 export const UPDATE_SUGGESTIONS_TIMEOUT = 100;
 
-const PUNCT_SPACE_REGEX = XRegExp('^(\\p{P}|\\p{S}|\\p{Cc}|\\p{Z})+$');
+const PUNCT_SPACE_REGEX = /^(?:\p{P}|\p{S}|\p{Cc}|\p{Z})+$/u;
 
 /** Scripture editing area. Used for Translate task. */
 @Component({

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/project.service.ts
@@ -1,9 +1,8 @@
-import merge from 'lodash-es/merge';
+import { escapeRegExp, merge } from 'lodash-es';
 import { Project } from 'realtime-server/lib/esm/common/models/project';
 import { ProjectRole } from 'realtime-server/lib/esm/common/models/project-role';
 import { combineLatest, Observable, Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
-import XRegExp from 'xregexp';
 import { CommandService } from './command.service';
 import { ProjectDoc } from './models/project-doc';
 import { NONE_ROLE, ProjectRoleInfo } from './models/project-role-info';
@@ -49,7 +48,7 @@ export abstract class ProjectService<
 
     return combineLatest([debouncedTerm$, queryParameters$]).pipe(
       switchMap(([term, queryParameters]) => {
-        term = XRegExp.escape(term.trim());
+        term = escapeRegExp(term.trim());
         let filters: Filters = {};
         if (term.length > 0) {
           filters = {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.spec.ts
@@ -4,6 +4,7 @@ import { MatCheckbox } from '@angular/material/checkbox';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
+import { escapeRegExp } from 'lodash-es';
 import merge from 'lodash-es/merge';
 import { Project } from 'realtime-server/lib/esm/common/models/project';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
@@ -12,7 +13,6 @@ import { switchMap } from 'rxjs/operators';
 import { anything, mock, verify, when } from 'ts-mockito';
 import { FileType } from 'xforge-common/models/file-offline-data';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
-import XRegExp from 'xregexp';
 import { ProjectDoc } from '../models/project-doc';
 import { NONE_ROLE, ProjectRoleInfo } from '../models/project-role-info';
 import { NoticeService } from '../notice.service';
@@ -212,7 +212,7 @@ class TestEnvironment {
         combineLatest([term$, parameters$]).pipe(
           switchMap(([term, queryParameters]) => {
             const filters: Filters = {
-              [obj<Project>().pathStr(p => p.name)]: { $regex: `.*${XRegExp.escape(term)}.*`, $options: 'i' }
+              [obj<Project>().pathStr(p => p.name)]: { $regex: `.*${escapeRegExp(term)}.*`, $options: 'i' }
             };
             return from(
               this.realtimeService.onlineQuery<TestProjectDoc>(

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
+import { escapeRegExp } from 'lodash-es';
 import merge from 'lodash-es/merge';
 import { Project } from 'realtime-server/lib/esm/common/models/project';
 import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
@@ -14,7 +15,6 @@ import { switchMap } from 'rxjs/operators';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { FileType } from 'xforge-common/models/file-offline-data';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
-import XRegExp from 'xregexp';
 import { environment } from '../../environments/environment';
 import { AvatarTestingModule } from '../avatar/avatar-testing.module';
 import { ProjectDoc } from '../models/project-doc';
@@ -179,7 +179,7 @@ class TestEnvironment {
         combineLatest([term$, parameters$, reload$]).pipe(
           switchMap(([term, queryParameters]) => {
             const filters: Filters = {
-              [obj<User>().pathStr(u => u.name)]: { $regex: `.*${XRegExp.escape(term)}.*`, $options: 'i' }
+              [obj<User>().pathStr(u => u.name)]: { $regex: `.*${escapeRegExp(term)}.*`, $options: 'i' }
             };
             return from(this.realtimeService.onlineQuery<UserDoc>(UserDoc.COLLECTION, merge(filters, queryParameters)));
           })

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
@@ -1,11 +1,11 @@
 import { MdcDialog, MdcDialogRef } from '@angular-mdc/web/dialog';
 import { Injectable } from '@angular/core';
+import { escapeRegExp } from 'lodash-es';
 import merge from 'lodash-es/merge';
 import { User } from 'realtime-server/lib/esm/common/models/user';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { combineLatest, from, Observable } from 'rxjs';
 import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
-import XRegExp from 'xregexp';
 import { AuthService } from './auth.service';
 import { CommandService } from './command.service';
 import { EditNameDialogComponent, EditNameDialogResult } from './edit-name-dialog/edit-name-dialog.component';
@@ -72,7 +72,7 @@ export class UserService {
 
     return combineLatest([debouncedTerm$, queryParameters$, reload$]).pipe(
       switchMap(([term, queryParameters]) => {
-        term = XRegExp.escape(term.trim());
+        term = escapeRegExp(term.trim());
         let filters: Filters = {};
         if (term.length > 0) {
           filters = {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -20,21 +20,23 @@ export function objectId(): string {
 }
 
 export function supportedBrowser(): boolean {
-  // See https://caniuse.com/#feat=indexeddb2 for browsers supporting IndexedDB 2.0
+  // Minimum required versions are based largely on browser support data for the following features:
+  // https://caniuse.com/indexeddb2
+  // https://caniuse.com/mdn-javascript_builtins_regexp_property_escapes
   const isSupportedBrowser = BROWSER.satisfies({
-    chrome: '>=58',
-    chromium: '>=58',
+    chrome: '>=64',
+    chromium: '>=64',
     edge: '>=79',
-    firefox: '>=51',
+    firefox: '>=78',
     safari: '>=11.1',
 
     mobile: {
       chrome: '>=78',
-      firefox: '>=68',
-      opera: '>=46',
+      firefox: '>=79',
+      opera: '>=47',
       safari: '>=11.3',
       'android browser': '>=76',
-      'samsung internet': '>=7.2'
+      'samsung internet': '>=9.0'
     }
   });
   return isSupportedBrowser ? true : false;


### PR DESCRIPTION
We've been using XRegExp for two things:
1. Escaping strings to use them as part of a regex
2. [Unicode property escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes)

The former can be done using Lodash, and the latter is now supported in all modern browsers with the `u` flag added to a regex.

XRegExp is fairly sizeable (41.08 KB gzipped out of our total gzipped bundle size of 705.45 KB, making it 5.82% of our bundle) and we're not using it for much, so getting rid of it seemed like a good idea.

Unfortunately it's also used by @sillsdev/machine, which is one of our dependencies, so there's no actual reduction in bundle size. I didn't realize that until I'd made the change though, and it seems like something that's likely to eventually be removed from @sillsdev/machine, so I think at some point in the future we will see the slight size reduction, and there's no real advantage to continuing to use it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1327)
<!-- Reviewable:end -->
