### PR TITLE
Improve wording on checking overview page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -1,7 +1,7 @@
 <ng-container *transloco="let t; read: 'checking_overview'">
   <div [ngClass]="{ 'reviewer-panels': !canCreateQuestion }" class="header">
     <mat-icon>library_books</mat-icon>
-    <h2>{{ t("texts_with_questions") }}</h2>
+    <h2>{{ t(canCreateQuestion ? "manage_questions" : "my_progress") }}</h2>
     <ng-container *ngIf="canCreateQuestion; else overallProgressChart" class="primary-actions">
       <button mdc-button type="button" *ngIf="showImportButton" (click)="importDialog()" id="import-btn">
         {{ t("import_questions") }}
@@ -146,8 +146,13 @@
     </div>
   </ng-template>
 
+  <div class="header">
+    <mat-icon>donut_large</mat-icon>
+    <h2>{{ t(canCreateQuestion ? "project_stats" : "my_contributions") }}</h2>
+  </div>
+
   <div fxLayout="row wrap" fxLayoutAlign="space-between" class="reviewer-panels stat-panels">
-    <mat-card class="card card-content-question">
+    <mat-card class="card card-content-question" *ngIf="canCreateQuestion">
       <span fxFlex>
         <div class="stat-total">{{ allQuestionsCount }}</div>
         <div class="stat-label">{{ t("questions") }}</div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -217,8 +217,11 @@
     "comments": "Comments",
     "likes": "Likes",
     "loading_questions": "Loading questions...",
-    "questions": "Questions",
-    "texts_with_questions": "Texts with Questions"
+    "manage_questions": "Manage questions",
+    "my_contributions": "My contributions",
+    "my_progress": "My progress",
+    "project_stats": "Project stats",
+    "questions": "Questions"
   },
   "edit_name_dialog": {
     "cancel": "Cancel",


### PR DESCRIPTION
The checking overview page is trying to do three things at once:
- Manage questions
- Show project stats
- Show a user their own stats

Arguably these should be three separate components, but for now I've reworded things to try to clear things up.
- "Texts with questions" is extremely confusing, especially for community checkers.
-  The stats that are shown are confusing, because it's not clear what is being measured.

Mostly it's a change of wording, but also the number of questions  is no longer shown to checkers, because that stat is unlike the others. It's not that it's not a useful stat if shown in context, but as of now I think it just adds confusion (also, you can go to the all questions page and see the number of questions).

I'm not supper keen on some of my wording changes.
- Maybe "Manage questions" should be "Published questions" to better pair with "Archived questions" farther down the page?

I think this eventually needs a redesign, so I'm not trying to find the best possible solution, just low hanging fruit that reduces confusion.

&nbsp; | Before | After
----------|-----------|-------
Admin | ![admin_master](https://user-images.githubusercontent.com/6140710/195963902-fdceca7d-6bd5-468d-a45f-31668aecff1f.png) | ![admin_branch](https://user-images.githubusercontent.com/6140710/195963905-c26c4ac4-363a-4bc4-b6bf-6c1f0684abc0.png)
Checker | ![checker_master](https://user-images.githubusercontent.com/6140710/195963903-c605b8b5-565f-4e22-8b5f-4a5485f6fb2c.png) | ![checker_branch](https://user-images.githubusercontent.com/6140710/195963904-65bc3a1d-52d7-4101-ac8a-07ecbfce9f40.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1542)
<!-- Reviewable:end -->
