### PR TITLE
SF-1567 Fix sorting of projects to be case insensitive

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.spec.ts
@@ -70,8 +70,8 @@ describe('shared utils', () => {
   });
 
   it('compares projects for sorting', () => {
-    const projects = [{ shortName: 'BBB' }, { shortName: 'AAA' }] as SFProject[];
+    const projects = [{ shortName: 'bbb' }, { shortName: 'CCC' }, { shortName: 'AAA' }] as SFProject[];
     projects.sort(compareProjectsForSorting);
-    expect(projects[0].shortName).toBe('AAA');
+    expect(projects.map(project => project.shortName)).toEqual(['AAA', 'bbb', 'CCC']);
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -112,5 +112,5 @@ export function containsInvalidOp(ops: DeltaOperation[]): boolean {
 }
 
 export function compareProjectsForSorting(a: { shortName: string }, b: { shortName: string }): 1 | -1 {
-  return a.shortName < b.shortName ? -1 : 1;
+  return a.shortName.toLowerCase() < b.shortName.toLowerCase() ? -1 : 1;
 }


### PR DESCRIPTION
When I initially implemented the sort order I overlooked that all capital letters would come before all lower case letters.

Note: The branch name says SF-1553b, but the commit and PR title say SF-1567. That's because I opened this PR with the assumption the issue was going to be added to the original issue for sorting, rather than created as a separate issue. Not a big deal, just something to be aware of. GitHub doesn't allow changing the name of the branch without creating a new PR, so far as I am aware.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1360)
<!-- Reviewable:end -->
