### PR TITLE
SF-1564a Mark texts with duplicate chapters as invalid

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -9,7 +9,7 @@ import tinyColor from 'tinycolor2';
 import { objectId } from 'xforge-common/utils';
 import { Delta, TextDoc } from '../../core/models/text-doc';
 import { MultiCursorViewer } from '../../translate/editor/multi-viewer/multi-viewer.component';
-import { containsInvalidOp, VERSE_FROM_SEGMENT_REF_REGEX } from '../utils';
+import { isBadDelta, VERSE_FROM_SEGMENT_REF_REGEX } from '../utils';
 import { getAttributesAtPosition } from './quill-scripture';
 import { USFM_STYLE_DESCRIPTIONS } from './usfm-style-descriptions';
 
@@ -169,9 +169,7 @@ export class TextViewModel {
   }
 
   get areOpsCorrupted(): boolean {
-    return (
-      this.textDoc?.isLoaded === true && this.textDoc.data?.ops != null && containsInvalidOp(this.textDoc.data.ops)
-    );
+    return this.textDoc?.isLoaded === true && this.textDoc.data?.ops != null && isBadDelta(this.textDoc.data.ops);
   }
 
   bind(textDoc: TextDoc, subscribeToUpdates: boolean): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -95,8 +95,9 @@ export function projectLabel(project: SelectableProject | undefined): string {
  * several rules to see if any of them are violated.
  * @param ops An array of ops to check.
  */
-export function containsInvalidOp(ops: DeltaOperation[]): boolean {
-  return ops.some(
+export function isBadDelta(ops: DeltaOperation[]): boolean {
+  const chapterInsertsCount = ops.filter(op => op.insert?.chapter != null).length;
+  const containsBadOp = ops.some(
     op =>
       // insert must be defined for any op, and can't be nullish
       op.insert == null ||
@@ -109,6 +110,7 @@ export function containsInvalidOp(ops: DeltaOperation[]): boolean {
       // the segment identifier should not have null or undefined in it, like we've seen in the past
       (typeof op.attributes?.segment === 'string' && /(?:undefined|null)/.test(op.attributes.segment))
   );
+  return chapterInsertsCount > 1 || containsBadOp;
 }
 
 export function compareProjectsForSorting(a: { shortName: string }, b: { shortName: string }): 1 | -1 {


### PR DESCRIPTION
A project on live managed to duplicate the chapter numbers in a text, which causes sync problems (it's not valid to have duplicate chapters).

This makes the text not editable, and shows a message to the user indicating that it has become corrupted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1353)
<!-- Reviewable:end -->
