### PR TITLE
Change default settings for exporting answers

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -354,8 +354,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
       usersSeeEachOthersResponses: this.projectDoc.data.checkingConfig.usersSeeEachOthersResponses,
       checkingShareEnabled: this.projectDoc.data.checkingConfig.shareEnabled,
       checkingShareLevel: this.projectDoc.data.checkingConfig.shareLevel,
-      checkingAnswerExport:
-        this.projectDoc.data.checkingConfig.answerExportMethod ?? CheckingAnswerExport.MarkedForExport
+      checkingAnswerExport: this.projectDoc.data.checkingConfig.answerExportMethod ?? CheckingAnswerExport.All
     };
     this.form.reset(this.previousFormValues);
     this.setIndividualControlDisabledStates();

--- a/src/SIL.XForge.Scripture/Models/CheckingConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/CheckingConfig.cs
@@ -6,6 +6,6 @@ namespace SIL.XForge.Scripture.Models
         public bool UsersSeeEachOthersResponses { get; set; } = true;
         public bool ShareEnabled { get; set; } = false;
         public string ShareLevel { get; set; } = CheckingShareLevel.Specific;
-        public string AnswerExportMethod { get; set; } = CheckingAnswerExport.MarkedForExport;
+        public string AnswerExportMethod { get; set; }
     }
 }

--- a/src/SIL.XForge.Scripture/Models/SFProjectCreateSettings.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectCreateSettings.cs
@@ -6,5 +6,6 @@ namespace SIL.XForge.Scripture.Models
         public bool TranslationSuggestionsEnabled { get; set; }
         public string SourceParatextId { get; set; }
         public bool CheckingEnabled { get; set; }
+        public string AnswerExportMethod { get; set; } = CheckingAnswerExport.MarkedForExport;
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
@@ -105,7 +105,11 @@ namespace SIL.XForge.Scripture.Services
                     for (int j = 0; j < question.Answers.Count; j++)
                     {
                         Answer answer = question.Answers[j];
-                        if (answer.Status != AnswerStatus.Exportable && answerExportMethod != CheckingAnswerExport.All)
+                        if (
+                            answer.Status != AnswerStatus.Exportable
+                            && answerExportMethod != CheckingAnswerExport.All
+                            && answerExportMethod != null
+                        )
                         {
                             continue;
                         }

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -95,7 +95,11 @@ namespace SIL.XForge.Scripture.Services
                 {
                     TranslationSuggestionsEnabled = settings.TranslationSuggestionsEnabled
                 },
-                CheckingConfig = new CheckingConfig { CheckingEnabled = settings.CheckingEnabled }
+                CheckingConfig = new CheckingConfig
+                {
+                    CheckingEnabled = settings.CheckingEnabled,
+                    AnswerExportMethod = settings.AnswerExportMethod
+                }
             };
             Attempt<string> attempt = await TryGetProjectRoleAsync(project, curUserId);
             if (!attempt.TryResult(out string projectRole) || projectRole != SFProjectRole.Administrator)

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -2575,7 +2575,11 @@ namespace SIL.XForge.Scripture.Services
                                 IsRightToLeft = false
                             }
                         },
-                        CheckingConfig = new CheckingConfig { CheckingEnabled = checkingEnabled },
+                        CheckingConfig = new CheckingConfig
+                        {
+                            CheckingEnabled = checkingEnabled,
+                            AnswerExportMethod = CheckingAnswerExport.MarkedForExport
+                        },
                         Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
                         Sync = new Sync
                         {
@@ -2600,7 +2604,11 @@ namespace SIL.XForge.Scripture.Services
                         ParatextId = "source",
                         IsRightToLeft = false,
                         TranslateConfig = new TranslateConfig { TranslationSuggestionsEnabled = false },
-                        CheckingConfig = new CheckingConfig { CheckingEnabled = checkingEnabled },
+                        CheckingConfig = new CheckingConfig
+                        {
+                            CheckingEnabled = checkingEnabled,
+                            AnswerExportMethod = CheckingAnswerExport.MarkedForExport
+                        },
                         WritingSystem = new WritingSystem { Tag = "en" },
                         Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
                         Sync = new Sync { QueuedCount = 0, SyncedToRepositoryVersion = "beforeSR" }
@@ -2632,7 +2640,11 @@ namespace SIL.XForge.Scripture.Services
                                 IsRightToLeft = false
                             }
                         },
-                        CheckingConfig = new CheckingConfig { CheckingEnabled = checkingEnabled },
+                        CheckingConfig = new CheckingConfig
+                        {
+                            CheckingEnabled = checkingEnabled,
+                            AnswerExportMethod = CheckingAnswerExport.MarkedForExport
+                        },
                         Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
                         Sync = new Sync
                         {
@@ -2650,7 +2662,11 @@ namespace SIL.XForge.Scripture.Services
                         ParatextId = "paratext-project04",
                         IsRightToLeft = false,
                         TranslateConfig = new TranslateConfig { TranslationSuggestionsEnabled = false },
-                        CheckingConfig = new CheckingConfig { CheckingEnabled = checkingEnabled },
+                        CheckingConfig = new CheckingConfig
+                        {
+                            CheckingEnabled = checkingEnabled,
+                            AnswerExportMethod = CheckingAnswerExport.MarkedForExport
+                        },
                         WritingSystem = new WritingSystem { Tag = "en" },
                         Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
                         Sync = new Sync
@@ -2688,7 +2704,11 @@ namespace SIL.XForge.Scripture.Services
                                 IsRightToLeft = false
                             }
                         },
-                        CheckingConfig = new CheckingConfig { CheckingEnabled = checkingEnabled },
+                        CheckingConfig = new CheckingConfig
+                        {
+                            CheckingEnabled = checkingEnabled,
+                            AnswerExportMethod = CheckingAnswerExport.MarkedForExport
+                        },
                         Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
                         Sync = new Sync
                         {


### PR DESCRIPTION
- New projects added will default to "Answers marked for export"
- Existing projects with no method set will default to "All answers" to mimic the pre-existing workflow