### PR TITLE
Add close button to import questions dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -396,7 +396,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
       userId: this.userService.currentUserId,
       textsByBookId: this.textsByBookId
     };
-    this.matDialog.open(ImportQuestionsDialogComponent, { data });
+    this.matDialog.open(ImportQuestionsDialogComponent, { data, autoFocus: false });
   }
 
   getBookName(text: TextInfo): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
@@ -5,6 +5,7 @@
         ? t("import_questions")
         : t("import_progress", { completed: importedCount, total: toImportCount })
     }}
+    <button *ngIf="showCloseIcon" mat-icon-button mat-dialog-close><mat-icon>close</mat-icon></button>
   </h2>
   <mat-dialog-content class="mat-typography">
     <div *ngIf="status === 'file_import_errors'" class="dialog-content-header">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.scss
@@ -5,6 +5,9 @@
 
 .mat-dialog-title {
   margin-bottom: 0.25em;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .mat-dialog-content {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
@@ -398,6 +398,13 @@ describe('ImportQuestionsDialogComponent', () => {
     env.click(env.importFromTransceleratorButton);
     env.click(env.cancelButton);
   }));
+
+  it('has a close button on the initial view', fakeAsync(() => {
+    const env = new TestEnvironment();
+    expect(env.overlayContainerElement.hasChildNodes()).toBeTrue();
+    env.click(env.closeButton);
+    expect(env.overlayContainerElement.hasChildNodes()).withContext('close button closes dialog').toBeFalse();
+  }));
 });
 
 @Directive({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -197,6 +197,10 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable imple
     return this.filteredList.some(item => item.checked && item.sfVersionOfQuestion != null);
   }
 
+  get showCloseIcon(): boolean {
+    return this.status === 'initial' || this.status === 'loading';
+  }
+
   ngOnDestroy(): void {
     super.ngOnDestroy();
     this.promiseForQuestionDocQuery.then(query => query.dispose());


### PR DESCRIPTION
There are several views in the import questions dialog, and most of them have a close button with the text "Close." However, two views had no close button. The dialog could be closed by clicking outside the dialog, but that's not very discoverable, and it's a bit harder to do on mobile because there's very little area outside the dialog itself. I've added the close button in the top right corner.

### The initial view:

![](https://user-images.githubusercontent.com/6140710/165669057-3f1280a8-8b75-4f85-9bc1-9aaf8e71317b.png)

### The loading view:

![](https://user-images.githubusercontent.com/6140710/165669054-25a3ea42-e17d-45df-a354-9eb5e13b2bae.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1336)
<!-- Reviewable:end -->
