### PR TITLE
Separate SF and PT note thread rights

### DIFF
--- a/src/RealtimeServer/common/services/json-doc-service.ts
+++ b/src/RealtimeServer/common/services/json-doc-service.ts
@@ -1,5 +1,6 @@
 import ShareDB from 'sharedb';
 import { ObjProxyArg } from 'ts-object-path';
+import { OwnedData } from '../models/owned-data';
 import { obj, ObjPathTemplate } from '../utils/obj-path';
 import { DocService } from './doc-service';
 
@@ -16,20 +17,20 @@ export abstract class JsonDocService<T> extends DocService<T> {
     return obj<T>().pathTemplate(field, inherit);
   }
 
-  protected checkImmutableProps(ops: ShareDB.Op[] | ShareDB.Op): boolean {
+  protected checkImmutableProps(ops: ShareDB.Op[] | ShareDB.Op, entity?: OwnedData): boolean {
     if (ops instanceof Array) {
       for (const op of ops) {
-        if (this.getMatchingPathTemplate(this.immutableProps, op.p) !== -1) {
+        if (this.getMatchingPathTemplate(this.immutableProps, op.p, entity) !== -1) {
           return false;
         }
       }
       return true;
     }
 
-    return this.getMatchingPathTemplate(this.immutableProps, ops.p) === -1;
+    return this.getMatchingPathTemplate(this.immutableProps, ops.p, entity) === -1;
   }
 
-  protected getMatchingPathTemplate(pathTemplates: ObjPathTemplate[], path: ShareDB.Path): number {
+  protected getMatchingPathTemplate(pathTemplates: ObjPathTemplate[], path: ShareDB.Path, _entity?: OwnedData): number {
     for (let i = 0; i < pathTemplates.length; i++) {
       if (pathTemplates[i].matches(path)) {
         return i;

--- a/src/RealtimeServer/scriptureforge/models/note-thread.ts
+++ b/src/RealtimeServer/scriptureforge/models/note-thread.ts
@@ -5,7 +5,6 @@ import { VerseRefData } from './verse-ref-data';
 
 export const NOTE_THREAD_COLLECTION = 'note_threads';
 export const NOTE_THREAD_INDEX_PATHS = PROJECT_DATA_INDEX_PATHS;
-export const SF_NOTE_THREAD_PREFIX = 'SF_NOTE_THREAD_';
 
 /**
  * Note status, mimicking PT CommentList.cs.
@@ -64,5 +63,6 @@ export interface NoteThread extends ProjectData {
   position: TextAnchor;
   status: NoteStatus;
   tagIcon: string;
+  publishedToSF?: boolean;
   assignment?: string;
 }

--- a/src/RealtimeServer/scriptureforge/models/sf-project-rights.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project-rights.ts
@@ -10,7 +10,8 @@ export enum SFProjectDomain {
   AnswerComments = 'answer_comments',
   AnswerStatus = 'answer_status',
   Likes = 'likes',
-  NoteThreads = 'note_threads',
+  PTNoteThreads = 'pt_note_threads',
+  SFNoteThreads = 'sf_note_threads',
   Notes = 'notes'
 }
 
@@ -34,14 +35,16 @@ export class SFProjectRights extends ProjectRights {
 
       { projectDomain: SFProjectDomain.Likes, operation: Operation.View },
 
-      { projectDomain: SFProjectDomain.NoteThreads, operation: Operation.View },
+      { projectDomain: SFProjectDomain.SFNoteThreads, operation: Operation.View },
 
       { projectDomain: SFProjectDomain.Notes, operation: Operation.View }
     ];
     this.addRights(SFProjectRole.Observer, observerRights);
 
     const ptObserverRights: ProjectRight[] = observerRights.concat([
-      { projectDomain: SFProjectDomain.Project, operation: Operation.View }
+      { projectDomain: SFProjectDomain.Project, operation: Operation.View },
+
+      { projectDomain: SFProjectDomain.PTNoteThreads, operation: Operation.View }
     ]);
     this.addRights(SFProjectRole.ParatextObserver, ptObserverRights);
 
@@ -57,9 +60,9 @@ export class SFProjectRights extends ProjectRights {
       { projectDomain: SFProjectDomain.Likes, operation: Operation.Create },
       { projectDomain: SFProjectDomain.Likes, operation: Operation.DeleteOwn },
 
-      { projectDomain: SFProjectDomain.NoteThreads, operation: Operation.Create },
-      { projectDomain: SFProjectDomain.NoteThreads, operation: Operation.Edit },
-      { projectDomain: SFProjectDomain.NoteThreads, operation: Operation.Delete },
+      { projectDomain: SFProjectDomain.SFNoteThreads, operation: Operation.Create },
+      { projectDomain: SFProjectDomain.SFNoteThreads, operation: Operation.Edit },
+      { projectDomain: SFProjectDomain.SFNoteThreads, operation: Operation.Delete },
 
       { projectDomain: SFProjectDomain.Notes, operation: Operation.Create },
       { projectDomain: SFProjectDomain.Notes, operation: Operation.EditOwn },
@@ -69,7 +72,11 @@ export class SFProjectRights extends ProjectRights {
     this.addRights(SFProjectRole.CommunityChecker, reviewerRights);
 
     const ptReviewerRights: ProjectRight[] = reviewerRights.concat([
-      { projectDomain: SFProjectDomain.Project, operation: Operation.View }
+      { projectDomain: SFProjectDomain.Project, operation: Operation.View },
+
+      { projectDomain: SFProjectDomain.PTNoteThreads, operation: Operation.Create },
+      { projectDomain: SFProjectDomain.PTNoteThreads, operation: Operation.Edit },
+      { projectDomain: SFProjectDomain.PTNoteThreads, operation: Operation.Delete }
     ]);
     this.addRights(SFProjectRole.ParatextConsultant, ptReviewerRights);
 
@@ -97,9 +104,13 @@ export class SFProjectRights extends ProjectRights {
       { projectDomain: SFProjectDomain.Likes, operation: Operation.Create },
       { projectDomain: SFProjectDomain.Likes, operation: Operation.DeleteOwn },
 
-      { projectDomain: SFProjectDomain.NoteThreads, operation: Operation.Create },
-      { projectDomain: SFProjectDomain.NoteThreads, operation: Operation.Edit },
-      { projectDomain: SFProjectDomain.NoteThreads, operation: Operation.Delete },
+      { projectDomain: SFProjectDomain.PTNoteThreads, operation: Operation.Create },
+      { projectDomain: SFProjectDomain.PTNoteThreads, operation: Operation.Edit },
+      { projectDomain: SFProjectDomain.PTNoteThreads, operation: Operation.Delete },
+
+      { projectDomain: SFProjectDomain.SFNoteThreads, operation: Operation.Create },
+      { projectDomain: SFProjectDomain.SFNoteThreads, operation: Operation.Edit },
+      { projectDomain: SFProjectDomain.SFNoteThreads, operation: Operation.Delete },
 
       { projectDomain: SFProjectDomain.Notes, operation: Operation.Create },
       { projectDomain: SFProjectDomain.Notes, operation: Operation.EditOwn },

--- a/src/RealtimeServer/scriptureforge/models/sf-project-rights.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project-rights.ts
@@ -61,8 +61,7 @@ export class SFProjectRights extends ProjectRights {
       { projectDomain: SFProjectDomain.Likes, operation: Operation.DeleteOwn },
 
       { projectDomain: SFProjectDomain.SFNoteThreads, operation: Operation.Create },
-      { projectDomain: SFProjectDomain.SFNoteThreads, operation: Operation.Edit },
-      { projectDomain: SFProjectDomain.SFNoteThreads, operation: Operation.Delete },
+      { projectDomain: SFProjectDomain.SFNoteThreads, operation: Operation.DeleteOwn },
 
       { projectDomain: SFProjectDomain.Notes, operation: Operation.Create },
       { projectDomain: SFProjectDomain.Notes, operation: Operation.EditOwn },
@@ -75,7 +74,7 @@ export class SFProjectRights extends ProjectRights {
       { projectDomain: SFProjectDomain.Project, operation: Operation.View },
 
       { projectDomain: SFProjectDomain.PTNoteThreads, operation: Operation.Create },
-      { projectDomain: SFProjectDomain.PTNoteThreads, operation: Operation.Edit }
+      { projectDomain: SFProjectDomain.PTNoteThreads, operation: Operation.DeleteOwn }
     ]);
     this.addRights(SFProjectRole.ParatextConsultant, ptReviewerRights);
 

--- a/src/RealtimeServer/scriptureforge/models/sf-project-rights.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project-rights.ts
@@ -75,8 +75,7 @@ export class SFProjectRights extends ProjectRights {
       { projectDomain: SFProjectDomain.Project, operation: Operation.View },
 
       { projectDomain: SFProjectDomain.PTNoteThreads, operation: Operation.Create },
-      { projectDomain: SFProjectDomain.PTNoteThreads, operation: Operation.Edit },
-      { projectDomain: SFProjectDomain.PTNoteThreads, operation: Operation.Delete }
+      { projectDomain: SFProjectDomain.PTNoteThreads, operation: Operation.Edit }
     ]);
     this.addRights(SFProjectRole.ParatextConsultant, ptReviewerRights);
 

--- a/src/RealtimeServer/scriptureforge/realtime-server.ts
+++ b/src/RealtimeServer/scriptureforge/realtime-server.ts
@@ -41,7 +41,7 @@ class SFRealtimeServer extends RealtimeServer {
             !SF_PROJECT_RIGHTS.hasRight(p, userId, SFProjectDomain.PTNoteThreads, Operation.View) &&
             SF_PROJECT_RIGHTS.hasRight(p, userId, SFProjectDomain.SFNoteThreads, Operation.View)
           ) {
-            context.query = { ...context.query, ...{ publishedToSF: true } };
+            context.query = { ...context.query, publishedToSF: true };
           }
           next();
         });

--- a/src/RealtimeServer/scriptureforge/realtime-server.ts
+++ b/src/RealtimeServer/scriptureforge/realtime-server.ts
@@ -5,7 +5,7 @@ import { DocService } from '../common/services/doc-service';
 import { UserService } from '../common/services/user-service';
 import { Operation } from '../common/models/project-rights';
 import { SFProjectDomain, SF_PROJECT_RIGHTS } from './models/sf-project-rights';
-import { NOTE_THREAD_COLLECTION, SF_NOTE_THREAD_PREFIX } from './models/note-thread';
+import { NOTE_THREAD_COLLECTION } from './models/note-thread';
 import { SF_PROJECTS_COLLECTION } from './models/sf-project';
 import { NoteThreadService } from './services/note-thread-service';
 import { QuestionService } from './services/question-service';
@@ -34,17 +34,14 @@ class SFRealtimeServer extends RealtimeServer {
           next();
           return;
         }
+        const userId: string = context.agent.connectSession.userId;
         this.getProject(context.query.projectRef).then(p => {
           if (
             p != null &&
-            !SF_PROJECT_RIGHTS.hasRight(
-              p,
-              context.agent.connectSession.userId,
-              SFProjectDomain.PTNoteThreads,
-              Operation.View
-            )
+            !SF_PROJECT_RIGHTS.hasRight(p, userId, SFProjectDomain.PTNoteThreads, Operation.View) &&
+            SF_PROJECT_RIGHTS.hasRight(p, userId, SFProjectDomain.SFNoteThreads, Operation.View)
           ) {
-            context.query = { ...context.query, ...{ dataId: { $regex: SF_NOTE_THREAD_PREFIX } } };
+            context.query = { ...context.query, ...{ publishedToSF: true } };
           }
           next();
         });

--- a/src/RealtimeServer/scriptureforge/scripture-utils/utils.ts
+++ b/src/RealtimeServer/scriptureforge/scripture-utils/utils.ts
@@ -1,6 +1,0 @@
-import { isParatextRole, SFProjectRole } from '../models/sf-project-role';
-
-/** Determine if a user can view note threads created in Paratext. */
-export function canViewParatextNotes(role: string): boolean {
-  return isParatextRole(role) || role === SFProjectRole.Observer;
-}

--- a/src/RealtimeServer/scriptureforge/services/note-thread-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-service.spec.ts
@@ -31,8 +31,7 @@ import {
   NoteStatus,
   NoteThread,
   NoteType,
-  NoteConflictType,
-  SF_NOTE_THREAD_PREFIX
+  NoteConflictType
 } from '../models/note-thread';
 import { Note } from '../models/note';
 import { VerseRefData } from '../models/verse-ref-data';
@@ -115,7 +114,7 @@ describe('NoteThreadService', () => {
     expect(doc).not.toBeNull();
   });
 
-  it('prohibits reviewer user to read note threads not created in Scripture Forge', async () => {
+  it('prohibits reviewer user to read note threads not published in Scripture Forge', async () => {
     const env = new TestEnvironment();
     await env.createData();
     const conn: Connection = clientConnect(env.server, 'reviewer');
@@ -125,7 +124,7 @@ describe('NoteThreadService', () => {
       new Error(`403: Permission denied (read), collection: ${NOTE_THREAD_COLLECTION}, docId: ${noteThreadDocId}`)
     );
 
-    const threadId: string = SF_NOTE_THREAD_PREFIX + 'noteThread03';
+    const threadId = 'noteThread03';
     const doc = await fetchDoc(conn, NOTE_THREAD_COLLECTION, getNoteThreadDocId('project01', threadId));
     expect(doc).not.toBeNull();
   });
@@ -411,7 +410,7 @@ class TestEnvironment {
       tagIcon: ''
     });
 
-    const noteThreadId: string = SF_NOTE_THREAD_PREFIX + 'noteThread03';
+    const noteThreadId = 'noteThread03';
     await createDoc<NoteThread>(conn, NOTE_THREAD_COLLECTION, getNoteThreadDocId('project01', noteThreadId), {
       projectRef: 'project01',
       ownerRef: 'some-owner',
@@ -436,7 +435,8 @@ class TestEnvironment {
       originalContextAfter: '',
       position,
       status,
-      tagIcon: ''
+      tagIcon: '',
+      publishedToSF: true
     });
   }
 

--- a/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
@@ -4,12 +4,9 @@ import { OwnedData } from '../../common/models/owned-data';
 import { ProjectDomainConfig } from '../../common/services/project-data-service';
 import { ANY_INDEX } from '../../common/utils/obj-path';
 import { NoteThread, NOTE_THREAD_COLLECTION, NOTE_THREAD_INDEX_PATHS } from '../models/note-thread';
-import { SFProjectDomain, SF_PROJECT_RIGHTS } from '../models/sf-project-rights';
+import { SFProjectDomain } from '../models/sf-project-rights';
 import { SFProjectUserConfig, SF_PROJECT_USER_CONFIGS_COLLECTION } from '../models/sf-project-user-config';
 import { Note } from '../models/note';
-import { Project } from '../../common/models/project';
-import { ConnectSession } from '../../common/connect-session';
-import { Operation } from '../../common/models/project-rights';
 import { NOTE_THREAD_MIGRATIONS } from './note-thread-migrations';
 import { SFProjectDataService } from './sf-project-data-service';
 
@@ -40,11 +37,34 @@ export class NoteThreadService extends SFProjectDataService<NoteThread> {
         pathTemplate: this.pathTemplate()
       },
       {
+        projectDomain: SFProjectDomain.SFNoteThreads,
+        pathTemplate: this.pathTemplate()
+      },
+      {
         projectDomain: SFProjectDomain.Notes,
         pathTemplate: this.pathTemplate(t => t.notes[ANY_INDEX])
       }
     ];
   }
+
+  protected getApplicableDomains(entity?: OwnedData): ProjectDomainConfig[] {
+    const domains: ProjectDomainConfig[] = super.getApplicableDomains(entity);
+    const noteThread = entity as NoteThread | undefined;
+    if (noteThread == null) return domains;
+    const applicableDomains: ProjectDomainConfig[] = [];
+
+    for (const domain of domains) {
+      if (noteThread.publishedToSF === true && domain.projectDomain === SFProjectDomain.PTNoteThreads) {
+        continue;
+      }
+      if (noteThread.publishedToSF !== true && domain.projectDomain === SFProjectDomain.SFNoteThreads) {
+        continue;
+      }
+      applicableDomains.push(domain);
+    }
+    return applicableDomains;
+  }
+
   protected onDelete(userId: string, docId: string, projectDomain: string, entity: OwnedData): Promise<void> {
     if (projectDomain === SFProjectDomain.Notes) {
       this.removeEntityHaveReadRefs(userId, docId, projectDomain, entity);
@@ -58,22 +78,6 @@ export class NoteThreadService extends SFProjectDataService<NoteThread> {
       this.removeEntityHaveReadRefs(userId, docId, projectDomain, entity);
     }
     return Promise.resolve();
-  }
-
-  protected async allowRead(_docId: string, doc: NoteThread, session: ConnectSession): Promise<boolean> {
-    if (session.isServer || Object.keys(doc).length === 0) return true;
-
-    if (this.server == null) {
-      throw new Error('The doc service has not been initialized.');
-    }
-
-    const project: Project | undefined = await this.server.getProject(doc.projectRef);
-    const userId: string = session.userId;
-    if (project?.userRoles[userId] == null) return false;
-
-    const canReadPTNotes = SF_PROJECT_RIGHTS.hasRight(project, userId, SFProjectDomain.PTNoteThreads, Operation.View);
-    const canReadSFNotes = SF_PROJECT_RIGHTS.hasRight(project, userId, SFProjectDomain.SFNoteThreads, Operation.View);
-    return canReadPTNotes || (canReadSFNotes && doc.publishedToSF === true);
   }
 
   private async removeEntityHaveReadRefs(

--- a/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
@@ -9,12 +9,12 @@ import {
   NOTE_THREAD_INDEX_PATHS,
   SF_NOTE_THREAD_PREFIX
 } from '../models/note-thread';
-import { SFProjectDomain } from '../models/sf-project-rights';
+import { SFProjectDomain, SF_PROJECT_RIGHTS } from '../models/sf-project-rights';
 import { SFProjectUserConfig, SF_PROJECT_USER_CONFIGS_COLLECTION } from '../models/sf-project-user-config';
 import { Note } from '../models/note';
 import { Project } from '../../common/models/project';
 import { ConnectSession } from '../../common/connect-session';
-import { canViewParatextNotes } from '../scripture-utils/utils';
+import { Operation } from '../../common/models/project-rights';
 import { NOTE_THREAD_MIGRATIONS } from './note-thread-migrations';
 import { SFProjectDataService } from './sf-project-data-service';
 
@@ -41,7 +41,7 @@ export class NoteThreadService extends SFProjectDataService<NoteThread> {
   protected setupDomains(): ProjectDomainConfig[] {
     return [
       {
-        projectDomain: SFProjectDomain.NoteThreads,
+        projectDomain: SFProjectDomain.PTNoteThreads,
         pathTemplate: this.pathTemplate()
       },
       {
@@ -59,25 +59,26 @@ export class NoteThreadService extends SFProjectDataService<NoteThread> {
 
   protected onBeforeDelete(userId: string, docId: string, projectDomain: string, entity: OwnedData): Promise<void> {
     // Process an incoming deletion for a NoteThread before it happens so we can look at its list of notes.
-    if (projectDomain === SFProjectDomain.NoteThreads) {
+    if (projectDomain === SFProjectDomain.PTNoteThreads) {
       this.removeEntityHaveReadRefs(userId, docId, projectDomain, entity);
     }
     return Promise.resolve();
   }
 
   protected async allowRead(_docId: string, doc: NoteThread, session: ConnectSession): Promise<boolean> {
-    if (await super.allowRead(_docId, doc, session)) {
-      if (session.isServer || Object.keys(doc).length === 0) return true;
+    if (session.isServer || Object.keys(doc).length === 0) return true;
 
-      if (this.server == null) {
-        throw new Error('The doc service has not been initialized.');
-      }
+    if (this.server == null) {
+      throw new Error('The doc service has not been initialized.');
+    }
 
-      const project: Project | undefined = await this.server.getProject(doc.projectRef);
-      if (project == null) return false;
-      const userRole = project.userRoles[session.userId];
-      if (userRole == null) return false;
-      if (!canViewParatextNotes(userRole) && !doc.dataId.startsWith(SF_NOTE_THREAD_PREFIX)) return false;
+    const project: Project | undefined = await this.server.getProject(doc.projectRef);
+    if (project?.userRoles[session.userId] == null) return false;
+    if (
+      SF_PROJECT_RIGHTS.hasRight(project, session.userId, SFProjectDomain.PTNoteThreads, Operation.View) ||
+      (SF_PROJECT_RIGHTS.hasRight(project, session.userId, SFProjectDomain.SFNoteThreads, Operation.View) &&
+        doc.dataId.startsWith(SF_NOTE_THREAD_PREFIX))
+    ) {
       return true;
     }
     return false;
@@ -100,7 +101,8 @@ export class NoteThreadService extends SFProjectDataService<NoteThread> {
     const promises: Promise<boolean>[] = [];
     for (const doc of pucDocs) {
       switch (projectDomain) {
-        case SFProjectDomain.NoteThreads:
+        case SFProjectDomain.PTNoteThreads:
+        case SFProjectDomain.SFNoteThreads:
           (entity as NoteThread).notes.forEach((note: Note) => promises.push(this.removeNoteHaveReadRefs(doc, note)));
           break;
         case SFProjectDomain.Notes:

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -149,5 +149,5 @@ export function formatFontSizeToRems(fontSize: number | undefined): string | und
 }
 
 export function canInsertNote(project: SFProjectProfile, userId: string): boolean {
-  return SF_PROJECT_RIGHTS.hasRight(project, userId, SFProjectDomain.NoteThreads, Operation.Create);
+  return SF_PROJECT_RIGHTS.hasRight(project, userId, SFProjectDomain.SFNoteThreads, Operation.Create);
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -13,8 +13,7 @@ import {
   NoteConflictType,
   NoteStatus,
   NoteThread,
-  NoteType,
-  SF_NOTE_THREAD_PREFIX
+  NoteType
 } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { SFProject, SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { isParatextRole, SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
@@ -477,9 +476,9 @@ describe('NoteDialogComponent', () => {
     const [, noteThread] = capture(mockedProjectService.createNoteThread).last();
     expect(noteThread.verseRef).toEqual(verseData);
     expect(noteThread.originalSelectedText).toEqual('target: chapter 1, verse 3.');
+    expect(noteThread.publishedToSF).toBe(true);
     expect(noteThread.notes[0].ownerRef).toEqual('user01');
     expect(noteThread.notes[0].content).toEqual('Enter note content');
-    expect(noteThread.notes[0].threadId).toContain(SF_NOTE_THREAD_PREFIX);
     expect(noteThread.tagIcon).toEqual('defaultIcon');
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -10,8 +10,7 @@ import {
   NoteConflictType,
   NoteStatus,
   NoteThread,
-  NoteType,
-  SF_NOTE_THREAD_PREFIX
+  NoteType
 } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
 import { ParatextUserProfile } from 'realtime-server/lib/esm/scriptureforge/models/paratext-user-profile';
@@ -372,7 +371,7 @@ export class NoteDialogComponent implements OnInit {
     }
     if (this.noteBeingEdited.threadId === '') {
       // create a new thread
-      const threadId: string = SF_NOTE_THREAD_PREFIX + objectId();
+      const threadId: string = objectId();
       this.noteBeingEdited.threadId = threadId;
       const noteThread: NoteThread = {
         dataId: threadId,
@@ -385,7 +384,8 @@ export class NoteDialogComponent implements OnInit {
         originalSelectedText: this.segmentText,
         originalContextAfter: '',
         tagIcon: this.projectProfileDoc!.data!.tagIcon ?? DEFAULT_TAG_ICON,
-        status: NoteStatus.Todo
+        status: NoteStatus.Todo,
+        publishedToSF: true
       };
       await this.projectService.createNoteThread(this.projectId, noteThread);
       this.dialogRef.close(true);


### PR DESCRIPTION
This change separates the rights for PT and SF note threads. Note threads continue to use the same service in the realtime server, but permission to view note threads is based on the rights of the user to view pt notes and sf notes.
If desired, another step would be to further separate SF and PT notes into their own collections in mongo, but I do not see the need or benefit of that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1635)
<!-- Reviewable:end -->
