### PR TITLE
SF-1555 Prevent admin pages from scrolling away

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -159,7 +159,7 @@
       </mdc-select>
     </mdc-drawer-header>
     <mdc-drawer-content>
-      <mat-nav-list id="menu-list">
+      <mat-nav-list id="tools-menu-list">
         <a
           mat-list-item
           class="translate-nav-item"
@@ -187,7 +187,7 @@
             {{ getBookName(text) }}
           </a>
         </div>
-        <mat-divider *ngIf="isTranslateEnabled"></mat-divider>
+        <mat-divider *ngIf="isCheckingEnabled && isTranslateEnabled"></mat-divider>
         <a
           mat-list-item
           class="community-checking-nav-item"
@@ -226,8 +226,10 @@
             </a>
           </ng-container>
         </div>
+      </mat-nav-list>
+      <mat-nav-list id="admin-pages-menu-list" *ngIf="canSeeAdminPages$ | async">
+        <mat-divider></mat-divider>
         <div *ngIf="canSync$ | async">
-          <mat-divider *ngIf="isCheckingEnabled"></mat-divider>
           <a
             mat-list-item
             [appRouterLink]="getRouterLink('sync')"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -205,6 +205,7 @@ mat-nav-list .mat-list-item {
 
   ::ng-deep .mat-list-item-content {
     column-gap: 16px;
+    padding-inline-end: 8px;
   }
 }
 
@@ -212,6 +213,17 @@ mat-nav-list .mat-list-item {
   background-color: #e7e8e7;
 }
 
-#menu-list {
-  padding-top: 6px;
+mdc-drawer-content {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+#tools-menu-list,
+#admin-pages-menu-list {
+  padding-top: 0;
+}
+
+#tools-menu-list {
+  overflow-y: auto;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -634,7 +634,7 @@ class TestEnvironment {
   }
 
   get menuListItems(): DebugElement[] {
-    return this.fixture.debugElement.queryAll(By.css('#menu-list .mat-list-item'));
+    return this.fixture.debugElement.queryAll(By.css('#menu-drawer .mat-list-item'));
   }
 
   get helpMenuList(): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -69,6 +69,8 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   canSeeSettings$?: Observable<boolean>;
   canSeeUsers$?: Observable<boolean>;
   canSync$?: Observable<boolean>;
+  /** Whether the user can see at least one of settings, users, or sync page */
+  canSeeAdminPages$?: Observable<boolean>;
   hasUpdate: boolean = false;
 
   projectLabel = projectLabel;
@@ -334,6 +336,9 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
           this.canSeeSettings$ = this.settingsAuthGuard.allowTransition(projectId);
           this.canSeeUsers$ = this.usersAuthGuard.allowTransition(projectId);
           this.canSync$ = this.syncAuthGuard.allowTransition(projectId);
+          this.canSeeAdminPages$ = combineLatest([this.canSeeSettings$, this.canSeeUsers$, this.canSync$]).pipe(
+            map(([settings, users, sync]) => settings || users || sync)
+          );
           // the project deleted dialog should be closed by now, so we can reset its ref to null
           if (projectId == null) {
             this.projectDeletedDialogRef = null;


### PR DESCRIPTION
- Only part of the menu is now scrollable.
- Community checking no longer wraps in English when the scrollbar appears.
- Some incorrect behavior regarding when dividers are shown in the menu has been fixed (for example, for resources, previously a divider was shown under the list of books).
- I removed a few pixels of what I think was unnecessary padding at the top of the menu.

Before | After
----------|-------
![](https://user-images.githubusercontent.com/6140710/176985302-8b1e01eb-e527-4a9f-8559-89ec922718c0.png) | ![](https://user-images.githubusercontent.com/6140710/176985301-02259001-824f-46fc-9cf1-a6d6a985f871.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1420)
<!-- Reviewable:end -->
