### PR TITLE
Renew PT access tokens 2 minutes before expiration

### DIFF
--- a/src/SIL.XForge/Models/Tokens.cs
+++ b/src/SIL.XForge/Models/Tokens.cs
@@ -35,7 +35,7 @@ namespace SIL.XForge.Models
             }
             var accessToken = new JwtSecurityToken(AccessToken);
             var now = DateTime.UtcNow;
-            return now >= accessToken.ValidFrom && now <= accessToken.ValidTo - TimeSpan.FromMinutes(1);
+            return now >= accessToken.ValidFrom && now <= accessToken.ValidTo - TimeSpan.FromMinutes(2);
         }
     }
 }

--- a/test/SIL.XForge.Tests/Models/TokensTests.cs
+++ b/test/SIL.XForge.Tests/Models/TokensTests.cs
@@ -37,7 +37,7 @@ namespace SIL.XForge.Models
         public void ValidateLifetime_FalseIfAboutToExpire()
         {
             var issuedAt = DateTime.Now;
-            var expiration = issuedAt + TimeSpan.FromSeconds(50);
+            var expiration = issuedAt + TimeSpan.FromSeconds(119);
             var tokens = new Tokens()
             {
                 AccessToken = TokenHelper.CreateAccessToken(issuedAt, expiration, "paratext01"),
@@ -52,7 +52,7 @@ namespace SIL.XForge.Models
         public void ValidateLifetime_TrueIfUnexpired()
         {
             var issuedAt = DateTime.Now;
-            var expiration = issuedAt + TimeSpan.FromSeconds(70);
+            var expiration = issuedAt + TimeSpan.FromSeconds(121);
             var tokens = new Tokens()
             {
                 AccessToken = TokenHelper.CreateAccessToken(issuedAt, expiration, "paratext01"),


### PR DESCRIPTION
PT access tokens are valid for 20 minutes. Previously we would check if they were going to expire in the next 1 minute and renew if they were. This changes it to 2 minutes, since the registry server's clock has drifted in the past and resulted in errors.

This doesn't fully fix the problem, but I think it's a reasonable way to permanently reduce the frequency with which we run into this problem.