### PR TITLE
Rework styling of sync component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
@@ -1,10 +1,15 @@
 <ng-container *transloco="let t; read: 'sync'">
-  <div fxLayout="column" class="base-container">
+  <div class="base-container">
     <h2 id="title">{{ t("synchronize_project", { projectName: projectName }) }}</h2>
     <span *ngIf="!isAppOnline" class="offline-text"> {{ t("connect_network_to_synchronize") }} </span>
     <span *ngIf="syncDisabled" id="sync-disabled-message" [innerHTML]="syncDisabledMessage"> </span>
+    <span
+      *ngIf="showSyncFailureSupportMessage"
+      id="sync-failure-support-message"
+      [innerHTML]="syncFailureSupportMessage"
+    ></span>
     <mat-card class="sync-card">
-      <div fxLayout="column" class="card-content">
+      <div class="card-content">
         <button
           *ngIf="showParatextLogin && isAppOnline"
           mat-flat-button
@@ -51,10 +56,5 @@
         </ng-container>
       </div>
     </mat-card>
-    <span
-      *ngIf="showSyncFailureSupportMessage"
-      id="sync-failure-support-message"
-      [innerHTML]="syncFailureSupportMessage"
-    ></span>
   </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
@@ -1,6 +1,10 @@
 @use 'src/variables';
 
-.base-container {
+.base-container,
+.card-content {
+  display: flex;
+  flex-direction: column;
+  row-gap: 1rem;
   align-items: center;
 }
 
@@ -12,16 +16,10 @@
 
 .card-content {
   padding: 1rem;
-  align-items: center;
 }
 
 app-sync-progress {
   width: 100%;
-}
-
-#btn-sync,
-.progress-bar {
-  margin-bottom: 1rem;
 }
 
 #btn-log-in {
@@ -36,21 +34,8 @@ app-sync-progress {
   margin-right: 0.5rem;
 }
 
-#sync-message {
-  margin-bottom: 1rem;
-}
-
-.offline-text {
-  padding-bottom: 1rem;
-}
-
-#sync-disabled-message {
-  padding-bottom: 1rem;
-  max-width: 40rem;
-}
-
+#sync-disabled-message,
 #sync-failure-support-message {
-  padding: 1rem;
-  color: variables.$lighterTextColor;
   max-width: 40rem;
+  color: variables.$lighterTextColor;
 }


### PR DESCRIPTION
- Move sync failure support message above sync controls, where other messages are
- Make color of support messages consistent
- Use row-gap for spacing elements in flex containers, rather than margin

I've also avoided using fxLayout when it's just as easy to use CSS to do the styling. It seems odd and confusing to write something like:
``` css
.base-container {
  align-items: center;
}
```
because there's no indication in our CSS that `.base-container` is a flex container, because we set that using `fxLayout="column"` in the template. There may be times that fxLayout makes producing the layout we want easier, and it makes sense to use it then. But I don't see the benefit in this particular case.

Here's how it looks with all elements visible:

![](https://user-images.githubusercontent.com/6140710/176937544-76632e1d-45df-4a8c-b6dc-2a36630bb0ac.png)

And here's how that looks when the flex layout is visualized:

![](https://user-images.githubusercontent.com/6140710/176937591-76091b33-cc55-4829-885d-b90d3efdc410.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1418)
<!-- Reviewable:end -->
