### PR TITLE
SF-1760 Allow auth0 account users to edit name while online

### DIFF
--- a/src/RealtimeServer/common/models/user.ts
+++ b/src/RealtimeServer/common/models/user.ts
@@ -11,7 +11,8 @@ export enum AuthType {
   Paratext,
   Google,
   Facebook,
-  Account
+  Account,
+  SMS
 }
 
 export function getAuthType(authId: string): AuthType {
@@ -31,6 +32,9 @@ export function getAuthType(authId: string): AuthType {
   }
   if (authIdType.includes('auth0')) {
     return AuthType.Account;
+  }
+  if (authIdType.includes('sms')) {
+    return AuthType.SMS;
   }
   return AuthType.Unknown;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -105,14 +105,7 @@
                   {{ t("logged_in_as") }}
                   <div fxLayout="row" fxLayoutAlign="start center">
                     <strong class="user-menu-name">{{ currentUser.displayName }}</strong>
-                    <button
-                      *ngIf="isAppOnline"
-                      id="edit-name-btn"
-                      mdcIconButton
-                      icon="edit"
-                      type="button"
-                      (click)="editName()"
-                    ></button>
+                    <button id="edit-name-btn" mdcIconButton icon="edit" type="button" (click)="editName()"></button>
                   </div>
                 </div>
                 <div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -105,7 +105,14 @@
                   {{ t("logged_in_as") }}
                   <div fxLayout="row" fxLayoutAlign="start center">
                     <strong class="user-menu-name">{{ currentUser.displayName }}</strong>
-                    <button id="edit-name-btn" mdcIconButton icon="edit" type="button" (click)="editName()"></button>
+                    <button
+                      *ngIf="hasAccountAuthType"
+                      id="edit-name-btn"
+                      mdcIconButton
+                      icon="edit"
+                      type="button"
+                      (click)="editName()"
+                    ></button>
                   </div>
                 </div>
                 <div>
@@ -119,7 +126,7 @@
                       {{ t("system_administration") }}
                     </mdc-list-item>
                     <mdc-list-item appRouterLink="/projects">{{ t("project_home") }}</mdc-list-item>
-                    <mdc-list-item *ngIf="canChangePassword" (click)="changePassword()" [disabled]="!isAppOnline">
+                    <mdc-list-item *ngIf="hasAccountAuthType" (click)="changePassword()" [disabled]="!isAppOnline">
                       {{ t("change_password") }}
                     </mdc-list-item>
                     <mdc-list-item name="logout" (click)="logOut()"> {{ t("log_out") }} </mdc-list-item>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -95,6 +95,7 @@
             </mdc-icon>
             <mdc-menu
               #userMenu
+              id="user-menu"
               anchorCorner="bottomStart"
               [anchorElement]="userMenuAnchor"
               [defaultFocusState]="defaultFocusState"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -106,7 +106,7 @@
                   <div fxLayout="row" fxLayoutAlign="start center">
                     <strong class="user-menu-name">{{ currentUser.displayName }}</strong>
                     <button
-                      *ngIf="hasAccountAuthType"
+                      *ngIf="canUpdateDisplayName"
                       id="edit-name-btn"
                       mdcIconButton
                       icon="edit"
@@ -126,7 +126,7 @@
                       {{ t("system_administration") }}
                     </mdc-list-item>
                     <mdc-list-item appRouterLink="/projects">{{ t("project_home") }}</mdc-list-item>
-                    <mdc-list-item *ngIf="hasAccountAuthType" (click)="changePassword()" [disabled]="!isAppOnline">
+                    <mdc-list-item *ngIf="canChangePassword" (click)="changePassword()" [disabled]="!isAppOnline">
                       {{ t("change_password") }}
                     </mdc-list-item>
                     <mdc-list-item name="logout" (click)="logOut()"> {{ t("log_out") }} </mdc-list-item>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -105,7 +105,14 @@
                   {{ t("logged_in_as") }}
                   <div fxLayout="row" fxLayoutAlign="start center">
                     <strong class="user-menu-name">{{ currentUser.displayName }}</strong>
-                    <button id="edit-name-btn" mdcIconButton icon="edit" type="button" (click)="editName()"></button>
+                    <button
+                      *ngIf="isAppOnline"
+                      id="edit-name-btn"
+                      mdcIconButton
+                      icon="edit"
+                      type="button"
+                      (click)="editName()"
+                    ></button>
                   </div>
                 </div>
                 <div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -442,14 +442,17 @@ describe('AppComponent', () => {
     verify(mockedUserService.editDisplayName(false)).once();
   }));
 
-  it('hides edit name button when user is offline', fakeAsync(() => {
+  it('shows message when edit name button clicked while offline', fakeAsync(() => {
     const env = new TestEnvironment('offline');
     env.init();
 
     env.avatarIcon.nativeElement.click();
     env.wait();
     expect(env.userMenu).not.toBeNull();
-    expect(env.editNameIcon).toBeNull();
+    expect(env.editNameIcon).not.toBeNull();
+    env.clickEditDisplayName();
+    verify(mockedNoticeService.show(anything())).once();
+    verify(mockedUserService.editDisplayName(anything())).never();
   }));
 
   describe('Community Checking', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -431,6 +431,30 @@ describe('AppComponent', () => {
     verify(mockedAuthService.checkOnlineAuth()).once();
   }));
 
+  it('can edit name online', fakeAsync(() => {
+    const env = new TestEnvironment('online');
+    env.init();
+
+    env.avatarIcon.nativeElement.click();
+    env.wait();
+    expect(env.userMenu).not.toBeNull();
+    env.clickEditDisplayName();
+    verify(mockedNoticeService.show(anything())).never();
+    verify(mockedUserService.editDisplayName(false)).once();
+  }));
+
+  it('shows message if user attempts to edit their name offline', fakeAsync(() => {
+    const env = new TestEnvironment('offline');
+    env.init();
+
+    env.avatarIcon.nativeElement.click();
+    env.wait();
+    expect(env.userMenu).not.toBeNull();
+    env.clickEditDisplayName();
+    verify(mockedNoticeService.show(anything())).once();
+    verify(mockedUserService.editDisplayName(anything())).never();
+  }));
+
   describe('Community Checking', () => {
     it('no books showing in the menu', fakeAsync(() => {
       const env = new TestEnvironment();
@@ -688,8 +712,20 @@ class TestEnvironment {
     return this.fixture.debugElement.query(By.css('#help-menu-list'));
   }
 
+  get userMenu(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#user-menu'));
+  }
+
+  get editNameIcon(): DebugElement {
+    return this.userMenu.query(By.css('#edit-name-btn'));
+  }
+
   get navBar(): DebugElement {
     return this.fixture.debugElement.query(By.css('mdc-top-app-bar'));
+  }
+
+  get avatarIcon(): DebugElement {
+    return this.navBar.query(By.css('.avatar-icon'));
   }
 
   get refreshButton(): DebugElement {
@@ -737,16 +773,8 @@ class TestEnvironment {
     return this.menuListItems.find((item: DebugElement) => item.nativeElement.innerText.includes(substring));
   }
 
-  getHelpMenuItemContaining(substring: string): DebugElement | undefined {
-    return this.helpMenuList.children.find((item: DebugElement) => item.nativeElement.innerText.includes(substring));
-  }
-
   someMenuItemContains(substring: string): boolean {
     return this.getMenuItemContaining(substring) !== undefined;
-  }
-
-  someHelpMenuItemContains(substring: string): boolean {
-    return this.getHelpMenuItemContaining(substring) !== undefined;
   }
 
   remoteAddQuestion(newQuestion: Question): void {
@@ -830,6 +858,12 @@ class TestEnvironment {
       this.component.projectSelect!.setSelectionByValue(projectId);
     });
     this.wait();
+  }
+
+  clickEditDisplayName(): void {
+    this.editNameIcon.nativeElement.click();
+    tick();
+    this.fixture.detectChanges();
   }
 
   wait(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -431,28 +431,14 @@ describe('AppComponent', () => {
     verify(mockedAuthService.checkOnlineAuth()).once();
   }));
 
-  it('can edit name online', fakeAsync(() => {
+  it('social users cannot edit name', fakeAsync(() => {
     const env = new TestEnvironment('online');
     env.init();
 
     env.avatarIcon.nativeElement.click();
     env.wait();
     expect(env.userMenu).not.toBeNull();
-    env.clickEditDisplayName();
-    verify(mockedUserService.editDisplayName(false)).once();
-  }));
-
-  it('shows message when edit name button clicked while offline', fakeAsync(() => {
-    const env = new TestEnvironment('offline');
-    env.init();
-
-    env.avatarIcon.nativeElement.click();
-    env.wait();
-    expect(env.userMenu).not.toBeNull();
-    expect(env.editNameIcon).not.toBeNull();
-    env.clickEditDisplayName();
-    verify(mockedNoticeService.show(anything())).once();
-    verify(mockedUserService.editDisplayName(anything())).never();
+    expect(env.editNameIcon).toBeNull();
   }));
 
   describe('Community Checking', () => {
@@ -554,6 +540,32 @@ describe('AppComponent', () => {
       env.removeUserFromProject(projectId);
       verify(mockedSFProjectService.localDelete(projectId)).once();
     }));
+
+    it('can edit name online', fakeAsync(() => {
+      const env = new TestEnvironment('online');
+      env.setCurrentUser('user02');
+      env.init();
+
+      env.avatarIcon.nativeElement.click();
+      env.wait();
+      expect(env.userMenu).not.toBeNull();
+      env.clickEditDisplayName();
+      verify(mockedUserService.editDisplayName(false)).once();
+    }));
+
+    it('shows message when edit name button clicked while offline', fakeAsync(() => {
+      const env = new TestEnvironment('offline');
+      env.setCurrentUser('user02');
+      env.init();
+
+      env.avatarIcon.nativeElement.click();
+      env.wait();
+      expect(env.userMenu).not.toBeNull();
+      expect(env.editNameIcon).not.toBeNull();
+      env.clickEditDisplayName();
+      verify(mockedNoticeService.show(anything())).once();
+      verify(mockedUserService.editDisplayName(anything())).never();
+    }));
   });
 });
 
@@ -584,23 +596,8 @@ class TestEnvironment {
   private readonly realtimeService: TestRealtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);
 
   constructor(initialConnectionStatus?: 'online' | 'offline') {
-    this.realtimeService.addSnapshot<User>(UserDoc.COLLECTION, {
-      id: 'user01',
-      data: {
-        name: 'User 01',
-        email: 'user1@example.com',
-        role: SystemRole.User,
-        isDisplayNameConfirmed: true,
-        avatarUrl: '',
-        authId: 'auth01',
-        displayName: 'User 01',
-        sites: {
-          sf: {
-            projects: ['project01', 'project02', 'project03']
-          }
-        }
-      }
-    });
+    this.addUser('user01', 'User 01', 'paratext|user01');
+    this.addUser('user02', 'User 02', 'auth0|user02');
 
     this.realtimeService.addSnapshots<Question>(QuestionDoc.COLLECTION, []);
     when(mockedSFProjectService.queryQuestions(anything(), anything())).thenCall((_projectId, options) => {
@@ -610,16 +607,16 @@ class TestEnvironment {
       return this.realtimeService.subscribeQuery(QuestionDoc.COLLECTION, parameters);
     });
 
-    this.addProject('project01', { user01: SFProjectRole.ParatextTranslator }, [
+    this.addProject('project01', { user01: SFProjectRole.ParatextTranslator, user02: SFProjectRole.CommunityChecker }, [
       { bookNum: 40, hasSource: true, chapters: [], permissions: {} },
       { bookNum: 41, hasSource: false, chapters: [], permissions: {} }
     ]);
     // Books are out-of-order on purpose so that we can test that books are displayed in canonical order
-    this.addProject('project02', { user01: SFProjectRole.CommunityChecker }, [
+    this.addProject('project02', { user01: SFProjectRole.CommunityChecker, user02: SFProjectRole.CommunityChecker }, [
       { bookNum: 43, hasSource: false, chapters: [], permissions: {} },
       { bookNum: 42, hasSource: false, chapters: [], permissions: {} }
     ]);
-    this.addProject('project03', { user01: SFProjectRole.CommunityChecker }, [
+    this.addProject('project03', { user01: SFProjectRole.CommunityChecker, user02: SFProjectRole.CommunityChecker }, [
       { bookNum: 44, hasSource: true, chapters: [], permissions: {} },
       { bookNum: 45, hasSource: true, chapters: [], permissions: {} }
     ]);
@@ -631,11 +628,8 @@ class TestEnvironment {
     when(mockedSFProjectService.getProfile(anything())).thenCall(projectId =>
       this.realtimeService.subscribe(SFProjectProfileDoc.COLLECTION, projectId)
     );
-    when(mockedUserService.currentUserId).thenReturn('user01');
     when(mockedAuthService.isLoggedIn).thenResolve(true);
-    when(mockedUserService.getCurrentUser()).thenCall(() =>
-      this.realtimeService.subscribe(UserDoc.COLLECTION, 'user01')
-    );
+    this.setCurrentUser('user01');
     when(mockedUserService.currentProjectId(anything())).thenReturn('project01');
     when(mockedSettingsAuthGuard.allowTransition(anything())).thenReturn(this.canSeeSettings$);
     when(mockedSyncAuthGuard.allowTransition(anything())).thenReturn(this.canSync$);
@@ -771,6 +765,11 @@ class TestEnvironment {
 
   getMenuItemContaining(substring: string): DebugElement | undefined {
     return this.menuListItems.find((item: DebugElement) => item.nativeElement.innerText.includes(substring));
+  }
+
+  setCurrentUser(userId: string): void {
+    when(mockedUserService.currentUserId).thenReturn(userId);
+    when(mockedUserService.getCurrentUser()).thenCall(() => this.realtimeService.subscribe(UserDoc.COLLECTION, userId));
   }
 
   someMenuItemContains(substring: string): boolean {
@@ -911,6 +910,26 @@ class TestEnvironment {
 
   confirmProjectDeletedDialog() {
     this.ngZone.run(() => this.projectDeletedDialogRefAfterClosed$.next('close'));
+  }
+
+  private addUser(userId: string, name: string, authId: string): void {
+    this.realtimeService.addSnapshot<User>(UserDoc.COLLECTION, {
+      id: userId,
+      data: {
+        name,
+        email: `${userId}@example.com`,
+        role: SystemRole.User,
+        isDisplayNameConfirmed: true,
+        avatarUrl: '',
+        authId,
+        displayName: name,
+        sites: {
+          sf: {
+            projects: ['project01', 'project02', 'project03']
+          }
+        }
+      }
+    });
   }
 
   private addProject(projectId: string, userRoles: { [userRef: string]: string }, texts: TextInfo[]): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -439,20 +439,17 @@ describe('AppComponent', () => {
     env.wait();
     expect(env.userMenu).not.toBeNull();
     env.clickEditDisplayName();
-    verify(mockedNoticeService.show(anything())).never();
     verify(mockedUserService.editDisplayName(false)).once();
   }));
 
-  it('shows message if user attempts to edit their name offline', fakeAsync(() => {
+  it('hides edit name button when user is offline', fakeAsync(() => {
     const env = new TestEnvironment('offline');
     env.init();
 
     env.avatarIcon.nativeElement.click();
     env.wait();
     expect(env.userMenu).not.toBeNull();
-    env.clickEditDisplayName();
-    verify(mockedNoticeService.show(anything())).once();
-    verify(mockedUserService.editDisplayName(anything())).never();
+    expect(env.editNameIcon).toBeNull();
   }));
 
   describe('Community Checking', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -248,7 +248,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     return this.currentUserDoc == null ? undefined : this.currentUserDoc.data;
   }
 
-  get canChangePassword(): boolean {
+  get hasAccountAuthType(): boolean {
     if (this.currentUser == null) {
       return false;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -466,12 +466,8 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     }
   }
 
-  async editName(): Promise<void> {
-    if (this.pwaService.isOnline) {
-      this.userService.editDisplayName(false);
-    } else {
-      this.noticeService.show(translate('app.action_not_available_offline'));
-    }
+  editName(): void {
+    this.userService.editDisplayName(false);
   }
 
   logOut(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -467,7 +467,11 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   }
 
   async editName(): Promise<void> {
-    this.userService.editDisplayName(false);
+    if (this.pwaService.isOnline) {
+      this.userService.editDisplayName(false);
+    } else {
+      this.noticeService.show(translate('app.action_not_available_offline'));
+    }
   }
 
   logOut(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -467,7 +467,11 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   }
 
   editName(): void {
-    this.userService.editDisplayName(false);
+    if (this.isAppOnline) {
+      this.userService.editDisplayName(false);
+    } else {
+      this.noticeService.show(translate('app.action_not_available_offline'));
+    }
   }
 
   logOut(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -248,11 +248,17 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     return this.currentUserDoc == null ? undefined : this.currentUserDoc.data;
   }
 
-  get hasAccountAuthType(): boolean {
+  get canChangePassword(): boolean {
     if (this.currentUser == null) {
       return false;
     }
     return getAuthType(this.currentUser.authId) === AuthType.Account;
+  }
+
+  get canUpdateDisplayName(): boolean {
+    if (this.currentUser == null) return false;
+    const authType: AuthType = getAuthType(this.currentUser.authId);
+    return authType === AuthType.Account || authType === AuthType.SMS;
   }
 
   get selectedProjectId(): string | undefined {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -16,6 +16,7 @@ import { FileService } from 'xforge-common/file.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { FileType } from 'xforge-common/models/file-offline-data';
 import { NoticeService } from 'xforge-common/notice.service';
+import { PwaService } from 'xforge-common/pwa.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { UserService } from 'xforge-common/user.service';
 import { QuestionDoc } from '../../../core/models/question-doc';
@@ -120,6 +121,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     private readonly questionDialogService: QuestionDialogService,
     private readonly i18n: I18nService,
     private readonly fileService: FileService,
+    private readonly pwaService: PwaService,
     public media: MediaObserver
   ) {
     super();
@@ -479,7 +481,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     }
     this.saveAnswerDisabled = true;
     const userDoc = await this.userService.getCurrentUser();
-    if (userDoc.data != null && !userDoc.data.isDisplayNameConfirmed) {
+    if (this.pwaService.isOnline && userDoc.data?.isDisplayNameConfirmed !== true) {
       await this.userService.editDisplayName(true);
     }
     this.emitAnswerToSave();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -651,6 +651,15 @@ describe('CheckingComponent', () => {
       expect(env.getAnswerText(0)).toBe('Answering question 2 should pop up a dialog');
     }));
 
+    it('does not open dialog if offline', fakeAsync(() => {
+      const env = new TestEnvironment(CLEAN_CHECKER_USER, 'JHN', false);
+      env.selectQuestion(2);
+      env.answerQuestion('Answering question 2 offline');
+      verify(mockedUserService.editDisplayName(anything())).never();
+      expect(env.answers.length).toEqual(1);
+      expect(env.getAnswerText(0)).toBe('Answering question 2 offline');
+    }));
+
     it('inserts newer answer above older answers', fakeAsync(() => {
       const env = new TestEnvironment(CHECKER_USER);
       env.selectQuestion(7);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -642,7 +642,7 @@ describe('CheckingComponent', () => {
       expect(env.component.summary.answered).toEqual(3);
     }));
 
-    it('opens dialog if answering a question for the first time', fakeAsync(() => {
+    it('opens edit display name dialog if answering a question for the first time', fakeAsync(() => {
       const env = new TestEnvironment(CLEAN_CHECKER_USER);
       env.selectQuestion(2);
       env.answerQuestion('Answering question 2 should pop up a dialog');
@@ -651,7 +651,7 @@ describe('CheckingComponent', () => {
       expect(env.getAnswerText(0)).toBe('Answering question 2 should pop up a dialog');
     }));
 
-    it('does not open dialog if offline', fakeAsync(() => {
+    it('does not open edit display name dialog if offline', fakeAsync(() => {
       const env = new TestEnvironment(CLEAN_CHECKER_USER, 'JHN', false);
       env.selectQuestion(2);
       env.answerQuestion('Answering question 2 offline');

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -249,6 +249,7 @@
     "confirm_name": "Confirm the name that other people on this project will see when you post answers and comments",
     "confirm_your_name": "Confirm your name",
     "confirm": "Confirm",
+    "connect_to_edit_name": "Please connect to the internet to edit your name",
     "enter_name": "Please enter your name",
     "update_your_name": "Update your name",
     "update": "Update",
@@ -268,6 +269,7 @@
   },
   "error_messages": {
     "error_occurred_login": "An error occurred during login.",
+    "failed_to_update_avatar": "Your avatar image could not be updated.",
     "try_again": "Try Again"
   },
   "exception_handling_service": {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.html
@@ -2,6 +2,7 @@
   <h1 mat-dialog-title *ngIf="data.isConfirmation">{{ t("confirm_your_name") }}</h1>
   <h1 mat-dialog-title *ngIf="!data.isConfirmation">{{ t("update_your_name") }}</h1>
   <mat-dialog-content>
+    <span *ngIf="!isOnline" class="offline-text">{{ t("connect_to_edit_name") }}</span>
     <form id="name-form">
       <p *ngIf="data.isConfirmation">{{ t("confirm_name") }}</p>
       <p *ngIf="!data.isConfirmation">{{ t("enter_name") }}</p>
@@ -12,7 +13,7 @@
     </form>
   </mat-dialog-content>
   <mat-dialog-actions align="end">
-    <button mat-button type="button" (click)="cancelDialog()" *ngIf="!data.isConfirmation" id="cancel-button">
+    <button mat-button type="button" [mat-dialog-close]="'close'" *ngIf="!data.isConfirmation" id="cancel-button">
       {{ t("cancel") }}
     </button>
     <button mat-flat-button color="primary" type="submit" (click)="submitDialog()" id="submit-button">

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.html
@@ -1,41 +1,22 @@
 <ng-container *transloco="let t; read: 'edit_name_dialog'">
-  <mdc-dialog [dir]="i18n.direction">
-    <mdc-dialog-container>
-      <mdc-dialog-surface>
-        <mdc-dialog-title *ngIf="data.isConfirmation">{{ t("confirm_your_name") }}</mdc-dialog-title>
-        <mdc-dialog-title *ngIf="!data.isConfirmation">{{ t("update_your_name") }}</mdc-dialog-title>
-        <mdc-dialog-content>
-          <form id="name-form">
-            <p *ngIf="data.isConfirmation">{{ t("confirm_name") }}</p>
-            <p *ngIf="!data.isConfirmation">{{ t("enter_name") }}</p>
-            <mdc-form-field [fluid]="true">
-              <mdc-text-field [formControl]="name" id="name-input" label="{{ t('your_name') }}"></mdc-text-field>
-            </mdc-form-field>
-          </form>
-        </mdc-dialog-content>
-        <mdc-dialog-actions>
-          <button
-            form="name-form"
-            mdcDialogButton
-            type="button"
-            (click)="cancelDialog()"
-            *ngIf="!data.isConfirmation"
-            id="cancel-button"
-          >
-            {{ t("cancel") }}
-          </button>
-          <button
-            mdcDialogButton
-            form="name-form"
-            [unelevated]="true"
-            type="submit"
-            (click)="submitDialog()"
-            id="submit-button"
-          >
-            {{ data.isConfirmation ? t("confirm") : t("update") }}
-          </button>
-        </mdc-dialog-actions>
-      </mdc-dialog-surface>
-    </mdc-dialog-container>
-  </mdc-dialog>
+  <h1 mat-dialog-title *ngIf="data.isConfirmation">{{ t("confirm_your_name") }}</h1>
+  <h1 mat-dialog-title *ngIf="!data.isConfirmation">{{ t("update_your_name") }}</h1>
+  <mat-dialog-content>
+    <form id="name-form">
+      <p *ngIf="data.isConfirmation">{{ t("confirm_name") }}</p>
+      <p *ngIf="!data.isConfirmation">{{ t("enter_name") }}</p>
+      <mat-form-field appearance="fill">
+        <mat-label>{{ t("your_name") }}</mat-label>
+        <input matInput [formControl]="name" />
+      </mat-form-field>
+    </form>
+  </mat-dialog-content>
+  <mat-dialog-actions align="end">
+    <button mat-button type="button" (click)="cancelDialog()" *ngIf="!data.isConfirmation" id="cancel-button">
+      {{ t("cancel") }}
+    </button>
+    <button mat-flat-button color="primary" type="submit" (click)="submitDialog()" id="submit-button">
+      {{ data.isConfirmation ? t("confirm") : t("update") }}
+    </button>
+  </mat-dialog-actions>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.scss
@@ -1,5 +1,5 @@
 .mat-dialog-content {
-  min-width: 280px;
+  width: 280px;
   .mat-form-field {
     width: 100%;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.scss
@@ -1,0 +1,3 @@
+.mat-dialog-container {
+  min-width: 280px;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.scss
@@ -1,6 +1,3 @@
-.mat-dialog-content {
-  width: 280px;
-  .mat-form-field {
-    width: 100%;
-  }
+.mat-dialog-content .mat-form-field {
+  width: 100%;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.scss
@@ -1,3 +1,6 @@
-.mat-dialog-container {
+.mat-dialog-content {
   min-width: 280px;
+  .mat-form-field {
+    width: 100%;
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.spec.ts
@@ -62,13 +62,11 @@ describe('EditNameDialogComponent', () => {
     expect(env.component.confirmedName).toBeUndefined();
     env.setTextFieldValue(env.nameInput, '');
     env.submitButton.click();
-    tick();
-    env.fixture.detectChanges();
+    env.wait();
     expect(env.component.confirmedName).toBeUndefined();
     env.setTextFieldValue(env.nameInput, ' ');
     env.submitButton.click();
-    tick();
-    env.fixture.detectChanges();
+    env.wait();
     expect(env.component.confirmedName).toBeUndefined();
     env.setTextFieldValue(env.nameInput, 'Bob');
     env.clickSubmit();
@@ -155,8 +153,7 @@ class TestEnvironment {
 
   set isOnline(value: boolean) {
     this.onlineStatus$.next(value);
-    tick();
-    this.fixture.detectChanges();
+    this.wait();
   }
 
   openDialog(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.spec.ts
@@ -23,9 +23,7 @@ describe('EditNameDialogComponent', () => {
     expect(env.component.confirmedName).toBeUndefined();
     expect(env.nameInput.value).toBe('Simon Says');
     expect(env.cancelButton).not.toBe(null);
-    env.submitButton.click();
-    tick();
-    env.fixture.detectChanges();
+    env.clickSubmit();
     expect(env.component.confirmedName).toBe('Simon Says');
   }));
 
@@ -34,9 +32,7 @@ describe('EditNameDialogComponent', () => {
     env.openDialog();
     expect(env.component.confirmedName).toBeUndefined();
     env.setTextFieldValue(env.nameInput, 'Follow The Leader');
-    env.submitButton.click();
-    tick();
-    env.fixture.detectChanges();
+    env.clickSubmit();
     expect(env.component.confirmedName).toBe('Follow The Leader');
   }));
 
@@ -80,9 +76,7 @@ describe('EditNameDialogComponent', () => {
     env.openDialog();
     expect(env.title.textContent).toBe('Confirm your name');
     expect(env.description.textContent).toContain('Confirm the name that other people on this project will see');
-    env.submitButton.click();
-    tick();
-    env.fixture.detectChanges();
+    env.clickSubmit();
     expect(env.component.confirmedName).toBe('Simon Says');
   }));
 
@@ -91,9 +85,7 @@ describe('EditNameDialogComponent', () => {
     env.component.isConfirmContext = true;
     env.openDialog();
     expect(env.cancelButton).toBe(null);
-    env.submitButton.click();
-    env.fixture.detectChanges();
-    tick();
+    env.clickSubmit();
     expect(env.component.confirmedName).toBe('Simon Says');
   }));
 });
@@ -143,10 +135,15 @@ class TestEnvironment {
     tick(166);
   }
 
-  setTextFieldValue(element: HTMLElement, value: string) {
-    const inputElem = element as HTMLInputElement;
-    inputElem.value = value;
-    inputElem.dispatchEvent(new Event('input'));
+  clickSubmit(): void {
+    this.submitButton.click();
+    tick();
+    this.fixture.detectChanges();
+  }
+
+  setTextFieldValue(element: HTMLInputElement, value: string) {
+    element.value = value;
+    element.dispatchEvent(new Event('input'));
     this.fixture.detectChanges();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.spec.ts
@@ -3,7 +3,7 @@ import { Component, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { Subject } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 import { mock, when } from 'ts-mockito';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
@@ -51,7 +51,7 @@ describe('EditNameDialogComponent', () => {
     expect(env.cancelButton).not.toBe(null);
     if (env.cancelButton != null) {
       env.cancelButton.click();
-      env.fixture.detectChanges();
+      env.wait();
     }
     expect(env.component.confirmedName).toBeUndefined();
   }));
@@ -86,6 +86,7 @@ describe('EditNameDialogComponent', () => {
     expect(env.overlayContainerElement).not.toBeNull();
     expect(env.component.confirmedName).toBeUndefined();
     env.cancelButton!.click();
+    env.wait();
   }));
 
   it('shows messages in a confirmation context', fakeAsync(() => {
@@ -112,14 +113,14 @@ class TestEnvironment {
   fixture: ComponentFixture<DialogOpenerComponent>;
   component: DialogOpenerComponent;
 
-  private onlineStatus$: Subject<boolean> = new Subject<boolean>();
+  private onlineStatus$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(true);
 
   constructor() {
     TestBed.configureTestingModule({
       declarations: [DialogOpenerComponent],
       imports: [DialogTestModule, UICommonModule]
     });
-    when(mockedPwaService.onlineStatus).thenReturn(this.onlineStatus$);
+    when(mockedPwaService.onlineStatus$).thenReturn(this.onlineStatus$.asObservable());
     this.fixture = TestBed.createComponent(DialogOpenerComponent);
     this.component = this.fixture.componentInstance;
   }
@@ -168,13 +169,17 @@ class TestEnvironment {
 
   clickSubmit(): void {
     this.submitButton.click();
-    tick();
-    this.fixture.detectChanges();
+    this.wait();
   }
 
   setTextFieldValue(element: HTMLInputElement, value: string) {
     element.value = value;
     element.dispatchEvent(new Event('input'));
+    this.fixture.detectChanges();
+  }
+
+  wait(): void {
+    tick(20);
     this.fixture.detectChanges();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.ts
@@ -1,6 +1,6 @@
-import { MdcDialogRef, MDC_DIALOG_DATA } from '@angular-mdc/web/dialog';
 import { Component, Inject } from '@angular/core';
 import { UntypedFormControl, Validators } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { I18nService } from 'xforge-common/i18n.service';
 import { XFValidators } from 'xforge-common/xfvalidators';
 
@@ -9,15 +9,17 @@ export interface EditNameDialogResult {
 }
 
 @Component({
+  selector: 'app-edit-name-dialog',
+  styleUrls: ['./edit-name-dialog.component.scss'],
   templateUrl: './edit-name-dialog.component.html'
 })
 export class EditNameDialogComponent {
   name: UntypedFormControl = new UntypedFormControl('');
 
   constructor(
-    public dialogRef: MdcDialogRef<EditNameDialogComponent, EditNameDialogResult | 'close'>,
+    public dialogRef: MatDialogRef<EditNameDialogComponent, EditNameDialogResult | 'close'>,
     public i18n: I18nService,
-    @Inject(MDC_DIALOG_DATA) public data: { name: string; isConfirmation: boolean }
+    @Inject(MAT_DIALOG_DATA) public data: { name: string; isConfirmation: boolean }
   ) {
     this.name.setValidators([Validators.required, XFValidators.someNonWhitespace]);
     this.name.setValue(data.name);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.ts
@@ -2,6 +2,8 @@ import { Component, Inject } from '@angular/core';
 import { UntypedFormControl, Validators } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { I18nService } from 'xforge-common/i18n.service';
+import { PwaService } from 'xforge-common/pwa.service';
+import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { XFValidators } from 'xforge-common/xfvalidators';
 
 export interface EditNameDialogResult {
@@ -13,27 +15,25 @@ export interface EditNameDialogResult {
   styleUrls: ['./edit-name-dialog.component.scss'],
   templateUrl: './edit-name-dialog.component.html'
 })
-export class EditNameDialogComponent {
+export class EditNameDialogComponent extends SubscriptionDisposable {
   name: UntypedFormControl = new UntypedFormControl('');
+  isOnline: boolean = true;
 
   constructor(
     public dialogRef: MatDialogRef<EditNameDialogComponent, EditNameDialogResult | 'close'>,
     public i18n: I18nService,
+    readonly pwaService: PwaService,
     @Inject(MAT_DIALOG_DATA) public data: { name: string; isConfirmation: boolean }
   ) {
+    super();
     this.name.setValidators([Validators.required, XFValidators.someNonWhitespace]);
     this.name.setValue(data.name);
+    this.subscribe(this.pwaService.onlineStatus$, isOnline => (this.isOnline = isOnline));
   }
 
-  submitDialog() {
-    if (this.name.valid) {
+  submitDialog(): void {
+    if (this.name.valid && this.isOnline) {
       this.dialogRef.close({ displayName: this.name.value });
-    }
-  }
-
-  cancelDialog() {
-    if (!this.data.isConfirmation) {
-      this.dialogRef.close();
     }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.spec.ts
@@ -1,15 +1,14 @@
-import { anything, capture, instance, mock, when } from 'ts-mockito';
-import { MdcDialog } from '@angular-mdc/web';
-import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material/dialog';
+import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { User } from 'realtime-server/lib/esm/common/models/user';
-import { verify } from 'ts-mockito';
-import { MdcDialogRef } from '@angular-mdc/web/dialog';
 import { of } from 'rxjs';
+import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 import { EditNameDialogComponent } from 'xforge-common/edit-name-dialog/edit-name-dialog.component';
 import { CURRENT_PROJECT_ID_SETTING, UserService } from './user.service';
 import { AuthService } from './auth.service';
 import { CommandService } from './command.service';
+import { DialogService } from './dialog.service';
 import { LocalSettingsService } from './local-settings.service';
 import { UserDoc } from './models/user-doc';
 import { TestRealtimeService } from './test-realtime.service';
@@ -19,8 +18,8 @@ import { TypeRegistry } from './type-registry';
 
 const mockedAuthService = mock(AuthService);
 const mockedLocalSettingsService = mock(LocalSettingsService);
-const mockedDialog = mock(MdcDialog);
 const mockedCommandService = mock(CommandService);
+const mockedDialogService = mock(DialogService);
 
 describe('UserService', () => {
   configureTestingModule(() => ({
@@ -29,8 +28,8 @@ describe('UserService', () => {
       UserService,
       { provide: AuthService, useMock: mockedAuthService },
       { provide: LocalSettingsService, useMock: mockedLocalSettingsService },
-      { provide: MdcDialog, useMock: mockedDialog },
-      { provide: CommandService, useMock: mockedCommandService }
+      { provide: CommandService, useMock: mockedCommandService },
+      { provide: DialogService, useMock: mockedDialogService }
     ]
   }));
 
@@ -77,7 +76,7 @@ interface TestArgs {
 class TestEnvironment {
   readonly service: UserService;
   readonly realtimeService: TestRealtimeService;
-  readonly mockedEditNameDialogRef = mock<MdcDialogRef<EditNameDialogComponent>>(MdcDialogRef);
+  readonly mockedEditNameDialogRef = mock<MatDialogRef<EditNameDialogComponent>>(MatDialogRef);
 
   constructor(testArgs: TestArgs) {
     this.realtimeService = TestBed.inject(TestRealtimeService);
@@ -94,12 +93,15 @@ class TestEnvironment {
         sites: { sf: { currentProjectId: testArgs.storedProjectId, projects: ['project01', 'project02'] } }
       }
     });
+
     this.service = TestBed.inject(UserService);
 
     when(mockedLocalSettingsService.get<string>(CURRENT_PROJECT_ID_SETTING)).thenReturn(testArgs.localProjectId);
     when(mockedAuthService.currentUserId).thenReturn('user01');
     when(mockedAuthService.isLoggedIn).thenResolve(true);
-    when(mockedDialog.open(EditNameDialogComponent, anything())).thenReturn(instance(this.mockedEditNameDialogRef));
+    when(mockedDialogService.openMatDialog(EditNameDialogComponent, anything())).thenReturn(
+      instance(this.mockedEditNameDialogRef)
+    );
     when(this.mockedEditNameDialogRef.afterClosed()).thenReturn(of({ displayName: 'User Name' }));
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { MatDialogRef } from '@angular/material/dialog';
+import { translate } from '@ngneat/transloco';
 import { escapeRegExp } from 'lodash-es';
 import merge from 'lodash-es/merge';
 import { User } from 'realtime-server/lib/esm/common/models/user';
@@ -15,6 +16,7 @@ import { LocalSettingsService } from './local-settings.service';
 import { RealtimeQuery } from './models/realtime-query';
 import { UserDoc } from './models/user-doc';
 import { UserProfileDoc } from './models/user-profile-doc';
+import { NoticeService } from './notice.service';
 import { Filters, QueryParameters } from './query-parameters';
 import { RealtimeService } from './realtime.service';
 import { USERS_URL } from './url-constants';
@@ -36,7 +38,8 @@ export class UserService {
     private readonly authService: AuthService,
     private readonly commandService: CommandService,
     private readonly localSettings: LocalSettingsService,
-    private readonly dialogService: DialogService
+    private readonly dialogService: DialogService,
+    private readonly noticeService: NoticeService
   ) {}
 
   get currentUserId(): string {
@@ -118,7 +121,11 @@ export class UserService {
         op.set(u => u.displayName, result.displayName);
         op.set<boolean>(u => u.isDisplayNameConfirmed, true);
       });
-      await this.updateAvatarFromDisplayName();
+      try {
+        await this.updateAvatarFromDisplayName();
+      } catch {
+        this.noticeService.showError(translate('error_messages.failed_to_update_avatar'));
+      }
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
@@ -1,5 +1,5 @@
-import { MdcDialog, MdcDialogRef } from '@angular-mdc/web/dialog';
 import { Injectable } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
 import { escapeRegExp } from 'lodash-es';
 import merge from 'lodash-es/merge';
 import { User } from 'realtime-server/lib/esm/common/models/user';
@@ -9,6 +9,7 @@ import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
 import { environment } from '../environments/environment';
 import { AuthService } from './auth.service';
 import { CommandService } from './command.service';
+import { DialogService } from './dialog.service';
 import { EditNameDialogComponent, EditNameDialogResult } from './edit-name-dialog/edit-name-dialog.component';
 import { LocalSettingsService } from './local-settings.service';
 import { RealtimeQuery } from './models/realtime-query';
@@ -35,7 +36,7 @@ export class UserService {
     private readonly authService: AuthService,
     private readonly commandService: CommandService,
     private readonly localSettings: LocalSettingsService,
-    private readonly dialog: MdcDialog
+    private readonly dialogService: DialogService
   ) {}
 
   get currentUserId(): string {
@@ -107,11 +108,10 @@ export class UserService {
     if (currentUserDoc.data == null) {
       return;
     }
-    const dialogRef = this.dialog.open(EditNameDialogComponent, {
+    const dialogRef = this.dialogService.openMatDialog(EditNameDialogComponent, {
       data: { name: currentUserDoc.data.displayName, isConfirmation },
-      escapeToClose: !isConfirmation,
-      clickOutsideToClose: !isConfirmation
-    }) as MdcDialogRef<EditNameDialogComponent, EditNameDialogResult | 'close'>;
+      disableClose: isConfirmation
+    }) as MatDialogRef<EditNameDialogComponent, EditNameDialogResult | 'close'>;
     const result = await dialogRef.afterClosed().toPromise();
     if (result != null && result !== 'close') {
       await currentUserDoc.submitJson0Op(op => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
@@ -113,7 +113,8 @@ export class UserService {
     }
     const dialogRef = this.dialogService.openMatDialog(EditNameDialogComponent, {
       data: { name: currentUserDoc.data.displayName, isConfirmation },
-      disableClose: isConfirmation
+      disableClose: isConfirmation,
+      width: '280px'
     }) as MatDialogRef<EditNameDialogComponent, EditNameDialogResult | 'close'>;
     const result = await dialogRef.afterClosed().toPromise();
     if (result != null && result !== 'close') {


### PR DESCRIPTION
* detect if user is online before opening dialog
* show message if user is offline
* convert edit name dialog to angular material
* add scss style to edit name dialog
* do not show name confirmation dialog when user is offline

Before
![image](https://user-images.githubusercontent.com/17931130/195169126-2f2fba09-b7a9-4cd8-b569-1a132e826c71.png)

After
![image](https://user-images.githubusercontent.com/17931130/195167730-d9687367-99ba-455a-902d-8d13557b901f.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1532)
<!-- Reviewable:end -->
