### PR TITLE
Fix text doc history script connection to Mongo

### DIFF
--- a/scripts/db_tools/text-doc-history.js
+++ b/scripts/db_tools/text-doc-history.js
@@ -6,7 +6,7 @@
 const utils = require('./utils');
 const RichText = utils.requireFromRealTimeServer('rich-text');
 const ShareDB = utils.requireFromRealTimeServer('sharedb/lib/client');
-const MongoClient = utils.requireFromRealTimeServer('mongodb');
+const { MongoClient } = utils.requireFromRealTimeServer('mongodb');
 const OTJson0 = utils.requireFromRealTimeServer('ot-json0');
 
 // Edit these settings to specify which doc to visualize


### PR DESCRIPTION
It's not clear exactly what occurred, but the way Mongo was being imported no longer works. The `utils.requireFromRealTimeServer` thing is non-standard, so I'm not super surprised. 

As far as I can tell, this is the only script that needed to be changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1355)
<!-- Reviewable:end -->
