### PR TITLE
dev: format .ts, etc files from root

### DIFF
--- a/.lintstagedrc.yml
+++ b/.lintstagedrc.yml
@@ -1,1 +1,2 @@
+"*.{ts,js,json,css,scss,less,html,md,yml}": "prettier --write"
 "*.cs": "dotnet csharpier"

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -118,11 +118,6 @@
     "typescript": "~4.3.5",
     "webpack-bundle-analyzer": "^4.5.0"
   },
-  "lint-staged": {
-    "*.{ts,js,json,css,scss,less,html,md,yml}": [
-      "prettier --write"
-    ]
-  },
   "browser": {
     "moment": false
   }


### PR DESCRIPTION
lint-staged is configured to format .ts, .html, and .yml files in
ClientApp. But we have these files in other locations in the
repository. Move the configuration so that files in other locations
will be formatted by lint-staged.

---

**Stack**:
- #1452
- #1406
- #1445 ⮜


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1445)
<!-- Reviewable:end -->
