### PR TITLE
SF-1704 Allow user to add a note and edit notes in existing thread

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
@@ -30,19 +30,15 @@
           <div class="note-conflict-explanation" *ngIf="isConflictNote(note)">{{ t("acceptance_change_heading") }}</div>
           <div class="note-content" [innerHTML]="parseNote(note.acceptedChangeXml)" *ngIf="isConflictNote(note)"></div>
           <div class="note-conflict-explanation" *ngIf="isConflictNote(note)">{{ t("rejection_change_heading") }}</div>
-          <div class="row-layout">
+          <div class="note-content-and-actions">
             <div class="note-content" [innerHTML]="contentForDisplay(note)"></div>
-            <div fxHide.xs *ngIf="isNoteEditable(note)" class="edit-actions">
+            <div *ngIf="isNoteEditable(note)" class="edit-actions">
               <button mat-icon-button class="edit-button" (click)="editNote(note)"><mat-icon>edit</mat-icon></button>
               <button mat-icon-button class="delete-button" (click)="deleteNote(note)">
                 <mat-icon>delete</mat-icon>
               </button>
             </div>
           </div>
-        </div>
-        <div fxShow.xs fxHide.gt-xs *ngIf="isNoteEditable(note)" class="edit-actions">
-          <button mat-icon-button class="edit-button" (click)="editNote(note)"><mat-icon>edit</mat-icon></button>
-          <button mat-icon-button class="delete-button" (click)="deleteNote(note)"><mat-icon>delete</mat-icon></button>
         </div>
         <img [src]="noteIcon(note)" alt="" [title]="noteTitle(note)" />
         <app-owner [ownerRef]="note.ownerRef" [dateTime]="note.dateCreated"></app-owner>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
@@ -21,7 +21,7 @@
       </mat-menu>
     </div>
     <div class="notes">
-      <div *ngFor="let note of notes" class="note">
+      <div *ngFor="let note of notesToDisplay" class="note">
         <div class="content">
           <div *ngIf="note.assignment != null" class="assigned-user">>{{ getAssignedUserString(note.assignment) }}</div>
           <div *ngIf="note.reattached" class="verse-reattached">{{ reattachedVerse(note) }}</div>
@@ -30,14 +30,26 @@
           <div class="note-conflict-explanation" *ngIf="isConflictNote(note)">{{ t("acceptance_change_heading") }}</div>
           <div class="note-content" [innerHTML]="parseNote(note.acceptedChangeXml)" *ngIf="isConflictNote(note)"></div>
           <div class="note-conflict-explanation" *ngIf="isConflictNote(note)">{{ t("rejection_change_heading") }}</div>
-          <div class="note-content" [innerHTML]="contentForDisplay(note)"></div>
+          <div class="row-layout">
+            <div class="note-content" [innerHTML]="contentForDisplay(note)"></div>
+            <div fxHide.xs *ngIf="isNoteEditable(note)" class="edit-actions">
+              <button mat-icon-button class="edit-button" (click)="editNote(note)"><mat-icon>edit</mat-icon></button>
+              <button mat-icon-button class="delete-button" (click)="deleteNote(note)">
+                <mat-icon>delete</mat-icon>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div fxShow.xs fxHide.gt-xs *ngIf="isNoteEditable(note)" class="edit-actions">
+          <button mat-icon-button class="edit-button" (click)="editNote(note)"><mat-icon>edit</mat-icon></button>
+          <button mat-icon-button class="delete-button" (click)="deleteNote(note)"><mat-icon>delete</mat-icon></button>
         </div>
         <img [src]="noteIcon(note)" alt="" [title]="noteTitle(note)" />
         <app-owner [ownerRef]="note.ownerRef" [dateTime]="note.dateCreated"></app-owner>
       </div>
     </div>
     <mat-form-field *ngIf="canInsertNote" class="full-width" appearance="fill">
-      <textarea matInput [(ngModel)]="currentNote"></textarea>
+      <textarea matInput [(ngModel)]="currentNoteContent"></textarea>
     </mat-form-field>
   </mat-dialog-content>
   <mat-dialog-actions fxLayoutAlign="end">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
@@ -16,6 +16,9 @@ h1 {
     margin-right: -15px;
   }
 }
+.mat-dialog-content {
+  min-height: 300px;
+}
 .text-row {
   display: flex;
   min-height: 30px;
@@ -42,6 +45,15 @@ h1 {
     .content {
       color: #000;
       flex: 1 1 100%;
+      .row-layout {
+        display: flex;
+        .note-content {
+          flex-grow: 1;
+        }
+        .edit-actions {
+          flex: 0;
+        }
+      }
     }
     &:first-child {
       padding-top: 10px;
@@ -52,6 +64,12 @@ h1 {
     app-owner {
       display: block;
       margin: 5px;
+    }
+    .edit-actions {
+      display: flex;
+      align-items: end;
+      justify-content: end;
+      flex: 1 1 100%;
     }
     img {
       align-self: center;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
@@ -45,15 +45,6 @@ h1 {
     .content {
       color: #000;
       flex: 1 1 100%;
-      .row-layout {
-        display: flex;
-        .note-content {
-          flex-grow: 1;
-        }
-        .edit-actions {
-          flex: 0;
-        }
-      }
     }
     &:first-child {
       padding-top: 10px;
@@ -64,12 +55,6 @@ h1 {
     app-owner {
       display: block;
       margin: 5px;
-    }
-    .edit-actions {
-      display: flex;
-      align-items: end;
-      justify-content: end;
-      flex: 1 1 100%;
     }
     img {
       align-self: center;
@@ -102,5 +87,20 @@ h1 {
 .ltr {
   .note {
     flex-direction: row-reverse;
+  }
+}
+
+.note-content-and-actions {
+  display: flex;
+  @include media-breakpoint-down(xs) {
+    flex-direction: column;
+  }
+  .note-content {
+    flex-basis: 100%;
+  }
+  .edit-actions {
+    flex-basis: 0;
+    display: flex;
+    align-self: flex-end;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { sortBy } from 'lodash-es';
+import { cloneDeep, sortBy } from 'lodash-es';
 import { fromVerseRef, toVerseRef, VerseRefData } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { Note, REATTACH_SEPARATOR } from 'realtime-server/lib/esm/scriptureforge/models/note';
 import { I18nService } from 'xforge-common/i18n.service';
@@ -47,12 +47,14 @@ export interface NoteDialogResult {
 })
 export class NoteDialogComponent implements OnInit {
   showSegmentText: boolean = false;
-  currentNote: string = '';
+  currentNoteContent: string = '';
   private isAssignedToOtherUser: boolean = false;
   private threadDoc?: NoteThreadDoc;
   private projectProfileDoc?: SFProjectProfileDoc;
   private textDoc?: TextDoc;
   private paratextProjectUsers?: ParatextUserProfile[];
+  private noteBeingEdited?: Note;
+  private lastNoteId?: string;
 
   constructor(
     private readonly dialogRef: MatDialogRef<NoteDialogComponent, NoteDialogResult>,
@@ -84,6 +86,11 @@ export class NoteDialogComponent implements OnInit {
         );
       }
     }
+
+    this.noteBeingEdited = this.getNoteTemplate(this.threadId);
+    const notesCount: number = this.notesToDisplay.length;
+    const lastNoteId: string | undefined = notesCount > 0 ? this.notesToDisplay[notesCount - 1].dataId : undefined;
+    this.lastNoteId = lastNoteId;
   }
 
   get noteThreadAssignedUserRef(): string | undefined {
@@ -108,12 +115,12 @@ export class NoteDialogComponent implements OnInit {
     return this.projectProfileDoc.data.isRightToLeft ?? false;
   }
 
-  get notes(): Note[] {
+  get notesToDisplay(): Note[] {
     if (this.threadDoc?.data == null) {
       return [];
     }
     return sortBy(
-      this.threadDoc.data.notes.filter(n => !n.deleted),
+      this.threadDoc.data.notes.filter(n => !n.deleted && n.dataId !== this.noteBeingEdited?.dataId),
       n => n.dateCreated
     );
   }
@@ -204,6 +211,15 @@ export class NoteDialogComponent implements OnInit {
     return this.featureFlags.allowAddingNotes.enabled;
   }
 
+  editNote(note: Note): void {
+    this.noteBeingEdited = cloneDeep(note);
+    this.currentNoteContent = note.content ?? '';
+  }
+
+  deleteNote(note: Note): void {
+    console.log('TODO: delete note: ' + note.dataId);
+  }
+
   parseNote(content: string | undefined): string {
     // See also PT CommentEditHelper.cs and CommentEditHelperTests.cs for info and examples on how conflict
     // information is interpreted.
@@ -253,6 +269,10 @@ export class NoteDialogComponent implements OnInit {
     return note.reattached != null ? translate('note_dialog.note_reattached') : '';
   }
 
+  isNoteEditable(note: Note): boolean {
+    return note.dataId === this.lastNoteId && note.ownerRef === this.userService.currentUserId;
+  }
+
   reattachedText(note: Note): string {
     if (note.reattached == null) {
       return '';
@@ -291,7 +311,11 @@ export class NoteDialogComponent implements OnInit {
   }
 
   submit(): void {
-    if (this.currentNote == null || this.currentNote.trim().length === 0) {
+    if (
+      this.noteBeingEdited == null ||
+      this.currentNoteContent == null ||
+      this.currentNoteContent.trim().length === 0
+    ) {
       this.dialogRef.close();
       return;
     }
@@ -299,27 +323,36 @@ export class NoteDialogComponent implements OnInit {
     if (verseRef == null) return;
 
     const currentDate = new Date().toJSON();
-    const note: Note = {
-      dataId: objectId(),
-      // empty so that the editor component knows this is a new note
-      threadId: '',
+    if (this.noteBeingEdited.dataId === '') {
+      this.noteBeingEdited.dataId = objectId();
+      this.noteBeingEdited.dateCreated = currentDate;
+    }
+    this.noteBeingEdited.dateModified = currentDate;
+    this.noteBeingEdited.content = this.currentNoteContent;
+
+    const result: NoteDialogResult = {
+      verseRef: fromVerseRef(verseRef),
+      note: this.noteBeingEdited,
+      position: { start: 0, length: 0 },
+      selectedText: this.segmentText
+    };
+    this.dialogRef.close(result);
+  }
+
+  private getNoteTemplate(threadId: string | undefined): Note {
+    return {
+      dataId: '',
+      // thread id is the empty string when the note belongs to a new thread
+      threadId: threadId ?? '',
       ownerRef: this.userService.currentUserId,
-      content: this.currentNote,
-      dateCreated: currentDate,
-      dateModified: currentDate,
+      content: '',
+      dateCreated: '',
+      dateModified: '',
       conflictType: NoteConflictType.DefaultValue,
       extUserId: this.userService.currentUserId,
       type: NoteType.Normal,
       status: NoteStatus.Todo,
       deleted: false
     };
-
-    const result: NoteDialogResult = {
-      verseRef: fromVerseRef(verseRef),
-      note,
-      position: { start: 0, length: 0 },
-      selectedText: this.segmentText
-    };
-    this.dialogRef.close(result);
   }
 }


### PR DESCRIPTION
* make note dialog opens with text area by default
* show edit buttons on last note if user is the author
* detect when existing note content changes
* add note to thread if editing existing note is not selected
* get edit icons to display in mobile view

![Note-dialog-edit-actions](https://user-images.githubusercontent.com/17931130/188243410-076b36c5-8fdf-4a2a-adcd-3211a4bbc4e8.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1486)
<!-- Reviewable:end -->
