### PR TITLE
SF-1823 Web API for Machine API

### DIFF
--- a/src/Migrations/MachineApiMigration/MachineApiMigration.csproj
+++ b/src/Migrations/MachineApiMigration/MachineApiMigration.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\SIL.XForge.Scripture\SIL.XForge.Scripture.csproj" />
+    <ProjectReference Include="..\..\SIL.XForge\SIL.XForge.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Migrations/MachineApiMigration/MachineApiMigration.sln
+++ b/src/Migrations/MachineApiMigration/MachineApiMigration.sln
@@ -1,0 +1,42 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33205.214
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MachineApiMigration", "MachineApiMigration.csproj", "{FCE29858-6EF8-46CF-AB9A-390DA472F53E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIL.XForge", "..\..\SIL.XForge\SIL.XForge.csproj", "{665D56C2-6609-4477-91D0-16590AAEDDFD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIL.XForge.Scripture", "..\..\SIL.XForge.Scripture\SIL.XForge.Scripture.csproj", "{13D18568-D56E-4D4F-86C4-038DF06BBDDA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A3FFEBCE-071C-4FD7-BB5E-878802CA5302}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\..\.editorconfig = ..\..\..\.editorconfig
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FCE29858-6EF8-46CF-AB9A-390DA472F53E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FCE29858-6EF8-46CF-AB9A-390DA472F53E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FCE29858-6EF8-46CF-AB9A-390DA472F53E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FCE29858-6EF8-46CF-AB9A-390DA472F53E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{665D56C2-6609-4477-91D0-16590AAEDDFD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{665D56C2-6609-4477-91D0-16590AAEDDFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{665D56C2-6609-4477-91D0-16590AAEDDFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{665D56C2-6609-4477-91D0-16590AAEDDFD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{13D18568-D56E-4D4F-86C4-038DF06BBDDA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{13D18568-D56E-4D4F-86C4-038DF06BBDDA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{13D18568-D56E-4D4F-86C4-038DF06BBDDA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{13D18568-D56E-4D4F-86C4-038DF06BBDDA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EA40286F-FC4B-496F-B8D1-BC03011F6392}
+	EndGlobalSection
+EndGlobal

--- a/src/Migrations/MachineApiMigration/MachineApiMigrator.cs
+++ b/src/Migrations/MachineApiMigration/MachineApiMigrator.cs
@@ -1,0 +1,298 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Microsoft.FeatureManagement;
+using Org.BouncyCastle.Crypto;
+using SIL.XForge.DataAccess;
+using SIL.XForge.Models;
+using SIL.XForge.Realtime;
+using SIL.XForge.Scripture.Models;
+using SIL.XForge.Scripture.Services;
+
+namespace MachineApiMigration;
+
+/// <summary>
+/// Migrates all projects to the new Machine API, if translation is enabled.
+/// </summary>
+public class MachineApiMigrator
+{
+    /// <summary>
+    /// The feature manager.
+    /// </summary>
+    private readonly IFeatureManager _featureManager;
+
+    /// <summary>
+    /// The Machine project service.
+    /// </summary>
+    private readonly IMachineProjectService _machineProjectService;
+
+    /// <summary>
+    /// The Paratext service.
+    /// </summary>
+    private readonly IParatextService _paratextService;
+
+    /// <summary>
+    /// The project secrets repository.
+    /// </summary>
+    private readonly IRepository<SFProjectSecret> _projectSecrets;
+
+    /// <summary>
+    /// The project service.
+    /// </summary>
+    private readonly ISFProjectService _projectService;
+
+    /// <summary>
+    /// The realtime service.
+    /// </summary>
+    private readonly IRealtimeService _realtimeService;
+
+    /// <summary>
+    /// The user secrets repository.
+    /// </summary>
+    private readonly IRepository<UserSecret> _userSecrets;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MachineApiMigrator" /> class.
+    /// </summary>
+    /// <param name="machineProjectService">The Machine project service.</param>
+    /// <param name="paratextService">The Paratext service.</param>
+    /// <param name="projectSecrets">The SF project secrets repository.</param>
+    /// <param name="projectService">The SF project service.</param>
+    /// <param name="realtimeService">The realtime service.</param>
+    /// <param name="userSecrets">The user secrets repository.</param>
+    public MachineApiMigrator(
+        IFeatureManager featureManager,
+        IMachineProjectService machineProjectService,
+        IParatextService paratextService,
+        IRepository<SFProjectSecret> projectSecrets,
+        ISFProjectService projectService,
+        IRealtimeService realtimeService,
+        IRepository<UserSecret> userSecrets
+    )
+    {
+        _featureManager = featureManager;
+        _machineProjectService = machineProjectService;
+        _paratextService = paratextService;
+        _projectSecrets = projectSecrets;
+        _projectService = projectService;
+        _realtimeService = realtimeService;
+        _userSecrets = userSecrets;
+    }
+
+    public async Task MigrateAllProjectsAsync(
+        bool doWrite,
+        ICollection<string> sfProjectIdsToMigrate,
+        IDictionary<string, string> sfAdminsToUse,
+        CancellationToken cancellationToken
+    )
+    {
+        // Ensure that the feature flags are set correctly
+        if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
+        {
+            Program.Log("ERROR: Cannot proceed. The Machine API feature flag is disabled.");
+            return;
+        }
+
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+        {
+            Program.Log("ERROR: Cannot proceed. The In-Process Machine feature flag is enabled.");
+            return;
+        }
+
+        // Get all projects that have translation suggestions enabled, and are not configured for the Machine API
+        List<SFProject> projects = await _realtimeService
+            .QuerySnapshots<SFProject>()
+            .Where(p => p.TranslateConfig.TranslationSuggestionsEnabled)
+            .ToListAsync();
+
+        // If we are only to migrate some projects, restrict this list to them
+        if (sfProjectIdsToMigrate.Any())
+        {
+            projects.RemoveAll(p => !sfProjectIdsToMigrate.Contains(p.Id));
+            string ids = string.Join(' ', projects.Select(p => p.Id));
+            int count = projects.Count;
+            Program.Log($"Only working on the subset of projects (count {count}) with these SF project ids: {ids}");
+        }
+
+        // Get all of the project secrets that are not configured for the Machine API
+        List<SFProjectSecret> projectSecrets = await _projectSecrets
+            .Query()
+            .Where(p => p.MachineData == null || string.IsNullOrEmpty(p.MachineData!.TranslationEngineId))
+            .ToListAsync();
+
+        // Iterate over each project that is not configured for the Machine API
+        foreach (var project in projects.Where(p => projectSecrets.Select(ps => ps.Id).Contains(p.Id)))
+        {
+            Program.Log($"Migrating Project {project.Id}: {project.Name}");
+
+            // Get the admin users
+            List<string> projectSfAdminUserIds = project.UserRoles
+                .Where(ur => ur.Value == SFProjectRole.Administrator)
+                .Select(ur => ur.Key)
+                .ToList();
+            if (!projectSfAdminUserIds.Any())
+            {
+                List<string> projectSfUserIds = project.UserRoles.Select(ur => ur.Key).ToList();
+                string users = projectSfUserIds.Any() ? string.Join(", ", projectSfUserIds) : "None";
+                Program.Log($"Warning: No admin users. Non-admin users include: {users}");
+            }
+
+            // Report on all admins in a project
+            foreach (string sfUserId in projectSfAdminUserIds)
+            {
+                // See if we need to update the writing system tag
+                // We connect to the Paratext registry for this, so we need to make sure we can access it
+                if (string.IsNullOrWhiteSpace(project.WritingSystem.Tag))
+                {
+                    Program.Log("The writing system tag is not set, and will be updated.");
+
+                    // Ensure we have a user secret for this user
+                    UserSecret? userSecret = _userSecrets.Query().FirstOrDefault(us => us.Id == sfUserId);
+                    if (userSecret is null)
+                    {
+                        Program.Log($"Could not retrieve user secret for SF User: {sfUserId}");
+                        continue;
+                    }
+
+                    // Report on the Paratext username and id
+                    string ptUsername = string.Empty;
+                    string ptUserId;
+                    try
+                    {
+                        ptUsername = _paratextService.GetParatextUsername(userSecret) ?? string.Empty;
+                        ptUserId = GetParatextUserId(userSecret);
+                    }
+                    catch (Exception e)
+                    {
+                        Program.Log(
+                            "Failure getting SF user's PT username or PT user id. "
+                                + $"Skipping. SF user id was {sfUserId}. If known, PT username was {ptUsername}. "
+                                + $"Error with stack was {e}"
+                        );
+                        continue;
+                    }
+                    Program.Log(
+                        $"PT user '{ptUsername}', id {ptUserId}, using SF admin user id {sfUserId} on SF project."
+                    );
+
+                    // Display partial token details
+                    string rt = $"{userSecret.ParatextTokens.RefreshToken[..5]}..";
+                    string at = $"{userSecret.ParatextTokens.AccessToken[..5]}..";
+                    bool atv = userSecret.ParatextTokens.ValidateLifetime();
+                    Program.Log($"Paratext RefreshToken: {rt}, AccessToken: {at}, AccessToken initially valid: {atv}.");
+
+                    // Demonstrate access to PT Registry, and report Registry's statement of role.
+                    Program.Log("");
+                    IReadOnlyDictionary<string, string> ptProjectRoles;
+                    try
+                    {
+                        ptProjectRoles = await _paratextService.GetProjectRolesAsync(
+                            userSecret,
+                            project,
+                            cancellationToken
+                        );
+                    }
+                    catch (Exception e)
+                    {
+                        Program.Log($"Failure fetching user's PT project roles. Skipping. Error was {e.Message}");
+                        continue;
+                    }
+
+                    // Report that the user has a role on the project
+                    Program.Log(
+                        ptProjectRoles.TryGetValue(ptUserId, out string? ptRole)
+                            ? $"PT Registry report on role on PT project: {ptRole}"
+                            : "User role not found in PT Registry."
+                    );
+
+                    // Demonstrate access to PT Data Access.
+                    IReadOnlyList<ParatextProject> userPtProjects;
+                    try
+                    {
+                        userPtProjects = await _paratextService.GetProjectsAsync(userSecret);
+                    }
+                    catch (Exception e)
+                    {
+                        Program.Log($"Failure fetching user's PT projects. Skipping. Error was {e.Message}");
+                        continue;
+                    }
+
+                    // Report if the user can access a project
+                    List<string> ptProjectNamesList = userPtProjects
+                        .Where(ptProject => ptProject.ParatextId == project.ParatextId)
+                        .Select(ptProject => ptProject.ShortName)
+                        .ToList();
+                    if (ptProjectNamesList.Any())
+                    {
+                        string ptProjectNames = string.Join(',', ptProjectNamesList);
+                        Program.Log($"User can access PT Projects: {ptProjectNames}");
+                    }
+                    else
+                    {
+                        Program.Log(
+                            $"User is not on this project. PT reports they are on {userPtProjects.Count} PT projects"
+                        );
+                    }
+
+                    // If we are told to use specific admins, ensure they are used
+                    if (sfAdminsToUse.ContainsKey(project.Id))
+                    {
+                        sfAdminsToUse.TryGetValue(project.Id, out string? sfAdminIdToUse);
+                        bool isUserAtHand = sfUserId == sfAdminIdToUse;
+                        if (isUserAtHand)
+                        {
+                            Program.Log(
+                                $"For SF Project {project.Id}, we were asked to use this SF user {sfUserId} to migrate."
+                            );
+                        }
+                        else
+                        {
+                            Program.Log(
+                                $"For SF Project {project.Id}, we were asked to use SF user {sfAdminIdToUse}, "
+                                    + $"not {sfUserId}, to migrate. So skipping this user."
+                            );
+                            continue;
+                        }
+                    }
+
+                    if (doWrite)
+                    {
+                        await _projectService.EnsureWritingSystemTagIsSetAsync(sfUserId, project.Id);
+                    }
+                }
+                else
+                {
+                    Program.Log("The writing system tag does not need to be updated.");
+                }
+
+                // Add the project to the Machine API, and build it
+                if (doWrite)
+                {
+                    Program.Log("Adding project to Machine API...");
+                    await _machineProjectService.AddProjectAsync(sfUserId, project.Id, cancellationToken);
+                    Program.Log("Initiating first build...");
+                    await _machineProjectService.BuildProjectAsync(sfUserId, project.Id, cancellationToken);
+                }
+                else
+                {
+                    Program.Log("Project not migrated to Machine API, as test mode enabled.");
+                }
+
+                // We do not need to iterate any longer (the continue statements above ensure the correct user is used)
+                break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// As claimed by tokens in userSecret. Looks like it corresponds to `userId` in PT Registry project members
+    /// query.
+    /// </summary>
+    private static string GetParatextUserId(UserSecret userSecret)
+    {
+        if (userSecret.ParatextTokens is null)
+            return string.Empty;
+        var accessToken = new JwtSecurityToken(userSecret.ParatextTokens.AccessToken);
+        Claim? claim = accessToken.Claims.FirstOrDefault(c => c.Type == "sub");
+        return claim?.Value ?? string.Empty;
+    }
+}

--- a/src/Migrations/MachineApiMigration/MachineApiMigrator.cs
+++ b/src/Migrations/MachineApiMigration/MachineApiMigrator.cs
@@ -1,9 +1,5 @@
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
 using Microsoft.FeatureManagement;
-using Org.BouncyCastle.Crypto;
 using SIL.XForge.DataAccess;
-using SIL.XForge.Models;
 using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Scripture.Services;
@@ -26,19 +22,9 @@ public class MachineApiMigrator
     private readonly IMachineProjectService _machineProjectService;
 
     /// <summary>
-    /// The Paratext service.
-    /// </summary>
-    private readonly IParatextService _paratextService;
-
-    /// <summary>
     /// The project secrets repository.
     /// </summary>
     private readonly IRepository<SFProjectSecret> _projectSecrets;
-
-    /// <summary>
-    /// The project service.
-    /// </summary>
-    private readonly ISFProjectService _projectService;
 
     /// <summary>
     /// The realtime service.
@@ -46,36 +32,23 @@ public class MachineApiMigrator
     private readonly IRealtimeService _realtimeService;
 
     /// <summary>
-    /// The user secrets repository.
-    /// </summary>
-    private readonly IRepository<UserSecret> _userSecrets;
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="MachineApiMigrator" /> class.
     /// </summary>
+    /// <param name="featureManager">The feature manager.</param>
     /// <param name="machineProjectService">The Machine project service.</param>
-    /// <param name="paratextService">The Paratext service.</param>
     /// <param name="projectSecrets">The SF project secrets repository.</param>
-    /// <param name="projectService">The SF project service.</param>
     /// <param name="realtimeService">The realtime service.</param>
-    /// <param name="userSecrets">The user secrets repository.</param>
     public MachineApiMigrator(
         IFeatureManager featureManager,
         IMachineProjectService machineProjectService,
-        IParatextService paratextService,
         IRepository<SFProjectSecret> projectSecrets,
-        ISFProjectService projectService,
-        IRealtimeService realtimeService,
-        IRepository<UserSecret> userSecrets
+        IRealtimeService realtimeService
     )
     {
         _featureManager = featureManager;
         _machineProjectService = machineProjectService;
-        _paratextService = paratextService;
         _projectSecrets = projectSecrets;
-        _projectService = projectService;
         _realtimeService = realtimeService;
-        _userSecrets = userSecrets;
     }
 
     public async Task MigrateAllProjectsAsync(
@@ -136,135 +109,31 @@ public class MachineApiMigrator
                 Program.Log($"Warning: No admin users. Non-admin users include: {users}");
             }
 
-            // Report on all admins in a project
+            // Use the first admin in the project we are permitted to use
             foreach (string sfUserId in projectSfAdminUserIds)
             {
-                // See if we need to update the writing system tag
-                // We connect to the Paratext registry for this, so we need to make sure we can access it
-                if (string.IsNullOrWhiteSpace(project.WritingSystem.Tag))
+                // If we are told to use specific admins, ensure they are used
+                if (sfAdminsToUse.ContainsKey(project.Id))
                 {
-                    Program.Log("The writing system tag is not set, and will be updated.");
-
-                    // Ensure we have a user secret for this user
-                    UserSecret? userSecret = _userSecrets.Query().FirstOrDefault(us => us.Id == sfUserId);
-                    if (userSecret is null)
-                    {
-                        Program.Log($"Could not retrieve user secret for SF User: {sfUserId}");
-                        continue;
-                    }
-
-                    // Report on the Paratext username and id
-                    string ptUsername = string.Empty;
-                    string ptUserId;
-                    try
-                    {
-                        ptUsername = _paratextService.GetParatextUsername(userSecret) ?? string.Empty;
-                        ptUserId = GetParatextUserId(userSecret);
-                    }
-                    catch (Exception e)
+                    sfAdminsToUse.TryGetValue(project.Id, out string? sfAdminIdToUse);
+                    if (sfUserId == sfAdminIdToUse)
                     {
                         Program.Log(
-                            "Failure getting SF user's PT username or PT user id. "
-                                + $"Skipping. SF user id was {sfUserId}. If known, PT username was {ptUsername}. "
-                                + $"Error with stack was {e}"
+                            $"For SF Project {project.Id}, we were asked to use this SF user {sfUserId} to migrate."
                         );
-                        continue;
-                    }
-                    Program.Log(
-                        $"PT user '{ptUsername}', id {ptUserId}, using SF admin user id {sfUserId} on SF project."
-                    );
-
-                    // Display partial token details
-                    string rt = $"{userSecret.ParatextTokens.RefreshToken[..5]}..";
-                    string at = $"{userSecret.ParatextTokens.AccessToken[..5]}..";
-                    bool atv = userSecret.ParatextTokens.ValidateLifetime();
-                    Program.Log($"Paratext RefreshToken: {rt}, AccessToken: {at}, AccessToken initially valid: {atv}.");
-
-                    // Demonstrate access to PT Registry, and report Registry's statement of role.
-                    Program.Log("");
-                    IReadOnlyDictionary<string, string> ptProjectRoles;
-                    try
-                    {
-                        ptProjectRoles = await _paratextService.GetProjectRolesAsync(
-                            userSecret,
-                            project,
-                            cancellationToken
-                        );
-                    }
-                    catch (Exception e)
-                    {
-                        Program.Log($"Failure fetching user's PT project roles. Skipping. Error was {e.Message}");
-                        continue;
-                    }
-
-                    // Report that the user has a role on the project
-                    Program.Log(
-                        ptProjectRoles.TryGetValue(ptUserId, out string? ptRole)
-                            ? $"PT Registry report on role on PT project: {ptRole}"
-                            : "User role not found in PT Registry."
-                    );
-
-                    // Demonstrate access to PT Data Access.
-                    IReadOnlyList<ParatextProject> userPtProjects;
-                    try
-                    {
-                        userPtProjects = await _paratextService.GetProjectsAsync(userSecret);
-                    }
-                    catch (Exception e)
-                    {
-                        Program.Log($"Failure fetching user's PT projects. Skipping. Error was {e.Message}");
-                        continue;
-                    }
-
-                    // Report if the user can access a project
-                    List<string> ptProjectNamesList = userPtProjects
-                        .Where(ptProject => ptProject.ParatextId == project.ParatextId)
-                        .Select(ptProject => ptProject.ShortName)
-                        .ToList();
-                    if (ptProjectNamesList.Any())
-                    {
-                        string ptProjectNames = string.Join(',', ptProjectNamesList);
-                        Program.Log($"User can access PT Projects: {ptProjectNames}");
                     }
                     else
                     {
                         Program.Log(
-                            $"User is not on this project. PT reports they are on {userPtProjects.Count} PT projects"
+                            $"For SF Project {project.Id}, we were asked to use SF user {sfAdminIdToUse}, "
+                                + $"not {sfUserId}, to migrate. So skipping this user."
                         );
+                        continue;
                     }
-
-                    // If we are told to use specific admins, ensure they are used
-                    if (sfAdminsToUse.ContainsKey(project.Id))
-                    {
-                        sfAdminsToUse.TryGetValue(project.Id, out string? sfAdminIdToUse);
-                        bool isUserAtHand = sfUserId == sfAdminIdToUse;
-                        if (isUserAtHand)
-                        {
-                            Program.Log(
-                                $"For SF Project {project.Id}, we were asked to use this SF user {sfUserId} to migrate."
-                            );
-                        }
-                        else
-                        {
-                            Program.Log(
-                                $"For SF Project {project.Id}, we were asked to use SF user {sfAdminIdToUse}, "
-                                    + $"not {sfUserId}, to migrate. So skipping this user."
-                            );
-                            continue;
-                        }
-                    }
-
-                    if (doWrite)
-                    {
-                        await _projectService.EnsureWritingSystemTagIsSetAsync(sfUserId, project.Id);
-                    }
-                }
-                else
-                {
-                    Program.Log("The writing system tag does not need to be updated.");
                 }
 
                 // Add the project to the Machine API, and build it
+                // If the writing system tag is not set for the target or source, BuildProjectAsync will fix that
                 if (doWrite)
                 {
                     Program.Log("Adding project to Machine API...");
@@ -281,18 +150,5 @@ public class MachineApiMigrator
                 break;
             }
         }
-    }
-
-    /// <summary>
-    /// As claimed by tokens in userSecret. Looks like it corresponds to `userId` in PT Registry project members
-    /// query.
-    /// </summary>
-    private static string GetParatextUserId(UserSecret userSecret)
-    {
-        if (userSecret.ParatextTokens is null)
-            return string.Empty;
-        var accessToken = new JwtSecurityToken(userSecret.ParatextTokens.AccessToken);
-        Claim? claim = accessToken.Claims.FirstOrDefault(c => c.Type == "sub");
-        return claim?.Value ?? string.Empty;
     }
 }

--- a/src/Migrations/MachineApiMigration/MachineApiMigrator.cs
+++ b/src/Migrations/MachineApiMigration/MachineApiMigrator.cs
@@ -1,4 +1,5 @@
 using Microsoft.FeatureManagement;
+using SIL.ObjectModel;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
@@ -9,12 +10,17 @@ namespace MachineApiMigration;
 /// <summary>
 /// Migrates all projects to the new Machine API, if translation is enabled.
 /// </summary>
-public class MachineApiMigrator
+public class MachineApiMigrator : DisposableBase
 {
     /// <summary>
     /// The feature manager.
     /// </summary>
     private readonly IFeatureManager _featureManager;
+
+    /// <summary>
+    /// The HTTP client to test if the Machine API is accessible.
+    /// </summary>
+    private readonly HttpClient _httpClient;
 
     /// <summary>
     /// The Machine project service.
@@ -35,23 +41,26 @@ public class MachineApiMigrator
     /// Initializes a new instance of the <see cref="MachineApiMigrator" /> class.
     /// </summary>
     /// <param name="featureManager">The feature manager.</param>
+    /// <param name="httpClientFactory">The HTTP client factory.</param>
     /// <param name="machineProjectService">The Machine project service.</param>
     /// <param name="projectSecrets">The SF project secrets repository.</param>
     /// <param name="realtimeService">The realtime service.</param>
     public MachineApiMigrator(
         IFeatureManager featureManager,
+        IHttpClientFactory httpClientFactory,
         IMachineProjectService machineProjectService,
         IRepository<SFProjectSecret> projectSecrets,
         IRealtimeService realtimeService
     )
     {
         _featureManager = featureManager;
+        _httpClient = httpClientFactory.CreateClient(MachineServiceBase.ClientName);
         _machineProjectService = machineProjectService;
         _projectSecrets = projectSecrets;
         _realtimeService = realtimeService;
     }
 
-    public async Task MigrateAllProjectsAsync(
+    public async Task<bool> MigrateAllProjectsAsync(
         bool doWrite,
         ICollection<string> sfProjectIdsToMigrate,
         IDictionary<string, string> sfAdminsToUse,
@@ -62,13 +71,20 @@ public class MachineApiMigrator
         if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
         {
             Program.Log("ERROR: Cannot proceed. The Machine API feature flag is disabled.");
-            return;
+            return false;
         }
 
         if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
         {
             Program.Log("ERROR: Cannot proceed. The In-Process Machine feature flag is enabled.");
-            return;
+            return false;
+        }
+
+        // Validate that the Machine API is accessible
+        if (!await IsMachineApiAccessible(cancellationToken))
+        {
+            Program.Log("ERROR: Cannot proceed. The Machine API is not accessible.");
+            return false;
         }
 
         // Get all projects that have translation suggestions enabled, and are not configured for the Machine API
@@ -149,6 +165,40 @@ public class MachineApiMigrator
                 // We do not need to iterate any longer (the continue statements above ensure the correct user is used)
                 break;
             }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Disposes managed resources.
+    /// </summary>
+    protected override void DisposeManagedResources()
+    {
+        _httpClient.Dispose();
+    }
+
+    /// <summary>
+    /// Checks if the Machine API returns a valid response
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <returns><c>true</c> if the Machine API was successfully accessed; otherwise <c>false</c>.</returns>
+    private async Task<bool> IsMachineApiAccessible(CancellationToken cancellationToken)
+    {
+        Program.Log("Checking if the Machine API is accessible...");
+        try
+        {
+            using var response = await _httpClient.GetAsync(
+                "translation-engines/",
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken
+            );
+            return response.IsSuccessStatusCode;
+        }
+        catch (Exception e)
+        {
+            Program.Log(e.ToString());
+            return false;
         }
     }
 }

--- a/src/Migrations/MachineApiMigration/MigratorFeatureSessionManager.cs
+++ b/src/Migrations/MachineApiMigration/MigratorFeatureSessionManager.cs
@@ -1,0 +1,26 @@
+using Microsoft.FeatureManagement;
+using SIL.XForge.Scripture.Models;
+
+namespace MachineApiMigration;
+
+/// <summary>
+/// This feature filter enables the Machine API and disabled the In-Process Machine.
+/// </summary>
+public class MigratorFeatureSessionManager : ISessionManager
+{
+    /// <inheritdoc />
+    public Task SetAsync(string featureName, bool enabled) => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task<bool?> GetAsync(string featureName)
+    {
+        return Task.FromResult<bool?>(
+            featureName switch
+            {
+                FeatureFlags.MachineApi => true,
+                FeatureFlags.MachineInProcess => false,
+                _ => null,
+            }
+        );
+    }
+}

--- a/src/Migrations/MachineApiMigration/Program.cs
+++ b/src/Migrations/MachineApiMigration/Program.cs
@@ -79,7 +79,7 @@ public class Program
 
         // Migrate all projects to the new Machine API
         var machineApiMigrator = webHost.Services.GetService<MachineApiMigrator>();
-        await machineApiMigrator!.MigrateAllProjectsAsync(
+        bool success = await machineApiMigrator!.MigrateAllProjectsAsync(
             doWrite,
             sfProjectIdsToMigrate,
             sfAdminsToUse,
@@ -91,7 +91,7 @@ public class Program
         await webHost.StopAsync();
 
         Log(string.Empty);
-        Log("Finished Migration.");
+        Log(success ? "Finished Migration." : "Migration Failed.");
     }
 
     internal static void Log(string message)

--- a/src/Migrations/MachineApiMigration/Program.cs
+++ b/src/Migrations/MachineApiMigration/Program.cs
@@ -1,0 +1,144 @@
+using System.Diagnostics;
+using System.Reflection;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using SIL.XForge.Scripture.Services;
+
+namespace MachineApiMigration;
+
+/// <summary>
+/// The Machine API migration program.
+/// </summary>
+public class Program
+{
+    /// <summary>
+    /// Gets a value indicating whether to disable migrations.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if migrations are disabled; otherwise, <c>false</c>.
+    /// </value>
+    /// <remarks>
+    /// This exists for the <see cref="Startup" /> class to retrieve this value.
+    /// </remarks>
+    public static bool MigrationsDisabled { get; private set; }
+
+    /// <summary>
+    /// Defines the entry point of the application.
+    /// </summary>
+    /// <param name="args">The arguments.</param>
+    public static async Task Main(string[] args)
+    {
+        bool doWrite = (args.Length >= 1 ? args[0] : string.Empty) == "run";
+        MigrationsDisabled = !doWrite;
+        string sfAppDir = args.Length >= 2 ? args[1] : string.Empty;
+        string? sfProjectIdsSubset = Environment.GetEnvironmentVariable("SYNC_SET");
+        string? sfAdminRequestValues = Environment.GetEnvironmentVariable("SF_PROJECT_ADMINS");
+        if (string.IsNullOrWhiteSpace(sfAppDir))
+        {
+            // This calculated from "web-xforge\src\Migrations\MachineApiMigration\bin\Debug\net6.0"
+            sfAppDir = Environment.GetEnvironmentVariable("SF_APP_DIR") ?? "../../../../../SIL.XForge.Scripture";
+        }
+
+        Log("Migrate Projects to Machine API.");
+
+        if (!doWrite)
+        {
+            Log("Test Mode ONLY - no files are changed. Run `MachineApiMigration run` to change files.");
+            Log(string.Empty);
+        }
+
+        // Set up the web host, and start the real time server
+        Log("Starting Scripture Forge Server...");
+        Directory.SetCurrentDirectory(sfAppDir);
+        IWebHostBuilder builder = CreateWebHostBuilder(args);
+        IWebHost webHost = builder.Build();
+        try
+        {
+            await webHost.StartAsync();
+        }
+        catch (HttpRequestException)
+        {
+            Log(
+                "There was an error starting the program before getting to the migration"
+                    + " part. Maybe the SF server is running and needs shut down? Rethrowing."
+            );
+            throw;
+        }
+
+        // Get the project IDs and admin IDs, if they were set in the environment variables
+        string[] sfProjectIdsToMigrate = sfProjectIdsSubset?.Split(' ') ?? Array.Empty<string>();
+        Dictionary<string, string> sfAdminsToUse = new Dictionary<string, string>();
+        foreach (string sfAdminRequest in sfAdminRequestValues?.Split(' ') ?? Array.Empty<string>())
+        {
+            string[] request = sfAdminRequest.Split(':');
+            sfAdminsToUse.Add(request[0], request[1]);
+        }
+
+        // Migrate all projects to the new Machine API
+        var machineApiMigrator = webHost.Services.GetService<MachineApiMigrator>();
+        await machineApiMigrator!.MigrateAllProjectsAsync(
+            doWrite,
+            sfProjectIdsToMigrate,
+            sfAdminsToUse,
+            CancellationToken.None
+        );
+
+        // Stop the web host and real time server
+        Log("Stopping Scripture Forge Server...");
+        await webHost.StopAsync();
+
+        Log(string.Empty);
+        Log("Finished Migration.");
+    }
+
+    internal static void Log(string message)
+    {
+        string when = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+        Console.WriteLine(@$"{when} MachineApiMigration: {message}");
+#if DEBUG
+        Debug.WriteLine($"{when} MachineApiMigration: {message}");
+#endif
+    }
+
+    private static IWebHostBuilder CreateWebHostBuilder(string[] args)
+    {
+        IWebHostBuilder builder = WebHost.CreateDefaultBuilder(args);
+
+        // Secrets to connect to PT web API are associated with the SIL.XForge.Scripture assembly
+        var sfAssembly = Assembly.GetAssembly(typeof(ParatextService));
+
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddUserSecrets(sfAssembly)
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .Build();
+
+        return builder
+            .ConfigureAppConfiguration(
+                (context, config) =>
+                {
+                    IWebHostEnvironment env = context.HostingEnvironment;
+                    if (env.IsDevelopment() || env.IsEnvironment("Testing"))
+                    {
+                        config.AddJsonFile("appsettings.user.json", true);
+                    }
+                    else
+                    {
+                        config.AddJsonFile("secrets.json", true, true);
+                    }
+
+                    if (env.IsEnvironment("Testing"))
+                    {
+                        var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
+                        config.AddUserSecrets(appAssembly, true);
+                    }
+
+                    config.AddEnvironmentVariables();
+                }
+            )
+            .UseConfiguration(configuration)
+            .UseStartup<Startup>();
+    }
+}

--- a/src/Migrations/MachineApiMigration/Properties/launchSettings.json
+++ b/src/Migrations/MachineApiMigration/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "MachineApiMigration": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Migrations/MachineApiMigration/Startup.cs
+++ b/src/Migrations/MachineApiMigration/Startup.cs
@@ -1,0 +1,124 @@
+using System.Globalization;
+using Autofac;
+using Autofac.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.FeatureManagement;
+using SIL.XForge.Configuration;
+using SIL.XForge.Scripture;
+
+namespace MachineApiMigration;
+
+/// <summary>
+/// Configurations and services needed to bootstrap the Machine API Migration app.
+/// This was copied and modified from `SIL.XForge.Scripture/Startup.cs`.
+/// </summary>
+public class Startup
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Startup"/> class.
+    /// </summary>
+    /// <param name="configuration">The configuration.</param>
+    /// <param name="env">The env.</param>
+    /// <param name="loggerFactory">The logger factory.</param>
+    public Startup(IConfiguration configuration, IWebHostEnvironment env, ILoggerFactory loggerFactory)
+    {
+        Configuration = configuration;
+        Environment = env;
+        LoggerFactory = loggerFactory;
+    }
+
+    /// <summary>
+    /// Gets the configuration.
+    /// </summary>
+    /// <value>
+    /// The configuration.
+    /// </value>
+    public IConfiguration Configuration { get; }
+
+    /// <summary>
+    /// Gets the environment.
+    /// </summary>
+    /// <value>
+    /// The environment.
+    /// </value>
+    public IWebHostEnvironment Environment { get; }
+
+    /// <summary>
+    /// Gets the logger factory.
+    /// </summary>
+    /// <value>
+    /// The logger factory.
+    /// </value>
+    public ILoggerFactory LoggerFactory { get; }
+
+    /// <summary>
+    /// Gets the application container.
+    /// </summary>
+    /// <value>
+    /// The application container.
+    /// </value>
+    public IContainer? ApplicationContainer { get; private set; }
+
+    /// <summary>
+    /// Configures the services.
+    /// </summary>
+    /// <param name="services">The services.</param>
+    /// <returns>The service provider.</returns>
+    public IServiceProvider ConfigureServices(IServiceCollection services)
+    {
+        var containerBuilder = new ContainerBuilder();
+
+        services.AddExceptionReporting(Configuration);
+        services.AddConfiguration(Configuration);
+        services.AddFeatureManagement(Configuration).AddSessionManager<MigratorFeatureSessionManager>();
+        services.AddSFRealtimeServer(LoggerFactory, Configuration, nodeOptions: null, Program.MigrationsDisabled);
+        services.AddSFServices();
+        services.AddSFDataAccess(Configuration);
+        services.Configure<RequestLocalizationOptions>(opts =>
+        {
+            var supportedCultures = new List<CultureInfo>();
+            foreach (var culture in SharedResource.Cultures)
+            {
+                supportedCultures.Add(new CultureInfo(culture.Key));
+            }
+
+            opts.DefaultRequestCulture = new RequestCulture("en");
+            // Formatting numbers, dates, etc.
+            opts.SupportedCultures = supportedCultures;
+            // UI strings that we localized.
+            opts.SupportedUICultures = supportedCultures;
+        });
+        services.AddLocalization(options => options.ResourcesPath = "Resources");
+        services.AddSFMachine(Configuration, Environment);
+
+        services.AddSingleton<MachineApiMigrator>();
+
+        containerBuilder.Populate(services);
+        ApplicationContainer = containerBuilder.Build();
+        return new AutofacServiceProvider(ApplicationContainer);
+    }
+
+    /// <summary>
+    /// Configures the specified application.
+    /// </summary>
+    /// <param name="app">The application.</param>
+    /// <param name="appLifetime">The application lifetime.</param>
+    public void Configure(IApplicationBuilder app, IHostApplicationLifetime appLifetime)
+    {
+        Program.Log(@"Configuring app");
+        // Set a custom realtime port using the Realtime__Port environment variable
+        string realtimePort = Configuration["Realtime:Port"];
+        Program.Log(@$"Realtime:Port : {realtimePort}");
+        app.UseRealtimeServer();
+        app.UseSFDataAccess();
+        app.UseSFServices();
+        app.UseMachine();
+        appLifetime.ApplicationStopped.Register(() => ApplicationContainer?.Dispose());
+    }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/machine-http-client.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/machine-http-client.ts
@@ -4,7 +4,7 @@ import { HttpClient, HttpResponse } from '@sillsdev/machine';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-export const MACHINE_API_BASE_URL = 'machine-api/';
+export const MACHINE_API_BASE_URL = 'machine-api/v1/';
 
 @Injectable({
   providedIn: 'root'

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/machine-http-client.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/machine-http-client.ts
@@ -4,7 +4,7 @@ import { HttpClient, HttpResponse } from '@sillsdev/machine';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-export const MACHINE_API_BASE_URL = 'machine-api/v1/';
+export const MACHINE_API_BASE_URL = 'machine-api/v2/';
 
 @Injectable({
   providedIn: 'root'

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
@@ -128,6 +128,32 @@ describe('ExceptionHandlingService', () => {
     expect().nothing();
   }));
 
+  it('should silently report 503 errors from machine-api', fakeAsync(() => {
+    const env = new TestEnvironment();
+    spyOn<any>(env.service, 'handleAlert');
+
+    env.handleError(
+      new HttpErrorResponse({
+        status: 503,
+        statusText: 'Service Unavailable',
+        url: 'http://localhost:5000/machine-api/v1/translation/engines/some-end-point'
+      })
+    );
+
+    expect(env.service['handleAlert']).not.toHaveBeenCalled();
+
+    env.handleError(
+      new HttpErrorResponse({
+        status: 503,
+        statusText: 'Service Unavailable',
+        url: 'http://localhost:5000/command-api/some-end-point'
+      })
+    );
+
+    expect(env.service['handleAlert']).toHaveBeenCalled();
+    verify(mockedNoticeService.showError(anything())).never();
+  }));
+
   it('should silently report 504 errors from machine-api or command-api', fakeAsync(() => {
     const env = new TestEnvironment();
     spyOn<any>(env.service, 'handleAlert');

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
@@ -128,32 +128,6 @@ describe('ExceptionHandlingService', () => {
     expect().nothing();
   }));
 
-  it('should silently report 503 errors from machine-api', fakeAsync(() => {
-    const env = new TestEnvironment();
-    spyOn<any>(env.service, 'handleAlert');
-
-    env.handleError(
-      new HttpErrorResponse({
-        status: 503,
-        statusText: 'Service Unavailable',
-        url: 'http://localhost:5000/machine-api/v2/translation/engines/some-end-point'
-      })
-    );
-
-    expect(env.service['handleAlert']).not.toHaveBeenCalled();
-
-    env.handleError(
-      new HttpErrorResponse({
-        status: 503,
-        statusText: 'Service Unavailable',
-        url: 'http://localhost:5000/command-api/some-end-point'
-      })
-    );
-
-    expect(env.service['handleAlert']).toHaveBeenCalled();
-    verify(mockedNoticeService.showError(anything())).never();
-  }));
-
   it('should silently report 504 errors from machine-api or command-api', fakeAsync(() => {
     const env = new TestEnvironment();
     spyOn<any>(env.service, 'handleAlert');

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
@@ -40,7 +40,7 @@ class MockConsole {
         'Original error',
         'Http failure response for (unknown url): 400 Bad Request',
         'Http failure response for http://localhost:5000/command-api/some-end-point: 504 Gateway Timeout',
-        'Http failure response for http://localhost:5000/machine-api/translation/engines/some-end-point: 504 Gateway Timeout'
+        'Http failure response for http://localhost:5000/machine-api/v1/translation/engines/some-end-point: 504 Gateway Timeout'
       ].includes(val.message) &&
       !val.message?.startsWith('Unknown error')
     ) {
@@ -136,7 +136,7 @@ describe('ExceptionHandlingService', () => {
       new HttpErrorResponse({
         status: 504,
         statusText: 'Gateway Timeout',
-        url: 'http://localhost:5000/machine-api/translation/engines/some-end-point'
+        url: 'http://localhost:5000/machine-api/v1/translation/engines/some-end-point'
       })
     );
     env.handleError(

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
@@ -40,7 +40,7 @@ class MockConsole {
         'Original error',
         'Http failure response for (unknown url): 400 Bad Request',
         'Http failure response for http://localhost:5000/command-api/some-end-point: 504 Gateway Timeout',
-        'Http failure response for http://localhost:5000/machine-api/v1/translation/engines/some-end-point: 504 Gateway Timeout'
+        'Http failure response for http://localhost:5000/machine-api/v2/translation/engines/some-end-point: 504 Gateway Timeout'
       ].includes(val.message) &&
       !val.message?.startsWith('Unknown error')
     ) {
@@ -136,7 +136,7 @@ describe('ExceptionHandlingService', () => {
       new HttpErrorResponse({
         status: 503,
         statusText: 'Service Unavailable',
-        url: 'http://localhost:5000/machine-api/v1/translation/engines/some-end-point'
+        url: 'http://localhost:5000/machine-api/v2/translation/engines/some-end-point'
       })
     );
 
@@ -162,7 +162,7 @@ describe('ExceptionHandlingService', () => {
       new HttpErrorResponse({
         status: 504,
         statusText: 'Gateway Timeout',
-        url: 'http://localhost:5000/machine-api/v1/translation/engines/some-end-point'
+        url: 'http://localhost:5000/machine-api/v2/translation/engines/some-end-point'
       })
     );
     env.handleError(

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
@@ -196,6 +196,21 @@ export class ExceptionHandlingService extends BugsnagErrorHandler {
     }
 
     if (
+      error instanceof HttpErrorResponse &&
+      error.status === 503 &&
+      error.statusText === 'Service Unavailable' &&
+      error.url != null
+    ) {
+      // ignore 503 errors from ngsw-worker.js to machine-api,
+      // as the machine API is down and we do not want to interrupt the user's word
+      const url = new URL(error.url);
+      if (url.pathname.startsWith('/' + MACHINE_API_BASE_URL)) {
+        silently = true;
+      }
+    }
+
+    if (
+      typeof error === 'object' &&
       // these are the properties Bugsnag checks for, and will have problems if they don't exist
       !(
         (hasStringProp(error, 'name') || hasStringProp(error, 'errorClass')) &&

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
@@ -196,20 +196,6 @@ export class ExceptionHandlingService extends BugsnagErrorHandler {
     }
 
     if (
-      error instanceof HttpErrorResponse &&
-      error.status === 503 &&
-      error.statusText === 'Service Unavailable' &&
-      error.url != null
-    ) {
-      // ignore 503 errors from ngsw-worker.js to machine-api,
-      // as the machine API is down and we do not want to interrupt the user's word
-      const url = new URL(error.url);
-      if (url.pathname.startsWith('/' + MACHINE_API_BASE_URL)) {
-        silently = true;
-      }
-    }
-
-    if (
       // these are the properties Bugsnag checks for, and will have problems if they don't exist
       !(
         (hasStringProp(error, 'name') || hasStringProp(error, 'errorClass')) &&

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
@@ -210,7 +210,6 @@ export class ExceptionHandlingService extends BugsnagErrorHandler {
     }
 
     if (
-      typeof error === 'object' &&
       // these are the properties Bugsnag checks for, and will have problems if they don't exist
       !(
         (hasStringProp(error, 'name') || hasStringProp(error, 'errorClass')) &&

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -72,6 +72,33 @@ namespace SIL.XForge.Scripture.Controllers
             }
         }
 
+        [HttpGet(MachineApi.GetEngine)]
+        public async Task<ActionResult<EngineDto>> GetEngineAsync(string projectId, CancellationToken cancellationToken)
+        {
+            try
+            {
+                EngineDto engine = await _machineApiService.GetEngineAsync(
+                    _userAccessor.UserId,
+                    projectId,
+                    cancellationToken
+                );
+                return Ok(engine);
+            }
+            catch (BrokenCircuitException e)
+            {
+                _exceptionHandler.ReportException(e);
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
+            }
+            catch (DataNotFoundException)
+            {
+                return NotFound();
+            }
+            catch (ForbiddenException)
+            {
+                return Forbid();
+            }
+        }
+
         [HttpPost(MachineApi.GetWordGraph)]
         public async Task<ActionResult<WordGraphDto>> GetWordGraphAsync(
             string projectId,
@@ -134,17 +161,22 @@ namespace SIL.XForge.Scripture.Controllers
             }
         }
 
-        [HttpGet(MachineApi.GetEngine)]
-        public async Task<ActionResult<EngineDto>> GetEngineAsync(string projectId, CancellationToken cancellationToken)
+        [HttpPost(MachineApi.TrainSegment)]
+        public async Task<ActionResult> TrainSegmentAsync(
+            string projectId,
+            [FromBody] SegmentPairDto segmentPair,
+            CancellationToken cancellationToken
+        )
         {
             try
             {
-                EngineDto engine = await _machineApiService.GetEngineAsync(
+                await _machineApiService.TrainSegmentAsync(
                     _userAccessor.UserId,
                     projectId,
+                    segmentPair,
                     cancellationToken
                 );
-                return Ok(engine);
+                return Ok();
             }
             catch (BrokenCircuitException e)
             {

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -35,7 +35,7 @@ namespace SIL.XForge.Scripture.Controllers
 
         [HttpGet(MachineApi.GetBuild)]
         public async Task<ActionResult<BuildDto?>> GetBuildAsync(
-            string projectId,
+            string sfProjectId,
             string? buildId,
             [FromQuery] int? minRevision,
             CancellationToken cancellationToken
@@ -50,7 +50,7 @@ namespace SIL.XForge.Scripture.Controllers
                     {
                         build = await _machineApiService.GetCurrentBuildAsync(
                             _userAccessor.UserId,
-                            projectId,
+                            sfProjectId,
                             minRevision,
                             cancellationToken
                         );
@@ -59,7 +59,7 @@ namespace SIL.XForge.Scripture.Controllers
                     {
                         build = await _machineApiService.GetBuildAsync(
                             _userAccessor.UserId,
-                            projectId,
+                            sfProjectId,
                             buildId,
                             minRevision,
                             cancellationToken
@@ -95,13 +95,16 @@ namespace SIL.XForge.Scripture.Controllers
         }
 
         [HttpGet(MachineApi.GetEngine)]
-        public async Task<ActionResult<EngineDto>> GetEngineAsync(string projectId, CancellationToken cancellationToken)
+        public async Task<ActionResult<EngineDto>> GetEngineAsync(
+            string sfProjectId,
+            CancellationToken cancellationToken
+        )
         {
             try
             {
                 EngineDto engine = await _machineApiService.GetEngineAsync(
                     _userAccessor.UserId,
-                    projectId,
+                    sfProjectId,
                     cancellationToken
                 );
                 return Ok(engine);
@@ -123,7 +126,7 @@ namespace SIL.XForge.Scripture.Controllers
 
         [HttpPost(MachineApi.GetWordGraph)]
         public async Task<ActionResult<WordGraphDto>> GetWordGraphAsync(
-            string projectId,
+            string sfProjectId,
             [FromBody] string[] segment,
             CancellationToken cancellationToken
         )
@@ -132,7 +135,7 @@ namespace SIL.XForge.Scripture.Controllers
             {
                 WordGraphDto wordGraph = await _machineApiService.GetWordGraphAsync(
                     _userAccessor.UserId,
-                    projectId,
+                    sfProjectId,
                     segment,
                     cancellationToken
                 );
@@ -155,7 +158,7 @@ namespace SIL.XForge.Scripture.Controllers
 
         [HttpPost(MachineApi.StartBuild)]
         public async Task<ActionResult<BuildDto>> StartBuildAsync(
-            [FromBody] string projectId,
+            [FromBody] string sfProjectId,
             CancellationToken cancellationToken
         )
         {
@@ -163,7 +166,7 @@ namespace SIL.XForge.Scripture.Controllers
             {
                 BuildDto build = await _machineApiService.StartBuildAsync(
                     _userAccessor.UserId,
-                    projectId,
+                    sfProjectId,
                     cancellationToken
                 );
                 return Ok(build);
@@ -185,7 +188,7 @@ namespace SIL.XForge.Scripture.Controllers
 
         [HttpPost(MachineApi.TrainSegment)]
         public async Task<ActionResult> TrainSegmentAsync(
-            string projectId,
+            string sfProjectId,
             [FromBody] SegmentPairDto segmentPair,
             CancellationToken cancellationToken
         )
@@ -194,7 +197,7 @@ namespace SIL.XForge.Scripture.Controllers
             {
                 await _machineApiService.TrainSegmentAsync(
                     _userAccessor.UserId,
-                    projectId,
+                    sfProjectId,
                     segmentPair,
                     cancellationToken
                 );
@@ -217,7 +220,7 @@ namespace SIL.XForge.Scripture.Controllers
 
         [HttpPost(MachineApi.Translate)]
         public async Task<ActionResult<TranslationResultDto>> TranslateAsync(
-            string projectId,
+            string sfProjectId,
             [FromBody] string[] segment,
             CancellationToken cancellationToken
         )
@@ -226,7 +229,7 @@ namespace SIL.XForge.Scripture.Controllers
             {
                 TranslationResultDto translationResult = await _machineApiService.TranslateAsync(
                     _userAccessor.UserId,
-                    projectId,
+                    sfProjectId,
                     segment,
                     cancellationToken
                 );
@@ -249,7 +252,7 @@ namespace SIL.XForge.Scripture.Controllers
 
         [HttpPost(MachineApi.TranslateN)]
         public async Task<ActionResult<TranslationResultDto[]>> TranslateNAsync(
-            string projectId,
+            string sfProjectId,
             int n,
             [FromBody] string[] segment,
             CancellationToken cancellationToken
@@ -259,7 +262,7 @@ namespace SIL.XForge.Scripture.Controllers
             {
                 TranslationResultDto[] translationResults = await _machineApiService.TranslateNAsync(
                     _userAccessor.UserId,
-                    projectId,
+                    sfProjectId,
                     n,
                     segment,
                     cancellationToken

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -214,5 +214,71 @@ namespace SIL.XForge.Scripture.Controllers
                 return Forbid();
             }
         }
+
+        [HttpPost(MachineApi.Translate)]
+        public async Task<ActionResult<TranslationResultDto>> TranslateAsync(
+            string projectId,
+            [FromBody] string[] segment,
+            CancellationToken cancellationToken
+        )
+        {
+            try
+            {
+                TranslationResultDto translationResult = await _machineApiService.TranslateAsync(
+                    _userAccessor.UserId,
+                    projectId,
+                    segment,
+                    cancellationToken
+                );
+                return Ok(translationResult);
+            }
+            catch (BrokenCircuitException e)
+            {
+                _exceptionHandler.ReportException(e);
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
+            }
+            catch (DataNotFoundException)
+            {
+                return NotFound();
+            }
+            catch (ForbiddenException)
+            {
+                return Forbid();
+            }
+        }
+
+        [HttpPost(MachineApi.TranslateN)]
+        public async Task<ActionResult<TranslationResultDto[]>> TranslateNAsync(
+            string projectId,
+            int n,
+            [FromBody] string[] segment,
+            CancellationToken cancellationToken
+        )
+        {
+            try
+            {
+                TranslationResultDto[] translationResults = await _machineApiService.TranslateNAsync(
+                    _userAccessor.UserId,
+                    projectId,
+                    n,
+                    segment,
+                    cancellationToken
+                );
+                return Ok(translationResults);
+            }
+            catch (BrokenCircuitException e)
+            {
+                _exceptionHandler.ReportException(e);
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
+            }
+            catch (DataNotFoundException)
+            {
+                return NotFound();
+            }
+            catch (ForbiddenException)
+            {
+                return Forbid();
+            }
+        }
     }
 }

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -1,0 +1,57 @@
+using System.Security;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SIL.Machine.WebApi;
+using SIL.XForge.Scripture.Models;
+using SIL.XForge.Scripture.Services;
+using SIL.XForge.Services;
+
+namespace SIL.XForge.Scripture.Controllers
+{
+    [Route(MachineApi.Namespace)]
+    [ApiController]
+    [Authorize]
+    public class MachineApiController : ControllerBase
+    {
+        private readonly IMachineApiService _machineApiService;
+        private readonly IUserAccessor _userAccessor;
+
+        public MachineApiController(
+            IExceptionHandler exceptionHandler,
+            IMachineApiService machineApiService,
+            IUserAccessor userAccessor
+        )
+        {
+            _machineApiService = machineApiService;
+            _userAccessor = userAccessor;
+            exceptionHandler.RecordUserIdForException(_userAccessor.UserId);
+        }
+
+        [HttpGet(MachineApi.GetEngine)]
+        public async Task<ActionResult<MachineApiTranslationEngine>> GetEngineAsync(
+            string projectId,
+            CancellationToken cancellationToken
+        )
+        {
+            try
+            {
+                EngineDto engine = await _machineApiService.GetEngineAsync(
+                    _userAccessor.UserId,
+                    projectId,
+                    cancellationToken
+                );
+                return Ok(engine);
+            }
+            catch (DataNotFoundException)
+            {
+                return NoContent();
+            }
+            catch (SecurityException)
+            {
+                return NoContent();
+            }
+        }
+    }
+}

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -42,12 +42,20 @@ namespace SIL.XForge.Scripture.Controllers
         {
             try
             {
-                BuildDto? build = await _machineApiService.GetBuildAsync(
-                    _userAccessor.UserId,
-                    projectId,
-                    minRevision,
-                    cancellationToken
-                );
+                BuildDto? build;
+                try
+                {
+                    build = await _machineApiService.GetCurrentBuildAsync(
+                        _userAccessor.UserId,
+                        projectId,
+                        minRevision,
+                        cancellationToken
+                    );
+                }
+                catch (DataNotFoundException)
+                {
+                    return NotFound();
+                }
 
                 // A null means no build is running
                 if (build is null)

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -36,6 +36,7 @@ namespace SIL.XForge.Scripture.Controllers
         [HttpGet(MachineApi.GetBuild)]
         public async Task<ActionResult<BuildDto?>> GetBuildAsync(
             string projectId,
+            string? buildId,
             [FromQuery] int? minRevision,
             CancellationToken cancellationToken
         )
@@ -45,12 +46,25 @@ namespace SIL.XForge.Scripture.Controllers
                 BuildDto? build;
                 try
                 {
-                    build = await _machineApiService.GetCurrentBuildAsync(
-                        _userAccessor.UserId,
-                        projectId,
-                        minRevision,
-                        cancellationToken
-                    );
+                    if (string.IsNullOrWhiteSpace(buildId))
+                    {
+                        build = await _machineApiService.GetCurrentBuildAsync(
+                            _userAccessor.UserId,
+                            projectId,
+                            minRevision,
+                            cancellationToken
+                        );
+                    }
+                    else
+                    {
+                        build = await _machineApiService.GetBuildAsync(
+                            _userAccessor.UserId,
+                            projectId,
+                            buildId,
+                            minRevision,
+                            cancellationToken
+                        );
+                    }
                 }
                 catch (DataNotFoundException)
                 {

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -44,31 +44,24 @@ namespace SIL.XForge.Scripture.Controllers
             try
             {
                 BuildDto? build;
-                try
+                if (string.IsNullOrWhiteSpace(buildId))
                 {
-                    if (string.IsNullOrWhiteSpace(buildId))
-                    {
-                        build = await _machineApiService.GetCurrentBuildAsync(
-                            _userAccessor.UserId,
-                            sfProjectId,
-                            minRevision,
-                            cancellationToken
-                        );
-                    }
-                    else
-                    {
-                        build = await _machineApiService.GetBuildAsync(
-                            _userAccessor.UserId,
-                            sfProjectId,
-                            buildId,
-                            minRevision,
-                            cancellationToken
-                        );
-                    }
+                    build = await _machineApiService.GetCurrentBuildAsync(
+                        _userAccessor.UserId,
+                        sfProjectId,
+                        minRevision,
+                        cancellationToken
+                    );
                 }
-                catch (DataNotFoundException)
+                else
                 {
-                    return NotFound();
+                    build = await _machineApiService.GetBuildAsync(
+                        _userAccessor.UserId,
+                        sfProjectId,
+                        buildId,
+                        minRevision,
+                        cancellationToken
+                    );
                 }
 
                 // A null means no build is running

--- a/src/SIL.XForge.Scripture/Models/FeatureFlags.cs
+++ b/src/SIL.XForge.Scripture/Models/FeatureFlags.cs
@@ -6,5 +6,6 @@ namespace SIL.XForge.Scripture.Models
     public static class FeatureFlags
     {
         public const string MachineApi = "MachineApi";
+        public const string MachineInMemory = "MachineInMemory";
     }
 }

--- a/src/SIL.XForge.Scripture/Models/FeatureFlags.cs
+++ b/src/SIL.XForge.Scripture/Models/FeatureFlags.cs
@@ -6,6 +6,6 @@ namespace SIL.XForge.Scripture.Models
     public static class FeatureFlags
     {
         public const string MachineApi = "MachineApi";
-        public const string MachineInMemory = "MachineInMemory";
+        public const string MachineInProcess = "MachineInProcess";
     }
 }

--- a/src/SIL.XForge.Scripture/Models/MachineApi.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApi.cs
@@ -4,13 +4,19 @@ namespace SIL.XForge.Scripture.Models
     {
         public const string Namespace = "machine-api/v2";
         public const string StartBuild = "translation/builds";
-        public const string GetBuild = "translation/builds/{reference}:{projectId}";
+        public const string GetBuild = "translation/builds/{reference}:{projectId}.{buildId?}";
         public const string GetEngine = "translation/engines/project:{projectId}";
         public const string GetWordGraph = "translation/engines/project:{projectId}/actions/getWordGraph";
         public const string TrainSegment = "translation/engines/project:{projectId}/actions/trainSegment";
 
-        public static string GetBuildHref(string projectId) =>
-            $"{Namespace}/{GetBuild.Replace("{projectId}", projectId).Replace("{reference}", "id")}";
+        public static string GetBuildHref(string projectId, string buildId)
+        {
+            string buildHref = GetBuild
+                .Replace("{projectId}", projectId)
+                .Replace("{buildId?}", buildId)
+                .Replace("{reference}", "id");
+            return $"{Namespace}/{buildHref}";
+        }
 
         public static string GetEngineHref(string projectId) =>
             $"{Namespace}/{GetEngine.Replace("{projectId}", projectId)}";

--- a/src/SIL.XForge.Scripture/Models/MachineApi.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApi.cs
@@ -1,26 +1,30 @@
 namespace SIL.XForge.Scripture.Models
 {
+    /// <summary>
+    /// Machine API URL strings and helper methods.
+    /// </summary>
     public static class MachineApi
     {
         public const string Namespace = "machine-api/v2";
         public const string StartBuild = "translation/builds";
-        public const string GetBuild = "translation/builds/{reference}:{projectId}.{buildId?}";
-        public const string GetEngine = "translation/engines/project:{projectId}";
-        public const string GetWordGraph = "translation/engines/project:{projectId}/actions/getWordGraph";
-        public const string TrainSegment = "translation/engines/project:{projectId}/actions/trainSegment";
-        public const string Translate = "translation/engines/project:{projectId}/actions/translate";
-        public const string TranslateN = "translation/engines/project:{projectId}/actions/translate/{n}";
+        public const string GetBuild = "translation/builds/{locatorType}:{sfProjectId}.{buildId?}";
+        public const string GetEngine = "translation/engines/project:{sfProjectId}";
+        public const string GetWordGraph = "translation/engines/project:{sfProjectId}/actions/getWordGraph";
+        public const string TrainSegment = "translation/engines/project:{sfProjectId}/actions/trainSegment";
+        public const string Translate = "translation/engines/project:{sfProjectId}/actions/translate";
+        public const string TranslateN = "translation/engines/project:{sfProjectId}/actions/translate/{n}";
 
-        public static string GetBuildHref(string projectId, string buildId)
+        public static string GetBuildHref(string sfProjectId, string buildId)
         {
+            // The {locatorType} parameter is required to maintain compatibility with the v1 machine-api and machine.js
             string buildHref = GetBuild
-                .Replace("{projectId}", projectId)
+                .Replace("{sfProjectId}", sfProjectId)
                 .Replace("{buildId?}", buildId)
-                .Replace("{reference}", "id");
+                .Replace("{locatorType}", "id");
             return $"{Namespace}/{buildHref}";
         }
 
-        public static string GetEngineHref(string projectId) =>
-            $"{Namespace}/{GetEngine.Replace("{projectId}", projectId)}";
+        public static string GetEngineHref(string sfProjectId) =>
+            $"{Namespace}/{GetEngine.Replace("{sfProjectId}", sfProjectId)}";
     }
 }

--- a/src/SIL.XForge.Scripture/Models/MachineApi.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApi.cs
@@ -8,6 +8,8 @@ namespace SIL.XForge.Scripture.Models
         public const string GetEngine = "translation/engines/project:{projectId}";
         public const string GetWordGraph = "translation/engines/project:{projectId}/actions/getWordGraph";
         public const string TrainSegment = "translation/engines/project:{projectId}/actions/trainSegment";
+        public const string Translate = "translation/engines/project:{projectId}/actions/translate";
+        public const string TranslateN = "translation/engines/project:{projectId}/actions/translate/{n}";
 
         public static string GetBuildHref(string projectId, string buildId)
         {

--- a/src/SIL.XForge.Scripture/Models/MachineApi.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApi.cs
@@ -1,0 +1,11 @@
+namespace SIL.XForge.Scripture.Models
+{
+    public static class MachineApi
+    {
+        public const string Namespace = "machine-api/v2";
+        public const string GetEngine = "translation/engines/project:{projectId}";
+
+        public static string GetEngineHref(string projectId) =>
+            $"{Namespace}/{GetEngine.Replace("{projectId}", projectId)}";
+    }
+}

--- a/src/SIL.XForge.Scripture/Models/MachineApi.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApi.cs
@@ -7,6 +7,7 @@ namespace SIL.XForge.Scripture.Models
         public const string GetBuild = "translation/builds/{reference}:{projectId}";
         public const string GetEngine = "translation/engines/project:{projectId}";
         public const string GetWordGraph = "translation/engines/project:{projectId}/actions/getWordGraph";
+        public const string TrainSegment = "translation/engines/project:{projectId}/actions/trainSegment";
 
         public static string GetBuildHref(string projectId) =>
             $"{Namespace}/{GetBuild.Replace("{projectId}", projectId).Replace("{reference}", "id")}";

--- a/src/SIL.XForge.Scripture/Models/MachineApi.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApi.cs
@@ -3,7 +3,13 @@ namespace SIL.XForge.Scripture.Models
     public static class MachineApi
     {
         public const string Namespace = "machine-api/v2";
+        public const string StartBuild = "translation/builds";
+        public const string GetBuild = "translation/builds/{reference}:{projectId}";
         public const string GetEngine = "translation/engines/project:{projectId}";
+        public const string GetWordGraph = "translation/engines/project:{projectId}/actions/getWordGraph";
+
+        public static string GetBuildHref(string projectId) =>
+            $"{Namespace}/{GetBuild.Replace("{projectId}", projectId).Replace("{reference}", "id")}";
 
         public static string GetEngineHref(string projectId) =>
             $"{Namespace}/{GetEngine.Replace("{projectId}", projectId)}";

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -21,5 +21,11 @@ namespace SIL.XForge.Scripture.Services
             CancellationToken cancellationToken
         );
         Task<BuildDto> StartBuildAsync(string curUserId, string projectId, CancellationToken cancellationToken);
+        Task TrainSegmentAsync(
+            string curUserId,
+            string projectId,
+            SegmentPairDto segmentPair,
+            CancellationToken cancellationToken
+        );
     }
 }

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+
+namespace SIL.XForge.Scripture.Services
+{
+    using SIL.Machine.WebApi;
+    using System.Threading;
+
+    public interface IMachineApiService
+    {
+        Task<EngineDto> GetEngineAsync(string curUserId, string projectId, CancellationToken cancellationToken);
+    }
+}

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -1,12 +1,25 @@
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using SIL.Machine.WebApi;
 
 namespace SIL.XForge.Scripture.Services
 {
-    using SIL.Machine.WebApi;
-    using System.Threading;
-
     public interface IMachineApiService
     {
+        Task<BuildDto?> GetBuildAsync(
+            string curUserId,
+            string projectId,
+            long? minRevision,
+            CancellationToken cancellationToken
+        );
         Task<EngineDto> GetEngineAsync(string curUserId, string projectId, CancellationToken cancellationToken);
+        Task<WordGraphDto> GetWordGraphAsync(
+            string curUserId,
+            string projectId,
+            IEnumerable<string> segment,
+            CancellationToken cancellationToken
+        );
+        Task<BuildDto> StartBuildAsync(string curUserId, string projectId, CancellationToken cancellationToken);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -9,40 +9,40 @@ namespace SIL.XForge.Scripture.Services
     {
         Task<BuildDto?> GetBuildAsync(
             string curUserId,
-            string projectId,
+            string sfProjectId,
             string buildId,
             long? minRevision,
             CancellationToken cancellationToken
         );
         Task<BuildDto?> GetCurrentBuildAsync(
             string curUserId,
-            string projectId,
+            string sfProjectId,
             long? minRevision,
             CancellationToken cancellationToken
         );
-        Task<EngineDto> GetEngineAsync(string curUserId, string projectId, CancellationToken cancellationToken);
+        Task<EngineDto> GetEngineAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
         Task<WordGraphDto> GetWordGraphAsync(
             string curUserId,
-            string projectId,
+            string sfProjectId,
             IReadOnlyList<string> segment,
             CancellationToken cancellationToken
         );
-        Task<BuildDto> StartBuildAsync(string curUserId, string projectId, CancellationToken cancellationToken);
+        Task<BuildDto> StartBuildAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
         Task TrainSegmentAsync(
             string curUserId,
-            string projectId,
+            string sfProjectId,
             SegmentPairDto segmentPair,
             CancellationToken cancellationToken
         );
         Task<TranslationResultDto> TranslateAsync(
             string curUserId,
-            string projectId,
+            string sfProjectId,
             IReadOnlyList<string> segment,
             CancellationToken cancellationToken
         );
         Task<TranslationResultDto[]> TranslateNAsync(
             string curUserId,
-            string projectId,
+            string sfProjectId,
             int n,
             IReadOnlyList<string> segment,
             CancellationToken cancellationToken

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -24,7 +24,7 @@ namespace SIL.XForge.Scripture.Services
         Task<WordGraphDto> GetWordGraphAsync(
             string curUserId,
             string projectId,
-            IReadOnlyCollection<string> segment,
+            IReadOnlyList<string> segment,
             CancellationToken cancellationToken
         );
         Task<BuildDto> StartBuildAsync(string curUserId, string projectId, CancellationToken cancellationToken);
@@ -32,6 +32,19 @@ namespace SIL.XForge.Scripture.Services
             string curUserId,
             string projectId,
             SegmentPairDto segmentPair,
+            CancellationToken cancellationToken
+        );
+        Task<TranslationResultDto> TranslateAsync(
+            string curUserId,
+            string projectId,
+            IReadOnlyList<string> segment,
+            CancellationToken cancellationToken
+        );
+        Task<TranslationResultDto[]> TranslateNAsync(
+            string curUserId,
+            string projectId,
+            int n,
+            IReadOnlyList<string> segment,
             CancellationToken cancellationToken
         );
     }

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -7,6 +7,13 @@ namespace SIL.XForge.Scripture.Services
 {
     public interface IMachineApiService
     {
+        Task<BuildDto?> GetBuildAsync(
+            string curUserId,
+            string projectId,
+            string buildId,
+            long? minRevision,
+            CancellationToken cancellationToken
+        );
         Task<BuildDto?> GetCurrentBuildAsync(
             string curUserId,
             string projectId,

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -17,7 +17,7 @@ namespace SIL.XForge.Scripture.Services
         Task<WordGraphDto> GetWordGraphAsync(
             string curUserId,
             string projectId,
-            IEnumerable<string> segment,
+            IReadOnlyCollection<string> segment,
             CancellationToken cancellationToken
         );
         Task<BuildDto> StartBuildAsync(string curUserId, string projectId, CancellationToken cancellationToken);

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -7,7 +7,7 @@ namespace SIL.XForge.Scripture.Services
 {
     public interface IMachineApiService
     {
-        Task<BuildDto?> GetBuildAsync(
+        Task<BuildDto?> GetCurrentBuildAsync(
             string curUserId,
             string projectId,
             long? minRevision,

--- a/src/SIL.XForge.Scripture/Services/IMachineBuildService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineBuildService.cs
@@ -7,6 +7,12 @@ namespace SIL.XForge.Scripture.Services
     public interface IMachineBuildService
     {
         Task CancelCurrentBuildAsync(string translationEngineId, CancellationToken cancellationToken);
+        Task<BuildDto?> GetBuildAsync(
+            string translationEngineId,
+            string buildId,
+            long? minRevision,
+            CancellationToken cancellationToken
+        );
         Task<BuildDto?> GetCurrentBuildAsync(
             string translationEngineId,
             long? minRevision,

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -75,6 +75,7 @@ namespace SIL.XForge.Scripture.Services
         bool BackupRepository(UserSecret userSecret, string paratextId);
         bool RestoreRepository(UserSecret userSecret, string paratextId);
         bool LocalProjectDirExists(string projectPTId);
+        string GetLanguageId(UserSecret userSecret, string projectPTId);
 
         Task<ParatextProject> SendReceiveAsync(
             UserSecret userSecret,

--- a/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
@@ -26,5 +26,6 @@ namespace SIL.XForge.Scripture.Services
         bool IsSourceProject(string projectId);
         Task<IEnumerable<TransceleratorQuestion>> TransceleratorQuestions(string curUserId, string projectId);
         Task UpdatePermissionsAsync(string curUserId, IDocument<SFProject> projectDoc, CancellationToken token);
+        Task EnsureWritingSystemTagIsSetAsync(string curUserId, string projectId);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -47,7 +47,7 @@ namespace SIL.XForge.Scripture.Services
             IRealtimeService realtimeService
         )
         {
-            // In-Memory Machine Dependencies
+            // In Process Machine Dependencies
             _builds = builds;
             _engines = engines;
             _engineOptions = engineOptions;
@@ -77,11 +77,11 @@ namespace SIL.XForge.Scripture.Services
             // Ensure that the user has permission
             await EnsurePermissionAsync(curUserId, projectId);
 
-            // Execute the in-memory Machine instance, if it is enabled
-            // We can only use In Memory or the API - not both or unnecessary delays will result
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInMemory))
+            // Execute the In Process Machine instance, if it is enabled
+            // We can only use In Process or the API - not both or unnecessary delays will result
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
             {
-                buildDto = await GetInMemoryBuildAsync(BuildLocatorType.Id, buildId, minRevision, cancellationToken);
+                buildDto = await GetInProcessBuildAsync(BuildLocatorType.Id, buildId, minRevision, cancellationToken);
             }
             else if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
             {
@@ -121,12 +121,12 @@ namespace SIL.XForge.Scripture.Services
             // Ensure that the user has permission
             await EnsurePermissionAsync(curUserId, projectId);
 
-            // We can only use In Memory or the API - not both or unnecessary delays will result
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInMemory))
+            // We can only use In Process or the API - not both or unnecessary delays will result
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
             {
-                // Execute the in-memory Machine instance, if it is enabled
-                Engine engine = await GetInMemoryEngineAsync(projectId, cancellationToken);
-                buildDto = await GetInMemoryBuildAsync(
+                // Execute the In Process Machine instance, if it is enabled
+                Engine engine = await GetInProcessEngineAsync(projectId, cancellationToken);
+                buildDto = await GetInProcessBuildAsync(
                     BuildLocatorType.Engine,
                     engine.Id,
                     minRevision,
@@ -186,8 +186,8 @@ namespace SIL.XForge.Scripture.Services
                     }
                     catch (BrokenCircuitException e)
                     {
-                        // We do not want to throw the error if we are returning from in-memory API below
-                        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInMemory))
+                        // We do not want to throw the error if we are returning from In Process API below
+                        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
                         {
                             _exceptionHandler.ReportException(e);
                         }
@@ -197,17 +197,17 @@ namespace SIL.XForge.Scripture.Services
                         }
                     }
                 }
-                else if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineInMemory))
+                else if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
                 {
-                    // Only throw the exception if the in-memory instance will not be called below
+                    // Only throw the exception if the In Process instance will not be called below
                     throw new DataNotFoundException("The translation engine is not configured");
                 }
             }
 
-            // Execute the in-memory Machine instance, if it is enabled
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInMemory))
+            // Execute the In Process Machine instance, if it is enabled
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
             {
-                Engine engine = await GetInMemoryEngineAsync(projectId, cancellationToken);
+                Engine engine = await GetInProcessEngineAsync(projectId, cancellationToken);
                 engineDto = CreateDto(engine);
             }
 
@@ -243,8 +243,8 @@ namespace SIL.XForge.Scripture.Services
                     }
                     catch (BrokenCircuitException e)
                     {
-                        // We do not want to throw the error if we are returning from in-memory API below
-                        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInMemory))
+                        // We do not want to throw the error if we are returning from In Process API below
+                        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
                         {
                             _exceptionHandler.ReportException(e);
                         }
@@ -254,17 +254,17 @@ namespace SIL.XForge.Scripture.Services
                         }
                     }
                 }
-                else if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineInMemory))
+                else if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
                 {
-                    // Only throw the exception if the in-memory instance will not be called below
+                    // Only throw the exception if the In Process instance will not be called below
                     throw new DataNotFoundException("The translation engine is not configured");
                 }
             }
 
-            // Execute the in-memory Machine instance, if it is enabled
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInMemory))
+            // Execute the In Process Machine instance, if it is enabled
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
             {
-                Engine engine = await GetInMemoryEngineAsync(projectId, cancellationToken);
+                Engine engine = await GetInProcessEngineAsync(projectId, cancellationToken);
                 WordGraph wordGraph = await _engineService.GetWordGraphAsync(engine.Id, segment.ToArray());
                 wordGraphDto = CreateDto(wordGraph);
             }
@@ -295,8 +295,8 @@ namespace SIL.XForge.Scripture.Services
                     }
                     catch (BrokenCircuitException e)
                     {
-                        // We do not want to throw the error if we are returning from in-memory API below
-                        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInMemory))
+                        // We do not want to throw the error if we are returning from In Process API below
+                        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
                         {
                             _exceptionHandler.ReportException(e);
                         }
@@ -306,17 +306,17 @@ namespace SIL.XForge.Scripture.Services
                         }
                     }
                 }
-                else if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineInMemory))
+                else if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
                 {
-                    // Only throw the exception if the in-memory instance will not be called below
+                    // Only throw the exception if the In Process instance will not be called below
                     throw new DataNotFoundException("The translation engine is not configured");
                 }
             }
 
-            // Execute the in-memory Machine instance, if it is enabled
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInMemory))
+            // Execute the In Process Machine instance, if it is enabled
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
             {
-                Engine engine = await GetInMemoryEngineAsync(projectId, cancellationToken);
+                Engine engine = await GetInProcessEngineAsync(projectId, cancellationToken);
                 Build build = await _engineService.StartBuildAsync(engine.Id);
                 buildDto = CreateDto(build);
             }
@@ -353,8 +353,8 @@ namespace SIL.XForge.Scripture.Services
                 }
                 catch (BrokenCircuitException e)
                 {
-                    // We do not want to throw the error if we are returning from in-memory API below
-                    if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInMemory))
+                    // We do not want to throw the error if we are returning from In Process API below
+                    if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
                     {
                         _exceptionHandler.ReportException(e);
                     }
@@ -365,10 +365,10 @@ namespace SIL.XForge.Scripture.Services
                 }
             }
 
-            // Execute the in-memory Machine instance, if it is enabled
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInMemory))
+            // Execute the In Process Machine instance, if it is enabled
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
             {
-                Engine engine = await GetInMemoryEngineAsync(projectId, cancellationToken);
+                Engine engine = await GetInProcessEngineAsync(projectId, cancellationToken);
                 await _engineService.TrainSegmentAsync(
                     engine.Id,
                     segmentPair.SourceSegment,
@@ -490,7 +490,7 @@ namespace SIL.XForge.Scripture.Services
             }
         }
 
-        private async Task<BuildDto?> GetInMemoryBuildAsync(
+        private async Task<BuildDto?> GetInProcessBuildAsync(
             BuildLocatorType locatorType,
             string locator,
             long? minRevision,
@@ -523,7 +523,7 @@ namespace SIL.XForge.Scripture.Services
             return buildDto;
         }
 
-        private async Task<Engine> GetInMemoryEngineAsync(string projectId, CancellationToken cancellationToken)
+        private async Task<Engine> GetInProcessEngineAsync(string projectId, CancellationToken cancellationToken)
         {
             Engine? engine = await _engines.GetByLocatorAsync(EngineLocatorType.Project, projectId, cancellationToken);
             if (engine is null)

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -1,0 +1,92 @@
+using System.Threading;
+using System.Threading.Tasks;
+using SIL.Machine.WebApi;
+using SIL.XForge.DataAccess;
+using SIL.XForge.Realtime;
+using SIL.XForge.Scripture.Models;
+using SIL.XForge.Services;
+using SIL.XForge.Utils;
+
+namespace SIL.XForge.Scripture.Services
+{
+    public class MachineApiService : IMachineApiService
+    {
+        private readonly IMachineTranslationService _machineTranslationService;
+        private readonly IRepository<SFProjectSecret> _projectSecrets;
+        private readonly IRealtimeService _realtimeService;
+
+        public MachineApiService(
+            IMachineTranslationService machineTranslationService,
+            IRepository<SFProjectSecret> projectSecrets,
+            IRealtimeService realtimeService
+        )
+        {
+            _machineTranslationService = machineTranslationService;
+            _projectSecrets = projectSecrets;
+            _realtimeService = realtimeService;
+        }
+
+        public async Task<EngineDto> GetEngineAsync(
+            string curUserId,
+            string projectId,
+            CancellationToken cancellationToken
+        )
+        {
+            string translationEngineId = await GetTranslationIdAsync(curUserId, projectId);
+            var translationEngine = await _machineTranslationService.GetTranslationEngineAsync(
+                translationEngineId,
+                cancellationToken
+            );
+            return new EngineDto
+            {
+                Confidence = translationEngine.Confidence,
+                Href = MachineApi.GetEngineHref(projectId),
+                Id = projectId,
+                IsShared = false,
+                Projects = new[]
+                {
+                    new ResourceDto { Href = MachineApi.GetEngineHref(projectId), Id = projectId }
+                },
+                SourceLanguageTag = translationEngine.SourceLanguageTag,
+                TargetLanguageTag = translationEngine.TargetLanguageTag,
+                TrainedSegmentCount = translationEngine.CorpusSize,
+            };
+        }
+
+        private async Task<string> GetTranslationIdAsync(string curUserId, string projectId)
+        {
+            // Load the project from the realtime service
+            Attempt<SFProject> attempt = await _realtimeService.TryGetSnapshotAsync<SFProject>(projectId);
+            if (!attempt.TryResult(out SFProject project))
+            {
+                throw new DataNotFoundException("The project does not exist.");
+            }
+
+            // Check for permission
+            if (
+                !(
+                    project.UserRoles.TryGetValue(curUserId, out string role)
+                    && role is SFProjectRole.Administrator or SFProjectRole.Translator
+                )
+            )
+            {
+                throw new ForbiddenException();
+            }
+
+            // Load the project secret, so we can get the translation engine ID
+            if (!(await _projectSecrets.TryGetAsync(projectId)).TryResult(out SFProjectSecret projectSecret))
+            {
+                throw new DataNotFoundException("The project secret cannot be found.");
+            }
+
+            // Ensure we have a translation engine ID
+            string? translationEngineId = projectSecret.MachineData?.TranslationEngineId;
+            if (string.IsNullOrWhiteSpace(translationEngineId))
+            {
+                throw new DataNotFoundException("The translation engine is not configured");
+            }
+
+            return translationEngineId;
+        }
+    }
+}

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -45,7 +45,7 @@ namespace SIL.XForge.Scripture.Services
             );
 
             // Modify the Build DTO to reference the project
-            if (build != null)
+            if (build is not null)
             {
                 build = UpdateDto(build, projectId);
             }

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -30,6 +30,7 @@ namespace SIL.XForge.Scripture.Services
         private readonly IExceptionHandler _exceptionHandler;
         private readonly IFeatureManager _featureManager;
         private readonly IMachineBuildService _machineBuildService;
+        private readonly IMachineProjectService _machineProjectService;
         private readonly IMachineTranslationService _machineTranslationService;
         private readonly DataAccess.IRepository<SFProjectSecret> _projectSecrets;
         private readonly IRealtimeService _realtimeService;
@@ -42,6 +43,7 @@ namespace SIL.XForge.Scripture.Services
             IExceptionHandler exceptionHandler,
             IFeatureManager featureManager,
             IMachineBuildService machineBuildService,
+            IMachineProjectService machineProjectService,
             IMachineTranslationService machineTranslationService,
             DataAccess.IRepository<SFProjectSecret> projectSecrets,
             IRealtimeService realtimeService
@@ -59,6 +61,7 @@ namespace SIL.XForge.Scripture.Services
 
             // Machine API Dependencies
             _machineBuildService = machineBuildService;
+            _machineProjectService = machineProjectService;
             _machineTranslationService = machineTranslationService;
             _projectSecrets = projectSecrets;
             _realtimeService = realtimeService;
@@ -291,6 +294,12 @@ namespace SIL.XForge.Scripture.Services
                 {
                     try
                     {
+                        // We do not need the success boolean result , as we will still rebuild if no files have changed
+                        _ = await _machineProjectService.SyncProjectCorporaAsync(
+                            curUserId,
+                            projectId,
+                            cancellationToken
+                        );
                         buildDto = await _machineBuildService.StartBuildAsync(translationEngineId, cancellationToken);
                     }
                     catch (BrokenCircuitException e)

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -79,7 +79,7 @@ namespace SIL.XForge.Scripture.Services
             CancellationToken cancellationToken
         )
         {
-            BuildDto? buildDto = null;
+            BuildDto? buildDto;
 
             // Ensure that the user has permission
             await EnsurePermissionAsync(curUserId, sfProjectId);
@@ -106,6 +106,11 @@ namespace SIL.XForge.Scripture.Services
                     cancellationToken
                 );
             }
+            else
+            {
+                // No feature flags enabled, notify the user
+                throw new DataNotFoundException("No Machine learning engine is enabled");
+            }
 
             // Make sure the DTO conforms to the machine-api V2 URLs
             if (buildDto is not null)
@@ -123,7 +128,7 @@ namespace SIL.XForge.Scripture.Services
             CancellationToken cancellationToken
         )
         {
-            BuildDto? buildDto = null;
+            BuildDto? buildDto;
 
             // Ensure that the user has permission
             await EnsurePermissionAsync(curUserId, sfProjectId);
@@ -155,6 +160,11 @@ namespace SIL.XForge.Scripture.Services
                     cancellationToken
                 );
             }
+            else
+            {
+                // No feature flags enabled, notify the user
+                throw new DataNotFoundException("No Machine learning engine is enabled");
+            }
 
             // Make sure the DTO conforms to the machine-api V2 URLs
             if (buildDto is not null)
@@ -171,7 +181,7 @@ namespace SIL.XForge.Scripture.Services
             CancellationToken cancellationToken
         )
         {
-            var engineDto = new EngineDto();
+            EngineDto? engineDto = null;
 
             // Ensure that the user has permission
             await EnsurePermissionAsync(curUserId, sfProjectId);
@@ -218,6 +228,12 @@ namespace SIL.XForge.Scripture.Services
                 engineDto = CreateDto(engine);
             }
 
+            // This will be null if the Machine API is down, or if all feature flags are false
+            if (engineDto is null)
+            {
+                throw new DataNotFoundException("No translation engine could be retrieved");
+            }
+
             // Make sure the DTO conforms to the machine-api V2 URLs
             return UpdateDto(engineDto, sfProjectId);
         }
@@ -229,7 +245,7 @@ namespace SIL.XForge.Scripture.Services
             CancellationToken cancellationToken
         )
         {
-            var wordGraphDto = new WordGraphDto();
+            WordGraphDto? wordGraphDto = null;
 
             // Ensure that the user has permission
             await EnsurePermissionAsync(curUserId, sfProjectId);
@@ -276,6 +292,12 @@ namespace SIL.XForge.Scripture.Services
                 wordGraphDto = CreateDto(wordGraph);
             }
 
+            // This will be null if the Machine API is down, or if all feature flags are false
+            if (wordGraphDto is null)
+            {
+                throw new DataNotFoundException("No translation engine could be retrieved");
+            }
+
             return wordGraphDto;
         }
 
@@ -285,7 +307,7 @@ namespace SIL.XForge.Scripture.Services
             CancellationToken cancellationToken
         )
         {
-            var buildDto = new BuildDto();
+            BuildDto? buildDto = null;
 
             // Ensure that the user has permission
             await EnsurePermissionAsync(curUserId, sfProjectId);
@@ -332,6 +354,12 @@ namespace SIL.XForge.Scripture.Services
                 Engine engine = await GetInProcessEngineAsync(sfProjectId, cancellationToken);
                 Build build = await _engineService.StartBuildAsync(engine.Id);
                 buildDto = CreateDto(build);
+            }
+
+            // This will be null if the Machine API is down, or if all feature flags are false
+            if (buildDto is null)
+            {
+                throw new DataNotFoundException("No translation engine could be retrieved");
             }
 
             return UpdateDto(buildDto, sfProjectId);
@@ -401,7 +429,7 @@ namespace SIL.XForge.Scripture.Services
             CancellationToken cancellationToken
         )
         {
-            var translationResultDto = new TranslationResultDto();
+            TranslationResultDto? translationResultDto = null;
 
             // Ensure that the user has permission
             await EnsurePermissionAsync(curUserId, sfProjectId);
@@ -446,6 +474,12 @@ namespace SIL.XForge.Scripture.Services
                 Engine engine = await GetInProcessEngineAsync(sfProjectId, cancellationToken);
                 TranslationResult translationResult = await _engineService.TranslateAsync(engine.Id, segment);
                 translationResultDto = CreateDto(translationResult);
+            }
+
+            // This will be null if the Machine API is down, or if all feature flags are false
+            if (translationResultDto is null)
+            {
+                throw new DataNotFoundException("No translation engine could be retrieved");
             }
 
             return translationResultDto;

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -102,6 +102,17 @@ namespace SIL.XForge.Scripture.Services
             return UpdateDto(build, projectId);
         }
 
+        public async Task TrainSegmentAsync(
+            string curUserId,
+            string projectId,
+            SegmentPairDto segmentPair,
+            CancellationToken cancellationToken
+        )
+        {
+            string translationEngineId = await GetTranslationIdAsync(curUserId, projectId);
+            await _machineTranslationService.TrainSegmentAsync(translationEngineId, segmentPair, cancellationToken);
+        }
+
         private static BuildDto UpdateDto(BuildDto build, string projectId)
         {
             build.Href = MachineApi.GetBuildHref(projectId);

--- a/src/SIL.XForge.Scripture/Services/MachineBuildService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineBuildService.cs
@@ -6,6 +6,7 @@ using System.Net.Http.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using SIL.Machine.WebApi;
+using SIL.XForge.Services;
 
 namespace SIL.XForge.Scripture.Services
 {
@@ -52,13 +53,15 @@ namespace SIL.XForge.Scripture.Services
             // A 408 HTTP status code is returned if there is no build started/running within the timeout period
             if (response.StatusCode == HttpStatusCode.RequestTimeout)
             {
+                // This is equivalent to 204 in the V1 API and represents EntityChangeType.None
                 return null;
             }
 
             // No body is returned on a 204 HTTP status code
             if (response.StatusCode == HttpStatusCode.NoContent)
             {
-                return null;
+                // This is equivalent to 404 in the V1 API and represents EntityChangeType.Delete
+                throw new DataNotFoundException("Entity Deleted");
             }
 
             // Ensure we have a 2XX HTTP status code

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -550,8 +550,7 @@ namespace SIL.XForge.Scripture.Services
             bool corpusUpdated = false;
 
             // Get the language tag
-            string languageTag;
-            languageTag =
+            string languageTag =
                 type == TextCorpusType.Target
                     ? project.WritingSystem.Tag
                     : project.TranslateConfig.Source.WritingSystem.Tag;

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -452,7 +452,11 @@ namespace SIL.XForge.Scripture.Services
                 string key;
                 if (segment.SegmentRef is TextSegmentRef textSegmentRef)
                 {
-                    key = string.Join('_', textSegmentRef.Keys);
+                    // We pad the verse number so the string based key comparisons in Machine will be accurate
+                    key = string.Join(
+                        '_',
+                        textSegmentRef.Keys.Select(k => int.TryParse(k, out int _) ? k.PadLeft(3, '0') : k)
+                    );
                 }
                 else
                 {

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -449,15 +449,18 @@ namespace SIL.XForge.Scripture.Services
             var sb = new StringBuilder();
             foreach (TextSegment segment in text.GetSegments().Where(s => !s.IsEmpty))
             {
+                string key;
                 if (segment.SegmentRef is TextSegmentRef textSegmentRef)
                 {
-                    sb.Append(string.Join('_', textSegmentRef.Keys));
+                    key = string.Join('_', textSegmentRef.Keys);
                 }
                 else
                 {
-                    sb.Append(segment.SegmentRef);
+                    key = (string)segment.SegmentRef;
                 }
 
+                // Strip characters from the key that will corrupt the line
+                sb.Append(key.Replace('\n', '_').Replace('\t', '_'));
                 sb.Append('\t');
                 sb.Append(string.Join(' ', segment.Segment));
                 sb.Append('\t');

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -74,7 +74,12 @@ namespace SIL.XForge.Scripture.Services
                 SourceLanguageTag = project.TranslateConfig.Source.WritingSystem.Tag,
                 TargetLanguageTag = project.WritingSystem.Tag,
             };
-            await _engineService.AddProjectAsync(machineProject);
+
+            // Only add to the in-memory instance if it is enabled
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInMemory))
+            {
+                await _engineService.AddProjectAsync(machineProject);
+            }
 
             // Ensure that the Machine API feature flag is enabled
             if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
@@ -105,8 +110,11 @@ namespace SIL.XForge.Scripture.Services
 
         public async Task BuildProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken)
         {
-            // Build the project with the in process Machine instance
-            await _engineService.StartBuildByProjectIdAsync(sfProjectId);
+            // Build the project with the in-memory Machine instance
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInMemory))
+            {
+                await _engineService.StartBuildByProjectIdAsync(sfProjectId);
+            }
 
             // Ensure that the Machine API feature flag is enabled
             if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
@@ -142,8 +150,11 @@ namespace SIL.XForge.Scripture.Services
 
         public async Task RemoveProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken)
         {
-            // Remove the project from the in process Machine instance
-            await _engineService.RemoveProjectAsync(sfProjectId);
+            // Remove the project from the in-memory Machine instance
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInMemory))
+            {
+                await _engineService.RemoveProjectAsync(sfProjectId);
+            }
 
             // Ensure that the Machine API feature flag is enabled
             if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -451,7 +451,7 @@ namespace SIL.XForge.Scripture.Services
             {
                 if (segment.SegmentRef is TextSegmentRef textSegmentRef)
                 {
-                    sb.Append(string.Join('-', textSegmentRef.Keys));
+                    sb.Append(string.Join('_', textSegmentRef.Keys));
                 }
                 else
                 {

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -75,8 +75,8 @@ namespace SIL.XForge.Scripture.Services
                 TargetLanguageTag = project.WritingSystem.Tag,
             };
 
-            // Only add to the in-memory instance if it is enabled
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInMemory))
+            // Only add to the In Process instance if it is enabled
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
             {
                 await _engineService.AddProjectAsync(machineProject);
             }
@@ -110,8 +110,8 @@ namespace SIL.XForge.Scripture.Services
 
         public async Task BuildProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken)
         {
-            // Build the project with the in-memory Machine instance
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInMemory))
+            // Build the project with the In Process Machine instance
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
             {
                 await _engineService.StartBuildByProjectIdAsync(sfProjectId);
             }
@@ -150,8 +150,8 @@ namespace SIL.XForge.Scripture.Services
 
         public async Task RemoveProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken)
         {
-            // Remove the project from the in-memory Machine instance
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInMemory))
+            // Remove the project from the In Process Machine instance
+            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
             {
                 await _engineService.RemoveProjectAsync(sfProjectId);
             }

--- a/src/SIL.XForge.Scripture/Services/MachineServiceBase.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineServiceBase.cs
@@ -39,6 +39,16 @@ namespace SIL.XForge.Scripture.Services
             MachineClient.Dispose();
         }
 
+        /// <summary>
+        /// Validates an identifier for passing via a URL segment to the Machine API.
+        /// </summary>
+        /// <param name="id">The identifier.</param>
+        /// <exception cref="ArgumentException"></exception>
+        /// <remarks>
+        /// Calling this method on an ID string ensures that the ID can be included in a URL to a Machine API endpoint,
+        /// without risk of URL injection. This identifier will usually be a 24 character MongoDB generated identifier.
+        /// Length is not verified - the Machine API will return an error for an incorrect/missing ID.
+        /// </remarks>
         protected void ValidateId(string id)
         {
             if (!Regex.IsMatch(id, "^[a-zA-Z0-9]+$"))

--- a/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddMachine(config =>
                 {
                     config.AuthenticationSchemes = new[] { JwtBearerDefaults.AuthenticationScheme };
+                    config.Namespace = "machine-api/v1";
                 })
                 .AddEngineOptions(o => o.EnginesDir = Path.Combine(siteOptions.SiteDir, "engines"))
                 .AddMongoDataAccess(o =>

--- a/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .SetHandlerLifetime(TimeSpan.FromMinutes(5))
                 .AddPolicyHandler(GetRetryPolicy())
                 .AddPolicyHandler(GetCircuitBreakerPolicy());
+            services.AddSingleton<IMachineApiService, MachineApiService>();
             services.AddSingleton<IMachineBuildService, MachineBuildService>();
             services.AddSingleton<IMachineCorporaService, MachineCorporaService>();
             services.AddSingleton<IMachineProjectService, MachineProjectService>();

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1599,6 +1599,19 @@ namespace SIL.XForge.Scripture.Services
             return _fileSystemService.DirectoryExists(dir);
         }
 
+        /// <summary>
+        /// Gets the Language tag for a Paratext project.
+        /// </summary>
+        /// <param name="userSecret">The user secret.</param>
+        /// <param name="ptProjectId">The Project identifier</param>
+        /// <returns>The Language identifier.</returns>
+        /// <remarks>This is used to get the WritingSystem Tag for Back Translations.</remarks>
+        public string GetLanguageId(UserSecret userSecret, string ptProjectId)
+        {
+            using ScrText scrText = GetScrText(userSecret, ptProjectId);
+            return scrText.Language.Id;
+        }
+
         protected override void DisposeManagedResources()
         {
             _registryClient.Dispose();

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
-using SIL.Machine.WebApi.Models;
 using SIL.XForge.Configuration;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
@@ -706,6 +705,27 @@ namespace SIL.XForge.Scripture.Services
                     throw new ForbiddenException();
                 return _transceleratorService.Questions(projectDoc.Data.ParatextId);
             }
+        }
+
+        /// <summary>
+        /// Ensures that the <see cref="WritingSystem"/> Tag is not null.
+        /// </summary>
+        /// <param name="curUserId">The current user identifier.</param>
+        /// <param name="projectId">The project identifier.</param>
+        /// <returns>The asynchronous task.</returns>
+        /// <remarks>
+        /// This public method exists for the Machine API Migration utility.
+        /// </remarks>
+        public async Task EnsureWritingSystemTagIsSetAsync(string curUserId, string projectId)
+        {
+            using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
+            IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
+            if (!projectDoc.IsLoaded)
+            {
+                throw new DataNotFoundException("The project does not exist.");
+            }
+
+            await EnsureWritingSystemTagIsSetAsync(curUserId, projectDoc, null);
         }
 
         protected override async Task AddUserToProjectAsync(

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -1188,11 +1188,11 @@ namespace SIL.XForge.Scripture.Services
         /// <remarks>
         /// A issue was introduced in an early version of ScriptureForge where the writing system tag was not set when
         /// the project was created. This issue has since been fixed. The Machine API requires the writing system tag
-        /// requires the writing system tag to be specified, and so this method should be called before a project is
-        /// created in the Machine API to ensure that it can be created without an error. If the writing system tag is
-        /// already set, it is not modified. If this is a back translation, the writing system tag will not be set here,
-        /// but will be set on the first project build in <see cref="MachineProjectService"/>, as if this method does not
-        /// update the writing system tags, the Machine API Translation Engine creation will be delayed until first build.
+        /// to be specified, and so this method should be called before a project is created in the Machine API to
+        /// ensure that it can be created without error. If the writing system tag is already set, it is not modified.
+        /// If this is a back translation, the writing system tag will not be set here, but will be set on the first
+        /// project build in <see cref="MachineProjectService"/>, as if this method does not update the writing system
+        /// tags, the Machine API Translation Engine creation will be delayed until first build.
         /// </remarks>
         private async Task EnsureWritingSystemTagIsSetAsync(
             string curUserId,

--- a/src/SIL.XForge.Scripture/appsettings.Development.json
+++ b/src/SIL.XForge.Scripture/appsettings.Development.json
@@ -29,5 +29,8 @@
   },
   "Paratext": {
     "HgExe": "/usr/local/bin/hg"
+  },
+  "Machine": {
+    "TokenUrl": "https://sil-appbuilder.auth0.com/oauth/token"
   }
 }

--- a/src/SIL.XForge.Scripture/appsettings.Staging.json
+++ b/src/SIL.XForge.Scripture/appsettings.Staging.json
@@ -14,5 +14,8 @@
     "ManagementAudience": "https://dev-sillsdev.auth0.com/api/v2/",
     "FrontendClientId": "4eHLjo40mAEGFU6zUxdYjnpnC1K1Ydnj",
     "BackendClientId": "0je4EE9NauROSGjrR1SCryL74TpF2CVC"
+  },
+  "Machine": {
+    "TokenUrl": "https://dev-sillsdev.auth0.com/oauth/token"
   }
 }

--- a/src/SIL.XForge.Scripture/appsettings.Testing.json
+++ b/src/SIL.XForge.Scripture/appsettings.Testing.json
@@ -27,5 +27,8 @@
   },
   "Paratext": {
     "HgExe": "/usr/local/bin/hg"
+  },
+  "Machine": {
+    "TokenUrl": "https://sil-appbuilder.auth0.com/oauth/token"
   }
 }

--- a/src/SIL.XForge.Scripture/appsettings.json
+++ b/src/SIL.XForge.Scripture/appsettings.json
@@ -59,6 +59,7 @@
     "TokenUrl": "https://sil-appbuilder.auth0.com/oauth/token"
   },
   "FeatureManagement": {
-    "MachineApi": false
+    "MachineApi": false,
+    "MachineInMemory": true
   }
 }

--- a/src/SIL.XForge.Scripture/appsettings.json
+++ b/src/SIL.XForge.Scripture/appsettings.json
@@ -60,6 +60,6 @@
   },
   "FeatureManagement": {
     "MachineApi": false,
-    "MachineInMemory": true
+    "MachineInProcess": true
   }
 }

--- a/src/SIL.XForge.Scripture/appsettings.json
+++ b/src/SIL.XForge.Scripture/appsettings.json
@@ -56,7 +56,7 @@
   "Machine": {
     "ApiServer": "https://machine-api.org",
     "Audience": "https://machine.sil.org",
-    "TokenUrl": "https://sil-appbuilder.auth0.com/oauth/token"
+    "TokenUrl": "https://languagetechnology.auth0.com/oauth/token"
   },
   "FeatureManagement": {
     "MachineApi": false,

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NUnit.Framework;
+using SIL.Machine.WebApi;
+using SIL.XForge.Scripture.Services;
+using SIL.XForge.Services;
+
+namespace SIL.XForge.Scripture.Controllers
+{
+    [TestFixture]
+    public class MachineApiControllerTests
+    {
+        private const string Project01 = "project01";
+        private const string User01 = "user01";
+
+        [Test]
+        public async Task GetBuildAsync_NoBuildRunning()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .GetBuildAsync(User01, Project01, null, CancellationToken.None)
+                .Returns(Task.FromResult<BuildDto>(null));
+
+            // SUT
+            ActionResult<BuildDto> actual = await env.Controller.GetBuildAsync(Project01, null, CancellationToken.None);
+            Assert.IsInstanceOf<NoContentResult>(actual.Result);
+        }
+
+        [Test]
+        public async Task GetBuildAsync_NoPermission()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .GetBuildAsync(User01, Project01, null, CancellationToken.None)
+                .Throws(new ForbiddenException());
+
+            // SUT
+            ActionResult<BuildDto> actual = await env.Controller.GetBuildAsync(Project01, null, CancellationToken.None);
+            Assert.IsInstanceOf<ForbidResult>(actual.Result);
+        }
+
+        [Test]
+        public async Task GetBuildAsync_NoProject()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .GetBuildAsync(User01, Project01, null, CancellationToken.None)
+                .Throws(new DataNotFoundException(string.Empty));
+
+            // SUT
+            ActionResult<BuildDto> actual = await env.Controller.GetBuildAsync(Project01, null, CancellationToken.None);
+            Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+        }
+
+        [Test]
+        public async Task GetBuildAsync_Success()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .GetBuildAsync(User01, Project01, null, CancellationToken.None)
+                .Returns(Task.FromResult(new BuildDto()));
+
+            // SUT
+            ActionResult<BuildDto> actual = await env.Controller.GetBuildAsync(Project01, null, CancellationToken.None);
+            Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+        }
+
+        [Test]
+        public async Task GetEngineAsync_NoPermission()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .GetEngineAsync(User01, Project01, CancellationToken.None)
+                .Throws(new ForbiddenException());
+
+            // SUT
+            ActionResult<EngineDto> actual = await env.Controller.GetEngineAsync(Project01, CancellationToken.None);
+            Assert.IsInstanceOf<ForbidResult>(actual.Result);
+        }
+
+        [Test]
+        public async Task GetEngineAsync_NoProject()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .GetEngineAsync(User01, Project01, CancellationToken.None)
+                .Throws(new DataNotFoundException(string.Empty));
+
+            // SUT
+            ActionResult<EngineDto> actual = await env.Controller.GetEngineAsync(Project01, CancellationToken.None);
+            Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+        }
+
+        [Test]
+        public async Task GetEngineAsync_Success()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .GetEngineAsync(User01, Project01, CancellationToken.None)
+                .Returns(Task.FromResult(new EngineDto()));
+
+            // SUT
+            ActionResult<EngineDto> actual = await env.Controller.GetEngineAsync(Project01, CancellationToken.None);
+            Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+        }
+
+        [Test]
+        public async Task GetWordGraphAsync_NoPermission()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+                .Throws(new ForbiddenException());
+
+            // SUT
+            ActionResult<BuildDto> actual = await env.Controller.GetWordGraphAsync(
+                Project01,
+                Array.Empty<string>(),
+                CancellationToken.None
+            );
+            Assert.IsInstanceOf<ForbidResult>(actual.Result);
+        }
+
+        [Test]
+        public async Task GetWordGraphAsync_NoProject()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+                .Throws(new DataNotFoundException(string.Empty));
+
+            // SUT
+            ActionResult<BuildDto> actual = await env.Controller.GetWordGraphAsync(
+                Project01,
+                Array.Empty<string>(),
+                CancellationToken.None
+            );
+            Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+        }
+
+        [Test]
+        public async Task GetWordGraphAsync_Success()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+                .Returns(Task.FromResult(new WordGraphDto()));
+
+            // SUT
+            ActionResult<BuildDto> actual = await env.Controller.GetWordGraphAsync(
+                Project01,
+                Array.Empty<string>(),
+                CancellationToken.None
+            );
+            Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+        }
+
+        [Test]
+        public async Task StartBuildAsync_NoPermission()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .StartBuildAsync(User01, Project01, CancellationToken.None)
+                .Throws(new ForbiddenException());
+
+            // SUT
+            ActionResult<BuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
+            Assert.IsInstanceOf<ForbidResult>(actual.Result);
+        }
+
+        [Test]
+        public async Task StartBuildAsync_NoProject()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .StartBuildAsync(User01, Project01, CancellationToken.None)
+                .Throws(new DataNotFoundException(string.Empty));
+
+            // SUT
+            ActionResult<BuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
+            Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+        }
+
+        [Test]
+        public async Task StartBuildAsync_Success()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .StartBuildAsync(User01, Project01, CancellationToken.None)
+                .Returns(Task.FromResult(new BuildDto()));
+
+            // SUT
+            ActionResult<BuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
+            Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+        }
+
+        private class TestEnvironment
+        {
+            public TestEnvironment()
+            {
+                var userAccessor = Substitute.For<IUserAccessor>();
+                userAccessor.UserId.Returns(User01);
+                var exceptionHandler = Substitute.For<IExceptionHandler>();
+                MachineApiService = Substitute.For<IMachineApiService>();
+
+                Controller = new MachineApiController(exceptionHandler, MachineApiService, userAccessor);
+            }
+
+            public IMachineApiService MachineApiService { get; }
+            public MachineApiController Controller { get; }
+        }
+    }
+}

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -148,13 +148,13 @@ namespace SIL.XForge.Scripture.Controllers
             // Set up test environment
             var env = new TestEnvironment();
             env.MachineApiService
-                .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
+                .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
                 .Throws(new DataNotFoundException("Entity Deleted"));
 
             // SUT
             ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
                 Project01,
-                Build01,
+                buildId: null,
                 minRevision: null,
                 CancellationToken.None
             );

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -20,12 +20,31 @@ namespace SIL.XForge.Scripture.Controllers
         private const string User01 = "user01";
 
         [Test]
+        public async Task GetBuildAsync_BuildEnded()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
+                .Throws(new DataNotFoundException("Entity Deleted"));
+
+            // SUT
+            ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
+                Project01,
+                null,
+                CancellationToken.None
+            );
+
+            Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+        }
+
+        [Test]
         public async Task GetBuildAsync_MachineApiDown()
         {
             // Set up test environment
             var env = new TestEnvironment();
             env.MachineApiService
-                .GetBuildAsync(User01, Project01, null, CancellationToken.None)
+                .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
                 .Throws(new BrokenCircuitException());
 
             // SUT
@@ -46,7 +65,7 @@ namespace SIL.XForge.Scripture.Controllers
             // Set up test environment
             var env = new TestEnvironment();
             env.MachineApiService
-                .GetBuildAsync(User01, Project01, null, CancellationToken.None)
+                .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
                 .Returns(Task.FromResult<BuildDto>(null));
 
             // SUT
@@ -65,7 +84,7 @@ namespace SIL.XForge.Scripture.Controllers
             // Set up test environment
             var env = new TestEnvironment();
             env.MachineApiService
-                .GetBuildAsync(User01, Project01, null, CancellationToken.None)
+                .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
                 .Throws(new ForbiddenException());
 
             // SUT
@@ -84,7 +103,7 @@ namespace SIL.XForge.Scripture.Controllers
             // Set up test environment
             var env = new TestEnvironment();
             env.MachineApiService
-                .GetBuildAsync(User01, Project01, null, CancellationToken.None)
+                .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
                 .Throws(new DataNotFoundException(string.Empty));
 
             // SUT
@@ -103,7 +122,7 @@ namespace SIL.XForge.Scripture.Controllers
             // Set up test environment
             var env = new TestEnvironment();
             env.MachineApiService
-                .GetBuildAsync(User01, Project01, null, CancellationToken.None)
+                .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
                 .Returns(Task.FromResult(new BuildDto()));
 
             // SUT

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -548,6 +548,170 @@ namespace SIL.XForge.Scripture.Controllers
                 .TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None);
         }
 
+        [Test]
+        public async Task TranslateAsync_MachineApiDown()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+                .Throws(new BrokenCircuitException());
+
+            // SUT
+            ActionResult<TranslationResultDto> actual = await env.Controller.TranslateAsync(
+                Project01,
+                Array.Empty<string>(),
+                CancellationToken.None
+            );
+
+            env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+            Assert.IsInstanceOf<ObjectResult>(actual.Result);
+            Assert.AreEqual((int)HttpStatusCode.ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
+        }
+
+        [Test]
+        public async Task TranslateAsync_NoPermission()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+                .Throws(new ForbiddenException());
+
+            // SUT
+            ActionResult<TranslationResultDto> actual = await env.Controller.TranslateAsync(
+                Project01,
+                Array.Empty<string>(),
+                CancellationToken.None
+            );
+
+            Assert.IsInstanceOf<ForbidResult>(actual.Result);
+        }
+
+        [Test]
+        public async Task TranslateAsync_NoProject()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+                .Throws(new DataNotFoundException(string.Empty));
+
+            // SUT
+            ActionResult<TranslationResultDto> actual = await env.Controller.TranslateAsync(
+                Project01,
+                Array.Empty<string>(),
+                CancellationToken.None
+            );
+
+            Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+        }
+
+        [Test]
+        public async Task TranslateAsync_Success()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+                .Returns(Task.FromResult(new TranslationResultDto()));
+
+            // SUT
+            ActionResult<TranslationResultDto> actual = await env.Controller.TranslateAsync(
+                Project01,
+                Array.Empty<string>(),
+                CancellationToken.None
+            );
+
+            Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+        }
+
+        [Test]
+        public async Task TranslateNAsync_MachineApiDown()
+        {
+            // Set up test environment
+            int n = 1;
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None)
+                .Throws(new BrokenCircuitException());
+
+            // SUT
+            ActionResult<TranslationResultDto[]> actual = await env.Controller.TranslateNAsync(
+                Project01,
+                n,
+                Array.Empty<string>(),
+                CancellationToken.None
+            );
+
+            env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+            Assert.IsInstanceOf<ObjectResult>(actual.Result);
+            Assert.AreEqual((int)HttpStatusCode.ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
+        }
+
+        [Test]
+        public async Task TranslateNAsync_NoPermission()
+        {
+            // Set up test environment
+            int n = 1;
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None)
+                .Throws(new ForbiddenException());
+
+            // SUT
+            ActionResult<TranslationResultDto[]> actual = await env.Controller.TranslateNAsync(
+                Project01,
+                n,
+                Array.Empty<string>(),
+                CancellationToken.None
+            );
+
+            Assert.IsInstanceOf<ForbidResult>(actual.Result);
+        }
+
+        [Test]
+        public async Task TranslateNAsync_NoProject()
+        {
+            // Set up test environment
+            int n = 1;
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None)
+                .Throws(new DataNotFoundException(string.Empty));
+
+            // SUT
+            ActionResult<TranslationResultDto[]> actual = await env.Controller.TranslateNAsync(
+                Project01,
+                n,
+                Array.Empty<string>(),
+                CancellationToken.None
+            );
+
+            Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+        }
+
+        [Test]
+        public async Task TranslateNAsync_Success()
+        {
+            // Set up test environment
+            int n = 1;
+            var env = new TestEnvironment();
+            env.MachineApiService
+                .TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None)
+                .Returns(Task.FromResult(Array.Empty<TranslationResultDto>()));
+
+            // SUT
+            ActionResult<TranslationResultDto[]> actual = await env.Controller.TranslateNAsync(
+                Project01,
+                n,
+                Array.Empty<string>(),
+                CancellationToken.None
+            );
+
+            Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+        }
+
         private class TestEnvironment
         {
             public TestEnvironment()

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -34,7 +34,7 @@ namespace SIL.XForge.Scripture.Services
         private const string User01 = "user01";
 
         [Test]
-        public async Task GetBuildAsync_InMemoryNoRevisionNoBuildRunning()
+        public async Task GetBuildAsync_InProcessNoRevisionNoBuildRunning()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -56,7 +56,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public void GetBuildAsync_InMemorySpecificRevisionBuildEnded()
+        public void GetBuildAsync_InProcessSpecificRevisionBuildEnded()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -79,7 +79,7 @@ namespace SIL.XForge.Scripture.Services
             // Set up test environment
             var env = new TestEnvironment();
             int minRevision = 0;
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
             env.MachineBuildService
                 .GetBuildAsync(TranslationEngine01, Build01, minRevision, CancellationToken.None)
                 .Throws(new DataNotFoundException("Entity Deleted"));
@@ -95,7 +95,7 @@ namespace SIL.XForge.Scripture.Services
         {
             // Set up test environment
             var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
             env.MachineBuildService
                 .GetBuildAsync(TranslationEngine01, Build01, null, CancellationToken.None)
                 .Returns(Task.FromResult<BuildDto>(null));
@@ -155,7 +155,7 @@ namespace SIL.XForge.Scripture.Services
         {
             // Set up test environment
             var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
             // SUT
             Assert.ThrowsAsync<DataNotFoundException>(
@@ -164,7 +164,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task GetBuildAsync_InMemorySuccess()
+        public async Task GetBuildAsync_InProcessSuccess()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -235,7 +235,7 @@ namespace SIL.XForge.Scripture.Services
                         }
                     )
                 );
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
             // SUT
             BuildDto? actual = await env.Service.GetBuildAsync(
@@ -258,7 +258,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task GetBuildAsync_ExecutesOnlyInMemoryIfBothEnabled()
+        public async Task GetBuildAsync_ExecutesOnlyInProcessIfBothEnabled()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -273,7 +273,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task GetCurrentBuildAsync_InMemoryNoRevisionNoBuildRunning()
+        public async Task GetCurrentBuildAsync_InProcessNoRevisionNoBuildRunning()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -294,7 +294,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public void GetCurrentBuildAsync_InMemorySpecificRevisionBuildEnded()
+        public void GetCurrentBuildAsync_InProcessSpecificRevisionBuildEnded()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -317,7 +317,7 @@ namespace SIL.XForge.Scripture.Services
             // Set up test environment
             var env = new TestEnvironment();
             int minRevision = 0;
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
             env.MachineBuildService
                 .GetCurrentBuildAsync(TranslationEngine01, minRevision, CancellationToken.None)
                 .Throws(new DataNotFoundException("Entity Deleted"));
@@ -333,7 +333,7 @@ namespace SIL.XForge.Scripture.Services
         {
             // Set up test environment
             var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
             env.MachineBuildService
                 .GetCurrentBuildAsync(TranslationEngine01, null, CancellationToken.None)
                 .Returns(Task.FromResult<BuildDto>(null));
@@ -386,7 +386,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public void GetCurrentBuildAsync_InMemoryNoEngine()
+        public void GetCurrentBuildAsync_InProcessNoEngine()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -406,7 +406,7 @@ namespace SIL.XForge.Scripture.Services
         {
             // Set up test environment
             var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
             // SUT
             Assert.ThrowsAsync<DataNotFoundException>(
@@ -415,7 +415,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task GetCurrentBuildAsync_InMemorySuccess()
+        public async Task GetCurrentBuildAsync_InProcessSuccess()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -485,7 +485,7 @@ namespace SIL.XForge.Scripture.Services
                         }
                     )
                 );
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
             // SUT
             BuildDto? actual = await env.Service.GetCurrentBuildAsync(
@@ -507,7 +507,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task GetCurrentBuildAsync_ExecutesOnlyInMemoryIfBothEnabled()
+        public async Task GetCurrentBuildAsync_ExecutesOnlyInProcessIfBothEnabled()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -548,7 +548,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public void GetEngineAsync_InMemoryNoEngine()
+        public void GetEngineAsync_InProcessNoEngine()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -568,7 +568,7 @@ namespace SIL.XForge.Scripture.Services
         {
             // Set up test environment
             var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
             // SUT
             Assert.ThrowsAsync<DataNotFoundException>(
@@ -577,7 +577,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task GetEngineAsync_InMemorySuccess()
+        public async Task GetEngineAsync_InProcessSuccess()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -645,7 +645,7 @@ namespace SIL.XForge.Scripture.Services
                         }
                     )
                 );
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
             // SUT
             EngineDto actual = await env.Service.GetEngineAsync(User01, Project01, CancellationToken.None);
@@ -662,7 +662,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task GetEngineAsync_ExecutesApiAndInMemory()
+        public async Task GetEngineAsync_ExecutesApiAndInProcess()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -721,7 +721,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public void GetWordGraphAsync_InMemoryNoEngine()
+        public void GetWordGraphAsync_InProcessNoEngine()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -741,7 +741,7 @@ namespace SIL.XForge.Scripture.Services
         {
             // Set up test environment
             var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
             // SUT
             Assert.ThrowsAsync<DataNotFoundException>(
@@ -750,7 +750,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task GetWordGraphAsync_InMemorySuccess()
+        public async Task GetWordGraphAsync_InProcessSuccess()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -811,7 +811,7 @@ namespace SIL.XForge.Scripture.Services
                         }
                     )
                 );
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
             // SUT
             WordGraphDto actual = await env.Service.GetWordGraphAsync(
@@ -828,7 +828,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task GetWordGraphAsync_ExecutesApiAndInMemory()
+        public async Task GetWordGraphAsync_ExecutesApiAndInProcess()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -870,7 +870,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public void StartBuildAsync_InMemoryNoEngine()
+        public void StartBuildAsync_InProcessNoEngine()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -890,7 +890,7 @@ namespace SIL.XForge.Scripture.Services
         {
             // Set up test environment
             var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
             // SUT
             Assert.ThrowsAsync<DataNotFoundException>(
@@ -899,7 +899,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task StartBuildAsync_InMemorySuccess()
+        public async Task StartBuildAsync_InProcessSuccess()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -963,7 +963,7 @@ namespace SIL.XForge.Scripture.Services
                         }
                     )
                 );
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
             // SUT
             BuildDto actual = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
@@ -979,7 +979,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task StartBuildAsync_ExecutesApiAndInMemory()
+        public async Task StartBuildAsync_ExecutesApiAndInProcess()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -1029,7 +1029,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public void TrainSegmentAsync_InMemoryNoEngine()
+        public void TrainSegmentAsync_InProcessNoEngine()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -1049,7 +1049,7 @@ namespace SIL.XForge.Scripture.Services
         {
             // Set up test environment
             var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
             // SUT
             Assert.ThrowsAsync<DataNotFoundException>(
@@ -1058,7 +1058,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task TrainSegmentAsync_InMemorySuccess()
+        public async Task TrainSegmentAsync_InProcessSuccess()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -1083,7 +1083,7 @@ namespace SIL.XForge.Scripture.Services
         {
             // Set up test environment
             var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
             var segmentPair = new SegmentPairDto();
 
             // SUT
@@ -1095,7 +1095,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task TrainSegmentAsync_ExecutesApiAndInMemory()
+        public async Task TrainSegmentAsync_ExecutesApiAndInProcess()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -1142,7 +1142,7 @@ namespace SIL.XForge.Scripture.Services
                 ExceptionHandler = Substitute.For<IExceptionHandler>();
                 FeatureManager = Substitute.For<IFeatureManager>();
                 FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(true));
-                FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(true));
+                FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(true));
 
                 MachineBuildService = Substitute.For<IMachineBuildService>();
                 MachineTranslationService = Substitute.For<IMachineTranslationService>();

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -1139,6 +1139,7 @@ namespace SIL.XForge.Scripture.Services
                     );
                 IOptions<EngineOptions> engineOptions = Options.Create(new EngineOptions());
                 EngineService = Substitute.For<IEngineService>();
+                ExceptionHandler = Substitute.For<IExceptionHandler>();
                 FeatureManager = Substitute.For<IFeatureManager>();
                 FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(true));
                 FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(true));
@@ -1184,6 +1185,7 @@ namespace SIL.XForge.Scripture.Services
                     Engines,
                     engineOptions,
                     EngineService,
+                    ExceptionHandler,
                     FeatureManager,
                     MachineBuildService,
                     MachineTranslationService,
@@ -1195,6 +1197,7 @@ namespace SIL.XForge.Scripture.Services
             public IBuildRepository Builds { get; }
             public IEngineRepository Engines { get; }
             public IEngineService EngineService { get; }
+            public IExceptionHandler ExceptionHandler { get; }
             public IFeatureManager FeatureManager { get; }
             public IMachineBuildService MachineBuildService { get; }
             public IMachineTranslationService MachineTranslationService { get; }

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -1,0 +1,132 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using NUnit.Framework;
+using SIL.Machine.WebApi;
+using SIL.XForge.DataAccess;
+using SIL.XForge.Realtime;
+using SIL.XForge.Scripture.Models;
+using SIL.XForge.Scripture.Realtime;
+using SIL.XForge.Services;
+
+namespace SIL.XForge.Scripture.Services
+{
+    [TestFixture]
+    public class MachineApiServiceTests
+    {
+        private const string Project01 = "project01";
+        private const string Project02 = "project02";
+        private const string TranslationEngine01 = "translationEngine01";
+        private const string User01 = "user01";
+
+        [Test]
+        public void GetEngineAsync_NoPermission()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+
+            // SUT
+            Assert.ThrowsAsync<ForbiddenException>(
+                () => env.Service.GetEngineAsync("invalid_user_id", Project01, CancellationToken.None)
+            );
+        }
+
+        [Test]
+        public void GetEngineAsync_NoProject()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+
+            // SUT
+            Assert.ThrowsAsync<DataNotFoundException>(
+                () => env.Service.GetEngineAsync(User01, "invalid_project_id", CancellationToken.None)
+            );
+        }
+
+        [Test]
+        public async Task GetEngineAsync_Success()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            string sourceLanguageTag = "en_US";
+            string targetLanguageTag = "en_NZ";
+            int confidence = 100;
+            int corpusSize = 472;
+            env.MachineTranslationService
+                .GetTranslationEngineAsync(TranslationEngine01, Arg.Any<CancellationToken>())
+                .Returns(
+                    Task.FromResult(
+                        new MachineApiTranslationEngine
+                        {
+                            Confidence = confidence,
+                            CorpusSize = corpusSize,
+                            Href = "https://example.com",
+                            Id = Project01,
+                            IsBuilding = true,
+                            ModelRevision = 1,
+                            Name = "my_translation_engine",
+                            SourceLanguageTag = sourceLanguageTag,
+                            TargetLanguageTag = targetLanguageTag,
+                            Type = "SmtTransfer",
+                        }
+                    )
+                );
+
+            // SUT
+            EngineDto actual = await env.Service.GetEngineAsync(User01, Project01, CancellationToken.None);
+
+            Assert.AreEqual(confidence, actual.Confidence);
+            Assert.AreEqual(corpusSize, actual.TrainedSegmentCount);
+            Assert.AreEqual(sourceLanguageTag, actual.SourceLanguageTag);
+            Assert.AreEqual(targetLanguageTag, actual.TargetLanguageTag);
+            Assert.IsFalse(actual.IsShared);
+            Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Href);
+            Assert.AreEqual(1, actual.Projects.Length);
+            Assert.AreEqual(Project01, actual.Projects.First().Id);
+            Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Projects.First().Href);
+        }
+
+        private class TestEnvironment
+        {
+            public TestEnvironment()
+            {
+                MachineTranslationService = Substitute.For<IMachineTranslationService>();
+                var projectSecrets = new MemoryRepository<SFProjectSecret>(
+                    new[]
+                    {
+                        new SFProjectSecret
+                        {
+                            Id = Project01,
+                            MachineData = new MachineData { TranslationEngineId = TranslationEngine01, },
+                        },
+                        new SFProjectSecret { Id = Project02 },
+                    }
+                );
+
+                var realtimeService = new SFMemoryRealtimeService();
+                realtimeService.AddRepository(
+                    "sf_projects",
+                    OTType.Json0,
+                    new MemoryRepository<SFProject>(
+                        new[]
+                        {
+                            new SFProject
+                            {
+                                Id = Project01,
+                                UserRoles = new Dictionary<string, string> { { User01, SFProjectRole.Administrator }, },
+                            },
+                            new SFProject { Id = Project02, },
+                        }
+                    )
+                );
+
+                Service = new MachineApiService(MachineTranslationService, projectSecrets, realtimeService);
+            }
+
+            public IMachineTranslationService MachineTranslationService { get; }
+            public MachineApiService Service { get; }
+        }
+    }
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -68,7 +68,7 @@ namespace SIL.XForge.Scripture.Services
             string message = "Finalizing";
             double percentCompleted = 0.95;
             int revision = 553;
-            string state = "Active";
+            string state = "ACTIVE";
             env.MachineBuildService
                 .GetCurrentBuildAsync(TranslationEngine01, null, Arg.Any<CancellationToken>())
                 .Returns(
@@ -199,7 +199,7 @@ namespace SIL.XForge.Scripture.Services
             string message = "Training language model";
             double percentCompleted = 0.01;
             int revision = 2;
-            string state = "Active";
+            string state = "ACTIVE";
             env.MachineBuildService
                 .StartBuildAsync(TranslationEngine01, Arg.Any<CancellationToken>())
                 .Returns(

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -114,6 +114,20 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
+        public void GetBuildAsync_NoFeatureFlagsEnabled()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+            // SUT
+            Assert.ThrowsAsync<DataNotFoundException>(
+                () => env.Service.GetBuildAsync(User01, Project01, Build01, minRevision: null, CancellationToken.None)
+            );
+        }
+
+        [Test]
         public void GetBuildAsync_NoPermission()
         {
             // Set up test environment
@@ -351,6 +365,20 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
+        public void GetCurrentBuildAsync_NoFeatureFlagsEnabled()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+            // SUT
+            Assert.ThrowsAsync<DataNotFoundException>(
+                () => env.Service.GetCurrentBuildAsync(User01, Project01, minRevision: null, CancellationToken.None)
+            );
+        }
+
+        [Test]
         public void GetCurrentBuildAsync_NoPermission()
         {
             // Set up test environment
@@ -522,6 +550,20 @@ namespace SIL.XForge.Scripture.Services
             await env.MachineBuildService
                 .DidNotReceiveWithAnyArgs()
                 .GetCurrentBuildAsync(TranslationEngine01, minRevision: null, CancellationToken.None);
+        }
+
+        [Test]
+        public void GetEngineAsync_NoFeatureFlagsEnabled()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+            // SUT
+            Assert.ThrowsAsync<DataNotFoundException>(
+                () => env.Service.GetEngineAsync(User01, Project01, CancellationToken.None)
+            );
         }
 
         [Test]
@@ -720,6 +762,20 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
+        public void GetWordGraphAsync_NoFeatureFlagsEnabled()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+            // SUT
+            Assert.ThrowsAsync<DataNotFoundException>(
+                () => env.Service.GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+            );
+        }
+
+        [Test]
         public void GetWordGraphAsync_NoPermission()
         {
             // Set up test environment
@@ -912,6 +968,20 @@ namespace SIL.XForge.Scripture.Services
             await env.MachineTranslationService
                 .Received(1)
                 .GetWordGraphAsync(TranslationEngine01, Array.Empty<string>(), CancellationToken.None);
+        }
+
+        [Test]
+        public void StartBuildAsync_NoFeatureFlagsEnabled()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+            // SUT
+            Assert.ThrowsAsync<DataNotFoundException>(
+                () => env.Service.StartBuildAsync(User01, Project01, CancellationToken.None)
+            );
         }
 
         [Test]
@@ -1263,6 +1333,20 @@ namespace SIL.XForge.Scripture.Services
             await env.MachineTranslationService
                 .Received(1)
                 .TrainSegmentAsync(TranslationEngine01, segmentPair, CancellationToken.None);
+        }
+
+        [Test]
+        public void TranslateAsync_NoFeatureFlagsEnabled()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+            // SUT
+            Assert.ThrowsAsync<DataNotFoundException>(
+                () => env.Service.TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+            );
         }
 
         [Test]

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -1069,6 +1069,9 @@ namespace SIL.XForge.Scripture.Services
             // SUT
             BuildDto actual = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
 
+            await env.MachineProjectService
+                .Received(1)
+                .SyncProjectCorporaAsync(User01, Project01, CancellationToken.None);
             Assert.AreEqual(message, actual.Message);
             Assert.AreEqual(percentCompleted, actual.PercentCompleted);
             Assert.AreEqual(revision, actual.Revision);
@@ -1090,6 +1093,9 @@ namespace SIL.XForge.Scripture.Services
             _ = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
 
             await env.EngineService.Received(1).StartBuildAsync(TranslationEngine01);
+            await env.MachineProjectService
+                .Received(1)
+                .SyncProjectCorporaAsync(User01, Project01, CancellationToken.None);
             await env.MachineBuildService.Received(1).StartBuildAsync(TranslationEngine01, CancellationToken.None);
         }
 
@@ -1287,6 +1293,7 @@ namespace SIL.XForge.Scripture.Services
                 FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(true));
 
                 MachineBuildService = Substitute.For<IMachineBuildService>();
+                MachineProjectService = Substitute.For<IMachineProjectService>();
                 MachineTranslationService = Substitute.For<IMachineTranslationService>();
                 var projectSecrets = new MemoryRepository<SFProjectSecret>(
                     new[]
@@ -1330,6 +1337,7 @@ namespace SIL.XForge.Scripture.Services
                     ExceptionHandler,
                     FeatureManager,
                     MachineBuildService,
+                    MachineProjectService,
                     MachineTranslationService,
                     projectSecrets,
                     realtimeService
@@ -1342,6 +1350,7 @@ namespace SIL.XForge.Scripture.Services
             public IExceptionHandler ExceptionHandler { get; }
             public IFeatureManager FeatureManager { get; }
             public IMachineBuildService MachineBuildService { get; }
+            public IMachineProjectService MachineProjectService { get; }
             public IMachineTranslationService MachineTranslationService { get; }
             public MachineApiService Service { get; }
         }

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineBuildServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineBuildServiceTests.cs
@@ -13,6 +13,7 @@ namespace SIL.XForge.Scripture.Services
     [TestFixture]
     public class MachineBuildServiceTests
     {
+        private const string Build01 = "build01";
         private const string TranslationEngine01 = "translationEngine01";
 
         [Test]
@@ -50,15 +51,14 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task GetCurrentBuildAsync_Success()
+        public async Task GetBuildAsync_Success()
         {
             // Set up a mock Machine API
-            string buildId = "633fdb281a2e7ac760f7193a";
             string state = "Active";
             string message = "Finalizing";
             int revision = 553;
             double percentCompleted = 0.95;
-            string href = $"/translation-engines/{TranslationEngine01}/builds/{buildId}";
+            string href = $"/translation-engines/{TranslationEngine01}/builds/{Build01}";
             string response =
                 @$"{{
                     ""revision"": {revision},
@@ -70,11 +70,162 @@ namespace SIL.XForge.Scripture.Services
                     ""percentCompleted"": {percentCompleted},
                     ""message"": ""{message}"",
                     ""state"": ""{state}"",
-                    ""id"": ""{buildId}"",
+                    ""id"": ""{Build01}"",
                     ""href"": ""{href}""
                     }}";
             var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
             var httpClient = TestEnvironment.CreateHttpClient(handler);
+
+            // Set up test environment
+            var env = new TestEnvironment(httpClient);
+
+            // SUT
+            BuildDto? actual = await env.Service.GetBuildAsync(
+                TranslationEngine01,
+                Build01,
+                minRevision: null,
+                CancellationToken.None
+            );
+
+            Assert.NotNull(actual);
+            Assert.AreEqual(Build01, actual.Id);
+            Assert.AreEqual(percentCompleted, actual.PercentCompleted);
+            Assert.AreEqual(message, actual.Message);
+            Assert.AreEqual(revision, actual.Revision);
+            Assert.AreEqual(state.ToUpperInvariant(), actual.State);
+            Assert.AreEqual(1, handler.NumberOfCalls);
+        }
+
+        [Test]
+        public async Task GetBuildAsync_MinRevision()
+        {
+            // Set up a mock Machine API
+            int minRevision = 553;
+            string state = "Active";
+            string message = "Finalizing";
+            int revision = minRevision + 1;
+            double percentCompleted = 0.95;
+            string response =
+                @$"{{
+                    ""revision"": {revision},
+                    ""parent"": {{
+                        ""id"": ""{TranslationEngine01}"",
+                        ""href"": ""/translation-engines/{TranslationEngine01}""
+                    }},
+                    ""step"": 540,
+                    ""percentCompleted"": {percentCompleted},
+                    ""message"": ""{message}"",
+                    ""state"": ""{state}"",
+                    ""id"": ""{Build01}"",
+                    ""href"": ""/translation-engines/{TranslationEngine01}/builds/{Build01}""
+                    }}";
+            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+            var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+
+            // Set up test environment
+            var env = new TestEnvironment(httpClient);
+
+            // SUT
+            BuildDto? actual = await env.Service.GetBuildAsync(
+                TranslationEngine01,
+                Build01,
+                minRevision,
+                CancellationToken.None
+            );
+
+            Assert.NotNull(actual);
+            Assert.AreEqual(Build01, actual.Id);
+            Assert.AreEqual(percentCompleted, actual.PercentCompleted);
+            Assert.AreEqual(message, actual.Message);
+            Assert.AreEqual(revision, actual.Revision);
+            Assert.AreEqual(state.ToUpperInvariant(), actual.State);
+            Assert.AreEqual(1, handler.NumberOfCalls);
+        }
+
+        [Test]
+        public void GetBuildAsync_BuildEnded()
+        {
+            // Set up a mock Machine API
+            string response = string.Empty;
+            var handler = new MockHttpMessageHandler(response, HttpStatusCode.NoContent);
+            var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+
+            // Set up test environment
+            var env = new TestEnvironment(httpClient);
+
+            // SUT
+            Assert.ThrowsAsync<DataNotFoundException>(
+                () => env.Service.GetBuildAsync(TranslationEngine01, Build01, minRevision: 0, CancellationToken.None)
+            );
+
+            Assert.AreEqual(1, handler.NumberOfCalls);
+        }
+
+        [Test]
+        public async Task GetBuildAsync_NoBuildRunning()
+        {
+            // Set up a mock Machine API
+            string response = string.Empty;
+            var handler = new MockHttpMessageHandler(response, HttpStatusCode.RequestTimeout);
+            var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+
+            // Set up test environment
+            var env = new TestEnvironment(httpClient);
+
+            // SUT
+            BuildDto? actual = await env.Service.GetBuildAsync(
+                TranslationEngine01,
+                Build01,
+                minRevision: 0,
+                CancellationToken.None
+            );
+
+            Assert.Null(actual);
+            Assert.AreEqual(1, handler.NumberOfCalls);
+        }
+
+        [Test]
+        public void GetBuildAsync_NoPermission()
+        {
+            // Set up a mock Machine API
+            string response = string.Empty;
+            var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
+            var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+
+            // Set up test environment
+            var env = new TestEnvironment(httpClient);
+
+            // SUT
+            Assert.ThrowsAsync<HttpRequestException>(
+                () => env.Service.GetBuildAsync(TranslationEngine01, Build01, null, CancellationToken.None)
+            );
+        }
+
+        [Test]
+        public async Task GetCurrentBuildAsync_Success()
+        {
+            // Set up a mock Machine API
+            string state = "Active";
+            string message = "Finalizing";
+            int revision = 553;
+            double percentCompleted = 0.95;
+            string href = $"/translation-engines/{TranslationEngine01}/builds/{Build01}";
+            string response =
+                @$"{{
+                    ""revision"": {revision},
+                    ""parent"": {{
+                        ""id"": ""{TranslationEngine01}"",
+                        ""href"": ""/translation-engines/{TranslationEngine01}""
+                    }},
+                    ""step"": 540,
+                    ""percentCompleted"": {percentCompleted},
+                    ""message"": ""{message}"",
+                    ""state"": ""{state}"",
+                    ""id"": ""{Build01}"",
+                    ""href"": ""{href}""
+                    }}";
+            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+            var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
 
             // Set up test environment
             var env = new TestEnvironment(httpClient);
@@ -87,7 +238,7 @@ namespace SIL.XForge.Scripture.Services
             );
 
             Assert.NotNull(actual);
-            Assert.AreEqual(buildId, actual.Id);
+            Assert.AreEqual(Build01, actual.Id);
             Assert.AreEqual(href, actual.Href);
             Assert.AreEqual(percentCompleted, actual.PercentCompleted);
             Assert.AreEqual(message, actual.Message);
@@ -101,12 +252,11 @@ namespace SIL.XForge.Scripture.Services
         {
             // Set up a mock Machine API
             int minRevision = 553;
-            string buildId = "633fdb281a2e7ac760f7193a";
             string state = "Active";
             string message = "Finalizing";
             int revision = minRevision + 1;
             double percentCompleted = 0.95;
-            string href = $"/translation-engines/{TranslationEngine01}/builds/{buildId}";
+            string href = $"/translation-engines/{TranslationEngine01}/builds/{Build01}";
             string response =
                 @$"{{
                     ""revision"": {revision},
@@ -118,7 +268,7 @@ namespace SIL.XForge.Scripture.Services
                     ""percentCompleted"": {percentCompleted},
                     ""message"": ""{message}"",
                     ""state"": ""{state}"",
-                    ""id"": ""{buildId}"",
+                    ""id"": ""{Build01}"",
                     ""href"": ""{href}""
                     }}";
             var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
@@ -135,7 +285,7 @@ namespace SIL.XForge.Scripture.Services
             );
 
             Assert.NotNull(actual);
-            Assert.AreEqual(buildId, actual.Id);
+            Assert.AreEqual(Build01, actual.Id);
             Assert.AreEqual(href, actual.Href);
             Assert.AreEqual(percentCompleted, actual.PercentCompleted);
             Assert.AreEqual(message, actual.Message);
@@ -206,10 +356,9 @@ namespace SIL.XForge.Scripture.Services
         public async Task StartBuildAsync_Success()
         {
             // Set up a mock Machine API
-            string buildId = "633fdb281a2e7ac760f7193a";
             string state = "Pending";
             int revision = 2;
-            string href = $"/translation-engines/{TranslationEngine01}/builds/{buildId}";
+            string href = $"/translation-engines/{TranslationEngine01}/builds/{Build01}";
             string response =
                 @$"{{
                     ""revision"": {revision},
@@ -219,7 +368,7 @@ namespace SIL.XForge.Scripture.Services
                     }},
                     ""step"": 1,
                     ""state"": ""{state}"",
-                    ""id"": ""{buildId}"",
+                    ""id"": ""{Build01}"",
                     ""href"": ""{href}""
                     }}";
             var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
@@ -231,7 +380,7 @@ namespace SIL.XForge.Scripture.Services
             // SUT
             BuildDto actual = await env.Service.StartBuildAsync(TranslationEngine01, CancellationToken.None);
 
-            Assert.AreEqual(buildId, actual.Id);
+            Assert.AreEqual(Build01, actual.Id);
             Assert.AreEqual(href, actual.Href);
             Assert.Zero(actual.PercentCompleted);
             Assert.Null(actual.Message);

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineBuildServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineBuildServiceTests.cs
@@ -89,6 +89,7 @@ namespace SIL.XForge.Scripture.Services
 
             Assert.NotNull(actual);
             Assert.AreEqual(Build01, actual.Id);
+            Assert.AreEqual(href, actual.Href);
             Assert.AreEqual(percentCompleted, actual.PercentCompleted);
             Assert.AreEqual(message, actual.Message);
             Assert.AreEqual(revision, actual.Revision);
@@ -105,6 +106,7 @@ namespace SIL.XForge.Scripture.Services
             string message = "Finalizing";
             int revision = minRevision + 1;
             double percentCompleted = 0.95;
+            string href = $"/translation-engines/{TranslationEngine01}/builds/{Build01}";
             string response =
                 @$"{{
                     ""revision"": {revision},
@@ -117,10 +119,10 @@ namespace SIL.XForge.Scripture.Services
                     ""message"": ""{message}"",
                     ""state"": ""{state}"",
                     ""id"": ""{Build01}"",
-                    ""href"": ""/translation-engines/{TranslationEngine01}/builds/{Build01}""
+                    ""href"": ""{href}""
                     }}";
             var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+            var httpClient = TestEnvironment.CreateHttpClient(handler);
 
             // Set up test environment
             var env = new TestEnvironment(httpClient);
@@ -135,6 +137,7 @@ namespace SIL.XForge.Scripture.Services
 
             Assert.NotNull(actual);
             Assert.AreEqual(Build01, actual.Id);
+            Assert.AreEqual(href, actual.Href);
             Assert.AreEqual(percentCompleted, actual.PercentCompleted);
             Assert.AreEqual(message, actual.Message);
             Assert.AreEqual(revision, actual.Revision);
@@ -148,7 +151,7 @@ namespace SIL.XForge.Scripture.Services
             // Set up a mock Machine API
             string response = string.Empty;
             var handler = new MockHttpMessageHandler(response, HttpStatusCode.NoContent);
-            var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+            var httpClient = TestEnvironment.CreateHttpClient(handler);
 
             // Set up test environment
             var env = new TestEnvironment(httpClient);
@@ -167,7 +170,7 @@ namespace SIL.XForge.Scripture.Services
             // Set up a mock Machine API
             string response = string.Empty;
             var handler = new MockHttpMessageHandler(response, HttpStatusCode.RequestTimeout);
-            var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+            var httpClient = TestEnvironment.CreateHttpClient(handler);
 
             // Set up test environment
             var env = new TestEnvironment(httpClient);
@@ -190,7 +193,7 @@ namespace SIL.XForge.Scripture.Services
             // Set up a mock Machine API
             string response = string.Empty;
             var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
-            var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+            var httpClient = TestEnvironment.CreateHttpClient(handler);
 
             // Set up test environment
             var env = new TestEnvironment(httpClient);
@@ -225,7 +228,7 @@ namespace SIL.XForge.Scripture.Services
                     ""href"": ""{href}""
                     }}";
             var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+            var httpClient = TestEnvironment.CreateHttpClient(handler);
 
             // Set up test environment
             var env = new TestEnvironment(httpClient);

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineBuildServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineBuildServiceTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using NSubstitute;
 using NUnit.Framework;
 using SIL.Machine.WebApi;
+using SIL.XForge.Services;
 
 namespace SIL.XForge.Scripture.Services
 {
@@ -144,7 +145,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task GetCurrentBuildAsync_NoBuildRunning()
+        public void GetCurrentBuildAsync_BuildEnded()
         {
             // Set up a mock Machine API
             string response = string.Empty;
@@ -155,18 +156,15 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment(httpClient);
 
             // SUT
-            BuildDto? actual = await env.Service.GetCurrentBuildAsync(
-                TranslationEngine01,
-                minRevision: null,
-                CancellationToken.None
+            Assert.ThrowsAsync<DataNotFoundException>(
+                () => env.Service.GetCurrentBuildAsync(TranslationEngine01, minRevision: 0, CancellationToken.None)
             );
 
-            Assert.Null(actual);
             Assert.AreEqual(1, handler.NumberOfCalls);
         }
 
         [Test]
-        public async Task GetCurrentBuildAsync_NoBuildStarted()
+        public async Task GetCurrentBuildAsync_NoBuildRunning()
         {
             // Set up a mock Machine API
             string response = string.Empty;

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -78,11 +78,11 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task AddProjectAsync_DoesNotExecuteInMemoryMachineIfFeatureDisabled()
+        public async Task AddProjectAsync_DoesNotExecuteInProcessMachineIfFeatureDisabled()
         {
             // Set up test environment
             var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
             env.MachineTranslationService
                 .CreateTranslationEngineAsync(Project01, Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None)
                 .Returns(Task.FromResult(TranslationEngine01));
@@ -127,11 +127,11 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task BuildProjectAsync_DoesNotExecuteInMemoryMachineIfFeatureDisabled()
+        public async Task BuildProjectAsync_DoesNotExecuteInProcessMachineIfFeatureDisabled()
         {
             // Set up test environment
             var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
             // SUT
             await env.Service.BuildProjectAsync(User01, Project01, CancellationToken.None);
@@ -247,21 +247,21 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task RemoveProjectAsync_DoesNotExecuteInMemoryMachineIfFeatureDisabled()
+        public async Task RemoveProjectAsync_DoesNotExecuteInProcessMachineIfFeatureDisabled()
         {
             // Set up test environment
             var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
             // SUT
             await env.Service.RemoveProjectAsync(User01, Project02, CancellationToken.None);
 
-            // Ensure that the in memory instance was not called
+            // Ensure that the in process instance was not called
             await env.EngineService.DidNotReceiveWithAnyArgs().RemoveProjectAsync(Project02);
         }
 
         [Test]
-        public async Task RemoveProjectAsync_ExecutesInMemoryMachine()
+        public async Task RemoveProjectAsync_ExecutesInProcessMachine()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -600,7 +600,7 @@ namespace SIL.XForge.Scripture.Services
 
                 FeatureManager = Substitute.For<IFeatureManager>();
                 FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(true));
-                FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(true));
+                FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(true));
 
                 ProjectSecrets = new MemoryRepository<SFProjectSecret>(
                     new[]

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -84,7 +84,13 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
             env.MachineTranslationService
-                .CreateTranslationEngineAsync(Project01, Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None)
+                .CreateTranslationEngineAsync(
+                    Project01,
+                    Arg.Any<string>(),
+                    Arg.Any<string>(),
+                    true,
+                    CancellationToken.None
+                )
                 .Returns(Task.FromResult(TranslationEngine01));
 
             // SUT

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -84,12 +84,7 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
             env.MachineTranslationService
-                .CreateTranslationEngineAsync(
-                    Project01,
-                    Arg.Any<string>(),
-                    Arg.Any<string>(),
-                    Arg.Any<CancellationToken>()
-                )
+                .CreateTranslationEngineAsync(Project01, Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None)
                 .Returns(Task.FromResult(TranslationEngine01));
 
             // SUT

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -349,7 +349,7 @@ namespace SIL.XForge.Scripture.Services
                 .GetCorpusFilesAsync(Corpus01, CancellationToken.None)
                 .Returns(Task.FromResult<IList<MachineApiCorpusFile>>(Array.Empty<MachineApiCorpusFile>()));
             env.MachineCorporaService
-                .UploadCorpusTextAsync(Corpus01, "en", "textId_source", Arg.Any<string>(), CancellationToken.None)
+                .UploadCorpusTextAsync(Corpus01, "en", "textId", Arg.Any<string>(), CancellationToken.None)
                 .Returns(Task.FromResult("File03"));
             await env.ProjectSecrets.UpdateAsync(
                 Project02,
@@ -360,7 +360,7 @@ namespace SIL.XForge.Scripture.Services
                         {
                             FileChecksum = "a_previous_checksum",
                             FileId = "File03",
-                            TextId = "textId_source",
+                            TextId = "textId",
                         }
                     )
             );
@@ -385,7 +385,7 @@ namespace SIL.XForge.Scripture.Services
                 .CreateAsync(Arg.Any<IEnumerable<string>>(), TextCorpusType.Source)
                 .Returns(TestEnvironment.MockTextCorpus);
             env.MachineCorporaService
-                .UploadCorpusTextAsync(Corpus01, "en", "textId_source", Arg.Any<string>(), CancellationToken.None)
+                .UploadCorpusTextAsync(Corpus01, "en", "textId", Arg.Any<string>(), CancellationToken.None)
                 .Returns(Task.FromResult("File03"));
             string checksum = StringUtils.ComputeMd5Hash($"segRef\tsegment01\n");
             await env.ProjectSecrets.UpdateAsync(
@@ -397,7 +397,8 @@ namespace SIL.XForge.Scripture.Services
                         {
                             FileChecksum = checksum,
                             FileId = "File03",
-                            TextId = "textId_source",
+                            LanguageTag = "en",
+                            TextId = "textId",
                         }
                     )
             );
@@ -486,14 +487,14 @@ namespace SIL.XForge.Scripture.Services
                                 Id = "File03",
                                 Href = "/corpora/corpus01/files/File03",
                                 LanguageTag = "en",
-                                Name = "textId_source.txt",
-                                TextId = "textId_source",
+                                Name = "textId.txt",
+                                TextId = "textId",
                             },
                         }
                     )
                 );
             env.MachineCorporaService
-                .UploadCorpusTextAsync(Corpus01, "en", "textId_source", Arg.Any<string>(), CancellationToken.None)
+                .UploadCorpusTextAsync(Corpus01, "en", "textId", Arg.Any<string>(), CancellationToken.None)
                 .Returns(Task.FromResult("File03"));
             await env.ProjectSecrets.UpdateAsync(
                 Project02,
@@ -505,7 +506,7 @@ namespace SIL.XForge.Scripture.Services
                             FileChecksum = "a_previous_checksum",
                             FileId = "File03",
                             LanguageTag = "en",
-                            TextId = "textId_source",
+                            TextId = "textId",
                         }
                     )
             );
@@ -522,7 +523,88 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task SyncProjectCorporaAsync_UpdatesSourceAndTargetTexts()
+        public async Task SyncProjectCorporaAsync_UpdatesSourceAndTargetTextsWithDifferentSourceAndTargetLanguages()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.TextCorpusFactory
+                .CreateAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<TextCorpusType>())
+                .Returns(TestEnvironment.MockTextCorpus);
+            env.MachineCorporaService
+                .GetCorpusFilesAsync(Corpus01, CancellationToken.None)
+                .Returns(
+                    Task.FromResult<IList<MachineApiCorpusFile>>(
+                        new List<MachineApiCorpusFile>
+                        {
+                            new MachineApiCorpusFile
+                            {
+                                Id = "File03",
+                                Href = "/corpora/corpus01/files/File03",
+                                LanguageTag = "en",
+                                Name = "textId.txt",
+                                TextId = "textId",
+                            },
+                            new MachineApiCorpusFile
+                            {
+                                Id = "File04",
+                                Href = "/corpora/corpus01/files/File04",
+                                LanguageTag = "en_US",
+                                Name = "textId.txt",
+                                TextId = "textId",
+                            },
+                        }
+                    )
+                );
+            env.MachineCorporaService
+                .UploadCorpusTextAsync(Corpus01, "en", "textId", Arg.Any<string>(), CancellationToken.None)
+                .Returns(Task.FromResult("File03"));
+            env.MachineCorporaService
+                .UploadCorpusTextAsync(Corpus01, "en_US", "textId", Arg.Any<string>(), CancellationToken.None)
+                .Returns(Task.FromResult("File04"));
+            await env.ProjectSecrets.UpdateAsync(
+                Project02,
+                u =>
+                    u.Add(
+                            p => p.MachineData.Corpora[Corpus01].Files,
+                            new MachineCorpusFile
+                            {
+                                FileChecksum = "a_previous_checksum",
+                                FileId = "File03",
+                                LanguageTag = "en",
+                                TextId = "textId",
+                            }
+                        )
+                        .Add(
+                            p => p.MachineData.Corpora[Corpus01].Files,
+                            new MachineCorpusFile
+                            {
+                                FileChecksum = "another_previous_checksum",
+                                FileId = "File04",
+                                LanguageTag = "en_US",
+                                TextId = "textId",
+                            }
+                        )
+            );
+
+            // SUT
+            bool actual = await env.Service.SyncProjectCorporaAsync(User01, Project02, CancellationToken.None);
+            Assert.IsTrue(actual);
+            await env.MachineCorporaService
+                .Received(1)
+                .DeleteCorpusFileAsync(Corpus01, "File03", CancellationToken.None);
+            await env.MachineCorporaService
+                .Received(1)
+                .DeleteCorpusFileAsync(Corpus01, "File04", CancellationToken.None);
+            await env.MachineCorporaService
+                .Received(1)
+                .UploadCorpusTextAsync(Corpus01, "en", "textId", Arg.Any<string>(), CancellationToken.None);
+            await env.MachineCorporaService
+                .Received(1)
+                .UploadCorpusTextAsync(Corpus01, "en_US", "textId", Arg.Any<string>(), CancellationToken.None);
+        }
+
+        [Test]
+        public async Task SyncProjectCorporaAsync_UpdatesSourceAndTargetTextsWithTheSameSourceAndTargetLanguage()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -560,6 +642,7 @@ namespace SIL.XForge.Scripture.Services
             env.MachineCorporaService
                 .UploadCorpusTextAsync(Corpus01, "en", "textId_target", Arg.Any<string>(), CancellationToken.None)
                 .Returns(Task.FromResult("File04"));
+            await env.Projects.UpdateAsync(Project02, u => u.Set(p => p.WritingSystem.Tag, "en"));
             await env.ProjectSecrets.UpdateAsync(
                 Project02,
                 u =>
@@ -599,7 +682,7 @@ namespace SIL.XForge.Scripture.Services
                 .UploadCorpusTextAsync(Corpus01, "en", "textId_source", Arg.Any<string>(), CancellationToken.None);
             await env.MachineCorporaService
                 .Received(1)
-                .UploadCorpusTextAsync(Corpus01, "en_US", "textId_target", Arg.Any<string>(), CancellationToken.None);
+                .UploadCorpusTextAsync(Corpus01, "en", "textId_target", Arg.Any<string>(), CancellationToken.None);
         }
 
         private class TestEnvironment
@@ -648,62 +731,60 @@ namespace SIL.XForge.Scripture.Services
                     }
                 );
 
-                var userSecrets = new MemoryRepository<UserSecret>(new[] { new UserSecret { Id = User01 }, });
+                var userSecrets = new MemoryRepository<UserSecret>(new[] { new UserSecret { Id = User01 } });
+
+                Projects = new MemoryRepository<SFProject>(
+                    new[]
+                    {
+                        new SFProject
+                        {
+                            Id = Project01,
+                            Name = "project01",
+                            ShortName = "P01",
+                            CheckingConfig = new CheckingConfig { ShareEnabled = false },
+                            UserRoles = new Dictionary<string, string>(),
+                            TranslateConfig = new TranslateConfig
+                            {
+                                TranslationSuggestionsEnabled = true,
+                                Source = new TranslateSource
+                                {
+                                    ProjectRef = Project02,
+                                    WritingSystem = new WritingSystem { Tag = "en_US" },
+                                },
+                            },
+                            WritingSystem = new WritingSystem { Tag = "en_GB" },
+                        },
+                        new SFProject
+                        {
+                            Id = Project02,
+                            Name = "project02",
+                            ShortName = "P02",
+                            CheckingConfig = new CheckingConfig { ShareEnabled = false },
+                            UserRoles = new Dictionary<string, string>(),
+                            TranslateConfig = new TranslateConfig
+                            {
+                                TranslationSuggestionsEnabled = true,
+                                Source = new TranslateSource
+                                {
+                                    ProjectRef = Project03,
+                                    WritingSystem = new WritingSystem { Tag = "en" },
+                                },
+                            },
+                            WritingSystem = new WritingSystem { Tag = "en_US" },
+                        },
+                        new SFProject
+                        {
+                            Id = Project03,
+                            Name = "project03",
+                            ShortName = "P03",
+                            CheckingConfig = new CheckingConfig { ShareEnabled = false },
+                            UserRoles = new Dictionary<string, string>(),
+                        },
+                    }
+                );
 
                 var realtimeService = new SFMemoryRealtimeService();
-                realtimeService.AddRepository(
-                    "sf_projects",
-                    OTType.Json0,
-                    new MemoryRepository<SFProject>(
-                        new[]
-                        {
-                            new SFProject
-                            {
-                                Id = Project01,
-                                Name = "project01",
-                                ShortName = "P01",
-                                CheckingConfig = new CheckingConfig { ShareEnabled = false },
-                                UserRoles = new Dictionary<string, string>(),
-                                TranslateConfig = new TranslateConfig
-                                {
-                                    TranslationSuggestionsEnabled = true,
-                                    Source = new TranslateSource
-                                    {
-                                        ProjectRef = Project02,
-                                        WritingSystem = new WritingSystem { Tag = "en_US" },
-                                    },
-                                },
-                                WritingSystem = new WritingSystem { Tag = "en_GB" },
-                            },
-                            new SFProject
-                            {
-                                Id = Project02,
-                                Name = "project02",
-                                ShortName = "P02",
-                                CheckingConfig = new CheckingConfig { ShareEnabled = false },
-                                UserRoles = new Dictionary<string, string>(),
-                                TranslateConfig = new TranslateConfig
-                                {
-                                    TranslationSuggestionsEnabled = true,
-                                    Source = new TranslateSource
-                                    {
-                                        ProjectRef = Project03,
-                                        WritingSystem = new WritingSystem { Tag = "en" },
-                                    },
-                                },
-                                WritingSystem = new WritingSystem { Tag = "en_US" },
-                            },
-                            new SFProject
-                            {
-                                Id = Project03,
-                                Name = "project03",
-                                ShortName = "P03",
-                                CheckingConfig = new CheckingConfig { ShareEnabled = false },
-                                UserRoles = new Dictionary<string, string>(),
-                            },
-                        }
-                    )
-                );
+                realtimeService.AddRepository("sf_projects", OTType.Json0, Projects);
 
                 Service = new MachineProjectService(
                     EngineService,
@@ -753,6 +834,7 @@ namespace SIL.XForge.Scripture.Services
             public IMachineCorporaService MachineCorporaService { get; }
             public IMachineTranslationService MachineTranslationService { get; }
             public MemoryRepository<SFProjectSecret> ProjectSecrets { get; }
+            public MemoryRepository<SFProject> Projects { get; }
             public ITextCorpusFactory TextCorpusFactory { get; }
         }
     }

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -78,6 +78,27 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
+        public async Task AddProjectAsync_DoesNotExecuteInMemoryMachineIfFeatureDisabled()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+            env.MachineTranslationService
+                .CreateTranslationEngineAsync(
+                    Project01,
+                    Arg.Any<string>(),
+                    Arg.Any<string>(),
+                    Arg.Any<CancellationToken>()
+                )
+                .Returns(Task.FromResult(TranslationEngine01));
+
+            // SUT
+            await env.Service.AddProjectAsync(User01, Project01, CancellationToken.None);
+
+            await env.EngineService.DidNotReceiveWithAnyArgs().AddProjectAsync(Arg.Any<MachineProject>());
+        }
+
+        [Test]
         public async Task BuildProjectAsync_CallsMachineApiIfTranslationEngineIdPresent()
         {
             // Set up test environment
@@ -108,6 +129,19 @@ namespace SIL.XForge.Scripture.Services
             await env.MachineBuildService
                 .DidNotReceiveWithAnyArgs()
                 .StartBuildAsync(TranslationEngine02, CancellationToken.None);
+        }
+
+        [Test]
+        public async Task BuildProjectAsync_DoesNotExecuteInMemoryMachineIfFeatureDisabled()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+
+            // SUT
+            await env.Service.BuildProjectAsync(User01, Project01, CancellationToken.None);
+
+            await env.EngineService.DidNotReceive().StartBuildByProjectIdAsync(Project01);
         }
 
         [Test]
@@ -218,7 +252,21 @@ namespace SIL.XForge.Scripture.Services
         }
 
         [Test]
-        public async Task RemoveProjectAsync_ExecutesInProcessMachine()
+        public async Task RemoveProjectAsync_DoesNotExecuteInMemoryMachineIfFeatureDisabled()
+        {
+            // Set up test environment
+            var env = new TestEnvironment();
+            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(false));
+
+            // SUT
+            await env.Service.RemoveProjectAsync(User01, Project02, CancellationToken.None);
+
+            // Ensure that the in memory instance was not called
+            await env.EngineService.DidNotReceiveWithAnyArgs().RemoveProjectAsync(Project02);
+        }
+
+        [Test]
+        public async Task RemoveProjectAsync_ExecutesInMemoryMachine()
         {
             // Set up test environment
             var env = new TestEnvironment();
@@ -557,6 +605,7 @@ namespace SIL.XForge.Scripture.Services
 
                 FeatureManager = Substitute.For<IFeatureManager>();
                 FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(true));
+                FeatureManager.IsEnabledAsync(FeatureFlags.MachineInMemory).Returns(Task.FromResult(true));
 
                 ProjectSecrets = new MemoryRepository<SFProjectSecret>(
                     new[]

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -18,6 +18,7 @@ using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 using Paratext.Data;
+using Paratext.Data.Languages;
 using Paratext.Data.ProjectComments;
 using Paratext.Data.ProjectFileAccess;
 using Paratext.Data.RegistryServerAccess;
@@ -1167,7 +1168,8 @@ namespace SIL.XForge.Scripture.Services
         {
             var env = new TestEnvironment();
             IEnumerable<NoteThreadChange> changes = await env.PrepareChangeOnSingleCommentAsync(
-                (Paratext.Data.ProjectComments.Comment comment) => {
+                (Paratext.Data.ProjectComments.Comment comment) =>
+                {
                     // Not modifying comment.
                 }
             );
@@ -3232,6 +3234,19 @@ namespace SIL.XForge.Scripture.Services
             env.MockHgWrapper.Received().GetRepoRevision(Arg.Any<string>());
         }
 
+        [Test]
+        public void GetLanguageId_GetsTheLanguageIdFromTheScrText()
+        {
+            var env = new TestEnvironment();
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+            // SUT
+            string languageId = env.Service.GetLanguageId(userSecret, ptProjectId);
+            Assert.AreEqual(LanguageId.English.Id, languageId);
+        }
+
         private class TestEnvironment : IDisposable
         {
             public readonly string ParatextUserId01 = "paratext01";
@@ -4035,6 +4050,7 @@ namespace SIL.XForge.Scripture.Services
                 scrText.Permissions.CreateFirstAdminUser();
                 scrText.Data.Add("RUT", ruthBookUsfm);
                 scrText.Settings.BooksPresentSet = new BookSet("RUT");
+                scrText.Settings.LanguageID = LanguageId.English;
                 if (!hasEditPermission)
                     scrText.Permissions.SetPermission(null, 8, PermissionSet.Manual, false);
                 return scrText;

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -2507,6 +2507,7 @@ namespace SIL.XForge.Scripture.Services
             await env.Service.EnsureWritingSystemTagIsSetAsync(User01, Project01);
 
             // If the writing system tags are updated, the projects must be retrieved
+            // We check that this is not called, to ensure that it was not updated
             await env.ParatextService.DidNotReceive().GetProjectsAsync(Arg.Any<UserSecret>());
         }
 
@@ -2521,7 +2522,7 @@ namespace SIL.XForge.Scripture.Services
             // SUT
             await env.Service.EnsureWritingSystemTagIsSetAsync(User01, Project04);
 
-            // If the writing system tags are updated, the projects must be retrieved
+            // Ensure that our mock GetProjectsAsync created above is called
             await env.ParatextService.Received(1).GetProjectsAsync(Arg.Any<UserSecret>());
 
             Assert.IsNull(env.GetProject(Project04).WritingSystem.Tag);
@@ -2541,7 +2542,7 @@ namespace SIL.XForge.Scripture.Services
                 new ParatextProject
                 {
                     ParatextId = env.GetProject(Project04).TranslateConfig.Source.ParatextId,
-                    LanguageTag = languageTag02
+                    LanguageTag = languageTag02,
                 },
             };
             env.ParatextService.GetProjectsAsync(Arg.Any<UserSecret>()).Returns(Task.FromResult(ptProjects));
@@ -2549,7 +2550,7 @@ namespace SIL.XForge.Scripture.Services
             // SUT
             await env.Service.EnsureWritingSystemTagIsSetAsync(User01, Project04);
 
-            // If the writing system tags are updated, the projects must be retrieved
+            // Ensure that our mock GetProjectsAsync created above is called
             await env.ParatextService.Received(1).GetProjectsAsync(Arg.Any<UserSecret>());
 
             Assert.AreEqual(languageTag01, env.GetProject(Project04).WritingSystem.Tag);


### PR DESCRIPTION
Adds support for accessing the new Machine API via a Web API accessible from the Scripture Forge frontend.

Key changes include:
 * Moving the previous In Process Machine API implementation to /machine-api/v1/
 * Creating a fully compatible new Machine API implementation at /machine-api/v2/ as a drop in replacement for V1
 * Added a new `GetBuildById` endpoint to the C# API to enable better compatibility with the V1 API client (machine.js)
 * Fixed a bug where the Machine Build would not run on first sync (SF-1517)
 * Added a `MachineInMemory` feature flag to enable/disable the In Process Machine API (enabled by default)
 * Implemented the running of both the In Process and Machine API processes in tandem during the transition phase
 * Adding a Migration program to migrate projects to the new Machine API
 * Fixed a bug where the writing system tag was not set for Back Translations
 * Fixed a bug where verse segments (such as `\li`) were not included in a range, resulting in it being excluded from the training corpus

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1626)
<!-- Reviewable:end -->
