### PR TITLE
SF-1700 Save inflight op to position 0 in IndexedDB

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
@@ -139,7 +139,7 @@ export class SharedbRealtimeDocAdapter implements RealtimeDocAdapter {
       pendingOps = this.doc.pendingOps.slice();
 
       if (this.doc.inflightOp != null && this.doc.inflightOp.op != null) {
-        pendingOps.push(this.doc.inflightOp);
+        pendingOps.unshift(this.doc.inflightOp);
       }
     }
     return pendingOps;


### PR DESCRIPTION
To clarify the issue here:
- ShareDB has the concept of pending ops, which are ops that have not been sent to the server yet. A doc on the client has pending ops.
- A doc also can have an inflight op, which is an op that has been taken from position 0 of the pending ops array, and sent to the server, but no acknowledgement has been received from the server yet (so it's unknown whether it's been persisted on the server).
- If the connection is lost, ShareDB takes the inflight op and puts it back in pending ops at position 0, so it can be sent again later when the connection is restored.
- In order to make the data persist, we store the pending ops, and the inflight op, in IndexedDB. We combine them into a single array, so the inflight op (if it exists) is stored with the pending ops.

The problem in this case is that the inflight op was getting put at the end of the array, rather than the beginning. It's not clear what all problems this would cause, but it would cause ops to be submitted out of order, so it would not produce the desired behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1480)
<!-- Reviewable:end -->
