### PR TITLE
SF-1656 Do not build machine project when target has no source books

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/translation-engine.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/translation-engine.service.ts
@@ -7,6 +7,7 @@ import {
   RemoteTranslationEngine
 } from '@sillsdev/machine';
 import * as crc from 'crc-32';
+import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { SFProjectUserConfig } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config';
 import { getTextDocId } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
 import { Canon } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/canon';
@@ -50,6 +51,10 @@ export class TranslationEngineService extends SubscriptionDisposable {
 
   createTranslationEngine(projectId: string): RemoteTranslationEngine {
     return new RemoteTranslationEngine(projectId, this.machineHttp);
+  }
+
+  checkHasSourceBooks(project: SFProjectProfile): boolean {
+    return project.texts.filter(t => t.hasSource).length > 0;
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -643,6 +643,19 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('does not build machine project if no source books exists', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      when(mockedTranslationEngineService.checkHasSourceBooks(anything())).thenReturn(false);
+      env.wait();
+      verify(mockedTranslationEngineService.createTranslationEngine(anything())).never();
+      env.updateParams({ projectId: 'project02', bookId: 'MAT' });
+      env.wait();
+      verify(mockedTranslationEngineService.createTranslationEngine(anything())).never();
+      expect().nothing();
+      env.dispose();
+    }));
+
     it('change texts', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig({ selectedBookNum: 40, selectedChapterNum: 1, selectedSegment: 'verse_1_1' });
@@ -2573,6 +2586,7 @@ class TestEnvironment {
     this.addParatextNoteThread(4, 'MAT 1:3', 'verse', { start: 20, length: 5 }, ['user01']);
     this.addParatextNoteThread(5, 'MAT 1:4', 'Paragraph', { start: 28, length: 9 }, ['user01']);
     this.addParatextNoteThread(6, 'MAT 1:5', 'resolved note', { start: 0, length: 0 }, ['user01'], NoteStatus.Resolved);
+    when(mockedTranslationEngineService.checkHasSourceBooks(anything())).thenReturn(true);
     when(this.mockedRemoteTranslationEngine.getWordGraph(anything())).thenCall(segment =>
       Promise.resolve(this.createWordGraph(segment))
     );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -782,7 +782,11 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
     this.translator = undefined;
     this.translationEngine = undefined;
-    if (this.projectDoc == null || !this.translationSuggestionsProjectEnabled || !this.hasEditRight) {
+    if (this.projectDoc?.data == null) {
+      return;
+    }
+    const hasSourceBooks: boolean = this.translationEngineService.checkHasSourceBooks(this.projectDoc.data);
+    if (!this.translationSuggestionsProjectEnabled || !this.hasEditRight || !hasSourceBooks) {
       return;
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
@@ -1,8 +1,5 @@
 <ng-container *transloco="let t; read: 'translate_overview'">
   <div class="title mat-display-1">{{ t("translate_overview") }}</div>
-  <div *ngIf="showCannotTrainEngineMessage" class="translation-suggestions-info">
-    {{ t("cannot_train_suggestion_engine") }}
-  </div>
   <div class="card-wrapper">
     <mat-card class="books-card">
       <mat-card-header id="translate-overview-title" class="books-card-title">
@@ -67,6 +64,9 @@
         <div class="engine-card-segments">
           <span class="engine-card-segments-count">{{ trainedSegmentCount }}</span
           ><span>{{ t("trained_segments") }}</span>
+        </div>
+        <div *ngIf="showCannotTrainEngineMessage" class="translation-suggestions-info">
+          {{ t("cannot_train_suggestion_engine") }}
         </div>
       </mat-card-content>
       <mat-divider></mat-divider>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
@@ -1,5 +1,8 @@
 <ng-container *transloco="let t; read: 'translate_overview'">
   <div class="title mat-display-1">{{ t("translate_overview") }}</div>
+  <div *ngIf="cannotTrainSuggestionsEngine" class="translation-suggestions-info">
+    {{ t("cannot_train_suggestion_engine") }}
+  </div>
   <div class="card-wrapper">
     <mat-card class="books-card">
       <mat-card-header id="translate-overview-title" class="books-card-title">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; read: 'translate_overview'">
   <div class="title mat-display-1">{{ t("translate_overview") }}</div>
-  <div *ngIf="cannotTrainSuggestionsEngine" class="translation-suggestions-info">
+  <div *ngIf="showCannotTrainEngineMessage" class="translation-suggestions-info">
     {{ t("cannot_train_suggestion_engine") }}
   </div>
   <div class="card-wrapper">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
@@ -21,6 +21,12 @@ mat-card {
   gap: 20px 40px;
 }
 
+.translation-suggestions-info {
+  max-width: 40rem;
+  color: $lighterTextColor;
+  margin-bottom: 2rem;
+}
+
 .books-card {
   width: 18rem;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
@@ -22,9 +22,8 @@ mat-card {
 }
 
 .translation-suggestions-info {
-  max-width: 40rem;
   color: $lighterTextColor;
-  margin-bottom: 2rem;
+  padding: 16px;
 }
 
 .books-card {
@@ -107,5 +106,10 @@ mat-card {
         margin-right: 8px;
       }
     }
+  }
+
+  .mat-card-actions {
+    margin: 0;
+    padding: 8px;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
@@ -166,8 +166,7 @@ describe('TranslateOverviewComponent', () => {
 
     it('should not create engine if no source text docs', fakeAsync(() => {
       const env = new TestEnvironment(false);
-      env.simulateNoSourceTextDocs();
-
+      when(mockedTranslationEngineService.checkHasSourceBooks(anything())).thenReturn(false);
       verify(mockedTranslationEngineService.createTranslationEngine(anything())).never();
       expect(env.translationSuggestionsInfoMessage).toBeFalsy();
       env.simulateTranslateSuggestionsEnabled(true);
@@ -196,6 +195,7 @@ class TestEnvironment {
     when(mockedTranslationEngineService.createTranslationEngine('project01')).thenReturn(
       instance(this.mockedRemoteTranslationEngine)
     );
+    when(mockedTranslationEngineService.checkHasSourceBooks(anything())).thenReturn(true);
     when(this.mockedRemoteTranslationEngine.getStats()).thenResolve({ confidence: 0.25, trainedSegmentCount: 100 });
     when(this.mockedRemoteTranslationEngine.listenForTrainingStatus()).thenReturn(defer(() => this.trainingProgress$));
     when(mockedSFProjectService.getText(anything())).thenCall(id =>
@@ -393,15 +393,6 @@ class TestEnvironment {
       op => op.set<boolean>(p => p.translateConfig.translationSuggestionsEnabled, enabled),
       false
     );
-    this.wait();
-  }
-
-  simulateNoSourceTextDocs() {
-    const projectDoc: SFProjectProfileDoc = this.realtimeService.get(SFProjectProfileDoc.COLLECTION, 'project01');
-    const textCount: number = projectDoc.data!.texts.length;
-    projectDoc.submitJson0Op(op => {
-      for (let i = 0; i < textCount; i++) op.set(p => p.texts[i].hasSource, false);
-    }, false);
     this.wait();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
@@ -91,6 +91,14 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
     );
   }
 
+  get cannotTrainSuggestionsEngine(): boolean {
+    return (
+      this.projectDoc?.data != null &&
+      this.projectDoc.data.translateConfig.translationSuggestionsEnabled &&
+      this.projectDoc.data.texts.filter(t => t.hasSource).length < 1
+    );
+  }
+
   ngOnInit(): void {
     this.subscribe(this.activatedRoute.params.pipe(map(params => params['projectId'])), async projectId => {
       this.loadingStarted();
@@ -183,7 +191,10 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
       this.trainingSub = undefined;
     }
     this.translationEngine = undefined;
-    if (this.projectDoc == null || !this.translationSuggestionsEnabled || !this.canEditTexts) {
+    if (this.projectDoc?.data == null) {
+      return;
+    }
+    if (!this.translationSuggestionsEnabled || !this.canEditTexts || this.cannotTrainSuggestionsEngine) {
       return;
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
@@ -93,7 +93,7 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
 
   get showCannotTrainEngineMessage(): boolean {
     if (this.projectDoc?.data == null) {
-      return true;
+      return false;
     }
     const hasSourceBooks: boolean = this.translationEngineService.checkHasSourceBooks(this.projectDoc.data);
     return this.translationSuggestionsEnabled && !hasSourceBooks;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
@@ -91,12 +91,12 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
     );
   }
 
-  get cannotTrainSuggestionsEngine(): boolean {
-    return (
-      this.projectDoc?.data != null &&
-      this.projectDoc.data.translateConfig.translationSuggestionsEnabled &&
-      this.projectDoc.data.texts.filter(t => t.hasSource).length < 1
-    );
+  get showCannotTrainEngineMessage(): boolean {
+    if (this.projectDoc?.data == null) {
+      return true;
+    }
+    const hasSourceBooks: boolean = this.translationEngineService.checkHasSourceBooks(this.projectDoc.data);
+    return this.translationSuggestionsEnabled && !hasSourceBooks;
   }
 
   ngOnInit(): void {
@@ -194,7 +194,8 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
     if (this.projectDoc?.data == null) {
       return;
     }
-    if (!this.translationSuggestionsEnabled || !this.canEditTexts || this.cannotTrainSuggestionsEngine) {
+    const hasSourceBooks: boolean = this.translationEngineService.checkHasSourceBooks(this.projectDoc.data);
+    if (!this.translationSuggestionsEnabled || !this.canEditTexts || !hasSourceBooks) {
       return;
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -263,7 +263,7 @@
     "not_available_offline": "This text is not available offline. Connect to the Internet to see the text."
   },
   "translate_overview": {
-    "cannot_train_suggestion_engine": "This project currently has translation suggestions enabled but your source project does not contain any of the books in this project. Select a source project containing the books in this project to get translation suggestions.",
+    "cannot_train_suggestion_engine": "Translation suggestions are unavailable. Please select a source project that shares books in common with this project to get translation suggestions.",
     "progress": "Progress",
     "quality": "Quality",
     "retrain": "Retrain",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -263,6 +263,7 @@
     "not_available_offline": "This text is not available offline. Connect to the Internet to see the text."
   },
   "translate_overview": {
+    "cannot_train_suggestion_engine": "This project currently has translation suggestions enabled but your source project does not contain any of the books in this project. Select a source project containing the books in this project to get translation suggestions.",
     "progress": "Progress",
     "quality": "Quality",
     "retrain": "Retrain",

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1306,7 +1306,8 @@ namespace SIL.XForge.Scripture.Services
                 await _conn.CommitTransactionAsync();
 
                 // The project document and text documents must be committed before we can train the model
-                if (TranslationSuggestionsEnabled && trainEngine)
+                bool hasSourceTextDocs = _projectDoc.Data.Texts.Any(t => t.HasSource);
+                if (TranslationSuggestionsEnabled && trainEngine && hasSourceTextDocs)
                 {
                     // Start training Machine engine
                     await _engineService.StartBuildByProjectIdAsync(_projectDoc.Id);

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -177,6 +177,25 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
+        public async Task SyncAsync_NewProjectOnlyNoMatchingSourceText_TranslationSuggestionEnabled()
+        {
+            var env = new TestEnvironment();
+            env.SetupSFData(true, false, false, false);
+            env.SetupPTData(new Book("MAT", 2, false));
+
+            await env.Runner.RunAsync("project02", "user01", true, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", true, CancellationToken.None);
+
+            Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
+            Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
+            Assert.That(env.ContainsText("project02", "MAT", 1), Is.False);
+            Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
+
+            await env.EngineService.DidNotReceive().StartBuildByProjectIdAsync("project01");
+            env.VerifyProjectSync(true);
+        }
+
+        [Test]
         public async Task SyncAsync_DataNotChanged()
         {
             var env = new TestEnvironment();


### PR DESCRIPTION
* detect and create suggestion engine only if conditions met on front end
* notify user when source project does not contain target books
* do not create translation engine if source books not available on back end

The recent update to Machine 2.5.11 has revealed some existing problems with how we handle building our translation engine using Machine. This corrects how we were using Machine by detecting whether we have texts to generate a translation suggestion engine with. In the event that no source texts are available for any book in our project, we skip over the step of creating a translation suggestion engine.

![image](https://user-images.githubusercontent.com/17931130/182960385-2724230d-251d-45ca-9734-2707d8120daa.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1450)
<!-- Reviewable:end -->
