### PR TITLE
Added spin animation to the sync icon in the menu

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -251,7 +251,14 @@
             [class.list-item-disabled]="!isAppOnline"
             (click)="itemSelected()"
           >
-            <mat-icon mat-list-icon matBadge="error" [matBadgeHidden]="!lastSyncFailed" id="sync-icon">sync</mat-icon>
+            <mat-icon
+              mat-list-icon
+              matBadge="error"
+              [matBadgeHidden]="!lastSyncFailed"
+              [class.sync-in-progress]="syncInProgress"
+              id="sync-icon"
+              >sync</mat-icon
+            >
             {{ t("synchronize") }}
           </a>
         </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -233,6 +233,16 @@ mdc-drawer-content {
   overflow-y: auto;
 }
 
+.sync-in-progress {
+  animation: spin 0.75s linear infinite;
+}
+
+@keyframes spin {
+  100% {
+    transform: rotate(-360deg);
+  }
+}
+
 ::ng-deep #sync-icon .mat-badge-content {
   font-family: 'Material Icons';
   background: transparent;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -402,6 +402,21 @@ describe('AppComponent', () => {
     expect(env.lastSyncFailedBadgeIsPresent).toBeTrue();
   }));
 
+  it('add spin class to sync icon when in progress', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.navigate(['/projects', 'project01']);
+    env.init();
+
+    expect(env.syncInProgressClassIsPresent).toBeFalse();
+    env.setFakeSyncInProgress('project01', true);
+    // SUT 1
+    expect(env.syncInProgressClassIsPresent).toBeTrue();
+
+    env.setFakeSyncInProgress('project01', false);
+    // SUT 2
+    expect(env.syncInProgressClassIsPresent).toBeFalse();
+  }));
+
   it('checks online auth status when browser comes online but app is not fully online', fakeAsync(() => {
     const env = new TestEnvironment('offline');
     env.init();
@@ -700,6 +715,11 @@ class TestEnvironment {
     return this.realtimeService.get(UserDoc.COLLECTION, 'user01');
   }
 
+  get syncInProgressClassIsPresent(): boolean {
+    const iconIfClassSet = this.menuDrawer.query(By.css('#sync-icon.sync-in-progress'));
+    return iconIfClassSet != null;
+  }
+
   get lastSyncFailedBadgeIsPresent(): boolean {
     const iconIfBadgeHidden = this.menuDrawer.query(By.css('#sync-icon.mat-badge-hidden'));
     if (iconIfBadgeHidden != null) {
@@ -832,6 +852,12 @@ class TestEnvironment {
   removeUserFromProject(projectId: string): void {
     const projectDoc = this.realtimeService.get<SFProjectProfileDoc>(SFProjectProfileDoc.COLLECTION, projectId);
     projectDoc.submitJson0Op(op => op.unset<string>(p => p.userRoles['user01']), false);
+    this.wait();
+  }
+
+  setFakeSyncInProgress(projectId: string, inProgress: boolean): void {
+    const projectDoc = this.realtimeService.get<SFProjectProfileDoc>(SFProjectProfileDoc.COLLECTION, projectId);
+    projectDoc.submitJson0Op(op => op.set<number>(p => p.sync.queuedCount!, inProgress ? 1 : 0));
     this.wait();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -547,7 +547,11 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   }
 
   get lastSyncFailed(): boolean {
-    return this.selectedProjectDoc?.data?.sync.lastSyncSuccessful === false;
+    return this.selectedProjectDoc?.data?.sync.lastSyncSuccessful === false && !this.syncInProgress;
+  }
+
+  get syncInProgress(): boolean {
+    return this.selectedProjectDoc?.data != null && this.selectedProjectDoc.data.sync.queuedCount > 0;
   }
 
   private async refreshQuestionsQuery(projectId: string): Promise<void> {


### PR DESCRIPTION
 - Spin class is turned on if the queueCount indicates there is an active sync in the queue
 - Remove sync failure icon if an active sync is in progress

![rotating settings](https://user-images.githubusercontent.com/17464863/203892617-2ef8da34-36c1-4d2a-8881-8c441903b1c7.gif)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1620)
<!-- Reviewable:end -->
