### PR TITLE
Make Mongo query for finding corrupted texts print ids

### DIFF
--- a/mongodb/Texts/CorruptedTexts.mongodb
+++ b/mongodb/Texts/CorruptedTexts.mongodb
@@ -4,17 +4,25 @@
 
 use('xforge');
 
-console.log(
-  db.texts.countDocuments({
-    ops: {
-      $elemMatch: {
-        $or: [
-          { 'insert.verse': true },
-          { 'attributes.segment': /(?:null|undefined)/ },
-          // This will match delete and retain ops, which should not exist, but have been found in production
-          { insert: { $exists: false } }
-        ]
-      }
+const texts = db.texts.find({
+  ops: {
+    $elemMatch: {
+      $or: [
+        { 'insert.verse': true },
+        { 'attributes.segment': /(?:null|undefined)/ },
+        // This will match delete and retain ops, which should not exist, but have been found in production
+        { insert: { $exists: false } }
+      ]
     }
-  })
-);
+  }
+}, {
+  _id: 1
+}).toArray();
+
+if (texts.length > 0) {
+  console.log(texts.map(text => text._id).join('\n'));
+} else {
+  console.log('none');
+}
+
+texts


### PR DESCRIPTION
This just makes it one less set to find the corrupted texts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1389)
<!-- Reviewable:end -->
