### PR TITLE
SF-1677 Fix suggestions settings dialog for RTL UI

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
@@ -2,9 +2,9 @@
   <h1 mat-dialog-title>{{ t("translation_suggestions_settings") }}</h1>
   <mat-dialog-content class="content-padding" fxLayout="column" fxLayoutGap="25px">
     <div class="offline-text" *ngIf="!pwaService.isOnline">{{ t("settings_not_available_offline") }}</div>
-    <mdc-form-field [formGroup]="suggestionsSwitchFormGroup">
+    <mdc-form-field [formGroup]="suggestionsSwitchFormGroup" class="suggestions-switch">
       <mdc-switch id="suggestions-enabled-switch" *ngIf="open" formControlName="suggestionsEnabledSwitch"></mdc-switch>
-      <label class="switch-label">{{ t("translation_suggestions") }}</label>
+      <label>{{ t("translation_suggestions") }}</label>
     </mdc-form-field>
     <mdc-select
       id="num-suggestions-select"
@@ -20,7 +20,7 @@
         </mdc-list>
       </mdc-menu>
     </mdc-select>
-    <mdc-form-field>
+    <mdc-form-field class="suggestions-confidence-field">
       <label mdcSubtitle2>{{ t("suggestion_confidence") }}</label>
       <div class="slider-labels" fxLayout="row" fxLayoutAlign="space-between">
         <span mdcCaption>{{ t("more") }}</span> <span mdcCaption>{{ confidenceThreshold }}%</span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
@@ -2,8 +2,8 @@
   margin-top: 15px;
 }
 
-.switch-label {
-  margin-left: 12px;
+.suggestions-switch {
+  column-gap: 12px;
 }
 
 mat-dialog-content.content-padding {
@@ -15,11 +15,13 @@ mat-dialog-content.content-padding {
   width: 100%;
 }
 
-mat-slider.mat-slider-horizontal ::ng-deep {
-  width: 100%;
-  > .mat-slider-wrapper {
-    left: 0;
-    right: 0;
+.suggestions-confidence-field {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden; // prevent slider from causing scrollbar when rtl
+
+  .mat-slider {
+    margin: 0 2px; // prevent slider thumb from being clipped by hiding of overflow
   }
 }
 


### PR DESCRIPTION
Before | After
---------|--------
![](https://user-images.githubusercontent.com/6140710/182744615-2d4a457b-8111-4b1d-8390-993b6a9c3bde.png) | ![](https://user-images.githubusercontent.com/6140710/182744808-0e31067b-42b8-473a-8067-712dc335be48.png)


You can't see it in the screenshots, but the main issue was that the slider causes a scrollbar. The other issue was the toggle was too close to the text.

This _doesn't_ fix the issue of the dialog flowing the wrong direction if the language has been changed, and the page hasn't been reloaded. A number of dialogs had that problem, and it's easier to fix them all at once.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1458)
<!-- Reviewable:end -->
