### PR TITLE
Remove requireFromRealTimeServer from scripts

### DIFF
--- a/scripts/db_tools/doc-history.js
+++ b/scripts/db_tools/doc-history.js
@@ -4,9 +4,9 @@
 // text-doc-history.js
 
 const utils = require('./utils.js');
-const RichText = utils.requireFromRealTimeServer('rich-text');
-const OTJson0 = utils.requireFromRealTimeServer('ot-json0');
-const ShareDB = utils.requireFromRealTimeServer('sharedb/lib/client');
+const RichText = require('rich-text');
+const OTJson0 = require('ot-json0');
+const ShareDB = require('sharedb/lib/client');
 
 // Edit these settings to specify which doc to show
 const docId = '';

--- a/scripts/db_tools/fix-doc.js
+++ b/scripts/db_tools/fix-doc.js
@@ -5,8 +5,8 @@
 // intended to be edited to be used as needed.
 
 const utils = require('./utils.js');
-const RichText = utils.requireFromRealTimeServer('rich-text');
-const ShareDB = utils.requireFromRealTimeServer('sharedb/lib/client');
+const RichText = require('rich-text');
+const ShareDB = require('sharedb/lib/client');
 
 // Edit these settings to specify which doc to revert
 const docId = '';

--- a/scripts/db_tools/import-doc.js
+++ b/scripts/db_tools/import-doc.js
@@ -5,8 +5,8 @@
 // another given state.
 
 const utils = require('./utils.js');
-const RichText = utils.requireFromRealTimeServer('rich-text');
-const ShareDB = utils.requireFromRealTimeServer('sharedb/lib/client');
+const RichText = require('rich-text');
+const ShareDB = require('sharedb/lib/client');
 
 // Edit these settings to specify what doc to import to where
 const fromDocId = '';

--- a/scripts/db_tools/revert-doc.js
+++ b/scripts/db_tools/revert-doc.js
@@ -4,8 +4,8 @@
 // previous version
 
 const utils = require('./utils.js');
-const RichText = utils.requireFromRealTimeServer('rich-text');
-const ShareDB = utils.requireFromRealTimeServer('sharedb/lib/client');
+const RichText = require('rich-text');
+const ShareDB = require('sharedb/lib/client');
 
 // Edit these settings to specify which doc to revert
 const docId = '';

--- a/scripts/db_tools/text-doc-history.js
+++ b/scripts/db_tools/text-doc-history.js
@@ -4,10 +4,10 @@
 // Sequential edits by the same user are grouped together so the size of the history is manageable.
 
 const utils = require('./utils');
-const RichText = utils.requireFromRealTimeServer('rich-text');
-const ShareDB = utils.requireFromRealTimeServer('sharedb/lib/client');
-const { MongoClient } = utils.requireFromRealTimeServer('mongodb');
-const OTJson0 = utils.requireFromRealTimeServer('ot-json0');
+const RichText = require('rich-text');
+const ShareDB = require('sharedb/lib/client');
+const { MongoClient } = require('mongodb');
+const OTJson0 = require('ot-json0');
 
 // Edit these settings to specify which doc to visualize
 const projectShortName = 'AAA';

--- a/scripts/db_tools/utils.js
+++ b/scripts/db_tools/utils.js
@@ -1,11 +1,4 @@
-const WebSocket = requireFromRealTimeServer('ws');
-
-/**
- * @param {string} packageName The name of the package to import
- */
-function requireFromRealTimeServer(packageName) {
-  return require('../../src/RealtimeServer/node_modules/' + packageName);
-}
+const WebSocket = require('ws');
 
 /**
  * @param {ShareDB.Doc} doc The doc to fetch
@@ -188,7 +181,6 @@ databaseConfigs.set('qa', qaConfig);
 databaseConfigs.set('live', liveConfig);
 
 module.exports = {
-  requireFromRealTimeServer,
   fetchDoc,
   submitDocOp,
   deleteDoc,


### PR DESCRIPTION
The function `requireFromRealTimeServer()` was used in the scripts before there was a pckage.json in the same folder. Now that we install the dependencies in the same folder, it is no longer needed, and we can call `require()` directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1398)
<!-- Reviewable:end -->
