### PR TITLE
SF-1820 Suggestion incorrectly displays current word after inserting a suggestion

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -746,6 +746,11 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
     const selectIndex = range.index + insertText.length;
     this.insertSuggestionEnd = selectIndex;
+    // If the segment is blank, then the selection is after the blank. The blank will be deleted, so we need
+    // to shift end of the inserted suggestion back one.
+    if (this.target.segmentText === '') {
+      this.insertSuggestionEnd--;
+    }
     const previousContents = this.target.editor.getContents();
     this.target.editor.updateContents(delta, 'user');
     const updatedContents = this.target.editor.getContents();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.ts
@@ -191,6 +191,11 @@ export class SuggestionsComponent extends SubscriptionDisposable implements OnDe
     if (selection == null) {
       return;
     }
+    // If the segment is blank, then the selection is after the blank. We want to align the suggestion to the beginning
+    // of the segment, so we shift the selection back one index.
+    if (this.text?.segmentText === '') {
+      selection.index--;
+    }
     const reference = this.editor.getBounds(selection.index, selection.length);
     const left = reference.left + 1;
     // root.scrollTop should be 0 if scrollContainer !== root


### PR DESCRIPTION
- correctly set EditorComponent.insertSuggestionEnd when segment is blank
- correctly position suggestion when segment is blank

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1601)
<!-- Reviewable:end -->
