### PR TITLE
SF-1752 - Fix live reload

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/angular.json
+++ b/src/SIL.XForge.Scripture/ClientApp/angular.json
@@ -122,7 +122,8 @@
               "browserTarget": "SIL.XForge.Scripture:build:production"
             },
             "development": {
-              "browserTarget": "SIL.XForge.Scripture:build:development"
+              "browserTarget": "SIL.XForge.Scripture:build:development",
+              "publicHost": "localhost:4200"
             }
           },
           "defaultConfiguration": "development"


### PR DESCRIPTION
- Add publicHost to angular.json

"Issue" appears to be with webpack in Angular 13 using the domain the app is viewed in. As we are running via localhost:5000 it isn't allowed to connect to angular live dev tools at localhost:4200. This update states that we can.

Other suggestions were to set the `allowedHosts` property.

Can also be set manually at CLI: `ng serve --public-host localhost:4200`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1511)
<!-- Reviewable:end -->
