### PR TITLE
SF-1750 Fix multiple browsers causing infinite writing of currentProjectId

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
@@ -48,6 +48,9 @@ export class UserService {
 
   async setCurrentProjectId(user: UserDoc, value: string | undefined): Promise<void> {
     this.localSettings.set(CURRENT_PROJECT_ID_SETTING, value);
+    if (user.data?.sites[this.siteId].currentProjectId === value) {
+      return;
+    }
     await user.submitJson0Op(update => {
       if (value != null) {
         update.set(u => u.sites[this.siteId].currentProjectId, value);


### PR DESCRIPTION
This is probably only a partial fix.

I can't even test #1506 because of how pervasive this bug is. I don't know what all it takes to reproduce it, but logging in as the same user in two different browsers does it for me. Memory usage skyrockets as each browser keeps fighting to write currentProjectId to the user.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1507)
<!-- Reviewable:end -->
