### PR TITLE
Convert auth service to use the new Auth0 SPA

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -22,6 +22,7 @@
         "@angular/pwa": "~12.2.17",
         "@angular/router": "~12.2.16",
         "@angular/service-worker": "~12.2.16",
+        "@auth0/auth0-spa-js": "^1.21.0",
         "@bugsnag/js": "^7.16.5",
         "@bugsnag/plugin-angular": "^7.16.5",
         "@ngneat/transloco": "^3.2.0",
@@ -816,6 +817,30 @@
       "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.10.1.tgz",
       "integrity": "sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==",
       "dev": true
+    },
+    "node_modules/@auth0/auth0-spa-js": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.21.0.tgz",
+      "integrity": "sha512-a+8+onJdOIUSEEjdIzP/BGd731DZjBn2Q0tH+v7H+bN9ldeuBOifnjPbFwQAriL+94SwkaqhoFx3L6uGDk3+vg==",
+      "dependencies": {
+        "abortcontroller-polyfill": "^1.7.3",
+        "browser-tabs-lock": "^1.2.15",
+        "core-js": "^3.20.3",
+        "es-cookie": "^1.3.2",
+        "fast-text-encoding": "^1.0.3",
+        "promise-polyfill": "^8.2.1",
+        "unfetch": "^4.2.0"
+      }
+    },
+    "node_modules/@auth0/auth0-spa-js/node_modules/core-js": {
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.2.tgz",
+      "integrity": "sha512-Z5I2vzDnEIqO2YhELVMFcL1An2CIsFe9Q7byZhs8c/QxummxZlAHw33TUHbIte987LkisOgL0LwQ1P9D6VISnA==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.16.7",
@@ -4853,6 +4878,11 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
+    "node_modules/abortcontroller-polyfill": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
+      "integrity": "sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q=="
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -5703,6 +5733,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-tabs-lock": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/browser-tabs-lock/-/browser-tabs-lock-1.2.15.tgz",
+      "integrity": "sha512-J8K9vdivK0Di+b8SBdE7EZxDr88TnATing7XoLw6+nFkXMQ6sVBh92K3NQvZlZU91AIkFRi0w3sztk5Z+vsswA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "lodash": ">=4.17.21"
       }
     },
     "node_modules/browserslist": {
@@ -8016,6 +8055,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-cookie": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-cookie/-/es-cookie-1.3.2.tgz",
+      "integrity": "sha512-UTlYYhXGLOy05P/vKVT2Ui7WtC7NiRzGtJyAKKn32g5Gvcjn7KAClLPWlipCtxIus934dFg9o9jXiBL0nP+t9Q=="
+    },
     "node_modules/es-module-lexer": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz",
@@ -9376,6 +9420,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+    },
+    "node_modules/fast-text-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
+      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
     },
     "node_modules/fast-url-parser": {
       "version": "1.1.3",
@@ -18911,6 +18960,11 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
+    "node_modules/promise-polyfill": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
+      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg=="
+    },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
@@ -23854,6 +23908,27 @@
       "integrity": "sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==",
       "dev": true
     },
+    "@auth0/auth0-spa-js": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.21.0.tgz",
+      "integrity": "sha512-a+8+onJdOIUSEEjdIzP/BGd731DZjBn2Q0tH+v7H+bN9ldeuBOifnjPbFwQAriL+94SwkaqhoFx3L6uGDk3+vg==",
+      "requires": {
+        "abortcontroller-polyfill": "^1.7.3",
+        "browser-tabs-lock": "^1.2.15",
+        "core-js": "^3.20.3",
+        "es-cookie": "^1.3.2",
+        "fast-text-encoding": "^1.0.3",
+        "promise-polyfill": "^8.2.1",
+        "unfetch": "^4.2.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.22.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.2.tgz",
+          "integrity": "sha512-Z5I2vzDnEIqO2YhELVMFcL1An2CIsFe9Q7byZhs8c/QxummxZlAHw33TUHbIte987LkisOgL0LwQ1P9D6VISnA=="
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
@@ -27116,6 +27191,11 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
+    "abortcontroller-polyfill": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
+      "integrity": "sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q=="
+    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -27758,6 +27838,14 @@
       "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "browser-tabs-lock": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/browser-tabs-lock/-/browser-tabs-lock-1.2.15.tgz",
+      "integrity": "sha512-J8K9vdivK0Di+b8SBdE7EZxDr88TnATing7XoLw6+nFkXMQ6sVBh92K3NQvZlZU91AIkFRi0w3sztk5Z+vsswA==",
+      "requires": {
+        "lodash": ">=4.17.21"
       }
     },
     "browserslist": {
@@ -29489,6 +29577,11 @@
         "unbox-primitive": "^1.0.2"
       }
     },
+    "es-cookie": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-cookie/-/es-cookie-1.3.2.tgz",
+      "integrity": "sha512-UTlYYhXGLOy05P/vKVT2Ui7WtC7NiRzGtJyAKKn32g5Gvcjn7KAClLPWlipCtxIus934dFg9o9jXiBL0nP+t9Q=="
+    },
     "es-module-lexer": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz",
@@ -30491,6 +30584,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+    },
+    "fast-text-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
+      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
     },
     "fast-url-parser": {
       "version": "1.1.3",
@@ -37517,6 +37615,11 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
+    },
+    "promise-polyfill": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
+      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg=="
     },
     "promise-retry": {
       "version": "2.0.1",

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -33,6 +33,7 @@
     "@angular/pwa": "~12.2.17",
     "@angular/router": "~12.2.16",
     "@angular/service-worker": "~12.2.16",
+    "@auth0/auth0-spa-js": "^1.21.0",
     "@bugsnag/js": "^7.16.5",
     "@bugsnag/plugin-angular": "^7.16.5",
     "@ngneat/transloco": "^3.2.0",

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app-routing.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app-routing.module.ts
@@ -12,7 +12,7 @@ import { StartComponent } from './start/start.component';
 import { SyncComponent } from './sync/sync.component';
 
 const routes: Routes = [
-  { path: 'callback', component: StartComponent, canActivate: [AuthGuard] },
+  { path: 'callback/auth0', component: StartComponent, canActivate: [AuthGuard] },
   { path: 'connect-project', component: ConnectProjectComponent, canActivate: [AuthGuard] },
   { path: 'login', redirectTo: 'projects', pathMatch: 'full' },
   { path: 'projects/:projectId/settings', component: SettingsComponent, canActivate: [SettingsAuthGuard] },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app-routing.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app-routing.module.ts
@@ -12,6 +12,7 @@ import { StartComponent } from './start/start.component';
 import { SyncComponent } from './sync/sync.component';
 
 const routes: Routes = [
+  { path: 'callback', component: StartComponent, canActivate: [AuthGuard] },
   { path: 'connect-project', component: ConnectProjectComponent, canActivate: [AuthGuard] },
   { path: 'login', redirectTo: 'projects', pathMatch: 'full' },
   { path: 'projects/:projectId/settings', component: SettingsComponent, canActivate: [SettingsAuthGuard] },

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.spec.ts
@@ -149,6 +149,6 @@ class TestEnvironment {
     this.httpClient = TestBed.inject(HttpClient);
 
     when(mockedAuthService.isAuthenticated()).thenResolve(isAuthenticated);
-    when(mockedAuthService.accessToken).thenReturn(isAuthenticated === true ? TestEnvironment.accessToken : '');
+    when(mockedAuthService.getAccessToken()).thenResolve(isAuthenticated === true ? TestEnvironment.accessToken : '');
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.ts
@@ -33,7 +33,7 @@ export class AuthHttpInterceptor implements HttpInterceptor {
     }
     // Add access token to the request header
     const authReq = req.clone({
-      headers: req.headers.set('Authorization', 'Bearer ' + this.authService.accessToken)
+      headers: req.headers.set('Authorization', 'Bearer ' + (await this.authService.getAccessToken()))
     });
     return await next.handle(authReq).toPromise();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
@@ -409,6 +409,10 @@ describe('AuthService', () => {
     });
     expect(env.isAuthenticated).toBe(true);
     verify(mockedLocationService.reload()).once();
+    verify(mockedNoticeService.showMessageDialog(anything(), anything())).once();
+    // handleOnlineAuth gets called a second time after the dialog is closed
+    verify(mockedRouter.navigateByUrl('/projects', anything())).twice();
+
     env.discardTokenExpiryTimer();
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
@@ -286,10 +286,11 @@ describe('AuthService', () => {
   }));
 
   it('should link with Paratext', fakeAsync(() => {
-    const env = new TestEnvironment();
+    const env = new TestEnvironment({ isOnline: true, isLoggedIn: true });
     const returnUrl = 'test-returnUrl';
 
     env.service.linkParatext(returnUrl);
+    tick();
 
     verify(mockedWebAuth.loginWithRedirect(anything())).once();
     const authOptions: RedirectLoginOptions | undefined = capture<RedirectLoginOptions | undefined>(
@@ -304,6 +305,7 @@ describe('AuthService', () => {
       expect(authOptions.language).toEqual(env.language);
       expect(authOptions.login_hint).toEqual(env.language);
     }
+    env.discardTokenExpiryTimer();
   }));
 
   it('should update interface language if logged in', fakeAsync(() => {
@@ -390,7 +392,8 @@ describe('AuthService', () => {
       isOnline: true,
       isNewlyLoggedIn: true,
       loginState: {
-        linking: true
+        linking: true,
+        currentSub: 'user01'
       }
     });
     expect(env.isAuthenticated).toBe(true);
@@ -403,7 +406,8 @@ describe('AuthService', () => {
       isOnline: true,
       isNewlyLoggedIn: true,
       loginState: {
-        linking: true
+        linking: true,
+        currentSub: 'user01'
       },
       accountLinkingResponse: new CommandError(CommandErrorCode.Other, 'paratext-linked-to-another-user')
     });
@@ -604,8 +608,8 @@ class TestEnvironment {
         if (accountLinkingResponse != null) {
           throw accountLinkingResponse;
         }
-        if (params?.authId != null) {
-          this._loginLinkedAccountId = params.authId;
+        if (params?.secondaryId != null) {
+          this._loginLinkedAccountId = params.secondaryId;
         }
       }
     );

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
@@ -571,6 +571,9 @@ class TestEnvironment {
       if (isLoggedIn && !isNewlyLoggedIn) {
         this.setLocalLoginData();
       }
+      if (isNewlyLoggedIn) {
+        when(mockedWebAuth.handleRedirectCallback()).thenResolve(this.auth0Response!.loginResult);
+      }
     } else {
       this.setLoginRequiredResponse();
     }
@@ -584,7 +587,11 @@ class TestEnvironment {
       this.localSettings.clear();
     });
     when(mockedLocationService.origin).thenReturn('http://localhost:5000');
-    when(mockedLocationService.href).thenReturn('http://localhost:5000/callback?code=1234&state=abcd');
+    if (isNewlyLoggedIn) {
+      when(mockedLocationService.href).thenReturn('http://localhost:5000/callback/auth0?code=1234&state=abcd');
+    } else {
+      when(mockedLocationService.href).thenReturn('http://localhost:5000/projects');
+    }
     when(mockedNoticeService.showMessageDialog(anything(), anything())).thenResolve();
     when(mockedAuth0Service.init(anything())).thenReturn(instance(mockedWebAuth));
     when(mockedAuth0Service.changePassword(anything())).thenReturn(new Promise(r => r));
@@ -693,7 +700,6 @@ class TestEnvironment {
       };
     }
     this.auth0Response = auth0Response;
-    when(mockedWebAuth.handleRedirectCallback()).thenResolve(this.auth0Response!.loginResult);
     when(mockedWebAuth.getTokenSilently()).thenResolve(this.auth0Response!.token.access_token);
     when(mockedWebAuth.getTokenSilently(anything())).thenResolve(this.auth0Response!.token);
     when(mockedWebAuth.getIdTokenClaims()).thenResolve(this.auth0Response!.idToken);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { translate } from '@ngneat/transloco';
 import {
+  Auth0Client,
   GetTokenSilentlyVerboseResponse,
   IdToken,
   LogoutOptions,
@@ -61,7 +62,7 @@ export class AuthService {
   private refreshSubscription?: Subscription;
   private renewTokenPromise?: Promise<void>;
   private checkSessionPromise?: Promise<GetTokenSilentlyVerboseResponse | null>;
-  private readonly auth0 = this.auth0Service.init({
+  private readonly auth0: Auth0Client = this.auth0Service.init({
     client_id: environment.authClientId,
     domain: environment.authDomain,
     redirect_uri: this.locationService.origin + '/callback/auth0',
@@ -160,7 +161,7 @@ export class AuthService {
 
   async getAccessToken(): Promise<string | undefined> {
     try {
-      return await this.auth0!.getTokenSilently();
+      return await this.auth0?.getTokenSilently();
     } catch {
       return undefined;
     }
@@ -334,6 +335,7 @@ export class AuthService {
             () => translate('connect_project.proceed')
           )
           .then(async () => {
+            // Strip out the state so that we don't process linking again
             const withoutState = clone(authDetails);
             if (withoutState != null) {
               withoutState.loginResult.appState = undefined;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -64,7 +64,7 @@ export class AuthService {
   private readonly auth0 = this.auth0Service.init({
     client_id: environment.authClientId,
     domain: environment.authDomain,
-    redirect_uri: this.locationService.origin + '/callback',
+    redirect_uri: this.locationService.origin + '/callback/auth0',
     scope: 'openid profile email ' + environment.scope,
     audience: environment.audience,
     cacheLocation: 'localstorage',
@@ -364,7 +364,7 @@ export class AuthService {
       callbackUrl = this.locationService.origin + callbackUrl;
     }
     const url = new URL(callbackUrl);
-    return url.origin + url.pathname === this.locationService.origin + '/callback';
+    return url.origin + url.pathname === this.locationService.origin + '/callback/auth0';
   }
 
   private scheduleRenewal(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -330,8 +330,8 @@ export class AuthService {
     if (primaryId != null && secondaryId != null) {
       try {
         await this.commandService.onlineInvoke(USERS_URL, 'linkParatextAccount', { primaryId, secondaryId });
-        // Trigger the login phase again so that local auth0 switches back its understanding to the primary account
-        // await this.logIn(state.returnUrl ?? '');
+        // Trigger a session check with auth0 so that tokens are reversed back to the primary account and not
+        // the Paratext account that was just merged into the primary - this causes a redirect back to auth0
         await this.auth0.checkSession({ ignoreCache: true });
       } catch (err) {
         if (!(err instanceof CommandError) || !err.message.includes(this.ptLinkedToAnotherUserKey)) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -340,12 +340,11 @@ export class AuthService {
             () => translate('connect_project.proceed')
           )
           .then(async () => {
-            // Strip out the state so that we don't process linking again
-            const withoutState = clone(authDetails);
-            if (withoutState != null) {
-              withoutState.loginResult.appState = undefined;
-            }
-            await this.handleOnlineAuth(withoutState);
+            // Strip out the linking state so that we don't process linking again
+            const withoutLinkingState = clone(authDetails);
+            delete state.linking;
+            withoutLinkingState.loginResult.appState = JSON.stringify(state);
+            await this.handleOnlineAuth(withoutLinkingState);
             // Reload the app for the new current user id to take effect
             this.locationService.reload();
           });

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -238,7 +238,12 @@ export class AuthService {
         return { loggedIn: false, newlyLoggedIn: false };
       }
       // If we have no valid auth0 data then we have to validate online first
-      if (this.idToken == null || this.expiresAt == null || (this.pwaService.isOnline && (await this.hasExpired()))) {
+      if (
+        this.idToken == null ||
+        this.expiresAt == null ||
+        (this.pwaService.isOnline && (await this.hasExpired())) ||
+        this.isCallbackUrl()
+      ) {
         return await this.tryOnlineLogIn();
       }
       // We don't want to check for an access token unless we know it is likely to be there
@@ -259,7 +264,7 @@ export class AuthService {
     try {
       if (await this.pwaService.checkOnline()) {
         // Check if this is a valid callback from auth0
-        if (!this.isCallbackUrl(this.locationService.href)) {
+        if (!this.isCallbackUrl()) {
           // Check session with auth0 as it may be able to renew silently
           const token = await this.checkSession();
           if (token == null) {
@@ -366,7 +371,7 @@ export class AuthService {
     return !(returnUrl == null || this.isCallbackUrl(returnUrl) || returnUrl === '/login');
   }
 
-  private isCallbackUrl(callbackUrl: string | undefined): boolean {
+  private isCallbackUrl(callbackUrl: string | undefined = undefined): boolean {
     if (callbackUrl == null) {
       callbackUrl = this.locationService.href;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth0.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth0.service.spec.ts
@@ -1,0 +1,49 @@
+import { anything, capture, mock, when } from 'ts-mockito';
+import { HttpClient } from '@angular/common/http';
+import { configureTestingModule } from 'xforge-common/test-utils';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { Auth0Service } from 'xforge-common/auth0.service';
+import { Auth0ClientOptions } from '@auth0/auth0-spa-js';
+import { of } from 'rxjs';
+
+const mockedHttpClient = mock(HttpClient);
+
+describe('Auth0Service', () => {
+  configureTestingModule(() => ({
+    providers: [{ provide: HttpClient, useMock: mockedHttpClient }]
+  }));
+
+  it('should init a new Auth0 Client', fakeAsync(() => {
+    const env = new TestEnvironment();
+    const options: Auth0ClientOptions = {
+      client_id: '12345',
+      domain: 'localhost:5000'
+    };
+
+    const client = env.service.init(options);
+    expect(client).toBeDefined();
+    client.buildAuthorizeUrl().then(authUrl => {
+      const url = new URL(authUrl);
+      expect(url.searchParams.get('client_id')).toBe(options.client_id);
+    });
+    tick();
+  }));
+
+  it('should generate a new change password request', fakeAsync(() => {
+    const env = new TestEnvironment();
+    const email = 'test@example.com';
+    env.service.changePassword(email);
+    const httpOptions = capture(mockedHttpClient.post).last();
+    expect(httpOptions[0].includes('dbconnections/change_password')).toBe(true);
+    expect(httpOptions[1]).toEqual({ connection: 'Username-Password-Authentication', email });
+  }));
+});
+
+class TestEnvironment {
+  readonly service: Auth0Service;
+
+  constructor() {
+    when(mockedHttpClient.post(anything(), anything(), anything())).thenReturn(of());
+    this.service = TestBed.inject(Auth0Service);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth0.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth0.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@angular/core';
-import { AuthOptions, WebAuth } from 'auth0-js';
+import { Auth0Client, Auth0ClientOptions } from '@auth0/auth0-spa-js';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../environments/environment';
 
 /**
  * Wrapper around WebAuth. This injectable service can be mocked to make dependencies of it testable.
@@ -8,7 +10,17 @@ import { AuthOptions, WebAuth } from 'auth0-js';
   providedIn: 'root'
 })
 export class Auth0Service {
-  init(options: AuthOptions): WebAuth {
-    return new WebAuth(options);
+  constructor(private readonly http: HttpClient) {}
+
+  init(options: Auth0ClientOptions): Auth0Client {
+    return new Auth0Client(options);
+  }
+
+  changePassword(email: string): Promise<any> {
+    const url = `https://${environment.authDomain}/dbconnections/change_password`;
+    const body = { connection: 'Username-Password-Authentication', email };
+    return this.http
+      .post(url, body, { headers: { 'Content-Type': 'application/json' }, responseType: 'text' })
+      .toPromise();
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth0.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth0.service.ts
@@ -16,7 +16,7 @@ export class Auth0Service {
     return new Auth0Client(options);
   }
 
-  changePassword(email: string): Promise<any> {
+  changePassword(email: string): Promise<string> {
     const url = `https://${environment.authDomain}/dbconnections/change_password`;
     const body = { connection: 'Username-Password-Authentication', email };
     return this.http

--- a/src/SIL.XForge.Scripture/Pages/Index.cshtml
+++ b/src/SIL.XForge.Scripture/Pages/Index.cshtml
@@ -4,22 +4,20 @@
 @inject IHtmlLocalizer<SharedResource> SharedLocalizer
 @model IndexModel
 @section scripts {
-<script src="https://cdn.auth0.com/js/auth0/9.16/auth0.min.js"></script>
+<script src="https://cdn.auth0.com/js/auth0-spa-js/1.12/auth0-spa-js.production.js"></script>
 <script type="text/javascript">
-    var webAuth = new auth0.WebAuth({
-        clientID: '@ViewData["ClientId"]',
+    var webAuth = new Auth0Client({
+        client_id: '@ViewData["ClientId"]',
         domain: '@ViewData["Domain"]',
-        responseType: 'token id_token',
-        redirectUri: window.location.origin + '/projects',
+        redirect_uri: window.location.origin + '/callback',
         scope: 'openid profile email @ViewData["Scope"]',
-        audience: '@ViewData["Audience"]'
+        audience: '@ViewData["Audience"]',
+        cacheLocation: 'localstorage',
+        useRefreshTokens: true
     });
-    webAuth.checkSession({}, function (err, authResult) {
-        if (!err) {
-            var options = { state: JSON.stringify({}) };
-            webAuth.authorize(options);
-        }
-    });
+    webAuth.getTokenSilently().then(() => {
+        window.location.href = "/projects";
+    }).catch(() => { });
 </script>
 }
 
@@ -82,7 +80,7 @@
                             "</span>",
                             "<a href=\"https://paratext.org/\" rel=\"noopener noreferrer\" target=\"_blank\">", "</a>",
                             "<a href=\"https://paratext.org/features/translation-notes-and-comments/\" " +
-                                "rel=\"noopener noreferrer\" target=\"_blank\">"
+                            "rel=\"noopener noreferrer\" target=\"_blank\">"
                             ]))</p>
                     </div>
                     <div class="about-feature">

--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -53,6 +53,7 @@ namespace SIL.XForge.Scripture
         };
         private static readonly HashSet<string> SpaGetRoutes = new HashSet<string>
         {
+            "callback",
             "connect-project",
             "login",
             "projects",

--- a/src/SIL.XForge/Controllers/UsersRpcController.cs
+++ b/src/SIL.XForge/Controllers/UsersRpcController.cs
@@ -51,11 +51,11 @@ namespace SIL.XForge.Controllers
             return Ok();
         }
 
-        public async Task<IRpcMethodResult> LinkParatextAccount(string authId)
+        public async Task<IRpcMethodResult> LinkParatextAccount(string primaryId, string secondaryId)
         {
             try
             {
-                await _userService.LinkParatextAccountAsync(UserId, AuthId, authId);
+                await _userService.LinkParatextAccountAsync(primaryId, secondaryId);
                 return Ok();
             }
             catch (ArgumentException e)

--- a/src/SIL.XForge/Services/IUserService.cs
+++ b/src/SIL.XForge/Services/IUserService.cs
@@ -5,7 +5,7 @@ namespace SIL.XForge.Services
     public interface IUserService
     {
         Task UpdateUserFromProfileAsync(string curUserId, string userProfileJson);
-        Task LinkParatextAccountAsync(string curUserId, string primaryAuthId, string secondaryAuthId);
+        Task LinkParatextAccountAsync(string primaryAuthId, string secondaryAuthId);
         Task UpdateInterfaceLanguageAsync(string curUserId, string authId, string language);
         Task DeleteAsync(string curUserId, string systemRole, string userId);
     }

--- a/test/SIL.XForge.Tests/Services/UserServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/UserServiceTests.cs
@@ -92,7 +92,7 @@ namespace SIL.XForge.Services
             JObject ptProfile = env.CreateUserProfile("newPtProfile", "paratext|paratext01", env.IssuedAt);
             env.AuthService.GetUserAsync("paratext|paratext01").Returns(Task.FromResult(ptProfile.ToString()));
 
-            await env.Service.LinkParatextAccountAsync("user02", "auth02", "paratext|paratext01");
+            await env.Service.LinkParatextAccountAsync("auth02", "paratext|paratext01");
             User user2 = env.GetUser("user02");
             Assert.That(user2.ParatextId, Is.EqualTo("paratext01"));
             UserSecret userSecret = env.UserSecrets.Get("user02");
@@ -107,7 +107,7 @@ namespace SIL.XForge.Services
             env.AuthService.GetUserAsync("notPt03").Returns(Task.FromResult(userProfile.ToString()));
 
             Assert.ThrowsAsync<ArgumentException>(() =>
-                env.Service.LinkParatextAccountAsync("user02", "auth02", "notPt03")
+                env.Service.LinkParatextAccountAsync("auth02", "notPt03")
             );
         }
 


### PR DESCRIPTION
- Converted `AuthService` to use the new Auth0 SPA package
- Enable use of refresh tokens which then automatically uses the offline scope
- Fixed tests setup to better replicate different logging in flows
- Improved handling of return URL to avoid redirect loops
- Used a new dedicated callback URL to know when to check with auth0 on handling the callback code

Updates made to auth0 configuration
- Added `http://localhost:5000/callback` as a new callback URL
- Removed old beta callback URLs
- Refresh token rotation enabled
- API access settings | enabled Allow Offline Access

There appears to be a few different circumstances to trigger an update to tokens:
- API token settings expiry is hit - this appear to be our main use of the `expires_at` setting
- Application ID Token expiration

Both of those are stored and handled but the auth0 package and it will automatically renew them as required. We currently have a renewal timer set on the API expiration so that we can force a refresh early enough before we send the access token to the backend. The default for the ID Token expiration is 36000 or 10 hours. I currently have both of these set to 300 or 5 minutes. 30 seconds prior to this a silent token exchange will take place and the expiration will be reset to another 5 minutes. All going well there will be no redirect take place as it was at this point browsers that blocked 3rd party cookies would return a `login_required` response.

The expected behavior after switching to the new auth flow is:
- If the browser is already running the app then nothing will change. On an expired token if the browser supports 3rd party cookies then it will continue to authenticate fine. If the browser does not support 3rd party cookies it will get the usual `login_required` response sending you back to auth0. Auth0 will likely assume you're already logged in and send you back to SF. SF will not have the new token data required from the new auth0 package and will attempt to log the user in again but this time with the correct callback and scope. Auth0 will now prompt for the `offline_access` scope and then redirect back to SF where you left off.
- If the browser is reloaded, and you're already logged in, then it will be redirected to auth0 for the new `offline_access` scope

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1375)
<!-- Reviewable:end -->
