### PR TITLE
CodeQL fixes in Unit Tests

### DIFF
--- a/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
@@ -61,8 +61,8 @@ namespace SIL.XForge.Scripture.Services
 
         private class TestEnvironment
         {
-            public IJwtTokenHelper MockJwtTokenHelper;
-            public InternetSharedRepositorySourceProvider Provider;
+            public readonly IJwtTokenHelper MockJwtTokenHelper;
+            public readonly InternetSharedRepositorySourceProvider Provider;
 
             public TestEnvironment()
             {

--- a/test/SIL.XForge.Scripture.Tests/Services/JwtInternetSharedRepositorySourceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/JwtInternetSharedRepositorySourceTests.cs
@@ -57,8 +57,8 @@ namespace SIL.XForge.Scripture.Services
 
         private class TestEnvironment
         {
-            public JwtInternetSharedRepositorySource RepoSource;
-            public IRESTClient MockPTArchivesClient;
+            public readonly JwtInternetSharedRepositorySource RepoSource;
+            public readonly IRESTClient MockPTArchivesClient;
 
             public TestEnvironment()
             {

--- a/test/SIL.XForge.Scripture.Tests/Services/MockCommentTags.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockCommentTags.cs
@@ -11,7 +11,7 @@ namespace SIL.XForge.Scripture.Services
 
         public CommentTags.CommentTagList TagsList
         {
-            set { list = value; }
+            set => list = value;
         }
 
         public static MockCommentTags GetCommentTags(string username, string ptProjectId)
@@ -29,11 +29,11 @@ namespace SIL.XForge.Scripture.Services
             for (int i = 0; i < tagIds.Length; i++)
             {
                 int tagId = tagIds[i];
-                tags[i] = new Paratext.Data.ProjectComments.CommentTag($"tag{tagId}", $"icon{tagId}", tagId);
+                tags[i] = new CommentTag($"tag{tagId}", $"icon{tagId}", tagId);
             }
-            var list = new CommentTags.CommentTagList();
-            list.SerializedData = tags;
-            TagsList = list;
+            var tagsList = new CommentTagList();
+            tagsList.SerializedData = tags;
+            TagsList = tagsList;
         }
 
         protected override void ReadFromDisk()

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextNoteExtensions.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextNoteExtensions.cs
@@ -39,7 +39,7 @@ namespace SIL.XForge.Scripture.Services
                 thread.OriginalContextBefore
                 + thread.OriginalSelectedText
                 + thread.OriginalContextAfter
-                + $"{selection}-{thread.VerseRef.ToString()}-{thread.TagIcon}";
+                + $"{selection}-{thread.VerseRef}-{thread.TagIcon}";
             return result;
         }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -381,7 +381,7 @@ namespace SIL.XForge.Scripture.Services
             UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
 
             // Set up mock REST client to return a successful GET request
-            ISFRestClientFactory mockRestClientFactory = env.SetRestClientFactory(user01Secret);
+            env.SetRestClientFactory(user01Secret);
 
             var paratextId = "resid_is_16_char";
             var permission = await env.Service.GetResourcePermissionAsync(
@@ -448,10 +448,7 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             string ptProjectId = env.PTProjectIds[env.Project01].Id;
             UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            IInternetSharedRepositorySource mockSource = env.SetSharedRepositorySource(
-                user01Secret,
-                UserRoles.Administrator
-            );
+            env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
             env.MockScrTextCollection.FindById(env.Username01, ptProjectId).Returns(i => null);
 
             // SUT
@@ -1025,7 +1022,6 @@ namespace SIL.XForge.Scripture.Services
             UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
             env.AddTextDoc(40, 1);
             string threadId = "thread01";
-            string threadOwner = env.User01;
 
             env.MockGuidService.NewObjectId().Returns("thread01note01");
 
@@ -1124,7 +1120,7 @@ namespace SIL.XForge.Scripture.Services
             };
             env.AddParatextComment(comment);
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            using (await env.RealtimeService.ConnectAsync())
             {
                 IEnumerable<IDocument<NoteThread>> noteThreadDocs = new IDocument<NoteThread>[0];
                 Dictionary<int, ChapterDelta> chapterDeltas = new Dictionary<int, ChapterDelta>();
@@ -1715,7 +1711,7 @@ namespace SIL.XForge.Scripture.Services
                 }
             );
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            using (await env.RealtimeService.ConnectAsync())
             {
                 var deltas = env.GetChapterDeltasByBook(
                     env.Project01,
@@ -2141,10 +2137,7 @@ namespace SIL.XForge.Scripture.Services
             string projectId = env.SetupProject(env.Project01, associatedPtUser);
             UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
 
-            IInternetSharedRepositorySource mockSource = env.SetSharedRepositorySource(
-                user01Secret,
-                UserRoles.Administrator
-            );
+            env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
             env.SetupSuccessfulSendReceive();
             // Setup share changes to be unsuccessful
             env.MockSharingLogicWrapper
@@ -2174,7 +2167,7 @@ namespace SIL.XForge.Scripture.Services
         {
             var env = new TestEnvironment();
             var associatedPtUser = new SFParatextUser(env.Username01);
-            string projectId = env.SetupProject(env.Project01, associatedPtUser);
+            env.SetupProject(env.Project01, associatedPtUser);
             UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
 
             IInternetSharedRepositorySource mockSource = env.SetSharedRepositorySource(
@@ -2196,10 +2189,7 @@ namespace SIL.XForge.Scripture.Services
             string projectId = env.SetupProject(env.Project01, associatedPtUser);
             UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
 
-            IInternetSharedRepositorySource mockSource = env.SetSharedRepositorySource(
-                user01Secret,
-                UserRoles.Administrator
-            );
+            env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
             env.SetupSuccessfulSendReceive();
             // Setup share changes to be unsuccessful, but return true
             // This scenario occurs if a project is locked on the PT server
@@ -2388,10 +2378,7 @@ namespace SIL.XForge.Scripture.Services
             var associatedPtUser = new SFParatextUser(env.Username01);
             string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
             UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            IInternetSharedRepositorySource mockSource = env.SetSharedRepositorySource(
-                user01Secret,
-                UserRoles.Administrator
-            );
+            env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
             env.SetupSuccessfulSendReceive();
             env.SetRestClientFactory(user01Secret);
             ScrTextCollection.Initialize("/srv/scriptureforge/projects");
@@ -2407,10 +2394,7 @@ namespace SIL.XForge.Scripture.Services
             var associatedPtUser = new SFParatextUser(env.Username01);
             string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
             UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            IInternetSharedRepositorySource mockSource = env.SetSharedRepositorySource(
-                user01Secret,
-                UserRoles.Administrator
-            );
+            env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
             env.SetupSuccessfulSendReceive();
             env.SetRestClientFactory(user01Secret);
             ScrTextCollection.Initialize("/srv/scriptureforge/projects");
@@ -2527,16 +2511,10 @@ namespace SIL.XForge.Scripture.Services
 
             source
                 .GetRepositories()
-                .Returns(x =>
-                {
-                    throw Paratext.Data.HttpException.Create(
-                        new WebException("401: Unauthorized"),
-                        (HttpWebRequest)null
-                    );
-                });
+                .Returns(x => throw HttpException.Create(new WebException("401: Unauthorized"), (HttpWebRequest)null));
 
             // SUT
-            Paratext.Data.HttpException thrown = Assert.ThrowsAsync<Paratext.Data.HttpException>(
+            Assert.ThrowsAsync<HttpException>(
                 () => env.Service.GetProjectRolesAsync(userSecret, project, CancellationToken.None)
             );
 
@@ -2589,7 +2567,7 @@ namespace SIL.XForge.Scripture.Services
             UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
             // Note that the following user secret has same PT username and id as the other user. This presumably
             // represents a bad DB state.
-            var dos = env.MakeUserSecret(env.User02, env.Username01, env.ParatextUserId01);
+            env.MakeUserSecret(env.User02, env.Username01, env.ParatextUserId01);
             env.MockJwtTokenHelper
                 .GetParatextUsername(Arg.Is<UserSecret>(u => u.Id == env.User02))
                 .Returns(env.Username01);
@@ -2944,7 +2922,7 @@ namespace SIL.XForge.Scripture.Services
         public async Task CanUserAuthenticateToPTArchivesAsync_Works()
         {
             var env = new TestEnvironment();
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+            env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
 
             string userSFId = env.User01;
 
@@ -3262,33 +3240,27 @@ namespace SIL.XForge.Scripture.Services
             public readonly string AlternateBefore = "Alternate before ";
             public readonly string AlternateAfter = " alternate after.";
             public readonly string ReattachedSelectedText = "reattached text";
-            public Dictionary<string, string> usernamesToIds = new Dictionary<string, string>
-            {
-                { "User 01", "user01" },
-                { "User 02", "user02" },
-                { "User 03", "user03" }
-            };
 
             private string ruthBookUsfm =
                 "\\id RUT - ProjectNameHere\n" + "\\c 1\n" + "\\v 1 Verse 1 here.\n" + "\\v 2 Verse 2 here.";
 
-            public IWebHostEnvironment MockWebHostEnvironment;
-            public IOptions<ParatextOptions> MockParatextOptions;
-            public IRepository<UserSecret> MockRepository;
-            public SFMemoryRealtimeService RealtimeService;
-            public IExceptionHandler MockExceptionHandler;
-            public IOptions<SiteOptions> MockSiteOptions;
-            public IFileSystemService MockFileSystemService;
-            public IScrTextCollection MockScrTextCollection;
-            public ISharingLogicWrapper MockSharingLogicWrapper;
-            public IHgWrapper MockHgWrapper;
-            public MockLogger<ParatextService> MockLogger;
-            public IJwtTokenHelper MockJwtTokenHelper;
-            public IParatextDataHelper MockParatextDataHelper;
-            public IInternetSharedRepositorySourceProvider MockInternetSharedRepositorySourceProvider;
-            public ISFRestClientFactory MockRestClientFactory;
-            public IGuidService MockGuidService;
-            public ParatextService Service;
+            public readonly IWebHostEnvironment MockWebHostEnvironment;
+            public readonly IOptions<ParatextOptions> MockParatextOptions;
+            public readonly IRepository<UserSecret> MockRepository;
+            public readonly SFMemoryRealtimeService RealtimeService;
+            public readonly IExceptionHandler MockExceptionHandler;
+            public readonly IOptions<SiteOptions> MockSiteOptions;
+            public readonly IFileSystemService MockFileSystemService;
+            public readonly IScrTextCollection MockScrTextCollection;
+            public readonly ISharingLogicWrapper MockSharingLogicWrapper;
+            public readonly IHgWrapper MockHgWrapper;
+            public readonly MockLogger<ParatextService> MockLogger;
+            public readonly IJwtTokenHelper MockJwtTokenHelper;
+            public readonly IParatextDataHelper MockParatextDataHelper;
+            public readonly IInternetSharedRepositorySourceProvider MockInternetSharedRepositorySourceProvider;
+            public readonly ISFRestClientFactory MockRestClientFactory;
+            public readonly IGuidService MockGuidService;
+            public readonly ParatextService Service;
 
             public TestEnvironment()
             {
@@ -4211,7 +4183,8 @@ namespace SIL.XForge.Scripture.Services
                 bool includeExtraLastVerseSegment
             )
             {
-                string chapterText = "[ { \"insert\": { \"chapter\": { \"number\": \"" + chapterNum + "\" } }}";
+                var chapterText = new StringBuilder();
+                chapterText.Append("[ { \"insert\": { \"chapter\": { \"number\": \"" + chapterNum + "\" } }}");
                 for (int i = 1; i <= verses; i++)
                 {
                     string noteSelectedText = useThreadSuffix ? selectedText + $" thread{i}" : selectedText;
@@ -4224,52 +4197,52 @@ namespace SIL.XForge.Scripture.Services
                         after = AlternateAfter;
                         noteSelectedText = ReattachedSelectedText;
                     }
-                    chapterText =
-                        chapterText
-                        + ","
-                        + "{ \"insert\": { \"verse\": { \"number\": \""
-                        + i
-                        + "\" } }}, "
-                        + "{ \"insert\": \""
-                        + before
-                        + noteSelectedText
-                        + after
-                        + "\", "
-                        + "\"attributes\": { \"segment\": \"verse_"
-                        + chapterNum
-                        + "_"
-                        + i
-                        + "\" } }";
+                    chapterText.Append(
+                        ","
+                            + "{ \"insert\": { \"verse\": { \"number\": \""
+                            + i
+                            + "\" } }}, "
+                            + "{ \"insert\": \""
+                            + before
+                            + noteSelectedText
+                            + after
+                            + "\", "
+                            + "\"attributes\": { \"segment\": \"verse_"
+                            + chapterNum
+                            + "_"
+                            + i
+                            + "\" } }"
+                    );
                     if (i == 8 || i == 9)
                     {
                         // create a new section heading after verse 8
-                        chapterText =
-                            chapterText
-                            + " ,"
-                            + "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"p\" } }}, "
-                            + "{ \"insert\": \"Section heading text\", \"attributes\": { \"segment\": \"s_1\" } }, "
-                            + "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"s\" } }}, "
-                            + "{ \"insert\": { \"blank\": true }, \"attributes\": { \"segment\": \"p_1\" } }";
+                        chapterText.Append(
+                            " ,"
+                                + "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"p\" } }}, "
+                                + "{ \"insert\": \"Section heading text\", \"attributes\": { \"segment\": \"s_1\" } }, "
+                                + "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"s\" } }}, "
+                                + "{ \"insert\": { \"blank\": true }, \"attributes\": { \"segment\": \"p_1\" } }"
+                        );
                     }
                 }
                 if (includeExtraLastVerseSegment)
                 {
                     // Add a second segment in the last verse (Note the segment name ends with "/p_1").
                     string verseRef = $"verse_{chapterNum}_{verses}";
-                    chapterText =
-                        chapterText
-                        + ", { \"insert\": \"\n\" },"
-                        + "{ \"insert\": { \"note\": { \"caller\": \"*\" } }, "
-                        + "\"attributes\": { \"segment\": \""
-                        + verseRef
-                        + "\" } },"
-                        + "{ \"insert\": \"other text in verse\", "
-                        + "\"attributes\": { \"segment\": \""
-                        + verseRef
-                        + "/p_1\" } }";
+                    chapterText.Append(
+                        ", { \"insert\": \"\n\" },"
+                            + "{ \"insert\": { \"note\": { \"caller\": \"*\" } }, "
+                            + "\"attributes\": { \"segment\": \""
+                            + verseRef
+                            + "\" } },"
+                            + "{ \"insert\": \"other text in verse\", "
+                            + "\"attributes\": { \"segment\": \""
+                            + verseRef
+                            + "/p_1\" } }"
+                    );
                 }
-                chapterText = chapterText + "]";
-                return new Delta(JToken.Parse(chapterText));
+                chapterText.Append("]");
+                return new Delta(JToken.Parse(chapterText.ToString()));
             }
 
             private ProjectMetadata GetMetadata(string projectId, string fullname)

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1011,30 +1011,23 @@ namespace SIL.XForge.Scripture.Services
         [Test]
         public async Task RunAsync_NoRecordOfSyncedToRepositoryVersion_DoesFullSync()
         {
-            foreach (bool isChanged in new bool[] { true, false })
-            {
-                var env = new TestEnvironment();
-                string projectSFId = "project03";
-                string userId = "user01";
+            var env = new TestEnvironment();
+            string projectSFId = "project03";
+            string userId = "user01";
 
-                SFProject project = env.SetupProjectWithExpectedImportedRev(projectSFId, null);
-                Assert.That(
-                    project.Sync.DataInSync,
-                    Is.Null,
-                    "setup. Should be testing what happens when this is null."
-                );
-                string projectPTId = project.ParatextId;
-                env.ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), projectPTId).Returns("1", "2");
-                // The expected after-sync repository version can be past the original, before-sync project version,
-                // even if there were no local changes, since there may be incoming changes from the PT Archives server.
-                string expectedRepositoryVersion = "2";
-                // SUT
-                await env.RunAndAssertContinuesAsync(projectSFId, userId, expectedRepositoryVersion);
-                // Shouldn't be setting repo rev.
-                env.ParatextService
-                    .DidNotReceive()
-                    .SetRepoToRevision(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<string>());
-            }
+            SFProject project = env.SetupProjectWithExpectedImportedRev(projectSFId, null);
+            Assert.That(project.Sync.DataInSync, Is.Null, "setup. Should be testing what happens when this is null.");
+            string projectPTId = project.ParatextId;
+            env.ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), projectPTId).Returns("1", "2");
+            // The expected after-sync repository version can be past the original, before-sync project version,
+            // even if there were no local changes, since there may be incoming changes from the PT Archives server.
+            string expectedRepositoryVersion = "2";
+            // SUT
+            await env.RunAndAssertContinuesAsync(projectSFId, userId, expectedRepositoryVersion);
+            // Shouldn't be setting repo rev.
+            env.ParatextService
+                .DidNotReceive()
+                .SetRepoToRevision(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<string>());
         }
 
         [Test]
@@ -1142,7 +1135,7 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             env.SetupSFData(true, true, false, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-            var cancellationTokenSource = new CancellationTokenSource();
+            using var cancellationTokenSource = new CancellationTokenSource();
 
             // Setup a trap to crash the task
             env.NotesMapper
@@ -1217,7 +1210,7 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             env.SetupSFData(true, true, false, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-            var cancellationTokenSource = new CancellationTokenSource();
+            using var cancellationTokenSource = new CancellationTokenSource();
 
             // Setup a trap to cancel the task
             env.NotesMapper
@@ -1264,7 +1257,7 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             env.SetupSFData(true, true, false, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-            var cancellationTokenSource = new CancellationTokenSource();
+            using var cancellationTokenSource = new CancellationTokenSource();
 
             // Setup a trap to cancel the task
             env.ParatextService
@@ -1297,7 +1290,7 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             env.SetupSFData(true, false, true, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-            var cancellationTokenSource = new CancellationTokenSource();
+            using var cancellationTokenSource = new CancellationTokenSource();
             env.ParatextService.BackupExists(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(true);
             env.ParatextService.RestoreRepository(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(false);
 
@@ -1331,7 +1324,7 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             env.SetupSFData(true, true, false, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-            var cancellationTokenSource = new CancellationTokenSource();
+            using var cancellationTokenSource = new CancellationTokenSource();
 
             // Cancel the token before awaiting the task
             cancellationTokenSource.Cancel();
@@ -1355,7 +1348,7 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment(substituteRealtimeService: true);
             env.SetupSFData(true, true, false, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-            var cancellationTokenSource = new CancellationTokenSource();
+            using var cancellationTokenSource = new CancellationTokenSource();
 
             // Return the project so InitAsync will execute successfully
             var project = Substitute.For<IDocument<SFProject>>();
@@ -1404,7 +1397,7 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment(substituteRealtimeService: true);
             env.SetupSFData(true, true, false, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-            var cancellationTokenSource = new CancellationTokenSource();
+            using var cancellationTokenSource = new CancellationTokenSource();
 
             // Throw an TaskCanceledException in InitAsync after the exclusions have been called
             // InitAsync calls the IConnection.FetchAsync() extension, which calls IConnection.Get()
@@ -1446,7 +1439,7 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             env.SetupSFData(true, true, false, false);
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-            var cancellationTokenSource = new CancellationTokenSource();
+            using var cancellationTokenSource = new CancellationTokenSource();
 
             // Run the task
             await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
@@ -2872,7 +2865,7 @@ namespace SIL.XForge.Scripture.Services
                     {
                         { "user01", "User 1" },
                         { "user02", "User 2" },
-                        { "user03", "User 3" }
+                        { "user03", "User 3" },
                     };
                     ParatextService
                         .GetParatextUsernameMappingAsync(
@@ -2881,15 +2874,6 @@ namespace SIL.XForge.Scripture.Services
                             CancellationToken.None
                         )
                         .Returns(userIdsToUsernames);
-                }
-                else
-                {
-                    var noteChange = new Paratext.Data.ProjectComments.Comment(new SFParatextUser("User 1"))
-                    {
-                        Thread = threadId,
-                        VerseRefStr = verseRef
-                    };
-                    var changeList = (new[] { (new[] { noteChange }).ToList() }).ToList();
                 }
             }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -479,7 +479,6 @@ namespace SIL.XForge.Scripture.Services
         {
             var env = new TestEnvironment();
             SFProject project = env.GetProject(Project03);
-            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
 
             Assert.That(project.UserRoles.ContainsKey(User04), Is.False, "setup");
             var invitees = await env.Service.InvitedUsersAsync(User01, Project03);
@@ -494,7 +493,7 @@ namespace SIL.XForge.Scripture.Services
             // Use the sharekey linked to user03
             await env.Service.CheckLinkSharingAsync(User04, Project03, "key1234");
             project = env.GetProject(Project03);
-            projectSecret = env.ProjectSecrets.Get(Project03);
+            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
             Assert.That(project.UserRoles.ContainsKey(User04), Is.True, "User should have been added to project");
             Assert.That(
                 projectSecret.ShareKeys.Any(sk => sk.Key == "key1234"),
@@ -1727,7 +1726,6 @@ namespace SIL.XForge.Scripture.Services
         {
             string project01PTId = "paratext_" + Project01;
             var env = new TestEnvironment();
-            SFProject sfProject = env.GetProject(Project01);
             env.ParatextService.GetBookList(Arg.Any<UserSecret>(), project01PTId).Returns(new List<int>() { 40, 41 });
             Assert.That(env.ProjectSecrets.Contains(User04), Is.False, "setup");
 
@@ -1746,16 +1744,14 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             string project01PTId = "paratext_" + Project01;
 
-            SFProject sfProject = env.GetProject(Project01);
-
             env.ParatextService.GetBookList(Arg.Any<UserSecret>(), project01PTId).Returns(new List<int>() { 40, 41 });
 
-            var ptBookPermissions = new Dictionary<string, string>()
+            var ptBookPermissions = new Dictionary<string, string>
             {
                 { User01, TextInfoPermission.Read },
                 { User02, TextInfoPermission.Write },
             };
-            var ptChapterPermissions = new Dictionary<string, string>()
+            var ptChapterPermissions = new Dictionary<string, string>
             {
                 { User01, TextInfoPermission.Write },
                 { User02, TextInfoPermission.Read },
@@ -1780,7 +1776,7 @@ namespace SIL.XForge.Scripture.Services
                 )
                 .Returns(Task.FromResult(ptChapterPermissions));
 
-            sfProject = env.GetProject(Project01);
+            SFProject sfProject = env.GetProject(Project01);
             Assert.That(sfProject.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
             Assert.That(sfProject.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
 
@@ -1809,16 +1805,14 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             string project01PTId = "paratext_" + Project01;
 
-            SFProject sfProject = env.GetProject(Project01);
-
             env.ParatextService.GetBookList(Arg.Any<UserSecret>(), project01PTId).Returns(new List<int>() { 40, 41 });
 
-            var ptBookPermissions = new Dictionary<string, string>()
+            var ptBookPermissions = new Dictionary<string, string>
             {
                 { User01, TextInfoPermission.Read },
                 { User02, TextInfoPermission.None },
             };
-            var ptChapterPermissions = new Dictionary<string, string>()
+            var ptChapterPermissions = new Dictionary<string, string>
             {
                 { User01, TextInfoPermission.Read },
                 { User02, TextInfoPermission.None },
@@ -1843,7 +1837,7 @@ namespace SIL.XForge.Scripture.Services
                 )
                 .Returns(Task.FromResult(ptChapterPermissions));
 
-            sfProject = env.GetProject(Project01);
+            SFProject sfProject = env.GetProject(Project01);
             Assert.That(sfProject.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
             Assert.That(sfProject.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
 
@@ -1872,22 +1866,20 @@ namespace SIL.XForge.Scripture.Services
             var env = new TestEnvironment();
             string project01PTId = "paratext_" + Project01;
 
-            SFProject sfProject = env.GetProject(Project01);
-
-            var bookList = new List<int>() { 40, 41 };
+            var bookList = new List<int> { 40, 41 };
             env.ParatextService.GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(bookList);
 
-            var ptBookPermissions = new Dictionary<string, string>()
+            var ptBookPermissions = new Dictionary<string, string>
             {
                 { User01, TextInfoPermission.Write },
                 { User02, TextInfoPermission.Write },
             };
-            var ptChapterPermissions = new Dictionary<string, string>()
+            var ptChapterPermissions = new Dictionary<string, string>
             {
                 { User01, TextInfoPermission.Write },
                 { User02, TextInfoPermission.Write },
             };
-            var ptSourcePermissions = new Dictionary<string, string>()
+            var ptSourcePermissions = new Dictionary<string, string>
             {
                 { User01, TextInfoPermission.Read },
                 { User02, TextInfoPermission.None },
@@ -1922,7 +1914,7 @@ namespace SIL.XForge.Scripture.Services
                 )
                 .Returns(Task.FromResult(ptSourcePermissions));
 
-            sfProject = env.GetProject(Project01);
+            SFProject sfProject = env.GetProject(Project01);
             Assert.That(sfProject.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
             Assert.That(sfProject.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
 

--- a/test/SIL.XForge.Tests/DataAccess/MemoryUpdateBuilderTests.cs
+++ b/test/SIL.XForge.Tests/DataAccess/MemoryUpdateBuilderTests.cs
@@ -63,7 +63,6 @@ namespace SIL.XForge.DataAccess
         {
             // Setup environment
             var env = new TestEnvironment();
-            string oldValue = env.TestEntity.TestStringField;
             string expected = "updated_test_value";
 
             // Test string field set
@@ -91,7 +90,6 @@ namespace SIL.XForge.DataAccess
         {
             // Setup environment
             var env = new TestEnvironment(true);
-            string oldValue = env.TestEntity.TestStringField;
             string expected = "updated_test_value";
 
             // Test string field set

--- a/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
@@ -408,7 +408,7 @@ namespace SIL.XForge.Realtime
             List<Json0Op> op = builder.Op;
 
             // SUT
-            var result = await env.Service.SubmitOpAsync(collection, id, op, snapshot.Data, snapshot.Version);
+            await env.Service.SubmitOpAsync(collection, id, op, snapshot.Data, snapshot.Version);
 
             // Verify queue
             Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
@@ -421,8 +421,8 @@ namespace SIL.XForge.Realtime
 
         private class TestEnvironment
         {
-            public Connection Service = null;
-            public RealtimeService RealtimeService = null;
+            public readonly Connection Service;
+            public readonly RealtimeService RealtimeService;
 
             public TestEnvironment()
             {

--- a/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
@@ -211,8 +211,8 @@ namespace SIL.XForge.Realtime
 
         private class TestEnvironment
         {
-            public RealtimeService Service = null;
-            public IMongoDatabase MongoDatabase = Substitute.For<IMongoDatabase>();
+            public readonly RealtimeService Service;
+            public readonly IMongoDatabase MongoDatabase = Substitute.For<IMongoDatabase>();
 
             public TestEnvironment()
             {

--- a/test/SIL.XForge.Tests/Services/ProjectServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/ProjectServiceTests.cs
@@ -31,7 +31,7 @@ namespace SIL.XForge.Services
             env.FileSystemService.OpenFile(Arg.Any<string>(), FileMode.Create).Returns(new MemoryStream());
             env.FileSystemService.FileExists(filePath).Returns(true);
 
-            var stream = new MemoryStream();
+            using var stream = new MemoryStream();
             Uri uri = await env.Service.SaveAudioAsync(User01, Project01, dataId, ".wav", stream);
             Assert.That(
                 uri.ToString().StartsWith($"http://localhost/assets/audio/project01/user01_{dataId}.mp3?t="),
@@ -49,7 +49,7 @@ namespace SIL.XForge.Services
             env.FileSystemService.OpenFile(Arg.Any<string>(), FileMode.Create).Returns(new MemoryStream());
             env.FileSystemService.FileExists(filePath).Returns(true);
 
-            var stream = new MemoryStream();
+            using var stream = new MemoryStream();
             Uri uri = await env.Service.SaveAudioAsync(User01, Project01, dataId, ".mp3", stream);
             Assert.That(
                 uri.ToString().StartsWith($"http://localhost/assets/audio/project01/user01_{dataId}.mp3?t="),
@@ -64,7 +64,7 @@ namespace SIL.XForge.Services
         {
             var env = new TestEnvironment();
 
-            var stream = new MemoryStream();
+            using var stream = new MemoryStream();
             Assert.ThrowsAsync<FormatException>(
                 () => env.Service.SaveAudioAsync(User01, Project01, "/../test/abc.txt", ".wav", stream)
             );
@@ -75,7 +75,7 @@ namespace SIL.XForge.Services
         {
             var env = new TestEnvironment();
 
-            var stream = new MemoryStream();
+            using var stream = new MemoryStream();
             Assert.ThrowsAsync<DataNotFoundException>(
                 () => env.Service.SaveAudioAsync(User01, "/../abc.txt", "507f1f77bcf86cd799439011", ".wav", stream)
             );

--- a/test/SIL.XForge.Tests/Services/UserServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/UserServiceTests.cs
@@ -295,9 +295,9 @@ namespace SIL.XForge.Services
             public UserService Service { get; }
             public MemoryRepository<UserSecret> UserSecrets { get; }
             public MemoryRealtimeService RealtimeService { get; }
-            public IAuthService AuthService = Substitute.For<IAuthService>();
-            public DateTime IssuedAt => DateTime.UtcNow;
-            public IProjectService ProjectService = Substitute.For<IProjectService>();
+            public readonly IAuthService AuthService = Substitute.For<IAuthService>();
+            public readonly DateTime IssuedAt = DateTime.UtcNow;
+            public readonly IProjectService ProjectService = Substitute.For<IProjectService>();
 
             public TestEnvironment()
             {


### PR DESCRIPTION
This PR fixes many straightforward CodeQL warnings in the unit tests. This should reduce the CodeQL alert count, and mean that we can then start looking at the CodeQL warnings in the main project.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1645)
<!-- Reviewable:end -->
