### PR TITLE
Fully qualify all references to Paratext.Data.HttpException

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -216,7 +216,7 @@ namespace SIL.XForge.Scripture.Services
                     {
                         source.UnlockRemoteRepository(sharedProj.Repository);
                     }
-                    catch (HttpException)
+                    catch (Paratext.Data.HttpException)
                     {
                         // A 403 error will be thrown if the repo is not locked
                     }
@@ -577,7 +577,7 @@ namespace SIL.XForge.Scripture.Services
             {
                 return ptRepoSource.GetRepositories();
             }
-            catch (HttpException e)
+            catch (Paratext.Data.HttpException e)
             {
                 string message = $"Problem fetching repositories: {contextInformation}";
                 _logger.LogWarning(e, message);

--- a/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
+++ b/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
@@ -241,7 +241,7 @@ namespace SIL.XForge.Scripture.Services
             {
                 // Paratext throws an HttpException instead of a WebException
                 // If you need it, the WebException is the InnerException
-                if (ex is HttpException httpException)
+                if (ex is Paratext.Data.HttpException httpException)
                 {
                     if (httpException.Response.StatusCode == HttpStatusCode.Unauthorized)
                     {

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -1808,11 +1808,11 @@ namespace SIL.XForge.Scripture.Services
 
             source.GetRepositories().Returns(x =>
             {
-                throw HttpException.Create(new WebException("401: Unauthorized"), (HttpWebRequest)null);
+                throw Paratext.Data.HttpException.Create(new WebException("401: Unauthorized"), (HttpWebRequest)null);
             });
 
             // SUT
-            HttpException thrown = Assert.ThrowsAsync<HttpException>(() =>
+            Paratext.Data.HttpException thrown = Assert.ThrowsAsync<Paratext.Data.HttpException>(() =>
                 env.Service.GetProjectRolesAsync(userSecret, project, CancellationToken.None));
 
             // Various pieces of significant data are reported when a 401 Unauthorized goes thru.
@@ -2412,7 +2412,7 @@ namespace SIL.XForge.Scripture.Services
 
                 // An HttpException means that the repo is already unlocked, so any code should be OK with this
                 mockSource.When(s => s.UnlockRemoteRepository(Arg.Any<SharedRepository>()))
-                    .Do(x => throw HttpException.Create(new WebException(),
+                    .Do(x => throw Paratext.Data.HttpException.Create(new WebException(),
                         GenericRequest.Create(new Uri("http://localhost/"))));
                 MockInternetSharedRepositorySourceProvider.GetSource(Arg.Is<UserSecret>(s => s.Id == userSecret.Id),
                         Arg.Any<string>(), Arg.Any<string>()).Returns(mockSource);


### PR DESCRIPTION
I spent a good while thinking that our references to `HttpException` referred to `System.Web.HttpException`. They actually refer to `Paratext.Data.HttpException`, which wraps `System.Net.WebException` in the instances that I've seen.

I think it's less confusing to just fully qualify what is being referenced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1382)
<!-- Reviewable:end -->
