### PR TITLE
SF-1577 Opening nav drawer doesn't close keyboard on mobile

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
@@ -19,7 +19,7 @@
   [dir]="$any(textDirection)"
   [lang]="lang"
   [attr.data-browser-engine]="browserEngine"
-  (onBlur)="focused.emit(false)"
+  (focusout)="focused.emit(false)"
   (onFocus)="focused.emit(true)"
 >
 </quill-editor>


### PR DESCRIPTION
- Change quill to use focusout instead of onBlur

[focusout](https://developer.mozilla.org/en-US/docs/Web/API/Element/focusout_event) operates slightly differently where it also checks the focus of its dependents rather than onBlur which only checks the element it was set on. This simple switch is enough to correctly trigger and set our `targetFocused` property resolving the issue of the editor not immediately gaining focus again after the keyboard closes and triggers a height calculation on the editor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1597)
<!-- Reviewable:end -->
