### PR TITLE
SF-1557 Fix share dialog menus appearing behind dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
@@ -1,19 +1,12 @@
 <ng-container *transloco="let t; read: 'share_dialog'">
-  <mdc-dialog>
-    <mdc-dialog-container>
-      <mdc-dialog-surface class="dialog-size">
-        <mdc-dialog-title>{{ t("share_with_others") }}</mdc-dialog-title>
-        <mdc-dialog-content>
-          <app-share-control
-            class="share-dialog"
-            [projectId]="data.projectId"
-            [defaultRole]="data.defaultRole"
-          ></app-share-control>
-        </mdc-dialog-content>
-        <mdc-dialog-actions align="end">
-          <button id="close-btn" mdcDialogButton type="button" mdcDialogAction="close">{{ t("done") }}</button>
-        </mdc-dialog-actions>
-      </mdc-dialog-surface>
-    </mdc-dialog-container>
-  </mdc-dialog>
+  <h1 mat-dialog-title>{{ t("share_with_others") }}</h1>
+  <app-share-control
+    mat-dialog-content
+    class="share-dialog"
+    [projectId]="data.projectId"
+    [defaultRole]="data.defaultRole"
+  ></app-share-control>
+  <div mat-dialog-actions align="end">
+    <button id="close-btn" mat-flat-button mat-dialog-close>{{ t("done") }}</button>
+  </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.scss
@@ -1,6 +1,3 @@
-mdc-dialog-container {
-  width: 100%;
-  > mdc-dialog-surface {
-    width: 100%;
-  }
+.mat-dialog-content {
+  width: 30em;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
@@ -1,5 +1,5 @@
-import { MDC_DIALOG_DATA } from '@angular-mdc/web/dialog';
 import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 
 export interface ShareDialogData {
@@ -12,5 +12,5 @@ export interface ShareDialogData {
   styleUrls: ['./share-dialog.component.scss']
 })
 export class ShareDialogComponent {
-  constructor(@Inject(MDC_DIALOG_DATA) public readonly data: ShareDialogData) {}
+  constructor(@Inject(MAT_DIALOG_DATA) public readonly data: ShareDialogData) {}
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share.component.ts
@@ -1,5 +1,5 @@
-import { MdcDialog } from '@angular-mdc/web/dialog';
 import { Component, Input, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { map } from 'rxjs/operators';
@@ -15,7 +15,7 @@ export class ShareComponent implements OnInit {
 
   private projectId?: string;
 
-  constructor(private readonly dialog: MdcDialog, private readonly activatedRoute: ActivatedRoute) {}
+  constructor(private readonly dialog: MatDialog, private readonly activatedRoute: ActivatedRoute) {}
 
   ngOnInit(): void {
     this.activatedRoute.params.pipe(map(params => params['projectId'] as string)).subscribe(async projectId => {


### PR DESCRIPTION
Start by reading the issue and steps to reproduce: https://jira.sil.org/browse/SF-1557

This was caused by an interaction between Angular Material and Angular MDC. The mix of a MDC dialog and a Material mat-select within it caused the menu to appear behind the dialog. This problem only manifests itself if a Material dialog was opened prior to this dialog being opened.

I solved the problem by changing the dialog to use Angular Material. I'm fairly confident there are other workarounds, but this gets us closer to using only Angular Material.

Here's a before and after for the normal case, where everything is fine:
Before | After
----------|-------
![](https://user-images.githubusercontent.com/6140710/167479809-1c3a6280-2e35-4c5a-b01e-54b9506734c2.png) | ![](https://user-images.githubusercontent.com/6140710/167479822-69ebea49-3b64-4774-af46-dce4a95b94c8.png)

As you can see, the main visual change is width. We didn't have a width set before; it was being chosen by Angular MDC as far as I can tell. So I picked a width that felt about right, and it's a little less wide than before.

And here's how it looks when you follow the steps to reproduce the bug. As a write this the screenshots look blurry, but if I click on them they clear up. That's not an actual issue with the UI; it seems to be something weird GitHub is doing.

Before | After
---------|--------
![](https://user-images.githubusercontent.com/6140710/167480314-0c967986-eb8d-4585-b852-5da9cdcf4d31.png) | ![](https://user-images.githubusercontent.com/6140710/167480311-813b1bca-fef2-4b9f-9e3f-38726dc2fd09.png)

Also, very fun to fix a bug like this by adding negative 10 lines of code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1342)
<!-- Reviewable:end -->
