### PR TITLE
SF-1566 Wrap assigned users on mobile viewports

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
@@ -4,18 +4,20 @@
     <div *ngIf="noteThreadAssignedUserRef != null" id="assignedUser" class="assigned-user">
       >{{ getAssignedUserString(noteThreadAssignedUserRef) }}
     </div>
-    <button mat-icon-button [matMenuTriggerFor]="menu"><mat-icon>more_vert</mat-icon></button>
-    <mat-menu #menu="matMenu">
-      <button mat-menu-item (click)="toggleSegmentText()">
-        <mat-icon>compare</mat-icon>
-        <span>{{ showSegmentText ? t("hide_changes") : t("show_changes") }}</span>
-      </button>
-    </mat-menu>
   </h1>
   <mat-dialog-content class="content-padding" [ngClass]="{ rtl: isRtl, ltr: !isRtl }">
-    <div class="text">
-      <div class="note-text" [innerHTML]="noteContextText"></div>
-      <div *ngIf="showSegmentText" class="segment-text" [innerHTML]="segmentText"></div>
+    <div class="text-row">
+      <div class="text">
+        <div class="note-text" [innerHTML]="noteContextText"></div>
+        <div *ngIf="showSegmentText" class="segment-text" [innerHTML]="segmentText"></div>
+      </div>
+      <button mat-icon-button [matMenuTriggerFor]="menu"><mat-icon>more_vert</mat-icon></button>
+      <mat-menu #menu="matMenu">
+        <button mat-menu-item (click)="toggleSegmentText()">
+          <mat-icon>compare</mat-icon>
+          <span>{{ showSegmentText ? t("hide_changes") : t("show_changes") }}</span>
+        </button>
+      </mat-menu>
     </div>
     <div class="notes">
       <div *ngFor="let note of notes" class="note">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
@@ -4,27 +4,33 @@
 h1 {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   margin: -10px 0 10px;
 
   span {
     flex: 1;
-    margin-left: 10px;
+    margin: 0 10px;
+    white-space: nowrap;
   }
   > button {
     margin-right: -15px;
   }
 }
-.text {
-  color: $greenDark;
-  background: rgba(0, 0, 0, 0.05);
-  padding: 6px;
-  border-radius: 4px;
-  font-size: 0.9em;
-  .segment-text {
-    padding-top: 6px;
-    border-top: 2px solid $greenDark;
-    margin-top: 6px;
-    white-space: pre-wrap;
+.text-row {
+  display: flex;
+  .text {
+    color: $greenDark;
+    background: rgba(0, 0, 0, 0.05);
+    padding: 6px;
+    border-radius: 4px;
+    font-size: 0.9em;
+    flex: 1;
+    .segment-text {
+      padding-top: 6px;
+      border-top: 2px solid $greenDark;
+      margin-top: 6px;
+      white-space: pre-wrap;
+    }
   }
 }
 .notes {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -148,7 +148,7 @@
     "close": "Close",
     "hide_changes": "Hide changes",
     "note_reattached": "Note reattached",
-    "paratext_user": "Paratext user",
+    "paratext_user": "Assigned to a Paratext user",
     "reattached": "(Re-attached)",
     "show_changes": "Show changes",
     "status_resolved": "Resolved",


### PR DESCRIPTION
The note dialog would try to condense the information about the verse and assigned user on the same line on mobile viewports. This didn't look good when names and verse references were longer. This wraps the assigned user onto the second line, and moves the selected text menu button on the line with the selected text.

Before
<img width="199" alt="image" src="https://user-images.githubusercontent.com/17931130/169102572-7a74e68f-ce26-4355-9d94-612a3a890116.png">

After
<img width="191" alt="image" src="https://user-images.githubusercontent.com/17931130/169102236-e59b2cee-ecad-4502-a5d8-5ef07a23c06f.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1368)
<!-- Reviewable:end -->
