### PR TITLE
SF-1748 Properly display verse refs in RTL script

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
@@ -216,7 +216,7 @@
 
 .answer-scripture-verse {
   font-size: 0.8em;
-  padding-left: 5px;
+  padding-inline-start: 5px;
   display: inline-block;
   font-style: italic;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { TranslocoService } from '@ngneat/transloco';
 import { CookieService } from 'ngx-cookie-service';
+import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
@@ -127,6 +128,15 @@ describe('I18nService', () => {
     service.setLocale('ar', mockedAuthService);
     verify(mockedDocumentBody.setAttribute('dir', 'rtl')).once();
     expect().nothing();
+  });
+
+  it('should localize references', () => {
+    when(mockedTranslocoService.translate<string>('canon.book_names.GEN')).thenReturn('Genesis');
+    const service = getI18nService();
+    expect(service.localizeReference(VerseRef.parse('GEN 1:2-3'))).toBe('Genesis 1:2-3');
+    service.setLocale('ar', mockedAuthService);
+    // Expect right to left mark before : and - characters
+    expect(service.localizeReference(VerseRef.parse('GEN 1:2-3'))).toBe('Genesis 1\u200F:2\u200F-3');
   });
 });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -199,7 +199,13 @@ export class I18nService {
   }
 
   localizeReference(verse: VerseRef) {
-    return `${this.localizeBook(verse.bookNum)} ${verse.chapterNum}:${verse.verse}`;
+    // Add RTL mark before colon and hyphen characters, if in a RTL script.
+    // See https://software.sil.org/arabicfonts/support/faq/ for description of this solution, under the section
+    // "How do I get correct display for “Chapter:Verse” references using a regular “Roman” colon?"
+    const directionMark = this.locale.direction === 'ltr' ? '' : '\u200F';
+    // TODO Some ranges use a comma (and possibly other characters?) as a separator
+    const range = verse.verse.split('-').join(directionMark + '-');
+    return `${this.localizeBook(verse.bookNum)} ${verse.chapterNum}${directionMark}:${range}`;
   }
 
   localizeRole(role: string) {


### PR DESCRIPTION
How Matthew 1:21-22 looks before and after. The parentheses are inserted by the text chooser dialog, which I used for these screenshots.

Note that while this appears to be the most common way to show a reference in RTL, it's not the only way that is used.

Before | After
---------|--------
![](https://user-images.githubusercontent.com/6140710/194627366-2740c23b-06a1-404b-8f07-9502013a631e.png) | ![](https://user-images.githubusercontent.com/6140710/194627364-4717966a-4394-4a3a-ba08-1ac67c8c67dc.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1528)
<!-- Reviewable:end -->
