### PR TITLE
SF-1552b Multi-viewer toolbar

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from '@angular/core';
 import cloneDeep from 'lodash-es/cloneDeep';
 import Quill, { DeltaOperation, DeltaStatic, RangeStatic, Sources, StringMap } from 'quill';
 import QuillCursors from 'quill-cursors';
@@ -7,6 +8,7 @@ import { LocalPresence, Presence } from 'sharedb/lib/sharedb';
 import tinyColor from 'tinycolor2';
 import { objectId } from 'xforge-common/utils';
 import { Delta, TextDoc } from '../../core/models/text-doc';
+import { MultiCursorViewer } from '../../translate/editor/multi-viewer/multi-viewer.component';
 import { containsInvalidOp, VERSE_FROM_SEGMENT_REF_REGEX } from '../utils';
 import { getAttributesAtPosition } from './quill-scripture';
 import { USFM_STYLE_DESCRIPTIONS } from './usfm-style-descriptions';
@@ -88,11 +90,12 @@ export interface EditorRange {
 }
 
 export interface PresenceData {
-  viewer: {
-    displayName: string;
-    cursorColor: string;
-  };
+  viewer: MultiCursorViewer;
   range: RangeStatic;
+}
+
+export interface RemotePresences {
+  [id: string]: PresenceData;
 }
 
 class SegmentInfo {
@@ -135,7 +138,7 @@ export class TextViewModel {
 
   private onPresenceReceive = (_presenceId: string, _presenceData: PresenceData | null) => {};
 
-  constructor() {
+  constructor(private presenceChange?: EventEmitter<RemotePresences | undefined>) {
     let localCursorColor = localStorage.getItem(this.cursorColorStorageKey);
     if (localCursorColor == null) {
       // keep the cursor color from getting too close to white since the text is white
@@ -203,11 +206,13 @@ export class TextViewModel {
     this.onPresenceReceive = (presenceId: string, presenceData: PresenceData | null) => {
       if (presenceData == null) {
         cursors.removeCursor(presenceId);
+        this.presenceChange?.emit(this.presence?.remotePresences);
         return;
       }
 
       cursors.createCursor(presenceId, presenceData.viewer.displayName, presenceData.viewer.cursorColor);
       cursors.moveCursor(presenceId, presenceData.range);
+      this.presenceChange?.emit(this.presence?.remotePresences);
     };
     this.presence.on('receive', this.onPresenceReceive);
   }
@@ -225,14 +230,15 @@ export class TextViewModel {
       if (error) throw error;
     });
     this.presence?.off('receive', this.onPresenceReceive);
-    this.presence = undefined;
     this.localPresence?.submit(null as unknown as PresenceData);
 
     if (this.editor != null) {
       this.editor.setText('', 'silent');
       const cursors: QuillCursors = this.editor.getModule('cursors');
       cursors.clearCursors();
+      this.presenceChange?.emit(this.presence?.remotePresences);
     }
+    this.presence = undefined;
     this._segments.clear();
     this._embeddedElements.clear();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -601,8 +601,8 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     const currentUserDoc: UserDoc = await this.userService.getCurrentUser();
     // If the avatar src is empty ('') then it generates one with the same background and cursor color
     // Do this for email/password accounts
-    const authType = getAuthType(currentUserDoc.data?.authId ?? '');
-    const avatarUrl = authType === AuthType.Account ? '' : currentUserDoc.data?.avatarUrl ?? '';
+    const authType: AuthType = getAuthType(currentUserDoc.data?.authId ?? '');
+    const avatarUrl: string = authType === AuthType.Account ? '' : currentUserDoc.data?.avatarUrl ?? '';
     const presenceData: PresenceData = {
       viewer: {
         displayName: currentUserDoc.data?.displayName || this.transloco.translate('editor.anonymous'),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -1,30 +1,37 @@
 <ng-container *transloco="let t; read: 'editor'">
   <div class="content" mdcMenuSurfaceAnchor #trainingProgressAnchor fxLayout="column">
-    <div class="toolbar" fxLayout="row wrap" fxLayoutAlign="start center">
-      <app-chapter-nav [bookNum]="bookNum" [(chapter)]="chapter" [chapters]="chapters"></app-chapter-nav>
-      <ng-container *ngIf="showSource">
-        <div class="toolbar-separator">&nbsp;</div>
-        <button
-          mdc-icon-button
-          appBlurOnClick
-          icon="swap_horiz"
-          type="button"
-          (click)="isTargetTextRight = !isTargetTextRight"
-          title="{{ t('swap_source_and_target') }}"
-          fxHide.xs
-        ></button>
-        <button
-          mdc-icon-button
-          appBlurOnClick
-          icon="settings"
-          type="button"
-          (click)="openSuggestionsSettings()"
-          title="{{ t('configure_translation_suggestions') }}"
-        ></button>
-      </ng-container>
-      <ng-container *ngIf="canShare">
-        <div class="toolbar-separator">&nbsp;</div>
-        <app-share [defaultRole]="defaultShareRole"></app-share>
+    <div class="toolbar" fxLayout="row" fxLayoutAlign="start center">
+      <div fxFlex fxLayout="row wrap">
+        <app-chapter-nav [bookNum]="bookNum" [(chapter)]="chapter" [chapters]="chapters"></app-chapter-nav>
+        <ng-container *ngIf="showSource">
+          <div class="toolbar-separator">&nbsp;</div>
+          <button
+            mdc-icon-button
+            appBlurOnClick
+            icon="swap_horiz"
+            type="button"
+            (click)="isTargetTextRight = !isTargetTextRight"
+            title="{{ t('swap_source_and_target') }}"
+            fxHide.xs
+          ></button>
+          <button
+            mdc-icon-button
+            appBlurOnClick
+            icon="settings"
+            type="button"
+            (click)="openSuggestionsSettings()"
+            title="{{ t('configure_translation_suggestions') }}"
+          ></button>
+        </ng-container>
+        <ng-container *ngIf="canShare">
+          <div class="toolbar-separator">&nbsp;</div>
+          <app-share [defaultRole]="defaultShareRole"></app-share>
+        </ng-container>
+      </div>
+      <ng-container *ngIf="showMultiViewers">
+        <div fxFlexAlign="center">
+          <app-multi-viewer [viewers]="multiCursorViewers"></app-multi-viewer>
+        </div>
       </ng-container>
     </div>
     <div [fxLayout]="isTargetTextRight ? 'row' : 'row-reverse'" fxLayoutGap="5px">
@@ -78,6 +85,7 @@
             "
             (loaded)="onTextLoaded('target')"
             (focused)="targetFocused = $event"
+            (presenceChange)="onPresenceChange($event)"
             [highlightSegment]="targetFocused && canEdit"
             [markInvalid]="true"
             [isRightToLeft]="isTargetRightToLeft"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -50,7 +50,7 @@ import { TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
 import { Segment } from '../../shared/text/segment';
-import { RemotePresences } from '../../shared/text/text-view-model';
+import { PresenceData, RemotePresences } from '../../shared/text/text-view-model';
 import { FeaturedVerseRefInfo, TextComponent } from '../../shared/text/text.component';
 import { threadIdFromMouseEvent } from '../../shared/utils';
 import { MultiCursorViewer } from './multi-viewer/multi-viewer.component';
@@ -593,7 +593,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   onPresenceChange(remotePresences?: RemotePresences): void {
     if (remotePresences != null) {
-      const uniquePresences = Object.values(remotePresences).filter(
+      const uniquePresences: PresenceData[] = Object.values(remotePresences).filter(
         (a, index, self) =>
           index ===
           self.findIndex(
@@ -601,9 +601,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
           )
       );
       const multiCursorViewers: MultiCursorViewer[] = [];
-      const currentUser = this.currentUserDoc?.data;
+      const currentUser: User | undefined = this.currentUserDoc?.data;
       for (const presence of uniquePresences) {
-        const viewer = presence.viewer;
+        const viewer: MultiCursorViewer = presence.viewer;
         if (viewer.displayName !== currentUser?.displayName && viewer.avatarUrl !== currentUser?.avatarUrl) {
           multiCursorViewers.push(viewer);
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.html
@@ -1,18 +1,17 @@
 <div fxLayout="row" fxLayoutAlign="start center">
   <ng-container *ngFor="let viewer of avatarViewers">
-    <div class="app-avatar-container" [title]="viewer.displayName" style="width: 36px; height: 36px">
+    <div class="app-avatar-container" [title]="viewer.displayName">
       <app-avatar [user]="viewer" [size]="32" [round]="true" [borderColor]="viewer.cursorColor"></app-avatar>
     </div>
   </ng-container>
   <ng-container *ngIf="viewers.length > maxAvatars">
-    <div class="app-avatar-container" style="width: 36px; height: 36px">
+    <div class="app-avatar-container">
       <button
         mat-mini-fab
         [matMenuTriggerFor]="menu"
         class="mat-elevation-z"
         [title]="otherViewersLabel"
         (click)="toggleMenu()"
-        style="width: 32px; height: 32px"
       >
         <span *ngIf="!isMenuOpen"><span *ngIf="maxAvatars > 1">+</span>{{ viewers.length - maxAvatars + 1 }}</span>
         <mat-icon *ngIf="isMenuOpen">arrow_drop_up</mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.html
@@ -1,0 +1,31 @@
+<div fxLayout="row" fxLayoutAlign="start center">
+  <ng-container *ngFor="let viewer of avatarViewers">
+    <div class="app-avatar-container" [title]="viewer.displayName" style="width: 36px; height: 36px">
+      <app-avatar [user]="viewer" [size]="32" [round]="true" [borderColor]="viewer.cursorColor"></app-avatar>
+    </div>
+  </ng-container>
+  <ng-container *ngIf="viewers.length > maxAvatars">
+    <div class="app-avatar-container" style="width: 36px; height: 36px">
+      <button
+        mat-mini-fab
+        [matMenuTriggerFor]="menu"
+        class="mat-elevation-z"
+        [title]="otherViewersLabel"
+        (click)="toggleMenu()"
+        style="width: 32px; height: 32px"
+      >
+        <span *ngIf="!isMenuOpen"><span *ngIf="maxAvatars > 1">+</span>{{ viewers.length - maxAvatars + 1 }}</span>
+        <mat-icon *ngIf="isMenuOpen">arrow_drop_up</mat-icon>
+      </button>
+      <mat-menu #menu="matMenu" (closed)="closeMenu()">
+        <button mat-menu-item disabled>{{ otherViewersLabel }}</button>
+        <ng-container *ngFor="let viewer of viewers">
+          <button mat-menu-item (click)="closeMenu()">
+            <app-avatar [user]="viewer" [size]="32" [round]="true" [borderColor]="viewer.cursorColor"></app-avatar>
+            <span fxFlex>{{ viewer.displayName }}</span>
+          </button>
+        </ng-container>
+      </mat-menu>
+    </div>
+  </ng-container>
+</div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.scss
@@ -2,6 +2,14 @@
   border-radius: 50%;
   border: 2px solid white;
   margin-left: -8px;
+  height: 36px;
+  width: 36px;
+}
+
+.app-avatar-container > button,
+::ng-deep div.avatar-content {
+  height: 32px;
+  width: 32px;
 }
 
 .mat-mini-fab {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.scss
@@ -1,0 +1,21 @@
+.app-avatar-container {
+  border-radius: 50%;
+  border: 2px solid white;
+  margin-left: -8px;
+}
+
+.mat-mini-fab {
+  background-color: #eaeaea;
+}
+
+::ng-deep .mat-mini-fab span.mat-button-wrapper {
+  padding: 0;
+}
+
+.mat-menu-item app-avatar {
+  margin: auto;
+}
+
+.mat-menu-item span {
+  margin: auto 10px;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.spec.ts
@@ -1,0 +1,75 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MultiViewerComponent } from './multi-viewer.component';
+
+describe('MultiViewerComponent', () => {
+  let component: MultiViewerComponent;
+  let fixture: ComponentFixture<MultiViewerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [MultiViewerComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MultiViewerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should have all avatars when the menu is closed', () => {
+    component.viewers = [
+      { displayName: 'v 1', avatarUrl: '', cursorColor: '' },
+      { displayName: 'v 2', avatarUrl: '', cursorColor: '' },
+      { displayName: 'v 3', avatarUrl: '', cursorColor: '' }
+    ];
+    expect(component.maxAvatars).withContext('setup').toEqual(3);
+
+    expect(component.avatarViewers.length).toEqual(3);
+  });
+
+  it('should not have avatars when the menu is open', () => {
+    component.viewers = [
+      { displayName: 'v 1', avatarUrl: '', cursorColor: '' },
+      { displayName: 'v 2', avatarUrl: '', cursorColor: '' },
+      { displayName: 'v 3', avatarUrl: '', cursorColor: '' }
+    ];
+
+    component.isMenuOpen = true;
+
+    expect(component.avatarViewers.length).toEqual(0);
+  });
+
+  it('should limit the avatars when there are many', () => {
+    component.viewers = [
+      { displayName: 'v 1', avatarUrl: '', cursorColor: '' },
+      { displayName: 'v 2', avatarUrl: '', cursorColor: '' },
+      { displayName: 'v 3', avatarUrl: '', cursorColor: '' },
+      { displayName: 'v 4', avatarUrl: '', cursorColor: '' }
+    ];
+    expect(component.maxAvatars).withContext('setup').toEqual(3);
+
+    expect(component.avatarViewers.length).toEqual(2);
+  });
+
+  it('should toggle the menu', () => {
+    expect(component.isMenuOpen).withContext('setup').toBeFalse();
+
+    component.toggleMenu();
+
+    expect(component.isMenuOpen).toBeTrue();
+
+    component.toggleMenu();
+
+    expect(component.isMenuOpen).toBeFalse();
+  });
+
+  it('should close the menu', () => {
+    component.isMenuOpen = true;
+    expect(component.isMenuOpen).withContext('setup').toBeTrue();
+
+    component.closeMenu();
+
+    expect(component.isMenuOpen).toBeFalse();
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.ts
@@ -1,0 +1,59 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { MediaChange, MediaObserver } from '@angular/flex-layout';
+import { translate } from '@ngneat/transloco';
+import { slice } from 'lodash-es';
+import { UserProfile } from 'realtime-server/lib/esm/common/models/user';
+import { filter, map } from 'rxjs/operators';
+import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
+
+export interface MultiCursorViewer extends UserProfile {
+  cursorColor: string;
+}
+
+@Component({
+  selector: 'app-multi-viewer',
+  templateUrl: './multi-viewer.component.html',
+  styleUrls: ['./multi-viewer.component.scss']
+})
+export class MultiViewerComponent extends SubscriptionDisposable implements OnInit {
+  @Input() viewers: MultiCursorViewer[] = [];
+  maxAvatars: number = 3;
+  isMenuOpen: boolean = false;
+
+  constructor(private readonly media: MediaObserver) {
+    super();
+  }
+
+  get avatarViewers(): MultiCursorViewer[] {
+    if (this.isMenuOpen) return [];
+
+    return this.viewers.length > this.maxAvatars ? slice(this.viewers, 0, this.maxAvatars - 1) : this.viewers;
+  }
+
+  get otherViewersLabel(): string {
+    return translate('editor.other_viewers', { count: this.viewers.length });
+  }
+
+  ngOnInit(): void {
+    this.subscribe(
+      this.media.asObservable().pipe(
+        filter((changes: MediaChange[]) => changes.length > 0),
+        map((changes: MediaChange[]) => changes[0])
+      ),
+      (change: MediaChange) => {
+        const isViewportBigger = ['xl', 'lt-xl', 'lg', 'lt-lg', 'md', 'lt-md'].includes(change.mqAlias);
+        this.maxAvatars = isViewportBigger ? 6 : 3;
+        const isViewportXS = ['xs'].includes(change.mqAlias);
+        this.maxAvatars = isViewportXS ? 1 : this.maxAvatars;
+      }
+    );
+  }
+
+  toggleMenu(): void {
+    this.isMenuOpen = !this.isMenuOpen;
+  }
+
+  closeMenu(): void {
+    this.isMenuOpen = false;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.ts
@@ -31,7 +31,7 @@ export class MultiViewerComponent extends SubscriptionDisposable implements OnIn
   }
 
   get otherViewersLabel(): string {
-    return translate('editor.other_viewers', { count: this.viewers.length });
+    return translate('multi_viewer.other_viewers', { count: this.viewers.length });
   }
 
   ngOnInit(): void {
@@ -41,9 +41,9 @@ export class MultiViewerComponent extends SubscriptionDisposable implements OnIn
         map((changes: MediaChange[]) => changes[0])
       ),
       (change: MediaChange) => {
-        const isViewportBigger = ['xl', 'lt-xl', 'lg', 'lt-lg', 'md', 'lt-md'].includes(change.mqAlias);
+        const isViewportBigger: boolean = ['xl', 'lt-xl', 'lg', 'lt-lg', 'md', 'lt-md'].includes(change.mqAlias);
         this.maxAvatars = isViewportBigger ? 6 : 3;
-        const isViewportXS = ['xs'].includes(change.mqAlias);
+        const isViewportXS: boolean = ['xs'].includes(change.mqAlias);
         this.maxAvatars = isViewportXS ? 1 : this.maxAvatars;
       }
     );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate.module.ts
@@ -5,6 +5,7 @@ import { UICommonModule } from 'xforge-common/ui-common.module';
 import { XForgeCommonModule } from 'xforge-common/xforge-common.module';
 import { SharedModule } from '../shared/shared.module';
 import { EditorComponent } from './editor/editor.component';
+import { MultiViewerComponent } from './editor/multi-viewer/multi-viewer.component';
 import { NoteDialogComponent } from './editor/note-dialog/note-dialog.component';
 import { SuggestionsSettingsDialogComponent } from './editor/suggestions-settings-dialog.component';
 import { SuggestionsComponent } from './editor/suggestions.component';
@@ -14,10 +15,11 @@ import { TranslateRoutingModule } from './translate-routing.module';
 @NgModule({
   declarations: [
     EditorComponent,
+    MultiViewerComponent,
+    NoteDialogComponent,
     SuggestionsComponent,
-    TranslateOverviewComponent,
     SuggestionsSettingsDialogComponent,
-    NoteDialogComponent
+    TranslateOverviewComponent
   ],
   imports: [TranslateRoutingModule, CommonModule, SharedModule, UICommonModule, XForgeCommonModule, TranslocoModule]
 })

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -83,6 +83,7 @@
     "completed_successfully": "Completed successfully",
     "configure_translation_suggestions": "Configure translation suggestions",
     "more_notes": "--- {{ count }} more note(s) ---",
+    "other_viewers": "{{ count }} other viewers",
     "project_text_not_editable": "Text in this project is not editable. This setting can be changed in Paratext.",
     "project_data_out_of_sync": "Your project data is out of sync. Please synchronize your project to edit this text.",
     "swap_source_and_target": "Swap source and target",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -83,7 +83,6 @@
     "completed_successfully": "Completed successfully",
     "configure_translation_suggestions": "Configure translation suggestions",
     "more_notes": "--- {{ count }} more note(s) ---",
-    "other_viewers": "{{ count }} other viewers",
     "project_text_not_editable": "Text in this project is not editable. This setting can be changed in Paratext.",
     "project_data_out_of_sync": "Your project data is out of sync. Please synchronize your project to edit this text.",
     "swap_source_and_target": "Swap source and target",
@@ -138,6 +137,9 @@
     "transcelerator_paratext": "{1}Transcelerator{2} is a plugin for {3}Paratext{4} to aid with creating and translating scripture checking questions.",
     "transcelerator_some_questions_already_imported": "Note: Some selected questions have already been imported. Questions that have been edited in Transcelerator will be updated in Scripture Forge, and exact duplicates will be skipped.",
     "update_transcelerator": "The version of Transcelerator used in this project is not supported. Please update to at least Transcelerator version 1.5.3."
+  },
+  "multi_viewer": {
+    "other_viewers": "{{ count }} other viewers"
   },
   "note_dialog": {
     "declare_conflict": "There is a conflict. Colors correspond to older (red) and newer (green) text.",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.html
@@ -1,4 +1,12 @@
-<ngx-avatar [src]="avatarUrl" [name]="name" [size]="size" [round]="round" [cornerRadius]="3"></ngx-avatar>
+<ngx-avatar
+  [src]="avatarUrl"
+  [name]="name"
+  [size]="size"
+  [round]="round"
+  [cornerRadius]="3"
+  [borderColor]="borderColor"
+  [bgColor]="borderColor"
+></ngx-avatar>
 <div *ngIf="showOnlineStatus" class="online-status">
   <mdc-icon *ngIf="(pwaService.onlineStatus | async) !== true">cloud_off</mdc-icon>
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.scss
@@ -7,3 +7,7 @@
     text-shadow: 0 0 2px #000;
   }
 }
+
+::ng-deep img.avatar-content {
+  border-width: 2px !important;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.scss
@@ -8,6 +8,6 @@
   }
 }
 
-::ng-deep img.avatar-content {
+::ng-deep .avatar-content {
   border-width: 2px !important;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.ts
@@ -11,6 +11,7 @@ export class AvatarComponent {
   @Input() round: boolean = false;
   @Input() size: number = 32;
   @Input() user?: UserProfile;
+  @Input() borderColor?: string;
   @Input() showOnlineStatus: boolean = false;
 
   constructor(readonly pwaService: PwaService) {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/memory-realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/memory-realtime-remote-store.ts
@@ -68,6 +68,7 @@ export class MemoryRealtimeDocAdapter implements RealtimeDocAdapter {
   readonly delete$ = new Subject<void>();
   readonly idle$ = EMPTY;
   readonly docPresence: Presence = {
+    remotePresences: {},
     subscribe: (_callback?: Callback) => {},
     unsubscribe: (_callback?: Callback) => {},
     create: (_id?: string) =>


### PR DESCRIPTION
- add tests
- move matching getters and setters together in `text.component.ts`.

I couldn't add as many tests as I had hoped but we are at the limit of what we can unit test in multi-viewer scenarios. I've added a bunch of **Acceptance Checks** to the [issue](https://jira.sil.org/browse/SF-1552). Ideally these would be codified in E2E tests or at least BVTs.

Note this PR is currently against the `feature/multiCursor` branch.

Screenshot of the same viewer on the same device and browser having the same color cursor for them and for other viewers:
![image](https://user-images.githubusercontent.com/5582153/168022519-045465b6-ba99-4087-ab44-7505c335373d.png)

Screenshot of extra small screens with more than 1 viewer:
![image](https://user-images.githubusercontent.com/5582153/168026500-6c83df95-d3d6-49f4-907f-b7a3fdc2bfc9.png)

Screenshot of extra small and medium screens with more than 3 viewers:
![image](https://user-images.githubusercontent.com/5582153/168027376-4a64e3c0-6a54-4319-a6f0-ecfe6d19d21c.png)

Note the cursor colors don't all match between screens in the above screenshot for V* viewers because I did a code hack to add more than 2 viewers to show the **Viewers** button and dropdown.

The [previous PR#1349](https://github.com/sillsdev/web-xforge/pull/1349) for this branch was accidentally closed by GH when the [related PR](https://github.com/sillsdev/web-xforge/pull/1337) was merged. If responding to code review from that previous PR then feel free to do it there if that is easier. Otherwise create new responses in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1350)
<!-- Reviewable:end -->
