### PR TITLE
SF-1596 Enable passwordless login

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.guard.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.guard.spec.ts
@@ -1,5 +1,5 @@
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
-import { anything, instance, mock, resetCalls, verify, when } from 'ts-mockito';
+import { anything, deepEqual, instance, mock, resetCalls, verify, when } from 'ts-mockito';
 import { AuthGuard } from './auth.guard';
 import { AuthService } from './auth.service';
 import { LocationService } from './location.service';
@@ -28,7 +28,7 @@ describe('AuthGuard', () => {
 
     canActivate$.subscribe(canActivate => {
       expect(canActivate).toBe(true);
-      verify(mockedAuthService.logIn(anything(), anything(), anything())).never();
+      verify(mockedAuthService.logIn({ returnUrl: anything() })).never();
       done();
     });
   });
@@ -47,7 +47,7 @@ describe('AuthGuard', () => {
 
     canActivate$.subscribe(canActivate => {
       expect(canActivate).toBe(false);
-      verify(mockedAuthService.logIn(anything(), false, undefined)).once();
+      verify(mockedAuthService.logIn(anything())).once();
       done();
     });
   });
@@ -58,6 +58,8 @@ describe('AuthGuard', () => {
     expect(authGuard).toBeDefined();
     when(mockedAuthService.isLoggedIn).thenResolve(false);
     when(mockedActivatedRouteSnapshot.queryParams).thenReturn({ sharing: 'true', 'sign-up': 'false' });
+    when(mockedLocationService.pathname).thenReturn('/');
+    when(mockedLocationService.search).thenReturn('');
 
     const canActivate$ = authGuard.canActivate(
       instance(mockedActivatedRouteSnapshot),
@@ -66,7 +68,16 @@ describe('AuthGuard', () => {
 
     canActivate$.subscribe(canActivate => {
       expect(canActivate).toBe(false);
-      verify(mockedAuthService.logIn(anything(), true, undefined)).once();
+      verify(
+        mockedAuthService.logIn(
+          deepEqual({
+            returnUrl: anything(),
+            signUp: true,
+            locale: anything(),
+            promptPasswordlessLogin: true
+          })
+        )
+      ).once();
       done();
     });
   });
@@ -85,7 +96,16 @@ describe('AuthGuard', () => {
 
     canActivate$.subscribe(canActivate => {
       expect(canActivate).toBe(false);
-      verify(mockedAuthService.logIn(anything(), true, undefined)).once();
+      verify(
+        mockedAuthService.logIn(
+          deepEqual({
+            returnUrl: anything(),
+            signUp: true,
+            locale: undefined,
+            promptPasswordlessLogin: false
+          })
+        )
+      ).once();
       done();
     });
   });
@@ -105,7 +125,11 @@ describe('AuthGuard', () => {
 
     canActivate$.subscribe(canActivate => {
       expect(canActivate).toBe(false);
-      verify(mockedAuthService.logIn(anything(), false, locale)).once();
+      verify(
+        mockedAuthService.logIn(
+          deepEqual({ returnUrl: anything(), signUp: false, locale, promptPasswordlessLogin: false })
+        )
+      ).once();
       done();
     });
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.guard.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.guard.ts
@@ -17,7 +17,12 @@ export class AuthGuard implements CanActivate {
         if (!isLoggedIn) {
           const signUp = route.queryParams['sharing'] === 'true' || route.queryParams['sign-up'] === 'true';
           const locale: string = route.queryParams['locale'];
-          this.authService.logIn(this.locationService.pathname + this.locationService.search, signUp, locale);
+          this.authService.logIn({
+            returnUrl: this.locationService.pathname + this.locationService.search,
+            signUp,
+            locale,
+            promptPasswordlessLogin: route.queryParams['sharing'] === 'true'
+          });
         }
       })
     );

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
@@ -426,6 +426,7 @@ describe('AuthService', () => {
       isOnline: true,
       isNewlyLoggedIn: true,
       loginState: {
+        returnUrl: '',
         linking: true,
         currentSub: 'user01'
       }
@@ -440,6 +441,7 @@ describe('AuthService', () => {
       isOnline: true,
       isNewlyLoggedIn: true,
       loginState: {
+        returnUrl: '',
         linking: true,
         currentSub: 'user01'
       },
@@ -599,7 +601,7 @@ class TestEnvironment {
     isOnline = false,
     isLoggedIn,
     isNewlyLoggedIn,
-    loginState = {},
+    loginState = { returnUrl: '' },
     accountLinkingResponse,
     callback
   }: TestEnvironmentConstructorArgs = {}) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
@@ -211,7 +211,7 @@ describe('AuthService', () => {
     const env = new TestEnvironment();
     const returnUrl = 'test-returnUrl';
 
-    env.service.logIn(returnUrl);
+    env.service.logIn({ returnUrl });
 
     verify(mockedWebAuth.loginWithRedirect(anything())).once();
     const authOptions: RedirectLoginOptions | undefined = capture<RedirectLoginOptions | undefined>(
@@ -231,7 +231,7 @@ describe('AuthService', () => {
     const returnUrl = 'test-returnUrl';
     const signUp = false;
 
-    env.service.logIn(returnUrl, signUp);
+    env.service.logIn({ returnUrl, signUp });
 
     verify(mockedWebAuth.loginWithRedirect(anything())).once();
     const authOptions: RedirectLoginOptions | undefined = capture<RedirectLoginOptions | undefined>(
@@ -250,7 +250,7 @@ describe('AuthService', () => {
     const returnUrl = 'test-returnUrl';
     const signUp = true;
 
-    env.service.logIn(returnUrl, signUp);
+    env.service.logIn({ returnUrl, signUp });
 
     verify(mockedWebAuth.loginWithRedirect(anything())).once();
     const authOptions: RedirectLoginOptions | undefined = capture<RedirectLoginOptions | undefined>(
@@ -271,7 +271,7 @@ describe('AuthService', () => {
     const locale = 'es';
     expect(locale).withContext('setup').not.toEqual(env.language);
 
-    env.service.logIn(returnUrl, signUp, locale);
+    env.service.logIn({ returnUrl, signUp, locale });
 
     verify(mockedWebAuth.loginWithRedirect(anything())).once();
     const authOptions: RedirectLoginOptions | undefined = capture<RedirectLoginOptions | undefined>(
@@ -282,6 +282,40 @@ describe('AuthService', () => {
       expect(authOptions.language).toEqual(env.language);
       expect(authOptions.login_hint).toEqual(locale);
       expect(authOptions.mode).toEqual('signUp');
+    }
+  }));
+
+  it('should login with passwordless enabled', fakeAsync(() => {
+    const env = new TestEnvironment();
+    const returnUrl = 'test-returnUrl';
+
+    env.service.logIn({ returnUrl });
+
+    verify(mockedWebAuth.loginWithRedirect(anything())).once();
+    const authOptions: RedirectLoginOptions | undefined = capture<RedirectLoginOptions | undefined>(
+      mockedWebAuth.loginWithRedirect
+    ).last()[0];
+    expect(authOptions).toBeDefined();
+    if (authOptions != null) {
+      expect(authOptions.enablePasswordless).toEqual(true);
+      expect(authOptions.promptPasswordlessLogin).toEqual(false);
+    }
+  }));
+
+  it('should login with passwordless enabled and prompt for passwordless login', fakeAsync(() => {
+    const env = new TestEnvironment();
+    const returnUrl = 'test-returnUrl';
+
+    env.service.logIn({ returnUrl, promptPasswordlessLogin: true });
+
+    verify(mockedWebAuth.loginWithRedirect(anything())).once();
+    const authOptions: RedirectLoginOptions | undefined = capture<RedirectLoginOptions | undefined>(
+      mockedWebAuth.loginWithRedirect
+    ).last()[0];
+    expect(authOptions).toBeDefined();
+    if (authOptions != null) {
+      expect(authOptions.enablePasswordless).toEqual(true);
+      expect(authOptions.promptPasswordlessLogin).toEqual(true);
     }
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -54,6 +54,13 @@ interface LoginResult {
   newlyLoggedIn: boolean;
 }
 
+interface LoginParams {
+  locale?: string;
+  promptPasswordlessLogin?: boolean;
+  returnUrl: string;
+  signUp?: boolean;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -179,14 +186,16 @@ export class AuthService {
     return true;
   }
 
-  async logIn(returnUrl: string, signUp?: boolean, locale?: string): Promise<void> {
+  async logIn({ returnUrl, signUp, locale, promptPasswordlessLogin }: LoginParams = { returnUrl: '' }): Promise<void> {
     const state: AuthState = { returnUrl };
     const language: string = getAspCultureCookieLanguage(this.cookieService.get(ASP_CULTURE_COOKIE_NAME));
     const ui_locales: string = language;
     const authOptions: RedirectLoginOptions = {
       appState: JSON.stringify(state),
       language,
-      login_hint: ui_locales
+      login_hint: ui_locales,
+      enablePasswordless: true,
+      promptPasswordlessLogin: promptPasswordlessLogin === true
     };
     if (signUp) {
       authOptions.mode = 'signUp';
@@ -449,7 +458,7 @@ export class AuthService {
         }
       })
         .catch(() => {
-          this.logIn(this.locationService.pathname + this.locationService.search);
+          this.logIn({ returnUrl: this.locationService.pathname + this.locationService.search });
         })
         .then(() => {
           this.renewTokenPromise = undefined;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -38,7 +38,7 @@ export const ROLE_SETTING = 'role';
 export const EXPIRES_AT_SETTING = 'expires_at';
 
 export interface AuthState {
-  returnUrl?: string;
+  returnUrl: string;
   linking?: boolean;
   currentSub?: string;
 }
@@ -385,8 +385,8 @@ export class AuthService {
   /**
    * Check to help avoid redirect loops where sometimes the return URL can end up as the login page or auth0 callback
    */
-  private isValidReturnUrl(returnUrl: string | undefined): boolean {
-    return !(returnUrl == null || this.isCallbackUrl(returnUrl) || returnUrl === '/login');
+  private isValidReturnUrl(returnUrl: string): boolean {
+    return !(returnUrl === '' || this.isCallbackUrl(returnUrl) || returnUrl === '/login');
   }
 
   private isCallbackUrl(callbackUrl: string | undefined = undefined): boolean {


### PR DESCRIPTION
- Pass additional auth config options to auth0 to enable passwordless login
- Use passwordless login by default when using a shared key

Default login/sign up screen shows an additional phone number option:
![image](https://user-images.githubusercontent.com/17464863/179440617-fc2cb94d-9a5f-4fac-8f20-aba23e189a40.png)

When choosing to login with phone number the user only sees an option to enter their phone number:
![image](https://user-images.githubusercontent.com/17464863/179440822-451c9333-8fbd-43e1-b13b-3ca0e3b0c44c.png)

When using a shared link, and not currently logged in, passwordless is enabled and you see phone number login instead of email/password and PT is hidden:
![image](https://user-images.githubusercontent.com/17464863/179440752-7cf82587-de11-4efe-b12e-3084ec1509b4.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1428)
<!-- Reviewable:end -->
