### PR TITLE
SF-1626b Restore sync progress indicator

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
@@ -15,6 +15,10 @@
   align-items: center;
 }
 
+app-sync-progress {
+  width: 100%;
+}
+
 #btn-sync,
 .progress-bar {
   margin-bottom: 1rem;


### PR DESCRIPTION
The progress indicator was accidentally hidden via CSS in #1411 (76a1ab6a4588d25e892ef889e140fc45adafc6fb)

Setting `align-items: center` on the parent of the `app-sync-progress` caused the `app-sync-progress` to shrink to the point of being invisible.

I'll have a followup PR with a bunch more changes, but this is sufficient to fix the regression.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1417)
<!-- Reviewable:end -->
