### PR TITLE
SF-1556b Reuse ShareDB connections on back end to improve performance

### DIFF
--- a/src/RealtimeServer/common/diagnostics.ts
+++ b/src/RealtimeServer/common/diagnostics.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import inspector from 'inspector';
 import path from 'path';
 
-const secondsToProfile = 5;
+const secondsToProfile = 30;
 
 // POSIX defines SIGUSR1 and SIGUSR2 as user-defined signals, but SIGUSR1 is reserved by Node.js to start the debugger.
 // Send the signal using e.g. kill -USR2 <node process id>


### PR DESCRIPTION
Previously we were creating a new ShareDB connection every single time we check whether a user has permission to access a document (in order to determine whether a user can access e.g. a text, we have to look up the associated project and see if the user is on it). The [documentation for `Backend.prototype.connect()`](https://share.github.io/sharedb/api/backend#connect) says:

> Connects to ShareDB and returns an instance of a [`Connection`](https://share.github.io/sharedb/api/connection) client for interacting with ShareDB. This is the server-side equivalent of `new Connection(socket)` in the browser.

While not explicitly stated, this makes me believe creating thousands of connections for a single end user may cause performance issues. In my testing it appears this change reduces the amount of time the process spends to about 1/2 to 1/3 of what it was previously. That's not nearly as significant of a change as I would like, but I suspect the difference may grow as the number of connections grow, meaning the difference may be greater on live.

I don't consider this the end of the matter, but I think it will improve performance a bit for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1347)
<!-- Reviewable:end -->
