### PR TITLE
SF-1641 Fix production build by building RealtimeServer before ClientApp

### DIFF
--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -100,8 +100,8 @@
 
   <Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
     <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
     <Exec WorkingDirectory="$(RealtimeServerRoot)" Command="npm install" />
+    <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
     <Exec WorkingDirectory="$(SpaRoot)" Command="npm run build -- --configuration=$(AngularConfig)" />
     <Exec WorkingDirectory="$(SpaRoot)" Command="npm run build:ssr -- --configuration=$(AngularConfig)" Condition=" '$(BuildServerSideRenderer)' == 'true' " />
 


### PR DESCRIPTION
I spent a lot more time researching this than I would like, and I don't want to explain everything I found because it would probably take an hour to type out. But here's the basics:
- The production build failed on TeamCity
- It was running `npm install` in ClientApp
- ClientApp installs RealtimeServer, so RealtimeServer's prepare script is run
- The prepare script runs `tsc`, the TypeScript compiler, which it assumes is installed in node_modules
- But the packages haven't been installed, so it fails

Previously npm didn't run the prepare script in this situation; that changed in npm v7.20.0, which we upgraded to September 2021. Before that you could just run `npm install` in ClientApp and it should properly build RealtimeServer.

There were basically two options for fixing this:
1. Change how we have npm scripts configured so we can run `npm i` in ClientApp and it installs RealtimeServer fine
2. Change the build process to build RealtimeServer first

I thought the first option was the right one, and there were two ways I found to accomplish it:
A. Remove the prepare script (it's what causes the failure, and it's not necessary in this case)
B. Change the prepare script to run `npm install --ignore-scripts` before running `tsc`

Option A might have worked fine, but I was a little concerned something might be relying on the prepare script. I didn't investigate that fully.
Option B works, but the package-lock.json files that get produced by that are _slightly different_ for unknown reasons (the RealtimeServer has 5 lines deleted). That's not major but I wanted to avoid that.

I also think that having ClientApp install RealtimeServer and then installing RealtimeServer separately is kind of inefficient. Building the dependency first makes sense. So the change I made was to run `npm install` in RealtimeServer before it's run in ClientApp.

The biggest question I have left is why it was working before. I know why it was working before we updated to npm v7.20.0. Since then, I don't know, but it's not _that_ surprising that a .NET update would bump it somehow. Or maybe TeamCity keeps the old node_modules around from the last build? I would hope not; that would make builds be able to effect each other.

For further discussion we could talk about this on a call.

P.S. The steps I'm using to do a production build are:
1. Delete node_modules in ClientApp and RealtimeServer
2. Run (from repo root) `dotnet publish "src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj" -c "Release" -r "linux-x64" -o "artifacts/app" /p:Version="9.9.9" /p:AngularConfig="production" --self-contained`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1437)
<!-- Reviewable:end -->
