### PR TITLE
SF-1568b Update CI scripts to use Node 16

### DIFF
--- a/.github/workflows/ci-lint-prettier.yml
+++ b/.github/workflows/ci-lint-prettier.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node_version: [12.x]
+        node_version: [16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-production-build.yml
+++ b/.github/workflows/ci-production-build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        node_version: [12.x, 16.x]
+        node_version: [16.x]
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
- Node v16 is what we're currently on
- Node v18 is current but not active

I initially created this PR with the production build run against both Node 16 and Node 18, but the Node 18 build failed somewhere in Webpack where it called a cryptographic hash function built in to Node. Presumably at some point in the future when we update Angular, Angular will specify a newer version of Webpack that has support for Node 18. At that point we should be able to remain on v16 while still having a build run against v18 to verify everything is working and that we can update when we are ready.

See https://nodejs.org/en/about/releases/
> Major Node.js versions enter Current release status for six months, which gives library authors time to add support for them. After six months, odd-numbered releases (9, 11, etc.) become unsupported, and even-numbered releases (10, 12, etc.) move to Active LTS status and are ready for general use. LTS release status is "long-term support", which typically guarantees that critical bugs will be fixed for a total of 30 months. Production applications should only use Active LTS or Maintenance LTS releases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1422)
<!-- Reviewable:end -->
