### PR TITLE
Fix Code Coverage on .NET 7.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -85,21 +85,21 @@ jobs:
         run: cd src/RealtimeServer && npm run test:ci
       - name: "Test: Backend"
         run: |
-          dotnet test xForge.sln \
+          dotnet test \
             -p:CollectCoverage=true \
-            -p:CoverletOutputFormat=opencover \
-            -p:Exclude=\"[NUnit3.TestAdapter]*,[SIL.XForge.*.Views]*,[SIL.XForge.Tests]*\"
+            -e:CoverletOutputFormat=opencover \
+            -e:Exclude=\"[NUnit3.TestAdapter]*,[SIL.XForge.*.Views]*,[SIL.XForge.Tests]*\"
       - name: "Test: Frontend"
         run: cd src/SIL.XForge.Scripture/ClientApp && npm run test:gha
 
-      # - name: "Coverage: Backend"
-      #   run: |
-      #     reportgenerator \
-      #       -reports:test/*/coverage.opencover.xml \
-      #       -targetdir:coverage \
-      #       "-reporttypes:HTML;TeamCitySummary"
-      # - name: "Coverage: Publish to Codecov"
-      #   uses: codecov/codecov-action@v3
+      - name: "Coverage: Backend"
+        run: |
+          reportgenerator \
+            -reports:test/*/coverage.opencover.xml \
+            -targetdir:coverage \
+            "-reporttypes:HTML;TeamCitySummary"
+      - name: "Coverage: Publish to Codecov"
+        uses: codecov/codecov-action@v3
 
   build-production:
     name: "Production build and test"

--- a/test/SIL.XForge.Scripture.Tests/SIL.XForge.Scripture.Tests.csproj
+++ b/test/SIL.XForge.Scripture.Tests/SIL.XForge.Scripture.Tests.csproj
@@ -11,11 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />

--- a/test/SIL.XForge.Tests/SIL.XForge.Tests.csproj
+++ b/test/SIL.XForge.Tests/SIL.XForge.Tests.csproj
@@ -12,11 +12,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />


### PR DESCRIPTION
The coverlet dependency used to create the opencover XML file has known issues with the MSBuild component .NET 7.0 (see https://github.com/coverlet-coverage/coverlet/issues/1391). This doesn't just apply to the project running on .NET 7.0, but also to the presence of .NET 7.0 on the computer building the coverage file.

This pull request:
 * Re-enables the coverage GHA
 * Modifies the Test: Backend GHA to generate the opencover XML file using the workaround documented on [this issue](https://github.com/coverlet-coverage/coverlet/issues/1391)
 * Updates MS Test to the latest version
 * Updates Coverlet to the latest version

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1633)
<!-- Reviewable:end -->
