### PR TITLE
SF-1742 Fix drag and drop by fixing type guards

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/utils.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/utils.spec.ts
@@ -1,0 +1,35 @@
+import { hasFunctionProp, hasProp, isObj } from './utils';
+
+const miscValues = [undefined, null, NaN, true, false, Infinity, -1, 0, Symbol(), '', '\0', () => {}, BigInt(3)];
+
+const objValues = [{}, [], new Error()];
+
+describe('type utils', () => {
+  it('checks whether a value is an object', () => {
+    for (const value of miscValues) expect(isObj(value)).toBeFalse();
+    for (const obj of objValues) expect(isObj(obj)).toBeTrue();
+  });
+
+  it('checks whether a value has a property', () => {
+    for (const value of [...miscValues, ...objValues]) expect(hasProp(value, 'hello')).toBeFalse();
+
+    expect(hasProp({}, 'hello')).toBeFalse();
+    expect(hasProp({ hello: false }, 'hello')).toBeTrue();
+    expect(hasProp({ hello: undefined }, 'hello')).toBeTrue();
+
+    const prototype = { hello: 'world' };
+    const objectFromPrototype = Object.create(prototype);
+    expect(prototype.hasOwnProperty('hello')).toBeTrue();
+    expect(objectFromPrototype.hasOwnProperty('hello')).toBeFalse();
+    expect(hasProp(prototype, 'hello')).toBeTrue();
+    expect(hasProp(objectFromPrototype, 'hello')).toBeTrue();
+  });
+
+  it('checks whether a value has a function property', () => {
+    for (const value of [...miscValues, ...objValues]) expect(hasFunctionProp(value, 'hello')).toBeFalse();
+
+    expect(hasFunctionProp({}, 'hello')).toBeFalse();
+    expect(hasFunctionProp({ hello: 'world' }, 'hello')).toBeFalse();
+    expect(hasFunctionProp({ hello: () => {} }, 'hello')).toBeTrue();
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/utils.ts
@@ -3,7 +3,7 @@ export function isObj(value: unknown): value is {} {
 }
 
 export function hasProp<X, Y extends PropertyKey>(value: X, property: Y): value is X & Record<Y, unknown> {
-  return isObj(value) && Object.prototype.hasOwnProperty.call(value, property);
+  return isObj(value) && property in value;
 }
 
 export function hasFunctionProp<X, Y extends PropertyKey>(value: X, property: Y): value is X & Record<Y, Function> {


### PR DESCRIPTION
When a drag and drop happens, we do a check using `hasFunctionProp(document, 'caretRangeFromPoint')`. Unfortunately, I implemented `hasProp` incorrectly, by using `hasOwnProperty`, which is too strict of a check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1503)
<!-- Reviewable:end -->
