### PR TITLE
Add Mongo query to find projects with answers

### DIFF
--- a/mongodb/Projects/FindProjectsWithAnswers.mongodb
+++ b/mongodb/Projects/FindProjectsWithAnswers.mongodb
@@ -1,0 +1,45 @@
+use('xforge');
+
+const minAnswers = 10;
+
+db.questions.aggregate([
+  // find questions that have the answers property
+  {$match: {
+    answers: { $exists: true }
+  }},
+  // strip out all fields except projectRef, and add an answerCount property
+  {$project: {
+    answerCount: { $size: '$answers' },
+    projectRef: 1
+  }},
+  // group the questions by projectRef, and sum the total answers from each project
+  {$group: {
+    _id: '$projectRef',
+    totalAnswers: { $sum: '$answerCount' }
+  }},
+  // filter out any projects that have fewer than minAnswers
+  {$match: {
+    totalAnswers: {$gte: minAnswers}
+  }},
+  // sort by the number of answers, descending
+  {$sort: {
+    totalAnswers: -1
+  }},
+  // lookup the project associated with the project id, and add it as a property
+  {$lookup: {
+    from: 'sf_projects',
+    localField: '_id',
+    foreignField: '_id',
+    as: 'project'
+  }},
+  // $lookup adds an array of projects with one result; change from an array to a single property
+  {$unwind: {
+    path: '$project'
+  }},
+  // only keep the values we're looking for
+  {$project: {
+    shortName: '$project.shortName',
+    name: '$project.name',
+    totalAnswers: 1,
+  }}
+]);


### PR DESCRIPTION
This script finds projects that have at least `n` answers. This is a more useful metric than how many questions a project has, since those can easily be added in bulk. Answers have to be created by another user.

Ideally this kind of information will end up on some dashboard, but for now this is better than anything we currently have. And in any case, when we do make a better system, it will be helpful to have something like this to base the query on.

When run against live this query returns 7 results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1343)
<!-- Reviewable:end -->
