### PR TITLE
Update TypeScript to 4.6.4 in RealtimeServer

### DIFF
--- a/src/RealtimeServer/package-lock.json
+++ b/src/RealtimeServer/package-lock.json
@@ -44,7 +44,7 @@
         "sharedb-mingo-memory": "^1.2.0",
         "ts-jest": "^27.1.5",
         "ts-mockito": "^2.6.1",
-        "typescript": "~4.3.5"
+        "typescript": "~4.6.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7255,9 +7255,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -13055,9 +13055,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
     },
     "unbox-primitive": {

--- a/src/RealtimeServer/package.json
+++ b/src/RealtimeServer/package.json
@@ -54,6 +54,6 @@
     "sharedb-mingo-memory": "^1.2.0",
     "ts-jest": "^27.1.5",
     "ts-mockito": "^2.6.1",
-    "typescript": "~4.3.5"
+    "typescript": "~4.6.4"
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -148,7 +148,7 @@
         "sharedb-mingo-memory": "^1.2.0",
         "ts-jest": "^27.1.5",
         "ts-mockito": "^2.6.1",
-        "typescript": "~4.3.5"
+        "typescript": "~4.6.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -32605,7 +32605,7 @@
         "ts-jest": "^27.1.5",
         "ts-mockito": "^2.6.1",
         "ts-object-path": "^0.1.2",
-        "typescript": "~4.3.5",
+        "typescript": "~4.6.4",
         "websocket-json-stream": "^0.0.3",
         "ws": "^8.6.0"
       }


### PR DESCRIPTION
This brings the version of TypeScript in line with what we're using in ClientApp and db_tools

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1527)
<!-- Reviewable:end -->
