### PR TITLE
SF-1591 Prevent error when switching to book with fewer chapters

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.html
@@ -1,34 +1,26 @@
 <ng-container *transloco="let t; read: 'chapter_nav'">
-  <mdc-select
-    #chapterSelect
-    class="chapter-select"
-    [(ngModel)]="chapterString"
-    (selectionChange)="chapterSelect._selectedText.elementRef.nativeElement.blur()"
-  >
-    <mdc-menu>
-      <mdc-list>
-        <mdc-list-item *ngFor="let cs of chapterStrings" [value]="cs">{{ cs }}</mdc-list-item>
-      </mdc-list>
-    </mdc-menu>
-  </mdc-select>
+  <mat-form-field appearance="fill" id="chapter-select">
+    <mat-select [(value)]="chapter" (valueChange)="chapterChanged()" panelClass="chapter-select-menu">
+      <mat-option *ngFor="let c of chapters" [value]="c">{{ bookName }} {{ c }}</mat-option>
+    </mat-select>
+  </mat-form-field>
   <button
-    mdc-icon-button
-    appBlurOnClick
-    icon="keyboard_arrow_left"
-    type="button"
+    mat-icon-button
     (click)="prevChapter()"
     [disabled]="isPrevChapterDisabled()"
     title="{{ t('previous_chapter') }}"
     fxHide.xs
-  ></button>
+  >
+    <mat-icon>keyboard_arrow_left</mat-icon>
+  </button>
   <button
-    mdc-icon-button
-    appBlurOnClick
+    mat-icon-button
     icon="keyboard_arrow_right"
-    type="button"
     (click)="nextChapter()"
     [disabled]="isNextChapterDisabled()"
     title="{{ t('next_chapter') }}"
     fxHide.xs
-  ></button>
+  >
+    <mat-icon>keyboard_arrow_right</mat-icon>
+  </button>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.scss
@@ -3,44 +3,34 @@
 
 :host {
   display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  align-items: center;
 }
 
-.mdc-icon-button {
-  @include icon-button.icon-size(24px, 24px, 8px);
-}
-
-// Unfortunately, using Sass mixins to style the select was not successful at the current version of @angular-mdc/web
-// (5.1.1) and @angular/material (9.2.4). Consider reviewing this after upgrading dependencies.
-.chapter-select {
-  ::ng-deep {
-    &,
-    .mdc-select__anchor,
-    .mdc-select__selected-text {
-      height: 40px;
+// Unfortunately there doesn't appear to be a good way to style a mat-select
+// These styles were written by inspecting the elements using developer and then adding rules until it looked right
+#chapter-select ::ng-deep {
+  .mat-form-field-wrapper {
+    padding-bottom: 0;
+    .mat-form-field-flex {
+      padding-top: 0;
     }
-
-    .mdc-select__anchor {
+    .mat-form-field-flex:not(:hover) {
       background-color: transparent;
     }
-
-    .mdc-line-ripple {
-      display: none;
-    }
-
-    .mdc-select__selected-text {
-      min-width: 140px;
-      padding: 8px 2em 8px 8px !important;
-    }
-
-    .mdc-select__dropdown-icon {
-      bottom: 8px;
-    }
+  }
+  .mat-form-field-underline {
+    display: none;
+  }
+  .mat-select-arrow-wrapper {
+    transform: unset;
+  }
+  .mat-form-field-infix {
+    // It appeared there was a transparent border being used as padding
+    border-top-width: 0;
+    padding-top: 12px;
+    padding-bottom: 10px;
   }
 }
 
-mdc-select mdc-list-item {
-  white-space: nowrap;
+::ng-deep .mat-select-panel.chapter-select-menu {
+  max-height: 85vh;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.spec.ts
@@ -1,29 +1,33 @@
-import { MdcSelect } from '@angular-mdc/web';
-import { Component, DebugElement, ViewChild } from '@angular/core';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { mock, when } from 'ts-mockito';
 import { I18nService } from 'xforge-common/i18n.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
+import { MatSelectHarness } from '@angular/material/select/testing';
 import { ChapterNavComponent } from './chapter-nav.component';
 
 const mockedI18nService = mock(I18nService);
 describe('ChapterNavComponent', () => {
   configureTestingModule(() => ({
-    imports: [TestTranslocoModule, UICommonModule],
+    imports: [TestTranslocoModule, UICommonModule, NoopAnimationsModule],
     declarations: [ChapterNavComponent, ChapterNavHostComponent],
     providers: [{ provide: I18nService, useMock: mockedI18nService }]
   }));
 
   it('should open to a book and chapter', fakeAsync(() => {
     const env = new TestEnvironment({ book: 2, chapter: 2 });
+    env.wait();
     expect(env.component.chapter).toEqual(2);
     expect(env.component.bookName).toBe('Book 2');
   }));
 
   it('should change book', fakeAsync(() => {
     const env = new TestEnvironment();
+    env.wait();
     expect(env.component.chapter).toEqual(1);
     expect(env.component.bookName).toBe('Book 1');
     env.hostComponent.activeBookNum = 2;
@@ -32,22 +36,30 @@ describe('ChapterNavComponent', () => {
     expect(env.component.bookName).toBe('Book 2');
   }));
 
-  it('should change chapter if selected', fakeAsync(() => {
+  it('should change chapter if selected', async () => {
     const env = new TestEnvironment();
-    expect(env.component.chapter).toEqual(1);
+    const select = await env.getSelectHarness();
+    await select.open();
+
     expect(env.hostComponent.hasChangeEmitted).toBe(false);
-    env.changeSelectValue(env.chapterSelect, 'Book 1 2');
-    expect(env.component.chapterString).toEqual('Book 1 2');
+    const options = await select.getOptions();
+    await options[1].click();
+    expect(await select.getValueText()).toBe('Book 1 2');
+    expect(env.component.chapter).toEqual(2);
     expect(env.hostComponent.hasChangeEmitted).toBe(true);
-  }));
+    await select.close();
+
+    // Hacky way to clean up the overlay container
+    document.querySelector('.cdk-overlay-container')!.remove();
+  });
 });
 
 @Component({
   template: `
     <app-chapter-nav
       [bookNum]="activeBookNum"
-      [(chapter)]="activeChapter"
-      (chapters)="(allChapters)"
+      [chapter]="activeChapter"
+      [chapters]="allChapters"
       (chapterChange)="hasChangeEmitted = true"
     ></app-chapter-nav>
   `
@@ -62,6 +74,7 @@ class ChapterNavHostComponent {
 
 class TestEnvironment {
   readonly fixture: ComponentFixture<ChapterNavHostComponent>;
+  readonly harnessLoader: HarnessLoader;
   readonly hostComponent: ChapterNavHostComponent;
   readonly component: ChapterNavComponent;
 
@@ -69,23 +82,17 @@ class TestEnvironment {
     when(mockedI18nService.localizeBook(1)).thenReturn('Book 1');
     when(mockedI18nService.localizeBook(2)).thenReturn('Book 2');
     this.fixture = TestBed.createComponent(ChapterNavHostComponent);
+    this.harnessLoader = TestbedHarnessEnvironment.loader(this.fixture);
     this.fixture.detectChanges();
     this.hostComponent = this.fixture.componentInstance;
     this.component = this.hostComponent.chapterNavComponent;
 
     this.hostComponent.activeBookNum = start == null ? 1 : start.book;
     this.hostComponent.activeChapter = start == null ? 1 : start.chapter;
-    this.wait();
   }
 
-  get chapterSelect(): DebugElement {
-    return this.fixture.debugElement.query(By.css('.chapter-select'));
-  }
-
-  changeSelectValue(element: DebugElement, value: string): void {
-    const select: MdcSelect = element.componentInstance;
-    select.value = value;
-    this.wait();
+  async getSelectHarness(): Promise<MatSelectHarness> {
+    return await this.harnessLoader.getHarness(MatSelectHarness);
   }
 
   wait(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.ts
@@ -19,21 +19,8 @@ export class ChapterNavComponent {
     return this.bookNum == null ? '' : this.i18n.localizeBook(this.bookNum);
   }
 
-  get chapterString(): string {
-    return this.chapter == null ? '' : `${this.bookName} ${this.chapter.toString()}`;
-  }
-
-  set chapterString(value: string) {
-    const numString = value.match(/\d+$/)![0];
-    const chapter = parseInt(numString, 10);
-    if (this.chapter !== chapter) {
-      this.chapter = chapter;
-      this.chapterChange.emit(this.chapter);
-    }
-  }
-
-  get chapterStrings(): string[] {
-    return this.chapters.map(c => `${this.bookName} ${c.toString()}`);
+  chapterChanged() {
+    this.chapterChange.emit(this.chapter);
   }
 
   prevChapter(): void {


### PR DESCRIPTION
- Previously, switching to a book with n chapters caused an error if the currently active chapter was n+1 or greater.
- This was solved by switching the chapter select from Angular MDC to Angular Material, which we were going to need to do at some point anyway.

One of the tests now uses a component harness, which I don't recall using in the past. See https://material.angular.io/cdk/test-harnesses/overview