### PR TITLE
SF-1660 Allow re-marking node as invalid

### DIFF
--- a/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
@@ -493,7 +493,7 @@ namespace SIL.XForge.Scripture.Services
             if (invalidNodes.Contains(node))
             {
                 attributes = (JObject)attributes?.DeepClone() ?? new JObject();
-                attributes.Add(new JProperty("invalid-inline", true));
+                attributes["invalid-inline"] = true;
             }
             return attributes;
         }
@@ -507,7 +507,7 @@ namespace SIL.XForge.Scripture.Services
             if (invalidNodes.Contains(node))
             {
                 attributes = (JObject)attributes?.DeepClone() ?? new JObject();
-                attributes.Add(new JProperty("invalid-block", true));
+                attributes["invalid-block"] = true;
             }
             return attributes;
         }

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -1605,6 +1605,41 @@ namespace SIL.XForge.Scripture.Services
             Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
         }
 
+
+        [Test]
+        public void ToDelta_DoublyInvalidInline()
+        {
+            // A node that is invalid for more than one reason is still just invalid, not crashing.
+
+            XDocument usxDoc = Usx("PHM",
+                Chapter("1"),
+                Para("p",
+                    Verse("1"),
+                    Char("tei",
+                        Char("ver", "blah")),
+                    Verse("2")));
+
+            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+            var expected = Delta.New()
+                .InsertChapter("1")
+                .InsertBlank("p_1")
+                .InsertVerse("1")
+                .InsertChar("blah", new List<CharAttr> {
+                    new CharAttr { Style ="tei", CharID = _testGuidService.Generate() },
+                    new CharAttr { Style ="ver", CharID = _testGuidService.Generate() }
+                    }, "verse_1_1", invalid:true)
+                .InsertVerse("2")
+                .InsertBlank("verse_1_2")
+                .InsertPara("p");
+
+            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(2));
+            Assert.That(chapterDeltas[0].IsValid, Is.False);
+            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+        }
+
         [Test]
         public void ToDelta_InvalidLastVerse()
         {


### PR DESCRIPTION
- A node may be marked as "invalid-inline". It can happen again to the
same node, but crashes, due to the API method used. Mark the node as
invalid in a way that can be re-done without crashing.
- A situation of "invalid-block" double-marking did not trigger from
the app or tests, but I applied the same adjustment to the
"invalid-block" marking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1454)
<!-- Reviewable:end -->
