### PR TITLE
SF-1640 Add attributes on the paste operation

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -691,7 +691,14 @@ export function registerScripture(): string[] {
       text = text.replace(/(?:\r?\n)+/, ' ');
       setTimeout(() => {
         this.container.innerHTML = text;
-        delta = delta.concat(this.convert()).delete(range.length);
+        const pasteDelta: DeltaStatic = this.convert();
+        if (pasteDelta.ops != null) {
+          for (const op of pasteDelta.ops) {
+            // add the attributes to the paste delta which should just be 1 insert op
+            op.attributes = getAttributesAtPosition(this.quill, range.index);
+          }
+        }
+        delta = delta.concat(pasteDelta).delete(range.length);
         this.quill.updateContents(delta, 'user');
         // range.length contributes to delta.length()
         this.quill.setSelection(delta.length() - range.length, 'silent');


### PR DESCRIPTION
We extend the QuillClipboard class to allow us to have custom handling when pasting text. This change adds to that custom handling to insert attributes alongside the text so that we do not create erroneous usx-segments. It was this erroneous segment created by pasting text that resulted in the note anchors being hidden in the DOM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1446)
<!-- Reviewable:end -->
