### PR TITLE
SF-1666 - The Avatar icon displayed as the first number of phone number

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
@@ -115,11 +115,18 @@ export class UserService {
         op.set(u => u.displayName, result.displayName);
         op.set<boolean>(u => u.isDisplayNameConfirmed, true);
       });
+      await this.updateAvatarFromDisplayName();
     }
   }
 
   async userMigrationComplete(): Promise<void> {
     await this.onlineInvoke('userMigrationComplete', { userId: this.currentUserId });
+  }
+
+  private async updateAvatarFromDisplayName(): Promise<void> {
+    if (await this.authService.isLoggedIn) {
+      await this.onlineInvoke('updateAvatarFromDisplayName');
+    }
   }
 
   private onlineInvoke<T>(method: string, params?: any): Promise<T | undefined> {

--- a/src/SIL.XForge/Controllers/UsersRpcController.cs
+++ b/src/SIL.XForge/Controllers/UsersRpcController.cs
@@ -94,6 +94,22 @@ namespace SIL.XForge.Controllers
             }
         }
 
+        public async Task<IRpcMethodResult> UpdateAvatarFromDisplayName()
+        {
+            try
+            {
+                await _userService.UpdateAvatarFromDisplayNameAsync(UserId, AuthId);
+                return Ok();
+            }
+            catch (Exception)
+            {
+                _exceptionHandler.RecordEndpointInfoForException(
+                    new Dictionary<string, string> { { "method", "UpdateAvatarFromDisplayName" }, }
+                );
+                throw;
+            }
+        }
+
         public async Task<IRpcMethodResult> UpdateInterfaceLanguage(string language)
         {
             try

--- a/src/SIL.XForge/Services/AuthService.cs
+++ b/src/SIL.XForge/Services/AuthService.cs
@@ -49,6 +49,12 @@ namespace SIL.XForge.Services
             return CallApiAsync(HttpMethod.Post, $"users/{primaryAuthId}/identities", content);
         }
 
+        public Task UpdateAvatar(string authId, string url)
+        {
+            var content = new JObject(new JProperty("picture", url));
+            return CallApiAsync(new HttpMethod("PATCH"), $"users/{authId}", content);
+        }
+
         public Task UpdateInterfaceLanguage(string authId, string language)
         {
             var content = new JObject(

--- a/src/SIL.XForge/Services/IAuthService.cs
+++ b/src/SIL.XForge/Services/IAuthService.cs
@@ -7,6 +7,7 @@ namespace SIL.XForge.Services
         bool ValidateWebhookCredentials(string username, string password);
         Task<string> GetUserAsync(string authId);
         Task LinkAccounts(string primaryAuthId, string secondaryAuthId);
+        Task UpdateAvatar(string authId, string url);
         Task UpdateInterfaceLanguage(string authId, string language);
     }
 }

--- a/src/SIL.XForge/Services/IUserService.cs
+++ b/src/SIL.XForge/Services/IUserService.cs
@@ -6,6 +6,7 @@ namespace SIL.XForge.Services
     {
         Task UpdateUserFromProfileAsync(string curUserId, string userProfileJson);
         Task LinkParatextAccountAsync(string primaryAuthId, string secondaryAuthId);
+        Task UpdateAvatarFromDisplayNameAsync(string curUserId, string authId);
         Task UpdateInterfaceLanguageAsync(string curUserId, string authId, string language);
         Task DeleteAsync(string curUserId, string systemRole, string userId);
     }

--- a/src/SIL.XForge/Utils/StringUtils.cs
+++ b/src/SIL.XForge/Utils/StringUtils.cs
@@ -1,11 +1,29 @@
 using MongoDB.Bson;
 using Newtonsoft.Json.Serialization;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace SIL.XForge.Utils
 {
     public static class StringUtils
     {
         private static readonly CamelCaseNamingStrategy CamelCaseNamingStrategy = new CamelCaseNamingStrategy();
+
+        public static string ComputeMd5Hash(string message)
+        {
+            using (MD5 md5 = MD5.Create())
+            {
+                byte[] input = Encoding.ASCII.GetBytes(message);
+                byte[] hash = md5.ComputeHash(input);
+
+                StringBuilder sb = new StringBuilder();
+                for (int i = 0; i < hash.Length; i++)
+                {
+                    sb.Append(hash[i].ToString("X2"));
+                }
+                return sb.ToString().ToLower();
+            }
+        }
 
         public static string ToCamelCase(this string str)
         {


### PR DESCRIPTION
 - Only applies to avatars currently served from Auth0 CDN
 - Supports Gravatar when an email address is available
 - Only allows for 2 characters - Auth0 limitation