### PR TITLE
SF-1462 Correctly define segments after stanza break

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
@@ -57,6 +57,25 @@ export function getCombinedVerseTextDoc(id: TextDocId): TextData {
   return delta;
 }
 
+export function getPoetryVerseTextDoc(id: TextDocId): TextData {
+  const delta = new Delta();
+  delta.insert(`Title for chapter ${id.chapterNum}`, { segment: 's_1' });
+  delta.insert('\n', { para: { style: 's' } });
+  delta.insert({ chapter: { number: id.chapterNum.toString(), style: 'c' } });
+  delta.insert({ blank: true }, { segment: 'q_1' });
+  delta.insert({ verse: { number: '1', style: 'v' } });
+  delta.insert('Poetry first line', { segment: `verse_${id.chapterNum}_1/q_1` });
+  delta.insert('\n', { para: { style: 'q' } });
+  delta.insert('Poetry second line', { segment: `verse_${id.chapterNum}_1/q_2` });
+  delta.insert('\n', { para: { style: 'q' } });
+  delta.insert('\n', { para: { style: 'b' } });
+  delta.insert('Poetry third line', { segment: `verse_${id.chapterNum}_1/q_3` });
+  delta.insert('\n', { para: { style: 'q' } });
+  delta.insert('Poetry fourth line.', { segment: `verse_${id.chapterNum}_1/q_4` });
+  delta.insert('\n', { para: { style: 'q' } });
+  return delta;
+}
+
 export function getSFProject(id: string): SFProjectProfile {
   return {
     name: `${id} name`,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
@@ -64,14 +64,14 @@ export function getPoetryVerseTextDoc(id: TextDocId): TextData {
   delta.insert({ chapter: { number: id.chapterNum.toString(), style: 'c' } });
   delta.insert({ blank: true }, { segment: 'q_1' });
   delta.insert({ verse: { number: '1', style: 'v' } });
-  delta.insert('Poetry first line', { segment: `verse_${id.chapterNum}_1/q_1` });
+  delta.insert('Poetry first line', { segment: `verse_${id.chapterNum}_1` });
   delta.insert('\n', { para: { style: 'q' } });
-  delta.insert('Poetry second line', { segment: `verse_${id.chapterNum}_1/q_2` });
+  delta.insert('Poetry second line', { segment: `verse_${id.chapterNum}_1/q_1` });
   delta.insert('\n', { para: { style: 'q' } });
   delta.insert('\n', { para: { style: 'b' } });
-  delta.insert('Poetry third line', { segment: `verse_${id.chapterNum}_1/q_3` });
+  delta.insert('Poetry third line', { segment: `verse_${id.chapterNum}_1/q_2` });
   delta.insert('\n', { para: { style: 'q' } });
-  delta.insert('Poetry fourth line.', { segment: `verse_${id.chapterNum}_1/q_4` });
+  delta.insert('Poetry fourth line.', { segment: `verse_${id.chapterNum}_1/q_3` });
   delta.insert('\n', { para: { style: 'q' } });
   return delta;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -604,7 +604,10 @@ export class TextViewModel {
             curIndex += curSegment.length;
           }
           curIndex += len;
-          curSegment = undefined;
+          if (curSegment != null) {
+            // continue with the current segment at the current index
+            curSegment = new SegmentInfo(curSegment.ref, curIndex);
+          }
         } else {
           // title/header
           if (curSegment == null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -28,7 +28,7 @@ import { SF_TYPE_REGISTRY } from '../../core/models/sf-type-registry';
 import { Delta, TextDoc, TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { SharedModule } from '../shared.module';
-import { getCombinedVerseTextDoc, getSFProject, getTextDoc } from '../test-utils';
+import { getCombinedVerseTextDoc, getPoetryVerseTextDoc, getSFProject, getTextDoc } from '../test-utils';
 import { DragAndDrop } from './drag-and-drop';
 import { TextComponent } from './text.component';
 import { PresenceData, RemotePresences, TextViewModel } from './text-view-model';
@@ -169,6 +169,17 @@ describe('TextComponent', () => {
     // The title segment should still have its data attribute, but no pseudo element
     expect(titleSegment.getAttribute('data-style-description')).toEqual('s - Heading - Section Level 1');
     expect(window.getComputedStyle(titleSegment, '::before').content).toEqual('none');
+  }));
+
+  it('correctly labels verse segments after line breaks', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.fixture.detectChanges();
+    env.id = new TextDocId('project01', 42, 1);
+    tick();
+    env.fixture.detectChanges();
+
+    const verseSegments: string[] = env.component.getVerseSegments(VerseRef.parse('LUK 1:1'));
+    expect(verseSegments).toEqual(['verse_1_1', 'verse_1_1/q_1', 'verse_1_1/q_2', 'verse_1_1/q_3']);
   }));
 
   describe('MultiCursor Presence', () => {
@@ -2788,6 +2799,7 @@ class TestEnvironment {
 
     const matTextDocId = new TextDocId('project01', 40, 1);
     const mrkTextDocId = new TextDocId('project01', 41, 1);
+    const lukTextDocId = new TextDocId('project01', 42, 1);
     this.realtimeService.addSnapshot<SFProjectProfile>(SFProjectProfileDoc.COLLECTION, {
       id: 'project01',
       data: getSFProject('project01')
@@ -2801,6 +2813,11 @@ class TestEnvironment {
       {
         id: mrkTextDocId.toString(),
         data: getCombinedVerseTextDoc(mrkTextDocId),
+        type: RichText.type.name
+      },
+      {
+        id: lukTextDocId.toString(),
+        data: getPoetryVerseTextDoc(lukTextDocId),
         type: RichText.type.name
       }
     ]);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -180,6 +180,8 @@ describe('TextComponent', () => {
 
     const verseSegments: string[] = env.component.getVerseSegments(VerseRef.parse('LUK 1:1'));
     expect(verseSegments).toEqual(['verse_1_1', 'verse_1_1/q_1', 'verse_1_1/q_2', 'verse_1_1/q_3']);
+    const segmentText = env.component.getSegmentText('verse_1_1/q_2');
+    expect(segmentText).toEqual('Poetry third line');
   }));
 
   describe('MultiCursor Presence', () => {

--- a/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
@@ -138,7 +138,9 @@ namespace SIL.XForge.Scripture.Services
                                 }
                                 else if (style == "b")
                                 {
-                                    state.CurRef = null;
+                                    // insert the line break and continue processing with the current verse ref
+                                    InsertPara(invalidNodes, chapterDelta, elem, state);
+                                    continue;
                                 }
                                 else
                                 {

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -2507,6 +2507,7 @@ namespace SIL.XForge.Scripture.Services
                 Para("p",
                     Verse("1"),
                     "Verse text."),
+                // support this even though we do not encourage users to type text in line breaks
                 Para("b",
                     "Text in line break"),
                 Para("p",

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -2500,6 +2500,37 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
+        public void ToDelta_BlankLineContainsText()
+        {
+            XDocument usxDoc = Usx("PHM",
+                Chapter("1"),
+                Para("p",
+                    Verse("1"),
+                    "Verse text."),
+                Para("b",
+                    "Text in line break"),
+                Para("p",
+                    "second segment in verse."));
+
+            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+            var expected = new Delta()
+                .InsertChapter("1")
+                .InsertBlank("p_1")
+                .InsertVerse("1")
+                .InsertText("Verse text.", "verse_1_1")
+                .InsertPara("p")
+                .InsertText("Text in line break")
+                .InsertPara("b")
+                .InsertText("second segment in verse.", "verse_1_1/p_1")
+                .InsertPara("p");
+
+            Assert.That(chapterDeltas.Count(), Is.EqualTo(1));
+            Assert.That(chapterDeltas[0].Delta.DeepEquals(expected));
+        }
+
+        [Test]
         public void ToDelta_InvalidParaInFirstChapter()
         {
             XDocument usxDoc = Usx("PHM",

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -2489,7 +2489,7 @@ namespace SIL.XForge.Scripture.Services
                 .InsertBlank("verse_1_2")
                 .InsertPara("p")
                 .InsertPara("b")
-                .InsertBlank("p_2")
+                .InsertBlank("verse_1_2/p_1")
                 .InsertVerse("3")
                 .InsertBlank("verse_1_3")
                 .InsertPara("p");
@@ -2691,6 +2691,40 @@ namespace SIL.XForge.Scripture.Services
 
             Assert.That(chapterDeltas.Count, Is.EqualTo(1));
             Assert.That(chapterDeltas[0].IsValid, Is.False);
+            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+        }
+
+        public void ToDelta_LineBreakWithinVerse()
+        {
+            XDocument usxDoc = Usx("PHM",
+                Chapter("1"),
+                Para("q",
+                    Verse("1"),
+                    "Poetry first line"),
+                Para("q", "Poetry second line"),
+                Para("b"),
+                Para("q", "Poetry third line"),
+                Para("q", "Poetry fourth line.")
+            );
+
+            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+            var expected = new Delta()
+                .InsertChapter("1")
+                .InsertBlank("q_1")
+                .InsertVerse("1")
+                .InsertText("Poetry first line", "verse_1_1")
+                .InsertPara("q")
+                .InsertText("Poetry second line", "verse_1_1/q_1")
+                .InsertPara("q")
+                .InsertPara("b")
+                .InsertText("Poetry third line", "verse_1_1/q_2")
+                .InsertPara("q")
+                .InsertText("Poetry fourth line.", "verse_1_1/q_3")
+                .InsertPara("q");
+
+            Assert.That(chapterDeltas.Count, Is.EqualTo(1));
             Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
         }
 


### PR DESCRIPTION
After a stanza break `\b` marker is introduce, our segment refs are reset and they do not include the verse ref which look like "verse_1_15". For example this would be the output of this usfm before and after this change.

USFM
\c 1
\q \v 1 Some text
\b
\q more in same verse

Before
[{ insert: { chapter } }, { insert: { blank } }, { insert { verse } }, { insert: "Some text" }, { insert: { para: { style: "p" } }, { insert: { para: { style: "b" } }, **{ insert: "more in same verse", attributes: { segment: "q_1" } }**, { insert: { para } }

After
[{ insert: { chapter } }, { insert: { blank } }, { insert { verse } }, { insert: "Some text" }, { insert: { para: { style: "p" } }, { insert: { para: { style: "b" } }, **{ insert: "more in same verse", attributes: { segment: "verse_1_1/q_1" } }**, { insert: { para } }

This assigns the correct verse ref to the text segment so that when we go to insert a note icon, it can correctly identify the right segment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1424)
<!-- Reviewable:end -->
