### PR TITLE
SF-1673 Add user to source project even when suggestions disabled

### DIFF
--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -710,14 +710,9 @@ namespace SIL.XForge.Scripture.Services
             }
 
             // Add to the source project, if required
-            bool translationSuggestionsEnabled = projectDoc.Data.TranslateConfig.TranslationSuggestionsEnabled;
             string sourceProjectId = projectDoc.Data.TranslateConfig.Source?.ProjectRef;
             string sourceParatextId = projectDoc.Data.TranslateConfig.Source?.ParatextId;
-            if (
-                translationSuggestionsEnabled
-                && !string.IsNullOrWhiteSpace(sourceProjectId)
-                && !string.IsNullOrWhiteSpace(sourceParatextId)
-            )
+            if (!string.IsNullOrWhiteSpace(sourceProjectId) && !string.IsNullOrWhiteSpace(sourceParatextId))
             {
                 // Load the source project role from MongoDB
                 IDocument<SFProject> sourceProjectDoc = await TryGetProjectDocAsync(sourceProjectId, conn);

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -1520,6 +1520,29 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
+        public async Task AddUserAsync_HasSourceProjectRole_AddedToSourceProject()
+        {
+            var env = new TestEnvironment();
+            SFProject project03 = env.GetProject(Project03);
+            SFProject source = env.GetProject(SourceOnly);
+            Assert.That(project03.UserRoles.ContainsKey(User03), Is.False, "setup");
+            Assert.That(source.UserRoles.ContainsKey(User03), Is.False, "setup");
+            User user = env.GetUser(User03);
+            Assert.That(user.Sites[SiteId].Projects, Is.Empty);
+            env.ParatextService
+                .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), "pt_source_no_suggestions", CancellationToken.None)
+                .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Translator)));
+
+            await env.Service.AddUserAsync(User03, Project03, SFProjectRole.Translator);
+            project03 = env.GetProject(Project03);
+            source = env.GetProject(SourceOnly);
+            Assert.That(project03.UserRoles.ContainsKey(User03));
+            Assert.That(source.UserRoles.ContainsKey(User03));
+            user = env.GetUser(User03);
+            Assert.That(user.Sites[SiteId].Projects, Is.EquivalentTo(new[] { Project03, SourceOnly }));
+        }
+
+        [Test]
         public async Task UpdatePermissionsAsync_SkipsBookNotInDB()
         {
             // If a user connects a new project, and we seek to set permissions for the user before actually


### PR DESCRIPTION
When we updated the settings page so a source project can be selected without enabling translation suggestions, we did not update the logic to add users to the source project. This change assumes that if a source project is selected, add the user to the source project if needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1464)
<!-- Reviewable:end -->
