### PR TITLE
SF-1695 Fix footnote dialog when project or UI is RTL

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.spec.ts
@@ -5,6 +5,7 @@ import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils
 import * as RichText from 'rich-text';
 import { BehaviorSubject } from 'rxjs';
 import { anything, mock, when } from 'ts-mockito';
+import { DialogService } from 'xforge-common/dialog.service';
 import { PwaService } from 'xforge-common/pwa.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
@@ -22,6 +23,7 @@ import { CheckingTextComponent } from './checking-text.component';
 const mockedPwaService = mock(PwaService);
 const mockedSFProjectService = mock(SFProjectService);
 const mockedUserService = mock(UserService);
+const mockedDialogService = mock(DialogService);
 
 describe('CheckingTextComponent', () => {
   configureTestingModule(() => ({
@@ -36,7 +38,8 @@ describe('CheckingTextComponent', () => {
     providers: [
       { provide: PwaService, useMock: mockedPwaService },
       { provide: SFProjectService, useMock: mockedSFProjectService },
-      { provide: UserService, useMock: mockedUserService }
+      { provide: UserService, useMock: mockedUserService },
+      { provide: DialogService, useMock: mockedDialogService }
     ]
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.html
@@ -2,6 +2,6 @@
   <span>{{ type }}</span>
   <button mat-icon-button mat-dialog-close><mat-icon>close</mat-icon></button>
 </h1>
-<mat-dialog-content class="content-padding" [ngClass]="{ rtl: isRtl, ltr: !isRtl }">
+<mat-dialog-content class="content-padding" [dir]="direction">
   {{ text }}
 </mat-dialog-content>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.ts
@@ -24,8 +24,8 @@ export class TextNoteDialogComponent {
     private readonly translocoService: TranslocoService
   ) {}
 
-  get isRtl(): boolean {
-    return this.data.isRightToLeft;
+  get direction(): 'ltr' | 'rtl' {
+    return this.data.isRightToLeft ? 'rtl' : 'ltr';
   }
 
   get text(): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -23,7 +23,7 @@ import { UICommonModule } from 'xforge-common/ui-common.module';
 import { MockConsole } from 'xforge-common/mock-console';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { UserService } from 'xforge-common/user.service';
-import { MatDialog } from '@angular/material/dialog';
+import { DialogService } from 'xforge-common/dialog.service';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SF_TYPE_REGISTRY } from '../../core/models/sf-type-registry';
 import { Delta, TextDoc, TextDocId } from '../../core/models/text-doc';
@@ -47,7 +47,7 @@ const mockedProjectService = mock(SFProjectService);
 const mockedTranslocoService = mock(TranslocoService);
 const mockedUserService = mock(UserService);
 const mockedConsole: MockConsole = MockConsole.install();
-const mockedMatDialog = mock(MatDialog);
+const mockedDialogService = mock(DialogService);
 
 describe('TextComponent', () => {
   configureTestingModule(() => ({
@@ -66,7 +66,7 @@ describe('TextComponent', () => {
       { provide: PwaService, useMock: mockedPwaService },
       { provide: TranslocoService, useMock: mockedTranslocoService },
       { provide: UserService, useMock: mockedUserService },
-      { provide: MatDialog, useMock: mockedMatDialog }
+      { provide: DialogService, useMock: mockedDialogService }
     ]
   }));
   beforeEach(() => {
@@ -2879,7 +2879,7 @@ describe('TextComponent', () => {
       expect(note).withContext(noteStyle).not.toBeNull();
       note!.click();
     });
-    verify(mockedMatDialog.open(TextNoteDialogComponent, anything())).thrice();
+    verify(mockedDialogService.openMatDialog(TextNoteDialogComponent, anything())).thrice();
   }));
 });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -25,7 +25,7 @@ import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { UserService } from 'xforge-common/user.service';
 import { getBrowserEngine } from 'xforge-common/utils';
-import { MatDialog } from '@angular/material/dialog';
+import { DialogService } from 'xforge-common/dialog.service';
 import { Delta, TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { NoteThreadIcon } from '../../core/models/note-thread-doc';
@@ -213,7 +213,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
 
   constructor(
     private readonly changeDetector: ChangeDetectorRef,
-    private readonly dialog: MatDialog,
+    private readonly dialogService: DialogService,
     private readonly projectService: SFProjectService,
     private readonly pwaService: PwaService,
     private readonly transloco: TranslocoService,
@@ -760,7 +760,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
           this.subscribe(fromEvent<MouseEvent>(element, 'click'), event => {
             const noteText = attributeFromMouseEvent(event, 'USX-NOTE', 'title');
             const noteType = attributeFromMouseEvent(event, 'USX-NOTE', 'data-style');
-            this.dialog.open(TextNoteDialogComponent, {
+            this.dialogService.openMatDialog(TextNoteDialogComponent, {
               autoFocus: false,
               width: '600px',
               data: {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/translate-metrics-session.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/translate-metrics-session.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { MatDialog } from '@angular/material/dialog';
 import { LatinWordTokenizer } from '@sillsdev/machine';
 import { QuillModule } from 'ngx-quill';
 import * as RichText from 'rich-text';
@@ -12,6 +11,7 @@ import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { UserService } from 'xforge-common/user.service';
+import { DialogService } from 'xforge-common/dialog.service';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SF_TYPE_REGISTRY } from '../../core/models/sf-type-registry';
 import { TextDoc, TextDocId } from '../../core/models/text-doc';
@@ -29,7 +29,7 @@ import {
 const mockedPwaService = mock(PwaService);
 const mockedSFProjectService = mock(SFProjectService);
 const mockedUserService = mock(UserService);
-const mockedMatDialog = mock(MatDialog);
+const mockedDialogService = mock(DialogService);
 
 describe('TranslateMetricsSession', () => {
   configureTestingModule(() => ({
@@ -39,7 +39,7 @@ describe('TranslateMetricsSession', () => {
       { provide: PwaService, useMock: mockedPwaService },
       { provide: SFProjectService, useMock: mockedSFProjectService },
       { provide: UserService, useMock: mockedUserService },
-      { provide: MatDialog, useMock: mockedMatDialog }
+      { provide: DialogService, useMock: mockedDialogService }
     ]
   }));
 


### PR DESCRIPTION
- The overall dialog should have the direction of the UI
- The text of the note should have the direction of the project text
- In order to properly test this, you have to make sure it's working correctly when switching languages _without reloading the page_.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1479)
<!-- Reviewable:end -->
