### PR TITLE
SF-1653 Update text anchor when multiple edits in a delta

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/segment.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/segment.ts
@@ -8,8 +8,6 @@ export class Segment {
   private _range: RangeStatic = { index: 0, length: 0 };
   private _checksum?: number;
   private initialTextLen: number = -1;
-  /** Mapping of embed ids to their position in the editor. Enables processing changes to embeds after text edits. */
-  private _segmentVerseEmbeddedElements: Map<string, number> = new Map<string, number>();
 
   constructor(public readonly bookNum: number, public readonly chapter: number, public readonly ref: string) {}
 
@@ -36,19 +34,14 @@ export class Segment {
     return this._text.length - this.initialTextLen;
   }
 
-  get embeddedElements(): Map<string, number> {
-    return this._segmentVerseEmbeddedElements;
-  }
-
   acceptChanges(): void {
     this.initialTextLen = this._text.length;
     this.initialChecksum = this.checksum;
   }
 
-  update(text: string, range: RangeStatic, embeddedElementIndices: Map<string, number>): void {
+  update(text: string, range: RangeStatic): void {
     this._text = text;
     this._range = range;
-    this._segmentVerseEmbeddedElements = embeddedElementIndices;
     this._checksum = undefined;
     if (this.initialTextLen === -1) {
       this.initialTextLen = text.length;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -165,12 +165,20 @@ export class TextViewModel {
     return this._segments.entries();
   }
 
+  get segmentsSnapshot(): IterableIterator<[string, RangeStatic]> {
+    return cloneDeep(this._segments).entries();
+  }
+
   get embeddedElements(): Map<string, number> {
     const embeddedElements: Map<string, number> = new Map<string, number>();
     for (const [embedId, embedPosition] of this._embeddedElements.entries()) {
       embeddedElements.set(embedId, embedPosition.position);
     }
     return embeddedElements;
+  }
+
+  get embeddedElementsSnapshot(): Map<string, number> {
+    return cloneDeep(this.embeddedElements);
   }
 
   get isLoaded(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -1032,9 +1032,11 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     let embedsByVerse = new Map<string, number>();
     const editPositions: number[] = this.getEditPositionsInDelta(delta);
     const embedsByEditedVerse: EmbedsByVerse[] = [];
+    // content before verse 1 are considered to be in verse 0
+    let baseVerse: string = '0';
     for (const [segment, range] of preDeltaSegmentCache) {
-      // TODO: if a section heading, continue in previous verse
-      const baseVerse: string = this.getBaseVerse(segment);
+      // if we cannot determine the base verse, consider it as part of the previous verse
+      baseVerse = this.getBaseVerse(segment) ?? baseVerse;
       if (currentVerse === '') {
         // set the current verse and range on the first pass
         currentVerse = baseVerse;
@@ -1096,9 +1098,13 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     return editPositions;
   }
 
-  private getBaseVerse(segmentRef: string): string {
+  /**
+   * Returns the base verse of the segment ref. e.g. 'verse_1_5'
+   * @return The segment ref of the first segment in the verse, or undefined if the segment does not belong to a verse.
+   */
+  private getBaseVerse(segmentRef: string): string | undefined {
     const matchArray: RegExpExecArray | null = VERSE_REGEX.exec(segmentRef);
-    return matchArray == null ? segmentRef : matchArray[0];
+    return matchArray == null ? undefined : matchArray[0];
   }
 
   private getVerseEndIndex(baseRef: string): number | undefined {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -997,24 +997,13 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       return;
     }
 
-    const matchArray: RegExpExecArray | null = VERSE_REGEX.exec(this._segment.ref);
-    const baseVerse = matchArray == null ? this._segment.ref : matchArray[0];
-    const startSegmentRange: RangeStatic | undefined = this.viewModel.getSegmentRange(baseVerse);
     const segmentRange: RangeStatic | undefined = this.viewModel.getSegmentRange(this._segment.ref);
     if (segmentRange == null) {
       return;
     }
 
-    const endIndex: number = this.getVerseEndIndex(baseVerse) ?? segmentRange.index + segmentRange.length;
-    const startIndex: number = startSegmentRange?.index ?? segmentRange.index;
     const text = this.viewModel.getSegmentText(this._segment.ref);
-    const verseEmbeddedElements: Map<string, number> = new Map<string, number>();
-    for (const [threadId, index] of this.embeddedElements.entries()) {
-      if (index >= startIndex && index < endIndex) {
-        verseEmbeddedElements.set(threadId, index);
-      }
-    }
-    this._segment.update(text, segmentRange, verseEmbeddedElements);
+    this._segment.update(text, segmentRange);
   }
 
   /** Gets the embeds affected */
@@ -1154,11 +1143,11 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       }
       const newEnd: number = Math.min(oldEnd, segEnd);
 
-      const embedIndices: number[] = Array.from(this._segment.embeddedElements.values()).sort();
-      if (newStart === this._segment.range.index || embedIndices.includes(newStart - 1)) {
+      const embedPositions: number[] = Array.from(this.embeddedElements.values()).sort();
+      if (newStart === this._segment.range.index || embedPositions.includes(newStart - 1)) {
         // if the selection is before an embed at the start of the segment or
         // the selection is between embeds, move the selection behind it
-        while (embedIndices.includes(newStart)) {
+        while (embedPositions.includes(newStart)) {
           newStart++;
         }
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -82,7 +82,7 @@
                 $event.segment,
                 $event.delta,
                 $event.prevSegment,
-                $event.oldVerseEmbeds,
+                $event.affectedEmbeds,
                 $event.isLocalUpdate
               )
             "

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1856,6 +1856,31 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('updates note anchor for non-verse segments', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      const origThread06Pos: TextAnchor = { start: 38, length: 7 };
+      env.addParatextNoteThread(6, 'LUK 1:2-3', 'section', origThread06Pos, ['user01']);
+      env.wait();
+      env.updateParams({ projectId: 'project01', bookId: 'LUK' });
+      env.wait();
+      const textBeforeNote = 'Text in ';
+      let range: RangeStatic = env.component.target!.getSegmentRange('s_2')!;
+      let notePosition: number = env.getNoteThreadEditorPosition('thread06');
+      expect(range.index + textBeforeNote.length).toEqual(notePosition);
+      const thread06Doc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread06');
+      let textAnchor: TextAnchor = thread06Doc.data!.position;
+      expect(textAnchor).toEqual(origThread06Pos);
+
+      const verse2_3Range: RangeStatic = env.component.target!.getSegmentRange('verse_1_2-3')!;
+      env.targetEditor.setSelection(verse2_3Range.index + verse2_3Range.length);
+      env.wait();
+      env.typeCharacters('T');
+      textAnchor = thread06Doc.data!.position;
+      expect(textAnchor).toEqual({ start: origThread06Pos.start + 1, length: origThread06Pos.length });
+      env.dispose();
+    }));
+
     it('can display note dialog', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1838,7 +1838,7 @@ describe('EditorComponent', () => {
       env.targetEditor.updateContents(deleteDelta, 'user');
       tick();
       env.fixture.detectChanges();
-      const insertStart: number = notePosition + ' 1, ver'.length;
+      const insertStart: number = notePosition + 'ter 1, ver'.length;
       const insertOps: DeltaOperation[] = [{ retain: insertStart }, { insert: text }];
       const insertDelta: DeltaStatic = new Delta(insertOps);
       env.targetEditor.updateContents(insertDelta, 'user');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -52,7 +52,7 @@ import { SFProjectService } from '../../core/sf-project.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
 import { Segment } from '../../shared/text/segment';
 import { PresenceData, RemotePresences } from '../../shared/text/text-view-model';
-import { FeaturedVerseRefInfo, TextComponent } from '../../shared/text/text.component';
+import { EmbedsByVerse, FeaturedVerseRefInfo, TextComponent } from '../../shared/text/text.component';
 import { formatFontSizeToRems, threadIdFromMouseEvent } from '../../shared/utils';
 import { MultiCursorViewer } from './multi-viewer/multi-viewer.component';
 import { NoteDialogComponent, NoteDialogData } from './note-dialog/note-dialog.component';
@@ -498,7 +498,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     segment?: Segment,
     delta?: DeltaStatic,
     prevSegment?: Segment,
-    oldVerseEmbeds?: Map<string, number>,
+    embedsBeforeDeltaInEditedVerses?: EmbedsByVerse[],
     isLocalUpdate?: boolean
   ): Promise<void> {
     if (this.target == null || this.target.editor == null) {
@@ -560,9 +560,14 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
           this.insertSuggestionEnd = -1;
           this.target.editor.setSelection(selectIndex, 0, 'user');
         }
-        if (segment != null && oldVerseEmbeds != null && this.shouldNoteThreadsRespondToEdits && !!isLocalUpdate) {
+        if (
+          segment != null &&
+          embedsBeforeDeltaInEditedVerses != null &&
+          this.shouldNoteThreadsRespondToEdits &&
+          !!isLocalUpdate
+        ) {
           // only update the note anchors if the update is local, otherwise remote edits will mess up the note anchors
-          await this.updateVerseNoteThreadAnchors(oldVerseEmbeds, delta);
+          await this.updateVerseNoteThreadAnchors(embedsBeforeDeltaInEditedVerses, delta);
         }
       }
 
@@ -1139,7 +1144,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   /** Update the text anchors for the note threads in the current segment. */
-  private async updateVerseNoteThreadAnchors(oldVerseEmbeds: Map<string, number>, delta: DeltaStatic): Promise<void> {
+  private async updateVerseNoteThreadAnchors(affectedEmbeds: EmbedsByVerse[], delta: DeltaStatic): Promise<void> {
     if (this.target == null || this.noteThreadQuery == null || this.noteThreadQuery.docs.length < 1) {
       return;
     }
@@ -1149,10 +1154,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
 
     const updatePromises: Promise<boolean>[] = [];
-    const editOpIndex: number | undefined = delta.ops[0].retain;
-    if (editOpIndex == null) {
-      return;
-    }
 
     // a user initiated delta with ops that include inserting a note embed can only be undo deleting a note icon
     const reinsertedNoteEmbeds: DeltaOperation[] = delta.filter(
@@ -1169,52 +1170,61 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     );
     const textDeleteOps: DeltaOperation[] = delta.filter(ops => ops.delete != null);
     const hasTextEditOp: boolean = textInsertOps.length > 0 || textDeleteOps.length > 0;
-    for (const [threadId, noteIndex] of oldVerseEmbeds.entries()) {
-      const noteThreadDoc: NoteThreadDoc | undefined = this.noteThreadQuery.docs.find(n => n.data?.dataId === threadId);
-      if (noteThreadDoc?.data == null) {
+    for (const affected of affectedEmbeds) {
+      const editPosition: number | undefined = this.getEditPositionWithinRange(affected.verseRange, delta);
+      if (editPosition == null) {
         continue;
       }
-
-      const noteCountInTextAnchor: number = this.getEmbedCountInAnchorRange(
-        oldVerseEmbeds,
-        noteIndex,
-        noteThreadDoc.data.position.length
-      );
-      const noteAnchorEndIndex: number = noteIndex + noteThreadDoc.data.position.length + noteCountInTextAnchor;
-      // A note anchor is only affected by the undo operation if the delta includes inserting the note embed, or
-      // if the edit op occurs before the note text anchor last character
-      // i.e. note anchors are unaffected if the edit index comes after the note and anchor
-      const noteIsAffected: boolean = noteAnchorEndIndex >= editOpIndex || reinsertedNoteIds.includes(threadId);
-      if (reinsertedNoteEmbeds.length > 0 && noteIsAffected && hasTextEditOp) {
-        updatePromises.push(
-          noteThreadDoc
-            .previousSnapshot()
-            .then(s => noteThreadDoc.submitJson0Op(op => op.set(n => n.position, s.data.position)))
+      for (const [threadId, notePos] of affected.embeds.entries()) {
+        const noteThreadDoc: NoteThreadDoc | undefined = this.noteThreadQuery.docs.find(
+          n => n.data?.dataId === threadId
         );
-        continue;
-      }
-      const oldNotePosition: TextAnchor = noteThreadDoc.data.position ?? { start: 0, length: 0 };
+        if (noteThreadDoc?.data == null) {
+          continue;
+        }
 
-      const newSelection: TextAnchor | undefined = this.getUpdatedTextAnchor(
-        oldNotePosition,
-        oldVerseEmbeds,
-        noteIndex,
-        editOpIndex,
-        delta
-      );
-      if (isEqual(oldNotePosition, newSelection)) {
-        continue;
-      }
-      updatePromises.push(noteThreadDoc.submitJson0Op(op => op.set(n => n.position, newSelection)));
-    }
-    await Promise.all(updatePromises);
+        const noteCountInTextAnchor: number = this.getEmbedCountInAnchorRange(
+          affected.embeds,
+          notePos,
+          noteThreadDoc.data.position.length
+        );
+        const noteAnchorEndIndex: number = notePos + noteThreadDoc.data.position.length + noteCountInTextAnchor;
+        const isUndoOperation: boolean = reinsertedNoteEmbeds.length > 0;
+        // A note anchor is only affected by the undo operation if the delta includes inserting the note embed, or
+        // if the edit op occurs before the note text anchor last character
+        // i.e. note anchors are unaffected if the edit index comes after the note and anchor
+        const noteIsAffected: boolean = noteAnchorEndIndex >= editPosition || reinsertedNoteIds.includes(threadId);
+        if (isUndoOperation && noteIsAffected && hasTextEditOp) {
+          updatePromises.push(
+            noteThreadDoc
+              .previousSnapshot()
+              .then(s => noteThreadDoc.submitJson0Op(op => op.set(n => n.position, s.data.position)))
+          );
+          continue;
+        }
 
-    // Re-apply the underline style to notes that were re-inserted
-    const embedPositions: Readonly<Map<string, number>> = this.target.embeddedElements;
-    for (const id of reinsertedNoteIds) {
-      const index: number | undefined = embedPositions.get(id);
-      if (index != null) {
-        this.target.editor?.formatText(index, 1, 'text-anchor', 'true', 'api');
+        const oldNotePosition: TextAnchor = noteThreadDoc.data.position ?? { start: 0, length: 0 };
+        const newTextAnchor: TextAnchor | undefined = this.getUpdatedTextAnchor(
+          oldNotePosition,
+          affected.embeds,
+          notePos,
+          affected.verseRange,
+          delta
+        );
+        if (isEqual(oldNotePosition, newTextAnchor)) {
+          continue;
+        }
+        updatePromises.push(noteThreadDoc.submitJson0Op(op => op.set(n => n.position, newTextAnchor)));
+      }
+      await Promise.all(updatePromises);
+
+      // Re-apply the underline style to notes that were re-inserted
+      const embedPositions: Readonly<Map<string, number>> = this.target.embeddedElements;
+      for (const id of reinsertedNoteIds) {
+        const position: number | undefined = embedPositions.get(id);
+        if (position != null) {
+          this.target.editor?.formatText(position, 1, 'text-anchor', 'true', 'api');
+        }
       }
     }
   }
@@ -1248,7 +1258,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     oldTextAnchor: TextAnchor,
     oldVerseEmbedPositions: Map<string, number>,
     noteIndex: number,
-    editIndex: number,
+    verseRange: RangeStatic,
     delta: DeltaStatic
   ): TextAnchor | undefined {
     if (oldTextAnchor.start === 0 && oldTextAnchor.length === 0) {
@@ -1260,7 +1270,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     let [startChange, lengthChange] = this.getAnchorChanges(
       noteIndex,
       noteAnchorEndIndex,
-      editIndex,
+      verseRange,
       delta,
       verseNotePositions
     );
@@ -1273,9 +1283,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   private getAnchorChanges(
-    embedIndex: number,
+    embedPosition: number,
     noteAnchorEndIndex: number,
-    editIndex: number,
+    verseRange: RangeStatic,
     delta: DeltaStatic,
     embedPositions: Set<number>
   ): [number, number] {
@@ -1284,11 +1294,21 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     if (delta.ops == null || delta.ops.length < 2) {
       return [0, 0];
     }
+    let curIndex = 0;
     // get the length that was inserted or deleted to apply to the verse text anchors
-    for (let i = 1; i < delta.ops.length; i++) {
-      const insertOp: any = delta.ops[i].insert;
-      const deleteOp: number | undefined = delta.ops[i].delete;
+    for (const op of delta.ops) {
+      const insertOp: any = op.insert;
+      const deleteOp: number | undefined = op.delete;
+      const retainOp: number | undefined = op.retain;
+      if (retainOp != null) {
+        curIndex += retainOp;
+        continue;
+      }
+
+      const editInVerseRange: boolean =
+        curIndex >= verseRange.index && curIndex <= verseRange.index + verseRange.length;
       if (insertOp != null) {
+        if (!editInVerseRange) continue;
         let length = 0;
         if (typeof insertOp === 'string') {
           length = insertOp.length;
@@ -1302,52 +1322,75 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
           length = 1;
         }
 
-        if (editIndex <= embedIndex) {
+        if (curIndex <= embedPosition) {
           startChange += length;
-        } else if (editIndex > embedIndex && editIndex <= noteAnchorEndIndex) {
+        } else if (curIndex > embedPosition && curIndex <= noteAnchorEndIndex) {
           // Note that if the user inserted text at the end of this note anchor, we consider
           // this inside the text anchor because the user could be expanding the last text anchor word.
           lengthChange += length;
         }
       } else if (deleteOp != null) {
-        let [deleteBefore, deleteWithin] = this.calculateDeletionUpdate(
-          editIndex,
-          embedIndex,
-          noteAnchorEndIndex,
-          deleteOp,
-          embedPositions
-        );
-        startChange -= deleteBefore;
-        lengthChange -= deleteWithin;
+        if (editInVerseRange) {
+          let [deleteBefore, deleteWithin] = this.calculateDeletionUpdate(
+            curIndex,
+            embedPosition,
+            noteAnchorEndIndex,
+            deleteOp,
+            embedPositions
+          );
+          startChange -= deleteBefore;
+          lengthChange -= deleteWithin;
+        }
+        curIndex += deleteOp;
       }
     }
 
     return [startChange, lengthChange];
   }
 
+  /** Gets the first edit position within the given range. */
+  private getEditPositionWithinRange(range: RangeStatic, delta: DeltaStatic): number | undefined {
+    if (delta.ops == null) {
+      return;
+    }
+    let curIndex = 0;
+    for (const op of delta.ops) {
+      const deleteOp: number | undefined = op.delete;
+      const insertOp: any | undefined = op.insert;
+      if ((deleteOp != null || insertOp != null) && curIndex >= range.index && curIndex <= range.index + range.length) {
+        // the edit op occurs within the range
+        return curIndex;
+      }
+
+      const retainOp: number | undefined = op.retain;
+      curIndex += retainOp == null ? 0 : retainOp;
+    }
+    return;
+  }
+
   private calculateDeletionUpdate(
-    editIndex: number,
-    embedIndex: number,
+    editPosition: number,
+    embedPosition: number,
     noteAnchorEndIndex: number,
     deleteLength: number,
     embedPositions: Set<number>
   ): [number, number] {
     let deleteBeforeLength = 0;
     let deleteWithinLength = 0;
-    for (let charIndex = editIndex; charIndex < editIndex + deleteLength; charIndex++) {
+    for (let charIndex = editPosition; charIndex < editPosition + deleteLength; charIndex++) {
       if (embedPositions.has(charIndex)) {
         // The edit involves deleting an embed icon. It neither counts as length within nor before
         continue;
       }
-      if (charIndex === embedIndex) {
+      if (charIndex === embedPosition) {
         console.warn(
-          `Warning: getUpdatedTextAnchor: embedIndex ${embedIndex} unexpectedly was not contained in embedPositions:`,
+          `Warning: getUpdatedTextAnchor: No embed at position ${embedPosition} was found in embedPositions:`,
           embedPositions
         );
       }
-      if (charIndex < embedIndex) {
+      if (charIndex < embedPosition) {
         deleteBeforeLength++;
-      } else if (charIndex > embedIndex && charIndex < noteAnchorEndIndex) {
+      } else if (charIndex > embedPosition && charIndex < noteAnchorEndIndex) {
         deleteWithinLength++;
       } else {
         break;


### PR DESCRIPTION
This change enables the ability to update a text anchor when multiple edit positions exist in a delta. Currently, this only happens when a user edits text via a drag and drop, and then undoes the drag and drop. Previously, this would cause the text anchor to be updated incorrectly because we only handled the first edit (insert or delete) that we saw in the delta.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1442)
<!-- Reviewable:end -->
