### PR TITLE
hotfix: disable multi-cursor feature and downgrade sharedb

### DIFF
--- a/src/RealtimeServer/package-lock.json
+++ b/src/RealtimeServer/package-lock.json
@@ -16,7 +16,7 @@
         "mongodb": "^4.6.0",
         "ot-json0": "^1.1.0",
         "rich-text": "^4.1.0",
-        "sharedb": "^1.9.2",
+        "sharedb": "1.1.0",
         "sharedb-access": "^5.0.0",
         "sharedb-mongo": "^1.0.0",
         "ts-object-path": "^0.1.2",
@@ -6559,12 +6559,12 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "node_modules/sharedb": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-1.9.2.tgz",
-      "integrity": "sha512-YioIGNOjITm+loRrGYSCF1S6tbid15MUHloQN7035tAbDlJuveHmxnQ/6e/CguAFsGvFom2zfj3xUJLXGaTyYg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-1.1.0.tgz",
+      "integrity": "sha512-0ZuWogy4VFe7PghoqoJw+zLMhKn6lHPE3OSJEeka3FDS2zUTebdMz5qABBKalBslFE/+fR9fIz+sDGJ3RiHGYQ==",
       "dependencies": {
         "arraydiff": "^0.1.1",
-        "async": "^2.6.3",
+        "async": "^1.4.2",
         "fast-deep-equal": "^2.0.1",
         "hat": "0.0.3",
         "ot-json0": "^1.0.1"
@@ -6601,6 +6601,28 @@
         "mongodb": "^2.1.2 || ^3.0.0 || ^4.0.0",
         "sharedb": "^1.9.1 || ^2.0.0"
       }
+    },
+    "node_modules/sharedb-mongo/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
+    },
+    "node_modules/sharedb-mongo/node_modules/sharedb": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-2.2.5.tgz",
+      "integrity": "sha512-uCy8Npx8Azf21PmNUGqfIKRbnisH2U+N9Z0CJILWq23+HqcWRAA5n35m/dMm4ZuTQalYeWlR2/kaV8Wm0nXr3g==",
+      "dependencies": {
+        "arraydiff": "^0.1.1",
+        "async": "^2.6.3",
+        "fast-deep-equal": "^2.0.1",
+        "hat": "0.0.3",
+        "ot-json0": "^1.0.1"
+      }
+    },
+    "node_modules/sharedb/node_modules/async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w=="
     },
     "node_modules/sharedb/node_modules/fast-deep-equal": {
       "version": "2.0.1",
@@ -12517,17 +12539,22 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "sharedb": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-1.9.2.tgz",
-      "integrity": "sha512-YioIGNOjITm+loRrGYSCF1S6tbid15MUHloQN7035tAbDlJuveHmxnQ/6e/CguAFsGvFom2zfj3xUJLXGaTyYg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-1.1.0.tgz",
+      "integrity": "sha512-0ZuWogy4VFe7PghoqoJw+zLMhKn6lHPE3OSJEeka3FDS2zUTebdMz5qABBKalBslFE/+fR9fIz+sDGJ3RiHGYQ==",
       "requires": {
         "arraydiff": "^0.1.1",
-        "async": "^2.6.3",
+        "async": "^1.4.2",
         "fast-deep-equal": "^2.0.1",
         "hat": "0.0.3",
         "ot-json0": "^1.0.1"
       },
       "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w=="
+        },
         "fast-deep-equal": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -12562,6 +12589,25 @@
         "async": "^2.6.3",
         "mongodb": "^2.1.2 || ^3.0.0 || ^4.0.0",
         "sharedb": "^1.9.1 || ^2.0.0"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
+        },
+        "sharedb": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-2.2.5.tgz",
+          "integrity": "sha512-uCy8Npx8Azf21PmNUGqfIKRbnisH2U+N9Z0CJILWq23+HqcWRAA5n35m/dMm4ZuTQalYeWlR2/kaV8Wm0nXr3g==",
+          "requires": {
+            "arraydiff": "^0.1.1",
+            "async": "^2.6.3",
+            "fast-deep-equal": "^2.0.1",
+            "hat": "0.0.3",
+            "ot-json0": "^1.0.1"
+          }
+        }
       }
     },
     "shebang-command": {

--- a/src/RealtimeServer/package.json
+++ b/src/RealtimeServer/package.json
@@ -26,7 +26,7 @@
     "mongodb": "^4.6.0",
     "ot-json0": "^1.1.0",
     "rich-text": "^4.1.0",
-    "sharedb": "^1.9.2",
+    "sharedb": "1.1.0",
     "sharedb-access": "^5.0.0",
     "sharedb-mongo": "^1.0.0",
     "ts-object-path": "^0.1.2",

--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -52,7 +52,7 @@
         "recordrtc": "^5.6.2",
         "rich-text": "^4.1.0",
         "rxjs": "^6.6.7",
-        "sharedb": "^1.9.2",
+        "sharedb": "1.1.0",
         "tinycolor2": "^1.4.2",
         "tslib": "^2.4.0",
         "uuid": "^8.3.2",
@@ -119,7 +119,7 @@
         "mongodb": "^4.6.0",
         "ot-json0": "^1.1.0",
         "rich-text": "^4.1.0",
-        "sharedb": "^1.9.2",
+        "sharedb": "1.1.0",
         "sharedb-access": "^5.0.0",
         "sharedb-mongo": "^1.0.0",
         "ts-object-path": "^0.1.2",
@@ -12196,7 +12196,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -20083,24 +20084,21 @@
       }
     },
     "node_modules/sharedb": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-1.9.2.tgz",
-      "integrity": "sha512-YioIGNOjITm+loRrGYSCF1S6tbid15MUHloQN7035tAbDlJuveHmxnQ/6e/CguAFsGvFom2zfj3xUJLXGaTyYg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-1.1.0.tgz",
+      "integrity": "sha512-0ZuWogy4VFe7PghoqoJw+zLMhKn6lHPE3OSJEeka3FDS2zUTebdMz5qABBKalBslFE/+fR9fIz+sDGJ3RiHGYQ==",
       "dependencies": {
         "arraydiff": "^0.1.1",
-        "async": "^2.6.3",
+        "async": "^1.4.2",
         "fast-deep-equal": "^2.0.1",
         "hat": "0.0.3",
         "ot-json0": "^1.0.1"
       }
     },
     "node_modules/sharedb/node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w=="
     },
     "node_modules/sharedb/node_modules/fast-deep-equal": {
       "version": "2.0.1",
@@ -32614,7 +32612,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash-es": {
       "version": "4.17.21",
@@ -37730,7 +37729,7 @@
         "ot-json0": "^1.1.0",
         "prettier": "^2.6.2",
         "rich-text": "^4.1.0",
-        "sharedb": "^1.9.2",
+        "sharedb": "1.1.0",
         "sharedb-access": "^5.0.0",
         "sharedb-mingo-memory": "^1.2.0",
         "sharedb-mongo": "^1.0.0",
@@ -38449,24 +38448,21 @@
       }
     },
     "sharedb": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-1.9.2.tgz",
-      "integrity": "sha512-YioIGNOjITm+loRrGYSCF1S6tbid15MUHloQN7035tAbDlJuveHmxnQ/6e/CguAFsGvFom2zfj3xUJLXGaTyYg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-1.1.0.tgz",
+      "integrity": "sha512-0ZuWogy4VFe7PghoqoJw+zLMhKn6lHPE3OSJEeka3FDS2zUTebdMz5qABBKalBslFE/+fR9fIz+sDGJ3RiHGYQ==",
       "requires": {
         "arraydiff": "^0.1.1",
-        "async": "^2.6.3",
+        "async": "^1.4.2",
         "fast-deep-equal": "^2.0.1",
         "hat": "0.0.3",
         "ot-json0": "^1.0.1"
       },
       "dependencies": {
         "async": {
-          "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-          "requires": {
-            "lodash": "^4.17.14"
-          }
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w=="
         },
         "fast-deep-equal": {
           "version": "2.0.1",

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -63,7 +63,7 @@
     "recordrtc": "^5.6.2",
     "rich-text": "^4.1.0",
     "rxjs": "^6.6.7",
-    "sharedb": "^1.9.2",
+    "sharedb": "1.1.0",
     "tinycolor2": "^1.4.2",
     "tslib": "^2.4.0",
     "uuid": "^8.3.2",

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -6,7 +6,7 @@ import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils
 import { Subscription } from 'rxjs';
 import { LocalPresence, Presence } from 'sharedb/lib/sharedb';
 import tinyColor from 'tinycolor2';
-import { objectId } from 'xforge-common/utils';
+// import { objectId } from 'xforge-common/utils';
 import { Delta, TextDoc } from '../../core/models/text-doc';
 import { MultiCursorViewer } from '../../translate/editor/multi-viewer/multi-viewer.component';
 import { isBadDelta, VERSE_FROM_SEGMENT_REF_REGEX } from '../utils';
@@ -125,7 +125,7 @@ export class TextViewModel {
   localPresence?: LocalPresence<PresenceData>;
 
   private readonly _segments: Map<string, RangeStatic> = new Map<string, RangeStatic>();
-  private readonly presenceId: string = objectId();
+  // private readonly presenceId: string = objectId();
   private readonly cursorColorStorageKey = 'cursor_color';
   private presence?: Presence<PresenceData>;
   private remoteChangesSub?: Subscription;
@@ -137,7 +137,7 @@ export class TextViewModel {
    */
   private _embeddedElements: Map<string, number> = new Map<string, number>();
 
-  private onPresenceReceive = (_presenceId: string, _presenceData: PresenceData | null) => {};
+  // private onPresenceReceive = (_presenceId: string, _presenceData: PresenceData | null) => {};
 
   constructor(private presenceChange?: EventEmitter<RemotePresences | undefined>) {
     let localCursorColor = localStorage.getItem(this.cursorColorStorageKey);
@@ -194,7 +194,7 @@ export class TextViewModel {
       }
       editor.history.clear();
     });
-
+    /*
     this.presence = textDoc.docPresence;
     this.presence.subscribe(error => {
       if (error) throw error;
@@ -215,6 +215,7 @@ export class TextViewModel {
       this.presenceChange?.emit(this.presence?.remotePresences);
     };
     this.presence.on('receive', this.onPresenceReceive);
+    */
   }
 
   unbind(): void {
@@ -226,19 +227,19 @@ export class TextViewModel {
     }
     this.textDoc = undefined;
 
-    this.presence?.unsubscribe(error => {
-      if (error) throw error;
-    });
-    this.presence?.off('receive', this.onPresenceReceive);
-    this.localPresence?.submit(null as unknown as PresenceData);
+    // this.presence?.unsubscribe(error => {
+    //   if (error) throw error;
+    // });
+    // this.presence?.off('receive', this.onPresenceReceive);
+    // this.localPresence?.submit(null as unknown as PresenceData);
 
     if (this.editor != null) {
       this.editor.setText('', 'silent');
       const cursors: QuillCursors = this.editor.getModule('cursors');
       cursors.clearCursors();
-      this.presenceChange?.emit(this.presence?.remotePresences);
+      // this.presenceChange?.emit(this.presence?.remotePresences);
     }
-    this.presence = undefined;
+    // this.presence = undefined;
     this._segments.clear();
     this._embeddedElements.clear();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -171,7 +171,7 @@ describe('TextComponent', () => {
     expect(window.getComputedStyle(titleSegment, '::before').content).toEqual('none');
   }));
 
-  describe('MultiCursor Presence', () => {
+  xdescribe('MultiCursor Presence', () => {
     it('should not update presence if something other than the user moves the cursor', fakeAsync(() => {
       const env: TestEnvironment = new TestEnvironment();
       env.fixture.detectChanges();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -359,7 +359,8 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   }
 
   get localPresence(): LocalPresence<PresenceData> | undefined {
-    return this.viewModel.localPresence;
+    // return this.viewModel.localPresence;
+    return undefined;
   }
 
   private get isPresenceEnabled(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/typings/sharedb.d.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/typings/sharedb.d.ts
@@ -60,7 +60,7 @@ declare module 'sharedb/lib/client' {
       callback?: (err: Error, snapshot: Snapshot) => void
     ): Snapshot;
     getPresence(channel: string): Presence;
-    getDocPresence(collection: string, id: string): Presence;
+    // getDocPresence(collection: string, id: string): Presence;
     close(): void;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
@@ -64,8 +64,9 @@ export abstract class RealtimeDoc<T = any, Ops = any, P = any> {
     return this.adapter.collection;
   }
 
-  get docPresence(): Presence<P> {
-    return this.adapter.docPresence;
+  get docPresence(): Presence<P> | undefined {
+    // return this.adapter.docPresence;
+    return undefined;
   }
 
   /** Fires when underlying data is recreated. */

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime-remote-store.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 import { OTType } from 'sharedb/lib/client';
-import { Presence } from 'sharedb/lib/sharedb';
+// import { Presence } from 'sharedb/lib/sharedb';
 import { Snapshot } from './models/snapshot';
 import { QueryParameters } from './query-parameters';
 
@@ -27,7 +27,7 @@ export interface RealtimeDocAdapter {
   readonly pendingOps: any[];
   readonly subscribed: boolean;
   readonly collection: string;
-  readonly docPresence: Presence;
+  // readonly docPresence: Presence;
 
   readonly idle$: Observable<void>;
   /** Fires when underlying data is recreated. */

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
@@ -5,7 +5,7 @@ import * as RichText from 'rich-text';
 import { fromEvent, Observable, Subject } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 import { Connection, Doc, OTType, Query, Snapshot, types } from 'sharedb/lib/client';
-import { Presence } from 'sharedb/lib/sharedb';
+// import { Presence } from 'sharedb/lib/sharedb';
 import { PwaService } from 'xforge-common/pwa.service';
 import { Snapshot as DataSnapshot } from 'xforge-common/models/snapshot';
 import { environment } from '../environments/environment';
@@ -129,9 +129,9 @@ export class SharedbRealtimeDocAdapter implements RealtimeDocAdapter {
     return this.doc.collection;
   }
 
-  get docPresence(): Presence {
-    return this.doc.connection.getDocPresence(this.collection, this.id);
-  }
+  // get docPresence(): Presence {
+  //   return this.doc.connection.getDocPresence(this.collection, this.id);
+  // }
 
   get pendingOps(): any[] {
     let pendingOps = [];


### PR DESCRIPTION
Upgrading sharedb to version 1.9.2 during the multi-cursor feature has caused some unexplained synchronization issues that result in corrupted text docs. Until further notice, this change disables the multi-cursor feature and downgrades the sharedb version to one that does not show the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1394)
<!-- Reviewable:end -->
