### PR TITLE
Fix Angular warnings regarding CommonJS and AMD modules

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/angular.json
+++ b/src/SIL.XForge.Scripture/ClientApp/angular.json
@@ -41,7 +41,22 @@
             "stylePreprocessorOptions": {
               "includePaths": ["node_modules"]
             },
-            "allowedCommonJsDependencies": ["@bugsnag/js"],
+            "allowedCommonJsDependencies": [
+              "@bugsnag/browser",
+              "@bugsnag/js",
+              "arraydiff",
+              "bowser",
+              "bson-objectid",
+              "crc-32",
+              "flat",
+              "gensequence",
+              "mingo",
+              "papaparse",
+              "quill",
+              "recordrtc",
+              "tinycolor2",
+              "ts-md5"
+            ],
             "scripts": [],
             "aot": false,
             "vendorChunk": true,


### PR DESCRIPTION
Angular prints warnings like this when building:
```
Warning: /home/nate/src/web-xforge/src/SIL.XForge.Scripture/ClientApp/node_modules/@sillsdev/machine/lib/tokenization/latin-word-tokenizer.js depends on 'xregexp'. CommonJS or AMD dependencies can cause optimization bailouts.
For more info see: https://angular.io/guide/build#configuring-commonjs-dependencies
```
CommonJS modules are defined in a such a way that prevent effective tree-shaking.

These warnings are "fixed" only in the sense that they are suppressed, by adding these packages to a list to ignore. As far as I am aware, there really isn't much we can do about these modules except stop using these packages (or hope they eventually change how they package output). 

I've deliberately not added xregexp to the list here, so that we will still be warned about it. It's significantly larger than most of the other packages, and we're in the process of removing it entirely.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1637)
<!-- Reviewable:end -->
