### PR TITLE
SF-1729 Ensure presence cursor is removed when going offline

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -280,14 +280,21 @@ describe('TextComponent', () => {
       env.id = new TextDocId('project01', 40, 1);
       tick();
       env.fixture.detectChanges();
+      const cursors: QuillCursors = env.component.editor!.getModule('cursors');
+      const cursorRemoveSpy = spyOn<any>(cursors, 'removeCursor').and.callThrough();
       const onSelectionChangedSpy = spyOn<any>(env.component, 'onSelectionChanged').and.callThrough();
       const localPresenceSubmitSpy = spyOn<any>(env.localPresenceDoc, 'submit').and.callThrough();
 
       env.component.editor?.setSelection(1, 1, 'user');
 
+      // ShareDB will trigger a presence "submit" event on the doc, so we need to simulate that event
+      const range: RangeStatic = env.component.getSegmentRange('verse_1_1')!;
+      (env.component as any).onPresenceDocReceive('presenceId', range);
+
       tick();
       expect(onSelectionChangedSpy).toHaveBeenCalledTimes(1);
       expect(localPresenceSubmitSpy).toHaveBeenCalledTimes(0);
+      expect(cursorRemoveSpy).toHaveBeenCalledTimes(1);
       verify(mockedUserService.getCurrentUser()).never();
     }));
 


### PR DESCRIPTION
- Added checks inside submit handlers to deal with being offline

Part of the underlaying issue is ShareDB still submitting an event for anyone subscribed to the the document presence. This fix checks again to see if they are online and ensures cursors are removed if they are not.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1519)
<!-- Reviewable:end -->
