### PR TITLE
Fix package-lock.json in scripts/db_tools

### DIFF
--- a/scripts/db_tools/.npmrc
+++ b/scripts/db_tools/.npmrc
@@ -1,0 +1,2 @@
+save=true
+

--- a/scripts/db_tools/package-lock.json
+++ b/scripts/db_tools/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "db_tools",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
@@ -14,12 +15,12 @@
         "sharedb": "1.0.0-beta.31",
         "sharedb-access": "^5.0.0",
         "sharedb-mongo": "^1.0.0-beta.17",
-        "ws": "7.5.0",
+        "ws": "8.2.3",
         "yargs": "^17.2.1"
       },
       "devDependencies": {
         "@types/mongodb": "^3.3.11",
-        "@types/ws": "7.4.5",
+        "@types/ws": "8.2.0",
         "@types/yargs": "^17.0.7",
         "sharedb-mingo-memory": "^1.1.4",
         "ts-node": "^10.4.0",
@@ -98,9 +99,9 @@
       "dev": true
     },
     "node_modules/@types/ws": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.5.tgz",
-      "integrity": "sha512-8mbDgtc8xpxDDem5Gwj76stBDJX35KQ3YBoayxlqUQcL5BZUthiqP/VQ4PQnLHqM4PmlbyO74t98eJpURO+gPA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.0.tgz",
+      "integrity": "sha512-cyeefcUCgJlEk+hk2h3N+MqKKsPViQgF5boi9TTHSK+PoR9KWBb/C5ccPcDyAqgsbAYHTwulch725DV84+pSpg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -956,11 +957,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-      "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
@@ -1084,9 +1085,9 @@
       "dev": true
     },
     "@types/ws": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.5.tgz",
-      "integrity": "sha512-8mbDgtc8xpxDDem5Gwj76stBDJX35KQ3YBoayxlqUQcL5BZUthiqP/VQ4PQnLHqM4PmlbyO74t98eJpURO+gPA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.0.tgz",
+      "integrity": "sha512-cyeefcUCgJlEk+hk2h3N+MqKKsPViQgF5boi9TTHSK+PoR9KWBb/C5ccPcDyAqgsbAYHTwulch725DV84+pSpg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -1695,9 +1696,9 @@
       }
     },
     "ws": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-      "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
       "requires": {}
     },
     "y18n": {


### PR DESCRIPTION
If you try to run `npm ci` in `scripts/db_tools` before this change, using `npm@8.8.0`, it produces an error:
```
$ npm ci
npm ERR! `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
npm ERR! 
npm ERR! Invalid: lock file's @types/ws@7.4.5 does not satisfy @types/ws@8.2.0
npm ERR! Invalid: lock file's ws@7.5.0 does not satisfy ws@8.2.3
npm ERR! 

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/nate/.npm/_logs/2022-05-14T02_13_48_301Z-debug-0.log
```

- Newer versions of npm seem to have a stricter definition of whether a package.json is in sync with a package-lock.json. In any event, npm@8.8.0 claims they are out of sync and it needs to rewrite package-lock.json
- Also added a .npmrc file to tell npm to save changes by default

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1354)
<!-- Reviewable:end -->
