### PR TITLE
SF-1614 Save the results of each sync to the database

### DIFF
--- a/src/SIL.XForge.Scripture/DataAccess/SFDataAccessApplicationBuilderExtensions.cs
+++ b/src/SIL.XForge.Scripture/DataAccess/SFDataAccessApplicationBuilderExtensions.cs
@@ -10,6 +10,7 @@ namespace Microsoft.AspNetCore.Builder
 
             app.InitRepository<TranslateMetrics>();
             app.InitRepository<SFProjectSecret>();
+            app.InitRepository<SyncMetrics>();
         }
     }
 }

--- a/src/SIL.XForge.Scripture/DataAccess/SFDataAccessServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/DataAccess/SFDataAccessServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddMongoRepository<TranslateMetrics>("translate_metrics", cm => cm.MapIdProperty(tm => tm.Id));
             services.AddMongoRepository<SFProjectSecret>("sf_project_secrets");
+            services.AddMongoRepository<SyncMetrics>("sync_metrics", cm => cm.MapIdProperty(sm => sm.Id));
 
             return services;
         }

--- a/src/SIL.XForge.Scripture/Models/NoteSyncMetricInfo.cs
+++ b/src/SIL.XForge.Scripture/Models/NoteSyncMetricInfo.cs
@@ -1,0 +1,34 @@
+namespace SIL.XForge.Scripture.Models
+{
+    /// <summary>
+    /// Information on the operations performed when syncing the notes subsystem.
+    /// </summary>
+    /// <remarks>This is to be used with <see cref="SyncMetrics"/>.</remarks>
+    public record NoteSyncMetricInfo : SyncMetricInfo
+    {
+        public NoteSyncMetricInfo() { }
+
+        public NoteSyncMetricInfo(int added, int deleted, int updated, int removed) : base(added, deleted, updated)
+        {
+            Removed = removed;
+        }
+
+        public int Removed { get; set; }
+
+        public static NoteSyncMetricInfo operator +(NoteSyncMetricInfo a, NoteSyncMetricInfo b)
+        {
+            if (a is null || b is null)
+            {
+                return a ?? b;
+            }
+
+            return new NoteSyncMetricInfo
+            {
+                Added = a.Added + b.Added,
+                Deleted = a.Deleted + b.Deleted,
+                Updated = a.Updated + b.Updated,
+                Removed = a.Removed + b.Removed,
+            };
+        }
+    }
+}

--- a/src/SIL.XForge.Scripture/Models/SFProjectSecret.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectSecret.cs
@@ -15,5 +15,17 @@ namespace SIL.XForge.Scripture.Models
         /// The <see cref="List{T}.Count">Count</see> should correspond to <see cref="QueuedCount" />.
         /// </remarks>
         public List<string> JobIds { get; set; } = new List<string>();
+
+        /// <summary>
+        /// The queued or active SyncMetrics Ids for the project.
+        /// </summary>
+        /// <value>
+        /// The SyncMetrics Ids.
+        /// </value>
+        /// <remarks>
+        /// This functions in a similar way to <see cref="JobIds"/>,
+        /// so that we can mark the <see cref="SyncMetrics"/> as cancelled.
+        /// </remarks>
+        public List<string> SyncMetricsIds { get; set; } = new List<string>();
     }
 }

--- a/src/SIL.XForge.Scripture/Models/SyncMetricInfo.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncMetricInfo.cs
@@ -1,0 +1,21 @@
+namespace SIL.XForge.Scripture.Models
+{
+    /// <summary>
+    /// Information on the operations performed when syncing a subsystem.
+    /// </summary>
+    /// <remarks>This is to be used with <see cref="SyncMetrics"/>.</remarks>
+    public class SyncMetricInfo
+    {
+        public int Added { get; set; }
+        public int Deleted { get; set; }
+        public int Updated { get; set; }
+
+        public static SyncMetricInfo operator +(SyncMetricInfo a, SyncMetricInfo b) =>
+            new SyncMetricInfo
+            {
+                Added = a.Added + b.Added,
+                Deleted = a.Deleted + b.Deleted,
+                Updated = a.Updated + b.Updated,
+            };
+    }
+}

--- a/src/SIL.XForge.Scripture/Models/SyncMetricInfo.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncMetricInfo.cs
@@ -4,18 +4,34 @@ namespace SIL.XForge.Scripture.Models
     /// Information on the operations performed when syncing a subsystem.
     /// </summary>
     /// <remarks>This is to be used with <see cref="SyncMetrics"/>.</remarks>
-    public class SyncMetricInfo
+    public record SyncMetricInfo
     {
+        public SyncMetricInfo() { }
+
+        public SyncMetricInfo(int added, int deleted, int updated)
+        {
+            Added = added;
+            Deleted = deleted;
+            Updated = updated;
+        }
+
         public int Added { get; set; }
         public int Deleted { get; set; }
         public int Updated { get; set; }
 
-        public static SyncMetricInfo operator +(SyncMetricInfo a, SyncMetricInfo b) =>
-            new SyncMetricInfo
+        public static SyncMetricInfo operator +(SyncMetricInfo a, SyncMetricInfo b)
+        {
+            if (a is not null && b is not null)
             {
-                Added = a.Added + b.Added,
-                Deleted = a.Deleted + b.Deleted,
-                Updated = a.Updated + b.Updated,
-            };
+                return new SyncMetricInfo
+                {
+                    Added = a.Added + b.Added,
+                    Deleted = a.Deleted + b.Deleted,
+                    Updated = a.Updated + b.Updated,
+                };
+            }
+
+            return a ?? b;
+        }
     }
 }

--- a/src/SIL.XForge.Scripture/Models/SyncMetricInfo.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncMetricInfo.cs
@@ -21,17 +21,17 @@ namespace SIL.XForge.Scripture.Models
 
         public static SyncMetricInfo operator +(SyncMetricInfo a, SyncMetricInfo b)
         {
-            if (a is not null && b is not null)
+            if (a is null || b is null)
             {
-                return new SyncMetricInfo
-                {
-                    Added = a.Added + b.Added,
-                    Deleted = a.Deleted + b.Deleted,
-                    Updated = a.Updated + b.Updated,
-                };
+                return a ?? b;
             }
 
-            return a ?? b;
+            return new SyncMetricInfo
+            {
+                Added = a.Added + b.Added,
+                Deleted = a.Deleted + b.Deleted,
+                Updated = a.Updated + b.Updated,
+            };
         }
     }
 }

--- a/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
@@ -1,0 +1,19 @@
+using System;
+using SIL.XForge.Models;
+
+namespace SIL.XForge.Scripture.Models
+{
+    /// <summary>
+    /// Information on each sync performed.
+    /// </summary>
+    public class SyncMetrics : IIdentifiable
+    {
+        public DateTime? DateFinished { get; set; }
+        public DateTime DateQueued { get; set; }
+        public DateTime? DateStarted { get; set; }
+        public string Id { get; set; }
+        public string ProjectRef { get; set; }
+        public bool Successful { get; set; }
+        public string UserRef { get; set; }
+    }
+}

--- a/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
@@ -22,6 +22,7 @@ namespace SIL.XForge.Scripture.Models
 
         // Sync Statistics
         public SyncMetricInfo Books { get; set; } = new SyncMetricInfo();
+        public NoteSyncMetricInfo Notes { get; set; } = new NoteSyncMetricInfo();
         public SyncMetricInfo NoteThreads { get; set; } = new SyncMetricInfo();
         public SyncMetricInfo ParatextBooks { get; set; } = new SyncMetricInfo();
         public SyncMetricInfo ParatextNotes { get; set; } = new SyncMetricInfo();

--- a/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
@@ -24,7 +24,7 @@ namespace SIL.XForge.Scripture.Models
         public SyncMetricInfo NoteThreads { get; set; } = new SyncMetricInfo();
         public SyncMetricInfo ParatextBooks { get; set; } = new SyncMetricInfo();
         public SyncMetricInfo ParatextNotes { get; set; } = new SyncMetricInfo();
-        public int QuestionsDeleted { get; set; }
+        public SyncMetricInfo Questions { get; set; } = new SyncMetricInfo();
         public bool RepositoryBackupCreated { get; set; }
         public bool RepositoryRestoredFromBackup { get; set; }
         public SyncMetricInfo ResourceUsers { get; set; } = new SyncMetricInfo();

--- a/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
@@ -20,8 +20,15 @@ namespace SIL.XForge.Scripture.Models
         public string UserRef { get; set; }
 
         // Sync Statistics
+        public SyncMetricInfo Books { get; set; } = new SyncMetricInfo();
+        public SyncMetricInfo NoteThreads { get; set; } = new SyncMetricInfo();
+        public SyncMetricInfo ParatextBooks { get; set; } = new SyncMetricInfo();
+        public SyncMetricInfo ParatextNotes { get; set; } = new SyncMetricInfo();
+        public int QuestionsDeleted { get; set; }
         public bool RepositoryBackupCreated { get; set; }
         public bool RepositoryRestoredFromBackup { get; set; }
-        public int UsersRemoved { get; set; }
+        public SyncMetricInfo ResourceUsers { get; set; } = new SyncMetricInfo();
+        public SyncMetricInfo TextDocs { get; set; } = new SyncMetricInfo();
+        public SyncMetricInfo Users { get; set; } = new SyncMetricInfo();
     }
 }

--- a/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
@@ -8,6 +8,7 @@ namespace SIL.XForge.Scripture.Models
     /// </summary>
     public class SyncMetrics : IIdentifiable
     {
+        // Sync Details
         public DateTime? DateFinished { get; set; }
         public DateTime DateQueued { get; set; }
         public DateTime? DateStarted { get; set; }
@@ -17,5 +18,10 @@ namespace SIL.XForge.Scripture.Models
         public string ProjectRef { get; set; }
         public SyncStatus Status { get; set; }
         public string UserRef { get; set; }
+
+        // Sync Statistics
+        public bool RepositoryBackupCreated { get; set; }
+        public bool RepositoryRestoredFromBackup { get; set; }
+        public int UsersRemoved { get; set; }
     }
 }

--- a/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
@@ -12,8 +12,10 @@ namespace SIL.XForge.Scripture.Models
         public DateTime DateQueued { get; set; }
         public DateTime? DateStarted { get; set; }
         public string Id { get; set; }
+        public string ErrorDetails { get; set; }
+        public string RequiresId { get; set; }
         public string ProjectRef { get; set; }
-        public bool Successful { get; set; }
+        public SyncStatus Status { get; set; }
         public string UserRef { get; set; }
     }
 }

--- a/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using SIL.XForge.Models;
 
 namespace SIL.XForge.Scripture.Models
@@ -30,5 +31,10 @@ namespace SIL.XForge.Scripture.Models
         public SyncMetricInfo ResourceUsers { get; set; } = new SyncMetricInfo();
         public SyncMetricInfo TextDocs { get; set; } = new SyncMetricInfo();
         public SyncMetricInfo Users { get; set; } = new SyncMetricInfo();
+
+        /// <summary>
+        /// The log messages from <see cref="Services.ParatextSyncRunner"/>.
+        /// </summary>
+        public List<string> Log { get; set; } = new List<string>();
     }
 }

--- a/src/SIL.XForge.Scripture/Models/SyncStatus.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncStatus.cs
@@ -1,0 +1,14 @@
+namespace SIL.XForge.Scripture.Models
+{
+    /// <summary>
+    /// The status of a sync for the <see cref="SyncMetrics"/>.
+    /// </summary>
+    public enum SyncStatus
+    {
+        Queued,
+        Running,
+        Successful,
+        Cancelled,
+        Failed,
+    }
+}

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -44,7 +44,7 @@ namespace SIL.XForge.Scripture.Services
 
         IReadOnlyList<int> GetBookList(UserSecret userSecret, string paratextId);
         string GetBookText(UserSecret userSecret, string paratextId, int bookNum);
-        Task PutBookText(
+        Task<int> PutBookText(
             UserSecret userSecret,
             string paratextId,
             int bookNum,
@@ -52,8 +52,8 @@ namespace SIL.XForge.Scripture.Services
             Dictionary<int, string> chapterAuthors = null
         );
         string GetNotes(UserSecret userSecret, string ptProjectId, int bookNum);
-        void PutNotes(UserSecret userSecret, string ptProjectId, string notesText);
-        Task UpdateParatextCommentsAsync(
+        SyncMetricInfo PutNotes(UserSecret userSecret, string ptProjectId, string notesText);
+        Task<SyncMetricInfo> UpdateParatextCommentsAsync(
             UserSecret userSecret,
             string projectId,
             int bookNum,

--- a/src/SIL.XForge.Scripture/Services/IParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextSyncRunner.cs
@@ -5,6 +5,6 @@ namespace SIL.XForge.Scripture.Services
 {
     public interface IParatextSyncRunner
     {
-        Task RunAsync(string projectId, string userId, bool trainEngine, CancellationToken token);
+        Task RunAsync(string projectId, string userId, string syncMetricsId, bool trainEngine, CancellationToken token);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1278,7 +1278,10 @@ namespace SIL.XForge.Scripture.Services
                     // If the restore is successful, then dataInSync will always be set to true because
                     // the restored repo can be assumed to be at the revision recorded in the project doc.
                     restoreSucceeded = _paratextService.RestoreRepository(_userSecret, _projectDoc.Data.ParatextId);
-                    _syncMetrics.RepositoryRestoredFromBackup = restoreSucceeded;
+                    if (_syncMetrics != null)
+                    {
+                        _syncMetrics.RepositoryRestoredFromBackup = restoreSucceeded;
+                    }
                 }
                 Log(
                     $"CompleteSync: Sync was not successful. {(restoreSucceeded ? "Rolled back" : "Failed to roll back")} local PT repo."
@@ -1376,7 +1379,11 @@ namespace SIL.XForge.Scripture.Services
                 }
             });
 
-            _syncMetrics.Users.Deleted = userIdsToRemove.Count;
+            if (_syncMetrics != null)
+            {
+                _syncMetrics.Users.Deleted = userIdsToRemove.Count;
+            }
+
             foreach (var userId in userIdsToRemove)
                 await _projectService.RemoveUserWithoutPermissionsCheckAsync(_userSecret.Id, _projectDoc.Id, userId);
 
@@ -1412,7 +1419,7 @@ namespace SIL.XForge.Scripture.Services
             }
 
             // If we have an id in the job ids collection, remove the first one
-            if (_projectSecret.JobIds.Any() || _projectSecret.SyncMetricsIds.Contains(_syncMetrics.Id))
+            if (_projectSecret.JobIds.Any() || _projectSecret.SyncMetricsIds.Contains(_syncMetrics?.Id))
             {
                 await _projectSecrets.UpdateAsync(
                     _projectSecret.Id,
@@ -1423,9 +1430,9 @@ namespace SIL.XForge.Scripture.Services
                             u.Remove(p => p.JobIds, _projectSecret.JobIds.First());
                         }
 
-                        if (_projectSecret.SyncMetricsIds.Contains(_syncMetrics.Id))
+                        if (_projectSecret.SyncMetricsIds.Contains(_syncMetrics?.Id))
                         {
-                            u.Remove(p => p.SyncMetricsIds, _syncMetrics.Id);
+                            u.Remove(p => p.SyncMetricsIds, _syncMetrics?.Id);
                         }
                     }
                 );
@@ -1449,7 +1456,11 @@ namespace SIL.XForge.Scripture.Services
                 if (!_paratextService.IsResource(_projectDoc.Data.ParatextId))
                 {
                     bool backupOutcome = _paratextService.BackupRepository(_userSecret, _projectDoc.Data.ParatextId);
-                    _syncMetrics.RepositoryBackupCreated = backupOutcome;
+                    if (_syncMetrics != null)
+                    {
+                        _syncMetrics.RepositoryBackupCreated = backupOutcome;
+                    }
+
                     if (!backupOutcome)
                     {
                         Log($"CompleteSync: Failure backing up local PT repo.");

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -865,7 +865,7 @@ namespace SIL.XForge.Scripture.Services
                 if (!chapterNums.Contains(questionDoc.Data.VerseRef.ChapterNum))
                 {
                     tasks.Add(questionDoc.DeleteAsync());
-                    _syncMetrics.QuestionsDeleted++;
+                    _syncMetrics.Questions.Deleted++;
                 }
             }
             await Task.WhenAll(tasks);
@@ -1142,7 +1142,7 @@ namespace SIL.XForge.Scripture.Services
                 tasks.Add(deleteQuestion());
             }
             await Task.WhenAll(tasks);
-            _syncMetrics.QuestionsDeleted += questionDocIds.Count;
+            _syncMetrics.Questions.Deleted += questionDocIds.Count;
         }
 
         private async Task<List<string>> DeleteNoteThreadDocsInChapters(int bookNum, IEnumerable<Chapter> chapters)

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -583,6 +583,7 @@ namespace SIL.XForge.Scripture.Services
             CancellationToken token
         )
         {
+            _logger.LogInformation($"Initializing sync for project {projectSFId} with sync metrics id {syncMetricsId}");
             if (!(await _syncMetricsRepository.TryGetAsync(syncMetricsId)).TryResult(out _syncMetrics))
             {
                 Log($"Could not find sync metrics.", syncMetricsId, userId);

--- a/src/SIL.XForge.Scripture/Services/SyncService.cs
+++ b/src/SIL.XForge.Scripture/Services/SyncService.cs
@@ -128,6 +128,12 @@ namespace SIL.XForge.Scripture.Services
                             null,
                             JobContinuationOptions.OnAnyFinishedState
                         );
+                        _logger.LogInformation(
+                            $"Queueing sync for source project {sourceProjectId} with sync metrics id {sourceSyncMetrics.Id}"
+                        );
+                        _logger.LogInformation(
+                            $"Queueing sync for target project {projectId} with sync metrics id {targetSyncMetrics.Id}"
+                        );
                         try
                         {
                             await sourceProjectDoc.SubmitJson0OpAsync(op =>
@@ -199,6 +205,7 @@ namespace SIL.XForge.Scripture.Services
                     r => r.RunAsync(projectId, curUserId, syncMetrics.Id, trainEngine, CancellationToken.None),
                     TimeSpan.FromMinutes(5)
                 );
+                _logger.LogInformation($"Queueing sync for project {projectId} with sync metrics id {syncMetrics.Id}");
                 try
                 {
                     await projectDoc.SubmitJson0OpAsync(op =>
@@ -288,6 +295,9 @@ namespace SIL.XForge.Scripture.Services
                 // Mark all sync metrics as cancelled
                 foreach (string syncMetricsId in projectSecret.SyncMetricsIds)
                 {
+                    _logger.LogInformation(
+                        $"Cancelling sync for project {projectSecret.Id} with sync metrics id {syncMetricsId}"
+                    );
                     await _syncMetrics.UpdateAsync(
                         syncMetricsId,
                         u =>

--- a/test/SIL.XForge.Scripture.Tests/Models/NoteSyncMetricInfoTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Models/NoteSyncMetricInfoTests.cs
@@ -1,0 +1,67 @@
+using NUnit.Framework;
+
+namespace SIL.XForge.Scripture.Models
+{
+    [TestFixture]
+    public class NoteNoteSyncMetricInfoTests
+    {
+        [Test]
+        public void NoteSyncMetricInfo_EmptyConstructor()
+        {
+            // SUT
+            var noteSyncMetricInfo = new NoteSyncMetricInfo();
+
+            Assert.That(noteSyncMetricInfo.Added, Is.Zero);
+            Assert.That(noteSyncMetricInfo.Deleted, Is.Zero);
+            Assert.That(noteSyncMetricInfo.Updated, Is.Zero);
+            Assert.That(noteSyncMetricInfo.Removed, Is.Zero);
+        }
+
+        [Test]
+        public void NoteSyncMetricInfo_ConstructorParameterOrder()
+        {
+            // SUT
+            var noteSyncMetricInfo = new NoteSyncMetricInfo(1, 2, 3, 4);
+
+            Assert.That(noteSyncMetricInfo.Added, Is.EqualTo(1));
+            Assert.That(noteSyncMetricInfo.Deleted, Is.EqualTo(2));
+            Assert.That(noteSyncMetricInfo.Updated, Is.EqualTo(3));
+            Assert.That(noteSyncMetricInfo.Removed, Is.EqualTo(4));
+        }
+
+        [Test]
+        public void NoteSyncMetricInfo_AddOperatorFirstNull()
+        {
+            var noteSyncMetricInfo = new NoteSyncMetricInfo(1, 2, 3, 4);
+
+            // SUT
+            var result = null + noteSyncMetricInfo;
+
+            Assert.That(result, Is.EqualTo(noteSyncMetricInfo));
+        }
+
+        [Test]
+        public void NoteSyncMetricInfo_AddOperatorSecondNull()
+        {
+            var noteSyncMetricInfo = new NoteSyncMetricInfo(1, 2, 3, 4);
+
+            // SUT
+            var result = noteSyncMetricInfo + null;
+
+            Assert.That(result, Is.EqualTo(noteSyncMetricInfo));
+        }
+
+        [Test]
+        public void NoteSyncMetricInfo_AddOperatorBothValues()
+        {
+            var firstNoteSyncMetricInfo = new NoteSyncMetricInfo(1, 2, 3, 5);
+            var secondNoteSyncMetricInfo = new NoteSyncMetricInfo(7, 11, 13, 17);
+            var addedNoteSyncMetricInfo = new NoteSyncMetricInfo(8, 13, 16, 22);
+
+            // SUT
+            var result = firstNoteSyncMetricInfo + secondNoteSyncMetricInfo;
+
+            Assert.That(result, Is.EqualTo(addedNoteSyncMetricInfo));
+        }
+    }
+}

--- a/test/SIL.XForge.Scripture.Tests/Models/SyncMetricInfoTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Models/SyncMetricInfoTests.cs
@@ -1,0 +1,65 @@
+using NUnit.Framework;
+
+namespace SIL.XForge.Scripture.Models
+{
+    [TestFixture]
+    public class SyncMetricInfoTests
+    {
+        [Test]
+        public void SyncMetricInfo_EmptyConstructor()
+        {
+            // SUT
+            var syncMetricInfo = new SyncMetricInfo();
+
+            Assert.That(syncMetricInfo.Added, Is.Zero);
+            Assert.That(syncMetricInfo.Deleted, Is.Zero);
+            Assert.That(syncMetricInfo.Updated, Is.Zero);
+        }
+
+        [Test]
+        public void SyncMetricInfo_ConstructorParameterOrder()
+        {
+            // SUT
+            var syncMetricInfo = new SyncMetricInfo(1, 2, 3);
+
+            Assert.That(syncMetricInfo.Added, Is.EqualTo(1));
+            Assert.That(syncMetricInfo.Deleted, Is.EqualTo(2));
+            Assert.That(syncMetricInfo.Updated, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void SyncMetricInfo_AddOperatorFirstNull()
+        {
+            var syncMetricInfo = new SyncMetricInfo(1, 2, 3);
+
+            // SUT
+            var result = null + syncMetricInfo;
+
+            Assert.That(result, Is.EqualTo(syncMetricInfo));
+        }
+
+        [Test]
+        public void SyncMetricInfo_AddOperatorSecondNull()
+        {
+            var syncMetricInfo = new SyncMetricInfo(1, 2, 3);
+
+            // SUT
+            var result = syncMetricInfo + null;
+
+            Assert.That(result, Is.EqualTo(syncMetricInfo));
+        }
+
+        [Test]
+        public void SyncMetricInfo_AddOperatorBothValues()
+        {
+            var firstSyncMetricInfo = new SyncMetricInfo(1, 2, 3);
+            var secondSyncMetricInfo = new SyncMetricInfo(5, 7, 11);
+            var addedSyncMetricInfo = new SyncMetricInfo(6, 9, 14);
+
+            // SUT
+            var result = firstSyncMetricInfo + secondSyncMetricInfo;
+
+            Assert.That(result, Is.EqualTo(addedSyncMetricInfo));
+        }
+    }
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -47,6 +47,10 @@ namespace SIL.XForge.Scripture.Services
 
             SFProject project = env.VerifyProjectSync(false);
             Assert.That(project.Sync.DataInSync, Is.True);
+
+            // Check that the failure was logged in the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
         }
 
         [Test]
@@ -61,6 +65,10 @@ namespace SIL.XForge.Scripture.Services
 
             SFProject project = env.VerifyProjectSync(false);
             Assert.That(project.Sync.DataInSync, Is.False);
+
+            // Check that the failure was logged in the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
         }
 
         [Test]
@@ -89,6 +97,14 @@ namespace SIL.XForge.Scripture.Services
 
             await env.EngineService.DidNotReceive().StartBuildByProjectIdAsync("project01");
             env.VerifyProjectSync(true);
+
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 4, deleted: 0, updated: 0)));
+            syncMetrics = env.GetSyncMetrics("project02");
+            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
         }
 
         [Test]
@@ -118,6 +134,14 @@ namespace SIL.XForge.Scripture.Services
 
             await env.EngineService.Received().StartBuildByProjectIdAsync("project01");
             env.VerifyProjectSync(true);
+
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 4, deleted: 0, updated: 0)));
+            syncMetrics = env.GetSyncMetrics("project02");
+            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
         }
 
         [Test]
@@ -147,6 +171,14 @@ namespace SIL.XForge.Scripture.Services
 
             await env.EngineService.Received().StartBuildByProjectIdAsync("project01");
             env.VerifyProjectSync(true);
+
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 4, deleted: 0, updated: 0)));
+            syncMetrics = env.GetSyncMetrics("project02");
+            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
         }
 
         [Test]
@@ -175,6 +207,14 @@ namespace SIL.XForge.Scripture.Services
 
             await env.EngineService.DidNotReceive().StartBuildByProjectIdAsync("project01");
             env.VerifyProjectSync(true);
+
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 4, deleted: 0, updated: 0)));
+            syncMetrics = env.GetSyncMetrics("project02");
+            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
         }
 
         [Test]
@@ -194,6 +234,14 @@ namespace SIL.XForge.Scripture.Services
 
             await env.EngineService.DidNotReceive().StartBuildByProjectIdAsync("project01");
             env.VerifyProjectSync(true);
+
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
+            syncMetrics = env.GetSyncMetrics("project02");
+            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
         }
 
         [Test]
@@ -378,6 +426,14 @@ namespace SIL.XForge.Scripture.Services
             SFProject project = env.GetProject();
             Assert.That(project.ParatextUsers.Count, Is.EqualTo(2));
             env.VerifyProjectSync(true);
+
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 2)));
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 4)));
+            syncMetrics = env.GetSyncMetrics("project02");
+            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 2)));
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 4)));
         }
 
         [Test]
@@ -414,6 +470,16 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
             Assert.That(env.ContainsNote(2), Is.True);
             env.VerifyProjectSync(true);
+
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 2)));
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 1, updated: 0)));
+            Assert.That(syncMetrics.Questions, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
+            syncMetrics = env.GetSyncMetrics("project02");
+            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 2)));
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 1, updated: 0)));
+            Assert.That(syncMetrics.Questions, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
         }
 
         [Test]
@@ -488,6 +554,18 @@ namespace SIL.XForge.Scripture.Services
 
             Assert.That(env.ContainsNote(2), Is.False);
             env.VerifyProjectSync(true);
+
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 1, updated: 1)));
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 2, updated: 0)));
+            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
+            Assert.That(syncMetrics.Questions, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 2, updated: 0)));
+            syncMetrics = env.GetSyncMetrics("project02");
+            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 1, updated: 1)));
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 2, updated: 0)));
+            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+            Assert.That(syncMetrics.Questions, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 2, updated: 0)));
         }
 
         [Test]
@@ -513,6 +591,10 @@ namespace SIL.XForge.Scripture.Services
             await env.SFProjectService
                 .Received()
                 .RemoveUserWithoutPermissionsCheckAsync("user01", "project01", "user02");
+
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Users, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
         }
 
         [Test]
@@ -634,6 +716,10 @@ namespace SIL.XForge.Scripture.Services
             await env.ParatextService
                 .DidNotReceiveWithAnyArgs()
                 .PutBookText(default, default, default, default, default);
+
+            // Check that the failure was logged in the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
         }
 
         [Test]
@@ -659,6 +745,10 @@ namespace SIL.XForge.Scripture.Services
 
             env.VerifyProjectSync(true);
             await env.SFProjectService.DidNotReceiveWithAnyArgs().RemoveUserAsync("user01", "project01", "user02");
+
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Users, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
         }
 
         [Test]
@@ -742,6 +832,12 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.GetText("project01", "LUK", 1).DeepEquals(delta), Is.True);
             Assert.That(env.GetText("project01", "LUK", 2).DeepEquals(delta), Is.True);
             env.VerifyProjectSync(true);
+
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
+            syncMetrics = env.GetSyncMetrics("project02");
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
         }
 
         [Test]
@@ -771,6 +867,12 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsText("project02", "MAT", 2), Is.True);
             Assert.That(env.GetText("project01", "MAT", 2).DeepEquals(chapterContent), Is.True);
             Assert.That(env.GetText("project02", "MAT", 2).DeepEquals(chapterContent), Is.True);
+
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+            syncMetrics = env.GetSyncMetrics("project02");
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
         }
 
         [Test]
@@ -808,6 +910,12 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
             Assert.That(env.ContainsText("project01", "MAT", 3), Is.True);
             Assert.That(env.ContainsText("project02", "MAT", 3), Is.True);
+
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
+            syncMetrics = env.GetSyncMetrics("project02");
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
         }
 
         [Test]
@@ -833,6 +941,12 @@ namespace SIL.XForge.Scripture.Services
             // DB should still be missing Source chapter 2.
             Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
             Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
+
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+            syncMetrics = env.GetSyncMetrics("project02");
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
         }
 
         [Test]
@@ -869,6 +983,12 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
             Assert.That(env.ContainsText("project01", "MAT", 3), Is.False);
             Assert.That(env.ContainsText("project02", "MAT", 3), Is.False);
+
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 2, updated: 1)));
+            syncMetrics = env.GetSyncMetrics("project02");
+            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 2, updated: 1)));
         }
 
         [Test]
@@ -1029,6 +1149,11 @@ namespace SIL.XForge.Scripture.Services
             // Check that the Exception was logged
             env.MockLogger.AssertHasEvent((LogEvent logEvent) => logEvent.Exception != null);
 
+            // Check that the exception was logged in the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
+            StringAssert.StartsWith("System.ArgumentException", syncMetrics.ErrorDetails);
+
             // Check that the task cancelled correctly
             SFProject project = env.VerifyProjectSync(false);
             Assert.That(project.Sync.DataInSync, Is.True); // Nothing was synced as this was cancelled OnInit()
@@ -1059,6 +1184,12 @@ namespace SIL.XForge.Scripture.Services
 
             await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
+            // Check that the failure was logged in the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
+            Assert.That(syncMetrics.RepositoryRestoredFromBackup, Is.True);
+
+            // Check that the sync restored correctly
             env.ParatextService.Received(1).RestoreRepository(Arg.Any<UserSecret>(), "target");
             SFProject project = env.VerifyProjectSync(false);
             Assert.That(project.Sync.DataInSync, Is.True);
@@ -1085,7 +1216,11 @@ namespace SIL.XForge.Scripture.Services
                             Arg.Any<CancellationToken>()
                         )
                 )
-                .Do(_ => throw new TaskCanceledException());
+                .Do(_ =>
+                {
+                    cancellationTokenSource.Cancel();
+                    throw new TaskCanceledException();
+                });
 
             // Run the task
             await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
@@ -1097,6 +1232,10 @@ namespace SIL.XForge.Scripture.Services
                 ),
                 Is.EqualTo(0)
             );
+
+            // Check that the cancellation was logged in the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
 
             // Check that the task cancelled correctly
             SFProject project = env.VerifyProjectSync(false);
@@ -1128,6 +1267,10 @@ namespace SIL.XForge.Scripture.Services
             // Run the task
             await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
 
+            // Check that the cancellation was logged in the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
+
             // Check that the task cancelled correctly
             SFProject project = env.VerifyProjectSync(false);
             Assert.That(project.Sync.DataInSync, Is.False);
@@ -1157,6 +1300,11 @@ namespace SIL.XForge.Scripture.Services
             await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
             env.ParatextService.Received(1).RestoreRepository(Arg.Any<UserSecret>(), Arg.Any<string>());
             SFProject project = env.VerifyProjectSync(false);
+
+            // Check that the cancellation was logged in the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
+
             // Data is out of sync due to the failed restore
             Assert.That(project.Sync.DataInSync, Is.False);
         }
@@ -1175,6 +1323,10 @@ namespace SIL.XForge.Scripture.Services
 
             // Run the task
             await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
+
+            // Check that the cancellation was logged in the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
 
             // Check that the task was cancelled after awaiting the check above
             SFProject project = env.VerifyProjectSync(false);
@@ -1224,6 +1376,10 @@ namespace SIL.XForge.Scripture.Services
             // Check for RollbackTransaction being executed, to ensure
             // that CompleteAsync executes to the end without exception
             env.Connection.Received(1).RollbackTransaction();
+
+            // Check that the cancellation was logged in the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
         }
 
         [Test]
@@ -1550,6 +1706,11 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(project.ParatextUsers.Single(u => u.Username == "User 3").SFUserId, Is.EqualTo("user03"));
             Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
             Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 1)));
         }
 
         [Test]
@@ -1579,6 +1740,11 @@ namespace SIL.XForge.Scripture.Services
                 "Context before Scripture text in project context after-" + $"Start:16-Length:22-MAT 1:1-icon1";
             Assert.That(thread01.NoteThreadToString(), Is.EqualTo(expected));
             Assert.That(thread01.Notes.Single(n => n.Reattached != null).Reattached, Is.EqualTo(reattached));
+
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 1)));
         }
 
         [Test]
@@ -1612,6 +1778,11 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsNoteThread("project01", "conflictthread01"), Is.True);
             project = env.GetProject();
             Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
         }
 
         [Test]
@@ -1660,6 +1831,11 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsNoteThread(sfProjectId, threadId), Is.False);
             project = env.GetProject();
             Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 2)));
         }
 
         [Test]
@@ -1686,13 +1862,23 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(thread02.VerseRef.ToString(), Is.EqualTo("MAT 1:1"));
             Assert.That(thread02.Status, Is.EqualTo(NoteStatus.Resolved.InternalValue));
 
+            // Verify the sync metrics
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 1)));
+
             // Change status back to false - happens if the note becomes unresolved again in Paratext
             env.SetupNoteStatusChange("thread02", NoteStatus.Todo.InternalValue);
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01_alt", false, CancellationToken.None);
 
             thread02 = env.GetNoteThread("project01", "thread02");
             Assert.That(thread02.VerseRef.ToString(), Is.EqualTo("MAT 1:1"));
             Assert.That(thread02.Status, Is.EqualTo(NoteStatus.Todo.InternalValue));
+
+            // Verify the sync metrics
+            syncMetrics = env.GetSyncMetrics("project01_alt");
+            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 1)));
         }
 
         [Test]
@@ -1721,6 +1907,11 @@ namespace SIL.XForge.Scripture.Services
             // No incoming note changes mean no changes to the SF DB Notes.
             // This is not a particularly thorough check, but is showing at least that a few pieces have not changed.
             Assert.That(note.NoteToString(), Is.EqualTo(origNoteData), "Note data should not have been changed");
+
+            // Verify the sync metrics - the note data will be updated, even though it is not changed
+            var syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 1)));
         }
 
         [Test]
@@ -1859,6 +2050,7 @@ namespace SIL.XForge.Scripture.Services
         private class TestEnvironment
         {
             private readonly MemoryRepository<SFProjectSecret> _projectSecrets;
+            private readonly MemoryRepository<SyncMetrics> _syncMetrics;
             private bool _sendReceivedCalled = false;
 
             /// <summary>
@@ -1889,10 +2081,11 @@ namespace SIL.XForge.Scripture.Services
                         new SFProjectSecret { Id = "project05" },
                     }
                 );
-                var syncMetrics = new MemoryRepository<SyncMetrics>(
+                _syncMetrics = new MemoryRepository<SyncMetrics>(
                     new[]
                     {
                         new SyncMetrics { Id = "project01" },
+                        new SyncMetrics { Id = "project01_alt" },
                         new SyncMetrics { Id = "project02" },
                         new SyncMetrics { Id = "project03" },
                         new SyncMetrics { Id = "project04" },
@@ -1959,7 +2152,7 @@ namespace SIL.XForge.Scripture.Services
                 Runner = new ParatextSyncRunner(
                     userSecrets,
                     _projectSecrets,
-                    syncMetrics,
+                    _syncMetrics,
                     SFProjectService,
                     EngineService,
                     ParatextService,
@@ -2041,6 +2234,11 @@ namespace SIL.XForge.Scripture.Services
                 return RealtimeService.GetRepository<NoteThread>().Get($"{projectId}:{threadId}");
             }
 
+            public SyncMetrics GetSyncMetrics(string projectId)
+            {
+                return _syncMetrics.Get(projectId);
+            }
+
             public SFProject AssertDBSyncMetadata(
                 string projectSFId,
                 bool lastSyncSuccess,
@@ -2053,6 +2251,18 @@ namespace SIL.XForge.Scripture.Services
                 Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
                 Assert.That(project.Sync.LastSyncSuccessful, Is.EqualTo(lastSyncSuccess));
                 Assert.That(project.Sync.SyncedToRepositoryVersion, Is.EqualTo(syncedToRepositoryVersion));
+
+                // Check for the correct system metrics status
+                var syncMetrics = GetSyncMetrics(projectSFId);
+                if (lastSyncSuccess)
+                {
+                    Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+                }
+                else
+                {
+                    Assert.That(syncMetrics.Status, Is.InRange(SyncStatus.Cancelled, SyncStatus.Failed));
+                }
+
                 return project;
             }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -3169,7 +3169,13 @@ namespace SIL.XForge.Scripture.Services
             )
             {
                 // SUT
-                await Runner.RunAsync(projectSFId, userId, trainEngine: false, token: CancellationToken.None);
+                await Runner.RunAsync(
+                    projectSFId,
+                    userId,
+                    syncMetricsId: projectSFId,
+                    trainEngine: false,
+                    token: CancellationToken.None
+                );
 
                 // We are in an out-of-sync situation and so should not be writing to PT.
 
@@ -3207,7 +3213,13 @@ namespace SIL.XForge.Scripture.Services
             )
             {
                 // SUT
-                await Runner.RunAsync(projectSFId, userId, trainEngine: false, token: CancellationToken.None);
+                await Runner.RunAsync(
+                    projectSFId,
+                    userId,
+                    syncMetricsId: projectSFId,
+                    trainEngine: false,
+                    token: CancellationToken.None
+                );
 
                 // We are not in an out-of-sync situation and should proceed with the sync.
 

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -32,7 +32,7 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
 
             // SUT
-            await env.Runner.RunAsync("project03", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project03", "user01", "project03", false, CancellationToken.None);
         }
 
         [Test]
@@ -42,7 +42,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, true, false);
             env.ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), "target").Returns("beforeSR");
 
-            await env.Runner.RunAsync("project01", "user03", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user03", "project01", false, CancellationToken.None);
 
             SFProject project = env.VerifyProjectSync(false);
             Assert.That(project.Sync.DataInSync, Is.True);
@@ -56,7 +56,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
             env.DeltaUsxMapper.When(d => d.ToChapterDeltas(Arg.Any<XDocument>())).Do(x => throw new Exception());
 
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             SFProject project = env.VerifyProjectSync(false);
             Assert.That(project.Sync.DataInSync, Is.False);
@@ -69,7 +69,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(false, false, false, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
 
-            await env.Runner.RunAsync("project01", "user01", true, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", true, CancellationToken.None);
 
             Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
             Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
@@ -97,8 +97,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, false, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
 
-            await env.Runner.RunAsync("project02", "user01", true, CancellationToken.None);
-            await env.Runner.RunAsync("project01", "user01", true, CancellationToken.None);
+            await env.Runner.RunAsync("project02", "user01", "project02", true, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", true, CancellationToken.None);
 
             Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
             Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
@@ -126,8 +126,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, false, false, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
 
-            await env.Runner.RunAsync("project02", "user01", true, CancellationToken.None);
-            await env.Runner.RunAsync("project01", "user01", true, CancellationToken.None);
+            await env.Runner.RunAsync("project02", "user01", "project02", true, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", true, CancellationToken.None);
 
             Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
             Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
@@ -155,7 +155,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(false, true, false, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
 
-            await env.Runner.RunAsync("project01", "user01", true, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", true, CancellationToken.None);
 
             Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
             Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
@@ -204,7 +204,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupPTData(books);
 
             // SUT
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             env.MockLogger.AssertEventCount(
                 (LogEvent logEvent) =>
@@ -253,8 +253,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, true, false, books);
             env.SetupPTData(books);
 
-            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             await env.ParatextService
                 .Received()
@@ -320,8 +320,8 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, false, true, false, books);
             env.SetupPTData(books);
 
-            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             await env.ParatextService
                 .Received()
@@ -388,8 +388,8 @@ namespace SIL.XForge.Scripture.Services
             env.AddParatextNoteThreadData(new Book("MRK", 2));
             Assert.That(env.ContainsNote(2), Is.True);
 
-            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
             env.ParatextService
                 .Received()
                 .GetNoteThreadChanges(
@@ -429,7 +429,7 @@ namespace SIL.XForge.Scripture.Services
             );
             env.SetupPTData(new Book("MAT", 2) { InvalidChapters = { 2 } }, new Book("MRK", 2));
 
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             SFProject project = env.GetProject();
             Assert.That(project.Texts[0].Chapters[0].IsValid, Is.True);
@@ -467,8 +467,8 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsNote(2), Is.True);
 
             // SUT
-            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             Assert.That(env.ContainsText("project01", "MRK", 1), Is.False);
             Assert.That(env.ContainsText("project01", "MRK", 2), Is.False);
@@ -505,7 +505,7 @@ namespace SIL.XForge.Scripture.Services
                 )
                 .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
 
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             SFProject project = env.VerifyProjectSync(true);
             Assert.That(project.UserRoles["user01"], Is.EqualTo(SFProjectRole.Translator));
@@ -531,7 +531,7 @@ namespace SIL.XForge.Scripture.Services
                 .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
 
             // SUT
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             await env.SFProjectService
                 .Received()
@@ -568,7 +568,7 @@ namespace SIL.XForge.Scripture.Services
                 .Returns(new ParatextSettings { Editable = false });
 
             // SUT
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
             await env.ParatextService
                 .DidNotReceiveWithAnyArgs()
                 .PutBookText(default, default, default, default, default);
@@ -604,7 +604,7 @@ namespace SIL.XForge.Scripture.Services
                 .Returns(new ParatextSettings { DefaultFontSize = newFontSize, DefaultFont = newFont });
 
             // SUT
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
             project = env.VerifyProjectSync(true);
             Assert.That(project.DefaultFontSize, Is.EqualTo(newFontSize));
             Assert.That(project.DefaultFont, Is.EqualTo(newFont));
@@ -628,7 +628,7 @@ namespace SIL.XForge.Scripture.Services
                 .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
             env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(x => null);
 
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
             env.VerifyProjectSync(false);
             await env.ParatextService
                 .DidNotReceiveWithAnyArgs()
@@ -654,7 +654,7 @@ namespace SIL.XForge.Scripture.Services
             await env.SetUserRole("user02", SFProjectRole.CommunityChecker);
             SFProject project = env.GetProject();
             Assert.That(project.UserRoles["user02"], Is.EqualTo(SFProjectRole.CommunityChecker));
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             env.VerifyProjectSync(true);
             await env.SFProjectService.DidNotReceiveWithAnyArgs().RemoveUserAsync("user01", "project01", "user02");
@@ -671,7 +671,7 @@ namespace SIL.XForge.Scripture.Services
             env.ParatextService
                 .GetParatextSettings(Arg.Any<UserSecret>(), "target")
                 .Returns(new ParatextSettings { IsRightToLeft = true });
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             SFProject project = env.GetProject();
             env.ParatextService.Received().GetParatextSettings(Arg.Any<UserSecret>(), "target");
@@ -691,7 +691,7 @@ namespace SIL.XForge.Scripture.Services
             env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), "target").Returns(new ParatextSettings());
 
             // SUT
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             SFProject project = env.GetProject();
             env.ParatextService.Received().GetParatextSettings(Arg.Any<UserSecret>(), "target");
@@ -712,7 +712,7 @@ namespace SIL.XForge.Scripture.Services
                 .Returns(new ParatextSettings { FullName = newFullName });
 
             // SUT
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             SFProject project = env.GetProject();
             env.ParatextService.Received().GetParatextSettings(Arg.Any<UserSecret>(), "target");
@@ -731,7 +731,7 @@ namespace SIL.XForge.Scripture.Services
                 );
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2), new Book("LUK", 2));
 
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             var delta = Delta.New().InsertText("text");
             Assert.That(env.GetText("project01", "MAT", 1).DeepEquals(delta), Is.True);
@@ -756,8 +756,8 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
 
             // SUT
-            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             // No errors or exceptions were logged
             env.MockLogger.AssertNoEvent(
@@ -792,8 +792,8 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsText("project02", "MAT", 3), Is.True);
 
             // SUT
-            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             // No errors or exceptions were logged
             env.MockLogger.AssertNoEvent(
@@ -822,7 +822,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
 
             // SUT
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             // No errors or exceptions were logged
             env.MockLogger.AssertNoEvent(
@@ -853,8 +853,8 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsText("project02", "MAT", 3), Is.True);
 
             // SUT
-            await env.Runner.RunAsync("project02", "user01", false, CancellationToken.None);
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             // No errors or exceptions were logged
             env.MockLogger.AssertNoEvent(
@@ -889,7 +889,7 @@ namespace SIL.XForge.Scripture.Services
                 env.ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), projectPTId).Returns("1", "2");
 
                 // SUT
-                await env.Runner.RunAsync(projectSFId, userId, false, CancellationToken.None);
+                await env.Runner.RunAsync(projectSFId, userId, projectSFId, false, CancellationToken.None);
 
                 project = env.GetProject(projectSFId);
                 // We should get into UpdateParatextBook() and fetch and perhaps put books.
@@ -1023,7 +1023,7 @@ namespace SIL.XForge.Scripture.Services
                 .Do(_ => throw new ArgumentException());
 
             // Run the task
-            await env.Runner.RunAsync("project01", "user01", false, cancellationTokenSource.Token);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
 
             // Check that the Exception was logged
             env.MockLogger.AssertHasEvent((LogEvent logEvent) => logEvent.Exception != null);
@@ -1056,7 +1056,7 @@ namespace SIL.XForge.Scripture.Services
                             .Returns("revNotMatchingVersion")
                 );
 
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             env.ParatextService.Received(1).RestoreRepository(Arg.Any<UserSecret>(), "target");
             SFProject project = env.VerifyProjectSync(false);
@@ -1087,7 +1087,7 @@ namespace SIL.XForge.Scripture.Services
                 .Do(_ => throw new TaskCanceledException());
 
             // Run the task
-            await env.Runner.RunAsync("project01", "user01", false, cancellationTokenSource.Token);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
 
             // The TaskCancelledException was not logged
             Assert.That(
@@ -1125,7 +1125,7 @@ namespace SIL.XForge.Scripture.Services
                 .Do(_ => cancellationTokenSource.Cancel());
 
             // Run the task
-            await env.Runner.RunAsync("project01", "user01", false, cancellationTokenSource.Token);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
 
             // Check that the task cancelled correctly
             SFProject project = env.VerifyProjectSync(false);
@@ -1153,7 +1153,7 @@ namespace SIL.XForge.Scripture.Services
                         )
                 )
                 .Do(_ => cancellationTokenSource.Cancel());
-            await env.Runner.RunAsync("project01", "user01", false, cancellationTokenSource.Token);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
             env.ParatextService.Received(1).RestoreRepository(Arg.Any<UserSecret>(), Arg.Any<string>());
             SFProject project = env.VerifyProjectSync(false);
             // Data is out of sync due to the failed restore
@@ -1173,7 +1173,7 @@ namespace SIL.XForge.Scripture.Services
             cancellationTokenSource.Cancel();
 
             // Run the task
-            await env.Runner.RunAsync("project01", "user01", false, cancellationTokenSource.Token);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
 
             // Check that the task was cancelled after awaiting the check above
             SFProject project = env.VerifyProjectSync(false);
@@ -1195,7 +1195,7 @@ namespace SIL.XForge.Scripture.Services
                 .Returns(Task.FromException<IDocument<SFProject>>(new TaskCanceledException()));
 
             // Run the task
-            await env.Runner.RunAsync("project01", "user01", false, cancellationTokenSource.Token);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
 
             // Only check for ExcludePropertyFromTransaction being executed,
             // as the substitute RealtimeService will not update documents.
@@ -1233,7 +1233,7 @@ namespace SIL.XForge.Scripture.Services
             var cancellationTokenSource = new CancellationTokenSource();
 
             // Run the task
-            await env.Runner.RunAsync("project01", "user01", false, cancellationTokenSource.Token);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
 
             // Cancel the token after awaiting the task
             cancellationTokenSource.Cancel();
@@ -1252,11 +1252,11 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, false, false, book);
 
             // SUT
-            await env.Runner.InitAsync("project01", "user01", CancellationToken.None);
+            await env.Runner.InitAsync("project01", "user01", "project01", CancellationToken.None);
             SortedList<int, IDocument<TextData>> targetFetch = await env.Runner.FetchTextDocsAsync(
                 env.TextInfoFromBook(book)
             );
-            await env.Runner.InitAsync("project02", "user01", CancellationToken.None);
+            await env.Runner.InitAsync("project02", "user01", "project02", CancellationToken.None);
             SortedList<int, IDocument<TextData>> sourceFetch = await env.Runner.FetchTextDocsAsync(
                 env.TextInfoFromBook(book)
             );
@@ -1296,10 +1296,10 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, false, false, book);
 
             // SUT
-            await env.Runner.InitAsync("project01", "user01", CancellationToken.None);
+            await env.Runner.InitAsync("project01", "user01", "project01", CancellationToken.None);
             var targetFetch = await env.Runner.FetchTextDocsAsync(env.TextInfoFromBook(book));
 
-            await env.Runner.InitAsync("project02", "user01", CancellationToken.None);
+            await env.Runner.InitAsync("project02", "user01", "project02", CancellationToken.None);
             var sourceFetch = await env.Runner.FetchTextDocsAsync(env.TextInfoFromBook(book));
 
             env.Runner.CloseConnection();
@@ -1320,7 +1320,7 @@ namespace SIL.XForge.Scripture.Services
             // But note that user05 must also be in the chapter permissions to be used
             var env = new TestEnvironment();
             TextInfo textInfo = env.SetupChapterAuthorsAndGetTextInfo(setChapterPermissions: false);
-            await env.Runner.InitAsync("project01", "user01", CancellationToken.None);
+            await env.Runner.InitAsync("project01", "user01", "project01", CancellationToken.None);
             var textDocs = await env.Runner.FetchTextDocsAsync(textInfo);
             textInfo.Chapters.First().Permissions.Add("user05", TextInfoPermission.Write);
             env.RealtimeService.LastModifiedUserId = "user05";
@@ -1339,7 +1339,7 @@ namespace SIL.XForge.Scripture.Services
             // So the user id will be retrieved from the user secret
             var env = new TestEnvironment();
             TextInfo textInfo = env.SetupChapterAuthorsAndGetTextInfo(setChapterPermissions: true);
-            await env.Runner.InitAsync("project01", "user01", CancellationToken.None);
+            await env.Runner.InitAsync("project01", "user01", "project01", CancellationToken.None);
             var textDocs = await env.Runner.FetchTextDocsAsync(textInfo);
 
             // SUT
@@ -1356,7 +1356,7 @@ namespace SIL.XForge.Scripture.Services
             // So the user id will be retrieved from the chapter permissions
             var env = new TestEnvironment();
             TextInfo textInfo = env.SetupChapterAuthorsAndGetTextInfo(setChapterPermissions: true);
-            await env.Runner.InitAsync("project01", "user02", CancellationToken.None);
+            await env.Runner.InitAsync("project01", "user02", "project01", CancellationToken.None);
             var textDocs = await env.Runner.FetchTextDocsAsync(textInfo);
 
             // SUT
@@ -1373,7 +1373,7 @@ namespace SIL.XForge.Scripture.Services
             // So the user id will be retrieved from the project doc
             var env = new TestEnvironment();
             TextInfo textInfo = env.SetupChapterAuthorsAndGetTextInfo(setChapterPermissions: false);
-            await env.Runner.InitAsync("project01", "user02", CancellationToken.None);
+            await env.Runner.InitAsync("project01", "user02", "project01", CancellationToken.None);
             var textDocs = await env.Runner.FetchTextDocsAsync(textInfo);
 
             // SUT
@@ -1391,7 +1391,7 @@ namespace SIL.XForge.Scripture.Services
             // But will not pass the chapter permissions test (only user05 has permission)
             var env = new TestEnvironment();
             TextInfo textInfo = env.SetupChapterAuthorsAndGetTextInfo(setChapterPermissions: false);
-            await env.Runner.InitAsync("project01", "user01", CancellationToken.None);
+            await env.Runner.InitAsync("project01", "user01", "project01", CancellationToken.None);
             var textDocs = await env.Runner.FetchTextDocsAsync(textInfo);
             textInfo.Chapters.First().Permissions.Add("user05", TextInfoPermission.Write);
             env.RealtimeService.LastModifiedUserId = "user06";
@@ -1412,7 +1412,7 @@ namespace SIL.XForge.Scripture.Services
             // However, user03 will be used because they are the project administrator
             var env = new TestEnvironment();
             TextInfo textInfo = env.SetupChapterAuthorsAndGetTextInfo(setChapterPermissions: false);
-            await env.Runner.InitAsync("project01", "user01", CancellationToken.None);
+            await env.Runner.InitAsync("project01", "user01", "project01", CancellationToken.None);
             var textDocs = await env.Runner.FetchTextDocsAsync(textInfo);
             textInfo.Chapters.First().Permissions.Add("user05", TextInfoPermission.Read);
             env.RealtimeService.LastModifiedUserId = "user05";
@@ -1440,7 +1440,7 @@ namespace SIL.XForge.Scripture.Services
                 Arg.Any<Dictionary<string, ParatextUserProfile>>()
             );
 
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
             await env.ParatextService
                 .Received(1)
                 .UpdateParatextCommentsAsync(
@@ -1472,7 +1472,7 @@ namespace SIL.XForge.Scripture.Services
             int expectedNoteCountChange = 1;
 
             // SUT
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             NoteThread thread01 = env.GetNoteThread("project01", "thread01");
             string expectedThreadTagIcon = "tag02";
@@ -1518,7 +1518,7 @@ namespace SIL.XForge.Scripture.Services
             string verseStr = "MAT 1:5";
             env.SetupNoteReattachedChange(threadId, verseStr);
 
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             NoteThread thread01 = env.GetNoteThread("project01", "thread01");
             string[] reattachedParts = new[]
@@ -1545,7 +1545,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupPTData(book);
             env.SetupNewNoteThreadChange("thread02", "syncuser01");
 
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             NoteThread thread02 = env.GetNoteThread("project01", "thread02");
             string expected =
@@ -1562,7 +1562,7 @@ namespace SIL.XForge.Scripture.Services
 
             // Add a conflict note
             env.SetupNewConflictNoteThreadChange("conflictthread01");
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             Assert.That(env.ContainsNoteThread("project01", "conflictthread01"), Is.True);
             project = env.GetProject();
@@ -1600,7 +1600,7 @@ namespace SIL.XForge.Scripture.Services
             );
 
             // SUT 1
-            await env.Runner.RunAsync(sfProjectId, "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync(sfProjectId, "user01", sfProjectId, false, CancellationToken.None);
 
             thread01 = env.GetNoteThread(sfProjectId, threadId);
             Assert.That(thread01.Notes.Select(n => n.DataId), Is.EquivalentTo(new[] { "n01", "n03" }));
@@ -1610,7 +1610,7 @@ namespace SIL.XForge.Scripture.Services
             // Remove the entire thread
             env.SetupNoteRemovedChange(threadId, null);
             // SUT 2
-            await env.Runner.RunAsync(sfProjectId, "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync(sfProjectId, "user01", sfProjectId, false, CancellationToken.None);
 
             Assert.That(env.ContainsNoteThread(sfProjectId, threadId), Is.False);
             project = env.GetProject();
@@ -1626,7 +1626,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupPTData(book);
             env.SetupNewNoteThreadChange("thread02", "syncuser01");
 
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             // Default resolved status is false
             NoteThread thread02 = env.GetNoteThread("project01", "thread02");
@@ -1635,7 +1635,7 @@ namespace SIL.XForge.Scripture.Services
 
             // Change resolve status to true
             env.SetupNoteStatusChange("thread02", NoteStatus.Resolved.InternalValue);
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             thread02 = env.GetNoteThread("project01", "thread02");
             Assert.That(thread02.VerseRef.ToString(), Is.EqualTo("MAT 1:1"));
@@ -1643,7 +1643,7 @@ namespace SIL.XForge.Scripture.Services
 
             // Change status back to false - happens if the note becomes unresolved again in Paratext
             env.SetupNoteStatusChange("thread02", NoteStatus.Todo.InternalValue);
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             thread02 = env.GetNoteThread("project01", "thread02");
             Assert.That(thread02.VerseRef.ToString(), Is.EqualTo("MAT 1:1"));
@@ -1669,7 +1669,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupThreadAndNoteChange(threadId, null, null);
 
             // SUT
-            await env.Runner.RunAsync(projectId, "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync(projectId, "user01", projectId, false, CancellationToken.None);
 
             thread03 = env.GetNoteThread(projectId, threadId);
             note = thread03.Notes[0];
@@ -1735,7 +1735,7 @@ namespace SIL.XForge.Scripture.Services
                 .Returns(new ParatextResource());
 
             // SUT
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             env.MockLogger.AssertEventCount(
                 (LogEvent logEvent) =>
@@ -1774,7 +1774,7 @@ namespace SIL.XForge.Scripture.Services
                 .Returns(new ParatextResource());
 
             // SUT
-            await env.Runner.RunAsync("project01", "user01", false, CancellationToken.None);
+            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             env.MockLogger.AssertEventCount(
                 (LogEvent logEvent) =>
@@ -1844,6 +1844,16 @@ namespace SIL.XForge.Scripture.Services
                         new SFProjectSecret { Id = "project05" },
                     }
                 );
+                var syncMetrics = new MemoryRepository<SyncMetrics>(
+                    new[]
+                    {
+                        new SyncMetrics { Id = "project01" },
+                        new SyncMetrics { Id = "project02" },
+                        new SyncMetrics { Id = "project03" },
+                        new SyncMetrics { Id = "project04" },
+                        new SyncMetrics { Id = "project05" },
+                    }
+                );
                 SFProjectService = Substitute.For<ISFProjectService>();
                 EngineService = Substitute.For<IEngineService>();
                 ParatextService = Substitute.For<IParatextService>();
@@ -1904,6 +1914,7 @@ namespace SIL.XForge.Scripture.Services
                 Runner = new ParatextSyncRunner(
                     userSecrets,
                     _projectSecrets,
+                    syncMetrics,
                     SFProjectService,
                     EngineService,
                     ParatextService,
@@ -2630,7 +2641,7 @@ namespace SIL.XForge.Scripture.Services
                 );
 
                 // SUT
-                await Runner.RunAsync(projectId, "user01", false, CancellationToken.None);
+                await Runner.RunAsync(projectId, "user01", projectId, false, CancellationToken.None);
 
                 thread03 = GetNoteThread(projectId, threadId);
                 note = thread03.Notes[0];

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -49,7 +49,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(project.Sync.DataInSync, Is.True);
 
             // Check that the failure was logged in the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
         }
 
@@ -67,7 +67,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(project.Sync.DataInSync, Is.False);
 
             // Check that the failure was logged in the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
         }
 
@@ -99,7 +99,7 @@ namespace SIL.XForge.Scripture.Services
             env.VerifyProjectSync(true);
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
             Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 4, deleted: 0, updated: 0)));
             syncMetrics = env.GetSyncMetrics("project02");
@@ -136,7 +136,7 @@ namespace SIL.XForge.Scripture.Services
             env.VerifyProjectSync(true);
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
             Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 4, deleted: 0, updated: 0)));
             syncMetrics = env.GetSyncMetrics("project02");
@@ -173,7 +173,7 @@ namespace SIL.XForge.Scripture.Services
             env.VerifyProjectSync(true);
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
             Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 4, deleted: 0, updated: 0)));
             syncMetrics = env.GetSyncMetrics("project02");
@@ -209,7 +209,7 @@ namespace SIL.XForge.Scripture.Services
             env.VerifyProjectSync(true);
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
             Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 4, deleted: 0, updated: 0)));
             syncMetrics = env.GetSyncMetrics("project02");
@@ -236,7 +236,7 @@ namespace SIL.XForge.Scripture.Services
             env.VerifyProjectSync(true);
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
             Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
             syncMetrics = env.GetSyncMetrics("project02");
@@ -428,7 +428,7 @@ namespace SIL.XForge.Scripture.Services
             env.VerifyProjectSync(true);
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 2)));
             Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 4)));
             syncMetrics = env.GetSyncMetrics("project02");
@@ -472,7 +472,7 @@ namespace SIL.XForge.Scripture.Services
             env.VerifyProjectSync(true);
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 2)));
             Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 1, updated: 0)));
             Assert.That(syncMetrics.Questions, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
@@ -556,14 +556,22 @@ namespace SIL.XForge.Scripture.Services
             env.VerifyProjectSync(true);
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 1, updated: 1)));
             Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 2, updated: 0)));
+            Assert.That(
+                syncMetrics.Notes,
+                Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
+            );
             Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
             Assert.That(syncMetrics.Questions, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 2, updated: 0)));
             syncMetrics = env.GetSyncMetrics("project02");
             Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 1, updated: 1)));
             Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 2, updated: 0)));
+            Assert.That(
+                syncMetrics.Notes,
+                Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
+            );
             Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
             Assert.That(syncMetrics.Questions, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 2, updated: 0)));
         }
@@ -593,7 +601,7 @@ namespace SIL.XForge.Scripture.Services
                 .RemoveUserWithoutPermissionsCheckAsync("user01", "project01", "user02");
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Users, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
         }
 
@@ -718,7 +726,7 @@ namespace SIL.XForge.Scripture.Services
                 .PutBookText(default, default, default, default, default);
 
             // Check that the failure was logged in the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
         }
 
@@ -747,7 +755,7 @@ namespace SIL.XForge.Scripture.Services
             await env.SFProjectService.DidNotReceiveWithAnyArgs().RemoveUserAsync("user01", "project01", "user02");
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Users, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
         }
 
@@ -834,7 +842,7 @@ namespace SIL.XForge.Scripture.Services
             env.VerifyProjectSync(true);
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
             syncMetrics = env.GetSyncMetrics("project02");
             Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
@@ -869,7 +877,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.GetText("project02", "MAT", 2).DeepEquals(chapterContent), Is.True);
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
             syncMetrics = env.GetSyncMetrics("project02");
             Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
@@ -912,7 +920,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsText("project02", "MAT", 3), Is.True);
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
             syncMetrics = env.GetSyncMetrics("project02");
             Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
@@ -943,7 +951,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
             syncMetrics = env.GetSyncMetrics("project02");
             Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
@@ -985,7 +993,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsText("project02", "MAT", 3), Is.False);
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 2, updated: 1)));
             syncMetrics = env.GetSyncMetrics("project02");
             Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 2, updated: 1)));
@@ -1150,7 +1158,7 @@ namespace SIL.XForge.Scripture.Services
             env.MockLogger.AssertHasEvent((LogEvent logEvent) => logEvent.Exception != null);
 
             // Check that the exception was logged in the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
             StringAssert.StartsWith("System.ArgumentException", syncMetrics.ErrorDetails);
 
@@ -1185,7 +1193,7 @@ namespace SIL.XForge.Scripture.Services
             await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
             // Check that the failure was logged in the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
             Assert.That(syncMetrics.RepositoryRestoredFromBackup, Is.True);
 
@@ -1234,7 +1242,7 @@ namespace SIL.XForge.Scripture.Services
             );
 
             // Check that the cancellation was logged in the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
 
             // Check that the task cancelled correctly
@@ -1268,7 +1276,7 @@ namespace SIL.XForge.Scripture.Services
             await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
 
             // Check that the cancellation was logged in the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
 
             // Check that the task cancelled correctly
@@ -1302,7 +1310,7 @@ namespace SIL.XForge.Scripture.Services
             SFProject project = env.VerifyProjectSync(false);
 
             // Check that the cancellation was logged in the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
 
             // Data is out of sync due to the failed restore
@@ -1325,7 +1333,7 @@ namespace SIL.XForge.Scripture.Services
             await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
 
             // Check that the cancellation was logged in the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
 
             // Check that the task was cancelled after awaiting the check above
@@ -1378,7 +1386,7 @@ namespace SIL.XForge.Scripture.Services
             env.Connection.Received(1).RollbackTransaction();
 
             // Check that the cancellation was logged in the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
         }
 
@@ -1708,8 +1716,12 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(project.Sync.LastSyncSuccessful, Is.True);
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+            Assert.That(
+                syncMetrics.Notes,
+                Is.EqualTo(new NoteSyncMetricInfo(added: 1, deleted: 1, updated: 1, removed: 0))
+            );
             Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 1)));
         }
 
@@ -1742,9 +1754,13 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(thread01.Notes.Single(n => n.Reattached != null).Reattached, Is.EqualTo(reattached));
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
-            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 1)));
+            Assert.That(
+                syncMetrics.Notes,
+                Is.EqualTo(new NoteSyncMetricInfo(added: 1, deleted: 0, updated: 0, removed: 0))
+            );
+            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
         }
 
         [Test]
@@ -1780,8 +1796,12 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(project.Sync.LastSyncSuccessful, Is.True);
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+            Assert.That(
+                syncMetrics.Notes,
+                Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
+            );
             Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
         }
 
@@ -1823,19 +1843,33 @@ namespace SIL.XForge.Scripture.Services
             SFProject project = env.GetProject();
             Assert.That(project.Sync.LastSyncSuccessful, Is.True);
 
+            // Verify the sync metrics
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+            Assert.That(
+                syncMetrics.Notes,
+                Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 1))
+            );
+            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+
             // Remove the entire thread
             env.SetupNoteRemovedChange(threadId, null);
+
             // SUT 2
-            await env.Runner.RunAsync(sfProjectId, "user01", sfProjectId, false, CancellationToken.None);
+            await env.Runner.RunAsync(sfProjectId, "user01", "project01_alt", false, CancellationToken.None);
 
             Assert.That(env.ContainsNoteThread(sfProjectId, threadId), Is.False);
             project = env.GetProject();
             Assert.That(project.Sync.LastSyncSuccessful, Is.True);
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            syncMetrics = env.GetSyncMetrics("project01_alt");
             Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
-            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 2)));
+            Assert.That(
+                syncMetrics.Notes,
+                Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
+            );
+            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
         }
 
         [Test]
@@ -1863,8 +1897,12 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(thread02.Status, Is.EqualTo(NoteStatus.Resolved.InternalValue));
 
             // Verify the sync metrics
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+            Assert.That(
+                syncMetrics.Notes,
+                Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
+            );
             Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 1)));
 
             // Change status back to false - happens if the note becomes unresolved again in Paratext
@@ -1878,6 +1916,10 @@ namespace SIL.XForge.Scripture.Services
             // Verify the sync metrics
             syncMetrics = env.GetSyncMetrics("project01_alt");
             Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+            Assert.That(
+                syncMetrics.Notes,
+                Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
+            );
             Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 1)));
         }
 
@@ -1909,9 +1951,13 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(note.NoteToString(), Is.EqualTo(origNoteData), "Note data should not have been changed");
 
             // Verify the sync metrics - the note data will be updated, even though it is not changed
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
-            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 1)));
+            Assert.That(
+                syncMetrics.Notes,
+                Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
+            );
+            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
         }
 
         [Test]
@@ -1987,7 +2033,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ContainsText("project01", "MRK", 2), Is.False);
 
             // Check that the resource users metrics have been updated
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.ResourceUsers, Is.EqualTo(new SyncMetricInfo(2, 0, 0)));
         }
 
@@ -2042,7 +2088,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(project.Sync.DataInSync, Is.True);
 
             // Check that the date started and date finished are set
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.DateStarted, Is.Not.Null);
             Assert.That(syncMetrics.DateFinished, Is.Not.Null);
         }
@@ -2058,8 +2104,7 @@ namespace SIL.XForge.Scripture.Services
             SFProject project = env.VerifyProjectSync(false);
             Assert.That(project.Sync.DataInSync, Is.True);
 
-            // Check that the date started and date finished are set
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.Log.Count, Is.Not.Zero);
         }
 
@@ -2082,7 +2127,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(project.Sync.DataInSync, Is.True);
 
             // Check that the metrics were updated
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.RepositoryBackupCreated, Is.True);
         }
 
@@ -2103,7 +2148,7 @@ namespace SIL.XForge.Scripture.Services
             env.VerifyProjectSync(true);
 
             // Check that as PutNotes was run twice, the metrics will be multiplied by two
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.ParatextNotes, Is.EqualTo(syncMetricInfo + syncMetricInfo));
         }
 
@@ -2142,7 +2187,7 @@ namespace SIL.XForge.Scripture.Services
             env.VerifyProjectSync(true);
 
             // Check that as PutBookText was run twice, the metrics will be that two books are added
-            var syncMetrics = env.GetSyncMetrics("project01");
+            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
             Assert.That(syncMetrics.ParatextBooks, Is.EqualTo(new SyncMetricInfo(0, 0, 2)));
         }
 
@@ -2373,7 +2418,7 @@ namespace SIL.XForge.Scripture.Services
                 Assert.That(project.Sync.SyncedToRepositoryVersion, Is.EqualTo(syncedToRepositoryVersion));
 
                 // Check for the correct system metrics status
-                var syncMetrics = GetSyncMetrics(projectSFId);
+                SyncMetrics syncMetrics = GetSyncMetrics(projectSFId);
                 if (lastSyncSuccess)
                 {
                     Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));

--- a/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
@@ -244,18 +244,16 @@ namespace SIL.XForge.Scripture.Services
         [Test]
         public async Task SyncAsync_SourceProjectSecretsRecordsSyncMetricsId()
         {
-            // Set up test environment
             var env = new TestEnvironment();
 
-            // Run sync
             await env.Service.SyncAsync("userid", Project01, false);
 
             // Verify that the sync metrics ids are recorded in the project secrets
-            Assert.That(env.SyncMetrics.Get(env.ProjectSecrets.Get(Project01).SyncMetricsIds.First()), Is.Not.Null);
+            string syncMetricsId = env.ProjectSecrets.Get(Project01).SyncMetricsIds.First();
+            Assert.That(env.SyncMetrics.Get(syncMetricsId), Is.Not.Null);
             Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
             Assert.That(env.ProjectSecrets.Get(Project03).SyncMetricsIds, Is.Empty);
 
-            // Cancel sync
             await env.Service.CancelSyncAsync("userid", Project01);
 
             // Verify that the sync metrics are cleared from the project secrets
@@ -267,18 +265,17 @@ namespace SIL.XForge.Scripture.Services
         [Test]
         public async Task SyncAsync_SourceAndTargetProjectSecretsRecordsSyncMetricsId()
         {
-            // Set up test environment
             var env = new TestEnvironment();
 
-            // Run sync
             await env.Service.SyncAsync("userid", Project03, false);
 
             // Verify that the sync metrics ids are recorded in the project secrets
-            Assert.That(env.SyncMetrics.Get(env.ProjectSecrets.Get(Project01).SyncMetricsIds.First()), Is.Not.Null);
+            string syncMetricsId01 = env.ProjectSecrets.Get(Project01).SyncMetricsIds.First();
+            string syncMetricsId03 = env.ProjectSecrets.Get(Project03).SyncMetricsIds.First();
+            Assert.That(env.SyncMetrics.Get(syncMetricsId01), Is.Not.Null);
             Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
-            Assert.That(env.SyncMetrics.Get(env.ProjectSecrets.Get(Project03).SyncMetricsIds.First()), Is.Not.Null);
+            Assert.That(env.SyncMetrics.Get(syncMetricsId03), Is.Not.Null);
 
-            // Cancel sync
             await env.Service.CancelSyncAsync("userid", Project03);
 
             // Verify that the sync metrics are cleared from the project secrets
@@ -290,21 +287,20 @@ namespace SIL.XForge.Scripture.Services
         [Test]
         public async Task SyncAsync_SourceWithCancelledTargetProjectSecretsRecordsSyncMetricsId()
         {
-            // Set up test environment
             var env = new TestEnvironment();
 
-            // Run sync
             await env.Service.SyncAsync("userid", Project03, false);
 
             // Verify that the sync metrics ids are recorded in the project secrets
-            Assert.That(env.SyncMetrics.Get(env.ProjectSecrets.Get(Project01).SyncMetricsIds.First()), Is.Not.Null);
+            string syncMetricsId01 = env.ProjectSecrets.Get(Project01).SyncMetricsIds.First();
+            string syncMetricsId03 = env.ProjectSecrets.Get(Project03).SyncMetricsIds.First();
+            Assert.That(env.SyncMetrics.Get(syncMetricsId01), Is.Not.Null);
             Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
-            Assert.That(env.SyncMetrics.Get(env.ProjectSecrets.Get(Project03).SyncMetricsIds.First()), Is.Not.Null);
+            Assert.That(env.SyncMetrics.Get(syncMetricsId03), Is.Not.Null);
 
-            // Cancel sync
             await env.Service.CancelSyncAsync("userid", Project01);
 
-            // Verify that the sync metrics are cleared from the project secrets
+            // Verify that the sync metrics are only cleared from the target project secrets
             Assert.That(env.ProjectSecrets.Get(Project01).SyncMetricsIds, Is.Empty);
             Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
             Assert.That(env.SyncMetrics.Get(env.ProjectSecrets.Get(Project03).SyncMetricsIds.First()), Is.Not.Null);
@@ -316,7 +312,6 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             Assert.That(env.SyncMetrics.Query().Any(), Is.False);
 
-            // Run sync
             await env.Service.SyncAsync("userid", Project03, false);
 
             // Verify the sync metrics as queued
@@ -329,7 +324,6 @@ namespace SIL.XForge.Scripture.Services
                 Is.EqualTo(SyncStatus.Queued)
             );
 
-            // Cancel sync
             await env.Service.CancelSyncAsync("userid", Project03);
 
             // Verify the sync metrics as cancelled
@@ -349,7 +343,6 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             Assert.That(env.SyncMetrics.Query().Any(), Is.False);
 
-            // Run sync
             await env.Service.SyncAsync("userid", Project03, false);
 
             // Verify the sync metrics
@@ -369,7 +362,6 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             Assert.That(env.SyncMetrics.Query().Any(), Is.False);
 
-            // Run sync
             await env.Service.SyncAsync("userid", Project03, false);
 
             // Verify the sync metrics as queued
@@ -382,7 +374,6 @@ namespace SIL.XForge.Scripture.Services
                 Is.EqualTo(SyncStatus.Queued)
             );
 
-            // Cancel sync
             await env.Service.CancelSyncAsync("userid", Project01);
 
             // Verify the sync metrics as cancelled
@@ -402,7 +393,6 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             Assert.That(env.SyncMetrics.Query().Any(), Is.False);
 
-            // Run sync
             await env.Service.SyncAsync("userid", Project03, false);
 
             // Verify the sync metrics
@@ -419,14 +409,11 @@ namespace SIL.XForge.Scripture.Services
             DateTime beforeSync = DateTime.UtcNow;
             Assert.That(env.SyncMetrics.Query().Any(), Is.False);
 
-            // Run sync
             await env.Service.SyncAsync("userid", Project01, false);
             DateTime afterSync = DateTime.UtcNow;
 
             // Verify the sync metrics
             var syncMetrics = env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01);
-            Assert.That(syncMetrics.DateQueued, Is.Not.EqualTo(DateTime.MinValue));
-            Assert.That(syncMetrics.DateQueued, Is.Not.EqualTo(DateTime.MaxValue));
             Assert.That(syncMetrics.DateQueued, Is.GreaterThanOrEqualTo(beforeSync));
             Assert.That(syncMetrics.DateQueued, Is.LessThanOrEqualTo(afterSync));
             Assert.That(syncMetrics.DateStarted, Is.Null);
@@ -440,7 +427,6 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.SyncMetrics.Query().Any(), Is.False);
             string curUserId = "userid";
 
-            // Run sync
             await env.Service.SyncAsync(curUserId, Project01, false);
 
             // Verify the sync metrics
@@ -453,7 +439,6 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             Assert.That(env.SyncMetrics.Query().Any(), Is.False);
 
-            // Run sync
             await env.Service.SyncAsync("userid", Project01, false);
 
             // Verify the sync metrics as queued
@@ -462,7 +447,6 @@ namespace SIL.XForge.Scripture.Services
                 Is.EqualTo(SyncStatus.Queued)
             );
 
-            // Cancel sync
             await env.Service.CancelSyncAsync("userid", Project01);
 
             // Verify the sync metrics as cancelled
@@ -478,7 +462,6 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             Assert.That(env.SyncMetrics.Query().Any(), Is.False);
 
-            // Run sync
             await env.Service.SyncAsync("userid", Project01, false);
 
             // Verify the sync metrics

--- a/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Hangfire;
 using Hangfire.Common;
@@ -40,6 +42,9 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
             Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
             Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.EqualTo(1));
 
             // Cancel sync
             await env.Service.CancelSyncAsync("userid", Project03);
@@ -55,6 +60,9 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Is.Empty);
             Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
             Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.EqualTo(1));
         }
 
         [Test]
@@ -77,6 +85,9 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
             Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
             Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.EqualTo(1));
 
             // Cancel sync
             await env.Service.CancelSyncAsync("userid", Project01);
@@ -92,6 +103,9 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Is.Empty);
             Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
             Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.EqualTo(1));
         }
 
         [Test]
@@ -114,6 +128,9 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
             Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
             Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.Zero);
 
             // Cancel sync
             await env.Service.CancelSyncAsync("userid", Project01);
@@ -129,6 +146,9 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Is.Empty);
             Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
             Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.Zero);
         }
 
         [Test]
@@ -160,6 +180,9 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
             Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
             Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.EqualTo(1));
         }
 
         [Test]
@@ -188,6 +211,9 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
             Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
             Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.EqualTo(1));
         }
 
         [Test]
@@ -210,6 +236,187 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
             Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
             Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
+            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.Zero);
+        }
+
+        [Test]
+        public async Task SyncAsync_SyncMetricsSourceAndTargetCancelled()
+        {
+            var env = new TestEnvironment();
+            Assert.That(env.SyncMetrics.Query().Any(), Is.False);
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project03, false);
+
+            // Verify the sync metrics as queued
+            Assert.That(
+                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
+                Is.EqualTo(SyncStatus.Queued)
+            );
+            Assert.That(
+                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project03).Status,
+                Is.EqualTo(SyncStatus.Queued)
+            );
+
+            // Cancel sync
+            await env.Service.CancelSyncAsync("userid", Project03);
+
+            // Verify the sync metrics as cancelled
+            Assert.That(
+                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
+                Is.EqualTo(SyncStatus.Cancelled)
+            );
+            Assert.That(
+                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project03).Status,
+                Is.EqualTo(SyncStatus.Cancelled)
+            );
+        }
+
+        [Test]
+        public async Task SyncAsync_SyncMetricsSourceAndTargetQueued()
+        {
+            var env = new TestEnvironment();
+            Assert.That(env.SyncMetrics.Query().Any(), Is.False);
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project03, false);
+
+            // Verify the sync metrics
+            Assert.That(
+                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
+                Is.EqualTo(SyncStatus.Queued)
+            );
+            Assert.That(
+                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project03).Status,
+                Is.EqualTo(SyncStatus.Queued)
+            );
+        }
+
+        [Test]
+        public async Task SyncAsync_SyncMetricsSourceNotTargetCancelled()
+        {
+            var env = new TestEnvironment();
+            Assert.That(env.SyncMetrics.Query().Any(), Is.False);
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project03, false);
+
+            // Verify the sync metrics as queued
+            Assert.That(
+                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
+                Is.EqualTo(SyncStatus.Queued)
+            );
+            Assert.That(
+                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project03).Status,
+                Is.EqualTo(SyncStatus.Queued)
+            );
+
+            // Cancel sync
+            await env.Service.CancelSyncAsync("userid", Project01);
+
+            // Verify the sync metrics as cancelled
+            Assert.That(
+                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
+                Is.EqualTo(SyncStatus.Cancelled)
+            );
+            Assert.That(
+                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project03).Status,
+                Is.EqualTo(SyncStatus.Queued)
+            );
+        }
+
+        [Test]
+        public async Task SyncAsync_SyncMetricsSourceRequiresTarget()
+        {
+            var env = new TestEnvironment();
+            Assert.That(env.SyncMetrics.Query().Any(), Is.False);
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project03, false);
+
+            // Verify the sync metrics
+            string sourceId = env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Id;
+            string requiresId = env.SyncMetrics.Query().Single(s => s.ProjectRef == Project03).RequiresId;
+            Assert.That(string.IsNullOrWhiteSpace(requiresId), Is.False);
+            Assert.That(requiresId, Is.EqualTo(sourceId));
+        }
+
+        [Test]
+        public async Task SyncAsync_SyncMetricsSpecifiesDateQueued()
+        {
+            var env = new TestEnvironment();
+            DateTime beforeSync = DateTime.UtcNow;
+            Assert.That(env.SyncMetrics.Query().Any(), Is.False);
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project01, false);
+            DateTime afterSync = DateTime.UtcNow;
+
+            // Verify the sync metrics
+            var syncMetrics = env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01);
+            Assert.That(syncMetrics.DateQueued, Is.Not.EqualTo(DateTime.MinValue));
+            Assert.That(syncMetrics.DateQueued, Is.Not.EqualTo(DateTime.MaxValue));
+            Assert.That(syncMetrics.DateQueued, Is.GreaterThanOrEqualTo(beforeSync));
+            Assert.That(syncMetrics.DateQueued, Is.LessThanOrEqualTo(afterSync));
+            Assert.That(syncMetrics.DateStarted, Is.Null);
+            Assert.That(syncMetrics.DateFinished, Is.Null);
+        }
+
+        [Test]
+        public async Task SyncAsync_SyncMetricsSpecifiesUser()
+        {
+            var env = new TestEnvironment();
+            Assert.That(env.SyncMetrics.Query().Any(), Is.False);
+            string curUserId = "userid";
+
+            // Run sync
+            await env.Service.SyncAsync(curUserId, Project01, false);
+
+            // Verify the sync metrics
+            Assert.That(env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).UserRef, Is.EqualTo(curUserId));
+        }
+
+        [Test]
+        public async Task SyncAsync_SyncMetricsTargetOnlyCancelled()
+        {
+            var env = new TestEnvironment();
+            Assert.That(env.SyncMetrics.Query().Any(), Is.False);
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project01, false);
+
+            // Verify the sync metrics as queued
+            Assert.That(
+                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
+                Is.EqualTo(SyncStatus.Queued)
+            );
+
+            // Cancel sync
+            await env.Service.CancelSyncAsync("userid", Project01);
+
+            // Verify the sync metrics as cancelled
+            Assert.That(
+                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
+                Is.EqualTo(SyncStatus.Cancelled)
+            );
+        }
+
+        [Test]
+        public async Task SyncAsync_SyncMetricsTargetOnlyQueued()
+        {
+            var env = new TestEnvironment();
+            Assert.That(env.SyncMetrics.Query().Any(), Is.False);
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project01, false);
+
+            // Verify the sync metrics
+            Assert.That(
+                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
+                Is.EqualTo(SyncStatus.Queued)
+            );
         }
 
         [Test]
@@ -265,7 +472,7 @@ namespace SIL.XForge.Scripture.Services
                         new SFProjectSecret { Id = "project03" },
                     }
                 );
-                var syncMetrics = new MemoryRepository<SyncMetrics>();
+                SyncMetrics = new MemoryRepository<SyncMetrics>();
                 RealtimeService = new SFMemoryRealtimeService();
 
                 RealtimeService.AddRepository(
@@ -313,7 +520,7 @@ namespace SIL.XForge.Scripture.Services
                 Service = new SyncService(
                     BackgroundJobClient,
                     ProjectSecrets,
-                    syncMetrics,
+                    SyncMetrics,
                     RealtimeService,
                     MockLogger
                 );
@@ -323,6 +530,7 @@ namespace SIL.XForge.Scripture.Services
             public IBackgroundJobClient BackgroundJobClient { get; }
             public MemoryRepository<SFProjectSecret> ProjectSecrets { get; }
             public SFMemoryRealtimeService RealtimeService { get; }
+            public MemoryRepository<SyncMetrics> SyncMetrics { get; }
         }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
@@ -242,6 +242,75 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
+        public async Task SyncAsync_SourceProjectSecretsRecordsSyncMetricsId()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project01, false);
+
+            // Verify that the sync metrics ids are recorded in the project secrets
+            Assert.That(env.SyncMetrics.Get(env.ProjectSecrets.Get(Project01).SyncMetricsIds.First()), Is.Not.Null);
+            Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project03).SyncMetricsIds, Is.Empty);
+
+            // Cancel sync
+            await env.Service.CancelSyncAsync("userid", Project01);
+
+            // Verify that the sync metrics are cleared from the project secrets
+            Assert.That(env.ProjectSecrets.Get(Project01).SyncMetricsIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project03).SyncMetricsIds, Is.Empty);
+        }
+
+        [Test]
+        public async Task SyncAsync_SourceAndTargetProjectSecretsRecordsSyncMetricsId()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project03, false);
+
+            // Verify that the sync metrics ids are recorded in the project secrets
+            Assert.That(env.SyncMetrics.Get(env.ProjectSecrets.Get(Project01).SyncMetricsIds.First()), Is.Not.Null);
+            Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
+            Assert.That(env.SyncMetrics.Get(env.ProjectSecrets.Get(Project03).SyncMetricsIds.First()), Is.Not.Null);
+
+            // Cancel sync
+            await env.Service.CancelSyncAsync("userid", Project03);
+
+            // Verify that the sync metrics are cleared from the project secrets
+            Assert.That(env.ProjectSecrets.Get(Project01).SyncMetricsIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project03).SyncMetricsIds, Is.Empty);
+        }
+
+        [Test]
+        public async Task SyncAsync_SourceWithCancelledTargetProjectSecretsRecordsSyncMetricsId()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+
+            // Run sync
+            await env.Service.SyncAsync("userid", Project03, false);
+
+            // Verify that the sync metrics ids are recorded in the project secrets
+            Assert.That(env.SyncMetrics.Get(env.ProjectSecrets.Get(Project01).SyncMetricsIds.First()), Is.Not.Null);
+            Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
+            Assert.That(env.SyncMetrics.Get(env.ProjectSecrets.Get(Project03).SyncMetricsIds.First()), Is.Not.Null);
+
+            // Cancel sync
+            await env.Service.CancelSyncAsync("userid", Project01);
+
+            // Verify that the sync metrics are cleared from the project secrets
+            Assert.That(env.ProjectSecrets.Get(Project01).SyncMetricsIds, Is.Empty);
+            Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
+            Assert.That(env.SyncMetrics.Get(env.ProjectSecrets.Get(Project03).SyncMetricsIds.First()), Is.Not.Null);
+        }
+
+        [Test]
         public async Task SyncAsync_SyncMetricsSourceAndTargetCancelled()
         {
             var env = new TestEnvironment();

--- a/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
@@ -265,6 +265,7 @@ namespace SIL.XForge.Scripture.Services
                         new SFProjectSecret { Id = "project03" },
                     }
                 );
+                var syncMetrics = new MemoryRepository<SyncMetrics>();
                 RealtimeService = new SFMemoryRealtimeService();
 
                 RealtimeService.AddRepository(
@@ -309,7 +310,13 @@ namespace SIL.XForge.Scripture.Services
 
                 MockLogger = new MockLogger<SyncService>();
 
-                Service = new SyncService(BackgroundJobClient, ProjectSecrets, RealtimeService, MockLogger);
+                Service = new SyncService(
+                    BackgroundJobClient,
+                    ProjectSecrets,
+                    syncMetrics,
+                    RealtimeService,
+                    MockLogger
+                );
             }
 
             public SyncService Service { get; }


### PR DESCRIPTION
This pull request saves the results of each sync to Mongo in a new collection, `sync_metrics`. A new document is created in this collection for every sync.

The metrics recorded include:

 * Project that is being synced
 * User doing the sync
 * Time sync was queued
 * Time sync started
 * Time sync finished
 * Status of sync (queued, running, successful, failed, cancelled)
 * On failure, the error message
 * Whether this sync had to wait on another sync
 * Whether a backup is created and/or restored
 * Books in SF added/deleted/updated
 * Books in PT updated
 * Notes in SF added/deleted/updated
 * Notes in PT added/deleted/updated
 * Questions in SF deleted
 * TextDocs in SF added/deleted/updated
 * Resource User access in SF added or removed
 * User access in SF removed from the project
 * A log including:
   * The log messages from `ParatextSyncRunner`
   * The time various stages of the sync occur

**Notes**

 * There is no interface for viewing these metrics in the frontend.
 * The realtime server is not used for storing the metrics, as they are not sent to the frontend.
 * The log does not log messages from `ParatextService`, as this would have convoluted the implementation of `ParatextService` due to its singleton scope.
 * Existing unit tests have been updated to utilize the sync metrics

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1485)
<!-- Reviewable:end -->
