### PR TITLE
text: disallow selection past current segment

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -2429,6 +2429,11 @@ describe('TextComponent', () => {
       },
 
       {
+        description: 'past end (out of bounds)',
+        range: { index: segmentRange.index + segmentRange.length + 1, length: 0 },
+        shouldBeValid: false
+      },
+      {
         description: 'range past end (out of bounds)',
         range: { index: segmentRange.index + segmentRange.length + 1, length: 1 },
         shouldBeValid: false

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -1017,9 +1017,16 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       newSel = { index: this._segment.range.index + this._segment.range.length, length: 0 };
     } else if (!this.multiSegmentSelection) {
       // selections outside of the text chooser dialog are not permitted to extend across segments
-      let newStart: number = Math.max(sel.index, this._segment.range.index);
+
+      const oldStart: number = sel.index;
       const oldEnd: number = sel.index + sel.length;
+      const segStart: number = this._segment.range.index;
       const segEnd: number = this._segment.range.index + this._segment.range.length;
+
+      let newStart: number = Math.max(oldStart, segStart);
+      if (newStart > segEnd) {
+        newStart = segEnd;
+      }
       const newEnd: number = Math.min(oldEnd, segEnd);
 
       const embedIndices: number[] = Array.from(this._segment.embeddedElements.values()).sort();


### PR DESCRIPTION
- I am not aware that this is happening as a bug, but when writing
test cases it seemed to be a hole that was open.

---

**Stack**:
- #1406
- #1405
- #1402 ⮜


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1402)
<!-- Reviewable:end -->
