### PR TITLE
Search for projects by shortName on sysadmin page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -76,7 +76,7 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
     this.projectProfileDocChangesSubscription?.unsubscribe();
     this.project = projectProfileDoc?.data;
     if (projectProfileDoc != null) {
-      this.projectProfileDocChangesSubscription = this.subscribe(projectProfileDoc?.changes$, () => {
+      this.projectProfileDocChangesSubscription = this.subscribe(projectProfileDoc.changes$, () => {
         this.changeDetector.markForCheck();
       });
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.spec.ts
@@ -207,7 +207,7 @@ class TestEnvironment {
     when(mockedProjectService.onlineAddCurrentUser(anything(), anything())).thenResolve();
     when(mockedProjectService.onlineRemoveUser(anything(), 'user01')).thenResolve();
     when(mockedProjectService.onlineUpdateCurrentUserRole(anything(), anything())).thenResolve();
-    when(mockedProjectService.onlineQuery(anything(), anything())).thenCall(
+    when(mockedProjectService.onlineQuery(anything(), anything(), anything())).thenCall(
       (term$: Observable<string>, parameters$: Observable<QueryParameters>) =>
         combineLatest([term$, parameters$]).pipe(
           switchMap(([term, queryParameters]) => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.ts
@@ -1,6 +1,7 @@
 import { Component, HostBinding, OnInit } from '@angular/core';
 import { Project } from 'realtime-server/lib/esm/common/models/project';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
+import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { BehaviorSubject } from 'rxjs';
 import { DataLoadingComponent } from '../data-loading-component';
 import { ProjectDoc } from '../models/project-doc';
@@ -78,13 +79,19 @@ export class SaProjectsComponent extends DataLoadingComponent implements OnInit 
 
   ngOnInit() {
     this.loadingStarted();
-    this.subscribe(this.projectService.onlineQuery(this.searchTerm$, this.queryParameters$), searchResults => {
-      this.loadingStarted();
-      this.projectDocs = searchResults.docs;
-      this.length = searchResults.unpagedCount;
-      this.generateRows();
-      this.loadingFinished();
-    });
+    this.subscribe(
+      this.projectService.onlineQuery(this.searchTerm$, this.queryParameters$, [
+        obj<Project>().pathStr(p => p.name),
+        obj<SFProject>().pathStr(p => p.shortName)
+      ]),
+      searchResults => {
+        this.loadingStarted();
+        this.projectDocs = searchResults.docs;
+        this.length = searchResults.unpagedCount;
+        this.generateRows();
+        this.loadingFinished();
+      }
+    );
   }
 
   updateSearchTerm(target: EventTarget | null): void {


### PR DESCRIPTION
Very often we have a project shortname, rather than a project name. The current system admin page only allows searching by name. This commit enables searching by shortname.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1330)
<!-- Reviewable:end -->
