### PR TITLE
SF-1565b Cancel paste when invalid selection

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -2530,6 +2530,104 @@ describe('TextComponent', () => {
 
     expect(cancelled).withContext('event should have been cancelled when invalid selection').toBeTrue();
   }));
+
+  it('does not cancel paste when valid selection', fakeAsync(() => {
+    const chapterNum = 2;
+    const segmentRef: string = `verse_${chapterNum}_1`;
+    const textDocOps: RichText.DeltaOperation[] = [
+      { insert: { chapter: { number: chapterNum.toString(), style: 'c' } } },
+      { insert: { verse: { number: '1', style: 'v' } } },
+      {
+        insert: `quick brown fox`,
+        attributes: {
+          segment: segmentRef
+        }
+      }
+    ];
+
+    const env = new TestEnvironment({ chapterNum, textDoc: textDocOps });
+
+    env.fixture.detectChanges();
+    tick();
+    env.component.setSegment(segmentRef);
+    tick();
+    env.component.editor?.setSelection(0);
+
+    const payload: string = 'abcd';
+    const clipboardData = new DataTransfer();
+    clipboardData.setData('text/plain', payload);
+    clipboardData.setData('text/html', `<span background="white">${payload}</span>`);
+
+    const pasteEvent: ClipboardEvent = new ClipboardEvent('paste', {
+      clipboardData,
+      cancelable: true
+    });
+
+    const quillUpdateContentsSpy: jasmine.Spy<any> = spyOn<any>(
+      env.component.editor,
+      'updateContents'
+    ).and.callThrough();
+    // When asked, the current selection will be called valid.
+    spyOn<any>(env.component, 'isValidSelectionForCurrentSegment').and.returnValue(true);
+
+    // I haven't been able to trigger quill's onPaste by dispatching a ClipboardEvent. So directly call it.
+
+    // SUT
+    (env.component.editor!.clipboard as any).onPaste(pasteEvent);
+    flush();
+    expect(pasteEvent.defaultPrevented).withContext('the quill onPaste cancels further processing').toBeTrue();
+
+    expect(quillUpdateContentsSpy).withContext('quill is edited').toHaveBeenCalled();
+  }));
+
+  it('cancels paste when invalid selection', fakeAsync(() => {
+    const chapterNum = 2;
+    const segmentRef: string = `verse_${chapterNum}_1`;
+    const textDocOps: RichText.DeltaOperation[] = [
+      { insert: { chapter: { number: chapterNum.toString(), style: 'c' } } },
+      { insert: { verse: { number: '1', style: 'v' } } },
+      {
+        insert: `quick brown fox`,
+        attributes: {
+          segment: segmentRef
+        }
+      }
+    ];
+
+    const env = new TestEnvironment({ chapterNum, textDoc: textDocOps });
+
+    env.fixture.detectChanges();
+    tick();
+    env.component.setSegment(segmentRef);
+    tick();
+    env.component.editor?.setSelection(0);
+
+    const payload: string = 'abcd';
+    const clipboardData = new DataTransfer();
+    clipboardData.setData('text/plain', payload);
+    clipboardData.setData('text/html', `<span background="white">${payload}</span>`);
+
+    const pasteEvent: ClipboardEvent = new ClipboardEvent('paste', {
+      clipboardData,
+      cancelable: true
+    });
+
+    const quillUpdateContentsSpy: jasmine.Spy<any> = spyOn<any>(
+      env.component.editor,
+      'updateContents'
+    ).and.callThrough();
+    // When asked, the current selection will be called invalid.
+    spyOn<any>(env.component, 'isValidSelectionForCurrentSegment').and.returnValue(false);
+
+    // I haven't been able to trigger quill's onPaste by dispatching a ClipboardEvent. So directly call it.
+
+    // SUT
+    (env.component.editor!.clipboard as any).onPaste(pasteEvent);
+    flush();
+    expect(pasteEvent.defaultPrevented).withContext('the quill onPaste cancels further processing').toBeTrue();
+
+    expect(quillUpdateContentsSpy).withContext('quill contents are not modified').not.toHaveBeenCalled();
+  }));
 });
 
 /** Represents both what the TextComponent understand to be the text in a segment, and what the editor

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -188,6 +188,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     history: {
       userOnly: true
     },
+    clipboard: { textComponent: this },
     dragAndDrop: { textComponent: this }
   };
   private _id?: TextDocId;
@@ -709,6 +710,19 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     return false;
   }
 
+  /** Is a given selection range valid for editing the current segment? */
+  isValidSelectionForCurrentSegment(sel: RangeStatic): boolean {
+    const newSel: RangeStatic | null = this.conformToValidSelectionForCurrentSegment(sel);
+    if (newSel == null) {
+      return false;
+    }
+
+    if (sel.index !== newSel.index || sel.length !== newSel.length) {
+      return false;
+    }
+    return true;
+  }
+
   private applyEditorStyles() {
     if (this._editor != null) {
       const container = this._editor.container as HTMLElement;
@@ -1018,19 +1032,6 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     }
 
     return newSel;
-  }
-
-  /** Is a given selection range valid for editing the current segment? */
-  private isValidSelectionForCurrentSegment(sel: RangeStatic): boolean {
-    const newSel: RangeStatic | null = this.conformToValidSelectionForCurrentSegment(sel);
-    if (newSel == null) {
-      return false;
-    }
-
-    if (sel.index !== newSel.index || sel.length !== newSel.length) {
-      return false;
-    }
-    return true;
   }
 
   /** Handler for beforeinput event on quill DOM element. */


### PR DESCRIPTION
- If the user selects text and pastes without releasing the mouse
button, the selected text is replaced. Even if the selection spans
something like a verse number.
- This change prevents this from happening by only performing the
paste if the selection is valid for editing. If the selection is
invalid for editing the current segment, onPaste() is returned from
early, and also preventDefault() was called.