### PR TITLE
SF-1743c sync: ensure correct revision is checked out when sync starts

### DIFF
--- a/src/SIL.XForge.Scripture/Services/HgWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/HgWrapper.cs
@@ -1,4 +1,6 @@
+#nullable enable annotations
 using System;
+using System.IO;
 using System.Linq;
 using Paratext.Data.Repository;
 
@@ -53,6 +55,19 @@ namespace SIL.XForge.Scripture.Services
         }
 
         /// <summary>
+        /// Returns the currently checked out revision of an hg repository.
+        /// </summary>
+        public string GetRepoRevision(string repositoryPath)
+        {
+            string rev = RunCommand(repositoryPath, "log --limit 1 --rev . --template {node}");
+            if (string.IsNullOrWhiteSpace(rev))
+            {
+                throw new InvalidDataException($"Unable to determine repo revision for hg repo at {repositoryPath}");
+            }
+            return rev;
+        }
+
+        /// <summary>
         /// Restores the repository.
         /// </summary>
         /// <param name="destination">The destination to restore to.</param>
@@ -94,6 +109,16 @@ namespace SIL.XForge.Scripture.Services
         public void Update(string repository)
         {
             Hg.Default.Update(repository);
+        }
+
+        /// <summary>
+        /// Set a hg repo's files to a particular revision in history. Similar to running
+        /// `git checkout --force --detach COMMITTISH`
+        /// Changes to tracked files will be discarded. Untracked files are left in place without being cleaned up.
+        /// </summary>
+        public void Update(string repositoryPath, string rev)
+        {
+            Hg.Default.Update(repositoryPath, rev);
         }
     }
 }

--- a/src/SIL.XForge.Scripture/Services/IHgWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/IHgWrapper.cs
@@ -7,9 +7,11 @@ namespace SIL.XForge.Scripture.Services
         void SetDefault(Hg hgDefault);
         void Init(string repository);
         void Update(string repository);
+        void Update(string repository, string rev);
         void BackupRepository(string repository, string backupFile);
         void RestoreRepository(string destination, string backupFile);
         string GetLastPublicRevision(string repository);
+        string GetRepoRevision(string repositoryPath);
         void MarkSharedChangeSetsPublic(string repository);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -69,9 +69,12 @@ namespace SIL.XForge.Scripture.Services
             Dictionary<string, ParatextUserProfile> ptProjectUsers
         );
         string? GetLatestSharedVersion(UserSecret userSecret, string paratextId);
+        string GetRepoRevision(UserSecret userSecret, string projectPTId);
+        void SetRepoToRevision(UserSecret userSecret, string projectPTId, string desiredRevision);
         bool BackupExists(UserSecret userSecret, string paratextId);
         bool BackupRepository(UserSecret userSecret, string paratextId);
         bool RestoreRepository(UserSecret userSecret, string paratextId);
+        bool LocalProjectDirExists(string projectPTId);
 
         Task<ParatextProject> SendReceiveAsync(
             UserSecret userSecret,


### PR DESCRIPTION
- The SF synchronize process records if 'DataInSync' at the end. The
next time SF synchronizes, it considers 'DataInSync' as part of
determining if it is safe to write data. If SF is abruptly terminated
during synchronize, we may not set 'DataInSync' to false when we would
have, resulting in the next sync incorrectly thinking it can safely
write data.
- This commit changes the behaviour. At the beginning of each
synchronize, set the local hg repository to the revision that we know
we last successfully imported from, and consider that we are always
'in sync', and so can safely write data. This is to make the
synchronize process more resilient against problems that occur during
its operation.
- The current hg repo revision is now being logged, in addition to the
latest shared/public revision, to identify possible problems in how we
use these.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1521)
<!-- Reviewable:end -->
