### PR TITLE
SF-1610 Larger cursor appears when presence is on a blank heading

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -318,7 +318,7 @@ quill-editor.rtl {
 
 usx-blank {
   width: 35px;
-  display: inline-block;
+  display: inline-flex;
   span {
     font-size: 0;
   }


### PR DESCRIPTION
- Change usx-blank to inline-flex to avoid stacking child elements

This issue is only obvious if the Paratext font size has been increased to something large i.e. 20

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1506)
<!-- Reviewable:end -->
