### PR TITLE
Use the to do comment tag icon for the project for new note threads

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/sf-project.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project.ts
@@ -25,6 +25,7 @@ export interface SFProjectProfile extends Project {
   editable: boolean;
   defaultFontSize?: number;
   defaultFont?: string;
+  noteIcon?: string;
 }
 
 export interface SFProject extends SFProjectProfile {

--- a/src/RealtimeServer/scriptureforge/models/sf-project.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project.ts
@@ -25,7 +25,7 @@ export interface SFProjectProfile extends Project {
   editable: boolean;
   defaultFontSize?: number;
   defaultFont?: string;
-  noteIcon?: string;
+  tagIcon?: string;
 }
 
 export interface SFProject extends SFProjectProfile {

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -30,7 +30,8 @@ const SF_PROJECT_PROFILE_FIELDS: ShareDB.ProjectionFields = {
   checkingConfig: true,
   texts: true,
   syncDisabled: true,
-  sync: true
+  sync: true,
+  noteIcon: true
 };
 
 /**

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -31,7 +31,7 @@ const SF_PROJECT_PROFILE_FIELDS: ShareDB.ProjectionFields = {
   texts: true,
   syncDisabled: true,
   sync: true,
-  noteIcon: true
+  tagIcon: true
 };
 
 /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
@@ -11,13 +11,13 @@ import { toVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-
 import { AssignedUsers } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { ParatextUserProfile } from 'realtime-server/lib/esm/scriptureforge/models/paratext-user-profile';
 
-export const DEFAULT_NOTE_ICON = '01flag1';
+export const DEFAULT_TAG_ICON = '01flag1';
 
-export function defaultNoteThreadIcon(noteIcon: string | undefined): NoteThreadIcon {
-  if (noteIcon == null) {
-    noteIcon = DEFAULT_NOTE_ICON;
+export function defaultNoteThreadIcon(tagIcon: string | undefined): NoteThreadIcon {
+  if (tagIcon == null) {
+    tagIcon = DEFAULT_TAG_ICON;
   }
-  const iconUrl = `/assets/icons/TagIcons/${noteIcon}.png`;
+  const iconUrl = `/assets/icons/TagIcons/${tagIcon}.png`;
   return { cssVar: `--icon-file: url(${iconUrl});`, url: iconUrl };
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
@@ -11,11 +11,13 @@ import { toVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-
 import { AssignedUsers } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { ParatextUserProfile } from 'realtime-server/lib/esm/scriptureforge/models/paratext-user-profile';
 
-export function defaultNoteThreadIcon(iconName: string | undefined): NoteThreadIcon {
-  if (iconName == null) {
-    iconName = '01flag1';
+export const DEFAULT_NOTE_ICON = '01flag1';
+
+export function defaultNoteThreadIcon(noteIcon: string | undefined): NoteThreadIcon {
+  if (noteIcon == null) {
+    noteIcon = DEFAULT_NOTE_ICON;
   }
-  const iconUrl = `/assets/icons/TagIcons/${iconName}.png`;
+  const iconUrl = `/assets/icons/TagIcons/${noteIcon}.png`;
   return { cssVar: `--icon-file: url(${iconUrl});`, url: iconUrl };
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
@@ -11,9 +11,11 @@ import { toVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-
 import { AssignedUsers } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { ParatextUserProfile } from 'realtime-server/lib/esm/scriptureforge/models/paratext-user-profile';
 
-export function defaultNoteThreadIcon(): NoteThreadIcon {
-  const iconTag: string = '01flag1';
-  const iconUrl = `/assets/icons/TagIcons/${iconTag}.png`;
+export function defaultNoteThreadIcon(iconName: string | undefined): NoteThreadIcon {
+  if (iconName == null) {
+    iconName = '01flag1';
+  }
+  const iconUrl = `/assets/icons/TagIcons/${iconName}.png`;
   return { cssVar: `--icon-file: url(${iconUrl});`, url: iconUrl };
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -650,7 +650,7 @@ class TestEnvironment {
     sync: { queuedCount: 0 },
     editable: true,
     userRoles: TestEnvironment.userRoles,
-    noteIcon: 'defaultIcon'
+    tagIcon: 'defaultIcon'
   };
   static paratextUsers: ParatextUserProfile[] = paratextUsersFromRoles(TestEnvironment.userRoles);
   static testProject: SFProject = {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -454,7 +454,7 @@ describe('NoteDialogComponent', () => {
   it('show insert note dialog content', fakeAsync(() => {
     env = new TestEnvironment({ verseRef: VerseRef.parse('MAT 1:1') });
     expect(env.noteInputElement).toBeTruthy();
-    expect(env.flagIcon).toEqual('/assets/icons/TagIcons/01flag1.png');
+    expect(env.flagIcon).toEqual('/assets/icons/TagIcons/defaultIcon.png');
     expect(env.verseRef).toEqual('Matthew 1:1');
     expect(env.noteText.nativeElement.innerText).toEqual('target: chapter 1, verse 1.');
     expect(env.threadAssignedUser.nativeElement.textContent).toContain('Unassigned');
@@ -478,6 +478,7 @@ describe('NoteDialogComponent', () => {
     expect(noteThread.notes[0].ownerRef).toEqual('user01');
     expect(noteThread.notes[0].content).toEqual('Enter note content');
     expect(noteThread.notes[0].threadId).toContain(SF_NOTE_THREAD_PREFIX);
+    expect(noteThread.tagIcon).toEqual('defaultIcon');
   }));
 
   it('does not save note if textarea is empty', fakeAsync(() => {
@@ -648,7 +649,8 @@ class TestEnvironment {
     texts: [TestEnvironment.matthewText],
     sync: { queuedCount: 0 },
     editable: true,
-    userRoles: TestEnvironment.userRoles
+    userRoles: TestEnvironment.userRoles,
+    noteIcon: 'defaultIcon'
   };
   static paratextUsers: ParatextUserProfile[] = paratextUsersFromRoles(TestEnvironment.userRoles);
   static testProject: SFProject = {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -21,7 +21,7 @@ import { I18nService } from 'xforge-common/i18n.service';
 import { UserService } from 'xforge-common/user.service';
 import { objectId } from 'xforge-common/utils';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
-import { NoteThreadDoc, defaultNoteThreadIcon, DEFAULT_NOTE_ICON } from '../../../core/models/note-thread-doc';
+import { NoteThreadDoc, defaultNoteThreadIcon, DEFAULT_TAG_ICON } from '../../../core/models/note-thread-doc';
 import { SFProjectDoc } from '../../../core/models/sf-project-doc';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
@@ -385,7 +385,7 @@ export class NoteDialogComponent implements OnInit {
         originalContextBefore: '',
         originalSelectedText: this.segmentText,
         originalContextAfter: '',
-        tagIcon: this.projectProfileDoc!.data!.tagIcon ?? DEFAULT_NOTE_ICON,
+        tagIcon: this.projectProfileDoc!.data!.tagIcon ?? DEFAULT_TAG_ICON,
         status: NoteStatus.Todo
       };
       await this.projectService.createNoteThread(this.projectId, noteThread);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -21,11 +21,11 @@ import { I18nService } from 'xforge-common/i18n.service';
 import { UserService } from 'xforge-common/user.service';
 import { objectId } from 'xforge-common/utils';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
-import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
-import { TextDoc, TextDocId } from '../../../core/models/text-doc';
-import { SFProjectService } from '../../../core/sf-project.service';
-import { NoteThreadDoc, defaultNoteThreadIcon } from '../../../core/models/note-thread-doc';
+import { NoteThreadDoc, defaultNoteThreadIcon, DEFAULT_NOTE_ICON } from '../../../core/models/note-thread-doc';
 import { SFProjectDoc } from '../../../core/models/sf-project-doc';
+import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
+import { SFProjectService } from '../../../core/sf-project.service';
+import { TextDoc, TextDocId } from '../../../core/models/text-doc';
 import { canInsertNote } from '../../../shared/utils';
 
 export interface NoteDialogData {
@@ -95,7 +95,7 @@ export class NoteDialogComponent implements OnInit {
 
   get flagIcon(): string {
     if (this.threadDoc?.data == null) {
-      return defaultNoteThreadIcon(this.projectProfileDoc?.data?.noteIcon).url;
+      return defaultNoteThreadIcon(this.projectProfileDoc?.data?.tagIcon).url;
     }
     return this.isAssignedToOtherUser ? this.threadDoc.iconGrayed.url : this.threadDoc.icon.url;
   }
@@ -385,7 +385,7 @@ export class NoteDialogComponent implements OnInit {
         originalContextBefore: '',
         originalSelectedText: this.segmentText,
         originalContextAfter: '',
-        tagIcon: this.projectProfileDoc!.data!.noteIcon ?? '01flag1',
+        tagIcon: this.projectProfileDoc!.data!.tagIcon ?? DEFAULT_NOTE_ICON,
         status: NoteStatus.Todo
       };
       await this.projectService.createNoteThread(this.projectId, noteThread);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -95,7 +95,7 @@ export class NoteDialogComponent implements OnInit {
 
   get flagIcon(): string {
     if (this.threadDoc?.data == null) {
-      return defaultNoteThreadIcon().url;
+      return defaultNoteThreadIcon(this.projectProfileDoc?.data?.noteIcon).url;
     }
     return this.isAssignedToOtherUser ? this.threadDoc.iconGrayed.url : this.threadDoc.icon.url;
   }
@@ -385,7 +385,7 @@ export class NoteDialogComponent implements OnInit {
         originalContextBefore: '',
         originalSelectedText: this.segmentText,
         originalContextAfter: '',
-        tagIcon: '01flag1',
+        tagIcon: this.projectProfileDoc!.data!.noteIcon ?? '01flag1',
         status: NoteStatus.Todo
       };
       await this.projectService.createNoteThread(this.projectId, noteThread);

--- a/src/SIL.XForge.Scripture/Models/ParatextSettings.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextSettings.cs
@@ -14,6 +14,6 @@ namespace SIL.XForge.Scripture.Models
         public string DefaultFont { get; set; }
 
         /// <summary> The tag icon used by default for note threads created in SF. </summary>
-        public string ToDoCommentIcon { get; set; }
+        public string TagIcon { get; set; }
     }
 }

--- a/src/SIL.XForge.Scripture/Models/ParatextSettings.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextSettings.cs
@@ -12,5 +12,8 @@ namespace SIL.XForge.Scripture.Models
         public bool Editable { get; set; }
         public int DefaultFontSize { get; set; }
         public string DefaultFont { get; set; }
+
+        /// <summary> The tag icon used by default for note threads created in SF. </summary>
+        public string ToDoCommentIcon { get; set; }
     }
 }

--- a/src/SIL.XForge.Scripture/Models/SFProject.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProject.cs
@@ -23,6 +23,6 @@ namespace SIL.XForge.Scripture.Models
         public bool Editable { get; set; } = true;
         public int? DefaultFontSize { get; set; }
         public string DefaultFont { get; set; }
-        public string NoteIcon { get; set; }
+        public string TagIcon { get; set; }
     }
 }

--- a/src/SIL.XForge.Scripture/Models/SFProject.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProject.cs
@@ -23,5 +23,6 @@ namespace SIL.XForge.Scripture.Models
         public bool Editable { get; set; } = true;
         public int? DefaultFontSize { get; set; }
         public string DefaultFont { get; set; }
+        public string NoteIcon { get; set; }
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -939,13 +939,15 @@ namespace SIL.XForge.Scripture.Services
             using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
             if (scrText == null)
                 return null;
+            CommentTags commentTags = CommentTags.Get(scrText);
             return new ParatextSettings
             {
                 FullName = scrText.FullName,
                 IsRightToLeft = scrText.RightToLeft,
                 Editable = scrText.Settings.Editable,
                 DefaultFontSize = scrText.Settings.DefaultFontSize,
-                DefaultFont = scrText.Settings.DefaultFont
+                DefaultFont = scrText.Settings.DefaultFont,
+                ToDoCommentIcon = commentTags.Get(CommentTag.toDoTagId).Icon
             };
         }
 

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -947,7 +947,7 @@ namespace SIL.XForge.Scripture.Services
                 Editable = scrText.Settings.Editable,
                 DefaultFontSize = scrText.Settings.DefaultFontSize,
                 DefaultFont = scrText.Settings.DefaultFont,
-                ToDoCommentIcon = commentTags.Get(CommentTag.toDoTagId).Icon
+                TagIcon = commentTags.Get(CommentTag.toDoTagId).Icon
             };
         }
 

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1350,7 +1350,7 @@ namespace SIL.XForge.Scripture.Services
                     op.Set(pd => pd.Editable, settings.Editable);
                     op.Set(pd => pd.DefaultFont, settings.DefaultFont);
                     op.Set(pd => pd.DefaultFontSize, settings.DefaultFontSize);
-                    op.Set(pd => pd.NoteIcon, settings.ToDoCommentIcon);
+                    op.Set(pd => pd.TagIcon, settings.TagIcon);
                 }
                 // The source can be null if there was an error getting a resource from the DBL
                 if (TranslationSuggestionsEnabled && _projectDoc.Data.TranslateConfig.Source != null)

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1350,6 +1350,7 @@ namespace SIL.XForge.Scripture.Services
                     op.Set(pd => pd.Editable, settings.Editable);
                     op.Set(pd => pd.DefaultFont, settings.DefaultFont);
                     op.Set(pd => pd.DefaultFontSize, settings.DefaultFontSize);
+                    op.Set(pd => pd.NoteIcon, settings.ToDoCommentIcon);
                 }
                 // The source can be null if there was an error getting a resource from the DBL
                 if (TranslationSuggestionsEnabled && _projectDoc.Data.TranslateConfig.Source != null)

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -2118,7 +2118,7 @@ namespace SIL.XForge.Scripture.Services
             string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
             UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
             ParatextSettings settings = env.Service.GetParatextSettings(userSecret, ptProjectId);
-            Assert.That(settings.ToDoCommentIcon, Is.EqualTo("icon1"));
+            Assert.That(settings.TagIcon, Is.EqualTo("icon1"));
         }
 
         [Test]

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -2111,6 +2111,17 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
+        public void GetParatextSettings_RetrievesTagIcons()
+        {
+            var env = new TestEnvironment();
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+            ParatextSettings settings = env.Service.GetParatextSettings(userSecret, ptProjectId);
+            Assert.That(settings.ToDoCommentIcon, Is.EqualTo("icon1"));
+        }
+
+        [Test]
         public void SendReceiveAsync_BadArguments()
         {
             var env = new TestEnvironment();

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -698,7 +698,7 @@ namespace SIL.XForge.Scripture.Services
                     {
                         DefaultFontSize = newFontSize,
                         DefaultFont = newFont,
-                        ToDoCommentIcon = toDoIcon
+                        TagIcon = toDoIcon
                     }
                 );
 
@@ -707,7 +707,7 @@ namespace SIL.XForge.Scripture.Services
             project = env.VerifyProjectSync(true);
             Assert.That(project.DefaultFontSize, Is.EqualTo(newFontSize));
             Assert.That(project.DefaultFont, Is.EqualTo(newFont));
-            Assert.That(project.NoteIcon, Is.EqualTo(toDoIcon));
+            Assert.That(project.TagIcon, Is.EqualTo(toDoIcon));
         }
 
         [Test]

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -668,7 +668,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task SyncAsync_SetsProjectFontAndFontSize()
+        public async Task SyncAsync_SetsProjectSettings()
         {
             var env = new TestEnvironment();
             Book[] books = { new Book("MAT", 1) };
@@ -690,15 +690,24 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(project.DefaultFont, Is.EqualTo(font));
             int newFontSize = 16;
             string newFont = "Doulos SIL";
+            string toDoIcon = "todoIcon1";
             env.ParatextService
                 .GetParatextSettings(Arg.Any<UserSecret>(), "target")
-                .Returns(new ParatextSettings { DefaultFontSize = newFontSize, DefaultFont = newFont });
+                .Returns(
+                    new ParatextSettings
+                    {
+                        DefaultFontSize = newFontSize,
+                        DefaultFont = newFont,
+                        ToDoCommentIcon = toDoIcon
+                    }
+                );
 
             // SUT
             await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
             project = env.VerifyProjectSync(true);
             Assert.That(project.DefaultFontSize, Is.EqualTo(newFontSize));
             Assert.That(project.DefaultFont, Is.EqualTo(newFont));
+            Assert.That(project.NoteIcon, Is.EqualTo(toDoIcon));
         }
 
         [Test]


### PR DESCRIPTION
* add the noteIcon property to the SFProject
* use the CommentTags of a project to get the to do icon name
* set the noteIcon property at sync time
* set the tagIcon to the project noteIcon on new note threads

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1534)
<!-- Reviewable:end -->
