### PR TITLE
SF-1791 Fix UpdateAvailableEvent deprecation in PWA service

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -623,8 +623,8 @@ class TestEnvironment {
     when(mockedPwaService.isOnline).thenReturn(this.browserOnline$.getValue() && this.webSocketOnline$.getValue());
     when(mockedPwaService.isBrowserOnline).thenReturn(this.browserOnline$.getValue());
     when(mockedPwaService.online).thenReturn(comesOnline);
-    when(mockedPwaService.onlineStatus).thenReturn(this.webSocketOnline$);
-    when(mockedPwaService.onlineBrowserStatus).thenReturn(this.browserOnline$);
+    when(mockedPwaService.onlineStatus$).thenReturn(this.webSocketOnline$);
+    when(mockedPwaService.onlineBrowserStatus$).thenReturn(this.browserOnline$);
     if (initialConnectionStatus === 'offline') {
       this.goFullyOffline();
     } else {
@@ -632,7 +632,7 @@ class TestEnvironment {
       this.goFullyOnline();
     }
     when(mockedFileService.notifyUserIfStorageQuotaBelow(anything())).thenResolve();
-    when(mockedPwaService.hasUpdate).thenReturn(this.hasUpdate$);
+    when(mockedPwaService.hasUpdate$).thenReturn(this.hasUpdate$);
     when(mockedMdcDialog.open(ProjectDeletedDialogComponent, anything())).thenReturn(
       instance(this.mockedProjectDeletedDialogRef)
     );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -127,7 +127,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
 
     // Check full online status changes
     this.isAppOnline = pwaService.isOnline;
-    this.subscribe(pwaService.onlineStatus, status => {
+    this.subscribe(pwaService.onlineStatus$, status => {
       if (status !== this.isAppOnline) {
         this.isAppOnline = status;
         this.checkDeviceStorage();
@@ -135,7 +135,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     });
 
     // Check browser online status to allow checks with Auth0
-    this.subscribe(pwaService.onlineBrowserStatus, status => {
+    this.subscribe(pwaService.onlineBrowserStatus$, status => {
       // Check authentication when coming back online
       // This is also run on first load when the websocket connects for the first time
       if (status && !this.isAppLoading) {
@@ -143,7 +143,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       }
     });
 
-    this.subscribe(pwaService.hasUpdate, () => (this.hasUpdate = true));
+    this.subscribe(pwaService.hasUpdate$, () => (this.hasUpdate = true));
 
     // Google Analytics - send data at end of navigation so we get data inside the SPA client-side routing
     if (environment.releaseStage === 'live') {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -889,7 +889,7 @@ class TestEnvironment {
     );
     this.setCurrentUser(this.adminUser);
 
-    when(mockedPwaService.onlineStatus).thenReturn(this.isOnline.asObservable());
+    when(mockedPwaService.onlineStatus$).thenReturn(this.isOnline.asObservable());
     when(mockedPwaService.isOnline).thenReturn(this.isOnline.getValue());
 
     this.fixture = TestBed.createComponent(CheckingOverviewComponent);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-combined/checking-audio-combined.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-combined/checking-audio-combined.component.spec.ts
@@ -107,7 +107,7 @@ class TestEnvironment {
       this.realtimeService.subscribe(UserDoc.COLLECTION, 'user01')
     );
     when(mockedPwaService.isOnline).thenReturn(true);
-    when(mockedPwaService.onlineStatus).thenReturn(of(true));
+    when(mockedPwaService.onlineStatus$).thenReturn(of(true));
     this.fixture.detectChanges();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.spec.ts
@@ -149,7 +149,7 @@ class TestEnvironment {
       imports: [UICommonModule, TestTranslocoModule]
     });
     when(this.mockedPwaService.isOnline).thenCall(() => isOnline);
-    when(this.mockedPwaService.onlineStatus).thenReturn(of(isOnline));
+    when(this.mockedPwaService.onlineStatus$).thenReturn(of(isOnline));
 
     TestBed.overrideComponent(HostComponent, { set: { template: template } });
     this.ngZone = TestBed.inject(NgZone);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.ts
@@ -65,7 +65,7 @@ export class CheckingAudioPlayerComponent extends SubscriptionDisposable impleme
       }
     });
 
-    this.subscribe(this.pwaService.onlineStatus, isOnline => {
+    this.subscribe(this.pwaService.onlineStatus$, isOnline => {
       if (isOnline && !this.audioDataLoaded) {
         // force the audio element to try loading again, now that the user is online again
         if (this.audio.src === '') {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.spec.ts
@@ -119,7 +119,7 @@ class TestEnvironment {
         this.rejectUserMedia ? Promise.reject() : navigator.mediaDevices.getUserMedia(mediaConstraints)
     } as MediaDevices);
     when(mockedPwaService.isOnline).thenReturn(true);
-    when(mockedPwaService.onlineStatus).thenReturn(of(true));
+    when(mockedPwaService.onlineStatus$).thenReturn(of(true));
     this.fixture.detectChanges();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.spec.ts
@@ -153,7 +153,7 @@ class TestEnvironment {
     when(mockedSFProjectService.getText(anything())).thenCall(id =>
       this.realtimeService.subscribe(TextDoc.COLLECTION, id.toString())
     );
-    when(mockedPwaService.onlineStatus).thenReturn(this.isOnline.asObservable());
+    when(mockedPwaService.onlineStatus$).thenReturn(this.isOnline.asObservable());
 
     this.fixture = TestBed.createComponent(CheckingTextComponent);
     this.component = this.fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1594,7 +1594,7 @@ class TestEnvironment {
     when(mockedUserService.editDisplayName(true)).thenResolve();
     this.isOnline = new BehaviorSubject<boolean>(hasConnection);
     when(mockedPwaService.isOnline).thenReturn(this.isOnline.getValue());
-    when(mockedPwaService.onlineStatus).thenReturn(this.isOnline.asObservable());
+    when(mockedPwaService.onlineStatus$).thenReturn(this.isOnline.asObservable());
     when(mockedPwaService.isOnline).thenReturn(hasConnection);
     when(
       mockedFileService.findOrUpdateCache(FileType.Audio, QuestionDoc.COLLECTION, anything(), anyString())

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -629,7 +629,7 @@ class TestEnvironment {
     when(mockedFileService.findOrUpdateCache(FileType.Audio, anything(), 'question01', anything())).thenResolve(
       createStorageFileData(QuestionDoc.COLLECTION, 'question01', '/path/to/audio.mp3', getAudioBlob())
     );
-    when(mockedPwaService.onlineStatus).thenReturn(of(true));
+    when(mockedPwaService.onlineStatus$).thenReturn(of(true));
     this.fixture.detectChanges();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
@@ -420,7 +420,7 @@ class TestEnvironment {
     when(mockedUserService.currentUserId).thenReturn('user01');
     when(mockedI18nService.translateAndInsertTags(anything())).thenReturn('A translated string.');
     this.isOnline = new BehaviorSubject<boolean>(hasConnection);
-    when(mockedPwaService.onlineStatus).thenReturn(this.isOnline.asObservable());
+    when(mockedPwaService.onlineStatus$).thenReturn(this.isOnline.asObservable());
     this.fixture = TestBed.createComponent(ConnectProjectComponent);
     this.component = this.fixture.componentInstance;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
@@ -145,7 +145,7 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
       }
     });
 
-    this.subscribe(this.pwaService.onlineStatus, async isOnline => {
+    this.subscribe(this.pwaService.onlineStatus$, async isOnline => {
       this.isAppOnline = isOnline;
       if (isOnline) {
         if (this._projects == null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/translation-engine.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/translation-engine.service.ts
@@ -36,7 +36,7 @@ export class TranslationEngineService extends SubscriptionDisposable {
     private readonly machineHttp: MachineHttpClient
   ) {
     super();
-    this.onlineStatus$ = this.pwaService.onlineStatus.pipe(
+    this.onlineStatus$ = this.pwaService.onlineStatus$.pipe(
       filter(online => online),
       share()
     );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
@@ -276,7 +276,7 @@ class TestEnvironment {
 
     when(mockedTranslocoService.translate<string>(anything())).thenReturn('The project link is invalid.');
     this.isOnline = new BehaviorSubject<boolean>(true);
-    when(mockedPwaService.onlineStatus).thenReturn(this.isOnline.asObservable());
+    when(mockedPwaService.onlineStatus$).thenReturn(this.isOnline.asObservable());
     this.setLinkSharing(false);
 
     this.fixture = TestBed.createComponent(ProjectComponent);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
@@ -49,12 +49,12 @@ export class ProjectComponent extends DataLoadingComponent implements OnInit {
       filter(id => !!userProjects?.includes(id) || this.route.snapshot.queryParams['sharing'] == null)
     );
     this.subscribe(navigateToProject$, projectId => this.navigateToProject(projectId));
-    const checkLinkSharing$ = combineLatest([projectId$, this.pwaService.onlineStatus]).pipe(
+    const checkLinkSharing$ = combineLatest([projectId$, this.pwaService.onlineStatus$]).pipe(
       filter(([_, isOnline]) => isOnline && (this.route.snapshot.queryParams['sharing'] as string) === 'true'),
       map(([projectId, _]) => projectId)
     );
     this.subscribe(checkLinkSharing$, projectId => this.checkLinkSharing(projectId));
-    const showOfflineMessage$ = combineLatest([projectId$, this.pwaService.onlineStatus]).pipe(
+    const showOfflineMessage$ = combineLatest([projectId$, this.pwaService.onlineStatus$]).pipe(
       filter(
         ([id, isOnline]) =>
           !userProjects?.includes(id) && !isOnline && (this.route.snapshot.queryParams['sharing'] as string) === 'true'

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -540,7 +540,7 @@ class TestEnvironment {
       this.realtimeService.subscribe(SFProjectDoc.COLLECTION, 'project01')
     );
     this.isOnline = new BehaviorSubject<boolean>(hasConnection);
-    when(mockedPwaService.onlineStatus).thenReturn(this.isOnline.asObservable());
+    when(mockedPwaService.onlineStatus$).thenReturn(this.isOnline.asObservable());
     when(mockedPwaService.isOnline).thenReturn(this.isOnline.getValue());
 
     when(mockedParatextService.getProjects()).thenResolve([

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -135,7 +135,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
       tap(() => (this.loading = this.isAppOnline)),
       map(params => params['projectId'] as string)
     );
-    this.subscribe(combineLatest([this.pwaService.onlineStatus, projectId$]), async ([isOnline, projectId]) => {
+    this.subscribe(combineLatest([this.pwaService.onlineStatus$, projectId$]), async ([isOnline, projectId]) => {
       this.isAppOnline = isOnline;
       if (isOnline && this.projects == null) {
         this.loading = true;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.spec.ts
@@ -368,7 +368,7 @@ class TestEnvironment {
     when(mockedProjectService.getProfile(anything())).thenCall(projectId =>
       this.realtimeService.subscribe(SFProjectProfileDoc.COLLECTION, projectId)
     );
-    when(mockedPwaService.onlineStatus).thenReturn(this._onlineStatus.asObservable());
+    when(mockedPwaService.onlineStatus$).thenReturn(this._onlineStatus.asObservable());
     when(mockedPwaService.isOnline).thenCall(() => this._onlineStatus.getValue());
     when(mockedUserService.currentUserId).thenReturn(args.userId!);
     when(mockedProjectService.onlineGetLinkSharingKey(args.projectId!, anything())).thenResolve(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
@@ -61,7 +61,7 @@ export class ShareControlComponent extends SubscriptionDisposable {
     private readonly featureFlags: FeatureFlagService
   ) {
     super();
-    this.subscribe(combineLatest([this.projectId$, this.pwaService.onlineStatus]), async ([projectId]) => {
+    this.subscribe(combineLatest([this.projectId$, this.pwaService.onlineStatus$]), async ([projectId]) => {
       if (projectId === '') {
         return;
       }
@@ -74,7 +74,7 @@ export class ShareControlComponent extends SubscriptionDisposable {
       }
       this.subscribe(this.projectDoc.remoteChanges$, () => this.updateFormEnabledStateAndLinkSharingKey());
     });
-    this.subscribe(combineLatest([this.pwaService.onlineStatus, this.roleControl.valueChanges]), () =>
+    this.subscribe(combineLatest([this.pwaService.onlineStatus$, this.roleControl.valueChanges]), () =>
       this.updateFormEnabledStateAndLinkSharingKey()
     );
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share.component.spec.ts
@@ -62,7 +62,7 @@ class TestEnvironment {
   readonly realtimeService: TestRealtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);
 
   constructor() {
-    when(mockedPwaService.onlineStatus).thenReturn(of(true));
+    when(mockedPwaService.onlineStatus$).thenReturn(of(true));
     when(mockedActivatedRoute.params).thenReturn(of({ projectId: 'project01' }));
     when(mockedProjectService.getProfile(anything())).thenCall(id =>
       this.realtimeService.subscribe(SFProjectProfileDoc.COLLECTION, id)

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -3035,7 +3035,7 @@ class TestEnvironment {
   private isOnline: boolean = true;
 
   constructor({ textDoc, chapterNum, presenceEnabled = true }: TestEnvCtorArgs = {}) {
-    when(mockedPwaService.onlineStatus).thenReturn(this._onlineStatus.asObservable());
+    when(mockedPwaService.onlineStatus$).thenReturn(this._onlineStatus.asObservable());
     when(mockedPwaService.isOnline).thenCall(() => this.isOnline);
     when(mockedTranslocoService.translate<string>(anything())).thenCall(
       (translationStringKey: string) => translationStringKey

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -453,7 +453,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   }
 
   ngAfterViewInit(): void {
-    this.subscribe(this.pwaService.onlineStatus, isOnline => {
+    this.subscribe(this.pwaService.onlineStatus$, isOnline => {
       this.updatePlaceholderText(isOnline);
       this.changeDetector.detectChanges();
       if (!isOnline && this._editor != null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
@@ -248,7 +248,7 @@ class TestEnvironment {
     when(mockedNoticeService.loadingFinished()).thenCall(() => (this.isLoading = false));
     when(mockedNoticeService.isAppLoading).thenCall(() => this.isLoading);
     this.isOnline = new BehaviorSubject(isOnline);
-    when(mockedPwaService.onlineStatus).thenReturn(this.isOnline.asObservable());
+    when(mockedPwaService.onlineStatus$).thenReturn(this.isOnline.asObservable());
 
     const date = new Date();
     date.setMonth(date.getMonth() - 2);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
@@ -117,7 +117,7 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.subscribe(this.pwaService.onlineStatus, async isOnline => {
+    this.subscribe(this.pwaService.onlineStatus$, async isOnline => {
       this.isAppOnline = isOnline;
       if (this.isAppOnline && this.paratextUsername == null) {
         const username = await this.paratextService.getParatextUsername().toPromise();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
@@ -505,7 +505,7 @@ class TestEnvironment {
     const chooserDialogResult = new VerseRef('LUK', '1', '2');
     when(this.mockedScriptureChooserMdcDialogRef.afterClosed()).thenReturn(of(chooserDialogResult));
     when(mockedPwaService.isOnline).thenReturn(true);
-    when(mockedPwaService.onlineStatus).thenReturn(of(true));
+    when(mockedPwaService.onlineStatus$).thenReturn(of(true));
 
     this.fixture.detectChanges();
     flush();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2949,7 +2949,7 @@ class TestEnvironment {
       })
     );
     when(mockedPwaService.isOnline).thenReturn(true);
-    when(mockedPwaService.onlineStatus).thenReturn(of(true));
+    when(mockedPwaService.onlineStatus$).thenReturn(of(true));
 
     this.fixture = TestBed.createComponent(EditorComponent);
     this.component = this.fixture.componentInstance;
@@ -3062,7 +3062,7 @@ class TestEnvironment {
 
   set onlineStatus(value: boolean) {
     when(mockedPwaService.isOnline).thenReturn(value);
-    when(mockedPwaService.onlineStatus).thenReturn(of(value));
+    when(mockedPwaService.onlineStatus$).thenReturn(of(value));
   }
 
   deleteText(textId: string): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
@@ -152,7 +152,7 @@ class TestEnvironment {
     this.fixture = TestBed.createComponent(ChildViewContainerComponent);
 
     when(mockedPwaService.isOnline).thenCall(() => this.onlineStatus.getValue());
-    when(mockedPwaService.onlineStatus).thenReturn(this.onlineStatus.asObservable());
+    when(mockedPwaService.onlineStatus$).thenReturn(this.onlineStatus.asObservable());
   }
 
   get overlayContainerElement(): HTMLElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.ts
@@ -67,7 +67,7 @@ export class SuggestionsSettingsDialogComponent extends SubscriptionDisposable {
         op.set<boolean>(puc => puc.translationSuggestionsEnabled, this.suggestionsEnabledSwitch.value)
       );
     });
-    this.subscribe(this.pwaService.onlineStatus, isOnline => {
+    this.subscribe(this.pwaService.onlineStatus$, isOnline => {
       isOnline ? this.suggestionsSwitchFormGroup.enable() : this.suggestionsEnabledSwitch.disable();
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/translate-metrics-session.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/translate-metrics-session.spec.ts
@@ -396,7 +396,7 @@ describe('TranslateMetricsSession', () => {
     // CommandError is ignored when offline
     resetCalls(mockedSFProjectService);
     when(mockedPwaService.isOnline).thenReturn(false);
-    when(mockedPwaService.onlineStatus).thenReturn(of(false));
+    when(mockedPwaService.onlineStatus$).thenReturn(of(false));
     when(mockedSFProjectService.onlineAddTranslateMetrics('project01', anything())).thenReject(commandError);
     expect(() => {
       env.keyPress('a');
@@ -438,7 +438,7 @@ class TestEnvironment {
     when(mockedSFProjectService.onlineAddTranslateMetrics('project01', anything())).thenResolve();
     when(mockedSFProjectService.getProfile(anything())).thenResolve({} as SFProjectProfileDoc);
     when(mockedPwaService.isOnline).thenReturn(true);
-    when(mockedPwaService.onlineStatus).thenReturn(of(true));
+    when(mockedPwaService.onlineStatus$).thenReturn(of(true));
     when(mockedUserService.getCurrentUser()).thenResolve({ data: { displayName: 'name' } } as UserDoc);
 
     this.sourceFixture = TestBed.createComponent(TextComponent);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
@@ -510,7 +510,7 @@ class TestEnvironment {
     ]);
 
     this.isOnline = new BehaviorSubject<boolean>(hasConnection);
-    when(mockedPwaService.onlineStatus).thenReturn(this.isOnline.asObservable());
+    when(mockedPwaService.onlineStatus$).thenReturn(this.isOnline.asObservable());
     when(mockedPwaService.isOnline).thenReturn(this.isOnline.value);
     when(mockedDialogService.confirm(anything(), anything())).thenResolve(true);
     this.fixture = TestBed.createComponent(CollaboratorsComponent);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.ts
@@ -152,7 +152,7 @@ export class CollaboratorsComponent extends DataLoadingComponent implements OnIn
         this.loadingFinished();
       }
     );
-    this.subscribe(this.pwaService.onlineStatus, isOnline => {
+    this.subscribe(this.pwaService.onlineStatus$, isOnline => {
       this.isAppOnline = isOnline;
       if (isOnline && this._userRows == null) {
         this.loadingStarted();
@@ -163,7 +163,7 @@ export class CollaboratorsComponent extends DataLoadingComponent implements OnIn
   }
 
   ngAfterViewInit(): void {
-    this.subscribe(this.pwaService.onlineStatus, isOnline => {
+    this.subscribe(this.pwaService.onlineStatus$, isOnline => {
       if (isOnline) {
         this.filterForm.enable();
       } else {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.html
@@ -8,5 +8,5 @@
   [bgColor]="borderColor"
 ></ngx-avatar>
 <div *ngIf="showOnlineStatus" class="online-status">
-  <mdc-icon *ngIf="(pwaService.onlineStatus | async) !== true">cloud_off</mdc-icon>
+  <mdc-icon *ngIf="(pwaService.onlineStatus$ | async) !== true">cloud_off</mdc-icon>
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.spec.ts
@@ -288,7 +288,7 @@ class TestEnvironment {
   constructor(isOnline: boolean = true) {
     this.isOnline = new BehaviorSubject<boolean>(isOnline);
     when(mockedPwaService.isOnline).thenReturn(isOnline);
-    when(mockedPwaService.onlineStatus).thenReturn(this.isOnline);
+    when(mockedPwaService.onlineStatus$).thenReturn(this.isOnline);
     when(mockedAuthService.isLoggedIn).thenResolve(true);
 
     this.realtimeService = TestBed.inject(TestRealtimeService);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
@@ -68,7 +68,7 @@ export class FileService extends SubscriptionDisposable {
 
   init(realtimeService: RealtimeService): void {
     this.realtimeService = realtimeService;
-    this.subscribe(this.pwaService.onlineStatus, isOnline => {
+    this.subscribe(this.pwaService.onlineStatus$, isOnline => {
       if (isOnline) {
         this.syncFiles();
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { discardPeriodicTasks, fakeAsync, flush, tick } from '@angular/core/testing';
+import { fakeAsync, flush, tick } from '@angular/core/testing';
 import { SwUpdate, VersionEvent, VersionReadyEvent } from '@angular/service-worker';
 import { instance, mock, resetCalls, verify, when } from 'ts-mockito';
 import { Subject } from 'rxjs';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.spec.ts
@@ -103,7 +103,7 @@ describe('PwaService', () => {
   it('hasUpdate should emit on VERSION_READY', fakeAsync(() => {
     const env = new TestEnvironment();
     let isVersionReady = false;
-    env.pwaService.hasUpdate.subscribe((event: VersionReadyEvent) => {
+    env.pwaService.hasUpdate$.subscribe((event: VersionReadyEvent) => {
       expect(event.type).toEqual('VERSION_READY');
       isVersionReady = true;
     });
@@ -119,6 +119,7 @@ class TestEnvironment {
   private versionUpdates$: Subject<VersionEvent> = new Subject<VersionEvent>();
 
   constructor() {
+    when(mockedSwUpdate.isEnabled).thenReturn(true);
     this.pwaService = new PwaService(
       instance(mockedHttpClient),
       instance(mockedSwUpdate),

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.spec.ts
@@ -1,42 +1,49 @@
 import { HttpClient } from '@angular/common/http';
-import { fakeAsync, flush } from '@angular/core/testing';
+import { fakeAsync, flush, tick } from '@angular/core/testing';
 import { SwUpdate } from '@angular/service-worker';
-import { instance, mock } from 'ts-mockito';
+import { instance, mock, verify } from 'ts-mockito';
 import { LocationService } from './location.service';
-import { PwaService } from './pwa.service';
+import { PWA_CHECK_FOR_UPDATES, PwaService } from './pwa.service';
+
+const mockedHttpClient = mock(HttpClient);
+const mockedSwUpdate = mock(SwUpdate);
+const mockedLocationService = mock(LocationService);
 
 describe('PwaService', () => {
-  let env: TestEnvironment;
-
-  beforeEach(() => {
-    env = new TestEnvironment();
-  });
-
   it('offline when navigator is set to offline', () => {
+    const env = new TestEnvironment();
     env.onlineStatus = false;
     expect(env.pwaService.isOnline).toBe(false);
+    env.dispose();
   });
 
   it('online when navigator is set to online', () => {
+    const env = new TestEnvironment();
     env.onlineStatus = true;
     expect(env.pwaService.isOnline).toBe(true);
+    env.dispose();
   });
 
   it('switch to offline when navigator changes status', () => {
+    const env = new TestEnvironment();
     env.onlineStatus = true;
     expect(env.pwaService.isOnline).toBe(true);
     env.onlineStatus = false;
     expect(env.pwaService.isOnline).toBe(false);
+    env.dispose();
   });
 
   it('switch to online when navigator changes status', () => {
+    const env = new TestEnvironment();
     env.onlineStatus = false;
     expect(env.pwaService.isOnline).toBe(false);
     env.onlineStatus = true;
     expect(env.pwaService.isOnline).toBe(true);
+    env.dispose();
   });
 
   it('informs the caller when the user is back online', fakeAsync(() => {
+    const env = new TestEnvironment();
     env.onlineStatus = false;
     let onlineFiredCount = 0;
     env.pwaService.online.then(() => onlineFiredCount++);
@@ -55,23 +62,42 @@ describe('PwaService', () => {
     env.pwaService.online.then(() => onlineFiredCount++);
     flush();
     expect(onlineFiredCount).toBe(2);
+    env.dispose();
   }));
 
   it('switch to offline when navigator is online but websocket status is false', () => {
+    const env = new TestEnvironment();
     env.onlineStatus = true;
     expect(env.pwaService.isOnline).toBe(true);
     env.pwaService.webSocketResponse = false;
     expect(env.pwaService.isOnline).toBe(false);
+    env.dispose();
   });
 
   it('switch to online when navigator is online and websocket comes back online', () => {
+    const env = new TestEnvironment();
     env.onlineStatus = true;
     expect(env.pwaService.isOnline).toBe(true);
     env.pwaService.webSocketResponse = false;
     expect(env.pwaService.isOnline).toBe(false);
     env.pwaService.webSocketResponse = true;
     expect(env.pwaService.isOnline).toBe(true);
+    env.dispose();
   });
+
+  it('checks for updates', fakeAsync(() => {
+    const env = new TestEnvironment();
+    // Shouldn't run immediately
+    verify(mockedSwUpdate.checkForUpdate()).never();
+    // Run after initial timer
+    tick(PWA_CHECK_FOR_UPDATES);
+    verify(mockedSwUpdate.checkForUpdate()).once();
+    // Ensure it is still running
+    tick(PWA_CHECK_FOR_UPDATES);
+    verify(mockedSwUpdate.checkForUpdate()).twice();
+    expect().nothing();
+    env.dispose();
+  }));
 });
 
 class TestEnvironment {
@@ -79,9 +105,6 @@ class TestEnvironment {
   private navigatorOnline: boolean = true;
 
   constructor() {
-    const mockedHttpClient = mock(HttpClient);
-    const mockedSwUpdate = mock(SwUpdate);
-    const mockedLocationService = mock(LocationService);
     this.pwaService = new PwaService(
       instance(mockedHttpClient),
       instance(mockedSwUpdate),
@@ -93,5 +116,9 @@ class TestEnvironment {
   set onlineStatus(status: boolean) {
     this.navigatorOnline = status;
     window.dispatchEvent(new Event(status ? 'online' : 'offline'));
+  }
+
+  dispose() {
+    this.pwaService.dispose();
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.spec.ts
@@ -1,7 +1,8 @@
 import { HttpClient } from '@angular/common/http';
 import { fakeAsync, flush, tick } from '@angular/core/testing';
-import { SwUpdate } from '@angular/service-worker';
-import { instance, mock, verify } from 'ts-mockito';
+import { SwUpdate, VersionEvent, VersionReadyEvent } from '@angular/service-worker';
+import { instance, mock, verify, when } from 'ts-mockito';
+import { Subject } from 'rxjs';
 import { LocationService } from './location.service';
 import { PWA_CHECK_FOR_UPDATES, PwaService } from './pwa.service';
 
@@ -98,11 +99,24 @@ describe('PwaService', () => {
     expect().nothing();
     env.dispose();
   }));
+
+  it('hasUpdate should emit on VERSION_READY', () => {
+    const env = new TestEnvironment();
+    let isVersionReady = false;
+    env.pwaService.hasUpdate.subscribe((event: VersionReadyEvent) => {
+      expect(event.type).toEqual('VERSION_READY');
+      isVersionReady = true;
+    });
+    env.triggerVersionEvent('VERSION_READY');
+    expect(isVersionReady).toEqual(true);
+    env.dispose();
+  });
 });
 
 class TestEnvironment {
   readonly pwaService: PwaService;
   private navigatorOnline: boolean = true;
+  private versionUpdates$: Subject<VersionEvent> = new Subject<VersionEvent>();
 
   constructor() {
     this.pwaService = new PwaService(
@@ -111,6 +125,7 @@ class TestEnvironment {
       instance(mockedLocationService)
     );
     spyOnProperty(window.navigator, 'onLine').and.returnValue(this.navigatorOnline);
+    when(mockedSwUpdate.versionUpdates).thenReturn(this.versionUpdates$);
   }
 
   set onlineStatus(status: boolean) {
@@ -120,5 +135,9 @@ class TestEnvironment {
 
   dispose() {
     this.pwaService.dispose();
+  }
+
+  triggerVersionEvent(type: 'VERSION_DETECTED' | 'VERSION_READY' | 'VERSION_INSTALLATION_FAILED') {
+    this.versionUpdates$.next({ currentVersion: {}, latestVersion: {}, type } as VersionEvent);
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.spec.ts
@@ -137,7 +137,6 @@ class TestEnvironment {
   }
 
   dispose() {
-    discardPeriodicTasks();
     this.pwaService.dispose();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.ts
@@ -6,7 +6,7 @@ import { filter, mapTo, take } from 'rxjs/operators';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { LocationService } from './location.service';
 
-export const PWA_CHECK_FOR_UPDATES = 30000;
+export const PWA_CHECK_FOR_UPDATES = 30_000;
 
 @Injectable({
   providedIn: 'root'

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.ts
@@ -12,9 +12,9 @@ export const PWA_CHECK_FOR_UPDATES = 30_000;
   providedIn: 'root'
 })
 export class PwaService extends SubscriptionDisposable {
-  private appOnlineStatus: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(navigator.onLine);
-  private windowOnLineStatus: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(navigator.onLine);
-  private webSocketStatus: BehaviorSubject<boolean | null> = new BehaviorSubject<boolean | null>(null);
+  private appOnlineStatus$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(navigator.onLine);
+  private windowOnLineStatus$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(navigator.onLine);
+  private webSocketStatus$: BehaviorSubject<boolean | null> = new BehaviorSubject<boolean | null>(null);
 
   constructor(
     private readonly http: HttpClient,
@@ -32,50 +32,53 @@ export class PwaService extends SubscriptionDisposable {
       status => {
         // Note that this isn't 100% as accurate as it sounds. "Online" simply means a valid network connection
         // and not a valid Internet connection. The websocket is another fallback which is constantly polled
-        this.windowOnLineStatus.next(status);
+        this.windowOnLineStatus$.next(status);
       }
     );
     // Check for changes to the online status or from the web socket status
-    this.subscribe(merge(this.windowOnLineStatus.asObservable(), this.webSocketStatus.asObservable()), () => {
+    this.subscribe(merge(this.windowOnLineStatus$.asObservable(), this.webSocketStatus$.asObservable()), () => {
       // The app is "online" if the browser/network thinks it's online AND
       // we have a valid web socket connection OR
       //    the web socket hasn't yet had a chance to connect i.e. (null) when the app first loads
-      this.appOnlineStatus.next(this.windowOnLineStatus.getValue() && this.webSocketStatus.getValue() !== false);
+      this.appOnlineStatus$.next(this.windowOnLineStatus$.getValue() && this.webSocketStatus$.getValue() !== false);
     });
-    // Check for updates periodically
-    const checkForUpdatesInterval = interval(PWA_CHECK_FOR_UPDATES).subscribe(() =>
-      this.updates.checkForUpdate().catch(() => {
-        // Stop checking for updates if the browser doesn't support it
-        checkForUpdatesInterval.unsubscribe();
-      })
-    );
+    // Check for updates periodically if enabled and the browser supports it
+    if (this.updates.isEnabled) {
+      const checkForUpdatesInterval$ = interval(PWA_CHECK_FOR_UPDATES).subscribe(() =>
+        this.updates.checkForUpdate().catch((error: any) => {
+          // Stop checking for updates and throw the error
+          checkForUpdatesInterval$.unsubscribe();
+          throw new Error(error);
+        })
+      );
+    }
   }
 
   get isBrowserOnline(): boolean {
-    return this.windowOnLineStatus.getValue();
+    return this.windowOnLineStatus$.getValue();
   }
 
   get isOnline(): boolean {
-    return this.appOnlineStatus.getValue();
+    return this.appOnlineStatus$.getValue();
   }
 
-  get onlineBrowserStatus(): Observable<boolean> {
-    return this.windowOnLineStatus.asObservable();
+  get onlineBrowserStatus$(): Observable<boolean> {
+    return this.windowOnLineStatus$.asObservable();
   }
 
-  get onlineStatus(): Observable<boolean> {
-    return this.appOnlineStatus.asObservable();
+  get onlineStatus$(): Observable<boolean> {
+    return this.appOnlineStatus$.asObservable();
   }
 
-  get hasUpdate(): Observable<VersionReadyEvent> {
+  get hasUpdate$(): Observable<VersionReadyEvent> {
     // Note that this isn't consistent on localhost unless port forwarding to another device
     // An event is triggered but VersionInstallationFailedEvent is emitted instead - refreshing loads the latest version
     return this.updates.versionUpdates.pipe(filter((evt): evt is VersionReadyEvent => evt.type === 'VERSION_READY'));
   }
 
   set webSocketResponse(status: boolean) {
-    if (status !== this.webSocketStatus.getValue()) {
-      this.webSocketStatus.next(status);
+    if (status !== this.webSocketStatus$.getValue()) {
+      this.webSocketStatus$.next(status);
     }
   }
 
@@ -84,7 +87,7 @@ export class PwaService extends SubscriptionDisposable {
    */
   get online(): Promise<void> {
     return new Promise<void>(resolve => {
-      this.onlineStatus
+      this.onlineStatus$
         .pipe(
           filter(isOnline => isOnline),
           take(1)

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { SwUpdate, VersionReadyEvent } from '@angular/service-worker';
-import { BehaviorSubject, fromEvent, interval, merge, Observable, of, timer } from 'rxjs';
+import { BehaviorSubject, fromEvent, interval, merge, Observable, of } from 'rxjs';
 import { filter, mapTo, take } from 'rxjs/operators';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { LocationService } from './location.service';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.ts
@@ -43,7 +43,12 @@ export class PwaService extends SubscriptionDisposable {
       this.appOnlineStatus.next(this.windowOnLineStatus.getValue() && this.webSocketStatus.getValue() !== false);
     });
     // Check for updates periodically
-    this.subscribe(interval(PWA_CHECK_FOR_UPDATES), () => this.updates.checkForUpdate());
+    const checkForUpdatesInterval = interval(PWA_CHECK_FOR_UPDATES).subscribe(() =>
+      this.updates.checkForUpdate().catch(() => {
+        // Stop checking for updates if the browser doesn't support it
+        checkForUpdatesInterval.unsubscribe();
+      })
+    );
   }
 
   get isBrowserOnline(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/retrying-request.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/retrying-request.service.ts
@@ -34,7 +34,7 @@ export class RetryingRequestService {
   invoke<T>(fetchOptions: FetchOptions, cancel$: Subject<void>): RetryingRequest<T> {
     return new RetryingRequest<T>(
       this.commandService,
-      this.pwaService.onlineStatus,
+      this.pwaService.onlineStatus$,
       cancel$,
       fetchOptions,
       this.console


### PR DESCRIPTION
The original PR for this, #1603 was merged and then I reverted it because if caused errors on localhost in every browser I tried. 

The error message in both Chrome and Firefox is "Service workers are disabled or not supported by this browser".

I'm not sure how @nigel-wells wouldn't have run into this while working on this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1622)
<!-- Reviewable:end -->
