### PR TITLE
SF-1609 Improve Resource Sync Efficiency

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/sf-project.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project.ts
@@ -19,6 +19,7 @@ export interface SFProjectProfile extends Project {
   isRightToLeft?: boolean;
   translateConfig: TranslateConfig;
   checkingConfig: CheckingConfig;
+  resourceConfig?: ResourceConfig;
   texts: TextInfo[];
   sync: Sync;
   editable: boolean;
@@ -28,4 +29,11 @@ export interface SFProjectProfile extends Project {
 
 export interface SFProject extends SFProjectProfile {
   paratextUsers: ParatextUserProfile[];
+}
+
+export interface ResourceConfig {
+  createdTimestamp: Date;
+  manifestChecksum: string;
+  permissionsChecksum: string;
+  revision: number;
 }

--- a/src/SIL.XForge.Scripture/Models/ParatextResource.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextResource.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Globalization;
 using System.Text;
 using SIL.XForge.Scripture.Services;
 
@@ -50,13 +52,48 @@ namespace SIL.XForge.Scripture.Models
         /// </remarks>
         internal SFInstallableDblResource InstallableResource { get; set; }
 
+        /// <summary>
+        /// Gets or sets the created timestamp.
+        /// </summary>
+        /// <value>
+        /// The created timestamp.
+        /// </value>
+        /// <remarks>
+        /// This is used to see if this is newer, if the manifest checksum is different.
+        /// </remarks>
+        public DateTime CreatedTimestamp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the manifest checksum.
+        /// </summary>
+        /// <value>
+        /// The manifest checksum.
+        /// </value>
+        /// <remarks>
+        /// This is used to see if the manifest has changed.
+        /// </remarks>
+        public string ManifestChecksum { get; set; }
+
+        /// <summary>
+        /// Gets or sets the permissions checksum.
+        /// </summary>
+        /// <value>
+        /// The permissions checksum.
+        /// </value>
+        /// <remarks>
+        /// This is used to see if the permissions have changed.
+        /// </remarks>
+        public string PermissionsChecksum { get; set; }
+
         /// <inheritdoc/>
         public override string ToString()
         {
             StringBuilder message = new StringBuilder();
             foreach (string item in new string[] { ParatextId, Name, ShortName, LanguageTag, ProjectId,
                 IsConnectable.ToString(), IsConnected.ToString(), IsInstalled.ToString(),
-                AvailableRevision.ToString(), InstalledRevision.ToString() })
+                AvailableRevision.ToString(), InstalledRevision.ToString(),
+                CreatedTimestamp.ToString(CultureInfo.CurrentCulture), ManifestChecksum, PermissionsChecksum
+            })
             {
                 message.Append(item);
                 message.Append(',');

--- a/src/SIL.XForge.Scripture/Models/ResourceConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/ResourceConfig.cs
@@ -1,0 +1,15 @@
+namespace SIL.XForge.Scripture.Models
+{
+    using System;
+
+    /// <summary>
+    /// Contains configuration information for Paratext resources.
+    /// </summary>
+    public class ResourceConfig
+    {
+        public DateTime CreatedTimestamp { get; set; }
+        public string ManifestChecksum { get; set; }
+        public string PermissionsChecksum { get; set; }
+        public int Revision { get; set; }
+    }
+}

--- a/src/SIL.XForge.Scripture/Models/SFProject.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProject.cs
@@ -12,6 +12,7 @@ namespace SIL.XForge.Scripture.Models
         public bool? IsRightToLeft { get; set; }
         public TranslateConfig TranslateConfig { get; set; } = new TranslateConfig();
         public CheckingConfig CheckingConfig { get; set; } = new CheckingConfig();
+        public ResourceConfig ResourceConfig { get; set; }
         public List<TextInfo> Texts { get; set; } = new List<TextInfo>();
         public Sync Sync { get; set; } = new Sync();
         /// <summary>

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -29,7 +29,7 @@ namespace SIL.XForge.Scripture.Services
         Task<Dictionary<string, string>> GetPermissionsAsync(UserSecret userSecret, SFProject project,
             IReadOnlyDictionary<string, string> ptUsernameMapping, int book = 0, int chapter = 0,
             CancellationToken token = default);
-        Task<bool> ResourceDocsNeedUpdatingAsync(UserSecret userSecret, SFProject project, CancellationToken token);
+        bool ResourceDocsNeedUpdating(SFProject project, ParatextResource resource);
 
         IReadOnlyList<int> GetBookList(UserSecret userSecret, string paratextId);
         string GetBookText(UserSecret userSecret, string paratextId, int bookNum);
@@ -47,7 +47,7 @@ namespace SIL.XForge.Scripture.Services
         bool BackupRepository(UserSecret userSecret, string paratextId);
         bool RestoreRepository(UserSecret userSecret, string paratextId);
 
-        Task SendReceiveAsync(UserSecret userSecret, string paratextId, IProgress<ProgressState> progress = null,
+        Task<ParatextProject> SendReceiveAsync(UserSecret userSecret, string paratextId, IProgress<ProgressState> progress = null,
             CancellationToken token = default);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -29,6 +29,7 @@ namespace SIL.XForge.Scripture.Services
         Task<Dictionary<string, string>> GetPermissionsAsync(UserSecret userSecret, SFProject project,
             IReadOnlyDictionary<string, string> ptUsernameMapping, int book = 0, int chapter = 0,
             CancellationToken token = default);
+        Task<bool> ResourceDocsNeedUpdatingAsync(UserSecret userSecret, SFProject project, CancellationToken token);
 
         IReadOnlyList<int> GetBookList(UserSecret userSecret, string paratextId);
         string GetBookText(UserSecret userSecret, string paratextId, int bookNum);

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -325,9 +325,9 @@ namespace SIL.XForge.Scripture.Services
         }
 
         /// <summary>
-        /// Determines whether a the <see cref="TextData"/> for a resource project requires updating.
+        /// Determines whether the <see cref="TextData"/> for a resource project requires updating.
         /// </summary>
-        /// <param name="project">The resource project.</param>
+        /// <param name="project">The Scripture Forge project.</param>
         /// <param name="resource">The Paratext resource.</param>
         /// <returns>
         /// <c>true</c> if the project's documents require updating; otherwise, <c>false</c>.
@@ -340,7 +340,7 @@ namespace SIL.XForge.Scripture.Services
         public bool ResourceDocsNeedUpdating(SFProject project, ParatextResource resource)
         {
             // Ensure that we are checking a resource. We will default to true if it is not a resource.
-            if (!this.IsResource(project.ParatextId))
+            if (!IsResource(project.ParatextId))
             {
                 return true;
             }
@@ -1135,7 +1135,7 @@ namespace SIL.XForge.Scripture.Services
         public bool BackupExists(UserSecret userSecret, string paratextId)
         {
             // We do not back up resources
-            if (paratextId == null || this.IsResource(paratextId))
+            if (paratextId == null || IsResource(paratextId))
             {
                 return false;
             }
@@ -1156,7 +1156,7 @@ namespace SIL.XForge.Scripture.Services
         public bool BackupRepository(UserSecret userSecret, string paratextId)
         {
             // We do not back up resources
-            if (paratextId == null || this.IsResource(paratextId))
+            if (paratextId == null || IsResource(paratextId))
             {
                 if (paratextId == null)
                 {
@@ -1208,13 +1208,13 @@ namespace SIL.XForge.Scripture.Services
         public bool RestoreRepository(UserSecret userSecret, string paratextId)
         {
             // We do not back up resources
-            if (paratextId == null || this.IsResource(paratextId))
+            if (paratextId == null || IsResource(paratextId))
             {
                 if (paratextId == null)
                 {
                     _logger.LogInformation("Not restoring local PT repo for null paratextId.");
                 }
-                else if (this.IsResource(paratextId))
+                else if (IsResource(paratextId))
                 {
                     _logger.LogInformation("Not restoring a DBL resource.");
                 }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1088,7 +1088,7 @@ namespace SIL.XForge.Scripture.Services
         public bool BackupExists(UserSecret userSecret, string paratextId)
         {
             // We do not back up resources
-            if (paratextId == null || paratextId.Length == SFInstallableDblResource.ResourceIdentifierLength)
+            if (paratextId == null || this.IsResource(paratextId))
             {
                 return false;
             }
@@ -1109,7 +1109,7 @@ namespace SIL.XForge.Scripture.Services
         public bool BackupRepository(UserSecret userSecret, string paratextId)
         {
             // We do not back up resources
-            if (paratextId == null || paratextId.Length == SFInstallableDblResource.ResourceIdentifierLength)
+            if (paratextId == null || this.IsResource(paratextId))
             {
                 if (paratextId == null)
                 {
@@ -1161,13 +1161,13 @@ namespace SIL.XForge.Scripture.Services
         public bool RestoreRepository(UserSecret userSecret, string paratextId)
         {
             // We do not back up resources
-            if (paratextId == null || paratextId.Length == SFInstallableDblResource.ResourceIdentifierLength)
+            if (paratextId == null || this.IsResource(paratextId))
             {
                 if (paratextId == null)
                 {
                     _logger.LogInformation("Not restoring local PT repo for null paratextId.");
                 }
-                else if (paratextId.Length == SFInstallableDblResource.ResourceIdentifierLength)
+                else if (this.IsResource(paratextId))
                 {
                     _logger.LogInformation("Not restoring a DBL resource.");
                 }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -324,7 +324,6 @@ namespace SIL.XForge.Scripture.Services
             return paratextId?.Length == SFInstallableDblResource.ResourceIdentifierLength;
         }
 
-
         /// <summary>
         /// Determines whether a the <see cref="TextData"/> for a resource project requires updating.
         /// </summary>

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -321,7 +321,7 @@ namespace SIL.XForge.Scripture.Services
                 // Check for cancellation
                 if (token.IsCancellationRequested)
                 {
-                    await CompleteSync(false, canRollbackParatext, token);
+                    await CompleteSync(false, canRollbackParatext, trainEngine, token);
                     return;
                 }
 

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -310,7 +310,7 @@ namespace SIL.XForge.Scripture.Services
                 }
 
                 bool resourceNeedsUpdating = paratextProject is ParatextResource paratextResource &&
-                                             _paratextService.ResourceDocsNeedUpdating(_projectDoc.Data, paratextResource);
+                    _paratextService.ResourceDocsNeedUpdating(_projectDoc.Data, paratextResource);
 
                 if (!_paratextService.IsResource(targetParatextId) || resourceNeedsUpdating)
                 {

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1125,7 +1125,7 @@ namespace SIL.XForge.Scripture.Services
                 }
 
                 // Backup the repository
-                if (_projectDoc.Data.ParatextId.Length != SFInstallableDblResource.ResourceIdentifierLength)
+                if (!_paratextService.IsResource(_projectDoc.Data.ParatextId))
                 {
                     bool backupOutcome = _paratextService.BackupRepository(_userSecret, _projectDoc.Data.ParatextId);
                     if (!backupOutcome)

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -2251,13 +2251,15 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             var project = new SFProject
             {
+                // Not a valid resource because its Paratext ID is not 16 characters
                 ParatextId = "not_a_resource",
             };
             var resource = new ParatextResource();
 
             // SUT
             var result = env.Service.ResourceDocsNeedUpdating(project, resource);
-            Assert.IsTrue(result);
+            Assert.That(env.Service.IsResource(project.ParatextId), Is.False);
+            Assert.That(result, Is.True);
         }
 
         [Test]
@@ -2267,13 +2269,15 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             var project = new SFProject
             {
+                // Valid, as a resource's Paratext ID is 16 characters long
                 ParatextId = "a_valid_resource",
             };
             var resource = new ParatextResource();
 
             // SUT
             var result = env.Service.ResourceDocsNeedUpdating(project, resource);
-            Assert.IsTrue(result);
+            Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
+            Assert.That(result, Is.True);
         }
 
         [Test]
@@ -2284,6 +2288,7 @@ namespace SIL.XForge.Scripture.Services
             var timestamp = DateTime.Now;
             var project = new SFProject
             {
+                // Valid, as a resource's Paratext ID is 16 characters long
                 ParatextId = "a_valid_resource",
                 ResourceConfig = new ResourceConfig
                 {
@@ -2303,7 +2308,8 @@ namespace SIL.XForge.Scripture.Services
 
             // SUT
             var result = env.Service.ResourceDocsNeedUpdating(project, resource);
-            Assert.IsFalse(result);
+            Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -2314,6 +2320,7 @@ namespace SIL.XForge.Scripture.Services
             var timestamp = DateTime.Now;
             var project = new SFProject
             {
+                // Valid, as a resource's Paratext ID is 16 characters long
                 ParatextId = "a_valid_resource",
                 ResourceConfig = new ResourceConfig
                 {
@@ -2333,7 +2340,8 @@ namespace SIL.XForge.Scripture.Services
 
             // SUT
             var result = env.Service.ResourceDocsNeedUpdating(project, resource);
-            Assert.IsFalse(result);
+            Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -2344,6 +2352,7 @@ namespace SIL.XForge.Scripture.Services
             var timestamp = DateTime.Now;
             var project = new SFProject
             {
+                // Valid, as a resource's Paratext ID is 16 characters long
                 ParatextId = "a_valid_resource",
                 ResourceConfig = new ResourceConfig
                 {
@@ -2363,7 +2372,8 @@ namespace SIL.XForge.Scripture.Services
 
             // SUT
             var result = env.Service.ResourceDocsNeedUpdating(project, resource);
-            Assert.IsFalse(result);
+            Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -2374,6 +2384,7 @@ namespace SIL.XForge.Scripture.Services
             var timestamp = DateTime.Now;
             var project = new SFProject
             {
+                // Valid, as a resource's Paratext ID is 16 characters long
                 ParatextId = "a_valid_resource",
                 ResourceConfig = new ResourceConfig
                 {
@@ -2393,7 +2404,8 @@ namespace SIL.XForge.Scripture.Services
 
             // SUT
             var result = env.Service.ResourceDocsNeedUpdating(project, resource);
-            Assert.IsTrue(result);
+            Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
+            Assert.That(result, Is.True);
         }
 
         [Test]
@@ -2404,6 +2416,7 @@ namespace SIL.XForge.Scripture.Services
             var timestamp = DateTime.Now;
             var project = new SFProject
             {
+                // Valid, as a resource's Paratext ID is 16 characters long
                 ParatextId = "a_valid_resource",
                 ResourceConfig = new ResourceConfig
                 {
@@ -2423,7 +2436,8 @@ namespace SIL.XForge.Scripture.Services
 
             // SUT
             var result = env.Service.ResourceDocsNeedUpdating(project, resource);
-            Assert.IsTrue(result);
+            Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
+            Assert.That(result, Is.True);
         }
 
         [Test]
@@ -2434,6 +2448,7 @@ namespace SIL.XForge.Scripture.Services
             var timestamp = DateTime.Now;
             var project = new SFProject
             {
+                // Valid, as a resource's Paratext ID is 16 characters long
                 ParatextId = "a_valid_resource",
                 ResourceConfig = new ResourceConfig
                 {
@@ -2453,7 +2468,8 @@ namespace SIL.XForge.Scripture.Services
 
             // SUT
             var result = env.Service.ResourceDocsNeedUpdating(project, resource);
-            Assert.IsTrue(result);
+            Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
+            Assert.That(result, Is.True);
         }
 
         private class TestEnvironment

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -2251,8 +2251,7 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             var project = new SFProject
             {
-                // Not a valid resource because its Paratext ID is not 16 characters
-                ParatextId = "not_a_resource",
+                ParatextId = env.PTProjectIds[env.Project01].Id,
             };
             var resource = new ParatextResource();
 
@@ -2269,8 +2268,7 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             var project = new SFProject
             {
-                // Valid, as a resource's Paratext ID is 16 characters long
-                ParatextId = "a_valid_resource",
+                ParatextId = env.Resource1Id,
             };
             var resource = new ParatextResource();
 
@@ -2288,8 +2286,7 @@ namespace SIL.XForge.Scripture.Services
             var timestamp = DateTime.Now;
             var project = new SFProject
             {
-                // Valid, as a resource's Paratext ID is 16 characters long
-                ParatextId = "a_valid_resource",
+                ParatextId = env.Resource1Id,
                 ResourceConfig = new ResourceConfig
                 {
                     CreatedTimestamp = timestamp,
@@ -2320,8 +2317,7 @@ namespace SIL.XForge.Scripture.Services
             var timestamp = DateTime.Now;
             var project = new SFProject
             {
-                // Valid, as a resource's Paratext ID is 16 characters long
-                ParatextId = "a_valid_resource",
+                ParatextId = env.Resource1Id,
                 ResourceConfig = new ResourceConfig
                 {
                     CreatedTimestamp = timestamp,
@@ -2352,8 +2348,7 @@ namespace SIL.XForge.Scripture.Services
             var timestamp = DateTime.Now;
             var project = new SFProject
             {
-                // Valid, as a resource's Paratext ID is 16 characters long
-                ParatextId = "a_valid_resource",
+                ParatextId = env.Resource1Id,
                 ResourceConfig = new ResourceConfig
                 {
                     CreatedTimestamp = timestamp,
@@ -2384,8 +2379,7 @@ namespace SIL.XForge.Scripture.Services
             var timestamp = DateTime.Now;
             var project = new SFProject
             {
-                // Valid, as a resource's Paratext ID is 16 characters long
-                ParatextId = "a_valid_resource",
+                ParatextId = env.Resource1Id,
                 ResourceConfig = new ResourceConfig
                 {
                     CreatedTimestamp = timestamp,
@@ -2416,8 +2410,7 @@ namespace SIL.XForge.Scripture.Services
             var timestamp = DateTime.Now;
             var project = new SFProject
             {
-                // Valid, as a resource's Paratext ID is 16 characters long
-                ParatextId = "a_valid_resource",
+                ParatextId = env.Resource1Id,
                 ResourceConfig = new ResourceConfig
                 {
                     CreatedTimestamp = timestamp,
@@ -2448,8 +2441,7 @@ namespace SIL.XForge.Scripture.Services
             var timestamp = DateTime.Now;
             var project = new SFProject
             {
-                // Valid, as a resource's Paratext ID is 16 characters long
-                ParatextId = "a_valid_resource",
+                ParatextId = env.Resource1Id,
                 ResourceConfig = new ResourceConfig
                 {
                     CreatedTimestamp = timestamp,

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1559,7 +1559,7 @@ namespace SIL.XForge.Scripture.Services
             env.MockLogger.AssertEventCount((LogEvent logEvent) => logEvent.LogLevel == LogLevel.Information &&
                 Regex.IsMatch(logEvent.Message, "Starting"), 1);
 
-            // The book text not is retrieved from Paratext as the resource did not change
+            // The book text is not retrieved from Paratext as the resource did not change
             env.ParatextService.DidNotReceive().GetBookText(
                 Arg.Any<UserSecret>(),
                 Arg.Any<string>(),

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1511,7 +1511,7 @@ namespace SIL.XForge.Scripture.Services
                 new Book("MAT", 2), new Book("MRK", 2));
             env.SetupPTData(new Book("MAT", 3), new Book("MRK", 1));
 
-            // Setup the environment so the Paratext service will return the the resource has changed
+            // Setup the environment so the Paratext service will return that the resource has changed
             env.ParatextService.IsResource(Arg.Any<string>()).Returns(true);
             env.ParatextService.ResourceDocsNeedUpdating(Arg.Any<SFProject>(), Arg.Any<ParatextResource>())
                 .Returns(true);
@@ -1525,6 +1525,12 @@ namespace SIL.XForge.Scripture.Services
             env.MockLogger.AssertEventCount((LogEvent logEvent) => logEvent.LogLevel == LogLevel.Information &&
                                                                    Regex.IsMatch(logEvent.Message, "Starting"), 1);
 
+            // The book text is retrieved from Paratext as the resource has changed
+            env.ParatextService.Received().GetBookText(
+                Arg.Any<UserSecret>(),
+                Arg.Any<string>(),
+                Arg.Any<int>());
+
             Assert.IsNotNull(env.GetProject().ResourceConfig);
             Assert.That(env.ContainsText("project01", "MAT", 3), Is.True);
             Assert.That(env.ContainsText("project01", "MRK", 2), Is.False);
@@ -1533,13 +1539,13 @@ namespace SIL.XForge.Scripture.Services
         [Test]
         public async Task SyncAsync_ResourceNotChanged()
         {
-            // Setup the environment so there will be Paratext changes
+            // Setup the environment so there will be no Paratext changes
             var env = new TestEnvironment();
             env.SetupSFData(true, true, false, false,
                 new Book("MAT", 2), new Book("MRK", 2));
-            env.SetupPTData(new Book("MAT", 3), new Book("MRK", 1));
+            env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
 
-            // Setup the environment so the Paratext service will return the the resource has not changed
+            // Setup the environment so the Paratext service will return that the resource has not changed
             env.ParatextService.IsResource(Arg.Any<string>()).Returns(true);
             env.ParatextService.ResourceDocsNeedUpdating(Arg.Any<SFProject>(), Arg.Any<ParatextResource>())
                 .Returns(false);
@@ -1553,8 +1559,14 @@ namespace SIL.XForge.Scripture.Services
             env.MockLogger.AssertEventCount((LogEvent logEvent) => logEvent.LogLevel == LogLevel.Information &&
                 Regex.IsMatch(logEvent.Message, "Starting"), 1);
 
+            // The book text not is retrieved from Paratext as the resource did not change
+            env.ParatextService.DidNotReceive().GetBookText(
+                Arg.Any<UserSecret>(),
+                Arg.Any<string>(),
+                Arg.Any<int>());
+
             Assert.IsNull(env.GetProject().ResourceConfig);
-            Assert.That(env.ContainsText("project01", "MAT", 3), Is.False);
+            Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
             Assert.That(env.ContainsText("project01", "MRK", 2), Is.True);
         }
 


### PR DESCRIPTION
This pull request contains the following changes:
 * Standardizes resource checking in `ParatextService` and `ParatextSyncRunner`
 * Added a `ResourceConfig` child class of `SFProject` to track resource checksums and revision number
 * `ResourceConfig` data is compared to the data from the Paratext feed to ensure that resource text data is only updated if the resource has changed
 * Added unit tests for new resource manifest and revision checking

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1430)
<!-- Reviewable:end -->
