### PR TITLE
SF-1544 dnd: Insert text via updateContents

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/drag-and-drop.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/drag-and-drop.ts
@@ -113,7 +113,7 @@ export class DragAndDrop {
           ];
           const insertionDelta = new Delta(insertionOps);
           // use updateContents() instead of insertText() to ensure that we do not mistakenly include underline format
-          // when dropping text before a note emb
+          // when dropping text before a note embed
           quill.updateContents(insertionDelta, 'user');
           setTimeout(() => {
             // If we inserted into a blank segment, and let SF respond by removing the blank in between our quill

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -1,9 +1,25 @@
 import cloneDeep from 'lodash-es/cloneDeep';
 import Parchment from 'parchment';
-import Quill, { Clipboard, DeltaOperation, DeltaStatic, History, HistoryStackType } from 'quill';
+import Quill, { Clipboard, DeltaOperation, DeltaStatic, History, HistoryStackType, StringMap } from 'quill';
 import { DragAndDrop } from './drag-and-drop';
 
 const Delta: new () => DeltaStatic = Quill.import('delta');
+
+export function getAttributesAtPosition(editor: Quill, editorPosition: number): StringMap {
+  // The format of the insertion point may only contain the block level formatting,
+  // the format classes and other information we get from the character following the insertion point
+  const insertionFormat: StringMap = editor.getFormat(editorPosition);
+  const characterFormat: StringMap = editor.getFormat(editorPosition, 1);
+  if (characterFormat['segment'] != null) {
+    for (const key of Object.keys(characterFormat)) {
+      // we ignore text anchor formatting because we cannot depend on the character format to tell us if it is needed
+      if (key !== 'text-anchor') {
+        insertionFormat[key] = characterFormat[key];
+      }
+    }
+  }
+  return insertionFormat;
+}
 
 function customAttributeName(key: string): string {
   return 'data-' + key;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -4,6 +4,7 @@ import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils
 import { Subscription } from 'rxjs';
 import { Delta, TextDoc } from '../../core/models/text-doc';
 import { containsInvalidOp, VERSE_FROM_SEGMENT_REF_REGEX } from '../utils';
+import { getAttributesAtPosition } from './quill-scripture';
 import { USFM_STYLE_DESCRIPTIONS } from './usfm-style-descriptions';
 
 const PARA_STYLES: Set<string> = new Set<string>([
@@ -722,7 +723,7 @@ export class TextViewModel {
         }
         previousOp = 'delete';
       } else if (cloneOp.insert != null) {
-        cloneOp.attributes = this.getAttributesAtPosition(editorStartPos);
+        cloneOp.attributes = getAttributesAtPosition(this.checkEditor(), editorStartPos);
         previousOp = 'insert';
       }
       (adjustedDelta as any).push(cloneOp);
@@ -753,22 +754,5 @@ export class TextViewModel {
       }
     }
     return embeddedElementsCount;
-  }
-
-  private getAttributesAtPosition(editorPosition: number): StringMap {
-    const editor: Quill = this.checkEditor();
-    // The format of the insertion point may only contain the block level formatting,
-    // the format classes and other information we get from the character following the insertion point
-    const insertionFormat: StringMap = editor.getFormat(editorPosition);
-    const characterFormat: StringMap = editor.getFormat(editorPosition, 1);
-    if (characterFormat['segment'] != null) {
-      for (const key of Object.keys(characterFormat)) {
-        // we ignore text anchor formatting because we cannot depend on the character format to tell us if it is needed
-        if (key !== 'text-anchor') {
-          insertionFormat[key] = characterFormat[key];
-        }
-      }
-    }
-    return insertionFormat;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -884,13 +884,13 @@ describe('TextComponent', () => {
       // Watch insert, delete, and set selction activity and record their call counts.
       const setSelectionSpy: jasmine.Spy<any> = spyOn<any>(env.component.editor!, 'setSelection').and.callThrough();
       const deleteTextSpy: jasmine.Spy<any> = spyOn<any>(env.component.editor!, 'deleteText').and.callThrough();
-      const insertTextSpy: jasmine.Spy<any> = spyOn<any>(env.component.editor!, 'insertText').and.callThrough();
+      const updateContentSpy: jasmine.Spy<any> = spyOn<any>(env.component.editor!, 'updateContents').and.callThrough();
 
       // Call counts of various quill methods, at times when TextComponent.updated emits are received by subscribers.
       const quillCallCountsAtUpdateFirings: {
         setSelectionCalls: number;
         deleteTextCalls: number;
-        insertTextCalls: number;
+        updateContentsCalls: number;
       }[] = [];
       const updatedSubscription: Subscription = env.component.updated.subscribe(() => {
         // Record call counts at the time of the 'updated' event.
@@ -899,7 +899,7 @@ describe('TextComponent', () => {
         quillCallCountsAtUpdateFirings.push({
           setSelectionCalls: setSelectionSpy.calls.count(),
           deleteTextCalls: deleteTextSpy.calls.count(),
-          insertTextCalls: insertTextSpy.calls.count()
+          updateContentsCalls: updateContentSpy.calls.count()
         });
       });
 
@@ -929,31 +929,31 @@ describe('TextComponent', () => {
 
       // For the following expect, setSelection may have been called before we get to our deleteText, or
       // maybe as part of processing it. But significantly in the following expect() is that TextComponent.updated
-      // fired after delete and before more setSelection or insertText calls.
+      // fired after delete and before more setSelection or updateContents calls.
       expect(quillCallCountsAtUpdateFirings).toContain({
         setSelectionCalls: 1,
         deleteTextCalls: 1,
-        insertTextCalls: 0
+        updateContentsCalls: 0
       });
       // Then setSelection is called.
       expect(quillCallCountsAtUpdateFirings).toContain({
         setSelectionCalls: 2,
         deleteTextCalls: 1,
-        insertTextCalls: 0
+        updateContentsCalls: 0
       });
       // Then insertText is called. Also setSelection must be getting called elsewhere as well. But importantly,
-      // insertTextCalls increased.
+      // updateContentsCalls increased.
       expect(quillCallCountsAtUpdateFirings).toContain({
-        setSelectionCalls: 5,
+        setSelectionCalls: 4,
         deleteTextCalls: 1,
-        insertTextCalls: 1
+        updateContentsCalls: 2
       });
       // Then setSelection is called. It may not be as significant that the selecting of the inserted text is
       // interleaved with TextComponent.updated events, but it is in case.
       expect(quillCallCountsAtUpdateFirings).toContain({
-        setSelectionCalls: 6,
+        setSelectionCalls: 5,
         deleteTextCalls: 1,
-        insertTextCalls: 1
+        updateContentsCalls: 2
       });
 
       // origin segment lost the text
@@ -1281,6 +1281,44 @@ describe('TextComponent', () => {
       // After text is dragged, the new selection should be the inserted text.
       expect(resultingSelection.index).toEqual(desiredSelectionStart);
       expect(resultingSelection.length).toEqual(desiredSelectionLength);
+    }));
+
+    it('only underlines text inserted within text anchor', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.fixture.detectChanges();
+      env.id = new TextDocId('project01', 40, 1);
+      tick();
+      env.embedNoteAtVerse(1);
+      tick();
+
+      let verse1Segment = env.component.editor!.container.querySelector('usx-segment[data-segment="verse_1_1"]')!;
+      let textAnchorContent: string = verse1Segment.querySelector('display-text-anchor')!.textContent!;
+      const expected = 'chapter';
+      expect(textAnchorContent.trim()).toEqual(expected);
+
+      const elementDropTarget: Element = env.component.editor!.container.querySelector(
+        'usx-segment[data-segment="verse_1_1"'
+      )!;
+      const specificNodeDropTarget: ChildNode = elementDropTarget.childNodes[0]!;
+      const insertText = 'abc';
+      const dataTransfer = new DataTransfer();
+      dataTransfer.setData('text/plain', insertText);
+      dataTransfer.setData('text/html', `<span background="white">${insertText}</span>`);
+
+      const dropEvent = new MockDragEvent('drop', { dataTransfer, cancelable: true });
+      dropEvent.setTarget(elementDropTarget);
+      const textBeforeDrop = 'target: ';
+      const dropDistanceIn = textBeforeDrop.length;
+
+      document.caretRangeFromPoint = (_x: number, _y: number) =>
+        ({ startOffset: dropDistanceIn, startContainer: specificNodeDropTarget as Node } as Range);
+      env.component.editor!.container.dispatchEvent(dropEvent);
+      flush();
+      env.fixture.detectChanges();
+
+      verse1Segment = env.component.editor!.container.querySelector('usx-segment[data-segment="verse_1_1"]')!;
+      textAnchorContent = verse1Segment.querySelector('display-text-anchor')!.textContent!;
+      expect(textAnchorContent.trim()).toEqual(expected);
     }));
 
     it('can drag-and-drop correctly near figure', fakeAsync(() => {
@@ -1793,10 +1831,7 @@ describe('TextComponent', () => {
         startEditorPosInSegment: editorLengthOfThreadIcon,
         editorLength: textToMove.length
       };
-      // It would make sense to here expect `['display-text-anchor', '#text']`, but initially, the target usx-segment
-      // element will be left with the display-text-anchor element alone, and a new usx-segment will be
-      // created with the text node.
-      const expectedTopLevelNodeSeriesAfterEvent: string[] = ['display-text-anchor'];
+      const expectedTopLevelNodeSeriesAfterEvent: string[] = ['display-text-anchor', '#text'];
 
       const env = new TestEnvironment({ chapterNum, textDoc });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -941,7 +941,7 @@ describe('TextComponent', () => {
         deleteTextCalls: 1,
         updateContentsCalls: 0
       });
-      // Then insertText is called. Also setSelection must be getting called elsewhere as well. But importantly,
+      // Then updateContents is called. Also setSelection must be getting called elsewhere as well. But importantly,
       // updateContentsCalls increased.
       expect(quillCallCountsAtUpdateFirings).toContain({
         setSelectionCalls: 4,
@@ -1283,7 +1283,7 @@ describe('TextComponent', () => {
       expect(resultingSelection.length).toEqual(desiredSelectionLength);
     }));
 
-    it('only underlines text inserted within text anchor', fakeAsync(() => {
+    it('dropped text does not acquire underline formatting from a following anchor', fakeAsync(() => {
       const env = new TestEnvironment();
       env.fixture.detectChanges();
       env.id = new TextDocId('project01', 40, 1);
@@ -1297,7 +1297,7 @@ describe('TextComponent', () => {
       expect(textAnchorContent.trim()).toEqual(expected);
 
       const elementDropTarget: Element = env.component.editor!.container.querySelector(
-        'usx-segment[data-segment="verse_1_1"'
+        'usx-segment[data-segment="verse_1_1"]'
       )!;
       const specificNodeDropTarget: ChildNode = elementDropTarget.childNodes[0]!;
       const insertText = 'abc';
@@ -1743,12 +1743,6 @@ describe('TextComponent', () => {
       // Some segments contain only a usx-blank. But usx-blank elements can also be accompanied by other pieces of
       // data in the text doc or in the DOM, such as a newline character or a display-text-anchor element (anchored
       // over an empty string).
-      // It is possible for segment containing a display-text-anchor and usx-blank to be represented in the
-      // DOM as children in the same usx-segment element, or as children in distinct usx-segment elements
-      // (both with the same data-segment segment ref value). This test is for the case of the
-      // display-text-anchor and usx-blank being in the same usx-segment element. The resulting DOM after
-      // the drop will be two usx-segment elements, one with the display-text-anchor and one with a text node
-      // containing the dropped text.
 
       // The user drags to the usx-blank element. Text is dropped immediately after the usx-blank element (which
       // then disappears).


### PR DESCRIPTION
* use update contents when inserted text dropped into a segment
* manually determine formatting at insertion position
* update test to expect dropped text in containing usx-segment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1332)
<!-- Reviewable:end -->
