### PR TITLE
SF-1579 Implement rtl ui

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -116,14 +116,8 @@
                 </div>
                 <mdc-list-divider></mdc-list-divider>
                 <div class="online-status">
-                  <div *ngIf="isAppOnline" fxLayout="row" fxLayoutAlign="center center">
-                    <mdc-icon>cloud</mdc-icon>
-                    {{ t("online") }}
-                  </div>
-                  <div *ngIf="!isAppOnline" fxLayout="row" fxLayoutAlign="center center">
-                    <mdc-icon mdcListItemGraphic>cloud_off</mdc-icon>
-                    {{ t("offline") }}
-                  </div>
+                  <ng-container *ngIf="isAppOnline"><mdc-icon>cloud</mdc-icon> {{ t("online") }}</ng-container>
+                  <ng-container *ngIf="!isAppOnline"><mdc-icon>cloud_off</mdc-icon> {{ t("offline") }}</ng-container>
                 </div>
               </mdc-list-group>
             </mdc-menu>
@@ -165,100 +159,108 @@
       </mdc-select>
     </mdc-drawer-header>
     <mdc-drawer-content>
-      <mdc-list id="menu-list">
-        <mdc-list-item
+      <mat-nav-list id="menu-list">
+        <a
+          mat-list-item
           class="translate-nav-item"
           *ngIf="isTranslateEnabled"
-          (selectionChange)="translateVisible = !translateVisible"
+          (click)="translateVisible = !translateVisible"
         >
-          <mdc-icon svgIcon="translate"></mdc-icon>
+          <mdc-icon svgIcon="translate" class="translate-icon"></mdc-icon>
           {{ t("translate") }}
-          <mdc-icon *ngIf="!hasSingleAppEnabled" mdcListItemMeta>
-            keyboard_arrow_{{ translateVisible ? "down" : "right" }}
-          </mdc-icon>
-        </mdc-list-item>
+          <mat-icon *ngIf="!hasSingleAppEnabled">
+            keyboard_arrow_{{ translateVisible ? "down" : i18n.forwardDirectionWord }}
+          </mat-icon>
+        </a>
         <div *ngIf="isTranslateEnabled && (translateVisible || hasSingleAppEnabled)">
-          <mdc-list-item [appRouterLink]="getRouterLink('translate')" (selectionChange)="itemSelected()">
-            <mdc-icon mdcListItemGraphic>apps</mdc-icon>
+          <a mat-list-item [appRouterLink]="getRouterLink('translate')" (click)="itemSelected()">
+            <mat-icon matListIcon>apps</mat-icon>
             {{ t("overview") }}
-          </mdc-list-item>
-          <mdc-list-item
+          </a>
+          <a
+            mat-list-item
             *ngFor="let text of texts"
             [appRouterLink]="getRouterLink('translate', getBookId(text))"
-            (selectionChange)="itemSelected()"
+            (click)="itemSelected()"
           >
-            <mdc-icon mdcListItemGraphic>book</mdc-icon>
+            <mat-icon matListIcon>book</mat-icon>
             {{ getBookName(text) }}
-          </mdc-list-item>
+          </a>
         </div>
-        <mdc-list-divider *ngIf="isTranslateEnabled"></mdc-list-divider>
-        <mdc-list-item
+        <mat-divider *ngIf="isTranslateEnabled"></mat-divider>
+        <a
+          mat-list-item
           class="community-checking-nav-item"
           *ngIf="isCheckingEnabled"
-          (selectionChange)="checkingVisible = !checkingVisible"
+          (click)="checkingVisible = !checkingVisible"
         >
-          <mdc-icon mdcListItemGraphic>question_answer</mdc-icon>
+          <mat-icon mat-list-icon>question_answer</mat-icon>
           {{ t("community_checking") }}
-          <mdc-icon *ngIf="!hasSingleAppEnabled" mdcListItemMeta>
-            keyboard_arrow_{{ checkingVisible ? "down" : "right" }}
-          </mdc-icon>
-        </mdc-list-item>
+          <mat-icon *ngIf="!hasSingleAppEnabled">
+            keyboard_arrow_{{ checkingVisible ? "down" : i18n.forwardDirectionWord }}
+          </mat-icon>
+        </a>
         <div *ngIf="isCheckingEnabled && (checkingVisible || hasSingleAppEnabled)">
-          <mdc-list-item [appRouterLink]="getRouterLink('checking')" (selectionChange)="itemSelected()">
-            <mdc-icon mdcListItemGraphic>apps</mdc-icon>
+          <a mat-list-item [appRouterLink]="getRouterLink('checking')" (click)="itemSelected()">
+            <mat-icon mat-list-icon>apps</mat-icon>
             {{ t("overview") }}
-          </mdc-list-item>
-          <mdc-list-item
+          </a>
+          <a
+            mat-list-item
             *ngIf="showAllQuestions"
             [appRouterLink]="getRouterLink('checking', 'ALL')"
-            (selectionChange)="itemSelected()"
+            (click)="itemSelected()"
           >
-            <mdc-icon mdcListItemGraphic>bookmarks</mdc-icon>
+            <mat-icon mat-list-icon>bookmarks</mat-icon>
             {{ t("all_questions") }}
-          </mdc-list-item>
+          </a>
           <ng-container *ngFor="let text of texts">
-            <mdc-list-item
+            <a
+              mat-list-item
               *ngIf="hasQuestions(text)"
               [appRouterLink]="getRouterLink('checking', getBookId(text))"
-              (selectionChange)="itemSelected()"
+              (click)="itemSelected()"
             >
-              <mdc-icon mdcListItemGraphic>book</mdc-icon>
+              <mat-icon mat-list-icon>book</mat-icon>
               {{ getBookName(text) }}
-            </mdc-list-item>
+            </a>
           </ng-container>
         </div>
         <div *ngIf="canSync$ | async">
-          <mdc-list-divider *ngIf="isCheckingEnabled"></mdc-list-divider>
-          <mdc-list-item
+          <mat-divider *ngIf="isCheckingEnabled"></mat-divider>
+          <a
+            mat-list-item
             [appRouterLink]="getRouterLink('sync')"
             [class.list-item-disabled]="!isAppOnline"
-            (selectionChange)="itemSelected()"
+            (click)="itemSelected()"
           >
-            <mdc-icon mdcListItemGraphic>sync</mdc-icon>
+            <mat-icon mat-list-icon>sync</mat-icon>
             {{ t("synchronize") }}
-          </mdc-list-item>
+          </a>
         </div>
         <div *ngIf="canSeeSettings$ | async">
-          <mdc-list-item
+          <a
+            mat-list-item
             [appRouterLink]="getRouterLink('settings')"
             [class.list-item-disabled]="!isAppOnline"
-            (selectionChange)="itemSelected()"
+            (click)="itemSelected()"
           >
-            <mdc-icon mdcListItemGraphic>settings</mdc-icon>
+            <mat-icon mat-list-icon>settings</mat-icon>
             {{ t("settings") }}
-          </mdc-list-item>
+          </a>
         </div>
         <div *ngIf="canSeeUsers$ | async">
-          <mdc-list-item
+          <a
+            mat-list-item
             [appRouterLink]="getRouterLink('users')"
             [class.list-item-disabled]="!isAppOnline"
-            (selectionChange)="itemSelected()"
+            (click)="itemSelected()"
           >
-            <mdc-icon mdcListItemGraphic>people</mdc-icon>
+            <mat-icon mat-list-icon>people</mat-icon>
             {{ t("users") }}
-          </mdc-list-item>
+          </a>
         </div>
-      </mdc-list>
+      </mat-nav-list>
     </mdc-drawer-content>
   </mdc-drawer>
   <!-- The cdkScrollable attribute is needed so the CDK can listen to scroll events within this container -->

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -35,32 +35,6 @@
           height: unset;
           min-height: 48px;
         }
-        .mdc-list-divider {
-          margin: 8px 0;
-        }
-      }
-    }
-  }
-
-  .mdc-list-item {
-    cursor: pointer;
-    &:hover,
-    &.mdc-list-item--activated {
-      mdc-icon {
-        color: $purpleLight;
-        fill: $purpleLight;
-      }
-    }
-    mdc-icon {
-      color: $purpleMedium;
-      fill: $purpleMedium;
-      transition: color 0.15s;
-    }
-    mdc-icon:first-child {
-      margin-right: 24px;
-      &.ngx-mdc-icon {
-        width: 24px;
-        height: 24px;
       }
     }
   }
@@ -79,7 +53,7 @@
     mdc-top-app-bar-section {
       mdc-menu {
         min-width: 200px;
-        text-align: left; // Needed for some menu items in Chrome but not Firefox
+        text-align: start; // Needed for some menu items in Chrome but not Firefox
         a {
           width: 100%;
           color: var(--mdc-theme-text-primary-on-background);
@@ -172,21 +146,20 @@ a {
   mdc-list-item:not(.active-locale) mdc-icon {
     visibility: hidden;
   }
-  mdc-icon {
-    margin-right: 0.5em;
-  }
 }
 
 .locale-menu .mdc-list-item {
   white-space: nowrap;
   font-family: $languageFonts;
+  column-gap: 0.5em;
 }
 
 .online-status {
+  display: flex;
+  column-gap: 10px;
+  justify-content: center;
+  align-items: center;
   padding-bottom: 8px;
-  mdc-icon {
-    margin-right: 10px;
-  }
 }
 
 :host,
@@ -198,4 +171,47 @@ a {
       fill: var(--mdc-theme-text-disabled-on-background);
     }
   }
+}
+
+.translate-icon {
+  width: 24px;
+  height: 24px;
+}
+
+mat-nav-list .mat-list-item {
+  height: 48px;
+  font-weight: 500;
+  font-size: 14px;
+
+  mat-icon,
+  mdc-icon {
+    color: $purpleMedium;
+    fill: $purpleMedium;
+    transition: color 0.15s;
+    padding: 0;
+  }
+  &.activated-nav-item,
+  &:hover {
+    mat-icon,
+    mdc-icon {
+      color: $purpleLight;
+      fill: $purpleLight;
+    }
+  }
+
+  mat-icon:last-child {
+    margin-left: auto;
+  }
+
+  ::ng-deep .mat-list-item-content {
+    column-gap: 16px;
+  }
+}
+
+.mat-list-item.activated-nav-item {
+  background-color: #e7e8e7;
+}
+
+#menu-list {
+  padding-top: 6px;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -1,5 +1,4 @@
 import { MdcDialog, MdcDialogRef } from '@angular-mdc/web';
-import { MdcList, MdcListItem } from '@angular-mdc/web/list';
 import { CommonModule, Location } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement, NgModule, NgZone } from '@angular/core';
@@ -434,7 +433,7 @@ describe('AppComponent', () => {
       env.remoteAddQuestion(env.questions[1]);
       // Expect: Community Checking | Overview | All Questions | Luke | John | Synchronize | Settings | Users
       expect(env.menuLength).toEqual(8);
-      expect(env.menuList.getListItemByIndex(2)!.getListItemElement().textContent).toContain('All Questions');
+      expect(env.menuListItems[2].nativeElement.textContent).toContain('All Questions');
     }));
 
     it('books displayed in canonical order', fakeAsync(() => {
@@ -634,14 +633,12 @@ class TestEnvironment {
     return this.fixture.debugElement.query(By.css('#menu-drawer'));
   }
 
-  get menuList(): MdcList {
-    const listElem = this.fixture.debugElement.query(By.css('#menu-list'));
-    return listElem.componentInstance;
+  get menuListItems(): DebugElement[] {
+    return this.fixture.debugElement.queryAll(By.css('#menu-list .mat-list-item'));
   }
 
-  get helpMenuList(): MdcList {
-    const listElem = this.fixture.debugElement.query(By.css('#help-menu-list'));
-    return listElem.componentInstance;
+  get helpMenuList(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#help-menu-list'));
   }
 
   get navBar(): DebugElement {
@@ -657,7 +654,7 @@ class TestEnvironment {
   }
 
   get menuLength(): number {
-    return this.menuList.items.length;
+    return this.menuListItems.length;
   }
 
   get isDrawerVisible(): boolean {
@@ -673,18 +670,15 @@ class TestEnvironment {
   }
 
   getMenuItemText(index: number): string {
-    const menuItem = this.fixture.debugElement.query(By.css('#menu-list div mdc-list-item:nth-child(' + index + ')'));
-    return menuItem.nativeElement.textContent;
+    return this.menuListItems[index].nativeElement.textContent;
   }
 
-  getMenuItemContaining(substring: string): MdcListItem | undefined {
-    return this.menuList.items.find((item: MdcListItem) => item.elementRef.nativeElement.innerText.includes(substring));
+  getMenuItemContaining(substring: string): DebugElement | undefined {
+    return this.menuListItems.find((item: DebugElement) => item.nativeElement.innerText.includes(substring));
   }
 
-  getHelpMenuItemContaining(substring: string): MdcListItem | undefined {
-    return this.helpMenuList.items.find((item: MdcListItem) =>
-      item.elementRef.nativeElement.innerText.includes(substring)
-    );
+  getHelpMenuItemContaining(substring: string): DebugElement | undefined {
+    return this.helpMenuList.children.find((item: DebugElement) => item.nativeElement.innerText.includes(substring));
   }
 
   someMenuItemContains(substring: string): boolean {
@@ -748,7 +742,7 @@ class TestEnvironment {
   }
 
   selectItem(index: number): void {
-    const elem = this.menuList.getListItemByIndex(index)!.getListItemElement();
+    const elem = this.menuListItems[index].nativeElement;
     elem.click();
     this.wait();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -1,8 +1,8 @@
 <ng-container *transloco="let t; read: 'checking_overview'">
-  <div fxLayout="row" fxLayoutAlign="start center" [ngClass]="{ 'reviewer-panels': !canCreateQuestion }">
-    <mat-icon fxFlex="32px">library_books</mat-icon>
-    <h2 fxFlex>{{ t("texts_with_questions") }}</h2>
-    <div fxFlexAlign="center" *ngIf="canCreateQuestion; else overallProgressChart" class="primary-actions">
+  <div [ngClass]="{ 'reviewer-panels': !canCreateQuestion }" class="header">
+    <mat-icon>library_books</mat-icon>
+    <h2>{{ t("texts_with_questions") }}</h2>
+    <ng-container *ngIf="canCreateQuestion; else overallProgressChart" class="primary-actions">
       <button mdc-button type="button" *ngIf="showImportButton" (click)="importDialog()" id="import-btn">
         {{ t("import_questions") }}
       </button>
@@ -16,7 +16,7 @@
       >
         <mat-icon>post_add</mat-icon> <span fxHide.xs>{{ t("add_question") }}</span>
       </button>
-    </div>
+    </ng-container>
     <ng-template #overallProgressChart>
       <div id="overall-progress-chart">
         <app-donut-chart [colors]="['#3a3a3a', '#edecec', '#B8D332']" [data]="overallProgress()"></app-donut-chart>
@@ -33,7 +33,7 @@
         >
           <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
             <mat-icon fxFlex="24px" mdcListItemMeta>
-              keyboard_arrow_{{ itemVisible[getBookId(text)] ? "down" : "right" }}
+              keyboard_arrow_{{ itemVisible[getBookId(text)] ? "down" : i18n.forwardDirectionWord }}
             </mat-icon>
             <span fxFlex>{{ getBookName(text) }}</span>
             <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
@@ -57,7 +57,9 @@
               <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
                 <span fxFlex="16px" class="indent"></span>
                 <mat-icon fxFlex="24px" mdcListItemMeta>
-                  keyboard_arrow_{{ itemVisible[getTextDocId(text.bookNum, chapter.number)] ? "down" : "right" }}
+                  keyboard_arrow_{{
+                    itemVisible[getTextDocId(text.bookNum, chapter.number)] ? "down" : i18n.forwardDirectionWord
+                  }}
                 </mat-icon>
                 <span fxFlex>{{ getBookName(text) + " " + chapter?.number }}</span>
                 <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
@@ -175,9 +177,9 @@
     </mat-card>
   </div>
 
-  <div fxLayout="row" fxLayoutAlign="start center" *ngIf="canEditQuestion">
-    <mat-icon fxFlex="32px">archive</mat-icon>
-    <h2 fxFlex>{{ t("archived_questions") }}</h2>
+  <div *ngIf="canEditQuestion" class="header">
+    <mat-icon>archive</mat-icon>
+    <h2>{{ t("archived_questions") }}</h2>
   </div>
 
   <div fxLayout="column" *ngIf="canEditQuestion">
@@ -189,7 +191,7 @@
         >
           <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
             <mat-icon fxFlex="24px" mdcListItemMeta
-              >keyboard_arrow_{{ itemVisibleArchived[getBookId(text)] ? "down" : "right" }}</mat-icon
+              >keyboard_arrow_{{ itemVisibleArchived[getBookId(text)] ? "down" : i18n.forwardDirectionWord }}</mat-icon
             ><span fxFlex>{{ getBookName(text) }}</span>
             <span fxFlex="80px" fxShow fxHide.xs fxLayoutAlign="end center" class="archived-questions-count">
               {{ questionCountLabel(bookQuestionCount(text, true)) }}
@@ -209,7 +211,7 @@
                 <span fxFlex="16px" class="indent"></span>
                 <mat-icon fxFlex="24px" mdcListItemMeta
                   >keyboard_arrow_{{
-                    itemVisibleArchived[getTextDocId(text.bookNum, chapter.number)] ? "down" : "right"
+                    itemVisibleArchived[getTextDocId(text.bookNum, chapter.number)] ? "down" : i18n.forwardDirectionWord
                   }}</mat-icon
                 >
                 <span fxFlex>{{ getBookName(text) + " " + chapter?.number }}</span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
@@ -1,8 +1,15 @@
 @import 'src/variables';
 @import 'bootstrap/scss/mixins/breakpoints';
 
-.primary-actions .mdc-button:not(:first-child) {
-  margin-left: $button-spacing;
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
+  column-gap: 8px;
+  h2 {
+    flex-grow: 1;
+  }
 }
 
 #add-question-button {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.scss
@@ -28,7 +28,7 @@
         position: absolute;
         content: '';
         background-color: transparent;
-        left: 0;
+        inset-inline-start: 0;
         top: 0;
         height: 100%;
         width: 5px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -11,7 +11,7 @@
         <div class="d-flex flex-max" id="questions-panel">
           <div class="flex-max">
             <div class="panel">
-              <div class="panel-heading">
+              <div class="panel-heading heading-with-icon">
                 <mdc-icon>help</mdc-icon>
                 <h2>{{ t("questions", { count: totalQuestions() }) }}</h2>
                 <button mdc-icon-button class="collapse-question-menu" (click)="collapseDrawer()" icon="clear"></button>
@@ -37,7 +37,7 @@
           <div class="panel">
             <div class="panel-heading">
               <div class="panel-nav">
-                <div>
+                <div class="heading-with-icon">
                   <mdc-icon fxHide.lt-md>library_books</mdc-icon>
                   <div #textNameAnchor mdcMenuSurfaceAnchor>
                     <h2
@@ -144,7 +144,8 @@
               [disabled]="!questionsPanel.checkCanChangeQuestion(-1)"
               class="prev-question"
             >
-              <mdc-icon>chevron_left</mdc-icon>{{ t("previous") }}
+              <mdc-icon>chevron_{{ i18n.backwardDirectionWord }}</mdc-icon
+              >{{ t("previous") }}
             </button>
             <button
               mdc-button
@@ -154,7 +155,7 @@
               [disabled]="!questionsPanel.checkCanChangeQuestion(1)"
               class="next-question"
             >
-              {{ t("next") }}<mdc-icon>chevron_right</mdc-icon>
+              {{ t("next") }}<mdc-icon>chevron_{{ i18n.forwardDirectionWord }}</mdc-icon>
             </button>
             <button
               mdc-icon-button
@@ -163,7 +164,7 @@
               (click)="questionsPanel.previousQuestion()"
               [disabled]="!questionsPanel.checkCanChangeQuestion(-1)"
               class="prev-question"
-              icon="chevron_left"
+              icon="chevron_{{ i18n.backwardDirectionWord }}"
             ></button>
             <button
               mdc-icon-button
@@ -172,7 +173,7 @@
               (click)="questionsPanel.nextQuestion()"
               [disabled]="!questionsPanel.checkCanChangeQuestion(1)"
               class="next-question"
-              icon="chevron_right"
+              icon="chevron_{{ i18n.forwardDirectionWord }}"
             ></button>
             <a [appRouterLink]="routerLink" id="project-summary">
               <app-donut-chart

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -135,3 +135,8 @@
     }
   }
 }
+
+.heading-with-icon {
+  display: flex;
+  column-gap: 10px;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -108,7 +108,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
     noticeService: NoticeService,
     private readonly router: Router,
     private readonly questionDialogService: QuestionDialogService,
-    private readonly i18n: I18nService,
+    readonly i18n: I18nService,
     private readonly pwaService: PwaService
   ) {
     super(noticeService);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; read: 'question_dialog'">
   <mdc-dialog>
-    <mdc-dialog-container>
+    <mdc-dialog-container [dir]="i18n.direction">
       <mdc-dialog-surface class="dialog-size">
         <mdc-dialog-title fxLayoutAlign="start center">
           <i class="material-icons">live_help</i> {{ modeLabel }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; read: 'scripture_chooser_dialog'">
   <mdc-dialog>
-    <mdc-dialog-container class="dialogContainer">
+    <mdc-dialog-container class="dialogContainer" [dir]="i18n.direction">
       <mdc-dialog-surface id="bookPane" *ngIf="showing === 'books'">
         <mdc-dialog-title>
           <button mdcIconButton class="backout-button" (click)="onClickBackoutButton()" (focus)="onCloseFocus($event)">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'delete_project_dialog'">
-  <mdc-dialog>
+  <mdc-dialog [dir]="i18n.direction">
     <mdc-dialog-container>
       <mdc-dialog-surface>
         <mdc-dialog-title id="title"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.html
@@ -14,7 +14,7 @@
   <button
     mdc-icon-button
     appBlurOnClick
-    icon="keyboard_arrow_left"
+    icon="keyboard_arrow_{{ i18n.backwardDirectionWord }}"
     type="button"
     (click)="prevChapter()"
     [disabled]="isPrevChapterDisabled()"
@@ -24,7 +24,7 @@
   <button
     mdc-icon-button
     appBlurOnClick
-    icon="keyboard_arrow_right"
+    icon="keyboard_arrow_{{ i18n.forwardDirectionWord }}"
     type="button"
     (click)="nextChapter()"
     [disabled]="isNextChapterDisabled()"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.scss
@@ -32,7 +32,10 @@
 
     .mdc-select__selected-text {
       min-width: 140px;
-      padding: 8px 2em 8px 8px !important;
+      padding-top: 8px !important;
+      padding-bottom: 8px !important;
+      padding-inline-start: 8px !important;
+      padding-inline-end: 2em !important;
     }
 
     .mdc-select__dropdown-icon {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.ts
@@ -13,7 +13,7 @@ export class ChapterNavComponent {
 
   @Output() chapterChange = new EventEmitter<number>();
 
-  constructor(private i18n: I18nService) {}
+  constructor(readonly i18n: I18nService) {}
 
   get bookName(): string {
     return this.bookNum == null ? '' : this.i18n.localizeBook(this.bookNum);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.scss
@@ -1,16 +1,24 @@
 @import 'bootstrap/scss/mixins/breakpoints';
 
 @import 'src/variables';
+
 form {
   display: flex;
   width: 100%;
+  column-gap: 20px;
   @include media-breakpoint-down(sm) {
     flex-direction: column;
   }
-  #email {
-    flex: 1;
-  }
 }
+
+#email {
+  flex-grow: 1;
+}
+
+:host.share-dialog form {
+  flex-direction: column;
+}
+
 mdc-text-field {
   width: 100%;
 }
@@ -23,22 +31,6 @@ mdc-text-field {
 #send-btn {
   // add margin that is same height as the text field helper text, so the button is centered properly
   margin-bottom: 19px;
-}
-
-:host:not(.share-dialog) {
-  mat-form-field {
-    &:not(:last-child) {
-      @include media-breakpoint-up(md) {
-        margin-right: 20px;
-      }
-    }
-  }
-}
-
-:host.share-dialog {
-  form {
-    flex-direction: column;
-  }
 }
 
 .invite-by-link .offline-text {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -34,7 +34,7 @@
         </div>
       </ng-container>
     </div>
-    <div [fxLayout]="isTargetTextRight ? 'row' : 'row-reverse'" fxLayoutGap="5px">
+    <div [fxLayout]="isTargetTextRight ? 'row' : 'row-reverse'" class="both-editors-wrapper">
       <div id="source-text-area" [fxShow.gt-xs]="showSource" fxHide.xs class="text-area">
         <div class="language-label" mdcSubtitle1>{{ sourceLabel }}</div>
         <div #sourceContainer class="text-container" [style.height]="textHeight">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -134,3 +134,7 @@ app-text {
   width: 24px;
   height: 24px;
 }
+
+.both-editors-wrapper {
+  column-gap: 5px;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; read: 'translate_overview'">
   <div class="title mat-display-1">{{ t("translate_overview") }}</div>
-  <div fxLayout="row wrap" fxLayoutAlign="start start">
+  <div class="card-wrapper">
     <mat-card class="books-card">
       <mat-card-header id="translate-overview-title" class="books-card-title">
         <mat-card-title fxLayout="row" fxLayoutAlign="space-between center"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
@@ -14,10 +14,15 @@ mat-card {
   }
 }
 
+.card-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 20px 40px;
+}
+
 .books-card {
   width: 18rem;
-  margin-right: 40px;
-  margin-bottom: 20px;
 
   .books-card-title ::ng-deep {
     margin-top: 8px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
@@ -46,9 +46,6 @@
     align-items: center;
     padding: 0.5rem 1rem;
     height: 56px;
-    .material-icons {
-      margin-right: 10px;
-    }
     h2 {
       margin: 0;
       flex: 1;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'edit_name_dialog'">
-  <mdc-dialog>
+  <mdc-dialog [dir]="i18n.direction">
     <mdc-dialog-container>
       <mdc-dialog-surface>
         <mdc-dialog-title *ngIf="data.isConfirmation">{{ t("confirm_your_name") }}</mdc-dialog-title>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.spec.ts
@@ -2,11 +2,19 @@ import { MdcDialog, MdcDialogRef } from '@angular-mdc/web/dialog';
 import { CommonModule } from '@angular/common';
 import { Component, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { TestTranslocoModule } from 'xforge-common/test-utils';
+import { mock } from 'ts-mockito';
+import { I18nService } from 'xforge-common/i18n.service';
+import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { EditNameDialogComponent, EditNameDialogResult } from './edit-name-dialog.component';
 
+const mockedI18nService = mock(I18nService);
+
 describe('EditNameDialogComponent', () => {
+  configureTestingModule(() => ({
+    providers: [{ provide: I18nService, useMock: mockedI18nService }]
+  }));
+
   it('should display name and cancel button', fakeAsync(() => {
     const env = new TestEnvironment();
     env.openDialog();

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.ts
@@ -1,6 +1,7 @@
 import { MdcDialogRef, MDC_DIALOG_DATA } from '@angular-mdc/web/dialog';
 import { Component, Inject } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
+import { I18nService } from 'xforge-common/i18n.service';
 import { XFValidators } from 'xforge-common/xfvalidators';
 
 export interface EditNameDialogResult {
@@ -15,6 +16,7 @@ export class EditNameDialogComponent {
 
   constructor(
     public dialogRef: MdcDialogRef<EditNameDialogComponent, EditNameDialogResult | 'close'>,
+    public i18n: I18nService,
     @Inject(MDC_DIALOG_DATA) public data: { name: string; isConfirmation: boolean }
   ) {
     this.name.setValidators([Validators.required, XFValidators.someNonWhitespace]);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import { HashMap, Translation, TranslocoLoader } from '@ngneat/transloco';
 import { TranslocoConfig, TranslocoService } from '@ngneat/transloco';
 import merge from 'lodash-es/merge';
@@ -13,6 +13,7 @@ import enChecking from '../assets/i18n/checking_en.json';
 import enNonChecking from '../assets/i18n/non_checking_en.json';
 import { environment } from '../environments/environment';
 import { AuthService } from './auth.service';
+import { DOCUMENT } from './browser-globals';
 import { BugsnagService } from './bugsnag.service';
 import { LocationService } from './location.service';
 import { Locale } from './models/i18n-locale';
@@ -93,7 +94,8 @@ export class I18nService {
     private readonly authService: AuthService,
     private readonly transloco: TranslocoService,
     private readonly cookieService: CookieService,
-    private readonly reportingService: ErrorReportingService
+    private readonly reportingService: ErrorReportingService,
+    @Inject(DOCUMENT) private readonly document: Document
   ) {
     // Note that if the user is already logged in, and the user has a different interface language specified in their
     // Auth0 profile, then the locale from the URL will end up being overridden.
@@ -114,6 +116,18 @@ export class I18nService {
 
   get localeCode() {
     return this.currentLocale.canonicalTag;
+  }
+
+  get direction(): 'ltr' | 'rtl' {
+    return this.currentLocale.direction;
+  }
+
+  get forwardDirectionWord(): 'right' | 'left' {
+    return this.currentLocale.direction === 'ltr' ? 'right' : 'left';
+  }
+
+  get backwardDirectionWord(): 'right' | 'left' {
+    return this.currentLocale.direction === 'ltr' ? 'left' : 'right';
   }
 
   get locales() {
@@ -159,6 +173,7 @@ export class I18nService {
       'log'
     );
     this.reportingService.addMeta({ localeId: this.localeCode });
+    this.document.body.setAttribute('dir', this.direction);
   }
 
   localizeBook(book: number | string) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/owner/owner.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/owner/owner.component.scss
@@ -9,13 +9,13 @@
         height: 1em;
       }
       .name {
-        margin-right: 5px;
+        margin-inline-end: 5px;
       }
     }
   }
 }
 .avatar {
-  margin-right: 5px;
+  margin-inline-end: 5px;
   img {
     border-radius: 50%;
     width: 32px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/route.directive.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/route.directive.ts
@@ -26,9 +26,11 @@ export class RouterDirective {
     return this._route;
   }
 
-  @HostBinding('class.mdc-list-item--activated')
+  @HostBinding('class.activated-nav-item')
   get active(): boolean {
-    return (this.element.nativeElement as HTMLElement).tagName === 'MDC-LIST-ITEM' && this.router.url === this.url;
+    return (
+      (this.element.nativeElement as HTMLElement).classList.contains('mat-list-item') && this.router.url === this.url
+    );
   }
 
   @HostListener('click', ['$event'])

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -17,11 +17,13 @@ import { MdcTabBarModule } from '@angular-mdc/web/tab-bar';
 import { MdcTextFieldModule } from '@angular-mdc/web/textfield';
 import { MdcTopAppBarModule } from '@angular-mdc/web/top-app-bar';
 import { MdcTypographyModule } from '@angular-mdc/web/typography';
+import { BidiModule } from '@angular/cdk/bidi';
 import { NgModule } from '@angular/core';
 import { BREAKPOINT, FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatButtonModule } from '@angular/material/button';
+import { MatListModule } from '@angular/material/list';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatOptionModule } from '@angular/material/core';
@@ -51,6 +53,7 @@ const modules = [
   DonutChartModule,
   FlexLayoutModule,
   FormsModule,
+  BidiModule,
   MatAutocompleteModule,
   MatButtonModule,
   MatCardModule,
@@ -60,6 +63,7 @@ const modules = [
   MatFormFieldModule,
   MatIconModule,
   MatInputModule,
+  MatListModule,
   MatMenuModule,
   MatOptionModule,
   MatPaginatorModule,

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -23,20 +23,24 @@ export function supportedBrowser(): boolean {
   // Minimum required versions are based largely on browser support data for the following features:
   // https://caniuse.com/indexeddb2
   // https://caniuse.com/mdn-javascript_builtins_regexp_property_escapes
+  // https://caniuse.com/mdn-css_properties_text-align_flow_relative_values_start_and_end
+  // https://caniuse.com/mdn-css_properties_column-gap_flex_context
+  // https://caniuse.com/mdn-css_properties_inset-inline-start
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-start#browser_compatibility
   const isSupportedBrowser = BROWSER.satisfies({
-    chrome: '>=64',
-    chromium: '>=64',
-    edge: '>=79',
+    chrome: '>=87',
+    chromium: '>=87',
+    edge: '>=87',
     firefox: '>=78',
-    safari: '>=11.1',
+    safari: '>=14.1',
 
     mobile: {
-      chrome: '>=78',
+      chrome: '>=87',
       firefox: '>=79',
-      opera: '>=47',
-      safari: '>=11.3',
-      'android browser': '>=76',
-      'samsung internet': '>=9.0'
+      opera: '>=73',
+      safari: '>=14.5',
+      'android browser': '>=87',
+      'samsung internet': '>=14.0'
     }
   });
   return isSupportedBrowser ? true : false;


### PR DESCRIPTION
This is initial work to get a right-to-left UI working. It is not intended to fully implement everything, just to have enough working so that when we start to pull in Arabic translations in the very near future, we'll have the interface mostly working correctly and we can meaningfully test the translations.

A few things to note:
- Angular Material seems to be able to do direction fine via the `BidiModule`. I couldn't find anything similar for Angular MDC. The dialogs that use MDC have to have the direction set on them in order to work properly. I only did this to the most important dialogs; I didn't actually go through every single dialog we have. For the simple dialogs it doesn't make much difference anyway.
- I had some challenges getting the app menu to work properly and ended up converting it to Angular Material. I figure we need to do that at some point anyway.
- `::ng-deep` is deprecated and I used it anyway. There are ways around it, but it seemed like the simplest option for now.
- If you don't know what `margin-inline-start` means (I didn't) you'll want to read about CSS logical properties: https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-end. There are similar properties for padding and positioning. When the text is LTR, margin-inline-start is the same as margin-left. When the text is RTL margin-inline-start is the same as margin-right. Browser support isn't the greatest for these properties, so we will need to consider the trade-offs. See https://caniuse.com/mdn-css_properties_scroll-margin-inline-start
- I have yet to fix the tests. Right now there are 28 failures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1377)
<!-- Reviewable:end -->
