### PR TITLE
Add .npmrc config files

### DIFF
--- a/src/RealtimeServer/.npmrc
+++ b/src/RealtimeServer/.npmrc
@@ -1,0 +1,1 @@
+save=true

--- a/src/SIL.XForge.Scripture/ClientApp/.npmrc
+++ b/src/SIL.XForge.Scripture/ClientApp/.npmrc
@@ -1,0 +1,2 @@
+save=true
+legacy-peer-deps=true


### PR DESCRIPTION
Documentation for how npm handles .npmrc files: https://docs.npmjs.com/cli/v8/configuring-npm/npmrc
Documentation for the values that go in these files: https://docs.npmjs.com/cli/v8/using-npm/config

There are two values that get set in the config files:
```
save=true
legacy-peer-deps=true
```
Both of these can get set on the command line, but it would be annoying.

Newer versions of npm fail to install ClientApp because we're using a version of @angular-mdc/web that has a requiredAngularVersion of ^9.0.0, whereas web-xforge is using Angular 12. This config will tell npm to continue allowing us to ignore the version mismatch. Alternatively we could always run `npm i --legacy-peer-deps` or `npm ci --legacy-peer-deps` whenever we do an install.

`save=true` tells npm to update the package.json file when updating a package. Please note that this option appears to be broken before npm@8.3.2, so if you're testing this out, keep that in mind. It can be specified via the command line by doing `npm update --save`, but I think we want it to be the default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1331)
<!-- Reviewable:end -->
