### PR TITLE
SF-1556 Prevent excessive queries from the front end

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -15,7 +15,7 @@ import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-
 import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
 import { Canon } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/canon';
 import { combineLatest, merge, Observable, Subscription } from 'rxjs';
-import { distinctUntilChanged, filter, map, startWith, tap } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map, startWith, tap, throttleTime } from 'rxjs/operators';
 import { AuthService } from 'xforge-common/auth.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { DialogService } from 'xforge-common/dialog.service';
@@ -399,7 +399,8 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
         if (this.removedFromProjectSub != null) {
           this.removedFromProjectSub.unsubscribe();
         }
-        this.removedFromProjectSub = this.selectedProjectDoc.remoteChanges$.subscribe(() => {
+        // TODO Find a better solution than merely throttling remote changes
+        this.removedFromProjectSub = this.selectedProjectDoc.remoteChanges$.pipe(throttleTime(1000)).subscribe(() => {
           if (
             this.selectedProjectDoc != null &&
             this.selectedProjectDoc.data != null &&

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -894,8 +894,7 @@ class TestEnvironment {
   waitForQuestions(): void {
     this.realtimeService.updateAllSubscribeQueries();
     this.fixture.detectChanges();
-    tick();
-    this.fixture.detectChanges();
+    this.waitForProjectDocChanges();
   }
 
   setSeeOtherUserResponses(isEnabled: boolean): void {
@@ -904,8 +903,7 @@ class TestEnvironment {
       op => op.set<boolean>(p => p.checkingConfig.usersSeeEachOthersResponses, isEnabled),
       false
     );
-    tick();
-    this.fixture.detectChanges();
+    this.waitForProjectDocChanges();
   }
 
   setCheckingEnabled(isEnabled: boolean): void {
@@ -913,7 +911,12 @@ class TestEnvironment {
       const projectDoc = this.realtimeService.get<SFProjectProfileDoc>(SFProjectProfileDoc.COLLECTION, 'project01');
       projectDoc.submitJson0Op(op => op.set<boolean>(p => p.checkingConfig.checkingEnabled, isEnabled), false);
     });
-    tick();
+    this.waitForProjectDocChanges();
+  }
+
+  // Project doc changes are throttled by 1000 ms, so we have to wait for them
+  waitForProjectDocChanges(): void {
+    tick(1000);
     this.fixture.detectChanges();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
@@ -264,6 +264,12 @@ class TestEnvironment {
     this.fixture.detectChanges();
   }
 
+  // Some project doc changes are throttled by 1000 ms, so we have to wait for them
+  waitForProjectDocChanges(): void {
+    tick(1000);
+    this.wait();
+  }
+
   expectContainsTextProgress(index: number, primary: string, secondary: string): void {
     const items = this.progressTextList.querySelectorAll('mdc-list-item');
     const item = items.item(index);
@@ -384,7 +390,7 @@ class TestEnvironment {
     const textIndex = projectDoc.data!.texts.findIndex(t => t.bookNum === bookNum);
     const chapterIndex = projectDoc.data!.texts[textIndex].chapters.findIndex(c => c.number === chapter);
     projectDoc.submitJson0Op(ops => ops.remove(p => p.texts[textIndex].chapters, chapterIndex), false);
-    this.wait();
+    this.waitForProjectDocChanges();
   }
 
   simulateTranslateSuggestionsEnabled(enabled: boolean = true) {
@@ -393,7 +399,7 @@ class TestEnvironment {
       op => op.set<boolean>(p => p.translateConfig.translationSuggestionsEnabled, enabled),
       false
     );
-    this.wait();
+    this.waitForProjectDocChanges();
   }
 
   private addTextDoc(id: TextDocId): void {


### PR DESCRIPTION
As far as I can tell, the main issue is that connecting a basic project (Stp22 in this case) created about 85,000+ question subscribe queries* for questions and 1,500,000+ text fetches

<sup>*A subscribe query is distinct from a fetch query in that the subscriber is asking for all future changes to the query in real time, which is presumably a much more expensive operation.</sup>

The problem is that rather than update the page with whatever changes come over the wire, we tend to completely recalculate everything from scratch every time something is updated. As an example, in the app component, every time the project doc was updated it would unsubscribe from any existing question queries and then create a new query for each book in the project.

A simple fix, which I have applied here, is to throttle incoming changes, but I don't think it's the ideal solution. I think it would be better to react to what actually changed, rather than re-initializing everything, though that's harder to do.

The `feature/realtime-server-stats` branch can be used to analyze realtime service usage and better see what's going on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1576)
<!-- Reviewable:end -->
