### PR TITLE
Remove deprecated Chrome debugger extension from recommended list

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,7 +8,6 @@
     "esbenp.prettier-vscode",
     "formulahendry.dotnet-test-explorer",
     "ms-dotnettools.csharp",
-    "msjsdiag.debugger-for-chrome",
     "orta.vscode-jest",
     "raagh.angular-karma-test-explorer",
     "streetsidesoftware.code-spell-checker",


### PR DESCRIPTION
This extension has the following message at the top of its readme:
> This extension has been deprecated as Visual Studio Code now has a bundled JavaScript Debugger that covers the same functionality. It is a debugger that debugs Node.js, Chrome, Edge, WebView2, VS Code extensions, and more. You can safely un-install this extension and you will still be able to have the functionality you need.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1379)
<!-- Reviewable:end -->
