### PR TITLE
SF-1495 Retain attributes when undo inserts a blank

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
@@ -76,6 +76,28 @@ export function getPoetryVerseTextDoc(id: TextDocId): TextData {
   return delta;
 }
 
+export function getEmptyChapterDoc(id: TextDocId): TextData {
+  const delta = new Delta();
+  delta.insert({ blank: true }, { segment: 's_1' });
+  delta.insert('\n', { para: { style: 's' } });
+  delta.insert({ chapter: { number: id.chapterNum.toString(), style: 'c' } });
+  delta.insert({ blank: true }, { segment: 's_2' });
+  delta.insert('\n', { para: { style: 's' } });
+  delta.insert({ blank: true }, { segment: 'p_1' });
+  delta.insert({ verse: { number: '1', style: 'v' } });
+  delta.insert({ blank: true }, { segment: 'verse_1_1' });
+  delta.insert({ verse: { number: '2', style: 'v' } });
+  delta.insert({ blank: true }, { segment: 'verse_1_2' });
+  delta.insert('\n', { para: { style: 'p' } });
+  delta.insert({ blank: true }, { segment: 's_3' });
+  delta.insert('\n', { para: { style: 's' } });
+  delta.insert({ blank: true }, { segment: 'p_2' });
+  delta.insert({ verse: { number: '3', style: 'v' } });
+  delta.insert({ blank: true }, { segment: 'verse_1_3' });
+  delta.insert('\n', { para: { style: 'p' } });
+  return delta;
+}
+
 export function getSFProject(id: string): SFProjectProfile {
   return {
     name: `${id} name`,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -740,7 +740,9 @@ export function registerScripture(): string[] {
         }
         if (typeof modelOp.insert === 'object') {
           // clear the formatting attributes on embeds to prevent dom elements from being corrupted
-          modelOp.attributes = undefined;
+          if (modelOp.insert.blank == null) {
+            modelOp.attributes = undefined;
+          }
         }
         (updatedDelta as any).push(modelOp);
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -727,7 +727,7 @@ export function registerScripture(): string[] {
 
   /**
    * Updates delta to remove segment highlights from segments that are not explicitly highlighted
-   * and strips off formatting from note thread embeds.
+   * and strips away formatting from embeds, excluding blanks.
    */
   function removeObsoleteSegmentAttrs(delta: DeltaStatic): DeltaStatic {
     const updatedDelta = new Delta();
@@ -739,7 +739,8 @@ export function registerScripture(): string[] {
           attrs['highlight-segment'] = false;
         }
         if (typeof modelOp.insert === 'object') {
-          // clear the formatting attributes on embeds to prevent dom elements from being corrupted
+          // clear the formatting attributes on embeds to prevent dom elements from being corrupted,
+          // excluding blanks, since empty segments do not have texts with formatting to reference
           if (modelOp.insert.blank == null) {
             modelOp.attributes = undefined;
           }


### PR DESCRIPTION
When the undo operation includes inserting a blank, the blank segment was getting attributes stripped away incorrectly. This change adds a check that a blank segment does not get attributes stripped away which causes the history stack to be updated incorrectly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1447)
<!-- Reviewable:end -->
