### PR TITLE
SF-1743a Stop sync if repo mismatch

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -138,6 +138,24 @@ namespace SIL.XForge.Scripture.Services
                 var targetTextDocsByBook = new Dictionary<int, SortedList<int, IDocument<TextData>>>();
                 var questionDocsByBook = new Dictionary<int, IReadOnlyList<IDocument<Question>>>();
                 string lastSharedVersion = _paratextService.GetLatestSharedVersion(_userSecret, targetParatextId);
+                if (lastSharedVersion != _projectDoc.Data.Sync.SyncedToRepositoryVersion)
+                {
+                    if (
+                        _projectDoc.Data.Sync.SyncedToRepositoryVersion == null
+                        && _projectDoc.Data.Sync.DataInSync == null
+                    )
+                    {
+                        // This project pre-dates when we started tracking this information, and does not yet have a record of it.
+                    }
+                    else
+                    {
+                        Log(
+                            $"RunAsync: The reported PT hg repo latest shared version '{lastSharedVersion}' does not match record of project SyncedToRepositoryVersion '{_projectDoc.Data.Sync.SyncedToRepositoryVersion}'. Refusing to continue, to protect data."
+                        );
+                        await CompleteSync(successful: false, canRollbackParatext, trainEngine, token);
+                        return;
+                    }
+                }
 
                 bool isDataInSync = _projectDoc.Data.Sync.DataInSync ?? false;
                 if (lastSharedVersion == null)


### PR DESCRIPTION
- SF cleans up at the end of the sync process. If the sync process is
abruptly terminated without being able to clean up, the sync process
makes poor assumptions next time about its state. Namely, it can think
that the data in sync.
- A better and future change can address checking and cleaning up at
the beginning of a sync. This change merely checks if we are in a bad
state and stops the sync.
- If the PT hg repo commit revision does not match the SF DB record of
what PT hg repo commit revision the project was syncronized to, stop
the sync. Except for a special case.
- Clearly there are code cleanup activities that can be done here.
This change prioritizes getting the behaviour changed.

Tests file:
- The test BackupRestoredPreviouslyRevNotMatching_WritesToPT seems to
request the bad behaviour. The implementation code may have moved on
since this time. I spoke with the author. I removed the test.
- Some tests were specifically requesting that we _do_ run SendReceive
even in a situation where we are out of sync. This expectation is
reversed with this change, where the sync should quit before calling
SendReceive.

commit-id:a5069a6a

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1515)
<!-- Reviewable:end -->
