### PR TITLE
SF-1607 Provide the src property to backend op acknowledge message

### DIFF
--- a/src/RealtimeServer/common/realtime-server.ts
+++ b/src/RealtimeServer/common/realtime-server.ts
@@ -50,6 +50,8 @@ class MigrationConnection extends Connection {
 
 /**
  * This class extends the ShareDB agent class to preserve the migration version property from the request.
+ * Note: Because this overrides behavior of ShareDB.Agent, when there are changes to ShareDB.Agent
+ * this class may need to be updated.
  */
 class MigrationAgent extends ShareDB.Agent {
   _handleMessage(request: any, callback: any): void {
@@ -62,7 +64,7 @@ class MigrationAgent extends ShareDB.Agent {
 
       // src can be provided if it is not the same as the current agent,
       // such as a resubmission after a reconnect, but it usually isn't needed
-      const src = request.src || this.clientId;
+      const src = request.src || this._src();
       // c, d, and m arguments are intentionally undefined. These are set later
       const op: any = { src, seq: request.seq, v: request.v, mv: request.mv, c: undefined, d: undefined, m: undefined };
       if (request.op != null) {

--- a/src/RealtimeServer/typings/sharedb/index.d.ts
+++ b/src/RealtimeServer/typings/sharedb/index.d.ts
@@ -130,6 +130,7 @@ declare namespace ShareDB {
     _handleMessage(request: any, callback: (...args: any[]) => any): void;
     _checkRequest(request: any): string | undefined;
     _submit(collection: string, id: string, op: any, callback: (...args: any[]) => any): void;
+    _src(): string;
   }
 
   abstract class PubSub {


### PR DESCRIPTION
It looks like it will be difficult to figure out how to hook into the realtime server to produce a valid test. I was not able to find the right way to set the src on the connection agent at the handshake stage.
There may still be issues involving using the dev tools to go offline, I see that when we use dev tools, the websocket reports that it is still open even though it cannot deliver the request. I propose that we get this fix to QA, and do some testing by disabling the network adaptor or unplugging the cable. I don't know if we can rely on using the dev tools to simulate the real world.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1399)
<!-- Reviewable:end -->
