### PR TITLE
SF-1534 - Ensure note icon in dialog is grey when assigned to another user

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
@@ -8,6 +8,8 @@ import { Note, REATTACH_SEPARATOR } from 'realtime-server/lib/esm/scriptureforge
 import { clone } from 'lodash-es';
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
 import { toVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
+import { AssignedUsers } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
+import { ParatextUserProfile } from 'realtime-server/lib/esm/scriptureforge/models/paratext-user-profile';
 
 export interface NoteThreadIcon {
   cssVar: string;
@@ -58,6 +60,19 @@ export class NoteThreadDoc extends ProjectDataDoc<NoteThread> {
 
     const verseStr: string = lastReattach.reattached.split(REATTACH_SEPARATOR)[0];
     return VerseRef.parse(verseStr);
+  }
+
+  isAssignedToOtherUser(currentUserId: string, paratextProjectUsers: ParatextUserProfile[]): boolean {
+    switch (this.data?.assignment) {
+      case AssignedUsers.TeamUser:
+      case AssignedUsers.Unspecified:
+      case undefined:
+        return false;
+    }
+    const ptUser: ParatextUserProfile | undefined = paratextProjectUsers?.find(
+      user => user.opaqueUserId === this.data?.assignment
+    );
+    return ptUser?.sfUserId !== currentUserId;
   }
 
   notesInOrderClone(notes: Note[]): Note[] {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -19,7 +19,6 @@ import Quill, { DeltaStatic, RangeStatic } from 'quill';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { User } from 'realtime-server/lib/esm/common/models/user';
 import { Note } from 'realtime-server/lib/esm/scriptureforge/models/note';
-import { AssignedUsers } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { ParatextUserProfile } from 'realtime-server/lib/esm/scriptureforge/models/paratext-user-profile';
 import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
@@ -1064,7 +1063,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       verseRef,
       id: threadDoc.data.dataId,
       preview,
-      icon: this.isAssignedToOtherUser(threadDoc) ? threadDoc.iconGrayed : threadDoc.icon,
+      icon: threadDoc.isAssignedToOtherUser(this.userService.currentUserId, this.paratextUsers)
+        ? threadDoc.iconGrayed
+        : threadDoc.icon,
       textAnchor: threadDoc.data.position,
       highlight: hasNewContent
     };
@@ -1359,19 +1360,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       return false;
     }
     return !this.projectUserConfigDoc.data.noteRefsRead.includes(noteId);
-  }
-
-  private isAssignedToOtherUser(thread: NoteThreadDoc): boolean {
-    switch (thread.data?.assignment) {
-      case AssignedUsers.TeamUser:
-      case AssignedUsers.Unspecified:
-      case undefined:
-        return false;
-    }
-    const ptUser: ParatextUserProfile | undefined = this.paratextUsers?.find(
-      user => user.opaqueUserId === thread.data?.assignment
-    );
-    return ptUser?.sfUserId !== this.userService.currentUserId;
   }
 
   private syncScroll(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
@@ -48,6 +48,7 @@ h1 {
     }
     img {
       align-self: center;
+      opacity: 0.5;
     }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -58,7 +58,11 @@ describe('NoteDialogComponent', () => {
   }));
 
   let env: TestEnvironment;
-  afterEach(fakeAsync(() => env.closeDialog()));
+  afterEach(fakeAsync(() => {
+    if (env.dialogContentArea != null) {
+      env.closeDialog();
+    }
+  }));
 
   it('show selected text and toggle visibility of related segment', fakeAsync(() => {
     env = new TestEnvironment();
@@ -356,6 +360,70 @@ describe('NoteDialogComponent', () => {
       TestEnvironment.paratextUsers.find(u => u.sfUserId === 'user01')!.username
     );
     expect(env.notes[1].nativeElement.querySelector('.assigned-user').textContent).toContain('Team');
+  }));
+
+  it('shows correct coloured icon based on assignment', fakeAsync(() => {
+    const currentUserId = 'user01';
+    const defaultIcon = 'flag02.png';
+    const grayIcon = 'flag04.png';
+    const assigned: { assigned?: AssignedUsers | string; expectedIcon: string }[] = [
+      {
+        assigned: undefined,
+        expectedIcon: defaultIcon
+      },
+      {
+        assigned: AssignedUsers.TeamUser,
+        expectedIcon: defaultIcon
+      },
+      {
+        assigned: AssignedUsers.Unspecified,
+        expectedIcon: defaultIcon
+      },
+      {
+        assigned: 'opaqueuser01', // Current user
+        expectedIcon: defaultIcon
+      },
+      {
+        assigned: 'opaqueuser02', // Another user
+        expectedIcon: grayIcon
+      }
+    ];
+    const noteThread: NoteThread = {
+      originalContextBefore: '',
+      originalContextAfter: '',
+      originalSelectedText: '',
+      dataId: 'thread01',
+      ownerRef: 'user01',
+      position: { start: 0, length: 0 },
+      projectRef: TestEnvironment.PROJECT01,
+      tagIcon: 'flag02',
+      verseRef: { bookNum: 40, chapterNum: 1, verseNum: 1 },
+      status: NoteStatus.Todo,
+      assignment: AssignedUsers.TeamUser,
+      notes: [
+        {
+          dataId: 'note01',
+          type: NoteType.Normal,
+          conflictType: NoteConflictType.DefaultValue,
+          threadId: 'thread01',
+          content: 'thread01',
+          extUserId: 'user01',
+          deleted: false,
+          ownerRef: 'user01',
+          status: NoteStatus.Todo,
+          dateCreated: '',
+          dateModified: ''
+        }
+      ]
+    };
+    for (const assignment of assigned) {
+      noteThread.assignment = assignment.assigned;
+      env = new TestEnvironment({ noteThread, currentUserId });
+      expect(env.component.flagIcon)
+        .withContext(assignment.assigned ?? 'Unassigned')
+        .toEqual('/assets/icons/TagIcons/' + assignment.expectedIcon);
+      env.closeDialog();
+    }
   }));
 
   it('hides assigned user for non-paratext users', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -34,6 +34,7 @@ export interface NoteDialogData {
 })
 export class NoteDialogComponent implements OnInit {
   showSegmentText: boolean = false;
+  private isAssignedToCurrentUser: boolean = false;
   private threadDoc?: NoteThreadDoc;
   private projectProfileDoc?: SFProjectProfileDoc;
   private textDoc?: TextDoc;
@@ -55,6 +56,10 @@ export class NoteDialogComponent implements OnInit {
       const projectDoc: SFProjectDoc | undefined = await this.projectService.tryGetForRole(this.projectId, userRole);
       if (projectDoc != null && projectDoc.data?.paratextUsers != null) {
         this.paratextProjectUsers = projectDoc.data.paratextUsers;
+        this.isAssignedToCurrentUser = this.threadDoc.isAssignedToOtherUser(
+          this.userService.currentUserId,
+          this.paratextProjectUsers
+        );
       }
     }
   }
@@ -67,7 +72,7 @@ export class NoteDialogComponent implements OnInit {
     if (this.threadDoc?.data == null) {
       return '';
     }
-    return this.threadDoc.icon.url;
+    return this.isAssignedToCurrentUser ? this.threadDoc.iconGrayed.url : this.threadDoc.icon.url;
   }
 
   get isRtl(): boolean {


### PR DESCRIPTION
- Moved `isAssignedToOtherUser` in to `NoteThreadDoc`, so it can be called by notes dialog
- Use grey icon in note dialog if assigned to another user
- Reduced opacity of icons in notes dialog to match PT
![image](https://user-images.githubusercontent.com/17464863/165432376-944367d1-b039-4570-8f97-313b53f9685a.png)
