### PR TITLE
Disable code coverage report to fix build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -92,14 +92,14 @@ jobs:
       - name: "Test: Frontend"
         run: cd src/SIL.XForge.Scripture/ClientApp && npm run test:gha
 
-      - name: "Coverage: Backend"
-        run: |
-          reportgenerator \
-            -reports:test/*/coverage.opencover.xml \
-            -targetdir:coverage \
-            "-reporttypes:HTML;TeamCitySummary"
-      - name: "Coverage: Publish to Codecov"
-        uses: codecov/codecov-action@v3
+      # - name: "Coverage: Backend"
+      #   run: |
+      #     reportgenerator \
+      #       -reports:test/*/coverage.opencover.xml \
+      #       -targetdir:coverage \
+      #       "-reporttypes:HTML;TeamCitySummary"
+      # - name: "Coverage: Publish to Codecov"
+      #   uses: codecov/codecov-action@v3
 
   build-production:
     name: "Production build and test"


### PR DESCRIPTION
This should be temporary. It appears the build fails when .NET 7.x is preinstalled, as code coverage does not get generated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1621)
<!-- Reviewable:end -->
