### PR TITLE
SF-1615 Improve wording on connect project page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
@@ -53,43 +53,25 @@
         ></p>
       </ng-template>
       <mat-card id="settings-card" *ngIf="showSettings" class="card-outline" formGroupName="settings">
-        <mat-card-header class="card-title">
-          <mat-card-title>{{ t("additional_settings") }}</mat-card-title>
-          <mat-card-subtitle>{{ t("you_can_change_later") }}</mat-card-subtitle>
-        </mat-card-header>
+        <mat-card-title>{{ t("project_settings") }}</mat-card-title>
+        <mat-card-subtitle>{{ t("you_can_change_later") }}</mat-card-subtitle>
         <mat-card-content class="card-content">
-          <mat-checkbox [disabled]="true" [checked]="true" class="checkbox-placeholder">
-            {{ translateFromSettings("translate") }}
-          </mat-checkbox>
-          <div fxLayout="row" fxLayoutAlign="start center">
-            <div fxFlex="24px" class="indent"></div>
-            <div fxLayout="column" fxFlex="grow">
-              <mat-hint class="helper-text checkbox-helper-text">
-                {{ translateFromSettings("translate_tool_is_always_available") }}
-              </mat-hint>
-              <mat-hint
-                class="indented-field-row"
-                [innerHTML]="i18n.translateAndInsertTags('settings.translation_based_on')"
-              ></mat-hint>
-              <app-project-select
-                formControlName="sourceParatextId"
-                placeholder="{{ t('based_on') }}"
-                [projects]="projects"
-                [resources]="resources"
-                [hideProjectId]="paratextIdControl.value"
-              ></app-project-select>
-              <mat-error *ngIf="showResourcesLoadingFailedMessage">{{ t("error_fetching_resources") }}</mat-error>
-            </div>
-          </div>
+          <p>{{ t("select_project_or_resource") }}</p>
+          <p>{{ t("translation_suggestions_require_source_text") }}</p>
+          <app-project-select
+            formControlName="sourceParatextId"
+            placeholder="Source text (optional)"
+            [projects]="projects"
+            [resources]="resources"
+            [hideProjectId]="paratextIdControl.value"
+          ></app-project-select>
+          <mat-error *ngIf="showResourcesLoadingFailedMessage">{{ t("error_fetching_resources") }}</mat-error>
           <ng-container *ngIf="isBasedOnProjectSet">
             <div fxLayout="row" fxLayoutAlign="start center">
-              <div fxFlex="24px" class="indent"></div>
               <div fxLayout="column" fxFlex="grow">
-                <div class="indented-field-row">
-                  <mat-checkbox formControlName="translationSuggestions" id="translation-suggestions-checkbox">
-                    {{ translateFromSettings("translation_suggestions") }}
-                  </mat-checkbox>
-                </div>
+                <mat-checkbox formControlName="translationSuggestions" id="translation-suggestions-checkbox">
+                  {{ t("enable_translation_suggestions") }}
+                </mat-checkbox>
                 <div>
                   <div fxFlex="24px" class="indent"></div>
                   <mat-hint
@@ -106,7 +88,7 @@
         <mat-card-content class="card-content">
           <div>
             <mat-checkbox formControlName="checking" id="checking-checkbox">
-              {{ t("community_checking") }}
+              {{ t("enable_community_checking") }}
             </mat-checkbox>
           </div>
           <div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
@@ -61,27 +61,14 @@
     }
 
     mat-card {
-      box-shadow: initial;
-      padding: 0;
       margin-top: 32px;
 
-      .card-title {
-        margin-top: 16px;
-      }
-
-      .card-content {
-        padding: 16px;
-        margin-bottom: 0;
+      mat-divider + .card-content {
+        padding-top: 16px;
       }
 
       mat-checkbox {
         padding-bottom: 12px;
-      }
-
-      mat-divider {
-        margin-left: 16px;
-        position: initial;
-        width: initial;
       }
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -45,14 +45,14 @@
     "share_with_others": "Share with others"
   },
   "connect_project": {
-    "additional_settings": "Additional Settings",
     "already_connected": "(already connected)",
     "based_on": "Based on",
-    "community_checking": "Community Checking",
     "connect_network_to_connect_project": "Please connect to the internet to enable connecting to a project",
     "connect_paratext_project": "Connect Paratext Project",
     "connect": "Connect",
     "connecting_to_project": "Connecting to {{ projectName }}...",
+    "enable_community_checking": "Enable Community Checking",
+    "enable_translation_suggestions": "Enable translation suggestions",
     "engage_the_wider_community_to_check_scripture": "Engage the wider community to ensure that the translation is clear, accurate, and natural. Select verses, ask targeted questions, allow discussion of answers.",
     "error_fetching_resources": "There was an error fetching the Digital Bible Library resources. You will only be able to select projects.",
     "log_in_with_paratext": "Log in with Paratext",
@@ -62,6 +62,9 @@
     "paratext_project": "Paratext Project",
     "problem_already_connected": "The project is already connected. Maybe another project administrator connected the project at the same time. Please try again. If it continues to be a problem, please report the issue so we can get it fixed.",
     "proceed": "Proceed",
+    "project_settings": "Project Settings",
+    "select_project_or_resource": "Select the Paratext project or Digital Bible Library resource that your project is based on. If your project is based on a Paratext project, it's best to set it up as a daughter project in Paratext.",
+    "translation_suggestions_require_source_text": "Note: Translation suggestions are only available if you select a source text.",
     "you_can_change_later": "You can change these later.",
     "you_must_be_logged_in_to_paratext": "You must login with your Paratext account to connect to a project."
   },


### PR DESCRIPTION
Before | After
----------|-------
![](https://user-images.githubusercontent.com/6140710/178532348-27167f41-0a2d-4770-81f2-bca23e73b3ba.png) | ![](https://user-images.githubusercontent.com/6140710/178532343-5fcc322d-5588-4a30-b45e-add3ecf688a9.png)

I think a similar change may be warranted on the settings page, but the wording there doesn't feel as wrong to me as the current wording on the connect project page.