### PR TITLE
Improve home page tagline

### DIFF
--- a/src/SIL.XForge.Scripture/Resources/Pages.Index.resx
+++ b/src/SIL.XForge.Scripture/Resources/Pages.Index.resx
@@ -148,7 +148,7 @@
     <value>3 {0}Invited users{1} can answer questions, leave comments on existing answers and like responses.</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>A free set of tools to do more with your Paratext project, wherever you are. </value>
+    <value>A free set of tools to engage the community with your Paratext project</value>
   </data>
   <data name="EngageChecking" xml:space="preserve">
     <value>Engage in community checking</value>


### PR DESCRIPTION
This is a proposal, not a final draft, but I think there's room for improvement in the wording of the home page. "do more with your Paratext project" is pretty vague. I like "engage the community", though I can see how the translate tool doesn't fully fit within that category. Suggestions are welcome.

I'm not marking this as a draft because in GitHub the idea of a draft is that it's *not* ready for review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1338)
<!-- Reviewable:end -->
