### PR TITLE
Add Mongo query to find active translate projects

### DIFF
--- a/mongodb/Projects/ActiveTranslateProjects.mongodb
+++ b/mongodb/Projects/ActiveTranslateProjects.mongodb
@@ -1,0 +1,32 @@
+use("xforge");
+
+// Find projects that have a text that has had at least 100 edits over all time, and has been edited in the last 30 days
+
+const daysAgo = 30;
+const minEdits = 100;
+
+const startTime = new Date().getTime() - (daysAgo * 60 * 60 * 24 * 1000);
+
+const texts = db.texts.find({ "_m.mtime": { $gt: startTime }, _v: { $gte: minEdits } }, { _id: 1 }).toArray();
+
+const unique = [];
+
+let projectIds = texts.map(text => text._id.split(":")[0]);
+
+for (const id of projectIds) {
+  if (!unique.includes(id)) {
+    unique.push(id);
+  }
+}
+
+console.log(unique.join("\n"));
+
+// Once the server reaches Mongo 5 we can just do:
+// db.texts.aggregate([
+//   {$match: {
+//     '_m.mtime': { $gt: startTime }, _v: { $gte: minEdits }
+//   }},
+//   {$group: {
+//     _id: {$first: { $split: ["$_id", ":"] } }
+//   }}
+// ])


### PR DESCRIPTION
This script finds projects that have a text that has had at least 100 edits over all time, and has been edited in the last 30 days.

I'm sure there are better metrics we could measure by, but this was something that was easy to query for, and seemed somewhat useful as a metric. I wrote this right before last week's meeting to find out what we actually had on the server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1344)
<!-- Reviewable:end -->
