### PR TITLE
SF-1528 Improve note text selection anchor update after drag and drop event

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -368,6 +368,10 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     return this.viewModel.embeddedElements;
   }
 
+  get embeddedPositions(): number[] {
+    return this.viewModel.embeddedPositions;
+  }
+
   get localPresence(): LocalPresence<PresenceData> | undefined {
     return this.viewModel.localPresence;
   }
@@ -690,7 +694,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     }
     let previousEmbedIndex = -1;
     const deleteDelta = new Delta();
-    for (const embedIndex of this.viewModel.embeddedElements.values()) {
+    for (const embedIndex of this.viewModel.embeddedPositions) {
       const lengthBetweenEmbeds: number = embedIndex - (previousEmbedIndex + 1);
       if (lengthBetweenEmbeds > 0) {
         // retain elements other than notes between the previous and current embed
@@ -1151,6 +1155,10 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
           newStart++;
         }
       }
+
+      // while (embedIndices.includes(newStart - 1)) {
+      //   newStart--;
+      // }
       newSel = { index: newStart, length: Math.max(0, newEnd - newStart) };
     } else {
       return null;
@@ -1177,7 +1185,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
    * positions to check.
    */
   private getEmbedCountInRange(editorStartPos: number, length: number): number {
-    const embedPositions: number[] = Array.from(this.embeddedElements.values());
+    const embedPositions: number[] = this.viewModel.embeddedPositions;
     return embedPositions.filter((pos: number) => pos >= editorStartPos && pos < editorStartPos + length).length;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -368,10 +368,6 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     return this.viewModel.embeddedElements;
   }
 
-  get embeddedPositions(): number[] {
-    return this.viewModel.embeddedPositions;
-  }
-
   get localPresence(): LocalPresence<PresenceData> | undefined {
     return this.viewModel.localPresence;
   }
@@ -694,7 +690,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     }
     let previousEmbedIndex = -1;
     const deleteDelta = new Delta();
-    for (const embedIndex of this.viewModel.embeddedPositions) {
+    for (const embedIndex of this.viewModel.embeddedElements.values()) {
       const lengthBetweenEmbeds: number = embedIndex - (previousEmbedIndex + 1);
       if (lengthBetweenEmbeds > 0) {
         // retain elements other than notes between the previous and current embed
@@ -1194,7 +1190,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
    * positions to check.
    */
   private getEmbedCountInRange(editorStartPos: number, length: number): number {
-    const embedPositions: number[] = this.viewModel.embeddedPositions;
+    const embedPositions: number[] = Array.from(this.viewModel.embeddedElements.values());
     return embedPositions.filter((pos: number) => pos >= editorStartPos && pos < editorStartPos + length).length;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -709,6 +709,18 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     }
   }
 
+  removeEmbeddedElement(embedId: string, source: Sources): void {
+    if (this.editor == null) {
+      return;
+    }
+
+    const position: EmbedPosition | undefined = this.embeddedElements.get(embedId);
+    if (position != null) {
+      const deltaOps: DeltaOperation[] = [{ retain: position.position }, { delete: 1 }];
+      this.editor.updateContents(new Delta(deltaOps), source);
+    }
+  }
+
   isSegmentBlank(ref: string): boolean {
     const segmentDelta: DeltaStatic | undefined = this.getSegmentContents(ref);
     if (segmentDelta?.ops == null) {
@@ -1156,9 +1168,6 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
         }
       }
 
-      // while (embedIndices.includes(newStart - 1)) {
-      //   newStart--;
-      // }
       newSel = { index: newStart, length: Math.max(0, newEnd - newStart) };
     } else {
       return null;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -12,7 +12,7 @@ import {
 import { TranslocoService } from '@ngneat/transloco';
 import isEqual from 'lodash-es/isEqual';
 import merge from 'lodash-es/merge';
-import Quill, { DeltaStatic, RangeStatic, Sources } from 'quill';
+import Quill, { DeltaOperation, DeltaStatic, RangeStatic, Sources } from 'quill';
 import QuillCursors from 'quill-cursors';
 import { AuthType, getAuthType } from 'realtime-server/lib/esm/common/models/user';
 import { TextAnchor } from 'realtime-server/lib/esm/scriptureforge/models/text-anchor';
@@ -714,9 +714,9 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       return;
     }
 
-    const position: EmbedPosition | undefined = this.embeddedElements.get(embedId);
+    const position: number | undefined = this.embeddedElements.get(embedId);
     if (position != null) {
-      const deltaOps: DeltaOperation[] = [{ retain: position.position }, { delete: 1 }];
+      const deltaOps: DeltaOperation[] = [{ retain: position }, { delete: 1 }];
       this.editor.updateContents(new Delta(deltaOps), source);
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2310,7 +2310,7 @@ describe('EditorComponent', () => {
       env.targetEditor.setSelection(note1Position - beforeNoteLength, deleteLength, 'user');
       env.deleteCharacters();
       newNotePosition = env.getNoteThreadEditorPosition('thread01');
-      const range = env.component.target!.getSegmentRange('verse_1_1')!;
+      let range = env.component.target!.getSegmentRange('verse_1_1')!;
       // note moves to the beginning of the verse
       expect(newNotePosition).toEqual(range.index);
       env.triggerUndo();
@@ -2331,6 +2331,8 @@ describe('EditorComponent', () => {
       expect(noteThread6.data!.position).toEqual(noteThread6Anchor);
       expect(noteThread1.data!.position).toEqual(noteThread1Anchor);
       expect(textDoc.data!.ops![3].insert).toEqual('target: chapter 1, verse 1.');
+      range = env.component.target!.getSegmentRange('verse_1_1')!;
+      expect(env.targetEditor.getText(range.index, range.length)).toEqual('target: chapter 1, verse 1.');
 
       // undo deleting multiple notes
       const noteThread3: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread03');
@@ -2357,6 +2359,9 @@ describe('EditorComponent', () => {
       expect(noteThread3.data!.position).toEqual(noteThread3Anchor);
       expect(noteThread4.data!.position).toEqual(noteThread4Anchor);
       expect(textDoc.data!.ops![8].insert).toEqual('target: chapter 1, verse 3.');
+      range = env.component.target!.getSegmentRange('verse_1_3')!;
+      expect(env.targetEditor.getText(range.index, range.length)).toEqual('target: chapter 1, verse 3.');
+
       env.dispose();
     }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -305,20 +305,19 @@ describe('EditorComponent', () => {
       env.deleteCharacters();
       segmentRange = env.component.target!.segment!.range;
       segmentContents = env.targetEditor.getContents(segmentRange.index, segmentRange.length);
-
-      // The note remains, the blank returns
+      // the blank returns
       op = segmentContents.ops![0];
-      expect(op.insert).toEqual({
+      expect(op.insert.blank).toBe(true);
+      expect(op.attributes!.segment).toEqual('verse_1_4/p_1');
+      // the note is reset to the start of the verse
+      const verseSegment = env.component.target!.getSegmentContents('verse_1_4')!;
+      expect(verseSegment.ops![0].insert).toEqual({
         'note-thread-embed': {
           iconsrc: '--icon-file: url(/assets/icons/TagIcons/01flag1.png);',
           preview: 'Note from user01',
           threadid: 'thread05'
         }
       });
-      op = segmentContents.ops![1];
-      expect(op.insert.blank).toBe(true);
-      expect(op.attributes!.segment).toEqual('verse_1_4/p_1');
-
       env.dispose();
     }));
 
@@ -1225,7 +1224,7 @@ describe('EditorComponent', () => {
     }));
   });
 
-  fdescribe('Note threads', () => {
+  describe('Note threads', () => {
     it('embeds note on verse segments', fakeAsync(() => {
       const env = new TestEnvironment();
       env.addParatextNoteThread(6, 'MAT 1:2', '', { start: 0, length: 0 }, ['user01']);
@@ -2361,7 +2360,7 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    fit('note dialog appears after undo delete-a-note', fakeAsync(() => {
+    it('note dialog appears after undo delete-a-note', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
       env.wait();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1225,7 +1225,7 @@ describe('EditorComponent', () => {
     }));
   });
 
-  describe('Note threads', () => {
+  fdescribe('Note threads', () => {
     it('embeds note on verse segments', fakeAsync(() => {
       const env = new TestEnvironment();
       env.addParatextNoteThread(6, 'MAT 1:2', '', { start: 0, length: 0 }, ['user01']);
@@ -1377,7 +1377,7 @@ describe('EditorComponent', () => {
       const noteStart5 = env.component.target!.getSegmentRange('verse_1_4')!.index + doc.data!.position.start;
       // positions are 11, 34, 55, 56, 94
       const expected = [noteStart1, noteStart2, noteStart3, noteStart4, noteStart5];
-      expect(Array.from(env.component.target!.embeddedElements.values())).toEqual(expected);
+      expect(Array.from(env.component.target!.embeddedPositions)).toEqual(expected);
       env.dispose();
     }));
 
@@ -1587,12 +1587,12 @@ describe('EditorComponent', () => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
       env.wait();
-      expect(Array.from(env.component.target!.embeddedElements.values())).toEqual([11, 34, 55, 56, 94]);
+      expect(Array.from(env.component.target!.embeddedPositions)).toEqual([11, 34, 55, 56, 94]);
 
       // deletes just the note icon
       env.targetEditor.setSelection(11, 1, 'user');
       env.deleteCharacters();
-      expect(Array.from(env.component.target!.embeddedElements.values())).toEqual([11, 34, 55, 56, 94]);
+      expect(Array.from(env.component.target!.embeddedPositions)).toEqual([11, 34, 55, 56, 94]);
       const textDoc = env.getTextDoc(new TextDocId('project01', 40, 1));
       expect(textDoc.data!.ops![3].insert).toBe('target: chapter 1, verse 1.');
 
@@ -1602,7 +1602,7 @@ describe('EditorComponent', () => {
       expect(noteThreadDoc.data!.position).toEqual({ start: 8, length: 9 });
       env.typeCharacters('t');
       // 4 characters deleted and 1 character inserted
-      expect(Array.from(env.component.target!.embeddedElements.values())).toEqual([10, 31, 52, 53, 91]);
+      expect(Array.from(env.component.target!.embeddedPositions)).toEqual([10, 31, 52, 53, 91]);
       expect(noteThreadDoc.data!.position).toEqual({ start: 7, length: 7 });
       expect(textDoc.data!.ops![3].insert).toBe('targettapter 1, verse 1.');
 
@@ -1613,7 +1613,7 @@ describe('EditorComponent', () => {
 
       env.updateParams({ projectId: 'project01', bookId: 'MAT' });
       env.wait();
-      expect(Array.from(env.component!.target!.embeddedElements.values())).toEqual([10, 31, 52, 53, 91]);
+      expect(Array.from(env.component!.target!.embeddedPositions)).toEqual([10, 31, 52, 53, 91]);
       env.dispose();
     }));
 
@@ -1935,6 +1935,95 @@ describe('EditorComponent', () => {
       verse4p1Index = env.component.target!.getSegmentRange('verse_1_4/p_1')!.index;
       note5Index = env.getNoteThreadEditorPosition('thread05');
       expect(note5Index).toEqual(verse4p1Index);
+      env.dispose();
+    }));
+
+    it('updates note anchors when drag and drop between multiple verses', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.wait();
+
+      const originalThread1Pos: TextAnchor = { start: 8, length: 9 };
+      const originalThread3Pos: TextAnchor = { start: 20, length: 7 };
+      const noteThread1Doc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread01');
+      expect(noteThread1Doc.data!.position).toEqual(originalThread1Pos);
+      const noteThread3Doc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread03');
+      expect(noteThread3Doc.data!.position).toEqual(originalThread3Pos);
+      // // simulate a drag and drop event
+      const dragStart: number = env.getNoteThreadEditorPosition('thread01') + 1;
+      const dragText = 'chapter 1';
+      const dropStart: number = env.getNoteThreadEditorPosition('thread03') - 5;
+      const spaceBetweenEdits: number = dropStart - (dragStart + dragText.length);
+
+      // \v 1 target: $chapter 1, verse 1. \v 2  \v 3 target: chapter 1, $$verse 3.
+      // drag this    ---------                        drop here   ^
+      const changes: DeltaOperation[] = [
+        { retain: dragStart },
+        { delete: dragText.length },
+        { retain: spaceBetweenEdits },
+        { insert: dragText }
+      ];
+
+      // SUT 1
+      env.targetEditor.setSelection(dragStart, dragText.length, 'user');
+      env.targetEditor.updateContents(new Delta(changes), 'user');
+      env.wait();
+
+      const expectedThread1Pos: TextAnchor = { start: 0, length: originalThread1Pos.length - dragText.length };
+      expect(noteThread1Doc.data!.position).toEqual(expectedThread1Pos);
+      let verse1Range: RangeStatic = env.component.target!.getSegmentRange('verse_1_1')!;
+      expect(env.getNoteThreadEditorPosition('thread01')).toEqual(verse1Range.index);
+
+      const expectedThread3Pos: TextAnchor = {
+        start: originalThread3Pos.start + dragText.length,
+        length: originalThread3Pos.length
+      };
+      expect(noteThread3Doc.data!.position).toEqual(expectedThread3Pos);
+      env.wait();
+
+      // SUT 2
+      env.triggerUndo();
+      env.wait();
+      expect(noteThread1Doc.data!.position).toEqual(expectedThread1Pos);
+      verse1Range = env.component.target!.getSegmentRange('verse_1_1')!;
+      expect(env.getNoteThreadEditorPosition('thread01')).toEqual(verse1Range.index);
+      expect(noteThread3Doc.data!.position).toEqual(originalThread3Pos);
+      env.dispose();
+    }));
+
+    it('updated note thread anchors when drag and drop within verse', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.wait();
+
+      const noteThreadDoc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread01');
+      const originalNoteAnchor: TextAnchor = { start: 8, length: 9 };
+      expect(noteThreadDoc.data!.position).toEqual(originalNoteAnchor);
+
+      const notePosition: number = env.getNoteThreadEditorPosition('thread01');
+      const dragStart: number = notePosition + 1;
+      const dragText = 'chapter';
+      const dropStart: number = notePosition + 16;
+      const spaceBetweenEdits: number = dropStart - (dragStart + dragText.length);
+
+      // target: $chapter 1, verse 1.
+      //    drag  -------   drop ^
+      const updateOps: DeltaOperation[] = [
+        { retain: dragStart },
+        { delete: dragText.length },
+        { retain: spaceBetweenEdits },
+        { insert: dragText }
+      ];
+      const updateDelta = new Delta(updateOps);
+      env.targetEditor.setSelection(dragStart, dragText.length);
+      env.targetEditor.updateContents(updateDelta, 'user');
+      env.wait();
+
+      const expectedNoteAnchor: TextAnchor = {
+        start: originalNoteAnchor.start,
+        length: originalNoteAnchor.length - dragText.length
+      };
+      expect(noteThreadDoc.data!.position).toEqual(expectedNoteAnchor);
       env.dispose();
     }));
 
@@ -2272,7 +2361,7 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('note dialog appears after undo delete-a-note', fakeAsync(() => {
+    fit('note dialog appears after undo delete-a-note', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
       env.wait();
@@ -3008,7 +3097,7 @@ class TestEnvironment {
 
   /** Editor position of note thread. */
   getNoteThreadEditorPosition(threadId: string): number {
-    return this.component.target!.embeddedElements.get(threadId)!;
+    return this.component.target!.embeddedElements.get(threadId)!.position;
   }
 
   getRemoteEditPosition(notePosition: number, positionAfter: number, noteCount: number): number {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1376,7 +1376,7 @@ describe('EditorComponent', () => {
       const noteStart5 = env.component.target!.getSegmentRange('verse_1_4')!.index + doc.data!.position.start;
       // positions are 11, 34, 55, 56, 94
       const expected = [noteStart1, noteStart2, noteStart3, noteStart4, noteStart5];
-      expect(Array.from(env.component.target!.embeddedPositions)).toEqual(expected);
+      expect(env.embedPositions).toEqual(expected);
       env.dispose();
     }));
 
@@ -1586,12 +1586,12 @@ describe('EditorComponent', () => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
       env.wait();
-      expect(Array.from(env.component.target!.embeddedPositions)).toEqual([11, 34, 55, 56, 94]);
+      expect(env.embedPositions).toEqual([11, 34, 55, 56, 94]);
 
       // deletes just the note icon
       env.targetEditor.setSelection(11, 1, 'user');
       env.deleteCharacters();
-      expect(Array.from(env.component.target!.embeddedPositions)).toEqual([11, 34, 55, 56, 94]);
+      expect(env.embedPositions).toEqual([11, 34, 55, 56, 94]);
       const textDoc = env.getTextDoc(new TextDocId('project01', 40, 1));
       expect(textDoc.data!.ops![3].insert).toBe('target: chapter 1, verse 1.');
 
@@ -1601,7 +1601,7 @@ describe('EditorComponent', () => {
       expect(noteThreadDoc.data!.position).toEqual({ start: 8, length: 9 });
       env.typeCharacters('t');
       // 4 characters deleted and 1 character inserted
-      expect(Array.from(env.component.target!.embeddedPositions)).toEqual([10, 31, 52, 53, 91]);
+      expect(env.embedPositions).toEqual([10, 31, 52, 53, 91]);
       expect(noteThreadDoc.data!.position).toEqual({ start: 7, length: 7 });
       expect(textDoc.data!.ops![3].insert).toBe('targettapter 1, verse 1.');
 
@@ -1612,7 +1612,7 @@ describe('EditorComponent', () => {
 
       env.updateParams({ projectId: 'project01', bookId: 'MAT' });
       env.wait();
-      expect(Array.from(env.component!.target!.embeddedPositions)).toEqual([10, 31, 52, 53, 91]);
+      expect(env.embedPositions).toEqual([10, 31, 52, 53, 91]);
       env.dispose();
     }));
 
@@ -1937,7 +1937,7 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('updates note anchors when drag and drop between multiple verses', fakeAsync(() => {
+    it('updates note anchors when multiple edits in multiple verses', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
       env.wait();
@@ -1949,32 +1949,33 @@ describe('EditorComponent', () => {
       const noteThread3Doc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread03');
       expect(noteThread3Doc.data!.position).toEqual(originalThread3Pos);
       // // simulate a drag and drop event
-      const dragStart: number = env.getNoteThreadEditorPosition('thread01') + 1;
-      const dragText = 'chapter 1';
-      const dropStart: number = env.getNoteThreadEditorPosition('thread03') - 5;
-      const spaceBetweenEdits: number = dropStart - (dragStart + dragText.length);
+      const deleteStart: number = env.getNoteThreadEditorPosition('thread01') + 1;
+      const text = 'chapter 1';
+      const insertStart: number = env.getNoteThreadEditorPosition('thread03') - 5;
+      const spaceBetweenEdits: number = insertStart - (deleteStart + text.length);
 
       // \v 1 target: $chapter 1, verse 1. \v 2  \v 3 target: chapter 1, $$verse 3.
-      // drag this    ---------                        drop here   ^
+      //    move this  ---------                             here   ^
       const changes: DeltaOperation[] = [
-        { retain: dragStart },
-        { delete: dragText.length },
+        { retain: deleteStart },
+        { delete: text.length },
         { retain: spaceBetweenEdits },
-        { insert: dragText }
+        { insert: text }
       ];
 
       // SUT 1
-      env.targetEditor.setSelection(dragStart, dragText.length, 'user');
+      env.targetEditor.setSelection(deleteStart, text.length, 'user');
       env.targetEditor.updateContents(new Delta(changes), 'user');
       env.wait();
 
-      const expectedThread1Pos: TextAnchor = { start: 0, length: originalThread1Pos.length - dragText.length };
+      // The entire note anchor is technically deleted, so the note moves to the beginning of the verse
+      const expectedThread1Pos: TextAnchor = { start: 0, length: originalThread1Pos.length - text.length };
       expect(noteThread1Doc.data!.position).toEqual(expectedThread1Pos);
       let verse1Range: RangeStatic = env.component.target!.getSegmentRange('verse_1_1')!;
       expect(env.getNoteThreadEditorPosition('thread01')).toEqual(verse1Range.index);
 
       const expectedThread3Pos: TextAnchor = {
-        start: originalThread3Pos.start + dragText.length,
+        start: originalThread3Pos.start + text.length,
         length: originalThread3Pos.length
       };
       expect(noteThread3Doc.data!.position).toEqual(expectedThread3Pos);
@@ -1990,7 +1991,7 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('updated note thread anchors when drag and drop within verse', fakeAsync(() => {
+    it('updated note thread anchors when multiple edits within a verse', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
       env.wait();
@@ -2000,27 +2001,27 @@ describe('EditorComponent', () => {
       expect(noteThreadDoc.data!.position).toEqual(originalNoteAnchor);
 
       const notePosition: number = env.getNoteThreadEditorPosition('thread01');
-      const dragStart: number = notePosition + 1;
-      const dragText = 'chapter';
-      const dropStart: number = notePosition + 16;
-      const spaceBetweenEdits: number = dropStart - (dragStart + dragText.length);
+      const deleteStart: number = notePosition + 1;
+      const text = 'chapter';
+      const insertStart: number = notePosition + 16;
+      const spaceBetweenEdits: number = insertStart - (deleteStart + text.length);
 
-      // target: $chapter 1, verse 1.
-      //    drag  -------   drop ^
+      //  target: $chapter 1, verse 1.
+      // move this --------- here ^
       const updateOps: DeltaOperation[] = [
-        { retain: dragStart },
-        { delete: dragText.length },
+        { retain: deleteStart },
+        { delete: text.length },
         { retain: spaceBetweenEdits },
-        { insert: dragText }
+        { insert: text }
       ];
       const updateDelta = new Delta(updateOps);
-      env.targetEditor.setSelection(dragStart, dragText.length);
+      env.targetEditor.setSelection(deleteStart, text.length);
       env.targetEditor.updateContents(updateDelta, 'user');
       env.wait();
 
       const expectedNoteAnchor: TextAnchor = {
         start: originalNoteAnchor.start,
-        length: originalNoteAnchor.length - dragText.length
+        length: originalNoteAnchor.length - text.length
       };
       expect(noteThreadDoc.data!.position).toEqual(expectedNoteAnchor);
       env.dispose();
@@ -2916,6 +2917,14 @@ class TestEnvironment {
     return this.component.target!.editor!;
   }
 
+  get embedPositions(): number[] {
+    const embeddedElements: Map<string, number> | undefined = this.component?.target?.embeddedElements;
+    if (embeddedElements == null) {
+      return [];
+    }
+    return Array.from(embeddedElements.values());
+  }
+
   set onlineStatus(value: boolean) {
     when(mockedPwaService.isOnline).thenReturn(value);
     when(mockedPwaService.onlineStatus).thenReturn(of(value));
@@ -3101,7 +3110,7 @@ class TestEnvironment {
 
   /** Editor position of note thread. */
   getNoteThreadEditorPosition(threadId: string): number {
-    return this.component.target!.embeddedElements.get(threadId)!.position;
+    return this.component.target!.embeddedElements.get(threadId)!;
   }
 
   getRemoteEditPosition(notePosition: number, positionAfter: number, noteCount: number): number {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -586,7 +586,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     if (delta != null) {
       // wait 20 ms so that note thread docs have time to receive the updated note positions
       setTimeout(() => {
-        this.console.log(delta);
         this.recreateDeletedNoteThreadEmbeds();
         if (segment != null) {
           this.subscribeClickEvents([segment.ref]);
@@ -743,9 +742,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       const featured: FeaturedVerseRefInfo | undefined = this.getFeaturedVerseRefInfo(noteThreadDoc);
       if (featured != null) {
         featureVerseRefInfo.push(featured);
-        const subscription = this.subscribe(noteThreadDoc.changes$, ops => {
-          this.console.log('note thread updated');
-          this.console.log(ops);
+        const subscription = this.subscribe(noteThreadDoc.changes$, () => {
           this.resetNoteThread(featured.id, 'api');
         });
         this.noteThreadPositionSubscriptions.push(subscription);
@@ -1164,7 +1161,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
 
     const updatePromises: Promise<boolean>[] = [];
-
     // a user initiated delta with ops that include inserting a note embed can only be undo deleting a note icon
     const reinsertedNoteEmbeds: DeltaOperation[] = delta.filter(
       op => op.insert != null && op.insert['note-thread-embed'] != null

--- a/src/SIL.XForge.Scripture/ClientApp/src/test.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/test.ts
@@ -9,6 +9,6 @@ declare const require: any;
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
 // Then we find all the tests.
-const context = require.context('./', true, /\.spec\.ts$/);
+const context = require.context('./', true, /editor\.component\.spec\.ts$/);
 // And load the modules.
 context.keys().map(context);

--- a/src/SIL.XForge.Scripture/ClientApp/src/test.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/test.ts
@@ -9,6 +9,6 @@ declare const require: any;
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
 // Then we find all the tests.
-const context = require.context('./', true, /editor\.component\.spec\.ts$/);
+const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.
 context.keys().map(context);


### PR DESCRIPTION
In the original issue, the note text anchor was not getting correctly reset if the text was fully removed via a drag and drop event. After experimenting with Paratext, it appears that Paratext does not reset note icons after a similar event, so I've chosen to not try to implement that behaviour.
Along the way, I discovered that we do not update note thread text anchors correctly if the edit delta contained multiple points of edit (such as a drag and drop). Two scenarios I identified are:
- The user drags within a verse
- The user drags text from one verse to another

I've added tests to show that this works now. I've also improved the detection and removal of duplicate note thread icons which appear when a user deletes an icon either through drag and drop, or simply backspace a selection. Now note thread icons are removed anytime duplicates are detected, then they get redrawn.

Here is a summary of the changes
* Note thread icons are reset when the text anchor changes
* Drag and drop events are handled when updating note thread text anchors
* Duplicate note icon positions explicitly recorded
* Duplicate note icons reset when explicitly identified
* Emit snapshot of delta and embedded elements when quill editor is updated
* Remove reference to embedded elements in the segment class

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1385)
<!-- Reviewable:end -->
