### PR TITLE
SF-1701 Allow archiving and republishing questions in bulk

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -36,13 +36,23 @@
               keyboard_arrow_{{ itemVisible[getBookId(text)] ? "down" : i18n.forwardDirectionWord }}
             </mat-icon>
             <span fxFlex>{{ getBookName(text) }}</span>
-            <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
+            <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center" class="questions-count">
               {{ questionCountLabel(bookQuestionCount(text)) }}
             </span>
             <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
               {{ answerCountLabel(bookAnswerCount(text)) }}
             </span>
-            <span fxFlex="64px" fxShow fxHide.xs fxLayoutAlign="end center">&nbsp;</span>
+            <span fxFlex="64px" fxLayoutAlign="end center">
+              <!-- $event.stopPropagation() is needed because the button is within a row that is listening for clicks -->
+              <button
+                mat-icon-button
+                (click)="$event.stopPropagation(); setArchiveStatusForQuestionsInBook(text, true)"
+                [title]="t('archive_multiple', { location: getBookName(text) })"
+                class="archive-btn"
+              >
+                <mat-icon>archive</mat-icon>
+              </button>
+            </span>
           </div>
         </mdc-list-item>
         <ng-container *ngIf="itemVisible[getBookId(text)]">
@@ -62,13 +72,23 @@
                   }}
                 </mat-icon>
                 <span fxFlex>{{ getBookName(text) + " " + chapter?.number }}</span>
-                <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
+                <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center" class="questions-count">
                   {{ questionCountLabel(questionCount(text.bookNum, chapter.number)) }}
                 </span>
                 <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
                   {{ answerCountLabel(chapterAnswerCount(text.bookNum, chapter.number)) }}
                 </span>
-                <span fxFlex="64px" fxShow fxHide.xs fxLayoutAlign="end center">&nbsp;</span>
+                <span fxFlex="64px" fxLayoutAlign="end center">
+                  <!-- $event.stopPropagation() is needed because the button is within a row that is listening for clicks -->
+                  <button
+                    mat-icon-button
+                    (click)="$event.stopPropagation(); setArchiveStatusForQuestionsInChapter(text, chapter, true)"
+                    [title]="t('archive_multiple', { location: getBookName(text) + ' ' + chapter.number })"
+                    class="archive-btn"
+                  >
+                    <mat-icon>archive</mat-icon>
+                  </button>
+                </span>
               </div>
             </mdc-list-item>
             <ng-container *ngIf="itemVisible[getTextDocId(text.bookNum, chapter.number)]">
@@ -90,8 +110,7 @@
                   </span>
                   <span fxFlex="64px" fxLayoutAlign="end center">
                     <button
-                      mdc-button
-                      type="button"
+                      mat-icon-button
                       (click)="setQuestionArchiveStatus(questionDoc, true)"
                       title="{{ t('archive') }}"
                       class="archive-btn"
@@ -198,10 +217,20 @@
             <mat-icon fxFlex="24px" mdcListItemMeta
               >keyboard_arrow_{{ itemVisibleArchived[getBookId(text)] ? "down" : i18n.forwardDirectionWord }}</mat-icon
             ><span fxFlex>{{ getBookName(text) }}</span>
-            <span fxFlex="80px" fxShow fxHide.xs fxLayoutAlign="end center" class="archived-questions-count">
+            <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center" class="archived-questions-count">
               {{ questionCountLabel(bookQuestionCount(text, true)) }}
             </span>
-            <span fxFlex="64px" fxShow fxHide.xs fxLayoutAlign="end center">&nbsp;</span>
+            <span fxFlex="64px" fxLayoutAlign="end center">
+              <!-- $event.stopPropagation() is needed because the button is within a row that is listening for clicks -->
+              <button
+                mat-icon-button
+                (click)="$event.stopPropagation(); setArchiveStatusForQuestionsInBook(text, false)"
+                [title]="t('republish_multiple', { location: getBookName(text) })"
+                class="publish-btn"
+              >
+                <mat-icon>public</mat-icon>
+              </button>
+            </span>
           </div>
         </mdc-list-item>
         <ng-container *ngIf="itemVisibleArchived[getBookId(text)]">
@@ -220,6 +249,20 @@
                   }}</mat-icon
                 >
                 <span fxFlex>{{ getBookName(text) + " " + chapter?.number }}</span>
+                <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center" class="archived-questions-count">
+                  {{ questionCountLabel(questionCount(text.bookNum, chapter.number, true)) }}
+                </span>
+                <span fxFlex="64px" fxLayoutAlign="end center">
+                  <!-- $event.stopPropagation() is needed because the button is within a row that is listening for clicks -->
+                  <button
+                    mat-icon-button
+                    (click)="$event.stopPropagation(); setArchiveStatusForQuestionsInChapter(text, chapter, false)"
+                    [title]="t('republish_multiple', { location: getBookName(text) + ' ' + chapter.number })"
+                    class="publish-btn"
+                  >
+                    <mat-icon>public</mat-icon>
+                  </button>
+                </span>
               </div>
             </mdc-list-item>
             <ng-container *ngIf="itemVisibleArchived[getTextDocId(text.bookNum, chapter.number)]">
@@ -232,13 +275,12 @@
                   <span fxFlex class="no-overflow-ellipsis">
                     <span *ngIf="questionDoc.data?.text">{{ questionDoc.data?.text }}</span>
                   </span>
-                  <span fxFlex="200px" fxHide.lt-sm fxLayoutAlign="end center" class="date-archived">{{
+                  <span fxFlex="210px" fxHide.lt-sm fxLayoutAlign="end center" class="date-archived">{{
                     timeArchivedStamp(questionDoc.data?.dateArchived)
                   }}</span>
                   <span fxFlex="64px" fxLayoutAlign="end center">
                     <button
-                      mdc-button
-                      type="button"
+                      mat-icon-button
                       (click)="setQuestionArchiveStatus(questionDoc, false)"
                       title="{{ t('republish') }}"
                       class="publish-btn"

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -20,13 +20,17 @@
   "checking_overview": {
     "add_question": "Add Question",
     "answer_count_label": "{{ count }} answers",
+    "archive_multiple": "Archive all questions in {{ location }}",
     "archive": "Archive",
     "archived_questions": "Archived Questions",
     "click_add_question": "Click {{ boldStart }}Add question{{ boldEnd }}, above.",
+    "confirm_bulk_archive": "Are you sure you want to archive all the questions in {{ scope }}?",
+    "confirm_bulk_republish": "Are you sure you want to republish all the questions in {{ scope }}?",
     "import_questions": "Bulk import",
     "no_archived_questions": "There are no archived questions.",
     "no_questions": "There are no published questions. ",
     "question_count_label": "{{ count }} questions",
+    "republish_multiple": "Republish all questions in {{ location }}",
     "republish": "Republish",
     "time_archived_stamp": "Archived on {{ timeStamp }}"
   },


### PR DESCRIPTION
This adds the ability to bulk archive and publish questions at the book or chapter level (rather than archiving or republishing questions only individually). A bulk operation will result in the user being prompted with a question like "Are you sure you want to archive all the questions in Genesis 4?"

Tests coming.

![](https://user-images.githubusercontent.com/6140710/197296223-915bae42-9970-44f9-ac00-b32418e96003.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1550)
<!-- Reviewable:end -->
