### PR TITLE
Add query for texts with lots of edits

### DIFF
--- a/mongodb/Texts/TextsWithLotsOfEdits.mongodb
+++ b/mongodb/Texts/TextsWithLotsOfEdits.mongodb
@@ -1,0 +1,28 @@
+use('xforge')
+
+const shortName = '';
+
+const project = db.sf_projects.findOne({shortName})
+const bookIds = project.texts.map(text => text.bookNum)
+const projectId = project._id
+
+db.o_texts.aggregate([
+  // find ops on this project that were created by a user
+  {$match: {
+    d: {$regex: `^${projectId}:`},
+   'm.uId': {$exists: true}
+  }},
+  // group them by text and count the number of ops for each text
+  {$group: {
+    _id: '$d',
+    count: { $sum: 1 },
+  }},
+  // filter for those with at least 100 ops
+  {$match: {
+    count: {$gte: 100}
+  }},
+  // sort the most edited texts to the top
+  {$sort: {
+    count: -1
+  }}
+]).toArray();


### PR DESCRIPTION
I created this query recently when asked for stats regarding a project. This just lists texts sorted by the number of edits it has had. This helps to get an idea where the most activity has been.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1555)
<!-- Reviewable:end -->
