### PR TITLE
SF-1788 Fix placement of nav component arrow icons

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -183,7 +183,7 @@
         >
           <mdc-icon svgIcon="translate" class="translate-icon"></mdc-icon>
           {{ t("translate") }}
-          <mat-icon *ngIf="!hasSingleAppEnabled">
+          <mat-icon *ngIf="!hasSingleAppEnabled" [class.fix-rtl-arrow-placement]="i18n.isRtl">
             keyboard_arrow_{{ translateVisible ? "down" : i18n.forwardDirectionWord }}
           </mat-icon>
         </a>
@@ -211,7 +211,7 @@
         >
           <mat-icon mat-list-icon>question_answer</mat-icon>
           {{ t("community_checking") }}
-          <mat-icon *ngIf="!hasSingleAppEnabled">
+          <mat-icon *ngIf="!hasSingleAppEnabled" [class.fix-rtl-arrow-placement]="i18n.isRtl">
             keyboard_arrow_{{ checkingVisible ? "down" : i18n.forwardDirectionWord }}
           </mat-icon>
         </a>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -235,3 +235,8 @@ mdc-drawer-content {
   font-weight: normal;
   font-size: 1.4rem;
 }
+
+.fix-rtl-arrow-placement {
+  margin-left: initial !important;
+  margin-right: auto;
+}


### PR DESCRIPTION
Before | After
----------|-------
![](https://user-images.githubusercontent.com/6140710/198164858-04455c30-dba8-440d-ab98-a74c07e40de5.png) | ![](https://user-images.githubusercontent.com/6140710/198164862-a26a4890-5798-44fa-81b7-03a12a831e24.png)

Yes, it's minor, but I was never able to fix it when I did the initial RTL work and it's been annoying me ever since.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1563)
<!-- Reviewable:end -->
