### PR TITLE
SF-1654 Fix chapter dropdown for RTL UI

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -271,6 +271,7 @@
     cdkScrollable
     class="app-content mdc-top-app-bar-adjust"
     [class.mdc-top-app-bar-adjust-double]="hasUpdate"
+    [dir]="i18n.direction"
   >
     <div>
       <router-outlet></router-outlet>


### PR DESCRIPTION
Material's BidiModule needs the dir directive to be set in order for Material components further down the tree to set the correct direction.

Note that the bug can only be seen if you change the language and haven't refreshed the page yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1456)
<!-- Reviewable:end -->
