### PR TITLE
Update socket.io-parser to 4.0.5 to fix potential vulnerability

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -18026,9 +18026,9 @@
       "dev": true
     },
     "node_modules/socket.io-parser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
-      "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.5.tgz",
+      "integrity": "sha512-sNjbT9dX63nqUFIOv95tTVm6elyIU4RvB1m8dOeZt+IgWwcWklFDOdmGcfo3zSiRsnR/3pJkjY5lfoGqEe4Eig==",
       "dev": true,
       "dependencies": {
         "@types/component-emitter": "^1.2.10",
@@ -33332,9 +33332,9 @@
       "dev": true
     },
     "socket.io-parser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
-      "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.5.tgz",
+      "integrity": "sha512-sNjbT9dX63nqUFIOv95tTVm6elyIU4RvB1m8dOeZt+IgWwcWklFDOdmGcfo3zSiRsnR/3pJkjY5lfoGqEe4Eig==",
       "dev": true,
       "requires": {
         "@types/component-emitter": "^1.2.10",


### PR DESCRIPTION
This relates this this security advisory: https://github.com/advisories/GHSA-qm95-pgcg-qqfq

Note: `npm audit` did not find any vulnerabilities in `src/RealtimeServer` or `scripts/db_tools`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1572)
<!-- Reviewable:end -->
