### PR TITLE
SF-1727 Make presence avatars clickable and scroll to position in the document

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -539,6 +539,19 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     return this.editor == null ? null : this.editor.container.querySelector(`usx-segment[data-segment="${segment}"]`);
   }
 
+  getViewerPosition(presenceId: string): RangeStatic | undefined {
+    if (this.presenceDoc == null) {
+      return;
+    }
+    const ranges: RangeStatic[] = Object.entries(this.presenceDoc.remotePresences)
+      .filter(remotePresence => remotePresence[0] === presenceId)
+      .map(remotePresence => remotePresence[1]);
+    if (ranges.length === 0) {
+      return;
+    }
+    return ranges[0];
+  }
+
   toggleFeaturedVerseRefs(
     value: boolean,
     featureVerseRefs: VerseRef[],
@@ -740,6 +753,38 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     if (deleteDelta.ops != null && deleteDelta.ops.length > 0) {
       this.editor.updateContents(deleteDelta, 'api');
     }
+  }
+
+  scrollToViewer(viewer: MultiCursorViewer): void {
+    if (this.editor == null) {
+      return;
+    }
+    if (this.presenceChannel?.remotePresences == null) {
+      return;
+    }
+    const presenceIds = Object.entries(this.presenceChannel.remotePresences)
+      .filter(remotePresence => remotePresence[1].viewer === viewer)
+      .map(remotePresence => remotePresence[0]);
+    if (presenceIds.length === 0) {
+      return;
+    }
+    const presenceId = presenceIds[0];
+    const range: RangeStatic | undefined = this.getViewerPosition(presenceId);
+    if (range == null) {
+      this.editor.root.scrollTop = 0;
+      return;
+    }
+    this.editor.setSelection(range);
+    this.editor.blur();
+    let presenceData: PresenceData = {
+      viewer: { ...viewer, activeInEditor: true }
+    };
+    this.onPresenceChannelReceive(presenceId, presenceData);
+    const active$ = timer(3000).subscribe(() => {
+      presenceData.viewer.activeInEditor = false;
+      this.onPresenceChannelReceive(presenceId, presenceData);
+      active$.unsubscribe();
+    });
   }
 
   isSegmentBlank(ref: string): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -540,16 +540,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   }
 
   getViewerPosition(presenceId: string): RangeStatic | undefined {
-    if (this.presenceDoc == null) {
-      return;
-    }
-    const ranges: RangeStatic[] = Object.entries(this.presenceDoc.remotePresences)
-      .filter(remotePresence => remotePresence[0] === presenceId)
-      .map(remotePresence => remotePresence[1]);
-    if (ranges.length === 0) {
-      return;
-    }
-    return ranges[0];
+    return Object.entries(this.presenceDoc?.remotePresences ?? {}).find(([id, _data]) => id === presenceId)?.[1];
   }
 
   toggleFeaturedVerseRefs(
@@ -756,19 +747,15 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   }
 
   scrollToViewer(viewer: MultiCursorViewer): void {
-    if (this.editor == null) {
+    if (this.editor == null || this.presenceChannel?.remotePresences == null) {
       return;
     }
-    if (this.presenceChannel?.remotePresences == null) {
+    const presenceId: string | undefined = Object.entries(this.presenceChannel?.remotePresences ?? {}).find(
+      ([_id, data]) => data.viewer === viewer
+    )?.[0];
+    if (presenceId == null) {
       return;
     }
-    const presenceIds = Object.entries(this.presenceChannel.remotePresences)
-      .filter(remotePresence => remotePresence[1].viewer === viewer)
-      .map(remotePresence => remotePresence[0]);
-    if (presenceIds.length === 0) {
-      return;
-    }
-    const presenceId = presenceIds[0];
     const range: RangeStatic | undefined = this.getViewerPosition(presenceId);
     if (range == null) {
       this.editor.root.scrollTop = 0;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -44,7 +44,7 @@
       </div>
       <ng-container *ngIf="showMultiViewers">
         <div fxFlexAlign="end" class="avatar-padding">
-          <app-multi-viewer [viewers]="multiCursorViewers"></app-multi-viewer>
+          <app-multi-viewer [viewers]="multiCursorViewers" (onViewerClick)="viewerClicked($event)"></app-multi-viewer>
         </div>
       </ng-container>
     </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1579,4 +1579,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     const otherBounds = this.source.editor.selection.getBounds(otherRange.index);
     this.source.editor.scrollingContainer.scrollTop += otherBounds.top - thisBounds.top;
   }
+
+  viewerClicked(viewer: MultiCursorViewer) {
+    this.target!.scrollToViewer(viewer);
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.html
@@ -1,7 +1,13 @@
 <div fxLayout="row" fxLayoutAlign="start center">
   <ng-container *ngFor="let viewer of avatarViewers">
     <div class="app-avatar-container" [title]="viewer.displayName">
-      <app-avatar [user]="viewer" [size]="32" [round]="true" [borderColor]="viewer.cursorColor"></app-avatar>
+      <app-avatar
+        [user]="viewer"
+        [size]="32"
+        [round]="true"
+        [borderColor]="viewer.cursorColor"
+        (click)="clickAvatar(viewer)"
+      ></app-avatar>
     </div>
   </ng-container>
   <ng-container *ngIf="viewers.length > maxAvatars">
@@ -20,7 +26,13 @@
         <button mat-menu-item disabled>{{ otherViewersLabel }}</button>
         <ng-container *ngFor="let viewer of viewers">
           <button mat-menu-item (click)="closeMenu()">
-            <app-avatar [user]="viewer" [size]="32" [round]="true" [borderColor]="viewer.cursorColor"></app-avatar>
+            <app-avatar
+              [user]="viewer"
+              [size]="32"
+              [round]="true"
+              [borderColor]="viewer.cursorColor"
+              (click)="clickAvatar(viewer)"
+            ></app-avatar>
             <span fxFlex>{{ viewer.displayName }}</span>
           </button>
         </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.html
@@ -25,14 +25,8 @@
       <mat-menu #menu="matMenu" (closed)="closeMenu()">
         <button mat-menu-item disabled>{{ otherViewersLabel }}</button>
         <ng-container *ngFor="let viewer of viewers">
-          <button mat-menu-item (click)="closeMenu()">
-            <app-avatar
-              [user]="viewer"
-              [size]="32"
-              [round]="true"
-              [borderColor]="viewer.cursorColor"
-              (click)="clickAvatar(viewer)"
-            ></app-avatar>
+          <button mat-menu-item (click)="closeMenu(); clickAvatar(viewer)">
+            <app-avatar [user]="viewer" [size]="32" [round]="true" [borderColor]="viewer.cursorColor"></app-avatar>
             <span fxFlex>{{ viewer.displayName }}</span>
           </button>
         </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.scss
@@ -27,3 +27,6 @@
 .mat-menu-item span {
   margin: auto 10px;
 }
+app-avatar {
+  cursor: pointer;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MediaChange, MediaObserver } from '@angular/flex-layout';
 import { translate } from '@ngneat/transloco';
 import { slice } from 'lodash-es';
@@ -18,6 +18,7 @@ export interface MultiCursorViewer extends UserProfile {
 })
 export class MultiViewerComponent extends SubscriptionDisposable implements OnInit {
   @Input() viewers: MultiCursorViewer[] = [];
+  @Output() onViewerClick: EventEmitter<MultiCursorViewer> = new EventEmitter<MultiCursorViewer>();
   maxAvatars: number = 3;
   isMenuOpen: boolean = false;
 
@@ -56,5 +57,9 @@ export class MultiViewerComponent extends SubscriptionDisposable implements OnIn
 
   closeMenu(): void {
     this.isMenuOpen = false;
+  }
+
+  clickAvatar(viewer: MultiCursorViewer) {
+    this.onViewerClick.emit(viewer);
   }
 }


### PR DESCRIPTION
- Clicking avatar in the toolbar will trigger a scroll to the segment of that viewer

The "scroll" simply uses the existing `setSelection` in quill which is the same when the document first loads and returns the user to their last known permission. This could be improved to a nicer animation scroll and even have the segment appear in the middle of the screen rather than the bottom.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1522)
<!-- Reviewable:end -->
