### PR TITLE
SF-1633 SF-1634 SF-1631 Fix direction of dialogs when UI is set to RTL

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -255,17 +255,17 @@ describe('CheckingOverviewComponent', () => {
       env.simulateRowClick(1, id);
       // Edit a question with no answers
       env.clickElement(env.questionEditButtons[3]);
-      verify(mockedMdcDialog.open(QuestionAnsweredDialogComponent)).never();
+      verify(mockedMdcDialog.open(QuestionAnsweredDialogComponent, anything())).never();
       resetCalls(mockedMdcDialog);
       when(env.mockedAnsweredDialogRef.afterClosed()).thenReturn(of('close'));
       // Edit a question with answers
       env.clickElement(env.questionEditButtons[0]);
-      verify(mockedMdcDialog.open(QuestionAnsweredDialogComponent)).once();
+      verify(mockedMdcDialog.open(QuestionAnsweredDialogComponent, anything())).once();
       verify(mockedMdcDialog.open(QuestionDialogComponent, anything())).never();
       resetCalls(mockedQuestionDialogService);
       when(env.mockedAnsweredDialogRef.afterClosed()).thenReturn(of('accept'));
       env.clickElement(env.questionEditButtons[0]);
-      verify(mockedMdcDialog.open(QuestionAnsweredDialogComponent)).twice();
+      verify(mockedMdcDialog.open(QuestionAnsweredDialogComponent, anything())).twice();
       verify(mockedQuestionDialogService.questionDialog(anything())).once();
       expect().nothing();
     }));
@@ -790,7 +790,9 @@ class TestEnvironment {
 
     when(mockedActivatedRoute.params).thenReturn(of({ projectId: 'project01' }));
     when(mockedQuestionDialogService.questionDialog(anything())).thenResolve();
-    when(mockedMdcDialog.open(QuestionAnsweredDialogComponent)).thenReturn(instance(this.mockedAnsweredDialogRef));
+    when(mockedMdcDialog.open(QuestionAnsweredDialogComponent, anything())).thenReturn(
+      instance(this.mockedAnsweredDialogRef)
+    );
     when(this.mockedAnsweredDialogRef.afterClosed()).thenReturn(of('accept'));
     when(mockedProjectService.getProfile(anything())).thenCall(id =>
       this.realtimeService.subscribe(SFProjectProfileDoc.COLLECTION, id)

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -1,6 +1,4 @@
-import { MdcDialog } from '@angular-mdc/web/dialog';
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
 import { translate } from '@ngneat/transloco';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
@@ -11,6 +9,7 @@ import { Canon } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/ca
 import { merge, Subscription } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
+import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -50,8 +49,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
-    private readonly mdcDialog: MdcDialog,
-    private readonly matDialog: MatDialog,
+    private readonly dialogService: DialogService,
     noticeService: NoticeService,
     readonly i18n: I18nService,
     private readonly projectService: SFProjectService,
@@ -369,7 +367,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
     }
     if (questionDoc != null && questionDoc.data != null) {
       if (questionDoc.data.answers.length > 0) {
-        const answeredDialogRef = this.mdcDialog.open(QuestionAnsweredDialogComponent);
+        const answeredDialogRef = this.dialogService.openMdcDialog(QuestionAnsweredDialogComponent);
         const response = (await answeredDialogRef.afterClosed().toPromise()) as string;
         if (response === 'close') {
           return;
@@ -396,7 +394,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
       userId: this.userService.currentUserId,
       textsByBookId: this.textsByBookId
     };
-    this.matDialog.open(ImportQuestionsDialogComponent, { data, autoFocus: false });
+    this.dialogService.openMatDialog(ImportQuestionsDialogComponent, { data, autoFocus: false });
   }
 
   getBookName(text: TextInfo): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share.component.ts
@@ -1,8 +1,8 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { map } from 'rxjs/operators';
+import { DialogService } from 'xforge-common/dialog.service';
 import { ShareDialogComponent, ShareDialogData } from './share-dialog.component';
 
 @Component({
@@ -15,7 +15,7 @@ export class ShareComponent implements OnInit {
 
   private projectId?: string;
 
-  constructor(private readonly dialog: MatDialog, private readonly activatedRoute: ActivatedRoute) {}
+  constructor(private readonly dialogService: DialogService, private readonly activatedRoute: ActivatedRoute) {}
 
   ngOnInit(): void {
     this.activatedRoute.params.pipe(map(params => params['projectId'] as string)).subscribe(async projectId => {
@@ -24,7 +24,7 @@ export class ShareComponent implements OnInit {
   }
 
   openDialog() {
-    this.dialog.open(ShareDialogComponent, {
+    this.dialogService.openMatDialog(ShareDialogComponent, {
       data: {
         projectId: this.projectId,
         defaultRole: this.defaultRole

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, Inject, OnDestroy, ViewChild } from '@angular/core';
 import { MediaObserver } from '@angular/flex-layout';
-import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
 import { translate } from '@ngneat/transloco';
 import {
@@ -39,6 +38,7 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { PwaService } from 'xforge-common/pwa.service';
 import { UserService } from 'xforge-common/user.service';
 import { getLinkHTML, issuesEmailTemplate } from 'xforge-common/utils';
+import { DialogService } from 'xforge-common/dialog.service';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { environment } from '../../../environments/environment';
 import { NoteThreadDoc } from '../../core/models/note-thread-doc';
@@ -137,7 +137,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     private readonly userService: UserService,
     private readonly projectService: SFProjectService,
     noticeService: NoticeService,
-    private readonly dialog: MatDialog,
+    private readonly dialogService: DialogService,
     private readonly mediaObserver: MediaObserver,
     private readonly pwaService: PwaService,
     private readonly translationEngineService: TranslationEngineService,
@@ -167,7 +167,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   set targetFocused(focused: boolean) {
-    focused = this.dialog.openDialogs.length > 0 ? true : focused;
+    focused = this.dialogService.openDialogCount > 0 ? true : focused;
     this._targetFocused = focused;
   }
 
@@ -685,13 +685,13 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       return;
     }
 
-    const dialogRef = this.dialog.open<SuggestionsSettingsDialogComponent, SuggestionsSettingsDialogData>(
+    const dialogRef = this.dialogService.openMatDialog<
       SuggestionsSettingsDialogComponent,
-      {
-        autoFocus: false,
-        data: { projectUserConfigDoc: this.projectUserConfigDoc }
-      }
-    );
+      SuggestionsSettingsDialogData
+    >(SuggestionsSettingsDialogComponent, {
+      autoFocus: false,
+      data: { projectUserConfigDoc: this.projectUserConfigDoc }
+    });
     dialogRef.afterClosed().subscribe(() => {
       if (this.projectUserConfigDoc != null && this.projectUserConfigDoc.data != null) {
         const pcnt = Math.round(this.projectUserConfigDoc.data.confidenceThreshold * 100);
@@ -739,7 +739,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   private showNoteThread(threadId: string): void {
-    const dialogRef = this.dialog.open(NoteDialogComponent, {
+    const dialogRef = this.dialogService.openMatDialog(NoteDialogComponent, {
       autoFocus: false,
       width: '600px',
       data: {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/dialog.service.ts
@@ -1,0 +1,31 @@
+import { MdcDialog, MdcDialogConfig, MdcDialogRef } from '@angular-mdc/web';
+import { ComponentType } from '@angular/cdk/portal';
+import { Injectable, TemplateRef } from '@angular/core';
+import { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
+import { I18nService } from './i18n.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DialogService {
+  constructor(
+    private readonly i18n: I18nService,
+    private readonly mdcDialog: MdcDialog,
+    private readonly matDialog: MatDialog
+  ) {}
+
+  openMdcDialog<T, D = any, R = any>(
+    componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
+    config?: MdcDialogConfig<D>
+  ): MdcDialogRef<T, R> {
+    return this.mdcDialog.open(componentOrTemplateRef, config);
+  }
+
+  openMatDialog<T, D = any, R = any>(component: ComponentType<T>, config?: MatDialogConfig<D>): MatDialogRef<T, R> {
+    return this.matDialog.open(component, { direction: this.i18n.direction, ...(config || {}) });
+  }
+
+  get openDialogCount(): number {
+    return this.mdcDialog.openDialogs.length + this.matDialog.openDialogs.length;
+  }
+}


### PR DESCRIPTION
The problem for all of these issues is that a MatDialog doesn't get the correct direction set if the direction changed after the page loaded (everything works fine if the locale hasn't changed since the page loaded).

Right now most of our dialogs are still MdcDialog, so the issue only affected a few dialogs. However, the number is likely to grow as we move towards Material, so I wanted a general solution to the problem. Hence the creation of a DialogService that sets the direction when the dialog is opened.

There are a some settings that can be set when opening a dialog that all seem like they should (generally) be the concern of the dialog itself. These include:
- Whether to autofocus the first focusable element
- The default width of the dialog
- Whether the user can use escape or clicking on the backdrop to close the dialog

However, these have to be set by the component that opens the dialog. One of my ideas in creating the service is that perhaps (as a future step) we can have dialog component specify default config values, and the dialog service can read those values from the component, so the calling component doesn't have to concern itself with any of this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1459)
<!-- Reviewable:end -->
