### PR TITLE
Replace deprecated substr with substring

### DIFF
--- a/src/RealtimeServer/common/models/user.ts
+++ b/src/RealtimeServer/common/models/user.ts
@@ -19,7 +19,7 @@ export function getAuthType(authId: string): AuthType {
     return AuthType.Unknown;
   }
 
-  const authIdType = authId.substr(0, authId.lastIndexOf('|'));
+  const authIdType = authId.substring(0, authId.lastIndexOf('|'));
   if (authIdType.includes('paratext')) {
     return AuthType.Paratext;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
@@ -91,7 +91,7 @@ export class ExceptionHandlingService extends BugsnagErrorHandler {
       }
       // Remove CSS specific selectors that Bugsnag added as they aren't compatible with the querySelector
       if (targetSelector.includes('>')) {
-        targetSelector = targetSelector.substr(0, targetSelector.indexOf('>')).trim();
+        targetSelector = targetSelector.substring(0, targetSelector.indexOf('>')).trim();
       }
       // Check we can still query the element
       const node = document.querySelector(targetSelector);


### PR DESCRIPTION
`substr()` is non-standard

The following are the descriptions MDN gives for these methods:

For [`substr()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr):
> The `substr()` method returns a portion of the string, starting at the specified index and extending for a given number of characters afterwards.

For [`substring()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring):
> The `substring()` method returns the part of the `string` between the start and end indexes, or to the end of the string.

So when the first argument is 0, they should be equivalent.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1618)
<!-- Reviewable:end -->
