### PR TITLE
Add scripts to visualize Paratext auth tokens

### DIFF
--- a/scripts/db_tools/auth0-token-info.ts
+++ b/scripts/db_tools/auth0-token-info.ts
@@ -1,0 +1,41 @@
+#!./node_modules/.bin/ts-node
+
+import axios from 'axios';
+import { showJwt } from './show-jwt';
+
+// This script uses the Auth0 Management API to search for a user by email address and print out the Paratext access
+// token for that user. It can be run by itself, or the token can be monitored by running e.g.
+// watch -n 10 ./auth0-token-info.ts
+// which will run the script every 10 seconds.
+
+// See https://auth0.com/docs/secure/tokens/access-tokens/management-api-access-tokens#get-management-api-tokens for
+// instructions regarding creating or revoking Auth0 Management API tokens
+const AUTH0_MANAGEMENT_API_ACCESS_TOKEN = '';
+// Set the authDomain to the domain users log in at, which varies depending on which tenant is being connected to.
+// Often this is a subdomain of auth0.com.
+const authDomain = '';
+// This script searches for users by email address and picks the first result. Change this to the email of the user to
+// fetch.
+const userEmail = '';
+
+var options = {
+  method: 'GET',
+  url: `https://${authDomain}/api/v2/users`,
+  params: { q: `email:"${userEmail}"`, search_engine: 'v3' },
+  headers: { authorization: `Bearer ${AUTH0_MANAGEMENT_API_ACCESS_TOKEN}` }
+};
+
+async function run() {
+  try {
+    const response = await axios.request(options);
+    const user = response.data[0];
+    const ids = user.identities;
+    const ptIdentity = ids.find((id: any) => id.connection == 'paratext');
+    const jwt = ptIdentity.access_token;
+    showJwt(jwt);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+run();

--- a/scripts/db_tools/db-token-info.ts
+++ b/scripts/db_tools/db-token-info.ts
@@ -1,0 +1,42 @@
+#!./node_modules/.bin/ts-node
+
+import { MongoClient } from 'mongodb';
+import { showJwt } from './show-jwt';
+import { devConfig } from './utils';
+
+// This script finds a user by email address and then looks up the Paratext access token for that user from the user
+// secrets collection. It can be run by itself, or the token can be monitored by running e.g.
+// watch -n 10 ./db-token-info.ts
+// which will run the script every 10 seconds.
+
+type UserSecret = {
+  _id: string;
+  paratextTokens: {
+    accessToken: string;
+    refreshToken: string;
+  };
+};
+
+// Set to the email of the user to look up
+const email = '';
+// Set to the connection to fetch the token from
+const connectionConfig = devConfig;
+
+async function run() {
+  const client = new MongoClient(connectionConfig.dbLocation);
+  try {
+    await client.connect();
+    const db = client.db();
+    const userCollection = db.collection<{ _id: string }>('users');
+    const user = await userCollection.findOne({ email });
+    const userId = user!._id;
+    const userSecretsCollection = db.collection<UserSecret>('user_secrets');
+    const userSecrets = await userSecretsCollection.findOne({ _id: userId });
+    const jwt = userSecrets!.paratextTokens.accessToken;
+    showJwt(jwt);
+  } finally {
+    client.close();
+  }
+}
+
+run();

--- a/scripts/db_tools/package-lock.json
+++ b/scripts/db_tools/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "axios": "^0.27.2",
         "mongodb": "^4.6.0",
         "ot-json0": "^1.1.0",
         "rich-text": "^4.1.0",
@@ -198,6 +199,20 @@
         "lodash": "^4.17.14"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -277,6 +292,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -297,6 +323,14 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/denque": {
@@ -338,6 +372,38 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -413,6 +479,25 @@
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
       "optional": true
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/mingo": {
       "version": "4.4.1",
@@ -929,6 +1014,20 @@
         "lodash": "^4.17.14"
       }
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -974,6 +1073,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -987,6 +1094,11 @@
       "requires": {
         "ms": "2.1.2"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "denque": {
       "version": "2.0.1",
@@ -1018,6 +1130,21 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
+    },
+    "follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -1070,6 +1197,19 @@
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
       "optional": true
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
     },
     "mingo": {
       "version": "4.4.1",

--- a/scripts/db_tools/package.json
+++ b/scripts/db_tools/package.json
@@ -9,6 +9,7 @@
   "main": "lib/cjs/common/index.js",
   "types": "lib/cjs/common/index.d.ts",
   "dependencies": {
+    "axios": "^0.27.2",
     "mongodb": "^4.6.0",
     "ot-json0": "^1.1.0",
     "rich-text": "^4.1.0",

--- a/scripts/db_tools/show-jwt.ts
+++ b/scripts/db_tools/show-jwt.ts
@@ -1,0 +1,13 @@
+export function showJwt(jwt: string) {
+  const payloadSection = jwt.split('.')[1];
+  const payload = JSON.parse(Buffer.from(payloadSection, 'base64').toString());
+  const expiration = new Date(payload.exp * 1000);
+  const currentTimeInSeconds = new Date().getTime() / 1000;
+  const relativeTime = (payload.exp - currentTimeInSeconds) / 60;
+  const formattedTime = Math.round(relativeTime * 100) / 100;
+  console.log(`Token for ${payload.username} expires at ${expiration.toISOString()} (in ${formattedTime} minutes)`);
+  console.log();
+  console.log(payload);
+  console.log();
+  console.log(jwt);
+}

--- a/scripts/db_tools/utils.d.ts
+++ b/scripts/db_tools/utils.d.ts
@@ -18,5 +18,7 @@ export type ConnectionSettings = { dbLocation: string; wsConnectionString: strin
 export function createWS(connectionConfig: ConnectionSettings): WebSocket;
 export var databaseConfigs: Map<string, ConnectionSettings>;
 export var devConfig: { dbLocation: string; wsConnectionString: string };
+export var qaConfig: { dbLocation: string; wsConnectionString: string };
+export var liveConfig: { dbLocation: string; wsConnectionString: string };
 export function useColor(ifUseColor: boolean): void;
 export var colors: any;


### PR DESCRIPTION
This adds two scripts, one for showing the state of a user's access token in Mongo, and the other to show the access token in Auth0.

The package axios is added for sending HTTP requests. I don't know that much about axios, but it's what Auth0 uses in their examples of how to call their API from Node.js.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1388)
<!-- Reviewable:end -->
