### PR TITLE
SF-1826 Fix error calling getWordGraph

### DIFF
--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -11,7 +11,7 @@
     <!-- Set this to true if you enable server-side prerendering -->
     <BuildServerSideRenderer>false</BuildServerSideRenderer>
     <UserSecretsId>4d0606c3-0fc7-4d76-b43b-236485004e81</UserSecretsId>
-    <MachineVersion>2.5.11</MachineVersion>
+    <MachineVersion>2.5.12</MachineVersion>
     <RealtimeServerRoot>..\RealtimeServer\</RealtimeServerRoot>
     <AngularConfig>production</AngularConfig>
     <Nullable>annotations</Nullable>


### PR DESCRIPTION
The error on the back end was "Input string was not in a correct format".

@ddaspit fixed the problem and published a new version of SIL Machine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1623)
<!-- Reviewable:end -->
