### PR TITLE
SF-1599 Mark chapter invalid when para incorrectly contains verse

### DIFF
--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -2671,6 +2671,30 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
+        public void ToDelta_InvalidParaContainingVerse()
+        {
+            XDocument usxDoc = Usx("PHM",
+                Chapter("1"),
+                Para("s",
+                    Verse("1"),
+                    "This verse should not exist within this paragraph style"));
+
+            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+            var expected = Delta.New()
+                .InsertChapter("1")
+                .InsertBlank("s_1")
+                .InsertVerse("1")
+                .InsertText("This verse should not exist within this paragraph style", "verse_1_1")
+                .InsertPara("s", true);
+
+            Assert.That(chapterDeltas.Count, Is.EqualTo(1));
+            Assert.That(chapterDeltas[0].IsValid, Is.False);
+            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+        }
+
+        [Test]
         public void ToDelta_Unmatched()
         {
             XDocument usxDoc = Usx("PHM",


### PR DESCRIPTION
Many paragraphs styles exist that should not contain verse text. An example of this is section headings and titles. The schema for checking if the USX from Paratext does not allow us to define that there are two different types of "para" elements. So the next best thing is to explicitly add invalid "para" elements to the list of invalid nodes.

![image](https://user-images.githubusercontent.com/17931130/176240266-61daf532-1fe0-45ac-a350-9cc284007955.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1416)
<!-- Reviewable:end -->
