### PR TITLE
SF-1577 Opening nav drawer doesn't close keyboard on mobile

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -43,6 +43,7 @@
         "ngx-avatar": "^4.1.0",
         "ngx-cookie-service": "^13.2.1",
         "ngx-quill": "14.1.1",
+        "on-screen-keyboard-detector": "^2.3.0",
         "ot-json0": "^1.1.0",
         "papaparse": "^5.3.2",
         "process": "^0.11.10",
@@ -3831,6 +3832,76 @@
         "@material/feature-targeting": "^5.1.0",
         "@material/theme": "^5.1.0"
       }
+    },
+    "node_modules/@most/adapter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@most/adapter/-/adapter-1.0.0.tgz",
+      "integrity": "sha512-+ECkLCTgKqc+uFK7q/fp2elaZahNRS1Tjz0XAu5QOiMynxJt8qN8LR+fuSoRZdhzQ0/+4nWf44X/x2fWUKe8fQ==",
+      "dependencies": {
+        "@most/types": "^1.0.1"
+      }
+    },
+    "node_modules/@most/core": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@most/core/-/core-1.6.1.tgz",
+      "integrity": "sha512-H989BS6v9QxSZRGPZlbomXTRpUU60iy76AHJoPveKtj27bE0Pv3mwMENRzNZijJK9ntUwhoJ0SYCoXaMCYuWEQ==",
+      "dependencies": {
+        "@most/disposable": "^1.3.0",
+        "@most/prelude": "^1.8.0",
+        "@most/scheduler": "^1.3.0",
+        "@most/types": "^1.1.0"
+      }
+    },
+    "node_modules/@most/disposable": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@most/disposable/-/disposable-1.3.0.tgz",
+      "integrity": "sha512-0lCve1GmWlZrvTGQpMgTFTHH6uRtzM31jyYTIN7303XX4KoLCLWw9L6hfTYLLBtge6s+QyiBQVokAhy2GjNAUQ==",
+      "dependencies": {
+        "@most/prelude": "^1.8.0",
+        "@most/types": "^1.1.0"
+      }
+    },
+    "node_modules/@most/dom-event": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@most/dom-event/-/dom-event-2.2.0.tgz",
+      "integrity": "sha512-pEnXCyj7ZEymozyKX87k9r3rhEsG86nAGerYwZPcpbBNEvemQMtyTcxwRP2+UipTHRpTzukaWuOSx20yLRpKAQ==",
+      "dependencies": {
+        "@most/scheduler": "^0.13.0",
+        "@most/types": "^0.11.1"
+      }
+    },
+    "node_modules/@most/dom-event/node_modules/@most/scheduler": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@most/scheduler/-/scheduler-0.13.1.tgz",
+      "integrity": "sha512-t14TLvEfUYPSLJQSLT/V5bQYxvKdLib8KFrz0hniOHZRoqyBgt6zhHKP1zywrEYQd9+sdhS5SZDnX9wAJ+xJxg==",
+      "dependencies": {
+        "@most/prelude": "^1.6.4",
+        "@most/types": "^0.11.1"
+      }
+    },
+    "node_modules/@most/dom-event/node_modules/@most/types": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@most/types/-/types-0.11.1.tgz",
+      "integrity": "sha512-acP+xy7F4W50GAbpOmfdNgATPwCfMUSLmWEhUb4MHli9k0qAtN828LTVPgK3AsTBh/Fkx0TulbgW+H2t06BsKA=="
+    },
+    "node_modules/@most/prelude": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@most/prelude/-/prelude-1.8.0.tgz",
+      "integrity": "sha512-t1CcURpZzfmBA6fEWwqmCqeNzWAj1w2WqEmCk/2yXMe/p8Ut000wFmVKMy8A1Rl9VVxZEZ5nBHd/pU0dR4bv/w=="
+    },
+    "node_modules/@most/scheduler": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@most/scheduler/-/scheduler-1.3.0.tgz",
+      "integrity": "sha512-bbJGyhbZxNqlkVjP8+YT9wIVMvYnpzWOzV8jZueqlTH2PJWewH2f54YziZn7/wWa6AJdN03H1vb8Tbi9GcA/cw==",
+      "dependencies": {
+        "@most/prelude": "^1.8.0",
+        "@most/types": "^1.1.0"
+      }
+    },
+    "node_modules/@most/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@most/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-v2trqAWu1jqP4Yd/CyI1O6mAeJyygK1uJOrFRpNPkPZIaYw4khA4EQe4WzcyOFKuXdiP8qAqaxGtXXJJ2LZdXg=="
     },
     "node_modules/@ngneat/transloco": {
       "version": "3.2.0",
@@ -15555,6 +15626,27 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-screen-keyboard-detector": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-screen-keyboard-detector/-/on-screen-keyboard-detector-2.3.0.tgz",
+      "integrity": "sha512-QJsruGIaSXHryZ7aYAR+B6YYubwxL+81ss189yNs4DdE5qpkx51AO6+H2bXTNrNzvxPtRRSG/a03nXnj1KxtwQ==",
+      "dependencies": {
+        "@most/adapter": "^1.0.0",
+        "@most/core": "^1.6.1",
+        "@most/dom-event": "^2.2.0",
+        "@most/prelude": "^1.8.0",
+        "@most/scheduler": "^1.3.0",
+        "ramda": "^0.27.1"
+      },
+      "peerDependencies": {
+        "emittery": "^0.6.0"
+      }
+    },
+    "node_modules/on-screen-keyboard-detector/node_modules/ramda": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -22928,6 +23020,78 @@
         "@material/feature-targeting": "^5.1.0",
         "@material/theme": "^5.1.0"
       }
+    },
+    "@most/adapter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@most/adapter/-/adapter-1.0.0.tgz",
+      "integrity": "sha512-+ECkLCTgKqc+uFK7q/fp2elaZahNRS1Tjz0XAu5QOiMynxJt8qN8LR+fuSoRZdhzQ0/+4nWf44X/x2fWUKe8fQ==",
+      "requires": {
+        "@most/types": "^1.0.1"
+      }
+    },
+    "@most/core": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@most/core/-/core-1.6.1.tgz",
+      "integrity": "sha512-H989BS6v9QxSZRGPZlbomXTRpUU60iy76AHJoPveKtj27bE0Pv3mwMENRzNZijJK9ntUwhoJ0SYCoXaMCYuWEQ==",
+      "requires": {
+        "@most/disposable": "^1.3.0",
+        "@most/prelude": "^1.8.0",
+        "@most/scheduler": "^1.3.0",
+        "@most/types": "^1.1.0"
+      }
+    },
+    "@most/disposable": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@most/disposable/-/disposable-1.3.0.tgz",
+      "integrity": "sha512-0lCve1GmWlZrvTGQpMgTFTHH6uRtzM31jyYTIN7303XX4KoLCLWw9L6hfTYLLBtge6s+QyiBQVokAhy2GjNAUQ==",
+      "requires": {
+        "@most/prelude": "^1.8.0",
+        "@most/types": "^1.1.0"
+      }
+    },
+    "@most/dom-event": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@most/dom-event/-/dom-event-2.2.0.tgz",
+      "integrity": "sha512-pEnXCyj7ZEymozyKX87k9r3rhEsG86nAGerYwZPcpbBNEvemQMtyTcxwRP2+UipTHRpTzukaWuOSx20yLRpKAQ==",
+      "requires": {
+        "@most/scheduler": "^0.13.0",
+        "@most/types": "^0.11.1"
+      },
+      "dependencies": {
+        "@most/scheduler": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/@most/scheduler/-/scheduler-0.13.1.tgz",
+          "integrity": "sha512-t14TLvEfUYPSLJQSLT/V5bQYxvKdLib8KFrz0hniOHZRoqyBgt6zhHKP1zywrEYQd9+sdhS5SZDnX9wAJ+xJxg==",
+          "requires": {
+            "@most/prelude": "^1.6.4",
+            "@most/types": "^0.11.1"
+          }
+        },
+        "@most/types": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/@most/types/-/types-0.11.1.tgz",
+          "integrity": "sha512-acP+xy7F4W50GAbpOmfdNgATPwCfMUSLmWEhUb4MHli9k0qAtN828LTVPgK3AsTBh/Fkx0TulbgW+H2t06BsKA=="
+        }
+      }
+    },
+    "@most/prelude": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@most/prelude/-/prelude-1.8.0.tgz",
+      "integrity": "sha512-t1CcURpZzfmBA6fEWwqmCqeNzWAj1w2WqEmCk/2yXMe/p8Ut000wFmVKMy8A1Rl9VVxZEZ5nBHd/pU0dR4bv/w=="
+    },
+    "@most/scheduler": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@most/scheduler/-/scheduler-1.3.0.tgz",
+      "integrity": "sha512-bbJGyhbZxNqlkVjP8+YT9wIVMvYnpzWOzV8jZueqlTH2PJWewH2f54YziZn7/wWa6AJdN03H1vb8Tbi9GcA/cw==",
+      "requires": {
+        "@most/prelude": "^1.8.0",
+        "@most/types": "^1.1.0"
+      }
+    },
+    "@most/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@most/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-v2trqAWu1jqP4Yd/CyI1O6mAeJyygK1uJOrFRpNPkPZIaYw4khA4EQe4WzcyOFKuXdiP8qAqaxGtXXJJ2LZdXg=="
     },
     "@ngneat/transloco": {
       "version": "3.2.0",
@@ -31522,6 +31686,26 @@
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
       "dev": true
+    },
+    "on-screen-keyboard-detector": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-screen-keyboard-detector/-/on-screen-keyboard-detector-2.3.0.tgz",
+      "integrity": "sha512-QJsruGIaSXHryZ7aYAR+B6YYubwxL+81ss189yNs4DdE5qpkx51AO6+H2bXTNrNzvxPtRRSG/a03nXnj1KxtwQ==",
+      "requires": {
+        "@most/adapter": "^1.0.0",
+        "@most/core": "^1.6.1",
+        "@most/dom-event": "^2.2.0",
+        "@most/prelude": "^1.8.0",
+        "@most/scheduler": "^1.3.0",
+        "ramda": "^0.27.1"
+      },
+      "dependencies": {
+        "ramda": {
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+          "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
+        }
+      }
     },
     "once": {
       "version": "1.4.0",

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -54,6 +54,7 @@
     "ngx-avatar": "^4.1.0",
     "ngx-cookie-service": "^13.2.1",
     "ngx-quill": "14.1.1",
+    "on-screen-keyboard-detector": "^2.3.0",
     "ot-json0": "^1.1.0",
     "papaparse": "^5.3.2",
     "process": "^0.11.10",


### PR DESCRIPTION
- Introduce new package to help calculator on-screen keyboard
- If keyboard has been open then don't try to re-focus the target editor

The package used in this solution has some limitations where the detection event is ~1 second before being emitted - they acknowledge this in their readme and code with reasons behind it. Still, it is better than what we currently experience on mobile devices.

My testing finds that it works well as long as you you don't have your tester hat on where you immediately try to close the keyboard in <1s which of course will trigger it to open again. If you tap it a second time I find that it stays away.

I've tested on a real Android phone and a simulated iOS phone.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1539)
<!-- Reviewable:end -->
