### PR TITLE
SF-1542 - Unassigned text does not appear on note dialog after note update

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
@@ -1,9 +1,7 @@
 <ng-container *transloco="let t; read: 'note_dialog'">
   <h1 mat-dialog-title>
     <img [src]="flagIcon" class="note-thread-icon" alt="" /> <span class="verse-reference">{{ verseRefDisplay }}</span>
-    <div *ngIf="noteThreadAssignedUserRef != null" id="assignedUser" class="assigned-user">
-      >{{ getAssignedUserString(noteThreadAssignedUserRef) }}
-    </div>
+    <div id="assignedUser" class="assigned-user">>{{ getAssignedUserString(noteThreadAssignedUserRef) }}</div>
   </h1>
   <mat-dialog-content class="content-padding" [ngClass]="{ rtl: isRtl, ltr: !isRtl }">
     <div class="text-row">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -371,6 +371,19 @@ describe('NoteDialogComponent', () => {
     expect(env.notes[1].nativeElement.querySelector('.assigned-user').textContent).toContain('Team');
   }));
 
+  it('shows unassigned user', fakeAsync(() => {
+    const noteThread = TestEnvironment.getNoteThread();
+    noteThread.assignment = '';
+    env = new TestEnvironment({ noteThread });
+    expect(env.threadAssignedUser.nativeElement.textContent).toContain('Unassigned');
+    env.closeDialog();
+
+    // Ensure it still shows unassigned if there is no assignment set
+    delete noteThread.assignment;
+    env = new TestEnvironment({ noteThread });
+    expect(env.threadAssignedUser.nativeElement.textContent).toContain('Unassigned');
+  }));
+
   it('shows correct coloured icon based on assignment', fakeAsync(() => {
     const currentUserId = 'user01';
     const defaultIcon = 'flag02.png';
@@ -444,7 +457,7 @@ describe('NoteDialogComponent', () => {
     expect(env.flagIcon).toEqual('/assets/icons/TagIcons/01flag1.png');
     expect(env.verseRef).toEqual('Matthew 1:1');
     expect(env.noteText.nativeElement.innerText).toEqual('target: chapter 1, verse 1.');
-    expect(env.threadAssignedUser).toBeNull();
+    expect(env.threadAssignedUser.nativeElement.textContent).toContain('Unassigned');
   }));
 
   it('can insert a note', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -89,8 +89,8 @@ export class NoteDialogComponent implements OnInit {
     this.noteBeingEdited = this.getNoteTemplate(this.threadId);
   }
 
-  get noteThreadAssignedUserRef(): string | undefined {
-    return this.threadDoc?.data?.assignment;
+  get noteThreadAssignedUserRef(): string {
+    return this.threadDoc?.data?.assignment ?? '';
   }
 
   get flagIcon(): string {

--- a/src/SIL.XForge.Scripture/Models/NoteThreadChange.cs
+++ b/src/SIL.XForge.Scripture/Models/NoteThreadChange.cs
@@ -58,6 +58,7 @@ namespace SIL.XForge.Scripture.Models
             string contextBefore,
             string contextAfter,
             string status,
+            string assignment,
             string tagIcon = null
         )
         {
@@ -66,6 +67,7 @@ namespace SIL.XForge.Scripture.Models
             SelectedText = selectedText;
             ContextBefore = contextBefore;
             ContextAfter = contextAfter;
+            Assignment = assignment;
             TagIcon = tagIcon;
             Status = status;
         }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1170,6 +1170,7 @@ namespace SIL.XForge.Scripture.Services
                     threadDoc.Data.OriginalContextBefore,
                     threadDoc.Data.OriginalContextAfter,
                     threadDoc.Data.Status,
+                    threadDoc.Data.Assignment,
                     threadDoc.Data.TagIcon
                 );
                 // Find the corresponding comment thread
@@ -1265,6 +1266,7 @@ namespace SIL.XForge.Scripture.Services
                     info.ContextBefore,
                     info.ContextAfter,
                     info.Status.InternalValue,
+                    info.AssignedUser,
                     initialTag.Icon
                 );
                 newThread.Position = GetThreadTextAnchor(thread, chapterDeltas);

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -1643,7 +1643,7 @@ namespace SIL.XForge.Scripture.Services
                 // Note tagsAdded updated but assigned user unchanged
                 NoteThreadChange change5 = changes.Single(c => c.ThreadId == "thread5");
                 Assert.That(change5.TagIcon, Is.EqualTo("icon2"));
-                Assert.That(change5.Assignment, Is.Null);
+                Assert.That(change5.Assignment, Is.EqualTo(""));
                 Assert.That(change5.NotesUpdated.Count, Is.EqualTo(1));
                 Assert.That(change5.NotesUpdated[0].Assignment, Is.EqualTo(unassignedUserString));
 

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -2833,6 +2833,7 @@ namespace SIL.XForge.Scripture.Services
                         "Context before ",
                         " context after",
                         NoteStatus.Todo.InternalValue,
+                        "",
                         "tag02"
                     );
                     noteThreadChange.ThreadUpdated = true;
@@ -2902,6 +2903,7 @@ namespace SIL.XForge.Scripture.Services
                     "Context before ",
                     " context after",
                     status,
+                    "",
                     "icon1"
                 );
                 noteThreadChange.ThreadUpdated = true;
@@ -2917,6 +2919,7 @@ namespace SIL.XForge.Scripture.Services
                     "Context before ",
                     " context after",
                     NoteStatus.Todo.InternalValue,
+                    "",
                     "icon1"
                 );
                 noteThreadChange.Position = new TextAnchor { Start = 0, Length = 0 };
@@ -2937,6 +2940,7 @@ namespace SIL.XForge.Scripture.Services
                     null,
                     null,
                     NoteStatus.Todo.InternalValue,
+                    "",
                     "conflict1"
                 );
                 noteThreadChange.Position = new TextAnchor { Start = 0, Length = 0 };
@@ -2956,6 +2960,7 @@ namespace SIL.XForge.Scripture.Services
                     "Context before ",
                     " context after",
                     NoteStatus.Resolved.InternalValue,
+                    "",
                     "icon1"
                 );
                 if (noteId == null)
@@ -2973,6 +2978,8 @@ namespace SIL.XForge.Scripture.Services
                     $"{threadId} selected text.",
                     "Context before ",
                     " context after",
+                    "",
+                    "",
                     null
                 );
                 string before = "Reattach before ";
@@ -3014,7 +3021,7 @@ namespace SIL.XForge.Scripture.Services
                 string status = NoteStatus.Todo.InternalValue;
                 string verseRef = "MAT 1:1";
                 // Create a NoteThreadChange, and allow client to adjust it.
-                var noteThreadChange = new NoteThreadChange(threadId, verseRef, null, null, null, status, "icon1");
+                var noteThreadChange = new NoteThreadChange(threadId, verseRef, null, null, null, status, "", "icon1");
                 if (modifyNoteThreadChange != null)
                 {
                     modifyNoteThreadChange(noteThreadChange);


### PR DESCRIPTION
- Ensure NoteThreadChange tracks the currently set assignment
- Always display unassigned on blank string or when null/undefined as a fallback for old data

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1535)
<!-- Reviewable:end -->
