### PR TITLE
SF-1462b Ignore length of paragraph breaks that cannot contain verse

### DIFF
--- a/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
@@ -101,6 +101,17 @@ namespace SIL.XForge.Scripture.Services
             ExceptionHandler = exceptionHandler;
         }
 
+        public static bool CanParaContainVerseText(string style)
+        {
+            // an empty style indicates an improperly formatted paragraph which could contain verse text
+            if (style == string.Empty)
+                return true;
+            if (char.IsDigit(style[style.Length - 1]))
+                style = style.Substring(0, style.Length - 1);
+            // paragraph, poetry, and list styles are the only types of valid paras that can contain verse text
+            return ParagraphPoetryListStyles.Contains(style);
+        }
+
         /// <summary>
         /// Create list of ChapterDelta objects from USX.
         ///
@@ -456,17 +467,6 @@ namespace SIL.XForge.Scripture.Services
                     newDelta.InsertBlank(segRef);
                 }
             }
-        }
-
-        private static bool CanParaContainVerseText(string style)
-        {
-            // an empty style indicates an improperly formatted paragraph which could contain verse text
-            if (style == string.Empty)
-                return true;
-            if (char.IsDigit(style[style.Length - 1]))
-                style = style.Substring(0, style.Length - 1);
-            // paragraph, poetry, and list styles are the only types of valid paras that can contain verse text
-            return ParagraphPoetryListStyles.Contains(style);
         }
 
         private static string GetParagraphRef(Dictionary<string, int> nextIds, string key, string prefix)

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2255,7 +2255,7 @@ namespace SIL.XForge.Scripture.Services
         private string GetVerseText(Delta delta, VerseRef verseRef)
         {
             string vref = string.IsNullOrEmpty(verseRef.Verse) ? verseRef.VerseNum.ToString() : verseRef.Verse;
-            return delta.TryConcatenateInserts(out string verseText, vref) ? verseText : string.Empty;
+            return delta.TryConcatenateInserts(out string verseText, vref, DeltaUsxMapper.CanParaContainVerseText) ? verseText : string.Empty;
         }
 
         private TextAnchor GetThreadTextAnchor(CommentThread thread, Dictionary<int, ChapterDelta> chapterDeltas)

--- a/src/SIL.XForge/Realtime/RichText/Delta.cs
+++ b/src/SIL.XForge/Realtime/RichText/Delta.cs
@@ -241,7 +241,8 @@ namespace SIL.XForge.Realtime.RichText
         /// <param name="verseRef">
         /// The reference to the verse. For example: "1". If the verses in the text data is combined, "1-2".
         /// </param>
-        public bool TryConcatenateInserts(out string opStr, string verseRef)
+        /// <param name="includeParaWithStyle">Function to determine if the paragraph break should be included.</param>
+        public bool TryConcatenateInserts(out string opStr, string verseRef, Func<string, bool> includeParaWithStyle)
         {
             List<JToken> verseOps = new List<JToken>();
             bool isTargetVerse = verseRef == "0";
@@ -262,6 +263,17 @@ namespace SIL.XForge.Realtime.RichText
                     else if (((JObject)op[InsertType]).Property("chapter")?.Value.Type == JTokenType.Object)
                         continue;
                 }
+                else if (op[Attributes]?.Type == JTokenType.Object)
+                {
+                    var paragraphObj = ((JObject)op[Attributes]).Property("para")?.Value;
+                    if (paragraphObj?.Type == JTokenType.Object)
+                    {
+                        string style = (string)((JObject)paragraphObj).Property("style").Value;
+                        if (!includeParaWithStyle(style))
+                            continue;
+                    }
+                }
+
                 if (isTargetVerse)
                     verseOps.Add(op);
             }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -1120,10 +1120,9 @@ namespace SIL.XForge.Scripture.Services
                     noteThreadDocs, chapterDeltas, ptProjectUsers);
                 Assert.That(changes.Count, Is.EqualTo(1));
                 NoteThreadChange change = changes.First();
+                // include the newline length of the q paragraph break, but not the b
                 int startPos = text1.Length + "\n".Length + text2.Length;
                 TextAnchor expected = new TextAnchor { Start = startPos, Length = selected.Length };
-                Console.WriteLine($"Expected: start: {expected.Start}, length: {expected.Length}");
-                Console.WriteLine($"Actual: start: {change.Position.Start}, length: {change.Position.Length}");
                 Assert.That(change.Position, Is.EqualTo(expected));
             }
         }


### PR DESCRIPTION
* refactor canContainVerseText into a static method
* check that a paragraph break insert should be included in verse text

This is how the note threads were being affected before and after this change.

Before
![Poetry Line Break (Before)](https://user-images.githubusercontent.com/17931130/177627519-4b8bb2fc-ed75-4a2c-bb22-648c4209bbfa.png)

After
![Poetry Line Break](https://user-images.githubusercontent.com/17931130/177627545-a7ba6788-187b-420f-99fd-44c4a2c0019d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1425)
<!-- Reviewable:end -->
