### PR TITLE
dev: update deps, vagrant

### DIFF
--- a/deploy/dependencies.yml
+++ b/deploy/dependencies.yml
@@ -140,7 +140,7 @@
       notify: restart network
       tags: ["network"]
 
-    - name: Enable convenient access to ng + npm from commandline | bin dir
+    - name: Enable convenient access to ng from commandline | bin dir
       become: no
       file:
         path: "{{lookup('env','HOME')}}/bin"
@@ -155,15 +155,6 @@
         force: yes
         follow: no
       when: inventory_hostname == "localhost"
-    - name: Enable convenient access to npm from commandline | symlink
-      become: no
-      file:
-        src: "{{repo_path}}/src/SIL.XForge.Scripture/ClientApp/node_modules/.bin/npm"
-        path: "{{lookup('env','HOME')}}/bin/npm"
-        state: link
-        force: yes
-        follow: no
-      when: inventory_hostname == "localhost"
 
     - name: Use chromium for unit tests
       become: no
@@ -172,9 +163,13 @@
         line: "CHROME_BIN=chromium-browser"
         create: yes
 
-    - name: Install/update reportgenerator
+    - name: Install reportgenerator
       become: no
-      shell: dotnet tool install -g dotnet-reportgenerator-globaltool || dotnet tool update -g dotnet-reportgenerator-globaltool
+      shell: dotnet tool update --global dotnet-reportgenerator-globaltool
+
+    - name: Install csharpier
+      become: no
+      shell: dotnet tool update csharpier
 
     - name: Set initial PT connection settings
       become: no

--- a/deploy/vagrant/sfdev/Vagrantfile
+++ b/deploy/vagrant/sfdev/Vagrantfile
@@ -11,8 +11,9 @@ Vagrant.configure("2") do |config|
     vb.cpus = 4
     # At least 3000 MB of RAM is needed to run tests. Using an initial value here of 6000 MB in case the machine is
     # opened on a computer with 8 GB RAM. Most of the time, 14000 MB RAM is enough for development, using Code,
-    # Chromium, running tests, etc. at the same time. Set the RAM value in a SFDEV_RAM environment variable by running
-    # a command such as
+    # Chromium, running tests, etc. at the same time. Though more, such as 24000, is sometimes needed.
+    # To set how much RAM the vagrant guest should use, you can set the RAM value in a SFDEV_RAM
+    # environment variable by running a command such as
     #   tee -a ~/.pam_environment <<< 'SFDEV_RAM="14000"'
     # and then logging back into your computer. Or temporarily set the value here.
     vb.memory = ENV['SFDEV_RAM'] || "6000"
@@ -48,10 +49,15 @@ Vagrant.configure("2") do |config|
     git checkout -- src/SIL.XForge.Scripture/ClientApp/package{,-lock}.json || true
     git pull --ff-only --recurse-submodules
 
+    # Clean up from dotnet 3.1, built in the basebox, so dotnet 6.0 can build.
+    cd ~/src/web-xforge
+    find test src -name obj -print0 | xargs -0 rm -vrf
+
+    # Remove local npm
+    rm -vf ~/bin/npm
+
     cd ~/src/web-xforge/deploy
     tryharderto ansible-playbook playbook_focal.yml --limit localhost
-
-    sudo n lts
 
     cd ~/src/web-xforge/
     dotnet clean
@@ -60,12 +66,21 @@ Vagrant.configure("2") do |config|
     pkill dotnet
     rm -rf /tmp/NuGetScratch/lock
 
+    # Install npm globally.
+    sudo npm install --global npm
+
     cd ~/src/web-xforge/src/RealtimeServer
-    npm i
+    npm ci
     cd ~/src/web-xforge/src/SIL.XForge.Scripture/ClientApp
-    npm i
+    npm ci
     cd ~/src/web-xforge/src/SIL.XForge.Scripture
     dotnet build
+
+    # Let vscode, dotnet, and npm test monitor lots of files.
+    sudo tee --append /etc/sysctl.conf <<END
+    fs.inotify.max_user_watches=10000000
+    fs.inotify.max_user_instances=10000000
+    END
 
     # Remove canary
     rm ~/Desktop/warning-not-provisioned.txt

--- a/deploy/vagrant/sfdev/base/provision
+++ b/deploy/vagrant/sfdev/base/provision
@@ -173,8 +173,8 @@ sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
 sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main" > /etc/apt/sources.list.d/vscode.list'
 tryharderto sudo apt-get update
 tryharderto sudo apt-get install code
-# Let VS Code watch lots of files.
-sudo tee -a /etc/sysctl.conf >/dev/null <<< 'fs.inotify.max_user_watches=524288'
+# Let VS Code and npm test watch lots of files. Whether from bug or need, 500000 is not enough.
+sudo tee -a /etc/sysctl.conf >/dev/null <<< 'fs.inotify.max_user_watches=10000000'
 sudo sysctl -p
 # mono-devel for OmniSharp
 tryharderto sudo apt-get install -y mono-devel


### PR DESCRIPTION
Deps:
- Don't set up symlink to npm in source repo, so not in way of a
globally installed npm.
- Use `dotnet tool update --global` for
dotnet-reportgenerator-globaltool, which works whether installed or
not.
- Install csharpier. Using `update` to align syntax with what was
helpful for `--global`.

Vagrant:
- The vagrant basebox was made with dotnet 3 and using an npm in the
source repo. Clean up `obj` dirs, to prepare for dotnet 6. Migrate to
a globally installed npm.
- Removing `sudo n lts` to have node version set to a specific value
from ansible.
- Increase inotify values.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1466)
<!-- Reviewable:end -->
