### PR TITLE
Update jest-expect-message and remove @types/jest-expect-message

### DIFF
--- a/src/RealtimeServer/common/utils/eq.spec.ts
+++ b/src/RealtimeServer/common/utils/eq.spec.ts
@@ -1,4 +1,5 @@
 import { eq } from './eq';
+import 'jest-expect-message';
 
 describe('eq', () => {
   it('compares two objects', () => {

--- a/src/RealtimeServer/package-lock.json
+++ b/src/RealtimeServer/package-lock.json
@@ -25,7 +25,6 @@
       },
       "devDependencies": {
         "@types/jest": "^27.5.1",
-        "@types/jest-expect-message": "^1.0.3",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/node": "^16.11.36",
         "@types/ws": "^8.5.3",
@@ -38,7 +37,7 @@
         "eslint-plugin-jsdoc": "^36.1.1",
         "eslint-plugin-prettier": "^4.0.0",
         "jest": "^27.5.1",
-        "jest-expect-message": "^1.0.2",
+        "jest-expect-message": "^1.1.3",
         "jest-teamcity-reporter": "^0.9.0",
         "prettier": "^2.6.2",
         "sharedb-mingo-memory": "^1.2.0",
@@ -1368,15 +1367,6 @@
       "dependencies": {
         "jest-matcher-utils": "^27.0.0",
         "pretty-format": "^27.0.0"
-      }
-    },
-    "node_modules/@types/jest-expect-message": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/jest-expect-message/-/jest-expect-message-1.0.3.tgz",
-      "integrity": "sha512-sp70Lc8POkOcXHEcLERpX/7B/BtQiqIYz3AvC9ZMNKSaiDttr8hKvz9DljIn7N6WJi3ioVoTtB1utDAX46oPlg==",
-      "dev": true,
-      "dependencies": {
-        "@types/jest": "*"
       }
     },
     "node_modules/@types/json-schema": {
@@ -4658,9 +4648,9 @@
       }
     },
     "node_modules/jest-expect-message": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jest-expect-message/-/jest-expect-message-1.0.2.tgz",
-      "integrity": "sha512-WFiXMgwS2lOqQZt1iJMI/hOXpUm32X+ApsuzYcQpW5m16Pv6/Gd9kgC+Q+Q1YVNU04kYcAOv9NXMnjg6kKUy6Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/jest-expect-message/-/jest-expect-message-1.1.3.tgz",
+      "integrity": "sha512-bTK77T4P+zto+XepAX3low8XVQxDgaEqh3jSTQOG8qvPpD69LsIdyJTa+RmnJh3HNSzJng62/44RPPc7OIlFxg==",
       "dev": true
     },
     "node_modules/jest-get-type": {
@@ -8644,15 +8634,6 @@
         "pretty-format": "^27.0.0"
       }
     },
-    "@types/jest-expect-message": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/jest-expect-message/-/jest-expect-message-1.0.3.tgz",
-      "integrity": "sha512-sp70Lc8POkOcXHEcLERpX/7B/BtQiqIYz3AvC9ZMNKSaiDttr8hKvz9DljIn7N6WJi3ioVoTtB1utDAX46oPlg==",
-      "dev": true,
-      "requires": {
-        "@types/jest": "*"
-      }
-    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -11069,9 +11050,9 @@
       }
     },
     "jest-expect-message": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jest-expect-message/-/jest-expect-message-1.0.2.tgz",
-      "integrity": "sha512-WFiXMgwS2lOqQZt1iJMI/hOXpUm32X+ApsuzYcQpW5m16Pv6/Gd9kgC+Q+Q1YVNU04kYcAOv9NXMnjg6kKUy6Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/jest-expect-message/-/jest-expect-message-1.1.3.tgz",
+      "integrity": "sha512-bTK77T4P+zto+XepAX3low8XVQxDgaEqh3jSTQOG8qvPpD69LsIdyJTa+RmnJh3HNSzJng62/44RPPc7OIlFxg==",
       "dev": true
     },
     "jest-get-type": {

--- a/src/RealtimeServer/package.json
+++ b/src/RealtimeServer/package.json
@@ -37,7 +37,6 @@
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",
-    "@types/jest-expect-message": "^1.0.3",
     "@types/jsonwebtoken": "^8.5.8",
     "@types/node": "^16.11.36",
     "@types/ws": "^8.5.3",
@@ -50,7 +49,7 @@
     "eslint-plugin-jsdoc": "^36.1.1",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^27.5.1",
-    "jest-expect-message": "^1.0.2",
+    "jest-expect-message": "^1.1.3",
     "jest-teamcity-reporter": "^0.9.0",
     "prettier": "^2.6.2",
     "sharedb-mingo-memory": "^1.2.0",


### PR DESCRIPTION
- jest-expect-message ships its own types, and @types/jest-expect-message is deprecated ue to being unnecessary
- Updated tsconfig.json to import types from jest-expect-message

See https://github.com/mattphillips/jest-expect-message#configure-typescript for jest-expect-message's documentation for how to configure types.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1610)
<!-- Reviewable:end -->
