### PR TITLE
Add logging before generating backend coverage report

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -92,6 +92,8 @@ jobs:
       - name: "Test: Frontend"
         run: cd src/SIL.XForge.Scripture/ClientApp && npm run test:gha
 
+      - name: "Coverage: Pre report generator report"
+        run: ls ; ls test ; ls test/*
       - name: "Coverage: Backend"
         run: |
           reportgenerator \


### PR DESCRIPTION
This is failing the CI fairly frequently. I've added some logging to try to see what is going on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1619)
<!-- Reviewable:end -->
