### PR TITLE
SF-1825 Add pseudo localization

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pseudo-localization.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pseudo-localization.spec.ts
@@ -1,0 +1,8 @@
+import { PseudoLocalization } from './pseudo-localization';
+
+describe('pseudo-localization', () => {
+  it('should localize', () => {
+    expect(PseudoLocalization.localize({ key: 'ABC {{ var }} xyz' })).toEqual({ key: 'BCD {{ var }} yza' });
+    expect(PseudoLocalization.localize({ a: { x: 'a' }, b: { y: 'b' } })).toEqual({ a: { x: 'b' }, b: { y: 'c' } });
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pseudo-localization.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pseudo-localization.ts
@@ -1,0 +1,52 @@
+import { Locale } from './models/i18n-locale';
+import { DateFormat } from './i18n.service';
+
+function pseudoLocalizeCharacter(char: string): string {
+  const lowerA = 'a'.charCodeAt(0);
+  const upperA = 'A'.charCodeAt(0);
+  const lowerZ = 'z'.charCodeAt(0);
+  const upperZ = 'Z'.charCodeAt(0);
+
+  const code = char.charCodeAt(0);
+  let charCode: number;
+  if (code >= lowerA && code <= lowerZ) charCode = lowerA + ((code - lowerA + 1) % (lowerZ - lowerA + 1));
+  else if (code >= upperA && code <= upperZ) charCode = upperA + ((code - upperA + 1) % (upperZ - upperA + 1));
+  else charCode = code;
+  return String.fromCharCode(charCode);
+}
+
+function pseudoLocalizeString(input: string): string {
+  let output = '';
+  let bracketDepth = 0;
+
+  for (const char of input) {
+    if (char === '{') bracketDepth++;
+    else if (char === '}') bracketDepth--;
+
+    if (bracketDepth === 0) output += pseudoLocalizeCharacter(char);
+    else output += char;
+  }
+  return output;
+}
+
+function pseudoLocalizeObject(obj: {}): Object {
+  const newObj = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (typeof value === 'string') newObj[key] = pseudoLocalizeString(obj[key]);
+    else if (typeof value === 'object' && value != null) newObj[key] = pseudoLocalizeObject(obj[key]);
+  }
+  return newObj;
+}
+
+export const PseudoLocalization = {
+  dateFormat: { month: 'short' } as DateFormat,
+  locale: {
+    localName: 'Pseudo localization',
+    englishName: 'Pseudo localization',
+    canonicalTag: 'pseudo',
+    direction: 'ltr',
+    tags: ['pseudo'],
+    production: false
+  } as Locale,
+  localize: pseudoLocalizeObject
+} as const;


### PR DESCRIPTION
Currently when the test team tests a new feature, it's not possible to tell whether it's been properly localized, because the strings haven't been translated yet, so it will always fall back to English.

This adds a locale behind a feature flag, with each string being generated by applying a [Caesar cipher](https://en.wikipedia.org/wiki/Caesar_cipher) with a right shift of 1 (a becomes b, b becomes c, z becomes a).

Here's an example from the settings page:
![](https://user-images.githubusercontent.com/6140710/203457419-baab5b93-20fb-4fdb-878a-e8ef1ef2fa0a.png)

Our i18n service already has the concept of an "unpublished" localization, and already hides them behind a feature flag, so hiding this behind a feature flag is just a matter of registering the locale with `production: false`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1614)
<!-- Reviewable:end -->
