### PR TITLE
SF-1734 Display note thread icons when query is ready

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2864,7 +2864,7 @@ class TestEnvironment {
       this.realtimeService.subscribe(TextDoc.COLLECTION, id.toString())
     );
     when(mockedSFProjectService.isProjectAdmin('project01', 'user04')).thenResolve(true);
-    when(mockedSFProjectService.queryNoteThreads('project01')).thenCall(id =>
+    when(mockedSFProjectService.queryNoteThreads(anything())).thenCall(id =>
       this.realtimeService.subscribeQuery(NoteThreadDoc.COLLECTION, {
         [obj<NoteThread>().pathStr(t => t.projectRef)]: id,
         [obj<NoteThread>().pathStr(t => t.status)]: NoteStatus.Todo

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -28,7 +28,7 @@ import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/model
 import { Canon } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/canon';
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
 import { DeltaOperation } from 'rich-text';
-import { BehaviorSubject, fromEvent, merge, Observable, Subject, Subscription, timer } from 'rxjs';
+import { BehaviorSubject, fromEvent, merge, Subject, Subscription, timer } from 'rxjs';
 import { debounceTime, delayWhen, filter, repeat, retryWhen, tap } from 'rxjs/operators';
 import { CONSOLE, ConsoleInterface } from 'xforge-common/browser-globals';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
@@ -1195,11 +1195,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     this.noteThreadQuery?.dispose();
     this.noteThreadQuery = await this.projectService.queryNoteThreads(projectId);
     this.toggleNoteThreadSub?.unsubscribe();
-    const toggleNoteThreadsReady$: Observable<void> = merge(
-      this.toggleNoteThreadVerseRefs$,
-      this.noteThreadQuery.ready$
+    this.toggleNoteThreadSub = this.subscribe(merge(this.toggleNoteThreadVerseRefs$, this.noteThreadQuery.ready$), () =>
+      this.toggleNoteThreadVerses(true)
     );
-    this.toggleNoteThreadSub = this.subscribe(toggleNoteThreadsReady$, () => this.toggleNoteThreadVerses(true));
   }
 
   private loadProjectUserConfig() {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -28,7 +28,7 @@ import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/model
 import { Canon } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/canon';
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
 import { DeltaOperation } from 'rich-text';
-import { BehaviorSubject, fromEvent, Subject, Subscription, timer } from 'rxjs';
+import { BehaviorSubject, fromEvent, merge, Observable, Subject, Subscription, timer } from 'rxjs';
 import { debounceTime, delayWhen, filter, repeat, retryWhen, tap } from 'rxjs/operators';
 import { CONSOLE, ConsoleInterface } from 'xforge-common/browser-globals';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
@@ -1192,9 +1192,14 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   private async loadNoteThreadDocs(projectId: string): Promise<void> {
+    this.noteThreadQuery?.dispose();
     this.noteThreadQuery = await this.projectService.queryNoteThreads(projectId);
     this.toggleNoteThreadSub?.unsubscribe();
-    this.toggleNoteThreadSub = this.subscribe(this.toggleNoteThreadVerseRefs$, () => this.toggleNoteThreadVerses(true));
+    const toggleNoteThreadsReady$: Observable<void> = merge(
+      this.toggleNoteThreadVerseRefs$,
+      this.noteThreadQuery.ready$
+    );
+    this.toggleNoteThreadSub = this.subscribe(toggleNoteThreadsReady$, () => this.toggleNoteThreadVerses(true));
   }
 
   private loadProjectUserConfig() {


### PR DESCRIPTION
* subscribe to the ready$ observable on the note thread query

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1514)
<!-- Reviewable:end -->
