### PR TITLE
ci: clarify production clean step

### DIFF
--- a/scripts/build-production
+++ b/scripts/build-production
@@ -27,7 +27,7 @@ cat <<EOF > src/SIL.XForge.Scripture/version.json
 }
 EOF
 
-rm -rf "${BUILD_OUTPUT}/app"/*
+rm -rf "${BUILD_OUTPUT}"
 dotnet publish "src/${PROJECT}/${PROJECT}.csproj" -c "${CONFIGURATION}" -r "${DEPLOY_RUNTIME}" \
   -o "${BUILD_OUTPUT}/app" /p:Version="${BUILD_NUMBER}" /p:AngularConfig="${ANGULAR_CONFIG}" \
   --self-contained


### PR DESCRIPTION
The production build cleans `BUILD_OUTPUT/app/*`. Nothing is written
into BUILD_OUTPUT other than into app.
Adjust the build-production script to make it more clear what the
scope is of what is being deleted, and that we are not leaving
something else in parallel to app. Also delete the whole directory,
not just what `*` will match.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1453)
<!-- Reviewable:end -->
