### PR TITLE
SF-1751 Fix error opening ScriptureChooserDialogComponent

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -1,4 +1,3 @@
-import { MdcDialog, MdcDialogConfig, MdcDialogRef } from '@angular-mdc/web/dialog';
 import { MdcList } from '@angular-mdc/web/list';
 import { MdcMenuSelectedEvent } from '@angular-mdc/web/menu';
 import { Component, ElementRef, HostBinding, OnDestroy, OnInit, ViewChild } from '@angular/core';
@@ -26,6 +25,8 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { PwaService } from 'xforge-common/pwa.service';
 import { UserService } from 'xforge-common/user.service';
 import { objectId } from 'xforge-common/utils';
+import { MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
+import { DialogService } from 'xforge-common/dialog.service';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { QuestionDoc } from '../../core/models/question-doc';
 import { SF_DEFAULT_SHARE_ROLE } from '../../core/models/sf-project-role-info';
@@ -104,7 +105,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
     private readonly projectService: SFProjectService,
     private readonly userService: UserService,
     private readonly media: MediaObserver,
-    private readonly dialog: MdcDialog,
+    private readonly dialogService: DialogService,
     noticeService: NoticeService,
     private readonly router: Router,
     private readonly questionDialogService: QuestionDialogService,
@@ -644,11 +645,11 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
   }
 
   openScriptureChooser() {
-    const dialogConfig: MdcDialogConfig<ScriptureChooserDialogData> = {
+    const dialogConfig: MatDialogConfig<ScriptureChooserDialogData> = {
       data: { booksAndChaptersToShow: this.textsByBookId, includeVerseSelection: false }
     };
 
-    const dialogRef = this.dialog.open(ScriptureChooserDialogComponent, dialogConfig) as MdcDialogRef<
+    const dialogRef = this.dialogService.openMatDialog(ScriptureChooserDialogComponent, dialogConfig) as MatDialogRef<
       ScriptureChooserDialogComponent,
       VerseRef | 'close'
     >;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
@@ -1,4 +1,4 @@
-import { MdcDialog, MdcDialogRef } from '@angular-mdc/web';
+import { MdcDialogRef } from '@angular-mdc/web';
 import { CommonModule } from '@angular/common';
 import { Component, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
@@ -18,6 +18,7 @@ import { BehaviorSubject, of, throwError } from 'rxjs';
 import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
 import { CsvService } from 'xforge-common/csv-service.service';
+import { DialogService } from 'xforge-common/dialog.service';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { TestingRetryingRequestService } from 'xforge-common/testing-retrying-request.service';
@@ -36,7 +37,7 @@ import {
 const mockedProjectService = mock(SFProjectService);
 const mockedAuthService = mock(AuthService);
 const mockedCookieService = mock(CookieService);
-const mockedMdcDialog = mock(MdcDialog);
+const mockedDialogService = mock(DialogService);
 const mockedCsvService = mock(CsvService);
 const mockedRealtimeQuery: RealtimeQuery<QuestionDoc> = mock(RealtimeQuery);
 
@@ -47,7 +48,7 @@ describe('ImportQuestionsDialogComponent', () => {
       { provide: AuthService, useMock: mockedAuthService },
       { provide: SFProjectService, useMock: mockedProjectService },
       { provide: CookieService, useMock: mockedCookieService },
-      { provide: MdcDialog, useMock: mockedMdcDialog },
+      { provide: DialogService, useMock: mockedDialogService },
       { provide: CsvService, useMock: mockedCsvService }
     ]
   }));
@@ -171,9 +172,9 @@ describe('ImportQuestionsDialogComponent', () => {
   it('show scripture chooser dialog', fakeAsync(() => {
     const env = new TestEnvironment();
     env.click(env.importFromTransceleratorButton);
-    when(env.mockedScriptureChooserMdcDialogRef.afterClosed()).thenReturn(of(VerseRef.parse('MAT 1:1')));
+    when(env.mockedScriptureChooserMatDialogRef.afterClosed()).thenReturn(of(VerseRef.parse('MAT 1:1')));
     env.openFromScriptureChooser();
-    verify(mockedMdcDialog.open(anything(), anything())).once();
+    verify(mockedDialogService.openMatDialog(anything(), anything())).once();
     expect(env.component.fromControl.value).toBe('MAT 1:1');
     env.click(env.cancelButton);
   }));
@@ -189,7 +190,7 @@ describe('ImportQuestionsDialogComponent', () => {
 
     when(env.mockedImportQuestionsConfirmationMdcDialogRef.afterClosed()).thenReturn(of([false, false]));
     env.clickSelectAll();
-    verify(mockedMdcDialog.open(anything(), anything())).once();
+    verify(mockedDialogService.openMdcDialog(anything(), anything())).once();
     expect(env.tableRows.length).toBe(4);
     expect(env.component.filteredList[0].checked).toBe(false);
     expect(env.component.filteredList[1].checked).toBe(false);
@@ -204,7 +205,7 @@ describe('ImportQuestionsDialogComponent', () => {
     env.click(env.importFromTransceleratorButton);
     expect(env.tableRows.length).toBe(4);
     env.clickSelectAll();
-    verify(mockedMdcDialog.open(anything(), anything())).once();
+    verify(mockedDialogService.openMdcDialog(anything(), anything())).once();
     env.click(env.importSelectedQuestionsButton);
     expect(env.editedTransceleratorQuestionIds).toEqual(['1', '4']);
   }));
@@ -449,7 +450,7 @@ class TestEnvironment {
   fixture: ComponentFixture<ChildViewContainerComponent>;
   component: ImportQuestionsDialogComponent;
   dialogRef: MatDialogRef<ImportQuestionsDialogComponent>;
-  mockedScriptureChooserMdcDialogRef = mock<MdcDialogRef<ScriptureChooserDialogComponent>>(MdcDialogRef);
+  mockedScriptureChooserMatDialogRef = mock<MatDialogRef<ScriptureChooserDialogComponent>>(MatDialogRef);
   mockedImportQuestionsConfirmationMdcDialogRef =
     mock<MdcDialogRef<ImportQuestionsConfirmationDialogComponent>>(MdcDialogRef);
   editedTransceleratorQuestionIds: string[] = [];
@@ -543,10 +544,10 @@ class TestEnvironment {
     this.dialogRef = TestBed.inject(MatDialog).open(ImportQuestionsDialogComponent, config);
     this.component = this.dialogRef.componentInstance;
 
-    when(mockedMdcDialog.open(ScriptureChooserDialogComponent, anything())).thenReturn(
-      instance<MdcDialogRef<ScriptureChooserDialogComponent>>(this.mockedScriptureChooserMdcDialogRef)
+    when(mockedDialogService.openMatDialog(ScriptureChooserDialogComponent, anything())).thenReturn(
+      instance<MatDialogRef<ScriptureChooserDialogComponent>>(this.mockedScriptureChooserMatDialogRef)
     );
-    when(mockedMdcDialog.open(ImportQuestionsConfirmationDialogComponent, anything())).thenReturn(
+    when(mockedDialogService.openMdcDialog(ImportQuestionsConfirmationDialogComponent, anything())).thenReturn(
       instance<MdcDialogRef<ImportQuestionsConfirmationDialogComponent>>(
         this.mockedImportQuestionsConfirmationMdcDialogRef
       )

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -1,8 +1,8 @@
-import { MdcDialog, MdcDialogConfig, MdcDialogRef } from '@angular-mdc/web';
+import { MdcDialogConfig, MdcDialogRef } from '@angular-mdc/web';
 import { Component, ElementRef, Inject, NgZone, OnDestroy, ViewChild } from '@angular/core';
 import { AbstractControl, FormControl, FormGroup } from '@angular/forms';
 import { MatCheckbox } from '@angular/material/checkbox';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialogConfig, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Question } from 'realtime-server/lib/esm/scriptureforge/models/question';
 import { fromVerseRef, toVerseRef, VerseRefData } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
@@ -14,6 +14,7 @@ import { I18nService } from 'xforge-common/i18n.service';
 import { ExternalUrlService } from 'xforge-common/external-url.service';
 import { CsvService } from 'xforge-common/csv-service.service';
 import { RetryingRequest } from 'xforge-common/retrying-request.service';
+import { DialogService } from 'xforge-common/dialog.service';
 import { environment } from '../../../environments/environment';
 import { QuestionDoc } from '../../core/models/question-doc';
 import { TextsByBookId } from '../../core/models/texts-by-book-id';
@@ -104,7 +105,7 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable imple
     private readonly projectService: SFProjectService,
     private readonly dialogRef: MatDialogRef<ImportQuestionsDialogComponent>,
     private readonly transloco: TranslocoService,
-    private readonly mdcDialog: MdcDialog,
+    private readonly dialogService: DialogService,
     private readonly zone: NgZone,
     private readonly csvService: CsvService,
     readonly i18n: I18nService,
@@ -259,12 +260,12 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable imple
   }
 
   openScriptureChooser(control: AbstractControl) {
-    const dialogConfig: MdcDialogConfig<ScriptureChooserDialogData> = {
+    const dialogConfig: MatDialogConfig<ScriptureChooserDialogData> = {
       data: { booksAndChaptersToShow: this.data.textsByBookId },
       autoFocus: false
     };
 
-    const dialogRef = this.mdcDialog.open(ScriptureChooserDialogComponent, dialogConfig) as MdcDialogRef<
+    const dialogRef = this.dialogService.openMatDialog(ScriptureChooserDialogComponent, dialogConfig) as MatDialogRef<
       ScriptureChooserDialogComponent,
       VerseRef | 'close'
     >;
@@ -451,10 +452,10 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable imple
       escapeToClose: false,
       clickOutsideToClose: false
     };
-    const dialogRef = this.mdcDialog.open(ImportQuestionsConfirmationDialogComponent, data) as MdcDialogRef<
+    const dialogRef = this.dialogService.openMdcDialog(
       ImportQuestionsConfirmationDialogComponent,
-      ImportQuestionsConfirmationDialogResult
-    >;
+      data
+    ) as MdcDialogRef<ImportQuestionsConfirmationDialogComponent, ImportQuestionsConfirmationDialogResult>;
     (await dialogRef.afterClosed().toPromise())!.forEach(
       (checked, index) => (changesToConfirm[index].checked = checked)
     );


### PR DESCRIPTION
This was broken in d4a45e8175e9b1af9c7d57d6bd6efa54489e5881

I went back to the commit where this broke and went through each dialog that was switched from MDC to Material and verified that there are no more instances of those dialogs being opened using MDC.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1508)
<!-- Reviewable:end -->
