### PR TITLE
SF-1678 Convert scripture view dialogs to angular material

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -11,6 +11,7 @@ import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scri
 import { fromVerseRef, toVerseRef, VerseRefData } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
 import { Subscription } from 'rxjs';
+import { DialogService } from 'xforge-common/dialog.service';
 import { FileService } from 'xforge-common/file.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { FileType } from 'xforge-common/models/file-offline-data';
@@ -103,6 +104,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
   constructor(
     private readonly userService: UserService,
     private readonly dialog: MdcDialog,
+    private readonly dialogService: DialogService,
     private readonly noticeService: NoticeService,
     private readonly questionDialogService: QuestionDialogService,
     private readonly i18n: I18nService,
@@ -340,7 +342,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
       selectedText: this.selectedText || '',
       selectedVerses: this.verseRef
     };
-    const dialogRef = this.dialog.open(TextChooserDialogComponent, { data: dialogData });
+    const dialogRef = this.dialogService.openMatDialog(TextChooserDialogComponent, { data: dialogData });
     dialogRef.afterClosed().subscribe(result => {
       if (result != null && result !== 'close') {
         const selection = result as TextSelection;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -2,6 +2,7 @@ import { MdcDialog, MdcDialogRef } from '@angular-mdc/web/dialog';
 import { Location } from '@angular/common';
 import { DebugElement, NgZone } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, ActivatedRouteSnapshot, Route } from '@angular/router';
@@ -35,6 +36,7 @@ import { anyString, anything, deepEqual, instance, mock, reset, resetCalls, spy,
 import { AuthService } from 'xforge-common/auth.service';
 import { AvatarTestingModule } from 'xforge-common/avatar/avatar-testing.module';
 import { BugsnagService } from 'xforge-common/bugsnag.service';
+import { DialogService } from 'xforge-common/dialog.service';
 import { FileService } from 'xforge-common/file.service';
 import { createStorageFileData, FileOfflineData, FileType } from 'xforge-common/models/file-offline-data';
 import { Snapshot } from 'xforge-common/models/snapshot';
@@ -82,6 +84,7 @@ const mockedTranslationEngineService = mock(TranslationEngineService);
 const mockedNoticeService = mock(NoticeService);
 const mockedActivatedRoute = mock(ActivatedRoute);
 const mockedMdcDialog = mock(MdcDialog);
+const mockedDialogService = mock(DialogService);
 const mockedTextChooserDialogComponent = mock(TextChooserDialogComponent);
 const mockedQuestionDialogService = mock(QuestionDialogService);
 const mockedBugsnagService = mock(BugsnagService);
@@ -154,6 +157,7 @@ describe('CheckingComponent', () => {
       { provide: TranslationEngineService, useMock: mockedTranslationEngineService },
       { provide: NoticeService, useMock: mockedNoticeService },
       { provide: MdcDialog, useMock: mockedMdcDialog },
+      { provide: DialogService, useMock: mockedDialogService },
       { provide: TextChooserDialogComponent, useMock: mockedTextChooserDialogComponent },
       { provide: QuestionDialogService, useMock: mockedQuestionDialogService },
       { provide: BugsnagService, useMock: mockedBugsnagService },
@@ -1456,7 +1460,7 @@ class TestEnvironment {
   readonly ngZone: NgZone = TestBed.inject(NgZone);
   readonly realtimeService: TestRealtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);
   readonly mockedAnsweredDialogRef = mock<MdcDialogRef<QuestionAnsweredDialogComponent>>(MdcDialogRef);
-  readonly mockedTextChooserDialogComponent = mock<MdcDialogRef<TextChooserDialogComponent>>(MdcDialogRef);
+  readonly mockedTextChooserDialogComponent = mock<MatDialogRef<TextChooserDialogComponent>>(MatDialogRef);
   readonly location: Location;
 
   questionReadTimer: number = 2000;
@@ -2353,7 +2357,7 @@ class TestEnvironment {
     );
 
     when(mockedMdcDialog.open(QuestionAnsweredDialogComponent)).thenReturn(instance(this.mockedAnsweredDialogRef));
-    when(mockedMdcDialog.open(TextChooserDialogComponent, anything())).thenReturn(
+    when(mockedDialogService.openMatDialog(TextChooserDialogComponent, anything())).thenReturn(
       instance(this.mockedTextChooserDialogComponent)
     );
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
@@ -1,108 +1,71 @@
 <ng-container *transloco="let t; read: 'question_dialog'">
-  <mdc-dialog>
-    <mdc-dialog-container [dir]="i18n.direction">
-      <mdc-dialog-surface class="dialog-size">
-        <mdc-dialog-title fxLayoutAlign="start center">
-          <i class="material-icons">live_help</i> {{ modeLabel }}
-        </mdc-dialog-title>
-        <mdc-dialog-content class="content-padding">
-          <form [formGroup]="questionForm" autocomplete="off" id="question-form">
-            <div fxLayout="row wrap" fxLayoutAlign="space-around start" fxLayoutGap.gt-xs="1em">
-              <mdc-form-field>
-                <!-- appAutofocus is needed because MdcDialog would focus the mdc-icon, since it is first in the dom -->
-                <mdc-text-field
-                  appAutofocus
-                  label="{{ t('scripture_reference') }}"
-                  type="text"
-                  formControlName="scriptureStart"
-                  [outlined]="true"
-                  id="scripture-start"
-                  (input)="updateScriptureEndEnabled()"
-                >
-                  <mdc-icon
-                    mdcTextFieldIcon
-                    [trailing]="true"
-                    [clickable]="true"
-                    (click)="openScriptureChooser(scriptureStart)"
-                    >expand_more</mdc-icon
-                  >
-                </mdc-text-field>
-                <mdc-helper-text
-                  [validation]="true"
-                  id="question-scripture-start-helper-text"
-                  class="scripture-helper-text"
-                >
-                  {{ scriptureInputErrorMessages.startError }}
-                </mdc-helper-text>
-              </mdc-form-field>
-              <mdc-form-field>
-                <mdc-text-field
-                  label="{{ t('end_reference') }}"
-                  type="text"
-                  formControlName="scriptureEnd"
-                  [outlined]="true"
-                  [errorStateMatcher]="parentAndStartMatcher"
-                  id="scripture-end"
-                >
-                  <mdc-icon
-                    mdcTextFieldIcon
-                    [trailing]="true"
-                    [clickable]="true"
-                    (click)="openScriptureChooser(scriptureEnd)"
-                    >expand_more</mdc-icon
-                  >
-                </mdc-text-field>
-                <mdc-helper-text id="question-scripture-end-helper-text" [validation]="true">
-                  {{ scriptureInputErrorMessages.endError }}
-                  <span
-                    *ngIf="questionForm.hasError('verseBeforeStart')"
-                    [innerHTML]="i18n.translateAndInsertTags('question_dialog.must_be_after_scripture_reference')"
-                  ></span>
-                </mdc-helper-text>
-              </mdc-form-field>
-            </div>
-            <div class="text-container">
-              <app-checking-text
-                [id]="textDocId"
-                placeholder="{{ t('enter_a_reference_to_load_text') }}"
-                [activeVerse]="selection"
-                [isRightToLeft]="isTextRightToLeft"
-              ></app-checking-text>
-            </div>
-            <mdc-form-field>
-              <mdc-textarea
-                label="{{ t('question') }}"
-                type="text"
-                formControlName="questionText"
-                [rows]="2"
-                [fullwidth]="true"
-                [helperText]="questionHelper"
-                id="question-text"
-              ></mdc-textarea>
-              <mdc-helper-text #questionHelper [validation]="true">{{ t("required_with_asterisk") }}</mdc-helper-text>
-            </mdc-form-field>
-            <app-checking-audio-combined
-              [source]="audioSource"
-              (update)="processAudio($event)"
-            ></app-checking-audio-combined>
-          </form>
-        </mdc-dialog-content>
-        <mdc-dialog-actions>
-          <button mdcDialogButton mdcDialogAction="close" type="button" id="question-cancel-btn">
-            {{ t("cancel") }}
-          </button>
-          <button
-            mdcDialogButton
-            [unelevated]="true"
-            form="question-form"
-            type="submit"
-            id="question-save-btn"
-            (click)="submit()"
-          >
-            {{ t("save") }}
-          </button>
-        </mdc-dialog-actions>
-      </mdc-dialog-surface>
-    </mdc-dialog-container>
-  </mdc-dialog>
+  <div>
+    <h1 mat-dialog-title fxLayoutAlign="start center"><i class="material-icons">live_help</i> {{ modeLabel }}</h1>
+    <mat-dialog-content class="content-padding">
+      <form [formGroup]="questionForm" autocomplete="off" id="question-form">
+        <div fxLayout="row wrap" fxLayoutAlign="space-around start" fxLayoutGap.gt-xs="1em">
+          <mat-form-field class="scripture-reference" id="scripture-start" appearance="outline">
+            <!-- cdkFocusInitial is needed because MatDialog would focus the icon, since it is first in the dom -->
+            <mat-label>{{ t("scripture_reference") }}</mat-label>
+            <input
+              matInput
+              cdkFocusInitial
+              type="text"
+              formControlName="scriptureStart"
+              (input)="updateScriptureEndEnabled()"
+            />
+            <button mat-icon-button matSuffix (click)="openScriptureChooser(scriptureStart)">
+              <mat-icon>expand_more</mat-icon>
+            </button>
+            <mat-error
+              *ngIf="scriptureInputErrorMessages.startError != null"
+              id="question-scripture-start-helper-text"
+              class="scripture-helper-text"
+            >
+              {{ scriptureInputErrorMessages.startError }}
+            </mat-error>
+          </mat-form-field>
+          <mat-form-field class="scripture-reference" id="scripture-end" appearance="outline">
+            <mat-label>{{ t("end_reference") }}</mat-label>
+            <input matInput type="text" formControlName="scriptureEnd" [errorStateMatcher]="parentAndStartMatcher" />
+            <button mat-icon-button matSuffix (click)="openScriptureChooser(scriptureEnd)">
+              <mat-icon>expand_more</mat-icon>
+            </button>
+            <mat-error id="question-scripture-end-helper-text" *ngIf="scriptureInputErrorMessages.endError != null">
+              {{ scriptureInputErrorMessages.endError }}
+              <span
+                *ngIf="questionForm.hasError('verseBeforeStart')"
+                [innerHTML]="i18n.translateAndInsertTags('question_dialog.must_be_after_scripture_reference')"
+              ></span>
+            </mat-error>
+          </mat-form-field>
+        </div>
+        <div class="text-container">
+          <app-checking-text
+            [id]="textDocId"
+            placeholder="{{ t('enter_a_reference_to_load_text') }}"
+            [activeVerse]="selection"
+            [isRightToLeft]="isTextRightToLeft"
+          ></app-checking-text>
+        </div>
+        <mat-form-field class="question-container" id="question-text" appearance="outline">
+          <mat-label>{{ t("question") }}</mat-label>
+          <textarea matInput type="text" formControlName="questionText" [rows]="2"></textarea>
+          <mat-hint #questionHelper>{{ t("required_with_asterisk") }}</mat-hint>
+        </mat-form-field>
+        <app-checking-audio-combined
+          [source]="audioSource"
+          (update)="processAudio($event)"
+        ></app-checking-audio-combined>
+      </form>
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button (click)="cancelDialog()" type="button" id="question-cancel-btn">
+        {{ t("cancel") }}
+      </button>
+      <button mat-flat-button form="question-form" type="submit" id="question-save-btn" (click)="submit()">
+        {{ t("save") }}
+      </button>
+    </mat-dialog-actions>
+  </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'question_dialog'">
-  <div>
+  <div class="dialog-container">
     <h1 mat-dialog-title fxLayoutAlign="start center"><i class="material-icons">live_help</i> {{ modeLabel }}</h1>
     <mat-dialog-content class="content-padding">
       <form [formGroup]="questionForm" autocomplete="off" id="question-form">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
@@ -60,7 +60,7 @@
       </form>
     </mat-dialog-content>
     <mat-dialog-actions align="end">
-      <button mat-button (click)="cancelDialog()" type="button" id="question-cancel-btn">
+      <button mat-button [mat-dialog-close]="'close'" type="button" id="question-cancel-btn">
         {{ t("cancel") }}
       </button>
       <button mat-flat-button form="question-form" type="submit" id="question-save-btn" (click)="submit()">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
@@ -1,69 +1,64 @@
 <ng-container *transloco="let t; read: 'question_dialog'">
   <div class="dialog-container">
     <h1 mat-dialog-title fxLayoutAlign="start center"><i class="material-icons">live_help</i> {{ modeLabel }}</h1>
-    <mat-dialog-content class="content-padding">
-      <form [formGroup]="questionForm" autocomplete="off" id="question-form">
-        <div fxLayout="row wrap" fxLayoutAlign="space-around start" fxLayoutGap.gt-xs="1em">
-          <mat-form-field class="scripture-reference" id="scripture-start" appearance="outline">
-            <!-- cdkFocusInitial is needed because MatDialog would focus the icon, since it is first in the dom -->
-            <mat-label>{{ t("scripture_reference") }}</mat-label>
-            <input
-              matInput
-              cdkFocusInitial
-              type="text"
-              formControlName="scriptureStart"
-              (input)="updateScriptureEndEnabled()"
-            />
-            <button mat-icon-button matSuffix (click)="openScriptureChooser(scriptureStart)">
-              <mat-icon>expand_more</mat-icon>
-            </button>
-            <mat-error
-              *ngIf="scriptureInputErrorMessages.startError != null"
-              id="question-scripture-start-helper-text"
-              class="scripture-helper-text"
-            >
-              {{ scriptureInputErrorMessages.startError }}
-            </mat-error>
-          </mat-form-field>
-          <mat-form-field class="scripture-reference" id="scripture-end" appearance="outline">
-            <mat-label>{{ t("end_reference") }}</mat-label>
-            <input matInput type="text" formControlName="scriptureEnd" [errorStateMatcher]="parentAndStartMatcher" />
-            <button mat-icon-button matSuffix (click)="openScriptureChooser(scriptureEnd)">
-              <mat-icon>expand_more</mat-icon>
-            </button>
-            <mat-error id="question-scripture-end-helper-text" *ngIf="scriptureInputErrorMessages.endError != null">
-              {{ scriptureInputErrorMessages.endError }}
-              <span
-                *ngIf="questionForm.hasError('verseBeforeStart')"
-                [innerHTML]="i18n.translateAndInsertTags('question_dialog.must_be_after_scripture_reference')"
-              ></span>
-            </mat-error>
-          </mat-form-field>
-        </div>
-        <div class="text-container">
-          <app-checking-text
-            [id]="textDocId"
-            placeholder="{{ t('enter_a_reference_to_load_text') }}"
-            [activeVerse]="selection"
-            [isRightToLeft]="isTextRightToLeft"
-          ></app-checking-text>
-        </div>
-        <mat-form-field class="question-container" id="question-text" appearance="outline">
-          <mat-label>{{ t("question") }}</mat-label>
-          <textarea matInput type="text" formControlName="questionText" [rows]="2"></textarea>
-          <mat-hint #questionHelper>{{ t("required_with_asterisk") }}</mat-hint>
+    <mat-dialog-content [formGroup]="questionForm" (ngSubmit)="submit()" class="content-padding" #dialogForm="ngForm">
+      <div fxLayout="row wrap" fxLayoutAlign="space-around start" fxLayoutGap.gt-xs="1em">
+        <mat-form-field class="scripture-reference" id="scripture-start" appearance="outline">
+          <mat-label>{{ t("scripture_reference") }}</mat-label>
+          <input matInput type="text" formControlName="scriptureStart" (input)="updateScriptureEndEnabled()" />
+          <button mat-icon-button matSuffix (click)="openScriptureChooser(scriptureStart)">
+            <mat-icon>expand_more</mat-icon>
+          </button>
+          <mat-error id="question-scripture-start-helper-text" class="scripture-helper-text">
+            {{ scriptureInputErrorMessages.startError }}
+          </mat-error>
         </mat-form-field>
-        <app-checking-audio-combined
-          [source]="audioSource"
-          (update)="processAudio($event)"
-        ></app-checking-audio-combined>
-      </form>
+        <mat-form-field class="scripture-reference" id="scripture-end" appearance="outline">
+          <mat-label>{{ t("end_reference") }}</mat-label>
+          <input matInput type="text" formControlName="scriptureEnd" [errorStateMatcher]="parentAndStartMatcher" />
+          <button
+            [disabled]="scriptureEnd.disabled"
+            mat-icon-button
+            matSuffix
+            (click)="openScriptureChooser(scriptureEnd)"
+          >
+            <mat-icon>expand_more</mat-icon>
+          </button>
+          <mat-error id="question-scripture-end-helper-text">
+            {{ scriptureInputErrorMessages.endError }}
+            <span
+              *ngIf="questionForm.hasError('verseBeforeStart')"
+              [innerHTML]="i18n.translateAndInsertTags('question_dialog.must_be_after_scripture_reference')"
+            ></span>
+          </mat-error>
+        </mat-form-field>
+      </div>
+      <div class="text-container">
+        <app-checking-text
+          [id]="textDocId"
+          placeholder="{{ t('enter_a_reference_to_load_text') }}"
+          [activeVerse]="selection"
+          [isRightToLeft]="isTextRightToLeft"
+        ></app-checking-text>
+      </div>
+      <mat-form-field class="question-container" id="question-text" appearance="outline">
+        <mat-label>{{ t("question") }}</mat-label>
+        <textarea matInput type="text" formControlName="questionText" [rows]="2"></textarea>
+        <mat-error #questionHelper>{{ t("required_with_asterisk") }}</mat-error>
+      </mat-form-field>
+      <app-checking-audio-combined [source]="audioSource" (update)="processAudio($event)"></app-checking-audio-combined>
     </mat-dialog-content>
     <mat-dialog-actions align="end">
       <button mat-button [mat-dialog-close]="'close'" type="button" id="question-cancel-btn">
         {{ t("cancel") }}
       </button>
-      <button mat-flat-button form="question-form" type="submit" id="question-save-btn" (click)="submit()">
+      <button
+        mat-flat-button
+        color="primary"
+        type="submit"
+        (click)="dialogForm.onSubmit($event)"
+        id="question-save-btn"
+      >
         {{ t("save") }}
       </button>
     </mat-dialog-actions>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.scss
@@ -1,20 +1,19 @@
-mdc-dialog-content.content-padding {
+.mat-dialog-content.content-padding {
   padding-top: 0.5em;
+  max-width: 560px;
 }
 
-mdc-form-field {
+mat-form-field {
   margin-bottom: 1em;
-  .scripture-helper-text {
+  .scripture-helper-text .scripture-reference {
     max-width: 248px;
+    .mat-form-field-suffix {
+      top: 0.5em;
+    }
   }
-}
-
-mdc-text-field {
-  max-width: 248px;
-}
-
-mdc-dialog-actions {
-  text-align: end;
+  &.question-container {
+    width: 100%;
+  }
 }
 
 .text-container {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.scss
@@ -15,6 +15,10 @@ mat-form-field {
   }
 }
 
+.dialog-container {
+  max-width: 560px;
+}
+
 .text-container {
   height: 10em;
   margin-bottom: 1em;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.scss
@@ -1,6 +1,5 @@
 .mat-dialog-content.content-padding {
   padding-top: 0.5em;
-  max-width: 560px;
 }
 
 mat-form-field {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -267,11 +267,16 @@ describe('QuestionDialogComponent', () => {
   it('passes start reference to end-reference chooser', fakeAsync(() => {
     env = new TestEnvironment();
     flush();
+    expect(env.scriptureEndInputIcon.classList).toContain('mat-button-disabled');
     env.component.scriptureStart.setValue('LUK 1:1');
     env.component.scriptureEnd.setValue('GEN 5:6');
+    tick();
+    env.fixture.detectChanges();
+    expect(env.component.scriptureEnd.enabled).toBe(true);
+    expect(env.scriptureEndInputIcon.classList).not.toContain('mat-button-disabled');
+    console.log(env.scriptureEndInputIcon);
 
     env.clickElement(env.scriptureEndInputIcon);
-    flush();
     // Dialog receives unhelpful input value that can be ignored.
     // rangeStart should have been passed in, and from scriptureStart value.
     verify(
@@ -653,16 +658,16 @@ class TestEnvironment {
     return this.overlayContainerElement.querySelector('#scripture-end') as HTMLInputElement;
   }
 
-  get scriptureEndInputIcon(): HTMLInputElement {
-    return this.scriptureEndInput.querySelector('mat-icon') as HTMLInputElement;
+  get scriptureEndInputIcon(): HTMLElement {
+    return this.scriptureEndInput.querySelector('button') as HTMLElement;
   }
 
   get scriptureStartInput(): HTMLInputElement {
     return this.overlayContainerElement.querySelector('#scripture-start') as HTMLInputElement;
   }
 
-  get scriptureStartInputIcon(): HTMLInputElement {
-    return this.scriptureStartInput.querySelector('mat-icon') as HTMLInputElement;
+  get scriptureStartInputIcon(): HTMLElement {
+    return this.scriptureStartInput.querySelector('button') as HTMLElement;
   }
 
   get scriptureStartValidationMsg(): HTMLElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -274,7 +274,6 @@ describe('QuestionDialogComponent', () => {
     env.fixture.detectChanges();
     expect(env.component.scriptureEnd.enabled).toBe(true);
     expect(env.scriptureEndInputIcon.classList).not.toContain('mat-button-disabled');
-    console.log(env.scriptureEndInputIcon);
 
     env.clickElement(env.scriptureEndInputIcon);
     // Dialog receives unhelpful input value that can be ignored.

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -188,11 +188,6 @@ export class QuestionDialogComponent extends SubscriptionDisposable implements O
 
   /** Edit text of control using Scripture chooser dialog. */
   openScriptureChooser(control: AbstractControl) {
-    if (this.scriptureStart.value === '') {
-      // the input element is losing focus, but the input is still being interacted with, so errors shouldn't be shown
-      this.scriptureStart.markAsUntouched();
-    }
-
     let currentVerseSelection: VerseRef | undefined;
     const { verseRef } = VerseRef.tryParse(control.value);
     if (verseRef.valid) {
@@ -216,6 +211,12 @@ export class QuestionDialogComponent extends SubscriptionDisposable implements O
       ScriptureChooserDialogComponent,
       VerseRef | 'close'
     >;
+    if (control.value === '') {
+      // the input element is losing focus, but the input is still being interacted with, so errors shouldn't be shown
+      dialogRef.afterOpened().subscribe(() => {
+        control.markAsUntouched();
+      });
+    }
     dialogRef.afterClosed().subscribe(result => {
       if (result != null && result !== 'close') {
         control.markAsTouched();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -186,10 +186,6 @@ export class QuestionDialogComponent extends SubscriptionDisposable implements O
     });
   }
 
-  cancelDialog(): void {
-    return this.dialogRef.close('close');
-  }
-
   /** Edit text of control using Scripture chooser dialog. */
   openScriptureChooser(control: AbstractControl) {
     if (this.scriptureStart.value === '') {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -1,9 +1,10 @@
-import { MdcDialog, MdcDialogConfig, MdcDialogRef, MDC_DIALOG_DATA } from '@angular-mdc/web/dialog';
 import { Component, Inject, OnInit, ViewChild } from '@angular/core';
 import { AbstractControl, FormControl, FormGroup, Validators } from '@angular/forms';
+import { MatDialogConfig, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { translate } from '@ngneat/transloco';
 import { toStartAndEndVerseRefs } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
+import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { FileType } from 'xforge-common/models/file-offline-data';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -59,11 +60,11 @@ export class QuestionDialogComponent extends SubscriptionDisposable implements O
   audioSource?: string;
 
   constructor(
-    private readonly dialogRef: MdcDialogRef<QuestionDialogComponent, QuestionDialogResult>,
-    @Inject(MDC_DIALOG_DATA) private data: QuestionDialogData,
+    private readonly dialogRef: MatDialogRef<QuestionDialogComponent, QuestionDialogResult | 'close'>,
+    @Inject(MAT_DIALOG_DATA) private data: QuestionDialogData,
     private noticeService: NoticeService,
     readonly i18n: I18nService,
-    readonly dialog: MdcDialog
+    readonly dialogService: DialogService
   ) {
     super();
   }
@@ -185,6 +186,10 @@ export class QuestionDialogComponent extends SubscriptionDisposable implements O
     });
   }
 
+  cancelDialog(): void {
+    return this.dialogRef.close('close');
+  }
+
   /** Edit text of control using Scripture chooser dialog. */
   openScriptureChooser(control: AbstractControl) {
     if (this.scriptureStart.value === '') {
@@ -206,12 +211,12 @@ export class QuestionDialogComponent extends SubscriptionDisposable implements O
       }
     }
 
-    const dialogConfig: MdcDialogConfig<ScriptureChooserDialogData> = {
+    const dialogConfig: MatDialogConfig<ScriptureChooserDialogData> = {
       data: { input: currentVerseSelection, booksAndChaptersToShow: this.data.textsByBookId, rangeStart },
       autoFocus: false
     };
 
-    const dialogRef = this.dialog.open(ScriptureChooserDialogComponent, dialogConfig) as MdcDialogRef<
+    const dialogRef = this.dialogService.openMatDialog(ScriptureChooserDialogComponent, dialogConfig) as MatDialogRef<
       ScriptureChooserDialogComponent,
       VerseRef | 'close'
     >;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.spec.ts
@@ -1,5 +1,6 @@
-import { MdcDialog, MdcDialogRef } from '@angular-mdc/web/dialog';
 import { TestBed } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { CheckingShareLevel } from 'realtime-server/lib/esm/scriptureforge/models/checking-config';
 import {
   getQuestionDocId,
@@ -14,12 +15,14 @@ import { fromVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/vers
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
 import { of } from 'rxjs';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { DialogService } from 'xforge-common/dialog.service';
 import { FileService } from 'xforge-common/file.service';
 import { FileType } from 'xforge-common/models/file-offline-data';
 import { NoticeService } from 'xforge-common/notice.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
 import { QuestionDoc } from '../../core/models/question-doc';
 import { SFProjectDoc } from '../../core/models/sf-project-doc';
@@ -29,7 +32,7 @@ import { SFProjectService } from '../../core/sf-project.service';
 import { QuestionDialogComponent, QuestionDialogData, QuestionDialogResult } from './question-dialog.component';
 import { QuestionDialogService } from './question-dialog.service';
 
-const mockedDialog = mock(MdcDialog);
+const mockedDialogService = mock(DialogService);
 const mockedProjectService = mock(SFProjectService);
 const mockedUserService = mock(UserService);
 const mockedNoticeService = mock(NoticeService);
@@ -37,10 +40,10 @@ const mockedFileService = mock(FileService);
 
 describe('QuestionDialogService', () => {
   configureTestingModule(() => ({
-    imports: [TestTranslocoModule, TestRealtimeModule.forRoot(SF_TYPE_REGISTRY)],
+    imports: [TestTranslocoModule, NoopAnimationsModule, UICommonModule, TestRealtimeModule.forRoot(SF_TYPE_REGISTRY)],
     providers: [
       QuestionDialogService,
-      { provide: MdcDialog, useMock: mockedDialog },
+      { provide: DialogService, useMock: mockedDialogService },
       { provide: SFProjectService, useMock: mockedProjectService },
       { provide: UserService, useMock: mockedUserService },
       { provide: NoticeService, useMock: mockedNoticeService },
@@ -160,7 +163,7 @@ interface UserInfo {
 
 class TestEnvironment {
   readonly service: QuestionDialogService;
-  readonly mockedDialogRef = mock<MdcDialogRef<QuestionDialogComponent, QuestionDialogResult | 'close'>>(MdcDialogRef);
+  readonly mockedDialogRef = mock<MatDialogRef<QuestionDialogComponent, QuestionDialogResult | 'close'>>(MatDialogRef);
   textsByBookId: TextsByBookId;
   matthewText: TextInfo = {
     bookNum: 40,
@@ -212,7 +215,7 @@ class TestEnvironment {
       data: this.testProject
     });
 
-    when(mockedDialog.open(anything(), anything())).thenReturn(instance(this.mockedDialogRef));
+    when(mockedDialogService.openMatDialog(anything(), anything())).thenReturn(instance(this.mockedDialogRef));
     when(mockedUserService.currentUserId).thenReturn(this.adminUser.id);
     when(mockedProjectService.get(anything())).thenCall(id =>
       this.realtimeService.subscribe(SFProjectDoc.COLLECTION, id)

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.ts
@@ -1,10 +1,11 @@
-import { MdcDialog, MdcDialogConfig, MdcDialogRef } from '@angular-mdc/web/dialog';
 import { Injectable } from '@angular/core';
+import { MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { TranslocoService } from '@ngneat/transloco';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { Question } from 'realtime-server/lib/esm/scriptureforge/models/question';
 import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { fromVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
+import { DialogService } from 'xforge-common/dialog.service';
 import { FileType } from 'xforge-common/models/file-offline-data';
 import { NoticeService } from 'xforge-common/notice.service';
 import { UserService } from 'xforge-common/user.service';
@@ -18,7 +19,7 @@ import { QuestionDialogComponent, QuestionDialogData, QuestionDialogResult } fro
 })
 export class QuestionDialogService {
   constructor(
-    private readonly dialog: MdcDialog,
+    private readonly dialogService: DialogService,
     private readonly projectService: SFProjectService,
     private readonly userService: UserService,
     private readonly noticeService: NoticeService,
@@ -29,8 +30,8 @@ export class QuestionDialogService {
   async questionDialog(config: QuestionDialogData): Promise<QuestionDoc | undefined> {
     const questionDoc = config.questionDoc;
     // handling auto focus is left for the template because MdcDialog would focus the wrong element
-    const dialogConfig: MdcDialogConfig = { data: config, clickOutsideToClose: false, autoFocus: false };
-    const dialogRef = this.dialog.open(QuestionDialogComponent, dialogConfig) as MdcDialogRef<
+    const dialogConfig: MatDialogConfig = { data: config, autoFocus: false, disableClose: true };
+    const dialogRef = this.dialogService.openMatDialog(QuestionDialogComponent, dialogConfig) as MatDialogRef<
       QuestionDialogComponent,
       QuestionDialogResult | 'close'
     >;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.ts
@@ -30,7 +30,7 @@ export class QuestionDialogService {
   async questionDialog(config: QuestionDialogData): Promise<QuestionDoc | undefined> {
     const questionDoc = config.questionDoc;
     // handling auto focus is left for the template because MdcDialog would focus the wrong element
-    const dialogConfig: MatDialogConfig = { data: config, autoFocus: false, disableClose: true };
+    const dialogConfig: MatDialogConfig = { data: config, autoFocus: true, disableClose: true };
     const dialogRef = this.dialogService.openMatDialog(QuestionDialogComponent, dialogConfig) as MatDialogRef<
       QuestionDialogComponent,
       QuestionDialogResult | 'close'

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.html
@@ -1,102 +1,101 @@
 <ng-container *transloco="let t; read: 'scripture_chooser_dialog'">
-  <mdc-dialog>
-    <mdc-dialog-container class="dialogContainer" [dir]="i18n.direction">
-      <mdc-dialog-surface id="bookPane" *ngIf="showing === 'books'">
-        <mdc-dialog-title>
-          <button mdcIconButton class="backout-button" (click)="onClickBackoutButton()" (focus)="onCloseFocus($event)">
-            <mdc-icon>close</mdc-icon>
-          </button>
-          <span>{{ t("choose_book") }}</span>
-        </mdc-dialog-title>
-        <mdc-dialog-content>
-          <div class="upperBookSet">
-            <button
-              *ngFor="let book of otBooks"
-              mdc-button
-              [unelevated]="data.input?.book === book"
-              (click)="onClickBook(book)"
-            >
-              {{ i18n.localizeBook(book) }}
-            </button>
-          </div>
+  <div class="dialogContainer">
+    <div id="bookPane" *ngIf="showing === 'books'">
+      <h1 mat-dialog-title>
+        <button mat-icon-button class="backout-button" (click)="onClickBackoutButton()" (focus)="onCloseFocus($event)">
+          <mat-icon>close</mat-icon>
+        </button>
+        <span>{{ t("choose_book") }}</span>
+      </h1>
+      <div mat-dialog-content>
+        <div class="upperBookSet">
           <button
-            *ngFor="let book of ntBooks"
-            mdc-button
-            [unelevated]="data.input?.book === book"
+            *ngFor="let book of otBooks"
+            mat-button
+            [ngClass]="{ 'mat-flat-button': data.input?.book === book }"
             (click)="onClickBook(book)"
           >
             {{ i18n.localizeBook(book) }}
           </button>
-        </mdc-dialog-content>
-      </mdc-dialog-surface>
-
-      <mdc-dialog-surface id="chapterPane" *ngIf="showing === 'chapters'">
-        <mdc-dialog-title>
-          <button mdcIconButton class="backout-button" (click)="onClickBackoutButton()">
-            <mdc-icon>navigate_before</mdc-icon>
-          </button>
-          <span>{{ t("choose_chapter") }}</span>
-        </mdc-dialog-title>
-        <mdc-dialog-content>
-          <div class="reference">{{ getBookName(selection?.book) }}</div>
-          <button
-            *ngFor="let chapter of chaptersOf(selection?.book)"
-            mdc-button
-            [unelevated]="data.input?.book === selection?.book && getNumOrNaN(data.input?.chapterNum) === +chapter"
-            (click)="onClickChapter(chapter)"
-          >
-            {{ chapter }}
-          </button>
-        </mdc-dialog-content>
-      </mdc-dialog-surface>
-
-      <mdc-dialog-surface id="versePane" *ngIf="showing === 'verses'">
-        <mdc-dialog-title>
-          <button mdcIconButton class="backout-button" (click)="onClickBackoutButton()">
-            <mdc-icon>navigate_before</mdc-icon>
-          </button>
-          <span>{{ t("choose_verse") }}</span>
-        </mdc-dialog-title>
-        <mdc-dialog-content>
-          <div class="reference">{{ getBookName(selection?.book) }} {{ selection.chapter }}</div>
-          <button
-            *ngFor="let verse of versesOf(selection?.book, selection?.chapter)"
-            mdc-button
-            [unelevated]="
+        </div>
+        <button
+          *ngFor="let book of ntBooks"
+          mat-button
+          [ngClass]="{ 'mat-flat-button': data.input?.book === book }"
+          (click)="onClickBook(book)"
+        >
+          {{ i18n.localizeBook(book) }}
+        </button>
+      </div>
+    </div>
+    <div id="chapterPane" *ngIf="showing === 'chapters'">
+      <h1 mat-dialog-title>
+        <button mat-icon-button class="backout-button" (click)="onClickBackoutButton()">
+          <mat-icon>navigate_before</mat-icon>
+        </button>
+        <span>{{ t("choose_chapter") }}</span>
+      </h1>
+      <div mat-dialog-content>
+        <div class="reference">{{ getBookName(selection?.book) }}</div>
+        <button
+          *ngFor="let chapter of chaptersOf(selection?.book)"
+          mat-button
+          [ngClass]="{
+            'mat-flat-button': data.input?.book === selection?.book && getNumOrNaN(data.input?.chapterNum) === +chapter
+          }"
+          (click)="onClickChapter(chapter)"
+        >
+          {{ chapter }}
+        </button>
+      </div>
+    </div>
+    <div id="versePane" *ngIf="showing === 'verses'">
+      <h1 mat-dialog-title>
+        <button mat-icon-button class="backout-button" (click)="onClickBackoutButton()">
+          <mat-icon>navigate_before</mat-icon>
+        </button>
+        <span>{{ t("choose_verse") }}</span>
+      </h1>
+      <div mat-dialog-content>
+        <div class="reference">{{ getBookName(selection?.book) }} {{ selection.chapter }}</div>
+        <button
+          *ngFor="let verse of versesOf(selection?.book, selection?.chapter)"
+          mat-button
+          [ngClass]="{
+            'mat-flat-button':
               data.input?.book === selection?.book &&
               data.input?.chapter === selection?.chapter &&
               getNumOrNaN(data.input?.verseNum) === +verse
-            "
-            (click)="onClickVerse(verse)"
-          >
-            {{ verse }}
-          </button>
-        </mdc-dialog-content>
-      </mdc-dialog-surface>
-
-      <mdc-dialog-surface id="rangeEndPane" *ngIf="showing === 'rangeEnd'">
-        <mdc-dialog-title>
-          <button mdcIconButton class="backout-button" (click)="onClickBackoutButton()" (focus)="onCloseFocus($event)">
-            <mdc-icon>close</mdc-icon>
-          </button>
-          <span>{{ t("choose_end_verse") }}</span>
-        </mdc-dialog-title>
-        <mdc-dialog-content>
-          <div class="reference">{{ getBookName(data.rangeStart?.book) }} {{ data.rangeStart?.chapter }}</div>
-          <button
-            *ngFor="let verse of versesOf(data.rangeStart?.book, data.rangeStart?.chapter, data.rangeStart?.verseNum)"
-            mdc-button
-            [unelevated]="
+          }"
+          (click)="onClickVerse(verse)"
+        >
+          {{ verse }}
+        </button>
+      </div>
+    </div>
+    <div id="rangeEndPane" *ngIf="showing === 'rangeEnd'">
+      <div mat-dialog-title>
+        <button mat-icon-button class="backout-button" (click)="onClickBackoutButton()" (focus)="onCloseFocus($event)">
+          <mat-icon>close</mat-icon>
+        </button>
+        <span>{{ t("choose_end_verse") }}</span>
+      </div>
+      <div mat-dialog-content>
+        <div class="reference">{{ getBookName(data.rangeStart?.book) }} {{ data.rangeStart?.chapter }}</div>
+        <button
+          *ngFor="let verse of versesOf(data.rangeStart?.book, data.rangeStart?.chapter, data.rangeStart?.verseNum)"
+          mat-button
+          [ngClass]="{
+            'mat-flat-button':
               data.input?.book === data.rangeStart?.book &&
               data.input?.chapter === data.rangeStart?.chapter &&
               getNumOrNaN(data.input?.verseNum) === +verse
-            "
-            (click)="onClickVerse(verse)"
-          >
-            {{ verse }}
-          </button>
-        </mdc-dialog-content>
-      </mdc-dialog-surface>
-    </mdc-dialog-container>
-  </mdc-dialog>
+          }"
+          (click)="onClickVerse(verse)"
+        >
+          {{ verse }}
+        </button>
+      </div>
+    </div>
+  </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'scripture_chooser_dialog'">
-  <div>
+  <div class="dialog-container">
     <div id="bookPane" *ngIf="showing === 'books'">
       <h1 mat-dialog-title>
         <button mat-icon-button class="backout-button" (click)="onClickBackoutButton()" (focus)="onCloseFocus($event)">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'scripture_chooser_dialog'">
-  <div class="dialogContainer">
+  <div>
     <div id="bookPane" *ngIf="showing === 'books'">
       <h1 mat-dialog-title>
         <button mat-icon-button class="backout-button" (click)="onClickBackoutButton()" (focus)="onCloseFocus($event)">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.scss
@@ -6,8 +6,9 @@
   padding-bottom: 1em;
 }
 
-.dialogContainer {
+.dialog-container {
   min-height: 400px;
+  max-width: 560px;
 }
 
 h1 > button,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.scss
@@ -10,7 +10,7 @@
   min-height: 400px;
 }
 
-mdc-dialog-title > button,
-mdc-dialog-title > span {
+h1 > button,
+h1 > span {
   vertical-align: middle;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.scss
@@ -7,7 +7,6 @@
 }
 
 .dialog-container {
-  min-height: 400px;
   max-width: 560px;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.spec.ts
@@ -1,4 +1,4 @@
-import { MdcDialog, MdcDialogConfig, MdcDialogModule, MdcDialogRef } from '@angular-mdc/web/dialog';
+import { MatDialog, MatDialogConfig, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -14,6 +14,7 @@ import { AuthService } from 'xforge-common/auth.service';
 import { BugsnagService } from 'xforge-common/bugsnag.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TextsByBookId } from '../core/models/texts-by-book-id';
 import { ScriptureChooserDialogComponent, ScriptureChooserDialogData } from './scripture-chooser-dialog.component';
 
@@ -30,7 +31,11 @@ describe('ScriptureChooserDialog', () => {
   }));
 
   let env: TestEnvironment;
-  afterEach(() => env.dialogRef.close());
+  afterEach(fakeAsync(() => {
+    while (env.backoutButton != null) {
+      env.click(env.backoutButton);
+    }
+  }));
 
   it('initially shows book chooser, close button', () => {
     env = new TestEnvironment();
@@ -431,8 +436,9 @@ describe('ScriptureChooserDialog', () => {
       HttpClientTestingModule,
       RouterTestingModule,
       UICommonModule,
-      MdcDialogModule,
-      TestTranslocoModule
+      MatDialogModule,
+      TestTranslocoModule,
+      NoopAnimationsModule
     ],
     declarations: [ViewContainerDirective, ChildViewContainerComponent, ScriptureChooserDialogComponent],
     exports: [ViewContainerDirective, ChildViewContainerComponent, ScriptureChooserDialogComponent]
@@ -442,7 +448,7 @@ describe('ScriptureChooserDialog', () => {
   class TestEnvironment {
     fixture: ComponentFixture<ChildViewContainerComponent>;
     component: ScriptureChooserDialogComponent;
-    dialogRef: MdcDialogRef<ScriptureChooserDialogComponent>;
+    dialogRef: MatDialogRef<ScriptureChooserDialogComponent>;
     dialogResult?: 'close' | VerseRef;
     closeIconName = 'close';
     backIconName = 'navigate_before';
@@ -501,12 +507,11 @@ describe('ScriptureChooserDialog', () => {
       const booksAndChaptersToShow: TextsByBookId = {};
       textsInProject.forEach(text => (booksAndChaptersToShow[Canon.bookNumberToId(text.bookNum)] = text));
 
-      const config: MdcDialogConfig<ScriptureChooserDialogData> = {
-        scrollable: true,
+      const config: MatDialogConfig<ScriptureChooserDialogData> = {
         viewContainerRef: viewContainerRef,
         data: { input: inputScriptureReference, booksAndChaptersToShow: booksAndChaptersToShow, rangeStart: rangeStart }
       };
-      this.dialogRef = TestBed.inject(MdcDialog).open(ScriptureChooserDialogComponent, config);
+      this.dialogRef = TestBed.inject(MatDialog).open(ScriptureChooserDialogComponent, config);
       this.dialogRef.afterClosed().subscribe(result => (this.dialogResult = result));
       this.component = this.dialogRef.componentInstance;
 
@@ -554,7 +559,7 @@ describe('ScriptureChooserDialog', () => {
     }
 
     get highlightedButton(): DebugElement {
-      return this.fixture.debugElement.query(By.css('.mdc-button--unelevated'));
+      return this.fixture.debugElement.query(By.css('.mat-flat-button'));
     }
 
     click(element: DebugElement): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.spec.ts
@@ -104,16 +104,19 @@ describe('ScriptureChooserDialog', () => {
 
   it('book not highlighted, if no (undefined) incoming reference', fakeAsync(() => {
     env = new TestEnvironment({ inputScriptureReference: undefined });
+    flush();
     expect(env.highlightedButton).toBeNull();
   }));
 
   it('book not highlighted, if no (omitted) incoming reference', fakeAsync(() => {
     env = new TestEnvironment();
+    flush();
     expect(env.highlightedButton).toBeNull();
   }));
 
   it('book highlighted', fakeAsync(() => {
     env = new TestEnvironment({ inputScriptureReference: new VerseRef('ROM', '11', '33') });
+    flush();
     env.fixture.detectChanges();
     expect(env.highlightedButton).not.toBeNull();
   }));
@@ -166,6 +169,7 @@ describe('ScriptureChooserDialog', () => {
 
   it('input is received', fakeAsync(() => {
     env = new TestEnvironment({ inputScriptureReference: new VerseRef('EPH', '3', '21') });
+    flush();
     expect(env.component.data.input!.book).toEqual('EPH');
     expect(env.component.data.input!.chapter).toEqual('3');
     expect(env.component.data.input!.verse).toEqual('21');
@@ -173,6 +177,7 @@ describe('ScriptureChooserDialog', () => {
 
   it('only shows books that we seed (from project)', fakeAsync(() => {
     env = new TestEnvironment();
+    flush();
     expect(env.dialogText).toContain('Exodus');
     expect(env.dialogText).toContain('Matthew');
     expect(env.dialogText).not.toContain('Genesis');
@@ -303,6 +308,7 @@ describe('ScriptureChooserDialog', () => {
       // rangeStart is for book that is not in texts
       rangeStart: new VerseRef('RUT', '3', '15')
     });
+    flush();
 
     // Is not 'rangeEnd'
     expect(env.component.showing).toEqual('books');
@@ -347,6 +353,7 @@ describe('ScriptureChooserDialog', () => {
       // rangeStart is for chapter that is not in texts
       rangeStart: new VerseRef('ROM', '4', '15')
     });
+    flush();
 
     // Is not 'rangeEnd'
     expect(env.component.showing).toEqual('books');
@@ -391,6 +398,7 @@ describe('ScriptureChooserDialog', () => {
       // rangeStart is for invalid verse
       rangeStart: new VerseRef('ROM', '3', '99')
     });
+    flush();
 
     // Is not 'rangeEnd'
     expect(env.component.showing).toEqual('books');
@@ -564,6 +572,8 @@ describe('ScriptureChooserDialog', () => {
 
     click(element: DebugElement): void {
       element!.nativeElement.click();
+      this.fixture.detectChanges();
+      flush();
       this.fixture.detectChanges();
       flush();
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.spec.ts
@@ -574,8 +574,6 @@ describe('ScriptureChooserDialog', () => {
       element!.nativeElement.click();
       this.fixture.detectChanges();
       flush();
-      this.fixture.detectChanges();
-      flush();
     }
 
     buttonWithText(text: string): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.ts
@@ -1,5 +1,5 @@
-import { MdcDialogRef, MDC_DIALOG_DATA } from '@angular-mdc/web/dialog';
 import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Canon } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/canon';
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
 import { I18nService } from 'xforge-common/i18n.service';
@@ -43,9 +43,9 @@ export class ScriptureChooserDialogComponent implements OnInit {
   selection: { book?: string; chapter?: string; verse?: string } = {};
 
   constructor(
-    public dialogRef: MdcDialogRef<ScriptureChooserDialogComponent>,
+    public dialogRef: MatDialogRef<ScriptureChooserDialogComponent>,
     readonly i18n: I18nService,
-    @Inject(MDC_DIALOG_DATA) public data: ScriptureChooserDialogData
+    @Inject(MAT_DIALOG_DATA) public data: ScriptureChooserDialogData
   ) {}
 
   get hasOTBooks() {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sfvalidators.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sfvalidators.ts
@@ -113,15 +113,12 @@ export class ParentAndStartErrorStateMatcher implements ErrorStateMatcher {
     }
 
     const invalidCtrl = control.invalid && control.parent.dirty;
-    const invalidStart =
-      !control.parent.controls['scriptureStart'].hasError('verseFormat') &&
-      !control.parent.controls['scriptureStart'].hasError('verseRange') &&
-      (control.parent.controls['scriptureStart'].invalid ||
-        control.parent.hasError('verseDifferentBookOrChapter') ||
-        control.parent.hasError('verseBeforeStart'));
+    const invalidParent =
+      control.parent.controls['scriptureStart'].valid &&
+      (control.parent.hasError('verseDifferentBookOrChapter') || control.parent.hasError('verseBeforeStart'));
     return (
       (control.touched && invalidCtrl) ||
-      ((control.touched || control.parent.controls['scriptureStart'].touched) && invalidStart)
+      ((control.touched || control.parent.controls['scriptureStart'].touched) && invalidParent)
     );
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.html
@@ -1,33 +1,29 @@
 <ng-container *transloco="let t; read: 'text_chooser_dialog'">
-  <mdc-dialog>
-    <mdc-dialog-container>
-      <mdc-dialog-surface>
-        <mdc-dialog-title>{{ t("select_scripture") }}</mdc-dialog-title>
-        <mdc-dialog-content>
-          <div class="select-chapter" (click)="openScriptureChooser()">
-            <mdc-icon>library_books</mdc-icon>
-            <h2>{{ bookName }} {{ chapterNum }}</h2>
-            <mdc-icon>keyboard_arrow_down</mdc-icon>
-          </div>
-          <app-text
-            #scriptureText
-            [id]="textDocId"
-            [multiSegmentSelection]="true"
-            [isRightToLeft]="isTextRightToLeft"
-          ></app-text>
-          <p class="selection-preview">
-            {{ (startClipped ? "…" : "") + (selectedText || "") + (endClipped ? "…" : "") }}
-            <span class="selection-reference">{{ referenceForDisplay }}</span>
-          </p>
-          <span class="error-message" *ngIf="showError">{{ t("select_text_error_message") }}</span>
-        </mdc-dialog-content>
-        <mdc-dialog-actions>
-          <button mdcDialogButton mdcDialogAction="close" type="button">{{ t("cancel") }}</button>
-          <button mdcDialogButton type="submit" [unelevated]="true" [default]="true" (click)="submit()">
-            {{ t("save") }}
-          </button>
-        </mdc-dialog-actions>
-      </mdc-dialog-surface>
-    </mdc-dialog-container>
-  </mdc-dialog>
+  <div class="dialog-container">
+    <h1 mat-dialog-title>{{ t("select_scripture") }}</h1>
+    <mat-dialog-content>
+      <div class="select-chapter" (click)="openScriptureChooser()">
+        <mat-icon>library_books</mat-icon>
+        <h2>{{ bookName }} {{ chapterNum }}</h2>
+        <mat-icon>keyboard_arrow_down</mat-icon>
+      </div>
+      <app-text
+        #scriptureText
+        [id]="textDocId"
+        [multiSegmentSelection]="true"
+        [isRightToLeft]="isTextRightToLeft"
+      ></app-text>
+      <p class="selection-preview">
+        {{ (startClipped ? "…" : "") + (selectedText || "") + (endClipped ? "…" : "") }}
+        <span class="selection-reference">{{ referenceForDisplay }}</span>
+      </p>
+      <span class="error-message" *ngIf="showError">{{ t("select_text_error_message") }}</span>
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button type="button" id="cancel-button" [mat-dialog-close]="'close'">{{ t("cancel") }}</button>
+      <button mat-flat-button type="submit" cdkFocusInitial (click)="submit()">
+        {{ t("save") }}
+      </button>
+    </mat-dialog-actions>
+  </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.html
@@ -13,10 +13,12 @@
         [multiSegmentSelection]="true"
         [isRightToLeft]="isTextRightToLeft"
       ></app-text>
-      <p class="selection-preview">
-        {{ (startClipped ? "…" : "") + (selectedText || "") + (endClipped ? "…" : "") }}
-        <span class="selection-reference">{{ referenceForDisplay }}</span>
-      </p>
+      <div class="selection-preview">
+        <p>
+          {{ (startClipped ? "…" : "") + (selectedText || "") + (endClipped ? "…" : "") }}
+          <span class="selection-reference">{{ referenceForDisplay }}</span>
+        </p>
+      </div>
       <span class="error-message" *ngIf="showError">{{ t("select_text_error_message") }}</span>
     </mat-dialog-content>
     <mat-dialog-actions align="end">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.html
@@ -21,7 +21,7 @@
     </mat-dialog-content>
     <mat-dialog-actions align="end">
       <button mat-button type="button" id="cancel-button" [mat-dialog-close]="'close'">{{ t("cancel") }}</button>
-      <button mat-flat-button type="submit" cdkFocusInitial (click)="submit()">
+      <button mat-flat-button color="primary" type="submit" cdkFocusInitial (click)="submit()">
         {{ t("save") }}
       </button>
     </mat-dialog-actions>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.scss
@@ -32,8 +32,12 @@ app-text {
 }
 
 .selection-preview {
-  height: 6em;
+  height: 16em;
   overflow-y: scroll;
+  margin-top: 1em;
+  > p {
+    margin-bottom: 0;
+  }
 }
 
 .error-message {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.scss
@@ -1,3 +1,8 @@
+.mat-dialog-content {
+  display: flex;
+  flex-direction: column;
+}
+
 .select-chapter {
   cursor: pointer;
   display: inline-flex;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.scss
@@ -3,6 +3,10 @@
   flex-direction: column;
 }
 
+.dialog-container {
+  max-width: 560px;
+}
+
 .select-chapter {
   cursor: pointer;
   display: inline-flex;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
@@ -1,10 +1,11 @@
-import { MdcDialog, MdcDialogConfig, MdcDialogRef, MDC_DIALOG_DATA } from '@angular-mdc/web';
 import { Component, ElementRef, Inject, Optional, ViewChild } from '@angular/core';
+import { MatDialogConfig, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { toVerseRef, VerseRefData } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
 import { fromEvent } from 'rxjs';
 import { auditTime } from 'rxjs/operators';
 import { DOCUMENT } from 'xforge-common/browser-globals';
+import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { TextDocId } from '../core/models/text-doc';
@@ -53,11 +54,11 @@ export class TextChooserDialogComponent extends SubscriptionDisposable {
   private readonly verseSegmentSelector = 'usx-segment[data-segment^=verse_]';
 
   constructor(
-    private readonly dialogRef: MdcDialogRef<TextChooserDialogComponent>,
-    readonly dialog: MdcDialog,
+    private readonly dialogRef: MatDialogRef<TextChooserDialogComponent>,
+    readonly dialogService: DialogService,
     private readonly i18n: I18nService,
     @Inject(DOCUMENT) private readonly document: Document,
-    @Optional() @Inject(MDC_DIALOG_DATA) private readonly data: TextChooserDialogData
+    @Optional() @Inject(MAT_DIALOG_DATA) private readonly data: TextChooserDialogData
   ) {
     super();
     // caniuse doesn't have complete data for the selection events api, but testing on BrowserStack shows the event is
@@ -116,11 +117,11 @@ export class TextChooserDialogComponent extends SubscriptionDisposable {
   }
 
   openScriptureChooser() {
-    const dialogConfig: MdcDialogConfig<ScriptureChooserDialogData> = {
+    const dialogConfig: MatDialogConfig<ScriptureChooserDialogData> = {
       data: { booksAndChaptersToShow: this.data.textsByBookId, includeVerseSelection: false }
     };
 
-    const dialogRef = this.dialog.open(ScriptureChooserDialogComponent, dialogConfig) as MdcDialogRef<
+    const dialogRef = this.dialogService.openMatDialog(ScriptureChooserDialogComponent, dialogConfig) as MatDialogRef<
       ScriptureChooserDialogComponent,
       VerseRef | 'close'
     >;

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -1,4 +1,5 @@
-@use '@angular/material' as mat;
+@use '~@angular/material' as mat;
+@use 'variables';
 @import 'variables';
 
 @include mat.core();
@@ -83,7 +84,9 @@ $material-app-theme: mat.define-light-theme(
   border: 1px solid #e0e0e0;
 }
 
-.mat-flat-button {
-  color: #fff;
-  background-color: #343a31;
+button.mat-icon-button {
+  transition: color 0.15s;
+  &:hover {
+    color: variables.$greenLight !important;
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -83,10 +83,6 @@ $material-app-theme: mat.define-light-theme(
   border: 1px solid #e0e0e0;
 }
 
-.mat-dialog-content {
-  max-width: 560px;
-}
-
 .mat-flat-button {
   color: #fff;
   background-color: #343a31;

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -82,3 +82,8 @@ $material-app-theme: mat.define-light-theme(
   @include mat.elevation(0);
   border: 1px solid #e0e0e0;
 }
+
+.mat-flat-button {
+  color: #fff;
+  background-color: #343a31;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -83,6 +83,10 @@ $material-app-theme: mat.define-light-theme(
   border: 1px solid #e0e0e0;
 }
 
+.mat-dialog-content {
+  max-width: 560px;
+}
+
 .mat-flat-button {
   color: #fff;
   background-color: #343a31;

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -1,4 +1,4 @@
-@use '~@angular/material' as mat;
+@use '@angular/material' as mat;
 @use 'variables';
 @import 'variables';
 


### PR DESCRIPTION
* convert templates to use angular material
* use dialog service to launch dialogs with scripture views
* add mat flat button styling

Before

![image](https://user-images.githubusercontent.com/17931130/184734183-aa4a7a2b-e68f-4f87-86b5-0d1cc28d04ee.png)

![Text-chooser-before](https://user-images.githubusercontent.com/17931130/185214116-c94592f6-ab4e-4247-a9f5-195800e64109.png)

After

![Question Dialog Material](https://user-images.githubusercontent.com/17931130/184734066-76809408-4d80-450a-9238-7ed3958fd73e.png)

![Text-chooser-after](https://user-images.githubusercontent.com/17931130/185214135-5fda134e-5cf5-4d0e-81ac-f72877664143.png)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1469)
<!-- Reviewable:end -->
