### PR TITLE
SF-1557b Prevent scrollbar in share dialog on mobile

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.scss
@@ -1,3 +1,7 @@
-.mat-dialog-content {
+// Note: ViewEncapsulation is disabled for this file, so all styles can apply to any element globally
+
+.share-dialog-component-panel {
   width: 30em;
+  // Angular Material sets max-width on the element itself, so this is the only way to override in CSS
+  max-width: 90vw !important;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
@@ -1,5 +1,5 @@
-import { Component, Inject } from '@angular/core';
-import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Component, Inject, ViewEncapsulation } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 
 export interface ShareDialogData {
@@ -9,8 +9,14 @@ export interface ShareDialogData {
 
 @Component({
   templateUrl: './share-dialog.component.html',
-  styleUrls: ['./share-dialog.component.scss']
+  styleUrls: ['./share-dialog.component.scss'],
+  encapsulation: ViewEncapsulation.None
 })
 export class ShareDialogComponent {
-  constructor(@Inject(MAT_DIALOG_DATA) public readonly data: ShareDialogData) {}
+  constructor(
+    readonly dialogRef: MatDialogRef<ShareDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public readonly data: ShareDialogData
+  ) {
+    dialogRef.addPanelClass('share-dialog-component-panel');
+  }
 }


### PR DESCRIPTION
This was broken in #1342 "SF-1557 Fix share dialog menus appearing behind dialog" (cb494c620519e0bcc6313166558976db71b38f11)

Unfortunately I didn't test this as well as I thought I did.

Before this fix | After this fix
-------------------|-----------------
![](https://user-images.githubusercontent.com/6140710/167944075-f35349e8-9b74-454b-8e20-da92370c3b03.png) | ![](https://user-images.githubusercontent.com/6140710/167944080-c74243dc-5c29-42c3-a055-88e1854b5821.png)


Disabling view encapsulation and using `!important` isn't the nicest solution, but the main alternative was to move the width specification to the component that opens the dialog and pass it in the config when calling `dialog.open()`. That seems like the wrong way to go, since we could easily start opening the dialog from a different place, and we don't want to have to write:
``` ts
this.dialog.open(ShareDialogComponent, {
  width: '30em',
  maxWidth: '90vw',
  ...
```
every time. In reality we would probably notice if the dialog width was completely wrong, but it still doesn't seem like something that should be duplicated. It should be possible to change it by changing it in one place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1348)
<!-- Reviewable:end -->
