### PR TITLE
SF-1565d Cancel dragstart when invalid selection

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/drag-and-drop.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/drag-and-drop.ts
@@ -20,6 +20,13 @@ export class DragAndDrop {
       // way, we can differentiate between drag-and-drops that have their origin as quill or from elsewhere, such as
       // elsewhere in the same web page window or from another window or application.
       dragEvent.dataTransfer?.setData(DragAndDrop.quillIsSourceToken, '');
+      const selection: RangeStatic | null | undefined = options.textComponent.editor?.getSelection();
+      if (selection == null) {
+        return;
+      }
+      if (!options.textComponent.isValidSelectionForCurrentSegment(selection)) {
+        dragEvent.preventDefault();
+      }
     });
 
     quill.container.addEventListener('drop', (event: Event) => {


### PR DESCRIPTION
- A selection can be made over a verse number, after which the text
can be dragged, messing up the document.
- Prevent this from happening by cancelling dragstart when the
selection is not valid for editing the current segment.

---

**Stack**:
- #1400
- #1395
- #1393


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*