### PR TITLE
SF-1587 SF-1580 SF-1611 Multi-cursor fixes to presence logic

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.spec.ts
@@ -126,6 +126,13 @@ describe('CheckingTextComponent', () => {
     env.wait();
     expect(env.fixture.nativeElement.querySelector('quill-editor[class="read-only-editor rtl"]')).not.toBeNull();
   }));
+
+  it('should have local presence disabled', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.wait();
+
+    expect(env.component.textComponent.enablePresence).toBe(false);
+  }));
 });
 
 class TestEnvironment {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/text-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/text-doc.ts
@@ -1,4 +1,4 @@
-import Quill, { DeltaOperation, DeltaStatic } from 'quill';
+import Quill, { DeltaOperation, DeltaStatic, RangeStatic } from 'quill';
 import {
   getTextDocId,
   TextData,
@@ -7,7 +7,6 @@ import {
   TEXT_INDEX_PATHS
 } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
 import { RealtimeDoc } from 'xforge-common/models/realtime-doc';
-import { PresenceData } from '../../shared/text/text-view-model';
 
 export const Delta: new (ops?: DeltaOperation[] | { ops: DeltaOperation[] }) => DeltaStatic = Quill.import('delta');
 
@@ -32,7 +31,7 @@ export class TextDocId {
  * This is the real-time doc for a text doc. Texts contain the textual data for one particular Scripture book
  * and chapter.
  */
-export class TextDoc extends RealtimeDoc<TextData, TextData, PresenceData> {
+export class TextDoc extends RealtimeDoc<TextData, TextData, RangeStatic> {
   static readonly COLLECTION = TEXTS_COLLECTION;
   static readonly INDEX_PATHS = TEXT_INDEX_PATHS;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -91,7 +91,7 @@ export interface EditorRange {
 
 export interface PresenceData {
   viewer: MultiCursorViewer;
-  range: RangeStatic;
+  range: RangeStatic | null;
 }
 
 export interface RemotePresences {
@@ -235,7 +235,7 @@ export class TextViewModel {
 
     const cursors: QuillCursors = editor.getModule('cursors');
     this.onPresenceReceive = (presenceId: string, presenceData: PresenceData | null) => {
-      if (presenceData == null) {
+      if (presenceData == null || presenceData.range == null) {
         cursors.removeCursor(presenceId);
         this.presenceChange?.emit(this.presence?.remotePresences);
         return;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -174,7 +174,6 @@ export class TextViewModel {
     if (this.textDoc != null) {
       this.unbind();
     }
-    console.log('bind text-view-model', textDoc.id);
 
     this.textDoc = textDoc;
     editor.setContents(this.textDoc.data as DeltaStatic);
@@ -195,7 +194,6 @@ export class TextViewModel {
 
   /** Break the association of the editor with the currently associated textdoc. */
   unbind(): void {
-    console.log('UNBIND text-view-model', this.textDoc?.id);
     if (this.remoteChangesSub != null) {
       this.remoteChangesSub.unsubscribe();
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
@@ -8,7 +8,7 @@
   [modules]="modules"
   (onEditorCreated)="onEditorCreated($event)"
   (onContentChanged)="onContentChanged($event.delta, $event.source)"
-  (onSelectionChanged)="onSelectionChanged($event.range, $event.source)"
+  (onSelectionChanged)="onSelectionChanged($event.range)"
   [ngClass]="{
     'read-only-editor': readOnlyEnabled,
     'template-editor': !readOnlyEnabled,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -254,7 +254,7 @@ describe('TextComponent', () => {
       tick();
       env.fixture.detectChanges();
       const onSelectionChangedSpy = spyOn<any>(env.component, 'onSelectionChanged').and.callThrough();
-      const localPresenceSubmitSpy = spyOn<any>(env.component.localPresence, 'submit').and.callThrough();
+      const localPresenceSubmitSpy = spyOn<any>(env.component.localPresenceChannel, 'submit').and.callThrough();
 
       env.component.editor?.setSelection(1, 1, 'api');
 
@@ -271,7 +271,7 @@ describe('TextComponent', () => {
       tick();
       env.fixture.detectChanges();
       const onSelectionChangedSpy = spyOn<any>(env.component, 'onSelectionChanged').and.callThrough();
-      const localPresenceSubmitSpy = spyOn<any>(env.component.localPresence, 'submit').and.callThrough();
+      const localPresenceSubmitSpy = spyOn<any>(env.component.localPresenceChannel, 'submit').and.callThrough();
 
       env.component.editor?.setSelection(1, 1, 'user');
 
@@ -289,7 +289,7 @@ describe('TextComponent', () => {
       tick();
       env.fixture.detectChanges();
       const onSelectionChangedSpy = spyOn<any>(env.component, 'onSelectionChanged').and.callThrough();
-      const localPresenceSubmitSpy = spyOn<any>(env.component.localPresence, 'submit').and.callThrough();
+      const localPresenceSubmitSpy = spyOn<any>(env.component.localPresenceChannel, 'submit').and.callThrough();
 
       env.component.editor?.setSelection(1, 1, 'user');
 
@@ -307,7 +307,7 @@ describe('TextComponent', () => {
       tick();
       env.fixture.detectChanges();
       const onSelectionChangedSpy = spyOn<any>(env.component, 'onSelectionChanged').and.callThrough();
-      const localPresenceSubmitSpy = spyOn<any>(env.component.localPresence, 'submit').and.callThrough();
+      const localPresenceSubmitSpy = spyOn<any>(env.component.localPresenceChannel, 'submit').and.callThrough();
 
       env.component.editor?.setSelection(1, 1, 'user');
 
@@ -324,7 +324,7 @@ describe('TextComponent', () => {
       tick();
       env.fixture.detectChanges();
       const onSelectionChangedSpy = spyOn<any>(env.component, 'onSelectionChanged').and.callThrough();
-      const localPresenceSubmitSpy = spyOn<any>(env.component.localPresence, 'submit').and.callThrough();
+      const localPresenceSubmitSpy = spyOn<any>(env.component.localPresenceChannel, 'submit').and.callThrough();
 
       env.component.onSelectionChanged({ index: 0, length: 0 }, 'user');
 
@@ -364,7 +364,7 @@ describe('TextComponent', () => {
       tick();
       env.fixture.detectChanges();
       const onSelectionChangedSpy = spyOn<any>(env.component, 'onSelectionChanged').and.callThrough();
-      const localPresenceSubmitSpy = spyOn<any>(env.component.localPresence, 'submit');
+      const localPresenceSubmitSpy = spyOn<any>(env.component.localPresenceChannel, 'submit');
 
       // SUT
       env.component.onSelectionChanged(null as unknown as RangeStatic, 'user');
@@ -382,7 +382,7 @@ describe('TextComponent', () => {
       tick();
       env.fixture.detectChanges();
       const onSelectionChangedSpy = spyOn<any>(env.component, 'onSelectionChanged').and.callThrough();
-      const localPresenceSubmitSpy = spyOn<any>(env.component.localPresence, 'submit');
+      const localPresenceSubmitSpy = spyOn<any>(env.component.localPresenceChannel, 'submit');
 
       // SUT
       env.component.onSelectionChanged({ index: 0, length: 0 }, 'user');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -398,18 +398,12 @@ describe('TextComponent', () => {
 
       // After a text update the channel will emit that the user is active
       let presenceData: PresenceData = presenceChannelSubmit.calls.mostRecent().args[0] as PresenceData;
-      expect(presenceData).toBeDefined();
-      if (presenceData != null) {
-        expect(presenceData.viewer.activeInEditor).toBe(true);
-      }
+      expect(presenceData.viewer.activeInEditor).toBe(true);
 
       // After a set period of time the channel will emit that the user is no longer active
       TestEnvironment.waitForPresenceTimer();
       presenceData = presenceChannelSubmit.calls.mostRecent().args[0] as PresenceData;
-      expect(presenceData).toBeDefined();
-      if (presenceData != null) {
-        expect(presenceData.viewer.activeInEditor).toBe(false);
-      }
+      expect(presenceData.viewer.activeInEditor).toBe(false);
     }));
 
     it('should not emit doc presence when in read only mode', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -263,7 +263,6 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
 
   @Input() set isReadOnly(value: boolean) {
     this._isReadOnly = value;
-    this.submitLocalPresenceChannel(this._isReadOnly);
   }
 
   get areOpsCorrupted(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -649,7 +649,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     }
   }
 
-  async onSelectionChanged(range: RangeStatic): Promise<void> {
+  async onSelectionChanged(range: RangeStatic | null): Promise<void> {
     this.update();
 
     this.submitLocalPresenceDoc(range);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -17,21 +17,25 @@ import QuillCursors from 'quill-cursors';
 import { AuthType, getAuthType } from 'realtime-server/lib/esm/common/models/user';
 import { TextAnchor } from 'realtime-server/lib/esm/scriptureforge/models/text-anchor';
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
-import { fromEvent, Subscription } from 'rxjs';
-import { LocalPresence } from 'sharedb/lib/sharedb';
+import { fromEvent, Subject, Subscription, timer } from 'rxjs';
+import { LocalPresence, Presence } from 'sharedb/lib/sharedb';
 import { PwaService } from 'xforge-common/pwa.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { UserService } from 'xforge-common/user.service';
 import { getBrowserEngine } from 'xforge-common/utils';
 import { DialogService } from 'xforge-common/dialog.service';
-import { Delta, TextDocId } from '../../core/models/text-doc';
+import { objectId } from 'xforge-common/utils';
+import tinyColor from 'tinycolor2';
+import { takeUntil } from 'rxjs/operators';
+import { Delta, TextDoc, TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { NoteThreadIcon } from '../../core/models/note-thread-doc';
 import { attributeFromMouseEvent, VERSE_REGEX } from '../utils';
+import { MultiCursorViewer } from '../../translate/editor/multi-viewer/multi-viewer.component';
 import { registerScripture } from './quill-scripture';
 import { Segment } from './segment';
-import { EditorRange, PresenceData, RemotePresences, TextViewModel } from './text-view-model';
+import { EditorRange, TextViewModel } from './text-view-model';
 import { TextNoteDialogComponent, NoteDialogData } from './text-note-dialog/text-note-dialog.component';
 
 const EDITORS = new Set<Quill>();
@@ -80,6 +84,14 @@ export interface FeaturedVerseRefInfo {
   highlight?: boolean;
 }
 
+export interface PresenceData {
+  viewer: MultiCursorViewer;
+}
+
+export interface RemotePresences {
+  [id: string]: PresenceData;
+}
+
 /** A verse's range and the embeds located within the range. */
 export interface EmbedsByVerse {
   verseRange: RangeStatic;
@@ -102,10 +114,13 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   @Output() focused = new EventEmitter<boolean>(true);
   @Output() presenceChange = new EventEmitter<RemotePresences | undefined>(true);
   lang: string = '';
+  localPresenceChannel?: LocalPresence<PresenceData>;
+  localPresenceDoc?: LocalPresence<RangeStatic | null>;
   // only use USX formats and not default Quill formats
   readonly allowedFormats: string[] = USX_FORMATS;
   // allow for different CSS based on the browser engine
   readonly browserEngine: string = getBrowserEngine();
+  readonly cursorColor: string;
 
   private clickSubs: Map<string, Subscription[]> = new Map<string, Subscription[]>();
   private _isReadOnly: boolean = true;
@@ -203,7 +218,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   private _isRightToLeft: boolean = false;
   private _modules: any = this.DEFAULT_MODULES;
   private _editor?: Quill;
-  private viewModel = new TextViewModel(this.presenceChange);
+  private viewModel = new TextViewModel();
   private _segment?: Segment;
   private initialTextFetched: boolean = false;
   private initialSegmentRef?: string;
@@ -214,7 +229,15 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   private highlightMarkerTop: number = 0;
   private highlightMarkerHeight: number = 0;
   private _placeholder?: string;
+  private readonly cursorColorStorageKey = 'cursor_color';
   private displayMessage: string = '';
+  private readonly presenceId: string = objectId();
+  /** The ShareDB presence information for the TextDoc that the quill is bound to. */
+  private presenceDoc?: Presence<RangeStatic>;
+  private presenceChannel?: Presence<PresenceData>;
+  private presenceActiveEditor$: Subject<boolean> = new Subject<boolean>();
+  private onPresenceDocReceive = (_presenceId: string, _range: RangeStatic | null) => {};
+  private onPresenceChannelReceive = (_presenceId: string, _presenceData: PresenceData | null) => {};
 
   constructor(
     private readonly changeDetector: ChangeDetectorRef,
@@ -225,11 +248,18 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     private readonly userService: UserService
   ) {
     super();
+    let localCursorColor = localStorage.getItem(this.cursorColorStorageKey);
+    if (localCursorColor == null) {
+      // keep the cursor color from getting too close to white since the text is white
+      localCursorColor = tinyColor({ s: 0.7, l: 0.5, h: Math.random() * 360 }).toHexString();
+      localStorage.setItem(this.cursorColorStorageKey, localCursorColor);
+    }
+    this.cursorColor = localCursorColor;
   }
 
   @Input() set isReadOnly(value: boolean) {
     this._isReadOnly = value;
-    this.viewModel.enablePresenceReceive = this.isPresenceEnabled;
+    this.submitLocalPresenceChannel(this._isReadOnly);
   }
 
   get areOpsCorrupted(): boolean {
@@ -263,7 +293,6 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
         this.bindQuill();
       }
       this.setLangFromText();
-      this.submitLocalPresence(null);
     }
   }
 
@@ -369,10 +398,6 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     return this.viewModel.embeddedElements;
   }
 
-  get localPresence(): LocalPresence<PresenceData> | undefined {
-    return this.viewModel.localPresence;
-  }
-
   private get isPresenceEnabled(): boolean {
     return !this._isReadOnly && this.pwaService.isOnline;
   }
@@ -389,7 +414,6 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
         const cursors: QuillCursors = this._editor.getModule('cursors');
         cursors.clearCursors();
       }
-      this.viewModel.enablePresenceReceive = this.isPresenceEnabled;
     });
   }
 
@@ -401,6 +425,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     if (this._editor != null) {
       EDITORS.delete(this._editor);
     }
+    this.dismissPresences();
   }
 
   onEditorCreated(editor: Quill): void {
@@ -474,6 +499,59 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
 
   getSegmentElement(segment: string): Element | null {
     return this.editor == null ? null : this.editor.container.querySelector(`usx-segment[data-segment="${segment}"]`);
+  }
+
+  attachPresences(textDoc: TextDoc): void {
+    if (this.editor == null) {
+      console.log('could not attach yet - no editor');
+      return;
+    }
+    const cursors: QuillCursors = this.editor.getModule('cursors');
+
+    // Subscribe to TextDoc specific presence changes - these only include RangeStatic updates from ShareDB
+    this.presenceDoc = textDoc.docPresence;
+    this.presenceDoc.subscribe(error => {
+      if (error) throw error;
+    });
+    this.localPresenceDoc = this.presenceDoc.create(this.presenceId);
+
+    this.onPresenceDocReceive = (presenceId: string, range: RangeStatic | null) => {
+      console.log('onPresenceDocReceive', presenceId, range);
+      if (range == null) {
+        cursors.removeCursor(presenceId);
+        console.log('removeCursor', presenceId);
+        return;
+      }
+      console.log(this.presenceChannel?.remotePresences);
+      const viewer: MultiCursorViewer | undefined = this.getPresenceViewer(presenceId);
+      if (viewer == null) {
+        return;
+      }
+      cursors.createCursor(presenceId, viewer.displayName, viewer.cursorColor);
+      cursors.moveCursor(presenceId, range);
+      console.log('moved cursor', viewer.activeInEditor);
+    };
+    this.presenceDoc.on('receive', this.onPresenceDocReceive);
+    console.info('presenceDoc setup');
+
+    // Subscribe to a generic channel for the TextDoc to keep track of who is viewing the document
+    // This includes those who may not have focus on the Quill editor
+    this.presenceChannel = textDoc.channelPresence;
+    this.presenceChannel.subscribe(error => {
+      if (error) throw error;
+    });
+    this.localPresenceChannel = this.presenceChannel.create(this.presenceId);
+
+    this.onPresenceChannelReceive = (presenceId: string, presenceData: PresenceData | null) => {
+      console.log('onPresenceChannelReceive', presenceId, presenceData);
+      if (presenceData != null) {
+        cursors.toggleFlag(presenceId, presenceData.viewer.activeInEditor);
+      }
+      this.presenceChange?.emit(this.presenceChannel?.remotePresences);
+    };
+    this.presenceChannel.on('receive', this.onPresenceChannelReceive);
+    this.submitLocalPresenceChannel(false);
+    console.info('presenceChannel setup');
   }
 
   toggleFeaturedVerseRefs(
@@ -623,12 +701,36 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
 
     // We only need to send presence updates if the user moves the cursor themselves. Cursor updates as a result of text
     // changes will automatically be handled by the remote client.
-    if ((source as Sources) !== 'user') return;
-    this.submitLocalPresence(range);
+    // if ((source as Sources) !== 'user') return;
+    console.log('onSelectionChanged', range, source);
+    this.submitLocalPresenceDoc(range);
   }
 
   clearHighlight(): void {
     this.highlight([]);
+  }
+
+  async dismissPresences(): Promise<void> {
+    await this.submitLocalPresenceChannel(null);
+    await this.submitLocalPresenceDoc(null);
+    if (this.editor != null) {
+      const cursors: QuillCursors = this.editor.getModule('cursors');
+      cursors.clearCursors();
+    }
+    this.presenceChannel?.unsubscribe(error => {
+      if (error) throw error;
+    });
+    this.presenceChannel?.off('receive', this.onPresenceChannelReceive);
+    this.presenceChannel = undefined;
+
+    this.presenceDoc?.unsubscribe(error => {
+      if (error) throw error;
+    });
+    this.presenceDoc?.off('receive', this.onPresenceDocReceive);
+    this.presenceDoc = undefined;
+    const noRemotePresences: RemotePresences = {};
+    console.log('noRemotePresences');
+    this.presenceChange?.emit(noRemotePresences);
   }
 
   highlight(segmentRefs?: string[]): void {
@@ -717,6 +819,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
 
   private async bindQuill(): Promise<void> {
     this.viewModel.unbind();
+    await this.dismissPresences();
     if (this._id == null) {
       return;
     }
@@ -728,6 +831,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     const textDoc = await this.projectService.getText(this._id);
     this.viewModel.bind(textDoc, this.subscribeToUpdates);
     this.updatePlaceholderText();
+    this.attachPresences(textDoc);
 
     this.loaded.emit();
     this.applyEditorStyles();
@@ -754,6 +858,18 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
         )
       );
     }
+  }
+
+  private getPresenceViewer(presenceId: string): MultiCursorViewer | undefined {
+    if (this.presenceChannel?.remotePresences != null) {
+      const viewer = Object.entries(this.presenceChannel.remotePresences)
+        .filter(remotePresence => remotePresence[0] === presenceId)
+        .map(remotePresence => remotePresence[1].viewer);
+      if (viewer.length > 0) {
+        return viewer[0];
+      }
+    }
+    return;
   }
 
   private isSelectionAtSegmentPosition(end: boolean): boolean {
@@ -835,25 +951,50 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     }
   }
 
-  private async submitLocalPresence(range: RangeStatic | null): Promise<void> {
-    if (!this.isPresenceEnabled) return;
+  private async submitLocalPresenceChannel(active: boolean | null): Promise<void> {
+    if (!this.isPresenceEnabled || this.localPresenceChannel == null) {
+      console.warn('submitLocalPresenceChannel not ready', this.isPresenceEnabled, this.localPresenceChannel);
+      return;
+    }
 
-    // In this particular instance, we can send extra information on the presence object. This ability will vary
-    // depending on type.
-    const currentUserDoc: UserDoc = await this.userService.getCurrentUser();
-    // If the avatar src is empty ('') then it generates one with the same background and cursor color
-    // Do this for email/password accounts
-    const authType: AuthType = getAuthType(currentUserDoc.data?.authId ?? '');
-    const avatarUrl: string = authType === AuthType.Account ? '' : currentUserDoc.data?.avatarUrl ?? '';
-    const presenceData: PresenceData = {
-      viewer: {
-        displayName: currentUserDoc.data?.displayName || this.transloco.translate('editor.anonymous'),
-        avatarUrl,
-        cursorColor: this.viewModel.cursorColor
-      },
-      range
-    };
-    this.viewModel.localPresence?.submit(presenceData, error => {
+    let presenceData: PresenceData = null as unknown as PresenceData;
+    if (active != null) {
+      // In this particular instance, we can send extra information on the presence object. This ability will vary
+      // depending on type.
+      const currentUserDoc: UserDoc = await this.userService.getCurrentUser();
+      // If the avatar src is empty ('') then it generates one with the same background and cursor color
+      // Do this for email/password accounts
+      const authType: AuthType = getAuthType(currentUserDoc.data?.authId ?? '');
+      const avatarUrl: string = authType === AuthType.Unknown ? '' : currentUserDoc.data?.avatarUrl ?? '';
+      presenceData = {
+        viewer: {
+          displayName: currentUserDoc.data?.displayName || this.transloco.translate('editor.anonymous'),
+          avatarUrl,
+          cursorColor: this.cursorColor,
+          activeInEditor: active
+        }
+      };
+      this.presenceActiveEditor$.next(active);
+      if (active) {
+        timer(3500)
+          .pipe(takeUntil(this.presenceActiveEditor$))
+          .subscribe(() => {
+            console.log('not active any more');
+            this.submitLocalPresenceChannel(false);
+          });
+      }
+    }
+    console.log('submitLocalPresenceChannel', presenceData);
+    this.localPresenceChannel.submit(presenceData, error => {
+      if (error) throw error;
+    });
+  }
+
+  private async submitLocalPresenceDoc(range: RangeStatic | null): Promise<void> {
+    if (!this.isPresenceEnabled || this.localPresenceDoc == null) return;
+
+    console.log('submitLocalPresenceDoc', range);
+    this.localPresenceDoc.submit(range, error => {
       if (error) throw error;
     });
   }
@@ -929,6 +1070,9 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       affectedEmbeds,
       isLocalUpdate: isUserEdit
     });
+    if (isUserEdit) {
+      this.submitLocalPresenceChannel(true);
+    }
   }
 
   private tryChangeSegment(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -90,6 +90,7 @@
             (focused)="targetFocused = $event"
             (presenceChange)="onPresenceChange($event)"
             [highlightSegment]="targetFocused && canEdit"
+            [enablePresence]="true"
             [markInvalid]="true"
             [isRightToLeft]="isTargetRightToLeft"
             [fontSize]="fontSize"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -68,6 +68,7 @@ import { SFProjectService } from '../../core/sf-project.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
 import { SharedModule } from '../../shared/shared.module';
 import { getCombinedVerseTextDoc, paratextUsersFromRoles } from '../../shared/test-utils';
+import { PRESENCE_EDITOR_ACTIVE_TIMEOUT } from '../../shared/text/text.component';
 import { EditorComponent, UPDATE_SUGGESTIONS_TIMEOUT } from './editor.component';
 import { NoteDialogComponent } from './note-dialog/note-dialog.component';
 import { SuggestionsComponent } from './suggestions.component';
@@ -3046,6 +3047,10 @@ class TestEnvironment {
     this.fixture.detectChanges();
   }
 
+  waitForPresenceTimer(): void {
+    tick(PRESENCE_EDITOR_ACTIVE_TIMEOUT);
+  }
+
   insertSuggestion(i: number = 0): void {
     const keydownEvent: any = document.createEvent('CustomEvent');
     if (i === 0) {
@@ -3160,6 +3165,7 @@ class TestEnvironment {
   dispose(): void {
     this.wait();
     this.component.metricsSession!.dispose();
+    this.waitForPresenceTimer();
   }
 
   addTextDoc(id: TextDocId, textType: TextType = 'target', corrupt = false): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -51,8 +51,7 @@ import { TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
 import { Segment } from '../../shared/text/segment';
-import { PresenceData, RemotePresences } from '../../shared/text/text-view-model';
-import { EmbedsByVerse, FeaturedVerseRefInfo, TextComponent } from '../../shared/text/text.component';
+import { EmbedsByVerse, FeaturedVerseRefInfo, TextComponent, PresenceData, RemotePresences } from '../../shared/text/text.component';
 import { formatFontSizeToRems, threadIdFromMouseEvent } from '../../shared/utils';
 import { MultiCursorViewer } from './multi-viewer/multi-viewer.component';
 import { NoteDialogComponent, NoteDialogData } from './note-dialog/note-dialog.component';
@@ -630,6 +629,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   onPresenceChange(remotePresences?: RemotePresences): void {
     if (remotePresences != null) {
+      console.log('before unique', remotePresences);
+      // Both source and target docs can emit a presence so only include one unique user
       const uniquePresences: PresenceData[] = Object.values(remotePresences).filter(
         (a, index, self) =>
           index ===
@@ -637,6 +638,14 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
             b => b.viewer.displayName === a.viewer.displayName && b.viewer.avatarUrl === a.viewer.avatarUrl
           )
       );
+      // this.multiCursorViewers = this.multiCursorViewers
+      //   .filter(v => uniquePresences.some(p => p.viewer.viewerId === v.viewerId))
+      //   .concat(
+      //     uniquePresences
+      //       .filter(p => !this.multiCursorViewers.some(v => v.viewerId === p.viewer.viewerId))
+      //       .map(p => p.viewer)
+      //   );
+      console.log(uniquePresences, this.multiCursorViewers);
       const multiCursorViewers: MultiCursorViewer[] = [];
       const currentUser: User | undefined = this.currentUserDoc?.data;
       for (const presence of uniquePresences) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -51,7 +51,13 @@ import { TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
 import { Segment } from '../../shared/text/segment';
-import { EmbedsByVerse, FeaturedVerseRefInfo, TextComponent, PresenceData, RemotePresences } from '../../shared/text/text.component';
+import {
+  EmbedsByVerse,
+  FeaturedVerseRefInfo,
+  TextComponent,
+  PresenceData,
+  RemotePresences
+} from '../../shared/text/text.component';
 import { formatFontSizeToRems, threadIdFromMouseEvent } from '../../shared/utils';
 import { MultiCursorViewer } from './multi-viewer/multi-viewer.component';
 import { NoteDialogComponent, NoteDialogData } from './note-dialog/note-dialog.component';
@@ -629,7 +635,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   onPresenceChange(remotePresences?: RemotePresences): void {
     if (remotePresences != null) {
-      console.log('before unique', remotePresences);
       // Both source and target docs can emit a presence so only include one unique user
       const uniquePresences: PresenceData[] = Object.values(remotePresences).filter(
         (a, index, self) =>
@@ -638,14 +643,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
             b => b.viewer.displayName === a.viewer.displayName && b.viewer.avatarUrl === a.viewer.avatarUrl
           )
       );
-      // this.multiCursorViewers = this.multiCursorViewers
-      //   .filter(v => uniquePresences.some(p => p.viewer.viewerId === v.viewerId))
-      //   .concat(
-      //     uniquePresences
-      //       .filter(p => !this.multiCursorViewers.some(v => v.viewerId === p.viewer.viewerId))
-      //       .map(p => p.viewer)
-      //   );
-      console.log(uniquePresences, this.multiCursorViewers);
       const multiCursorViewers: MultiCursorViewer[] = [];
       const currentUser: User | undefined = this.currentUserDoc?.data;
       for (const presence of uniquePresences) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -635,7 +635,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   onPresenceChange(remotePresences?: RemotePresences): void {
     if (remotePresences != null) {
-      // Both source and target docs can emit a presence so only include one unique user
       const uniquePresences: PresenceData[] = Object.values(remotePresences).filter(
         (a, index, self) =>
           index ===

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.spec.ts
@@ -19,9 +19,9 @@ describe('MultiViewerComponent', () => {
 
   it('should have all avatars when the menu is closed', () => {
     component.viewers = [
-      { displayName: 'v 1', avatarUrl: '', cursorColor: '' },
-      { displayName: 'v 2', avatarUrl: '', cursorColor: '' },
-      { displayName: 'v 3', avatarUrl: '', cursorColor: '' }
+      { displayName: 'v 1', avatarUrl: '', cursorColor: '', activeInEditor: false },
+      { displayName: 'v 2', avatarUrl: '', cursorColor: '', activeInEditor: false },
+      { displayName: 'v 3', avatarUrl: '', cursorColor: '', activeInEditor: false }
     ];
     expect(component.maxAvatars).withContext('setup').toEqual(3);
 
@@ -30,9 +30,9 @@ describe('MultiViewerComponent', () => {
 
   it('should not have avatars when the menu is open', () => {
     component.viewers = [
-      { displayName: 'v 1', avatarUrl: '', cursorColor: '' },
-      { displayName: 'v 2', avatarUrl: '', cursorColor: '' },
-      { displayName: 'v 3', avatarUrl: '', cursorColor: '' }
+      { displayName: 'v 1', avatarUrl: '', cursorColor: '', activeInEditor: false },
+      { displayName: 'v 2', avatarUrl: '', cursorColor: '', activeInEditor: false },
+      { displayName: 'v 3', avatarUrl: '', cursorColor: '', activeInEditor: false }
     ];
 
     component.isMenuOpen = true;
@@ -42,10 +42,10 @@ describe('MultiViewerComponent', () => {
 
   it('should limit the avatars when there are many', () => {
     component.viewers = [
-      { displayName: 'v 1', avatarUrl: '', cursorColor: '' },
-      { displayName: 'v 2', avatarUrl: '', cursorColor: '' },
-      { displayName: 'v 3', avatarUrl: '', cursorColor: '' },
-      { displayName: 'v 4', avatarUrl: '', cursorColor: '' }
+      { displayName: 'v 1', avatarUrl: '', cursorColor: '', activeInEditor: false },
+      { displayName: 'v 2', avatarUrl: '', cursorColor: '', activeInEditor: false },
+      { displayName: 'v 3', avatarUrl: '', cursorColor: '', activeInEditor: false },
+      { displayName: 'v 4', avatarUrl: '', cursorColor: '', activeInEditor: false }
     ];
     expect(component.maxAvatars).withContext('setup').toEqual(3);
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.ts
@@ -8,6 +8,7 @@ import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 
 export interface MultiCursorViewer extends UserProfile {
   cursorColor: string;
+  activeInEditor: boolean;
 }
 
 @Component({

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/memory-realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/memory-realtime-remote-store.ts
@@ -67,6 +67,18 @@ export class MemoryRealtimeDocAdapter implements RealtimeDocAdapter {
   readonly create$ = new Subject<void>();
   readonly delete$ = new Subject<void>();
   readonly idle$ = EMPTY;
+  readonly channelPresence: Presence = {
+    remotePresences: {},
+    subscribe: (_callback?: Callback) => {},
+    unsubscribe: (_callback?: Callback) => {},
+    create: (_id?: string) =>
+      ({
+        submit: (_value: any, _callback?: Callback) => {}
+      } as LocalPresence),
+    destroy: (_callback?: Callback) => {},
+    on: (_event: string, _handler: Function) => {},
+    off: (_event: string, _handler: Function) => {}
+  } as Presence;
   readonly docPresence: Presence = {
     remotePresences: {},
     subscribe: (_callback?: Callback) => {},

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
@@ -2,6 +2,7 @@ import { merge, Observable, Subject, Subscription } from 'rxjs';
 import { Presence } from 'sharedb/lib/sharedb';
 import { RealtimeService } from 'xforge-common/realtime.service';
 import { RealtimeDocAdapter } from '../realtime-remote-store';
+import { PresenceData } from '../../app/shared/text/text.component';
 import { Snapshot } from './snapshot';
 import { RealtimeOfflineData } from './realtime-offline-data';
 
@@ -62,6 +63,10 @@ export abstract class RealtimeDoc<T = any, Ops = any, P = any> {
 
   get collection(): string {
     return this.adapter.collection;
+  }
+
+  get channelPresence(): Presence<PresenceData> {
+    return this.adapter.channelPresence;
   }
 
   get docPresence(): Presence<P> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime-remote-store.ts
@@ -27,6 +27,7 @@ export interface RealtimeDocAdapter {
   readonly pendingOps: any[];
   readonly subscribed: boolean;
   readonly collection: string;
+  readonly channelPresence: Presence;
   readonly docPresence: Presence;
 
   readonly idle$: Observable<void>;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
@@ -129,6 +129,10 @@ export class SharedbRealtimeDocAdapter implements RealtimeDocAdapter {
     return this.doc.collection;
   }
 
+  get channelPresence(): Presence {
+    return this.doc.connection.getPresence(`${this.collection}:${this.id}`);
+  }
+
   get docPresence(): Presence {
     return this.doc.connection.getDocPresence(this.collection, this.id);
   }


### PR DESCRIPTION
- Update presence when text ID changes
- Don't remove presence on blur
- Refactored presence logic from `text-view-model.ts` to `text.component.ts`
- Subscribe to a presence channel and a presence doc
- Display name while actively editing a document
- Added community checking test to ensure presence is disabled

This PR aims to resolve SF-1587, SF-1580, and SF-1611.

The core issue was the app trying to use document presence to also work for a general "viewing the book and chapter" presence as well. ShareDB offers two separate ways to handle this. This PR now subscribes to the TextDoc specific presence as well as a generic channel for who is viewing the same TextDoc.

New features introduced were:
- Showing a users name while they are actively updating the document
- Showing any viewer looking at the TextDoc regardless of their permission or ability to edit the text

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1484)
<!-- Reviewable:end -->
