### PR TITLE
SF-1665 Clear edit history before chapter embeds are duplicated

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
@@ -76,10 +76,12 @@ export function getPoetryVerseTextDoc(id: TextDocId): TextData {
   return delta;
 }
 
-export function getEmptyChapterDoc(id: TextDocId): TextData {
+export function getEmptyChapterDoc(id: TextDocId, includeHeading: boolean = true): TextData {
   const delta = new Delta();
-  delta.insert({ blank: true }, { segment: 's_1' });
-  delta.insert('\n', { para: { style: 's' } });
+  if (includeHeading) {
+    delta.insert({ blank: true }, { segment: 's_1' });
+    delta.insert('\n', { para: { style: 's' } });
+  }
   delta.insert({ chapter: { number: id.chapterNum.toString(), style: 'c' } });
   delta.insert({ blank: true }, { segment: 's_2' });
   delta.insert('\n', { para: { style: 's' } });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -714,6 +714,15 @@ export function registerScripture(): string[] {
       if (delta == null) {
         return;
       }
+      const sourceDelta: DeltaStatic = delta[source];
+      // Workaround to cancel the op if an undo gets triggered that includes inserting a chapter embed.
+      // The delta diff algorithm has a problem if an op occurs before the first text inserts in a doc. Generally,
+      // this has no effect, but when edits are made in a blank section heading after a chapter embed at
+      // index 0, duplicate chapter headings appear and the doc gets corrupted.
+      if (sourceDelta.ops != null && sourceDelta.ops.filter(o => o.insert?.chapter != null).length > 0) {
+        this.clear();
+        return;
+      }
       this.stack[dest].push(delta);
       this.lastRecorded = 0;
       this.ignoreChange = true;


### PR DESCRIPTION
Texts were being corrupted when a user typed in the first section heading in a blank chapter with no introductory texts or headings. This is a side effect of a problem when Quill diffs the delta before and after a change is applied. The diff algorithm that Quill users to compare deltas cannot accurately determine if embeds have changed. Most of the time this is not an issue, and quill simply assumes that embeds have changed, reintroduces them, and deletes the originals.

This change clears the history stack if it finds a chapter embed is being inserted as a result of an undo operation. The user will not be able to undo their edits to the section heading.