### PR TITLE
SF-1668 Store the current project id and navigate on login

### DIFF
--- a/src/RealtimeServer/common/models/site.ts
+++ b/src/RealtimeServer/common/models/site.ts
@@ -1,3 +1,6 @@
 export interface Site {
+  // The most recent project a user has navigated to, which may be different than the current open project
+  // if a user is logged in on multiple browsers
+  currentProjectId?: string;
   projects: string[];
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -114,7 +114,7 @@ describe('AppComponent', () => {
     expect(env.isDrawerVisible).toEqual(true);
     expect(env.selectedProjectId).toEqual('project01');
     expect(env.menuLength).toEqual(5);
-    verify(mockedUserService.setCurrentProjectId('project01')).once();
+    verify(mockedUserService.setCurrentProjectId(anything(), 'project01')).once();
   }));
 
   it('navigate to different project', fakeAsync(() => {
@@ -128,7 +128,7 @@ describe('AppComponent', () => {
     expect(env.menuLength).toEqual(5);
     expect(env.component.isCheckingEnabled).toEqual(true);
     expect(env.component.isTranslateEnabled).toEqual(false);
-    verify(mockedUserService.setCurrentProjectId('project02')).once();
+    verify(mockedUserService.setCurrentProjectId(anything(), 'project02')).once();
   }));
 
   it('hide translate tool for community checkers', fakeAsync(() => {
@@ -142,7 +142,7 @@ describe('AppComponent', () => {
     expect(env.menuLength).toEqual(5);
     expect(env.component.isCheckingEnabled).toEqual(true);
     expect(env.component.isTranslateEnabled).toEqual(false);
-    verify(mockedUserService.setCurrentProjectId('project03')).once();
+    verify(mockedUserService.setCurrentProjectId(anything(), 'project03')).once();
 
     // Does not collapse Community Checking item when translate is disabled
     env.selectItem(0);
@@ -190,7 +190,7 @@ describe('AppComponent', () => {
     expect(env.isDrawerVisible).toEqual(true);
     expect(env.selectedProjectId).toEqual('project02');
     expect(env.location.path()).toEqual('/projects/project02');
-    verify(mockedUserService.setCurrentProjectId('project02')).once();
+    verify(mockedUserService.setCurrentProjectId(anything(), 'project02')).once();
   }));
 
   it('connect project', fakeAsync(() => {
@@ -224,7 +224,7 @@ describe('AppComponent', () => {
     // SUT
     env.deleteProject('project01', false);
     verify(mockedMdcDialog.open(ProjectDeletedDialogComponent)).once();
-    verify(mockedUserService.setCurrentProjectId()).once();
+    verify(mockedUserService.setCurrentProjectId(anything())).once();
     env.confirmProjectDeletedDialog();
     // Get past setTimeout to navigation
     tick();
@@ -241,7 +241,7 @@ describe('AppComponent', () => {
     env.init();
 
     expect(env.isDrawerVisible).toEqual(false);
-    verify(mockedUserService.setCurrentProjectId()).once();
+    verify(mockedUserService.setCurrentProjectId(anything())).once();
     expect(env.location.path()).toEqual('/projects');
   }));
 
@@ -582,7 +582,7 @@ class TestEnvironment {
     when(mockedUserService.getCurrentUser()).thenCall(() =>
       this.realtimeService.subscribe(UserDoc.COLLECTION, 'user01')
     );
-    when(mockedUserService.currentProjectId).thenReturn('project01');
+    when(mockedUserService.currentProjectId(anything())).thenReturn('project01');
     when(mockedSettingsAuthGuard.allowTransition(anything())).thenReturn(this.canSeeSettings$);
     when(mockedSyncAuthGuard.allowTransition(anything())).thenReturn(this.canSync$);
     when(mockedUsersAuthGuard.allowTransition(anything())).thenReturn(this.canSeeUsers$);
@@ -785,7 +785,7 @@ class TestEnvironment {
 
   deleteProject(projectId: string, isLocal: boolean): void {
     if (isLocal) {
-      when(mockedUserService.currentProjectId).thenReturn(undefined);
+      when(mockedUserService.currentProjectId(anything())).thenReturn(undefined);
     }
     this.ngZone.run(() => {
       const projectDoc = this.realtimeService.get(SFProjectProfileDoc.COLLECTION, projectId);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -224,7 +224,7 @@ describe('AppComponent', () => {
     // SUT
     env.deleteProject('project01', false);
     verify(mockedMdcDialog.open(ProjectDeletedDialogComponent)).once();
-    verify(mockedUserService.setCurrentProjectId(anything())).once();
+    verify(mockedUserService.setCurrentProjectId(anything(), undefined)).once();
     env.confirmProjectDeletedDialog();
     // Get past setTimeout to navigation
     tick();
@@ -241,7 +241,7 @@ describe('AppComponent', () => {
     env.init();
 
     expect(env.isDrawerVisible).toEqual(false);
-    verify(mockedUserService.setCurrentProjectId(anything())).once();
+    verify(mockedUserService.setCurrentProjectId(anything(), undefined)).once();
     expect(env.location.path()).toEqual('/projects');
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -363,10 +363,11 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
         // check if the currently selected project has been deleted
         if (
           projectId != null &&
-          projectId === this.userService.currentProjectId &&
+          this.currentUserDoc != null &&
+          projectId === this.userService.currentProjectId(this.currentUserDoc) &&
           (selectedProjectDoc == null || !selectedProjectDoc.isLoaded)
         ) {
-          this.userService.setCurrentProjectId();
+          await this.userService.setCurrentProjectId(this.currentUserDoc);
           this.navigateToStart();
           return;
         }
@@ -413,8 +414,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
         if (this._projectSelect != null) {
           this._projectSelect.value = this.selectedProjectDoc.id;
         }
-
-        this.userService.setCurrentProjectId(this.selectedProjectDoc.id);
+        await this.userService.setCurrentProjectId(this.currentUserDoc, this.selectedProjectDoc.id);
 
         this.checkCheckingBookQuestions();
         this.checkDeviceStorage();
@@ -588,8 +588,8 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     );
   }
 
-  private showProjectDeletedDialog(): void {
-    this.userService.setCurrentProjectId();
+  private async showProjectDeletedDialog(): Promise<void> {
+    await this.userService.setCurrentProjectId(this.currentUserDoc);
     this.projectDeletedDialogRef = this.dialog.open(ProjectDeletedDialogComponent);
     this.projectDeletedDialogRef.afterClosed().subscribe(() => this.navigateToStart());
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -367,7 +367,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
           projectId === this.userService.currentProjectId(this.currentUserDoc) &&
           (selectedProjectDoc == null || !selectedProjectDoc.isLoaded)
         ) {
-          await this.userService.setCurrentProjectId(this.currentUserDoc);
+          await this.userService.setCurrentProjectId(this.currentUserDoc, undefined);
           this.navigateToStart();
           return;
         }
@@ -414,7 +414,9 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
         if (this._projectSelect != null) {
           this._projectSelect.value = this.selectedProjectDoc.id;
         }
-        await this.userService.setCurrentProjectId(this.currentUserDoc, this.selectedProjectDoc.id);
+        if (this.currentUserDoc != null) {
+          await this.userService.setCurrentProjectId(this.currentUserDoc, this.selectedProjectDoc.id);
+        }
 
         this.checkCheckingBookQuestions();
         this.checkDeviceStorage();
@@ -589,7 +591,9 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   }
 
   private async showProjectDeletedDialog(): Promise<void> {
-    await this.userService.setCurrentProjectId(this.currentUserDoc);
+    if (this.currentUserDoc != null) {
+      await this.userService.setCurrentProjectId(this.currentUserDoc, undefined);
+    }
     this.projectDeletedDialogRef = this.dialog.open(ProjectDeletedDialogComponent);
     this.projectDeletedDialogRef.afterClosed().subscribe(() => this.navigateToStart());
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -414,9 +414,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
         if (this._projectSelect != null) {
           this._projectSelect.value = this.selectedProjectDoc.id;
         }
-        if (this.currentUserDoc != null) {
-          await this.userService.setCurrentProjectId(this.currentUserDoc, this.selectedProjectDoc.id);
-        }
+        await this.userService.setCurrentProjectId(this.currentUserDoc!, this.selectedProjectDoc.id);
 
         this.checkCheckingBookQuestions();
         this.checkDeviceStorage();
@@ -591,9 +589,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   }
 
   private async showProjectDeletedDialog(): Promise<void> {
-    if (this.currentUserDoc != null) {
-      await this.userService.setCurrentProjectId(this.currentUserDoc, undefined);
-    }
+    await this.userService.setCurrentProjectId(this.currentUserDoc!, undefined);
     this.projectDeletedDialogRef = this.dialog.open(ProjectDeletedDialogComponent);
     this.projectDeletedDialogRef.afterClosed().subscribe(() => this.navigateToStart());
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
@@ -262,7 +262,7 @@ class TestEnvironment {
     snapshot.queryParams = { sharing: 'true' };
     when(mockedActivatedRoute.snapshot).thenReturn(snapshot);
     when(mockedUserService.currentUserId).thenReturn('user01');
-    when(mockedUserService.currentProjectId).thenReturn('project01');
+    when(mockedUserService.currentProjectId(anything())).thenReturn('project01');
     when(mockedUserService.getCurrentUser()).thenCall(() =>
       this.realtimeService.subscribe(UserDoc.COLLECTION, 'user01')
     );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
@@ -133,7 +133,8 @@ export class ProjectComponent extends DataLoadingComponent implements OnInit {
   private async showOfflineMessage(): Promise<void> {
     await this.noticeService.showMessageDialog(() => this.transloco.translate('project.please_connect_to_use_link'));
     const userDoc: UserDoc = await this.userService.getCurrentUser();
-    const projectId: string | undefined = selectValidProject(userDoc, this.userService.currentProjectId);
+    const currentProjectId: string | undefined = this.userService.currentProjectId(userDoc);
+    const projectId: string | undefined = selectValidProject(userDoc, currentProjectId);
     if (projectId == null) {
       this.router.navigateByUrl('/projects', { replaceUrl: true });
     } else {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -504,7 +504,7 @@ describe('SettingsComponent', () => {
       env.setDialogResponse(true);
       env.wait();
       env.clickElement(env.deleteProjectButton);
-      verify(mockedUserService.setCurrentProjectId()).once();
+      verify(mockedUserService.setCurrentProjectId(anything(), undefined)).once();
       verify(mockedSFProjectService.onlineDelete(anything())).once();
       expect(env.location.path()).toEqual('/projects');
     }));
@@ -515,7 +515,7 @@ describe('SettingsComponent', () => {
       env.setDialogResponse(false);
       env.wait();
       env.clickElement(env.deleteProjectButton);
-      verify(mockedUserService.setCurrentProjectId()).never();
+      verify(mockedUserService.setCurrentProjectId(anything(), undefined)).never();
       verify(mockedSFProjectService.onlineDelete(anything())).never();
       expect().nothing();
     }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -536,7 +536,6 @@ class TestEnvironment {
     when(mockedSFProjectService.onlineIsSourceProject('project01')).thenResolve(isSource);
     when(mockedSFProjectService.onlineDelete(anything())).thenResolve();
     when(mockedSFProjectService.onlineUpdateSettings('project01', anything())).thenResolve();
-    when(mockedUserService.currentProjectId).thenReturn('project01');
     when(mockedSFProjectService.get('project01')).thenCall(() =>
       this.realtimeService.subscribe(SFProjectDoc.COLLECTION, 'project01')
     );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -201,7 +201,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     const dialogRef = this.dialog.open(DeleteProjectDialogComponent, config);
     dialogRef.afterClosed().subscribe(async result => {
       if (result === 'accept') {
-        this.userService.setCurrentProjectId();
+        await this.userService.setCurrentProjectId();
         if (this.projectDoc != null) {
           await this.projectService.onlineDelete(this.projectDoc.id);
           this.router.navigateByUrl('/projects', { replaceUrl: true });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -9,6 +9,7 @@ import { map, tap } from 'rxjs/operators';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { I18nService, TextAroundTemplate } from 'xforge-common/i18n.service';
 import { ElementState } from 'xforge-common/models/element-state';
+import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { PwaService } from 'xforge-common/pwa.service';
 import { UserService } from 'xforge-common/user.service';
@@ -201,7 +202,8 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     const dialogRef = this.dialog.open(DeleteProjectDialogComponent, config);
     dialogRef.afterClosed().subscribe(async result => {
       if (result === 'accept') {
-        await this.userService.setCurrentProjectId();
+        const user: UserDoc = await this.userService.getCurrentUser();
+        await this.userService.setCurrentProjectId(user, undefined);
         if (this.projectDoc != null) {
           await this.projectService.onlineDelete(this.projectDoc.id);
           this.router.navigateByUrl('/projects', { replaceUrl: true });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/start/start.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/start/start.component.spec.ts
@@ -102,7 +102,7 @@ class TestEnvironment {
   }
 
   setCurrentUserProjectData(projectId?: string, projects: string[] = ['project01', 'project02']): void {
-    when(mockedUserService.currentProjectId).thenReturn(projectId);
+    when(mockedUserService.currentProjectId(anything())).thenReturn(projectId);
 
     this.realtimeService.addSnapshot<User>(UserDoc.COLLECTION, {
       id: 'user01',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/start/start.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/start/start.component.ts
@@ -47,7 +47,8 @@ export class StartComponent extends SubscriptionDisposable implements OnInit {
   }
 
   private navigateToProject(userDoc: UserDoc): void {
-    const projectId = selectValidProject(userDoc, this.userService.currentProjectId);
+    const currentProjectId: string | undefined = this.userService.currentProjectId(userDoc);
+    const projectId = selectValidProject(userDoc, currentProjectId);
     if (projectId != null) {
       this.router.navigate(['./', projectId], { relativeTo: this.route, replaceUrl: true });
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.spec.ts
@@ -1,0 +1,87 @@
+import { mock, when } from 'ts-mockito';
+import { MdcDialog } from '@angular-mdc/web';
+import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
+import { TestBed } from '@angular/core/testing';
+import { User } from 'realtime-server/lib/esm/common/models/user';
+import { CURRENT_PROJECT_ID_SETTING, UserService } from './user.service';
+import { AuthService } from './auth.service';
+import { CommandService } from './command.service';
+import { LocalSettingsService } from './local-settings.service';
+import { UserDoc } from './models/user-doc';
+import { TestRealtimeService } from './test-realtime.service';
+import { configureTestingModule } from './test-utils';
+import { TestRealtimeModule } from './test-realtime.module';
+import { TypeRegistry } from './type-registry';
+
+const mockedAuthService = mock(AuthService);
+const mockedLocalSettingsService = mock(LocalSettingsService);
+const mockedDialog = mock(MdcDialog);
+const mockedCommandService = mock(CommandService);
+
+describe('UserService', () => {
+  configureTestingModule(() => ({
+    imports: [TestRealtimeModule.forRoot(new TypeRegistry([UserDoc], [], []))],
+    providers: [
+      UserService,
+      { provide: AuthService, useMock: mockedAuthService },
+      { provide: LocalSettingsService, useMock: mockedLocalSettingsService },
+      { provide: MdcDialog, useMock: mockedDialog },
+      { provide: CommandService, useMock: mockedCommandService }
+    ]
+  }));
+
+  it('returns current project id in local storage', async () => {
+    const env = new TestEnvironment({ localProjectId: 'project01', storedProjectId: 'project02' });
+    const user: UserDoc = await env.service.getCurrentUser();
+    expect(env.service.currentProjectId(user)).toEqual('project01');
+  });
+
+  it('returns stored project id if local settings is empty', async () => {
+    const env = new TestEnvironment({ storedProjectId: 'project02' });
+    const user: UserDoc = await env.service.getCurrentUser();
+    expect(env.service.currentProjectId(user)).toEqual('project02');
+  });
+
+  it('updates the stored project id when requested', async () => {
+    const env = new TestEnvironment({ storedProjectId: 'project01' });
+    const user: UserDoc = await env.service.getCurrentUser();
+    expect(user.data!.sites['sf'].currentProjectId).toEqual('project01');
+    env.service.setCurrentProjectId(user, 'project02');
+    expect(user.data!.sites['sf'].currentProjectId).toEqual('project02');
+
+    // remove current project id
+    env.service.setCurrentProjectId(user);
+    expect(user.data!.sites['sf'].currentProjectId).toBeUndefined();
+  });
+});
+
+interface TestArgs {
+  localProjectId?: string;
+  storedProjectId?: string;
+}
+
+class TestEnvironment {
+  readonly service: UserService;
+  readonly realtimeService: TestRealtimeService;
+
+  constructor(testArgs: TestArgs) {
+    this.realtimeService = TestBed.inject(TestRealtimeService);
+    this.realtimeService.addSnapshot<User>(UserDoc.COLLECTION, {
+      id: 'user01',
+      data: {
+        name: 'User 01',
+        role: SystemRole.User,
+        isDisplayNameConfirmed: true,
+        displayName: 'User 01',
+        email: 'user01@test.com',
+        authId: 'authuser01',
+        avatarUrl: 'avatar01',
+        sites: { sf: { currentProjectId: testArgs.storedProjectId, projects: ['project01', 'project02'] } }
+      }
+    });
+    this.service = TestBed.inject(UserService);
+
+    when(mockedLocalSettingsService.get<string>(CURRENT_PROJECT_ID_SETTING)).thenReturn(testArgs.localProjectId);
+    when(mockedAuthService.currentUserId).thenReturn('user01');
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.spec.ts
@@ -3,6 +3,7 @@ import { MdcDialog } from '@angular-mdc/web';
 import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { TestBed } from '@angular/core/testing';
 import { User } from 'realtime-server/lib/esm/common/models/user';
+import { verify } from 'ts-mockito';
 import { CURRENT_PROJECT_ID_SETTING, UserService } from './user.service';
 import { AuthService } from './auth.service';
 import { CommandService } from './command.service';
@@ -48,10 +49,12 @@ describe('UserService', () => {
     expect(user.data!.sites['sf'].currentProjectId).toEqual('project01');
     env.service.setCurrentProjectId(user, 'project02');
     expect(user.data!.sites['sf'].currentProjectId).toEqual('project02');
+    verify(mockedLocalSettingsService.set(CURRENT_PROJECT_ID_SETTING, 'project02')).once();
 
     // remove current project id
     env.service.setCurrentProjectId(user, undefined);
     expect(user.data!.sites['sf'].currentProjectId).toBeUndefined();
+    verify(mockedLocalSettingsService.set(CURRENT_PROJECT_ID_SETTING, undefined)).once();
   });
 });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.spec.ts
@@ -50,7 +50,7 @@ describe('UserService', () => {
     expect(user.data!.sites['sf'].currentProjectId).toEqual('project02');
 
     // remove current project id
-    env.service.setCurrentProjectId(user);
+    env.service.setCurrentProjectId(user, undefined);
     expect(user.data!.sites['sf'].currentProjectId).toBeUndefined();
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
@@ -46,9 +46,9 @@ export class UserService {
     return this.localSettings.get(CURRENT_PROJECT_ID_SETTING) ?? user.data?.sites?.[this.siteId].currentProjectId;
   }
 
-  async setCurrentProjectId(user?: UserDoc, value?: string): Promise<void> {
+  async setCurrentProjectId(user: UserDoc, value: string | undefined): Promise<void> {
     this.localSettings.set(CURRENT_PROJECT_ID_SETTING, value);
-    await user?.submitJson0Op(update => {
+    await user.submitJson0Op(update => {
       if (value != null) {
         update.set(u => u.sites[this.siteId].currentProjectId, value);
       } else {

--- a/src/SIL.XForge/Models/Site.cs
+++ b/src/SIL.XForge/Models/Site.cs
@@ -6,6 +6,7 @@ namespace SIL.XForge.Models
     [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
     public class Site
     {
+        public string CurrentProjectId { get; set; }
         public List<string> Projects { get; set; } = new List<string>();
     }
 }

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -314,6 +314,8 @@ namespace SIL.XForge.Services
             {
                 int index = userDoc.Data.Sites[siteId].Projects.IndexOf(projectDoc.Id);
                 op.Remove(u => u.Sites[siteId].Projects, index);
+                if (userDoc.Data.Sites[siteId].CurrentProjectId == projectDoc.Id)
+                    op.Unset(u => u.Sites[siteId].CurrentProjectId);
             });
         }
 

--- a/test/SIL.XForge.Tests/Services/ProjectServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/ProjectServiceTests.cs
@@ -244,12 +244,16 @@ namespace SIL.XForge.Services
             Assert.AreEqual(1, env.GetProject(project).UserPermissions.Count);
             Assert.That(env.GetProject(project).UserRoles, Does.ContainKey(userToDisassociate), "setup");
             Assert.That(env.GetProject(project).UserPermissions, Does.ContainKey(userToDisassociate), "setup");
-            Assert.That(env.GetUser(userToDisassociate).Sites[SiteId].Projects, Does.Contain(project), "setup");
+            Site userSite = env.GetUser(userToDisassociate).Sites[SiteId];
+            Assert.That(userSite.Projects, Does.Contain(project), "setup");
+            Assert.That(userSite.CurrentProjectId, Is.EqualTo(Project01));
             // SUT
             await env.Service.RemoveUserAsync(requestingUser, project, userToDisassociate);
             Assert.That(env.GetProject(project).UserRoles, Does.Not.ContainKey(userToDisassociate));
             Assert.That(env.GetProject(project).UserPermissions, Does.Not.ContainKey(userToDisassociate));
-            Assert.That(env.GetUser(userToDisassociate).Sites[SiteId].Projects, Does.Not.Contain(project));
+            userSite = env.GetUser(userToDisassociate).Sites[SiteId];
+            Assert.That(userSite.Projects, Does.Not.Contain(project));
+            Assert.That(userSite.CurrentProjectId, Is.Null);
         }
 
         [Test]
@@ -357,6 +361,7 @@ namespace SIL.XForge.Services
                                         SiteId,
                                         new Site()
                                         {
+                                            CurrentProjectId = Project01,
                                             Projects = new List<String>() { Project01, Project02 }
                                         }
                                     }
@@ -372,6 +377,7 @@ namespace SIL.XForge.Services
                                         SiteId,
                                         new Site()
                                         {
+                                            CurrentProjectId = Project01,
                                             Projects = new List<String>() { Project01, Project02 }
                                         }
                                     }


### PR DESCRIPTION
* add currentProjectId property on the Site class
* store the project id on the user's site in the data
* use the stored id when no project id exists in local storage
* modify user service currentProjectId to accept a user parameter
* add user service test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1468)
<!-- Reviewable:end -->
