### PR TITLE
log: provide more information when failing to refresh PT token

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2488,12 +2488,23 @@ namespace SIL.XForge.Scripture.Services
 
                 if (!userSecret.ParatextTokens.ValidateLifetime())
                 {
-                    Tokens refreshedUserTokens = await _jwtTokenHelper.RefreshAccessTokenAsync(
-                        _paratextOptions.Value,
-                        userSecret.ParatextTokens,
-                        _registryClient,
-                        token
-                    );
+                    Tokens refreshedUserTokens;
+                    try
+                    {
+                        refreshedUserTokens = await _jwtTokenHelper.RefreshAccessTokenAsync(
+                            _paratextOptions.Value,
+                            userSecret.ParatextTokens,
+                            _registryClient,
+                            token
+                        );
+                    }
+                    catch
+                    {
+                        _logger.LogWarning(
+                            $"ParatextService.GetParatextAccessLock for sfUserId {sfUserId} is throwing from call RefreshAccessTokenAsync()."
+                        );
+                        throw;
+                    }
                     userSecret = await _userSecretRepository.UpdateAsync(
                         sfUserId,
                         b => b.Set(u => u.ParatextTokens, refreshedUserTokens)


### PR DESCRIPTION
Currently this can throw without revealing what user it threw for.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1586)
<!-- Reviewable:end -->
