### PR TITLE
Remove Ubuntu 22.04 build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         # Environments in which to run, such as those used in development and production, or which are candidates to
         # move to.
-        os: ["ubuntu-20.04", "ubuntu-22.04"]
+        os: ["ubuntu-20.04"]
         dotnet_version: ["6.0.x"]
         node_version: ["16.15.0"]
         npm_version: ["8.10.0"]
@@ -105,7 +105,7 @@ jobs:
     name: "Production build and test"
     strategy:
       matrix:
-        os: ["ubuntu-20.04", "ubuntu-22.04"]
+        os: ["ubuntu-20.04"]
         dotnet_version: ["6.0.x"]
         node_version: ["16.15.0"]
         npm_version: ["8.10.0"]


### PR DESCRIPTION
After discussion with @marksvc, it seems we aren't getting that much value from running on 22.04, and the number of builds is a bit unwieldy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1613)
<!-- Reviewable:end -->
