### PR TITLE
Update CSharpier to 0.21

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,10 +3,8 @@
   "isRoot": true,
   "tools": {
     "csharpier": {
-      "version": "0.18.0",
-      "commands": [
-        "dotnet-csharpier"
-      ]
+      "version": "0.21.0",
+      "commands": ["dotnet-csharpier"]
     }
   }
 }

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -812,10 +812,11 @@ namespace SIL.XForge.Scripture.Services
                 Models.TextInfo text = projectDoc.Data.Texts[textIndex];
                 List<Chapter> chapters = text.Chapters;
                 Dictionary<string, string> bookPermissions = null;
-                IEnumerable<(int bookIndex, int chapterIndex, Dictionary<
-                        string,
-                        string
-                    > chapterPermissions)> chapterPermissionsInBook = null;
+                IEnumerable<(
+                    int bookIndex,
+                    int chapterIndex,
+                    Dictionary<string, string> chapterPermissions
+                )> chapterPermissionsInBook = null;
 
                 if (isResource)
                 {

--- a/test/SIL.XForge.Tests/Realtime/RichText/DeltaTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/RichText/DeltaTests.cs
@@ -209,7 +209,17 @@ namespace SIL.XForge.Realtime.RichText
         public void Compose_InsertRetain_MergeOps()
         {
             var a = Delta.New().Insert("A");
-            var b = Delta.New().Retain(1, new { bold = true, color = "red", font = (string)null });
+            var b = Delta
+                .New()
+                .Retain(
+                    1,
+                    new
+                    {
+                        bold = true,
+                        color = "red",
+                        font = (string)null
+                    }
+                );
             var expected = Delta.New().Insert("A", new { bold = true, color = "red" });
             Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
         }
@@ -263,8 +273,28 @@ namespace SIL.XForge.Realtime.RichText
         public void Compose_RetainRetain_MergeOps()
         {
             var a = Delta.New().Retain(1, new { color = "blue" });
-            var b = Delta.New().Retain(1, new { bold = true, color = "red", font = (string)null });
-            var expected = Delta.New().Retain(1, new { bold = true, color = "red", font = (string)null });
+            var b = Delta
+                .New()
+                .Retain(
+                    1,
+                    new
+                    {
+                        bold = true,
+                        color = "red",
+                        font = (string)null
+                    }
+                );
+            var expected = Delta
+                .New()
+                .Retain(
+                    1,
+                    new
+                    {
+                        bold = true,
+                        color = "red",
+                        font = (string)null
+                    }
+                );
             Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
         }
 


### PR DESCRIPTION
In particular this update fixes an odd tuple formatting quirk where the type parameters for a dictionary get split over multiple lines, resulting in a difficult to read method declaration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1632)
<!-- Reviewable:end -->
