### PR TITLE
SF-1618 SF-1619 Make question import more flexible

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
@@ -53,7 +53,11 @@
                 <li>
                   {{ csvInstructions[0] }}
                   <table>
-                    <!-- TODO internationalize the verse references, but only once we accept localized inputs -->
+                    <!-- TODO internationalize the references and headings, but only once we accept localized inputs -->
+                    <tr>
+                      <th>Reference</th>
+                      <th>Question</th>
+                    </tr>
                     <tr *ngFor="let verseNumber of [1, 2]">
                       <td>1JN 1:{{ verseNumber }}</td>
                       <td>{{ t("question_for_verse", { number: verseNumber }) }}</td>
@@ -159,6 +163,11 @@
 
       <div *ngIf="status === 'update_transcelerator'">{{ t("update_transcelerator") }}</div>
 
+      <div
+        *ngIf="status === 'missing_header_row'"
+        [innerHTML]="i18n.translateAndInsertTags('import_questions_dialog.missing_header_row')"
+      ></div>
+
       <div *ngIf="status === 'progress'">
         <mat-progress-bar mode="determinate" [value]="(importedCount / toImportCount) * 100"></mat-progress-bar>
       </div>
@@ -186,7 +195,7 @@
       {{ t("cancel") }}
     </button>
     <button
-      *ngIf="status === 'no_questions' || status === 'update_transcelerator'"
+      *ngIf="status === 'no_questions' || status === 'update_transcelerator' || status === 'missing_header_row'"
       mat-flat-button
       mat-dialog-close
       color="primary"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.scss
@@ -59,7 +59,8 @@
   table {
     font-size: small;
     border-collapse: collapse;
-    td {
+    td,
+    th {
       border: 1px solid lightgray;
       padding: 0 0.5em;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -15,6 +15,7 @@ import { ExternalUrlService } from 'xforge-common/external-url.service';
 import { CsvService } from 'xforge-common/csv-service.service';
 import { RetryingRequest } from 'xforge-common/retrying-request.service';
 import { DialogService } from 'xforge-common/dialog.service';
+import { Canon } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/canon';
 import { environment } from '../../../environments/environment';
 import { QuestionDoc } from '../../core/models/question-doc';
 import { TextsByBookId } from '../../core/models/texts-by-book-id';
@@ -60,7 +61,7 @@ interface DialogListItem {
   sfVersionOfQuestion?: QuestionDoc;
 }
 
-type DialogErrorState = 'update_transcelerator' | 'file_import_errors';
+type DialogErrorState = 'update_transcelerator' | 'file_import_errors' | 'missing_header_row';
 type DialogStatus = 'initial' | 'no_questions' | 'filter' | 'loading' | 'progress' | DialogErrorState;
 
 @Component({
@@ -386,30 +387,49 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable imple
   async fileSelected(file: File) {
     this.loading = true;
 
+    // extract the book id from the file name, if it exists (unfoldingWord puts the book id in the file name, and omits
+    // it from the reference, with file names like tq_GEN.tsv, and references like 5:3)
+    const possibleBookIds = file.name.split(/[-_.]/).filter(part => Canon.allBookIds.includes(part.toUpperCase()));
+    const defaultBookId = possibleBookIds.length === 1 ? possibleBookIds[0].toUpperCase() : undefined;
+
     const result = await this.csvService.parse(file);
+
+    const referenceColumn = result[0].findIndex(value => /^\s*References?\s*$/i.test(value));
+    const questionColumn = result[0].findIndex(value => /^\s*Questions?\s*$/i.test(value));
+
+    if (referenceColumn === -1 || questionColumn === -1) {
+      this.questionSource = 'csv_file';
+      this.errorState = 'missing_header_row';
+      return;
+    }
 
     let invalidRows: string[][] = [];
     const questions: SourceQuestion[] = [];
 
     for (const [index, row] of result.entries()) {
-      // skip rows where every cell is the empty string
-      if (!row.some(cell => cell !== '')) {
+      // skip the header row, and any row where every cell is the empty string
+      if (index === 0 || row.every(cell => cell === '')) {
         continue;
       }
       const rowNumber: string = index + 1 + '';
-      const reference: string = (row[0] || '').trim();
-      const questionText: string = (row[1] || '').trim();
+      const reference: string | undefined = row[referenceColumn]?.trim();
+      const questionText: string | undefined = row[questionColumn]?.trim();
       if (row.length < 2 || reference === '' || questionText === '') {
-        invalidRows.push([rowNumber].concat(row));
+        invalidRows.push([rowNumber, reference, questionText]);
         continue;
       }
       try {
+        // if the reference doesn't start with a book id, and the file name includes the book id, prepend the book id to
+        // the reference
+        const refStartsWithBook: boolean = Canon.allBookIds.includes(reference.slice(0, 3)) && reference[3] === ' ';
+        const fullReference: string =
+          refStartsWithBook || defaultBookId == null ? reference : defaultBookId + ' ' + reference;
         questions.push({
-          verseRef: VerseRef.parse(reference),
+          verseRef: VerseRef.parse(fullReference),
           text: questionText
         });
       } catch {
-        invalidRows.push([rowNumber].concat(row));
+        invalidRows.push([rowNumber, reference, questionText]);
       }
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -129,6 +129,7 @@
     "invalid_csv_rows_will_be_skipped": "These rows in the CSV file were invalid and will be skipped.",
     "learn_more": "Learn more",
     "loading": "Loading...",
+    "missing_header_row": "The file you imported needs to have a header row with columns titled {{ boldStart }}Reference{{ boldEnd }} and {{ boldStart }}Question{{ boldEnd }}.",
     "must_be_valid_reference": "Must be a valid reference",
     "network_error_transcelerator": "Network error fetching Transcelerator questions. Retrying ({{ count }}).",
     "no_questions_available": "There are no questions for the books in this project.",


### PR DESCRIPTION
Changes to how questions are imported
- Allow omitting book in references if it is specified in the file name
- Allow extraneous columns (data is now found by looking at headings)

Instructions before | Instructions after
--------------------------|----------------------
![](https://user-images.githubusercontent.com/6140710/206553540-064c1dbc-2710-429d-b6ff-56bdd83cef3b.png) | ![](https://user-images.githubusercontent.com/6140710/206553542-39e00578-2a10-44d2-9d27-529b4805d2fe.png)

Note that this is not backwards compatible; whereas previously files were not supposed to have headings, now they require them.

There are two main goals with this project:
1. It should be possible to import files from unfoldingWord with no changes to them.
2. Any "reasonable" spreadsheet should be able to be easily modified to produce a format that can be imported. For example, before this change the reference and question column had to be the first and second columns respectively. While that's not a difficult change to make for someone familiar with working with spreadsheets, it's a lot more straightforward to give a column a heading. It's also easier to communicate to users.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1639)
<!-- Reviewable:end -->
