### PR TITLE
sync: report on authentication ability before sync

### DIFF
--- a/src/SIL.XForge.Scripture/Services/IInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/IInternetSharedRepositorySource.cs
@@ -11,6 +11,7 @@ namespace SIL.XForge.Scripture.Services
         string[] Pull(string repository, SharedRepository pullRepo);
         void RefreshToken(string jwtToken);
         void UnlockRemoteRepository(SharedRepository sharedRepo);
+        bool CanUserAuthenticateToPTArchives();
         /// <summary> Access as a particular class. </summary>
         InternetSharedRepositorySource AsInternetSharedRepositorySource();
     }

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -12,6 +12,8 @@ namespace SIL.XForge.Scripture.Services
     public interface IParatextService
     {
         void Init();
+        Task<bool> CanUserAuthenticateToPTRegistryAsync(UserSecret userSecret);
+        Task<bool> CanUserAuthenticateToPTArchivesAsync(string userSFId);
         Task<IReadOnlyList<ParatextProject>> GetProjectsAsync(UserSecret userSecret);
         string GetParatextUsername(UserSecret userSecret);
         Task<Attempt<string>> TryGetProjectRoleAsync(UserSecret userSecret, string paratextId, CancellationToken token);

--- a/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
@@ -6,11 +6,12 @@ using Paratext;
 using Paratext.Data.Repository;
 using Paratext.Data.Users;
 using Paratext.Data.RegistryServerAccess;
+using Paratext.Data;
 
 namespace SIL.XForge.Scripture.Services
 {
     /// <summary> An internet shared repository source that networks using JWT authenticated REST clients. </summary>
-    class JwtInternetSharedRepositorySource : InternetSharedRepositorySource, IInternetSharedRepositorySource
+    public class JwtInternetSharedRepositorySource : InternetSharedRepositorySource, IInternetSharedRepositorySource
     {
         private readonly JwtRestClient _registryClient;
         private readonly IHgWrapper _hgWrapper;
@@ -34,6 +35,19 @@ namespace SIL.XForge.Scripture.Services
         public InternetSharedRepositorySource AsInternetSharedRepositorySource()
         {
             return this;
+        }
+
+        public bool CanUserAuthenticateToPTArchives()
+        {
+            try
+            {
+                GetClient().Get("listrepos");
+                return true;
+            }
+            catch (Paratext.Data.HttpException)
+            {
+                return false;
+            }
         }
 
         /// <summary>
@@ -112,6 +126,12 @@ namespace SIL.XForge.Scripture.Services
         {
             JArray projects = GetJsonArray("my/projects");
             return projects == null ? null : projects.Select(p => new ProjectMetadata((JObject)p)).ToList();
+        }
+
+        /// <remarks>Helps unit tests</remarks>
+        public virtual RESTClient GetClient()
+        {
+            return client;
         }
 
         /// <summary>

--- a/test/SIL.XForge.Scripture.Tests/Services/JwtInternetSharedRepositorySourceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/JwtInternetSharedRepositorySourceTests.cs
@@ -1,0 +1,85 @@
+using System.Net;
+using NSubstitute;
+using NSubstitute.Extensions;
+using NUnit.Framework;
+using Paratext.Data;
+using Paratext.Data.Users;
+using SIL.XForge.Scripture.Models;
+
+namespace SIL.XForge.Scripture.Services
+{
+    [TestFixture]
+    public class JwtInternetSharedRepositorySourceTests
+    {
+        [Test]
+        public void CanUserAuthenticateToPTArchives_Works()
+        {
+            var env = new TestEnvironment();
+            env.MockPTArchivesClient
+                .Configure()
+                .Get(Arg.Any<string>())
+                .Returns(_ =>
+                {
+                    throw Paratext.Data.HttpException.Create(
+                        new WebException(),
+                        HttpWebRequest.CreateHttp("https://example.com")
+                    );
+                });
+            // One SUT
+            Assert.That(env.RepoSource.CanUserAuthenticateToPTArchives(), Is.False, "problem when using server");
+
+            env.MockPTArchivesClient
+                .Configure()
+                .Get(Arg.Any<string>())
+                .Returns(
+                    "<repos><repo><proj>ABCD</proj><projid>4011111111111111111111111111111111111111"
+                        + "</projid><projecttype>BackTranslation</projecttype>"
+                        + "<baseprojid>4022222222222222222222222222222222222222</baseprojid>"
+                        + "<tipid>120000000000 tip</tipid><users><user>"
+                        + "<name>Tony Translator</name><role>pt_administrator</role></user></users></repo></repos>"
+                );
+            // One SUT
+            Assert.That(
+                env.RepoSource.CanUserAuthenticateToPTArchives(),
+                Is.True,
+                "successful authentication and received data"
+            );
+
+            env.MockPTArchivesClient.Configure().Get(Arg.Any<string>()).Returns(string.Empty);
+            // One SUT
+            Assert.That(
+                env.RepoSource.CanUserAuthenticateToPTArchives(),
+                Is.True,
+                "this would still be a successful authentication"
+            );
+        }
+
+        private class TestEnvironment
+        {
+            public JwtInternetSharedRepositorySource RepoSource;
+            public IRESTClient MockPTArchivesClient;
+
+            public TestEnvironment()
+            {
+                ParatextUser ptUser = new SFParatextUser("pt-username");
+                JwtRestClient mockPTRegistryClient = Substitute.For<JwtRestClient>(
+                    "https://baseUri.example.com",
+                    "applicationName",
+                    "jwtToken"
+                );
+                RepoSource = Substitute.ForPartsOf<JwtInternetSharedRepositorySource>(
+                    "access-token",
+                    mockPTRegistryClient,
+                    Substitute.For<IHgWrapper>(),
+                    ptUser,
+                    "sr-server-uri"
+                );
+                MockPTArchivesClient = Substitute.For<RESTClient>(
+                    "pt-archives-server.example.com",
+                    "product-version-123"
+                );
+                RepoSource.Configure().GetClient().Returns(MockPTArchivesClient);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- We have experienced various authentication problems. This change
adds two basic authentication checks for PT Registry and PT Archives.
- The checks try to do little, such as querying information about the
current user, rather than querying information about a particular
project the user may have access to.
- For PT Registry, the ParatextService CallApiAsync helper method is
used to query "userinfo".
- For PT Archives, ParatextData.dll is used to help query "listrepos".


_This is no longer in an spr. It can be merged independently._


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1410)
<!-- Reviewable:end -->
