### PR TITLE
Turn on TS option useUnknownInCatchVariables

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -274,7 +274,7 @@ export class AuthService {
       }
       await this.remoteStore.init(() => this.getAccessToken());
       return { loggedIn: true, newlyLoggedIn: false };
-    } catch (error) {
+    } catch (error: any) {
       await this.handleLoginError('tryLogIn', error);
       return { loggedIn: false, newlyLoggedIn: false };
     }
@@ -315,7 +315,7 @@ export class AuthService {
         }
       }
       return { loggedIn: true, newlyLoggedIn: false };
-    } catch (error) {
+    } catch (error: any) {
       await this.handleLoginError('tryOnlineLogIn', error);
       return { loggedIn: false, newlyLoggedIn: false };
     }
@@ -453,7 +453,7 @@ export class AuthService {
             success = true;
             resolve();
           }
-        } catch (err) {
+        } catch (err: any) {
           console.error('Error while renewing access token:', err);
           this.reportingService.silentError('Error while renewing access token', err);
           success = false;
@@ -478,7 +478,7 @@ export class AuthService {
         try {
           const tokenResponse = await this.getTokenDetails();
           resolve(tokenResponse);
-        } catch (err) {
+        } catch (err: any) {
           if (err.error === 'login_required') {
             resolve(null);
           } else if (retryUponTimeout && err.error === 'timeout') {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.ts
@@ -81,7 +81,7 @@ export class CommandService {
         throw response.error;
       }
       return response.result;
-    } catch (error) {
+    } catch (error: any) {
       // Transform the various kinds of errors into a CommandError.
 
       let code: CommandErrorCode = CommandErrorCode.Other;

--- a/src/SIL.XForge.Scripture/ClientApp/tsconfig.json
+++ b/src/SIL.XForge.Scripture/ClientApp/tsconfig.json
@@ -20,7 +20,6 @@
     "esModuleInterop": true,
     "typeRoots": ["node_modules/@types"],
     "resolveJsonModule": true,
-    "useUnknownInCatchVariables": false,
     "paths": {
       "xforge-common/*": ["./src/xforge-common/*"]
     }


### PR DESCRIPTION
See the documentation for useUnknownInCatchVariables: https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables

When you have this:
``` ts
catch (error) {
  // what is the type of error here?
}
```
It used to be `any`. If you turn on `useUnknownInCatchVariables`, it's `unknown`. A recent TS update made `useUnknownInCatchVariables` the default in strict mode. Rather than going around and changing a bunch of code when updating TS, I just turned the setting off temporarily. Now I'm turning it back on so any future code we write will have to either explicitly write `catch (error: any)`, or (preferable) write type-safe code, using type guards from `src/SIL.XForge.Scripture/ClientApp/src/type-utils.ts`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1552)
<!-- Reviewable:end -->
