### PR TITLE
SF-1809 Fix overflowing project name in project select in Firefox

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -25,9 +25,14 @@
           width: 100%;
         }
 
-        // Override styles spilling from mdc-drawer to mdc-select (both mdc-drawer and mdc-select can contain
-        // mdc-list-item and it appears the styles applied for the drawer's list items are now styling the select menu).
         .mdc-list-item {
+          // Fix overflow in Firefox when a project name uses the Khmer script. As of 2022-11-11, the DBL resource
+          // KHSV05 is one example that will cause overflow, which looks particularly bad in RTL mode because it
+          // overflows to the left in a menu that is layed out in LTR.
+          overflow-wrap: anywhere;
+
+          // Override styles spilling from mdc-drawer to mdc-select (both mdc-drawer and mdc-select can contain
+          // mdc-list-item and it appears the styles applied for the drawer's list items are now styling the select menu).
           @include typography.typography(subtitle1);
           margin: 0;
           border-radius: 0;


### PR DESCRIPTION
Chromium appears to see word breaks in this script where Firefox does not.

Before | After
----------|-------
![](https://user-images.githubusercontent.com/6140710/201392411-2db988d5-97ed-466d-b649-df0d7967261a.png) | ![](https://user-images.githubusercontent.com/6140710/201392415-348d32e0-1bf0-46d8-a908-66150d642ab0.png)

Both of these screenshots are of the `mdc-list`. The "before" screenshot shows more than the list because the overflow portion of the element is included and is hiding behind other elements. 

I did not address the project select on the connect project page for several reasons:
1. We're planning on removing the select from that page (replacing it with a list of projects), so it will become a non-issue.
2. The menu there is a lot wider, so overflow is less of an issue.
3. It's already behaving differently than the project select in the nav bar, even when I add `dir=auto` to it to try to bring it in line with the project select in the nav bar. So my plan of "fix it in the nav bar, then copy over whatever rules fixed it there" isn't going to work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1602)
<!-- Reviewable:end -->
