### PR TITLE
Try splitting up GHA job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,47 @@ on:
   workflow_dispatch:
 
 jobs:
+  test-frontend:
+    name: "Build and test frontend"
+    strategy:
+      matrix:
+        os: ["ubuntu-20.04"]
+        node_version: ["16.15.0"]
+      fail-fast: false
+    runs-on: ${{matrix.os}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: "Deps: Node"
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{matrix.node_version}}
+      - name: Pre-build report
+        run: |
+          set -xueo pipefail
+          lsb_release -a
+          which dotnet
+          dotnet --version
+          dpkg -l dotnet\*
+          dotnet --list-sdks
+          dotnet --list-runtimes
+          which node
+          node --version
+          which npm
+          npm --version
+
+      - name: "Deps: RealtimeServer npm"
+        run: cd src/RealtimeServer && npm ci
+      - name: "Deps: Frontend npm"
+        run: cd src/SIL.XForge.Scripture/ClientApp && npm ci
+
+      - name: "Build: Frontend"
+        run: cd src/SIL.XForge.Scripture/ClientApp && npm run build
+
+      - name: "Test: Frontend"
+        run: cd src/SIL.XForge.Scripture/ClientApp && npm run test:tc
+
   build-development:
     name: "Build and test"
     strategy:
@@ -68,8 +109,6 @@ jobs:
 
       - name: "Build: Backend, RealtimeServer"
         run: dotnet build xForge.sln
-      - name: "Build: Frontend"
-        run: cd src/SIL.XForge.Scripture/ClientApp && npm run build
 
       - name: "Test: RealtimeServer"
         run: cd src/RealtimeServer && npm run test:tc
@@ -79,8 +118,6 @@ jobs:
             -p:CollectCoverage=true \
             -p:CoverletOutputFormat=opencover \
             -p:Exclude=\"[NUnit3.TestAdapter]*,[SIL.XForge.*.Views]*,[SIL.XForge.Tests]*\"
-      - name: "Test: Frontend"
-        run: cd src/SIL.XForge.Scripture/ClientApp && npm run test:tc
 
       - name: "Coverage: Backend"
         run: |
@@ -91,8 +128,49 @@ jobs:
       - name: "Coverage: Publish to Codecov"
         uses: codecov/codecov-action@v3
 
+  test-production-frontend:
+    name: "Production build and test frontend"
+    strategy:
+      matrix:
+        os: ["ubuntu-20.04"]
+        dotnet_version: ["6.0"]
+        node_version: ["16.15.0"]
+      fail-fast: false
+    runs-on: ${{matrix.os}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: "Deps: Node"
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{matrix.node_version}}
+      - name: "Deps: System packages"
+        run: |
+          sudo apt-get install --assume-yes \
+            dotnet-sdk-${{matrix.dotnet_version}}
+      - name: Pre-build report
+        run: |
+          set -xueo pipefail
+          lsb_release -a
+          which dotnet
+          dotnet --version
+          dpkg -l dotnet\*
+          dotnet --list-sdks
+          dotnet --list-runtimes
+          which node
+          node --version
+          which npm
+          npm --version
+
+      - name: "Build: Frontend"
+        run: cd src/SIL.XForge.Scripture && dotnet build -t:PublishRunWebpack
+
+      - name: "Test: Frontend"
+        run: cd src/SIL.XForge.Scripture/ClientApp && npm run test:tc
+
   build-production:
-    name: "Production build and test"
+    name: "Production build, test backend and realtimeserver"
     strategy:
       matrix:
         os: ["ubuntu-20.04"]
@@ -138,5 +216,3 @@ jobs:
             -p:Exclude=\"[NUnit3.TestAdapter]*,[SIL.XForge.*.Views]*,[SIL.XForge.Tests]*\"
       - name: "Test: RealtimeServer"
         run: cd src/RealtimeServer && npm run test:tc
-      - name: "Test: Frontend"
-        run: cd src/SIL.XForge.Scripture/ClientApp && npm run test:tc

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,142 @@
+# Github Action to build and run tests
+
+name: Build
+
+on:
+  push:
+    branches: [develop, master, sf-qa, sf-live]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-development:
+    name: "Build and test"
+    strategy:
+      matrix:
+        # Environments in which to run, such as those used in development and production, or which are candidates to
+        # move to.
+        os: ["ubuntu-20.04"]
+        dotnet_version: ["6.0"]
+        node_version: ["16.15.0"]
+      # Continue building in other environments to see which are working.
+      fail-fast: false
+    runs-on: ${{matrix.os}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: "Deps: Node"
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{matrix.node_version}}
+      - name: "Deps: System packages"
+        run: |
+          sudo apt-get install --assume-yes \
+            dotnet-sdk-${{matrix.dotnet_version}} \
+            npm
+      - name: Pre-build report
+        run: |
+          set -xueo pipefail
+          lsb_release -a
+          which dotnet
+          dotnet --version
+          dpkg -l dotnet\*
+          dotnet --list-sdks
+          dotnet --list-runtimes
+          which node
+          node --version
+          which npm
+          npm --version
+
+      - name: "Deps: reportgenerator tool"
+        run: dotnet tool install -g dotnet-reportgenerator-globaltool
+      - name: "Deps: RealtimeServer npm"
+        run: cd src/RealtimeServer && npm ci
+      - name: "Deps: Backend nuget"
+        run: dotnet restore
+      - name: "Deps: Frontend npm"
+        run: cd src/SIL.XForge.Scripture/ClientApp && npm ci
+
+      - name: "Lint: RealtimeServer ng"
+        run: cd src/RealtimeServer && npm run lint
+      - name: "Lint: RealtimeServer Prettier"
+        run: cd src/RealtimeServer && npm run prettier:tc
+      - name: "Lint: Frontend ng"
+        run: cd src/SIL.XForge.Scripture/ClientApp && npm run lint
+      - name: "Lint: Frontend Prettier"
+        run: cd src/SIL.XForge.Scripture/ClientApp && npm run prettier:tc
+
+      - name: "Build: Backend, RealtimeServer"
+        run: dotnet build xForge.sln
+      - name: "Build: Frontend"
+        run: cd src/SIL.XForge.Scripture/ClientApp && npm run build
+
+      - name: "Test: RealtimeServer"
+        run: cd src/RealtimeServer && npm run test:tc
+      - name: "Test: Backend"
+        run: |
+          dotnet test xForge.sln \
+            -p:CollectCoverage=true \
+            -p:CoverletOutputFormat=opencover \
+            -p:Exclude=\"[NUnit3.TestAdapter]*,[SIL.XForge.*.Views]*,[SIL.XForge.Tests]*\"
+      - name: "Test: Frontend"
+        run: cd src/SIL.XForge.Scripture/ClientApp && npm run test:tc
+
+      - name: "Coverage: Backend"
+        run: |
+          reportgenerator \
+            -reports:test/*/coverage.opencover.xml \
+            -targetdir:coverage \
+            "-reporttypes:HTML;TeamCitySummary"
+      - name: "Coverage: Publish to Codecov"
+        uses: codecov/codecov-action@v3
+
+  build-production:
+    name: "Production build and test"
+    strategy:
+      matrix:
+        os: ["ubuntu-20.04"]
+        dotnet_version: ["6.0"]
+        node_version: ["16.15.0"]
+      fail-fast: false
+    runs-on: ${{matrix.os}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: "Deps: Node"
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{matrix.node_version}}
+      - name: "Deps: System packages"
+        run: |
+          sudo apt-get install --assume-yes \
+            dotnet-sdk-${{matrix.dotnet_version}} \
+            npm
+      - name: Pre-build report
+        run: |
+          set -xueo pipefail
+          lsb_release -a
+          which dotnet
+          dotnet --version
+          dpkg -l dotnet\*
+          dotnet --list-sdks
+          dotnet --list-runtimes
+          which node
+          node --version
+          which npm
+          npm --version
+
+      - name: "Production build"
+        run: scripts/build-production
+
+      - name: "Test: Backend"
+        run: |
+          dotnet test xForge.sln \
+            -p:CollectCoverage=true \
+            -p:CoverletOutputFormat=opencover \
+            -p:Exclude=\"[NUnit3.TestAdapter]*,[SIL.XForge.*.Views]*,[SIL.XForge.Tests]*\"
+      - name: "Test: RealtimeServer"
+        run: cd src/RealtimeServer && npm run test:tc
+      - name: "Test: Frontend"
+        run: cd src/SIL.XForge.Scripture/ClientApp && npm run test:tc

--- a/scripts/build-and-ship
+++ b/scripts/build-and-ship
@@ -2,30 +2,18 @@
 #
 # Build SF for Live or QA. Upload to server to deploy.
 
-set -ueo pipefail
+set -xueo pipefail
 
-CONFIGURATION="${CONFIGURATION:-Release}"
-DEPLOY_RUNTIME="${DEPLOY_RUNTIME:-linux-x64}"
-ANGULAR_CONFIG="${ANGULAR_CONFIG:-production}"
 BUILD_OUTPUT="artifacts"
 DEPLOY_PATH="/var/www/${APP_NAME}.org${APP_SUFFIX}"
 SERVICE_UNIT_SUFFIX=""
 # Relative to repo root
 ERROR_PAGES_PATH="src/SIL.XForge.Scripture/ErrorPages"
 
+scriptDir="$(dirname "$0")"
+"${scriptDir}"/build-production "$@"
+
 cd ..
-
-# Must be before `ng build` because the constant value is included during optimization.
-cat <<EOF > src/SIL.XForge.Scripture/version.json
-{
-  "version": "${BUILD_NUMBER}"
-}
-EOF
-
-rm -rf "${BUILD_OUTPUT}/app"/*
-dotnet publish "src/${PROJECT}/${PROJECT}.csproj" -c "${CONFIGURATION}" -r "${DEPLOY_RUNTIME}" \
-  -o "${BUILD_OUTPUT}/app" /p:Version="${BUILD_NUMBER}" /p:AngularConfig="${ANGULAR_CONFIG}" \
-  --self-contained
 
 cat <<EOF > "$BUILD_OUTPUT/app/secrets.json"
 {

--- a/scripts/build-production
+++ b/scripts/build-production
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Build a production SF, such as for Live or QA.
+# Note that development and production SF connect to different servers using different secrets.
+
+set -xueo pipefail
+
+# Set some default values for when not called from TeamCity.
+APP_NAME="${APP_NAME-scriptureforge}"
+APP_SUFFIX="${APP_SUFFIX-}"
+BUILD_NUMBER="${BUILD_NUMBER-9.9.9}"
+PROJECT="${PROJECT-SIL.XForge.Scripture}"
+
+BUILD_OUTPUT="${BUILD_OUTPUT-artifacts}"
+
+CONFIGURATION="${CONFIGURATION:-Release}"
+DEPLOY_RUNTIME="${DEPLOY_RUNTIME:-linux-x64}"
+ANGULAR_CONFIG="${ANGULAR_CONFIG:-production}"
+
+scriptDir="$(dirname "$0")"
+cd "${scriptDir}"/..
+
+# Must be before `ng build` because the constant value is included during optimization.
+cat <<EOF > src/SIL.XForge.Scripture/version.json
+{
+  "version": "${BUILD_NUMBER}"
+}
+EOF
+
+rm -rf "${BUILD_OUTPUT}/app"/*
+dotnet publish "src/${PROJECT}/${PROJECT}.csproj" -c "${CONFIGURATION}" -r "${DEPLOY_RUNTIME}" \
+  -o "${BUILD_OUTPUT}/app" /p:Version="${BUILD_NUMBER}" /p:AngularConfig="${ANGULAR_CONFIG}" \
+  --self-contained


### PR DESCRIPTION
This PR demonstrates breaking up the GHA so that frontend tests (and sometimes the frontend build) happen in parallel with other parts of the build. 

This does speed up the whole, perhaps taking 7 minutes instead of perhaps 11. It should be noted that comparing times between GHA job runs needs to account for quite a variance in the amount of time a job can take from run to run.

This PR tries to still run the right things to accomplish testing the same situation as prior to breaking out some steps. 

When the build steps are not broken up, it may be more clear that the build process is specified correctly. 

The time saved by breaking up the build steps may not help us if we are still waiting for other aspects of a PR to become ready.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1451)
<!-- Reviewable:end -->
