### PR TITLE
Add type safe I18nKey type

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/type-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/type-utils.ts
@@ -39,3 +39,50 @@ export interface CaretPosition {
   readonly offset: number;
   readonly offsetNode: Node;
 }
+
+// The following types up to ObjectPaths are fairly complicated. The earlier types are supporting types for the
+// ObjectPaths type definition
+// See https://stackoverflow.com/a/58436959 for an explanation of how this works.
+// Look up type manipulation in the TypeScript handbook for an explanation of the operators that are being used.
+
+// Define an array type that contains types that correspond to values ones less than the index they are at. This allows
+// subtracting one when evaluating the Leaves type below, thereby preventing excessive recursion (which would produce a
+// compiler error).
+// This is not a list of values. This is a list of types. For example, `5` is a type that contains only the number 5.
+type OneLessThan = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ...10[]];
+
+/**
+ * Given two types K and P:
+ * - If `K` is a string or number, and `P` is a string or number, and P is not the empty string, constructs a string
+ * type consisting of the concatenation of `K` and `P` with a `.` between them.
+ * - If `K` is a string or number, and `P` is the empty string, constructs a string type consisting of `K` converted to
+ * a string.
+ * - Otherwise resolves to `never`.
+ */
+type JoinWithDot<K, P> = K extends string | number
+  ? P extends string | number
+    ? `${K}${'' extends P ? '' : '.'}${P}`
+    : never
+  : never;
+
+/**
+ * Given an object type `T`, where T has properties, and the keys to those properties are numbers or strings, and the
+ * values of those properties are strings or objects (which objects in turn satisfy the same conditions, recursively):
+ * Resolves to a type that is the union of all string paths to string values within the object structure, formed joining
+ * the key paths with the `.` character between each key.
+ *
+ * For example, `ObjectPaths<{ a: { b: 'c' }, d: 'e' }>` will resolve to `"d" | "a.b"`.
+ *
+ * @param T The type from which to derive paths.
+ * @param Depth The maximum recursive depth to search for string values. Default is 10. Maximum is 10, and setting it
+ * higher than 10 will have the same effect as setting it to 10. This should be considered an approximate value, rather
+ * than a precise value, since the meaning of searching to a given depth is not clearly defined, and the implementation
+ * has not been carefully crafted to ensure it is precisely followed with no off-by-one-errors (since the precise
+ * value is considered unimportant).
+ */
+// prettier-ignore
+export type ObjectPaths<T, Depth extends number = 10> = Depth extends never
+  ? never
+  : T extends object
+    ? { [Key in keyof T]-?: JoinWithDot<Key, ObjectPaths<T[Key], OneLessThan[Depth]>> }[keyof T]
+    : '';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/dialog.service.ts
@@ -4,7 +4,7 @@ import { Injectable, TemplateRef } from '@angular/core';
 import { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { Observable } from 'rxjs';
 import { GenericDialogComponent, GenericDialogOptions } from './generic-dialog/generic-dialog.component';
-import { I18nService } from './i18n.service';
+import { I18nKey, I18nService } from './i18n.service';
 
 @Injectable({
   providedIn: 'root'
@@ -55,12 +55,12 @@ export class DialogService {
   /**
    * Shows a message in a dialog. The message and close button may be specified via an Observable<string>, or by passing
    * the key to a localization string.
-   * @param message The message to show. May be an Observable<string>, or a string which will be used as a translation
+   * @param message The message to show. May be an Observable<string>, or an I18nKey which will be used as a translation
    * key.
-   * @param close (optional) May be an Observable<string>, or a string which will be used as a translation key. If not
+   * @param close (optional) May be an Observable<string>, or an I18nKey which will be used as a translation key. If not
    * provided the button will use a default label for the close button.
    */
-  async message(message: string | Observable<string>, close?: string | Observable<string>): Promise<void> {
+  async message(message: I18nKey | Observable<string>, close?: I18nKey | Observable<string>): Promise<void> {
     const closeText = close instanceof Observable ? close : this.i18n.translate(close ?? 'dialog.close');
     await this.openGenericDialog({
       title: typeof message === 'string' ? this.i18n.translate(message) : message,

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -54,14 +54,14 @@ describe('I18nService', () => {
     when(mockedTranslocoService.translate<string>(anything(), anything())).thenReturn('translated key');
     const service = getI18nService();
     expect(
-      service.translateAndInsertTags('namespace.key', {
+      service.translateAndInsertTags('app.settings', {
         value: 2,
         spanClass: 'text'
       })
     ).toEqual('translated key');
     verify(
       mockedTranslocoService.translate(
-        'namespace.key',
+        'app.settings',
         deepEqual({
           value: 2,
           spanClass: 'text',
@@ -82,7 +82,7 @@ describe('I18nService', () => {
       'translated key with {{ boundary }}tag text{{ boundary }} in template'
     );
     const service = getI18nService();
-    expect(service.translateTextAroundTemplateTags('namespace.key')).toEqual({
+    expect(service.translateTextAroundTemplateTags('app.settings')).toEqual({
       before: 'translated key with ',
       templateTagText: 'tag text',
       after: ' in template'
@@ -107,11 +107,11 @@ describe('I18nService', () => {
   });
 
   it('should interpolate translations', () => {
-    when(mockedTranslocoService.translate<string>('sentence', anything())).thenReturn(
+    when(mockedTranslocoService.translate<string>('app.settings', anything())).thenReturn(
       'A quick brown { 1 }fox{ 2 } jumps over the lazy { 3 }dog{ 4 }.'
     );
     const service = getI18nService();
-    expect(service.interpolate('sentence')).toEqual([
+    expect(service.interpolate('app.settings')).toEqual([
       { text: 'A quick brown ' },
       { text: 'fox', id: 1 },
       { text: ' jumps over the lazy ' },

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -9,6 +9,7 @@ import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils
 import { Observable, of, zip } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
+import { ObjectPaths } from '../type-utils';
 import enChecking from '../assets/i18n/checking_en.json';
 import enNonChecking from '../assets/i18n/non_checking_en.json';
 import { AuthService } from './auth.service';
@@ -28,6 +29,12 @@ export interface TextAroundTemplate {
 }
 
 export const en = merge(enChecking, enNonChecking);
+
+export type I18nKey = ObjectPaths<typeof en>;
+// TODO create a I18nRoleKey and I18nRoleDescriptionKey type (e.g. `keyof typeof en.roles`). Right now the existence of
+// pt_read and pt_write_note in the SFProjectRole definition causes the type system to correctly conclude that there are
+// not corresponding localization strings for all of the roles we have defined. Determining the proper way to reconcile
+// this mismatch is left to be solved at another time.
 
 @Injectable()
 export class TranslationLoader implements TranslocoLoader {
@@ -216,11 +223,11 @@ export class I18nService {
     return this.transloco.translate(`role_descriptions.${role}`).replace(/\s*,\s*/, ' • ');
   }
 
-  translate(key: string, params: object = {}): Observable<string> {
+  translate(key: I18nKey, params: object = {}): Observable<string> {
     return this.transloco.selectTranslate<string>(key, params);
   }
 
-  translateAndInsertTags(key: string, params: object = {}) {
+  translateAndInsertTags(key: I18nKey, params: object = {}) {
     return this.transloco.translate(key, {
       ...params,
       boldStart: '<strong>',
@@ -245,7 +252,7 @@ export class I18nService {
         );
   }
 
-  translateTextAroundTemplateTags(key: string, params: object = {}): TextAroundTemplate | undefined {
+  translateTextAroundTemplateTags(key: I18nKey, params: object = {}): TextAroundTemplate | undefined {
     const boundary = '{{ boundary }}';
     const text: string = this.translateAndInsertTags(key, {
       ...params,
@@ -273,7 +280,7 @@ export class I18nService {
    * view, or a link for the text "fox" or "dog". This system has the advantage of being able to handle translations
    * that reorder "fox" and "dog".
    */
-  interpolate(key: string, params?: HashMap): { text: string; id?: number }[] {
+  interpolate(key: I18nKey, params?: HashMap): { text: string; id?: number }[] {
     const hashKey = this.localeCode + ' ' + key;
     if (this.interpolationCache[hashKey] != null) {
       return this.interpolationCache[hashKey];


### PR DESCRIPTION
Adds type checking of the localization keys we pass around, albeit not within the HTML templates (at least for now).

![](https://user-images.githubusercontent.com/6140710/203464332-543e7350-d150-4029-9c00-53147a0009bc.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1616)
<!-- Reviewable:end -->
