### PR TITLE
SF-1737 Yellow highlight does not appear for reference passages in the question dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
@@ -54,7 +54,7 @@ export class CheckingTextComponent extends SubscriptionDisposable {
       if (this.isEditorLoaded && !isEqual(this._id, textDocId)) {
         this._editorLoaded = false;
       }
-      if (this._activeVerse != null && this._id != null && this._id !== textDocId) {
+      if (this._activeVerse != null && this._id != null && !isEqual(this._id, textDocId)) {
         this.activeVerse = undefined;
       }
       this._id = textDocId;


### PR DESCRIPTION
- Changed comparison of TextDocId from `===` to `isEqual()`

It is interesting that the tests didn't have an issue with the `===` comparison.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1529)
<!-- Reviewable:end -->
