### PR TITLE
SF-1681 Fix padding in community checking RTL UI

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
@@ -14,7 +14,7 @@
 }
 
 .answer-question {
-  padding-left: 15px;
+  padding-inline-start: 15px;
   position: relative;
   &:before {
     position: absolute;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -99,7 +99,9 @@
     }
     #answer-panel {
       height: 100%;
-      padding: 12px 0 12px 15px;
+      padding-top: 12px;
+      padding-bottom: 12px;
+      padding-inline-start: 15px;
       @include media-breakpoint-down(sm) {
         padding-left: 0;
         padding-right: 0;


### PR DESCRIPTION
Note the lack of leading padding in the **Before** screenshot for RTL.

(These screenshots are now outdated. @marksvc pointed out that the padding was not the same in RTL and then I fixed it)

&nbsp; | LTR | RTL
----------|-------|------
Before | ![](https://user-images.githubusercontent.com/6140710/184756731-234ead66-80a7-472f-816e-dcba92137957.png) | ![](https://user-images.githubusercontent.com/6140710/184756752-c0fed527-ca9f-4258-b406-d31af4c2ee3e.png)
After | ![](https://user-images.githubusercontent.com/6140710/184756789-5dfe826e-5cf3-4f29-94d7-64e47723c564.png) | ![](https://user-images.githubusercontent.com/6140710/184756801-5d89fd2b-a3b4-4dcd-bcd8-430f74ea9ef0.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1473)
<!-- Reviewable:end -->
