### PR TITLE
SF-1577 Fix nav drawer not closing keyboard on mobile

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -145,7 +145,6 @@
     *ngIf="isProjectSelected"
     [drawer]="isDrawerPermanent ? 'permanent' : 'modal'"
     [open]="isExpanded"
-    [autoFocus]="false"
     (closed)="drawerCollapsed()"
   >
     <mdc-drawer-header>


### PR DESCRIPTION
Steps to see the issue this fixes (taken from Jira issue):
- On mobile, place the cursor in the editor of the translate tool. This should open the on-screen keyboard.
- Tap the menu icon in the top left corner
- Observe that the keyboard stays open. 

You can then tell the keyboard to close itself (usually a down arrow on the keyboard), _but it reopens immediately_. This is a separate bug, but very closely related (and it makes this bug so much more annoying).

The nav menu needs to steal the focus from the editor, so the cursor will no longer be in the editor, and the keyboard will close.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1374)
<!-- Reviewable:end -->
