### PR TITLE
Fix type guards in connect project component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
@@ -6,6 +6,7 @@ import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { PwaService } from 'xforge-common/pwa.service';
+import { hasStringProp } from '../../type-utils';
 import { ParatextProject } from '../core/models/paratext-project';
 import { SFProjectCreateSettings } from '../core/models/sf-project-create-settings';
 import { SFProjectDoc } from '../core/models/sf-project-doc';
@@ -188,8 +189,8 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
       let projectId: string = '';
       try {
         projectId = await this.projectService.onlineCreate(settings);
-      } catch (err) {
-        if (!err.message?.includes(ConnectProjectComponent.errorAlreadyConnectedKey)) {
+      } catch (err: unknown) {
+        if (!hasStringProp(err, 'message') || !err.message.includes(ConnectProjectComponent.errorAlreadyConnectedKey)) {
           throw err;
         }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/drag-and-drop.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/drag-and-drop.ts
@@ -1,5 +1,5 @@
 import Quill, { DeltaOperation, RangeStatic, StringMap } from 'quill';
-import { CaretPosition, hasFunctionProp } from '../../../utils';
+import { CaretPosition, hasFunctionProp } from '../../../type-utils';
 import { Delta } from '../../core/models/text-doc';
 import { getAttributesAtPosition } from './quill-scripture';
 import { TextComponent } from './text.component';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -25,7 +25,7 @@ import { UserDoc } from 'xforge-common/models/user-doc';
 import { UserService } from 'xforge-common/user.service';
 import { DialogService } from 'xforge-common/dialog.service';
 import { LocalPresence } from 'sharedb/lib/sharedb';
-import { CaretPosition } from '../../../utils';
+import { CaretPosition } from '../../../type-utils';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SF_TYPE_REGISTRY } from '../../core/models/sf-type-registry';
 import { Delta, TextDoc, TextDocId } from '../../core/models/text-doc';

--- a/src/SIL.XForge.Scripture/ClientApp/src/type-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/type-utils.ts
@@ -6,6 +6,10 @@ export function hasProp<X, Y extends PropertyKey>(value: X, property: Y): value 
   return isObj(value) && property in value;
 }
 
+export function hasStringProp<X, Y extends PropertyKey>(value: X, property: Y): value is X & Record<Y, String> {
+  return hasProp(value, property) && typeof value[property] === 'string';
+}
+
 export function hasFunctionProp<X, Y extends PropertyKey>(value: X, property: Y): value is X & Record<Y, Function> {
   return hasProp(value, property) && typeof value[property] === 'function';
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/utils.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/utils.spec.ts
@@ -1,4 +1,4 @@
-import { hasFunctionProp, hasProp, isObj } from './utils';
+import { hasFunctionProp, hasProp, hasStringProp, isObj } from './type-utils';
 
 const miscValues = [undefined, null, NaN, true, false, Infinity, -1, 0, Symbol(), '', '\0', () => {}, BigInt(3)];
 
@@ -23,6 +23,14 @@ describe('type utils', () => {
     expect(objectFromPrototype.hasOwnProperty('hello')).toBeFalse();
     expect(hasProp(prototype, 'hello')).toBeTrue();
     expect(hasProp(objectFromPrototype, 'hello')).toBeTrue();
+  });
+
+  it('checks whether a value has a string property', () => {
+    for (const value of [...miscValues, ...objValues]) expect(hasStringProp(value, 'hello')).toBeFalse();
+
+    expect(hasStringProp({}, 'hello')).toBeFalse();
+    expect(hasStringProp({ hello: () => {} }, 'hello')).toBeFalse();
+    expect(hasStringProp({ hello: 'world' }, 'hello')).toBeTrue();
   });
 
   it('checks whether a value has a function property', () => {


### PR DESCRIPTION
We recently updated the version of TypeScript we're using. There is now an option called `useUnknownInCatchVariables`. See https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables

> In TypeScript 4.0, support was added to allow changing the type of the variable in a catch clause from `any` to `unknown`. Allowing for code like:
``` ts
try {
  // ...
} catch (err) {
  // We have to verify err is an
  // error before using it as one.
  if (err instanceof Error) {
    console.log(err.message);
  }
}
```
> This pattern ensures that error handling code becomes more comprehensive because you cannot guarantee that the object being thrown _is_ a Error subclass ahead of time. With the flag `useUnknownInCatchVariables` enabled, then you do not need the additional syntax (`: unknown`) nor a linter rule to try enforce this behavior.

In strict mode, which we have enabled, `useUnknownInCatchVariables` defaults to true. I've temporarily set it to false in `tsconfig.json` in order to make the upgrade process smoother. This PR fixes one place that would fail to build once `useUnknownInCatchVariables` is set to true.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1502)
<!-- Reviewable:end -->
