### PR TITLE
SF-1593 Fix checking questions being unavailable offline

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-query.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-query.ts
@@ -180,11 +180,9 @@ export class RealtimeQuery<T extends RealtimeDoc = RealtimeDoc> {
     }
     this._unpagedCount = unpagedCount;
 
-    if (this.adapter.ready) {
-      this._docs$.next(this._docs);
-      if (changed && emitRemoteChanges) {
-        this._remoteChanges$.next();
-      }
+    this._docs$.next(this._docs);
+    if (changed && this.adapter.ready && emitRemoteChanges) {
+      this._remoteChanges$.next();
     }
   }
 


### PR DESCRIPTION
Steps to reproduce the problem:
1. Shut down back end or go offline
2. Go to a book with questions
3. Observe that the questions (and text) do not load

This was broken in #1301 when optimizing the checking component.

I remember not being sure exactly when to call `this._docs$.next(this._docs)` in this particular section of this method. Apparently I got it wrong. I think the previous version was determined experimentally, but I forgot about offline mode, and I don't think `this.adapter.ready` is true offline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1384)
<!-- Reviewable:end -->
