### PR TITLE
dev: add C# nullable annotation

### DIFF
--- a/src/SIL.XForge.Scripture/Models/ParatextProject.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextProject.cs
@@ -12,7 +12,7 @@ namespace SIL.XForge.Scripture.Models
         public string LanguageTag { get; set; }
 
         /// <summary> Id of corresponding SF project. </summary>
-        public string ProjectId { get; set; }
+        public string? ProjectId { get; set; }
 
         /// <summary>
         /// If the requesting user has access to the PT project, but not yet to a corresponding SF project, and has
@@ -30,7 +30,7 @@ namespace SIL.XForge.Scripture.Models
         {
             StringBuilder message = new StringBuilder();
             foreach (
-                string item in new string[]
+                string? item in new string?[]
                 {
                     ParatextId,
                     Name,

--- a/src/SIL.XForge.Scripture/Models/ParatextResource.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextResource.cs
@@ -50,7 +50,7 @@ namespace SIL.XForge.Scripture.Models
         /// <remarks>
         /// This is used solely for synchronization, and can be null if not appropriate.
         /// </remarks>
-        internal SFInstallableDblResource InstallableResource { get; set; }
+        internal SFInstallableDblResource? InstallableResource { get; set; }
 
         /// <summary>
         /// Gets or sets the created timestamp.
@@ -90,7 +90,7 @@ namespace SIL.XForge.Scripture.Models
         {
             StringBuilder message = new StringBuilder();
             foreach (
-                string item in new string[]
+                string? item in new string?[]
                 {
                     ParatextId,
                     Name,

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -293,7 +293,7 @@ namespace SIL.XForge.Scripture.Services
         /// registry.paratext.org.
         /// False if there is a problem with authorization or connecting to the PT Registry.
         /// </returns>
-        public async Task<bool> CanUserAuthenticateToPTRegistryAsync(UserSecret userSecret)
+        public async Task<bool> CanUserAuthenticateToPTRegistryAsync(UserSecret? userSecret)
         {
             if (userSecret == null)
             {
@@ -822,11 +822,19 @@ namespace SIL.XForge.Scripture.Services
                     null,
                     token
                 );
-                var members = JArray.Parse(response);
+                JArray? members = JArray.Parse(response);
+                if (members == null)
+                {
+                    throw new DataNotFoundException(
+                        $"Got a null list of members when parsing registry members list, for project SF id {project.Id}, using user secret id {userSecret.Id}."
+                    );
+                }
                 return members
                     .OfType<JObject>()
-                    .Where(m => !string.IsNullOrEmpty((string)m["userId"]) && !string.IsNullOrEmpty((string)m["role"]))
-                    .ToDictionary(m => (string)m["userId"], m => (string)m["role"]);
+                    .Where(
+                        m => !string.IsNullOrEmpty((string?)m["userId"]) && !string.IsNullOrEmpty((string?)m["role"])
+                    )
+                    .ToDictionary(m => (string)m["userId"]!, m => (string)m["role"]!);
             }
             else
             {
@@ -836,7 +844,7 @@ namespace SIL.XForge.Scripture.Services
                     CancellationToken.None
                 );
 
-                bool hasRole = project.UserRoles.TryGetValue(userSecret.Id, out string userRole);
+                bool hasRole = project.UserRoles.TryGetValue(userSecret.Id, out string? userRole);
                 string moreInformation =
                     $"SF user id '{userSecret.Id}', "
                     + $"while interested in unregistered PT project id '{project.ParatextId}' "
@@ -847,7 +855,7 @@ namespace SIL.XForge.Scripture.Services
                     ptRepoSource,
                     $"For {moreInformation}"
                 );
-                SharedRepository remotePtProject = remotePtProjects.SingleOrDefault(
+                SharedRepository? remotePtProject = remotePtProjects.SingleOrDefault(
                     p => p.SendReceiveId.Id == project.ParatextId
                 );
                 if (remotePtProject == null)
@@ -1704,7 +1712,7 @@ namespace SIL.XForge.Scripture.Services
             UserSecret userSecret,
             SharedRepository sharedRepository,
             IEnumerable<ProjectMetadata> metadata,
-            out ParatextProject ptProject
+            out ParatextProject? ptProject
         )
         {
             if (sharedRepository != null)
@@ -1989,9 +1997,12 @@ namespace SIL.XForge.Scripture.Services
             return syncMetricInfo;
         }
 
-        private CommentTags GetCommentTags(UserSecret userSecret, string projectId)
+        private CommentTags? GetCommentTags(UserSecret userSecret, string projectId)
         {
-            ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), projectId);
+            string? ptUsername = GetParatextUsername(userSecret);
+            if (ptUsername == null)
+                return null;
+            ScrText? scrText = ScrTextCollection.FindById(ptUsername, projectId);
             return scrText == null ? null : CommentTags.Get(scrText);
         }
 
@@ -1999,7 +2010,7 @@ namespace SIL.XForge.Scripture.Services
             UserSecret userSecret,
             HttpMethod method,
             string url,
-            string content = null,
+            string? content = null,
             CancellationToken token = default
         )
         {


### PR DESCRIPTION
- This change throws a DataNotFoundException with some context, where
previously a NullReferenceException would have immediately been
thrown.
- This change uses a null-forgiving operator (`!`) to declare that a
couple things are not null, based on the `Where` filtering.