### PR TITLE
SF-1586 Make note icon size constant regardless of text size

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -116,8 +116,8 @@ quill-editor.rtl {
     &:before {
       cursor: pointer;
       content: '';
-      width: 1.25em;
-      height: 1.25em;
+      width: 1.25rem;
+      height: 1.25rem;
       display: inline-block;
       background: var(--icon-file) no-repeat;
       margin: 0 0.1em;


### PR DESCRIPTION
This mimics the behavior in Paratext.

Before | After
---------|--------
![](https://user-images.githubusercontent.com/6140710/170548020-1ab0c210-a835-44c0-a0eb-380fe5160c0f.png) | ![](https://user-images.githubusercontent.com/6140710/170548068-1cd70a9e-251e-47d8-810a-93bc4a76bd2e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1380)
<!-- Reviewable:end -->
