### PR TITLE
Fixed erroneous reference to thot-new-model.zip

### DIFF
--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Update="$(NuGetPackageRoot)sil.machine.webapi\$(MachineVersion)\contentFiles\any\net6.0\thot-new-model.zip">
+    <Content Update="$(NuGetPackageRoot)sil.machine.webapi\$(MachineVersion)\contentFiles\any\netcoreapp3.1\thot-new-model.zip">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
This PR fixes an erroneous reference to thot-new-model.zip, which caused the build to fail on .NET 6.0 builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1427)
<!-- Reviewable:end -->
