### PR TITLE
SF-1822 Fix race condition for querying documents before share link has resolved

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -358,9 +358,6 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
         // the project deleted dialog should be closed by now, so we can reset its ref to null
         if (projectId == null) {
           this.projectDeletedDialogRef = null;
-        } else {
-          this.userService.setCurrentProjectId(this.currentUserDoc!, projectId);
-          this.refreshQuestionsQuery(projectId);
         }
       })
     );
@@ -396,6 +393,8 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       if (this.selectedProjectDoc == null || !this.selectedProjectDoc.isLoaded) {
         return;
       }
+      this.userService.setCurrentProjectId(this.currentUserDoc!, this.selectedProjectDoc.id);
+      this.refreshQuestionsQuery(this.selectedProjectDoc.id);
 
       // handle remotely deleted project
       this.selectedProjectDeleteSub = this.selectedProjectDoc.delete$.subscribe(() => {


### PR DESCRIPTION
- Moved questions query in the app component to after a valid project has been selected

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1615)
<!-- Reviewable:end -->
