### PR TITLE
Update package-lock.json in ClientApp

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -130,7 +130,6 @@
       },
       "devDependencies": {
         "@types/jest": "^27.5.1",
-        "@types/jest-expect-message": "^1.0.3",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/node": "^16.11.36",
         "@types/ws": "^8.5.3",
@@ -143,7 +142,7 @@
         "eslint-plugin-jsdoc": "^36.1.1",
         "eslint-plugin-prettier": "^4.0.0",
         "jest": "^27.5.1",
-        "jest-expect-message": "^1.0.2",
+        "jest-expect-message": "^1.1.3",
         "jest-teamcity-reporter": "^0.9.0",
         "prettier": "^2.6.2",
         "sharedb-mingo-memory": "^1.2.0",
@@ -32795,7 +32794,6 @@
       "requires": {
         "@bugsnag/js": "^7.16.5",
         "@types/jest": "^27.5.1",
-        "@types/jest-expect-message": "^1.0.3",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/node": "^16.11.36",
         "@types/ws": "^8.5.3",
@@ -32809,7 +32807,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "express": "^4.18.1",
         "jest": "^27.5.1",
-        "jest-expect-message": "^1.0.2",
+        "jest-expect-message": "^1.1.3",
         "jest-teamcity-reporter": "^0.9.0",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^2.1.2",


### PR DESCRIPTION
A change to Realtime server in 20e3c3f562a0a7451adf4ebdfb1744233a35b1b4 changes the output of npm install in ClientApp, but was overlooked when I made that update.

As a consequence, anyone running `npm install` in ClientApp will see a change to this file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1624)
<!-- Reviewable:end -->
