### PR TITLE
SF-1731 Add feature flag service

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -51,7 +51,7 @@
               id="helpMenuIcon"
               mdcTopAppBarActionItem
               title="{{ t('help') }}"
-              (click)="helpMenu.open = !helpMenu.open"
+              (click)="helpMenu.open = !helpMenu.open; versionNumberClickCount = 0"
               >help</mdc-icon
             >
             <mdc-menu #helpMenu anchorCorner="bottomStart" [anchorElement]="helpMenuAnchor">
@@ -68,8 +68,18 @@
                       </mdc-list-item-secondary>
                     </mdc-list-item-text>
                   </a>
+                  <ng-container *ngIf="versionNumberClickCount >= 10 || featureFlags.showFeatureFlags.enabled">
+                    <mdc-list-divider></mdc-list-divider>
+                    <mdc-list-item (click)="openFeatureFlagDialog()">Feature flags</mdc-list-item>
+                  </ng-container>
                   <mdc-list-divider></mdc-list-divider>
-                  <div mdcListGroupSubheader class="version">{{ t("product_version", { version: version }) }}</div>
+                  <div
+                    mdcListGroupSubheader
+                    class="version"
+                    (click)="versionNumberClickCount = versionNumberClickCount + 1"
+                  >
+                    {{ t("product_version", { version: version }) }}
+                  </div>
                 </mdc-list>
               </mdc-list-group>
             </mdc-menu>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -223,7 +223,7 @@ describe('AppComponent', () => {
     expect(env.selectedProjectId).toEqual('project01');
     // SUT
     env.deleteProject('project01', false);
-    verify(mockedMdcDialog.open(ProjectDeletedDialogComponent)).once();
+    verify(mockedMdcDialog.open(ProjectDeletedDialogComponent, anything())).once();
     verify(mockedUserService.setCurrentProjectId(anything(), undefined)).once();
     env.confirmProjectDeletedDialog();
     // Get past setTimeout to navigation
@@ -252,7 +252,7 @@ describe('AppComponent', () => {
 
     expect(env.selectedProjectId).toEqual('project01');
     env.removesUserFromProject('project01');
-    verify(mockedMdcDialog.open(ProjectDeletedDialogComponent)).once();
+    verify(mockedMdcDialog.open(ProjectDeletedDialogComponent, anything())).once();
     env.confirmProjectDeletedDialog();
     // Get past setTimeout to navigation
     tick();
@@ -603,7 +603,9 @@ class TestEnvironment {
     }
     when(mockedFileService.notifyUserIfStorageQuotaBelow(anything())).thenResolve();
     when(mockedPwaService.hasUpdate).thenReturn(this.hasUpdate$);
-    when(mockedMdcDialog.open(ProjectDeletedDialogComponent)).thenReturn(instance(this.mockedProjectDeletedDialogRef));
+    when(mockedMdcDialog.open(ProjectDeletedDialogComponent, anything())).thenReturn(
+      instance(this.mockedProjectDeletedDialogRef)
+    );
     when(this.mockedProjectDeletedDialogRef.afterClosed()).thenReturn(this.projectDeletedDialogRefAfterClosed$);
 
     this.router = TestBed.inject(Router);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { MdcIconRegistry } from '@angular-mdc/web';
-import { MdcDialog, MdcDialogRef } from '@angular-mdc/web/dialog';
+import { MdcDialogRef } from '@angular-mdc/web/dialog';
 import { MdcSelect } from '@angular-mdc/web/select';
 import { MdcTopAppBar } from '@angular-mdc/web/top-app-bar';
 import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
@@ -18,8 +18,11 @@ import { combineLatest, from, merge, Observable, Subscription } from 'rxjs';
 import { distinctUntilChanged, filter, map, startWith, switchMap, tap } from 'rxjs/operators';
 import { AuthService } from 'xforge-common/auth.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
+import { DialogService } from 'xforge-common/dialog.service';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
 import { ExternalUrlService } from 'xforge-common/external-url.service';
+import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
+import { FeatureFlagsComponent } from 'xforge-common/feature-flags/feature-flags.component';
 import { FileService } from 'xforge-common/file.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { LocationService } from 'xforge-common/location.service';
@@ -62,6 +65,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   issueEmail: string = environment.issueEmail;
   isAppOnline: boolean = false;
   isExpanded: boolean = false;
+  versionNumberClickCount = 0;
   translateVisible: boolean = false;
   checkingVisible: boolean = false;
 
@@ -95,13 +99,14 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     private readonly settingsAuthGuard: SettingsAuthGuard,
     private readonly syncAuthGuard: SyncAuthGuard,
     private readonly usersAuthGuard: UsersAuthGuard,
-    private readonly dialog: MdcDialog,
+    private readonly dialogService: DialogService,
     private readonly fileService: FileService,
     private readonly reportingService: ErrorReportingService,
     readonly noticeService: NoticeService,
     readonly i18n: I18nService,
     readonly media: MediaObserver,
     readonly urls: ExternalUrlService,
+    readonly featureFlags: FeatureFlagService,
     private readonly pwaService: PwaService,
     iconRegistry: MdcIconRegistry,
     sanitizer: DomSanitizer
@@ -296,7 +301,10 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       const isBrowserSupported = supportedBrowser();
       this.reportingService.addMeta({ isBrowserSupported });
       if (isNewlyLoggedIn && !isBrowserSupported) {
-        this.dialog.open(SupportedBrowsersDialogComponent, { autoFocus: false, data: BrowserIssue.Upgrade });
+        this.dialogService.openMdcDialog(SupportedBrowsersDialogComponent, {
+          autoFocus: false,
+          data: BrowserIssue.Upgrade
+        });
       }
 
       const projectDocs$ = this.currentUserDoc.remoteChanges$.pipe(
@@ -528,6 +536,10 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     this.pwaService.activateUpdates();
   }
 
+  openFeatureFlagDialog() {
+    this.dialogService.openMatDialog(FeatureFlagsComponent);
+  }
+
   get lastSyncFailed(): boolean {
     return this.selectedProjectDoc?.data?.sync.lastSyncSuccessful === false;
   }
@@ -590,7 +602,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
 
   private async showProjectDeletedDialog(): Promise<void> {
     await this.userService.setCurrentProjectId(this.currentUserDoc!, undefined);
-    this.projectDeletedDialogRef = this.dialog.open(ProjectDeletedDialogComponent);
+    this.projectDeletedDialogRef = this.dialogService.openMdcDialog(ProjectDeletedDialogComponent);
     this.projectDeletedDialogRef.afterClosed().subscribe(() => this.navigateToStart());
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { ExceptionHandlingService } from 'xforge-common/exception-handling-servi
 import { SupportedBrowsersDialogComponent } from 'xforge-common/supported-browsers-dialog/supported-browsers-dialog.component';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { XForgeCommonModule } from 'xforge-common/xforge-common.module';
+import { FeatureFlagsComponent } from 'xforge-common/feature-flags/feature-flags.component';
 import { environment } from '../environments/environment';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -45,6 +46,7 @@ import { TextNoteDialogComponent } from './shared/text/text-note-dialog/text-not
     SupportedBrowsersDialogComponent,
     ErrorComponent,
     EditNameDialogComponent,
+    FeatureFlagsComponent,
     ProjectSelectComponent,
     SyncProgressComponent,
     TextNoteDialogComponent

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -1,0 +1,79 @@
+import { Injectable } from '@angular/core';
+
+interface FeatureFlagStore {
+  enabled: boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class MemoryFlagStore implements FeatureFlagStore {
+  constructor(public enabled: boolean = false) {}
+}
+
+class LocalStorageFlagStore implements FeatureFlagStore {
+  static readonly keyPrefix = 'SF_FEATURE_FLAG_';
+
+  private readonly featureFlagKey;
+  private _enabled: boolean;
+
+  constructor(key: string, defaultValue: boolean = false) {
+    this.featureFlagKey = LocalStorageFlagStore.keyPrefix + key;
+    const itemFromStore = localStorage.getItem(this.featureFlagKey);
+    const valueFromStore = typeof itemFromStore === 'string' ? JSON.parse(itemFromStore) : undefined;
+    this._enabled = typeof valueFromStore === 'boolean' ? valueFromStore : defaultValue;
+  }
+
+  get enabled() {
+    return this._enabled;
+  }
+
+  set enabled(value: boolean) {
+    this._enabled = value;
+    localStorage.setItem(this.featureFlagKey, JSON.stringify(value));
+  }
+}
+
+class FeatureFlag {
+  constructor(private readonly storage: FeatureFlagStore, readonly description?: string) {}
+
+  get enabled() {
+    return this.storage.enabled;
+  }
+
+  set enabled(value: boolean) {
+    this.storage.enabled = value;
+  }
+
+  get flagVisibleInUI(): boolean {
+    return this.description != null;
+  }
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FeatureFlagService {
+  constructor() {}
+
+  showFeatureFlags: FeatureFlag = new FeatureFlag(
+    new LocalStorageFlagStore('SHOW_FEATURE_FLAGS'),
+    'Show feature flags'
+  );
+
+  showNonPublishedLocalizations: FeatureFlag = new FeatureFlag(
+    new LocalStorageFlagStore('SHOW_NON_PUBLISHED_LOCALIZATIONS'),
+    'Show non-published localizations'
+  );
+
+  allowAddingNotes: FeatureFlag = new FeatureFlag(
+    new LocalStorageFlagStore('ALLOW_ADDING_NOTES'),
+    'Allow adding notes'
+  );
+
+  get featureFlags(): FeatureFlag[] {
+    return Object.values(this).filter(value => value instanceof FeatureFlag);
+  }
+
+  get visibleFeatureFlags(): (FeatureFlag & { description: string })[] {
+    return this.featureFlags.filter(flag => flag.flagVisibleInUI) as any;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags.component.html
@@ -1,0 +1,6 @@
+<h2 mat-dialog-title><mat-icon>science</mat-icon> Experimental feature flags</h2>
+<mat-dialog-content class="mat-typography">
+  <mat-checkbox *ngFor="let flag of featureFlags.visibleFeatureFlags" [(ngModel)]="flag.enabled">
+    {{ flag.description }}
+  </mat-checkbox>
+</mat-dialog-content>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags.component.scss
@@ -1,0 +1,12 @@
+.mat-dialog-title {
+  display: flex;
+  align-items: center;
+  column-gap: 0.5em;
+}
+
+.mat-dialog-content {
+  display: flex;
+  flex-direction: column;
+  row-gap: 0.5em;
+  padding-bottom: 1em;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { FeatureFlagService } from './feature-flag.service';
+
+@Component({
+  templateUrl: './feature-flags.component.html',
+  styleUrls: ['./feature-flags.component.scss']
+})
+export class FeatureFlagsComponent {
+  constructor(readonly featureFlags: FeatureFlagService) {}
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/xforge-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/xforge-common.module.ts
@@ -1,6 +1,8 @@
 import { CommonModule } from '@angular/common';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { NgModule } from '@angular/core';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatListModule } from '@angular/material/list';
 import { RouterModule } from '@angular/router';
 import { TranslocoModule, TRANSLOCO_CONFIG, TRANSLOCO_LOADER } from '@ngneat/transloco';
 import { ngfModule } from 'angular-file';
@@ -42,7 +44,8 @@ const componentExports = [
     ngfModule,
     RouterModule,
     UICommonModule,
-    TranslocoModule
+    TranslocoModule,
+    MatDialogModule
   ],
   declarations: componentExports,
   exports: componentExports,


### PR DESCRIPTION
### Expected behavior
- By default, feature flags are completely hidden
- Clicking the build number 10 times makes the feature flag option temporarily appear in the menu help (Yes, this is kind of odd, but holding down a Ctrl or Shift key doesn't work on mobile. Tapping the build number 10 times is how you enable developer mode on Android).
- If you open the feature flag dialog, one of the feature flags that is available is a flag to keep them always available. This setting is stored locally.

### Current flags
- Toggle whether feature flags are available in the menu.
- Toggle whether non-published localizations are listed in the language menu (previously they were shown when not in production)
- Toggle whether creating notes should be enabled (currently this doesn't do anything)

### Expected benefits
- We can merge changes before a feature is entirely complete. This should reduce merge conflicts and make reviewing code easier, since we don't have to merge giant changes to master.
- We can test on mobile devices before enabling a feature. Currently it is very difficult to test our dev environment on an actual physical phone. For example, we should be able to test the notes feature on actual mobile devices before it's shipped to live.
- We can preview features with users before they're publicly available.

### Potential future enhancements
- Storing flags on projects
- Storing flags on users
- Allowing site admins to manage flags on projects and users

### Screenshots
![](https://user-images.githubusercontent.com/6140710/189800942-e8a2f339-70c6-40bb-900e-8b9dc5ce184c.png)
![](https://user-images.githubusercontent.com/6140710/189800940-5d063ce2-b5f4-4d6d-a7bd-b44d00307601.png)
