### PR TITLE
SF-1608 Improve quality of Bugsnag reporting

### DIFF
--- a/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
@@ -34,8 +34,6 @@ namespace SIL.XForge.Scripture.Controllers
             _paratextService = paratextService;
             _userAccessor = userAccessor;
             _exceptionHandler = exceptionHandler;
-
-            // Report the user id to bugsnag for this request
             _exceptionHandler.RecordUserIdForException(_userAccessor.UserId);
         }
 

--- a/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
@@ -18,6 +18,7 @@ namespace SIL.XForge.Scripture.Controllers
     [Authorize]
     public class ParatextController : ControllerBase
     {
+        private readonly Bugsnag.IClient _bugsnag;
         private readonly IRepository<UserSecret> _userSecrets;
         private readonly IParatextService _paratextService;
         private readonly IUserAccessor _userAccessor;
@@ -25,12 +26,26 @@ namespace SIL.XForge.Scripture.Controllers
         public ParatextController(
             IRepository<UserSecret> userSecrets,
             IParatextService paratextService,
-            IUserAccessor userAccessor
+            IUserAccessor userAccessor,
+            Bugsnag.IClient client
         )
         {
             _userSecrets = userSecrets;
             _paratextService = paratextService;
             _userAccessor = userAccessor;
+            _bugsnag = client;
+
+            // Report the user id to bugsnag for this request
+            if (!string.IsNullOrWhiteSpace(_userAccessor.UserId))
+            {
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.User = new Bugsnag.Payload.User
+                    {
+                        Id = _userAccessor.UserId,
+                    };
+                });
+            }
         }
 
         [HttpGet("projects")]

--- a/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
@@ -18,7 +18,7 @@ namespace SIL.XForge.Scripture.Controllers
     [Authorize]
     public class ParatextController : ControllerBase
     {
-        private readonly Bugsnag.IClient _bugsnag;
+        private readonly IExceptionHandler _exceptionHandler;
         private readonly IRepository<UserSecret> _userSecrets;
         private readonly IParatextService _paratextService;
         private readonly IUserAccessor _userAccessor;
@@ -27,25 +27,16 @@ namespace SIL.XForge.Scripture.Controllers
             IRepository<UserSecret> userSecrets,
             IParatextService paratextService,
             IUserAccessor userAccessor,
-            Bugsnag.IClient client
+            IExceptionHandler exceptionHandler
         )
         {
             _userSecrets = userSecrets;
             _paratextService = paratextService;
             _userAccessor = userAccessor;
-            _bugsnag = client;
+            _exceptionHandler = exceptionHandler;
 
             // Report the user id to bugsnag for this request
-            if (!string.IsNullOrWhiteSpace(_userAccessor.UserId))
-            {
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.User = new Bugsnag.Payload.User
-                    {
-                        Id = _userAccessor.UserId,
-                    };
-                });
-            }
+            _exceptionHandler.RecordUserIdForException(_userAccessor.UserId);
         }
 
         [HttpGet("projects")]

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -21,8 +21,8 @@ namespace SIL.XForge.Scripture.Controllers
 
         private readonly ISFProjectService _projectService;
 
-        public SFProjectsRpcController(IUserAccessor userAccessor, ISFProjectService projectService)
-            : base(userAccessor)
+        public SFProjectsRpcController(IUserAccessor userAccessor, ISFProjectService projectService,
+            Bugsnag.IClient client) : base(userAccessor, client)
         {
             _projectService = projectService;
         }

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -54,7 +54,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string>
                     {
@@ -86,7 +85,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string> { { "method", "Delete" }, { "projectId", projectId }, }
                 );
@@ -111,7 +109,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string>
                     {
@@ -148,7 +145,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string>
                     {
@@ -183,7 +179,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string>
                     {
@@ -209,7 +204,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string> { { "method", "GetProjectRole" }, { "projectId", projectId }, }
                 );
@@ -234,7 +228,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string>
                     {
@@ -265,7 +258,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string>
                     {
@@ -297,7 +289,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string> { { "method", "UninviteUser" }, { "projectId", projectId }, }
                 );
@@ -321,7 +312,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string> { { "method", "IsAlreadyInvited" }, { "projectId", projectId }, }
                 );
@@ -345,7 +335,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string> { { "method", "InvitedUsers" }, { "projectId", projectId }, }
                 );
@@ -370,7 +359,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string> { { "method", "CheckLinkSharing" }, { "projectId", projectId }, }
                 );
@@ -400,7 +388,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string>
                     {
@@ -430,7 +417,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string>
                     {
@@ -460,7 +446,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string> { { "method", "Sync" }, { "projectId", projectId }, }
                 );
@@ -485,7 +470,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string> { { "method", "CancelSync" }, { "projectId", projectId }, }
                 );
@@ -514,7 +498,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string>
                     {
@@ -545,7 +528,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string>
                     {
@@ -574,7 +556,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string>
                     {
@@ -607,7 +588,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string>
                     {

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using EdjCase.JsonRpc.Router.Abstractions;
 using SIL.XForge.Controllers;
@@ -19,11 +20,13 @@ namespace SIL.XForge.Scripture.Controllers
     {
         internal const string AlreadyProjectMemberResponse = "alreadyProjectMember";
 
+        private readonly Bugsnag.IClient _bugsnag;
         private readonly ISFProjectService _projectService;
 
         public SFProjectsRpcController(IUserAccessor userAccessor, ISFProjectService projectService,
             Bugsnag.IClient client) : base(userAccessor, client)
         {
+            _bugsnag = client;
             _projectService = projectService;
         }
 
@@ -46,6 +49,22 @@ namespace SIL.XForge.Scripture.Controllers
             {
                 return InvalidParamsError(e.Message);
             }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string>
+                    {
+                        { "method", "Create"},
+                        { "ParatextId", settings?.ParatextId },
+                        { "SourceParatextId", settings?.SourceParatextId },
+                        { "CheckingEnabled", settings?.CheckingEnabled.ToString() },
+                        { "TranslationSuggestionsEnabled", settings?.TranslationSuggestionsEnabled.ToString() },
+                    });
+                });
+                throw;
+            }
         }
 
         public async Task<IRpcMethodResult> Delete(string projectId)
@@ -62,6 +81,18 @@ namespace SIL.XForge.Scripture.Controllers
             catch (DataNotFoundException dnfe)
             {
                 return NotFoundError(dnfe.Message);
+            }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "Delete"},
+                        { "projectId", projectId },
+                    });
+                });
+                throw;
             }
         }
 
@@ -80,6 +111,26 @@ namespace SIL.XForge.Scripture.Controllers
             {
                 return NotFoundError(dnfe.Message);
             }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "UpdateSettings"},
+                        { "projectId", projectId },
+                        { "CheckingShareLevel", settings?.CheckingShareLevel },
+                        { "SourceParatextId", settings?.SourceParatextId },
+                        { "TranslateShareLevel", settings?.TranslateShareLevel },
+                        { "CheckingEnabled", settings?.CheckingEnabled?.ToString() },
+                        { "CheckingShareEnabled", settings?.CheckingShareEnabled?.ToString() },
+                        { "TranslateShareEnabled", settings?.TranslateShareEnabled?.ToString() },
+                        { "TranslationSuggestionsEnabled", settings?.TranslationSuggestionsEnabled?.ToString() },
+                        { "UsersSeeEachOthersResponses", settings?.UsersSeeEachOthersResponses?.ToString() },
+                    });
+                });
+                throw;
+            }
         }
 
         public async Task<IRpcMethodResult> AddUser(string projectId, string projectRole)
@@ -96,6 +147,19 @@ namespace SIL.XForge.Scripture.Controllers
             catch (DataNotFoundException dnfe)
             {
                 return NotFoundError(dnfe.Message);
+            }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "AddUser"},
+                        { "projectId", projectId },
+                        { "projectRole", projectRole },
+                    });
+                });
+                throw;
             }
         }
 
@@ -119,6 +183,19 @@ namespace SIL.XForge.Scripture.Controllers
             {
                 return NotFoundError(dnfe.Message);
             }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "RemoveUser"},
+                        { "projectId", projectId },
+                        { "projectUserId", projectUserId },
+                    });
+                });
+                throw;
+            }
         }
 
         public async Task<IRpcMethodResult> GetProjectRole(string projectId)
@@ -131,6 +208,18 @@ namespace SIL.XForge.Scripture.Controllers
             catch (DataNotFoundException dnfe)
             {
                 return NotFoundError(dnfe.Message);
+            }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "GetProjectRole"},
+                        { "projectId", projectId },
+                    });
+                });
+                throw;
             }
         }
 
@@ -148,6 +237,19 @@ namespace SIL.XForge.Scripture.Controllers
             catch (DataNotFoundException dnfe)
             {
                 return NotFoundError(dnfe.Message);
+            }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "UpdateRole"},
+                        { "projectId", projectId },
+                        { "projectRole", projectRole },
+                    });
+                });
+                throw;
             }
         }
 
@@ -167,6 +269,21 @@ namespace SIL.XForge.Scripture.Controllers
             {
                 return NotFoundError(dnfe.Message);
             }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "Invite"},
+                        { "projectId", projectId },
+                        // Exclude email as it is PII
+                        { "locale", locale },
+                        { "role", role },
+                    });
+                });
+                throw;
+            }
         }
 
         public async Task<IRpcMethodResult> UninviteUser(string projectId, string emailToUninvite)
@@ -184,6 +301,18 @@ namespace SIL.XForge.Scripture.Controllers
             {
                 return NotFoundError(dnfe.Message);
             }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "UninviteUser"},
+                        { "projectId", projectId },
+                    });
+                });
+                throw;
+            }
         }
 
         public async Task<IRpcMethodResult> IsAlreadyInvited(string projectId, string email)
@@ -199,6 +328,18 @@ namespace SIL.XForge.Scripture.Controllers
             catch (DataNotFoundException dnfe)
             {
                 return NotFoundError(dnfe.Message);
+            }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "IsAlreadyInvited"},
+                        { "projectId", projectId },
+                    });
+                });
+                throw;
             }
         }
 
@@ -216,6 +357,18 @@ namespace SIL.XForge.Scripture.Controllers
             {
                 return NotFoundError(dnfe.Message);
             }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "InvitedUsers"},
+                        { "projectId", projectId },
+                    });
+                });
+                throw;
+            }
         }
 
         public async Task<IRpcMethodResult> CheckLinkSharing(string projectId, string shareKey)
@@ -232,6 +385,18 @@ namespace SIL.XForge.Scripture.Controllers
             catch (DataNotFoundException dnfe)
             {
                 return NotFoundError(dnfe.Message);
+            }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "CheckLinkSharing"},
+                        { "projectId", projectId },
+                    });
+                });
+                throw;
             }
         }
 
@@ -255,6 +420,19 @@ namespace SIL.XForge.Scripture.Controllers
             {
                 return NotFoundError(dnfe.Message);
             }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "LinkSharingKey"},
+                        { "projectId", projectId },
+                        { "role", role },
+                    });
+                });
+                throw;
+            }
         }
 
         public async Task<IRpcMethodResult> AddTranslateMetrics(string projectId, TranslateMetrics metrics)
@@ -271,6 +449,19 @@ namespace SIL.XForge.Scripture.Controllers
             catch (DataNotFoundException dnfe)
             {
                 return NotFoundError(dnfe.Message);
+            }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "AddTranslateMetrics"},
+                        { "metricsId", metrics.Id },
+                        { "projectId", projectId },
+                    });
+                });
+                throw;
             }
         }
 
@@ -289,6 +480,18 @@ namespace SIL.XForge.Scripture.Controllers
             {
                 return NotFoundError(dnfe.Message);
             }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "Sync"},
+                        { "projectId", projectId },
+                    });
+                });
+                throw;
+            }
         }
 
         public async Task<IRpcMethodResult> CancelSync(string projectId)
@@ -305,6 +508,18 @@ namespace SIL.XForge.Scripture.Controllers
             catch (DataNotFoundException dnfe)
             {
                 return NotFoundError(dnfe.Message);
+            }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "CancelSync"},
+                        { "projectId", projectId },
+                    });
+                });
+                throw;
             }
         }
 
@@ -327,6 +542,20 @@ namespace SIL.XForge.Scripture.Controllers
             {
                 return InvalidParamsError(fe.Message);
             }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "DeleteAudio"},
+                        { "projectId", projectId },
+                        { "ownerId", ownerId },
+                        { "dataId", dataId },
+                    });
+                });
+                throw;
+            }
         }
 
         public async Task<IRpcMethodResult> SetSyncDisabled(string projectId, bool isDisabled)
@@ -344,6 +573,19 @@ namespace SIL.XForge.Scripture.Controllers
             {
                 return NotFoundError(dnfe.Message);
             }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "SetSyncDisabled"},
+                        { "projectId", projectId },
+                        { "isDisabled", isDisabled.ToString() },
+                    });
+                });
+                throw;
+            }
         }
 
         public async Task<IRpcMethodResult> TransceleratorQuestions(string projectId)
@@ -359,6 +601,18 @@ namespace SIL.XForge.Scripture.Controllers
             catch (DataNotFoundException dnfe)
             {
                 return NotFoundError(dnfe.Message);
+            }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "TransceleratorQuestions"},
+                        { "projectId", projectId },
+                    });
+                });
+                throw;
             }
         }
 
@@ -380,6 +634,20 @@ namespace SIL.XForge.Scripture.Controllers
             catch (DataNotFoundException dnfe)
             {
                 return NotFoundError(dnfe.Message);
+            }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "SetUserProjectPermissions"},
+                        { "projectId", projectId },
+                        { "userId", userId },
+                        { "permissions", string.Join(',', permissions) },
+                    });
+                });
+                throw;
             }
         }
     }

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -20,13 +20,16 @@ namespace SIL.XForge.Scripture.Controllers
     {
         internal const string AlreadyProjectMemberResponse = "alreadyProjectMember";
 
-        private readonly Bugsnag.IClient _bugsnag;
+        private readonly IExceptionHandler _exceptionHandler;
         private readonly ISFProjectService _projectService;
 
-        public SFProjectsRpcController(IUserAccessor userAccessor, ISFProjectService projectService,
-            Bugsnag.IClient client) : base(userAccessor, client)
+        public SFProjectsRpcController(
+            IUserAccessor userAccessor,
+            ISFProjectService projectService,
+            IExceptionHandler exceptionHandler
+        ) : base(userAccessor, exceptionHandler)
         {
-            _bugsnag = client;
+            _exceptionHandler = exceptionHandler;
             _projectService = projectService;
         }
 
@@ -52,17 +55,16 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string>
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string>
                     {
-                        { "method", "Create"},
+                        { "method", "Create" },
                         { "ParatextId", settings?.ParatextId },
                         { "SourceParatextId", settings?.SourceParatextId },
                         { "CheckingEnabled", settings?.CheckingEnabled.ToString() },
                         { "TranslationSuggestionsEnabled", settings?.TranslationSuggestionsEnabled.ToString() },
-                    });
-                });
+                    }
+                );
                 throw;
             }
         }
@@ -85,13 +87,9 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "Delete"},
-                        { "projectId", projectId },
-                    });
-                });
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string> { { "method", "Delete" }, { "projectId", projectId }, }
+                );
                 throw;
             }
         }
@@ -114,10 +112,10 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "UpdateSettings"},
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string>
+                    {
+                        { "method", "UpdateSettings" },
                         { "projectId", projectId },
                         { "CheckingShareLevel", settings?.CheckingShareLevel },
                         { "SourceParatextId", settings?.SourceParatextId },
@@ -127,8 +125,8 @@ namespace SIL.XForge.Scripture.Controllers
                         { "TranslateShareEnabled", settings?.TranslateShareEnabled?.ToString() },
                         { "TranslationSuggestionsEnabled", settings?.TranslationSuggestionsEnabled?.ToString() },
                         { "UsersSeeEachOthersResponses", settings?.UsersSeeEachOthersResponses?.ToString() },
-                    });
-                });
+                    }
+                );
                 throw;
             }
         }
@@ -151,14 +149,14 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "AddUser"},
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string>
+                    {
+                        { "method", "AddUser" },
                         { "projectId", projectId },
                         { "projectRole", projectRole },
-                    });
-                });
+                    }
+                );
                 throw;
             }
         }
@@ -186,14 +184,14 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "RemoveUser"},
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string>
+                    {
+                        { "method", "RemoveUser" },
                         { "projectId", projectId },
                         { "projectUserId", projectUserId },
-                    });
-                });
+                    }
+                );
                 throw;
             }
         }
@@ -212,13 +210,9 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "GetProjectRole"},
-                        { "projectId", projectId },
-                    });
-                });
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string> { { "method", "GetProjectRole" }, { "projectId", projectId }, }
+                );
                 throw;
             }
         }
@@ -241,14 +235,14 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "UpdateRole"},
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string>
+                    {
+                        { "method", "UpdateRole" },
                         { "projectId", projectId },
                         { "projectRole", projectRole },
-                    });
-                });
+                    }
+                );
                 throw;
             }
         }
@@ -272,16 +266,16 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "Invite"},
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string>
+                    {
+                        { "method", "Invite" },
                         { "projectId", projectId },
                         // Exclude email as it is PII
                         { "locale", locale },
                         { "role", role },
-                    });
-                });
+                    }
+                );
                 throw;
             }
         }
@@ -304,13 +298,9 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "UninviteUser"},
-                        { "projectId", projectId },
-                    });
-                });
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string> { { "method", "UninviteUser" }, { "projectId", projectId }, }
+                );
                 throw;
             }
         }
@@ -332,13 +322,9 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "IsAlreadyInvited"},
-                        { "projectId", projectId },
-                    });
-                });
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string> { { "method", "IsAlreadyInvited" }, { "projectId", projectId }, }
+                );
                 throw;
             }
         }
@@ -360,13 +346,9 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "InvitedUsers"},
-                        { "projectId", projectId },
-                    });
-                });
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string> { { "method", "InvitedUsers" }, { "projectId", projectId }, }
+                );
                 throw;
             }
         }
@@ -389,13 +371,9 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "CheckLinkSharing"},
-                        { "projectId", projectId },
-                    });
-                });
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string> { { "method", "CheckLinkSharing" }, { "projectId", projectId }, }
+                );
                 throw;
             }
         }
@@ -423,14 +401,14 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "LinkSharingKey"},
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string>
+                    {
+                        { "method", "LinkSharingKey" },
                         { "projectId", projectId },
                         { "role", role },
-                    });
-                });
+                    }
+                );
                 throw;
             }
         }
@@ -453,14 +431,14 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "AddTranslateMetrics"},
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string>
+                    {
+                        { "method", "AddTranslateMetrics" },
                         { "metricsId", metrics.Id },
                         { "projectId", projectId },
-                    });
-                });
+                    }
+                );
                 throw;
             }
         }
@@ -483,13 +461,9 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "Sync"},
-                        { "projectId", projectId },
-                    });
-                });
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string> { { "method", "Sync" }, { "projectId", projectId }, }
+                );
                 throw;
             }
         }
@@ -512,13 +486,9 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "CancelSync"},
-                        { "projectId", projectId },
-                    });
-                });
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string> { { "method", "CancelSync" }, { "projectId", projectId }, }
+                );
                 throw;
             }
         }
@@ -545,15 +515,15 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "DeleteAudio"},
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string>
+                    {
+                        { "method", "DeleteAudio" },
                         { "projectId", projectId },
                         { "ownerId", ownerId },
                         { "dataId", dataId },
-                    });
-                });
+                    }
+                );
                 throw;
             }
         }
@@ -576,14 +546,14 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "SetSyncDisabled"},
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string>
+                    {
+                        { "method", "SetSyncDisabled" },
                         { "projectId", projectId },
                         { "isDisabled", isDisabled.ToString() },
-                    });
-                });
+                    }
+                );
                 throw;
             }
         }
@@ -605,13 +575,13 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "TransceleratorQuestions"},
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string>
+                    {
+                        { "method", "TransceleratorQuestions" },
                         { "projectId", projectId },
-                    });
-                });
+                    }
+                );
                 throw;
             }
         }
@@ -638,15 +608,15 @@ namespace SIL.XForge.Scripture.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "SetUserProjectPermissions"},
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string>
+                    {
+                        { "method", "SetUserProjectPermissions" },
                         { "projectId", projectId },
                         { "userId", userId },
                         { "permissions", string.Join(',', permissions) },
-                    });
-                });
+                    }
+                );
                 throw;
             }
         }

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
@@ -30,8 +30,6 @@ namespace SIL.XForge.Scripture.Controllers
             _userAccessor = userAccessor;
             _projectService = projectService;
             _exceptionHandler = exceptionHandler;
-
-            // Report the user id to bugsnag for this request
             _exceptionHandler.RecordUserIdForException(_userAccessor.UserId);
         }
 
@@ -71,7 +69,6 @@ namespace SIL.XForge.Scripture.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string>
                     {

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -73,6 +74,19 @@ namespace SIL.XForge.Scripture.Controllers
             catch (FormatException)
             {
                 return BadRequest();
+            }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "UploadAudioAsync"},
+                        { "projectId", projectId },
+                        { "dataId", dataId },
+                    });
+                });
+                throw;
             }
         }
     }

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
@@ -16,13 +16,28 @@ namespace SIL.XForge.Scripture.Controllers
     [Route(UrlConstants.CommandApiNamespace + "/" + UrlConstants.Projects)]
     public class SFProjectsUploadController : ControllerBase
     {
+        private readonly Bugsnag.IClient _bugsnag;
         private readonly IUserAccessor _userAccessor;
         private readonly ISFProjectService _projectService;
 
-        public SFProjectsUploadController(IUserAccessor userAccessor, ISFProjectService projectService)
+        public SFProjectsUploadController(IUserAccessor userAccessor, ISFProjectService projectService,
+            Bugsnag.IClient client)
         {
             _userAccessor = userAccessor;
             _projectService = projectService;
+            _bugsnag = client;
+
+            // Report the user id to bugsnag for this request
+            if (!string.IsNullOrWhiteSpace(_userAccessor.UserId))
+            {
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.User = new Bugsnag.Payload.User
+                    {
+                        Id = _userAccessor.UserId,
+                    };
+                });
+            }
         }
 
         [HttpPost("audio")]

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2255,7 +2255,9 @@ namespace SIL.XForge.Scripture.Services
         private string GetVerseText(Delta delta, VerseRef verseRef)
         {
             string vref = string.IsNullOrEmpty(verseRef.Verse) ? verseRef.VerseNum.ToString() : verseRef.Verse;
-            return delta.TryConcatenateInserts(out string verseText, vref, DeltaUsxMapper.CanParaContainVerseText) ? verseText : string.Empty;
+            return delta.TryConcatenateInserts(out string verseText, vref, DeltaUsxMapper.CanParaContainVerseText)
+                ? verseText
+                : string.Empty;
         }
 
         private TextAnchor GetThreadTextAnchor(CommentThread thread, Dictionary<int, ChapterDelta> chapterDeltas)

--- a/src/SIL.XForge/Controllers/RpcControllerBase.cs
+++ b/src/SIL.XForge/Controllers/RpcControllerBase.cs
@@ -12,11 +12,25 @@ namespace SIL.XForge.Controllers
     [Authorize]
     public abstract class RpcControllerBase : RpcController
     {
+        private readonly Bugsnag.IClient _bugsnag;
         private readonly IUserAccessor _userAccessor;
 
-        protected RpcControllerBase(IUserAccessor userAccessor)
+        protected RpcControllerBase(IUserAccessor userAccessor, Bugsnag.IClient client)
         {
             _userAccessor = userAccessor;
+            _bugsnag = client;
+
+            // Report the user id to bugsnag for this request
+            if (!string.IsNullOrWhiteSpace(_userAccessor.UserId))
+            {
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.User = new Bugsnag.Payload.User
+                    {
+                        Id = _userAccessor.UserId,
+                    };
+                });
+            }
         }
 
         protected string UserId => _userAccessor.UserId;

--- a/src/SIL.XForge/Controllers/RpcControllerBase.cs
+++ b/src/SIL.XForge/Controllers/RpcControllerBase.cs
@@ -12,25 +12,16 @@ namespace SIL.XForge.Controllers
     [Authorize]
     public abstract class RpcControllerBase : RpcController
     {
-        private readonly Bugsnag.IClient _bugsnag;
+        private readonly IExceptionHandler _exceptionHandler;
         private readonly IUserAccessor _userAccessor;
 
-        protected RpcControllerBase(IUserAccessor userAccessor, Bugsnag.IClient client)
+        protected RpcControllerBase(IUserAccessor userAccessor, IExceptionHandler exceptionHandler)
         {
             _userAccessor = userAccessor;
-            _bugsnag = client;
+            _exceptionHandler = exceptionHandler;
 
             // Report the user id to bugsnag for this request
-            if (!string.IsNullOrWhiteSpace(_userAccessor.UserId))
-            {
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.User = new Bugsnag.Payload.User
-                    {
-                        Id = _userAccessor.UserId,
-                    };
-                });
-            }
+            exceptionHandler.RecordUserIdForException(_userAccessor.UserId);
         }
 
         protected string UserId => _userAccessor.UserId;

--- a/src/SIL.XForge/Controllers/RpcControllerBase.cs
+++ b/src/SIL.XForge/Controllers/RpcControllerBase.cs
@@ -19,8 +19,6 @@ namespace SIL.XForge.Controllers
         {
             _userAccessor = userAccessor;
             _exceptionHandler = exceptionHandler;
-
-            // Report the user id to bugsnag for this request
             exceptionHandler.RecordUserIdForException(_userAccessor.UserId);
         }
 

--- a/src/SIL.XForge/Controllers/UsersRpcController.cs
+++ b/src/SIL.XForge/Controllers/UsersRpcController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 using EdjCase.JsonRpc.Router.Abstractions;
@@ -16,6 +17,7 @@ namespace SIL.XForge.Controllers
     public class UsersRpcController : RpcControllerBase
     {
         private readonly IAuthService _authService;
+        private readonly Bugsnag.IClient _bugsnag;
         private readonly IWebHostEnvironment _hostingEnv;
         private readonly IUserService _userService;
 
@@ -30,6 +32,7 @@ namespace SIL.XForge.Controllers
             _userService = userService;
             _authService = authService;
             _hostingEnv = hostingEnv;
+            _bugsnag = client;
         }
 
         /// <summary>
@@ -38,7 +41,22 @@ namespace SIL.XForge.Controllers
         [Authorize(AuthenticationSchemes = BasicAuthenticationDefaults.AuthenticationScheme)]
         public Task PushAuthUserProfile(string userId, JsonElement userProfile)
         {
-            return _userService.UpdateUserFromProfileAsync(userId, userProfile.ToString());
+            try
+            {
+                return _userService.UpdateUserFromProfileAsync(userId, userProfile.ToString());
+            }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "PushAuthUserProfile"},
+                        { "userId", userId },
+                    });
+                });
+                throw;
+            }
         }
 
         /// <summary>
@@ -67,12 +85,40 @@ namespace SIL.XForge.Controllers
             {
                 return InvalidParamsError(e.Message);
             }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "LinkParatextAccount"},
+                        { "primaryId", primaryId },
+                        { "secondaryId", secondaryId },
+                    });
+                });
+                throw;
+            }
         }
 
         public async Task<IRpcMethodResult> UpdateInterfaceLanguage(string language)
         {
-            await _userService.UpdateInterfaceLanguageAsync(UserId, AuthId, language);
-            return Ok();
+            try
+            {
+                await _userService.UpdateInterfaceLanguageAsync(UserId, AuthId, language);
+                return Ok();
+            }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "UpdateInterfaceLanguage"},
+                        { "language", language },
+                    });
+                });
+                throw;
+            }
         }
 
         public async Task<IRpcMethodResult> Delete(string userId)
@@ -85,6 +131,18 @@ namespace SIL.XForge.Controllers
             catch (ForbiddenException)
             {
                 return ForbiddenError();
+            }
+            catch (Exception)
+            {
+                // Send additional to bugsnag, then rethrow the error
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
+                        { "method", "Delete"},
+                        { "userId", userId },
+                    });
+                });
+                throw;
             }
         }
 

--- a/src/SIL.XForge/Controllers/UsersRpcController.cs
+++ b/src/SIL.XForge/Controllers/UsersRpcController.cs
@@ -47,7 +47,6 @@ namespace SIL.XForge.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string> { { "method", "PushAuthUserProfile" }, { "userId", userId }, }
                 );
@@ -83,7 +82,6 @@ namespace SIL.XForge.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string>
                     {
@@ -105,7 +103,6 @@ namespace SIL.XForge.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string>
                     {
@@ -130,7 +127,6 @@ namespace SIL.XForge.Controllers
             }
             catch (Exception)
             {
-                // Send additional to bugsnag, then rethrow the error
                 _exceptionHandler.RecordEndpointInfoForException(
                     new Dictionary<string, string> { { "method", "Delete" }, { "userId", userId }, }
                 );

--- a/src/SIL.XForge/Controllers/UsersRpcController.cs
+++ b/src/SIL.XForge/Controllers/UsersRpcController.cs
@@ -23,8 +23,9 @@ namespace SIL.XForge.Controllers
             IUserAccessor userAccessor,
             IUserService userService,
             IAuthService authService,
-            IWebHostEnvironment hostingEnv
-        ) : base(userAccessor)
+            IWebHostEnvironment hostingEnv,
+            Bugsnag.IClient client
+        ) : base(userAccessor, client)
         {
             _userService = userService;
             _authService = authService;

--- a/src/SIL.XForge/Controllers/UsersRpcController.cs
+++ b/src/SIL.XForge/Controllers/UsersRpcController.cs
@@ -17,7 +17,7 @@ namespace SIL.XForge.Controllers
     public class UsersRpcController : RpcControllerBase
     {
         private readonly IAuthService _authService;
-        private readonly Bugsnag.IClient _bugsnag;
+        private readonly IExceptionHandler _exceptionHandler;
         private readonly IWebHostEnvironment _hostingEnv;
         private readonly IUserService _userService;
 
@@ -26,13 +26,13 @@ namespace SIL.XForge.Controllers
             IUserService userService,
             IAuthService authService,
             IWebHostEnvironment hostingEnv,
-            Bugsnag.IClient client
-        ) : base(userAccessor, client)
+            IExceptionHandler exceptionHandler
+        ) : base(userAccessor, exceptionHandler)
         {
             _userService = userService;
             _authService = authService;
             _hostingEnv = hostingEnv;
-            _bugsnag = client;
+            _exceptionHandler = exceptionHandler;
         }
 
         /// <summary>
@@ -48,13 +48,9 @@ namespace SIL.XForge.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "PushAuthUserProfile"},
-                        { "userId", userId },
-                    });
-                });
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string> { { "method", "PushAuthUserProfile" }, { "userId", userId }, }
+                );
                 throw;
             }
         }
@@ -88,14 +84,14 @@ namespace SIL.XForge.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "LinkParatextAccount"},
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string>
+                    {
+                        { "method", "LinkParatextAccount" },
                         { "primaryId", primaryId },
                         { "secondaryId", secondaryId },
-                    });
-                });
+                    }
+                );
                 throw;
             }
         }
@@ -110,13 +106,13 @@ namespace SIL.XForge.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "UpdateInterfaceLanguage"},
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string>
+                    {
+                        { "method", "UpdateInterfaceLanguage" },
                         { "language", language },
-                    });
-                });
+                    }
+                );
                 throw;
             }
         }
@@ -135,13 +131,10 @@ namespace SIL.XForge.Controllers
             catch (Exception)
             {
                 // Send additional to bugsnag, then rethrow the error
-                _bugsnag.BeforeNotify(report =>
-                {
-                    report.Event.Metadata.Add("endpoint", new Dictionary<string, string> {
-                        { "method", "Delete"},
-                        { "userId", userId },
-                    });
-                });
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string> { { "method", "Delete" }, { "userId", userId }, }
+                );
+
                 throw;
             }
         }

--- a/src/SIL.XForge/ExceptionLogging/ExceptionHandler.cs
+++ b/src/SIL.XForge/ExceptionLogging/ExceptionHandler.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Linq;
@@ -12,7 +13,7 @@ namespace SIL.XForge
     {
         private readonly Bugsnag.IClient _bugsnag;
 
-        public async static Task<string> CreateHttpRequestErrorMessage(HttpResponseMessage response)
+        public static async Task<string> CreateHttpRequestErrorMessage(HttpResponseMessage response)
         {
             string responseContent = string.Join(
                 "\n",
@@ -66,6 +67,25 @@ namespace SIL.XForge
                 var exceptionHandlerPathFeature = context.Features.Get<IExceptionHandlerPathFeature>();
                 ReportException(exceptionHandlerPathFeature.Error);
             });
+        }
+
+        public void RecordEndpointInfoForException(Dictionary<string, string> metadata)
+        {
+            _bugsnag.BeforeNotify(report =>
+            {
+                report.Event.Metadata.Add("endpoint", metadata);
+            });
+        }
+
+        public void RecordUserIdForException(string userId)
+        {
+            if (!string.IsNullOrWhiteSpace(userId))
+            {
+                _bugsnag.BeforeNotify(report =>
+                {
+                    report.Event.User = new Bugsnag.Payload.User { Id = userId, };
+                });
+            }
         }
     }
 }

--- a/src/SIL.XForge/ExceptionLogging/ExceptionHandlerServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/ExceptionLogging/ExceptionHandlerServiceCollectionExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.DependencyInjection
             IConfiguration configuration
         )
         {
-            services.AddSingleton<IExceptionHandler, ExceptionHandler>();
+            services.AddScoped<IExceptionHandler, ExceptionHandler>();
             return services
                 .AddBugsnag()
                 .Configure<Bugsnag.Configuration>(configuration.GetSection("Bugsnag"))

--- a/src/SIL.XForge/ExceptionLogging/IExceptionHandler.cs
+++ b/src/SIL.XForge/ExceptionLogging/IExceptionHandler.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -12,5 +13,9 @@ namespace SIL.XForge
         Task EnsureSuccessStatusCode(HttpResponseMessage response);
 
         void ReportExceptions(IApplicationBuilder app);
+
+        void RecordEndpointInfoForException(Dictionary<string, string> metadata);
+
+        void RecordUserIdForException(string userId);
     }
 }

--- a/src/SIL.XForge/SIL.XForge.csproj
+++ b/src/SIL.XForge/SIL.XForge.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.8.1" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.3.1" />
-    <PackageReference Include="Bugsnag.AspNet.Core" Version="2.2.0" />
+    <PackageReference Include="Bugsnag.AspNet.Core" Version="3.1.0" />
     <PackageReference Include="EdjCase.JsonRpc.Router" Version="4.0.6" />
     <PackageReference Include="Hangfire" Version="1.7.9" />
     <PackageReference Include="Hangfire.Mongo" Version="0.6.6" />

--- a/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
@@ -31,13 +31,13 @@ namespace SIL.XForge.Scripture.Controllers
         {
             public TestEnvironment()
             {
-                BugsNag = Substitute.For<Bugsnag.IClient>();
+                ExceptionHandler = Substitute.For<IExceptionHandler>();
                 SFProjectService = Substitute.For<ISFProjectService>();
                 UserAccessor = Substitute.For<IUserAccessor>();
-                Controller = new SFProjectsRpcController(UserAccessor, SFProjectService, BugsNag);
+                Controller = new SFProjectsRpcController(UserAccessor, SFProjectService, ExceptionHandler);
             }
 
-            public Bugsnag.IClient BugsNag { get; }
+            public IExceptionHandler ExceptionHandler { get; }
             public SFProjectsRpcController Controller { get; }
             public ISFProjectService SFProjectService { get; }
             public IUserAccessor UserAccessor { get; }

--- a/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
@@ -31,11 +31,13 @@ namespace SIL.XForge.Scripture.Controllers
         {
             public TestEnvironment()
             {
+                BugsNag = Substitute.For<Bugsnag.IClient>();
                 SFProjectService = Substitute.For<ISFProjectService>();
                 UserAccessor = Substitute.For<IUserAccessor>();
-                Controller = new SFProjectsRpcController(UserAccessor, SFProjectService);
+                Controller = new SFProjectsRpcController(UserAccessor, SFProjectService, BugsNag);
             }
 
+            public Bugsnag.IClient BugsNag { get; }
             public SFProjectsRpcController Controller { get; }
             public ISFProjectService SFProjectService { get; }
             public IUserAccessor UserAccessor { get; }

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -1605,31 +1605,35 @@ namespace SIL.XForge.Scripture.Services
             Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
         }
 
-
         [Test]
         public void ToDelta_DoublyInvalidInline()
         {
             // A node that is invalid for more than one reason is still just invalid, not crashing.
 
-            XDocument usxDoc = Usx("PHM",
+            XDocument usxDoc = Usx(
+                "PHM",
                 Chapter("1"),
-                Para("p",
-                    Verse("1"),
-                    Char("tei",
-                        Char("ver", "blah")),
-                    Verse("2")));
+                Para("p", Verse("1"), Char("tei", Char("ver", "blah")), Verse("2"))
+            );
 
             var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
             List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
 
-            var expected = Delta.New()
+            var expected = Delta
+                .New()
                 .InsertChapter("1")
                 .InsertBlank("p_1")
                 .InsertVerse("1")
-                .InsertChar("blah", new List<CharAttr> {
-                    new CharAttr { Style ="tei", CharID = _testGuidService.Generate() },
-                    new CharAttr { Style ="ver", CharID = _testGuidService.Generate() }
-                    }, "verse_1_1", invalid:true)
+                .InsertChar(
+                    "blah",
+                    new List<CharAttr>
+                    {
+                        new CharAttr { Style = "tei", CharID = _testGuidService.Generate() },
+                        new CharAttr { Style = "ver", CharID = _testGuidService.Generate() }
+                    },
+                    "verse_1_1",
+                    invalid: true
+                )
                 .InsertVerse("2")
                 .InsertBlank("verse_1_2")
                 .InsertPara("p");

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -1103,21 +1103,35 @@ namespace SIL.XForge.Scripture.Services
             {
                 IEnumerable<IDocument<NoteThread>> noteThreadDocs = new IDocument<NoteThread>[0];
                 Dictionary<int, ChapterDelta> chapterDeltas = new Dictionary<int, ChapterDelta>();
-                string chapterText = "[ { \"insert\": { \"chapter\": { \"style\": \"c\", \"number\": \"1\" } } }, " +
-                    "{ \"insert\": { \"blank\": true }, \"attributes\": { \"segment\": \"q_1\" } }," +
-                    "{ \"insert\": { \"verse\": { \"style\": \"v\", \"number\": \"1\" } } }, " +
-                    "{ \"insert\": \"" + text1 + "\", \"attributes\": { \"segment\": \"verse_1_1\" } }, " +
-                    "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"q\" } } }, " +
-                    "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"b\" } } }, " +
-                    "{ \"insert\": \"" + text2 + selected + text3 + "\", \"attributes\": { \"segment\": \"verse_1_1/q_1\" } } ]";
+                string chapterText =
+                    "[ { \"insert\": { \"chapter\": { \"style\": \"c\", \"number\": \"1\" } } }, "
+                    + "{ \"insert\": { \"blank\": true }, \"attributes\": { \"segment\": \"q_1\" } },"
+                    + "{ \"insert\": { \"verse\": { \"style\": \"v\", \"number\": \"1\" } } }, "
+                    + "{ \"insert\": \""
+                    + text1
+                    + "\", \"attributes\": { \"segment\": \"verse_1_1\" } }, "
+                    + "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"q\" } } }, "
+                    + "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"b\" } } }, "
+                    + "{ \"insert\": \""
+                    + text2
+                    + selected
+                    + text3
+                    + "\", \"attributes\": { \"segment\": \"verse_1_1/q_1\" } } ]";
                 var delta = new Delta(JToken.Parse(chapterText));
                 ChapterDelta chapterDelta = new ChapterDelta(1, 1, true, delta);
                 chapterDeltas.Add(1, chapterDelta);
                 Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
-                    { new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 } }
-                    .ToDictionary(u => u.Username);
-                IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(userSecret, ptProjectId, 40,
-                    noteThreadDocs, chapterDeltas, ptProjectUsers);
+                {
+                    new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+                }.ToDictionary(u => u.Username);
+                IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
+                    userSecret,
+                    ptProjectId,
+                    40,
+                    noteThreadDocs,
+                    chapterDeltas,
+                    ptProjectUsers
+                );
                 Assert.That(changes.Count, Is.EqualTo(1));
                 NoteThreadChange change = changes.First();
                 // include the newline length of the q paragraph break, but not the b


### PR DESCRIPTION
This pull request improves reporting to Bugsnag in .NET as follows:
 * Upgraded Bugsnag to 3.1.0 to improve .NET 6.0 support
 * Fixed a scoping issue that stopped request data from being sent to Bugsnag
 * The userId is now sent to Bugsnag
 * Endpoint specific data is now sent to Bugsnag , including the projectId, endpoint method name, and any relevant parameters that do not expose PII

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1449)
<!-- Reviewable:end -->
