### PR TITLE
SF-1443 Handle char style array

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -329,12 +329,14 @@ usx-segment:first-child usx-blank {
 }
 
 usx-char {
-  &[data-style='it'],
-  &[data-style='em'] {
+  // The data-style attribute is a space-delimited list of styles.
+
+  &[data-style~='it'],
+  &[data-style~='em'] {
     font-style: italic;
   }
 
-  &[data-style='va'] {
+  &[data-style~='va'] {
     font-size: 70%;
     color: #5faa5f;
     top: -0.5em;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -32,6 +32,7 @@ function getUsxValue<T>(node: HTMLElement): T {
   return node[USX_VALUE];
 }
 
+/** Record textdoc data that was used to make this node, to help later write back to the textdoc. */
 function setUsxValue(node: HTMLElement, value: any): void {
   node[USX_VALUE] = value;
 }
@@ -211,12 +212,29 @@ export function registerScripture(): string[] {
     static blotName = 'char';
     static tagName = 'usx-char';
 
-    static create(value: UsxStyle): Node {
+    static create(value: UsxStyle | UsxStyle[]): Node {
       const node = super.create(value) as HTMLElement;
-      if (value != null && value.style != null) {
-        node.setAttribute(customAttributeName('style'), value.style);
-        setUsxValue(node, value);
+      if (value == null) {
+        return node;
       }
+
+      let characterStyles: string = '';
+      if (Array.isArray(value)) {
+        // Transform an array of styles to a space-delimited list
+        characterStyles = value.map((styleItem: UsxStyle) => styleItem.style).join(' ');
+        if (characterStyles.trim() === '') {
+          return node;
+        }
+      } else {
+        if (value.style == null) {
+          return node;
+        }
+        characterStyles = value.style;
+      }
+
+      node.setAttribute(customAttributeName('style'), characterStyles);
+      setUsxValue(node, value);
+
       return node;
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -2224,6 +2224,51 @@ describe('TextComponent', () => {
 
     // End drag-and-drop section of tests.
   });
+
+  it('lists multiple character formatting', fakeAsync(() => {
+    const chapterNum = 2;
+    const originSegmentRef = `verse_${chapterNum}_1`;
+    const textDocOps: RichText.DeltaOperation[] = [
+      { insert: { chapter: { number: chapterNum.toString(), style: 'c' } } },
+      { insert: { verse: { number: '1', style: 'v' } } },
+      {
+        insert: `quick brown fox`,
+        attributes: {
+          segment: originSegmentRef,
+          char: {
+            style: 'wj',
+            cid: '1111'
+          }
+        }
+      },
+      {
+        insert: 'jumped over',
+        attributes: {
+          segment: originSegmentRef,
+          char: [
+            {
+              style: 'wj',
+              cid: '1111'
+            },
+            {
+              style: 'w',
+              cid: '2222'
+            }
+          ]
+        }
+      }
+    ];
+
+    const env = new TestEnvironment({ chapterNum, textDoc: textDocOps });
+    const usxCharElements: NodeListOf<Element> = env.component.editor!.container.querySelectorAll('usx-char');
+    expect(usxCharElements.length).withContext('unexpected number of formatted character runs').toEqual(2);
+    expect(usxCharElements[0].attributes.getNamedItem('data-style')?.value)
+      .withContext('first run should just have style wj')
+      .toEqual('wj');
+    expect(usxCharElements[1].attributes.getNamedItem('data-style')?.value)
+      .withContext('second run should have two styles')
+      .toEqual('wj w');
+  }));
 });
 
 /** Represents both what the TextComponent understand to be the text in a segment, and what the editor


### PR DESCRIPTION
quill-scripture.ts CharInline.create(value) was receiving a UsxStyle[]
array in situations where the textdoc ops had an array for `char`
instead of just a single style. Process this incoming array, storing
it in __usx_value, and storing a space-delimited list of its styles in
the data-style attribute.
_usx.scss can match the style items in the space-delimited list using
`~=`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1381)
<!-- Reviewable:end -->
