### PR TITLE
SF-1663 Consolidate how note threads are embedded

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1618,6 +1618,31 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('should re-embed deleted note and allow user to open note dialog', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.wait();
+
+      const position: number = env.getNoteThreadEditorPosition('thread03');
+      const length = 9;
+      // $target: chapter 1, |->$$verse 3<-|.
+      env.targetEditor.setSelection(position, length, 'api');
+      env.deleteCharacters();
+      const range: RangeStatic = env.component.target!.getSegmentRange('verse_1_3')!;
+      expect(env.getNoteThreadEditorPosition('thread02')).toEqual(range.index);
+      expect(env.getNoteThreadEditorPosition('thread03')).toEqual(range.index + 1);
+      expect(env.getNoteThreadEditorPosition('thread04')).toEqual(range.index + 2);
+
+      for (let i = 0; i <= 2; i++) {
+        const noteThreadId: number = i + 2;
+        const note: HTMLElement = env.getNoteThreadIconElement('verse_1_3', `thread0${noteThreadId}`)!;
+        note.click();
+        env.wait();
+        verify(mockedMatDialog.open(NoteDialogComponent, anything())).times(i + 1);
+      }
+      env.dispose();
+    }));
+
     it('handles deleting parts of two notes text anchors', fakeAsync(() => {
       const env = new TestEnvironment();
       env.addParatextNoteThread(6, 'MAT 1:1', 'verse', { start: 19, length: 5 }, ['user01']);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -735,37 +735,32 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   /** Insert or remove note thread embeds into the quill editor. */
-  private toggleNoteThreadVerses(value: boolean): void {
+  private toggleNoteThreadVerses(toggleOn: boolean): void {
     if (this.target?.editor == null || this.noteThreadQuery == null || this.bookNum == null || this._chapter == null) {
       return;
     }
+    if (!toggleOn) {
+      this.removeEmbeddedElements();
+      return;
+    }
+
     const chapterNoteThreadDocs: NoteThreadDoc[] = this.currentChapterNoteThreadDocs();
-    const featureVerseRefInfo: FeaturedVerseRefInfo[] = [];
+    const noteThreadVerseRefs: Set<VerseRef> = new Set<VerseRef>();
     for (const noteThreadDoc of chapterNoteThreadDocs) {
       const featured: FeaturedVerseRefInfo | undefined = this.getFeaturedVerseRefInfo(noteThreadDoc);
-      if (featured != null) {
-        featureVerseRefInfo.push(featured);
+      if (featured != null && !this.target.embeddedElements.has(featured.id)) {
+        this.embedNoteThread(featured);
+        noteThreadVerseRefs.add(featured.verseRef);
       }
     }
 
-    const noteThreadVerseRefs: Set<VerseRef> = new Set<VerseRef>();
-    if (value) {
-      for (const featured of featureVerseRefInfo) {
-        if (!this.target.embeddedElements.has(featured.id)) {
-          this.embedNoteThread(featured);
-          noteThreadVerseRefs.add(featured.verseRef);
-        }
-      }
-      // add the formatting to mark featured verses after notes are embedded
-      const segments: string[] = this.target.toggleFeaturedVerseRefs(
-        value,
-        Array.from(noteThreadVerseRefs.values()),
-        'note-thread'
-      );
-      this.subscribeClickEvents(segments);
-    } else {
-      this.removeEmbeddedElements();
-    }
+    // add the formatting to mark featured verses after notes are embedded
+    const segments: string[] = this.target.toggleFeaturedVerseRefs(
+      toggleOn,
+      Array.from(noteThreadVerseRefs.values()),
+      'note-thread'
+    );
+    this.subscribeClickEvents(segments);
   }
 
   private showNoteThread(threadId: string): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -586,10 +586,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       this.syncScroll();
     }
 
-    if (delta != null) {
+    if (delta != null && this.shouldNoteThreadsRespondToEdits) {
       // wait 20 ms so that note thread docs have time to receive the updated note positions
       setTimeout(() => {
-        this.recreateDeletedNoteThreadEmbeds();
+        this.toggleNoteThreadVerses(true);
         if (segment != null) {
           this.subscribeClickEvents([segment.ref]);
         }
@@ -734,6 +734,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
   }
 
+  /** Insert or remove note thread embeds into the quill editor. */
   private toggleNoteThreadVerses(value: boolean): void {
     if (this.target?.editor == null || this.noteThreadQuery == null || this.bookNum == null || this._chapter == null) {
       return;
@@ -746,14 +747,21 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         featureVerseRefInfo.push(featured);
       }
     }
-    const noteThreadVerseRefs: VerseRef[] = featureVerseRefInfo.map(f => f.verseRef);
 
+    const noteThreadVerseRefs: Set<VerseRef> = new Set<VerseRef>();
     if (value) {
       for (const featured of featureVerseRefInfo) {
-        this.embedNoteThread(featured);
+        if (!this.target.embeddedElements.has(featured.id)) {
+          this.embedNoteThread(featured);
+          noteThreadVerseRefs.add(featured.verseRef);
+        }
       }
       // add the formatting to mark featured verses after notes are embedded
-      const segments: string[] = this.target.toggleFeaturedVerseRefs(value, noteThreadVerseRefs, 'note-thread');
+      const segments: string[] = this.target.toggleFeaturedVerseRefs(
+        value,
+        Array.from(noteThreadVerseRefs.values()),
+        'note-thread'
+      );
       this.subscribeClickEvents(segments);
     } else {
       this.removeEmbeddedElements();
@@ -1420,31 +1428,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         nt.data.verseRef.chapterNum === this.chapter &&
         nt.data.notes.length > 0
     );
-  }
-
-  /** Re-create any note embeds that have been deleted by the user. */
-  private recreateDeletedNoteThreadEmbeds(): void {
-    if (this.target == null || !this.shouldNoteThreadsRespondToEdits) {
-      return;
-    }
-    const currentNotes: Readonly<Map<string, number>> = this.target.embeddedElements;
-    const segmentsToSubscribe: Set<string> = new Set<string>();
-    const noteThreadDocs: NoteThreadDoc[] = this.currentChapterNoteThreadDocs();
-    for (const noteThreadDoc of noteThreadDocs) {
-      if (noteThreadDoc?.data?.dataId == null || currentNotes.has(noteThreadDoc.data.dataId)) {
-        continue;
-      }
-
-      const featured: FeaturedVerseRefInfo | undefined = this.getFeaturedVerseRefInfo(noteThreadDoc);
-      if (featured == null) {
-        continue;
-      }
-      const segment: string | undefined = this.embedNoteThread(featured);
-      if (segment != null && !segmentsToSubscribe.has(segment)) {
-        segmentsToSubscribe.add(segment);
-      }
-    }
-    this.subscribeClickEvents(Array.from(segmentsToSubscribe.values()));
   }
 
   private embedNoteThread(featured: FeaturedVerseRefInfo): string | undefined {


### PR DESCRIPTION
* use the same function to toggle note threads
* do not re-embed notes if explicitly removed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1481)
<!-- Reviewable:end -->
