### PR TITLE
Use dotnet format with CSharpier

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "csharpier": {
-      "version": "0.21.0",
+      "version": "0.22.1",
       "commands": ["dotnet-csharpier"]
     }
   }

--- a/.editorconfig
+++ b/.editorconfig
@@ -44,45 +44,45 @@ tab_width = 4
 indent_size = 4
 continuation_indent_size = 4
 csharp_indent_labels = one_less_than_current
-csharp_using_directive_placement = outside_namespace:suggestion
-csharp_prefer_simple_using_statement = true:suggestion
+csharp_using_directive_placement = outside_namespace:warning
+csharp_prefer_simple_using_statement = true:warning
 csharp_prefer_braces = true:silent
-csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_namespace_declarations = file_scoped:warning
 csharp_style_prefer_method_group_conversion = true:silent
 csharp_style_prefer_top_level_statements = true:silent
-csharp_style_expression_bodied_methods = false:silent
-csharp_style_expression_bodied_constructors = false:silent
-csharp_style_expression_bodied_operators = false:silent
-csharp_style_expression_bodied_properties = true:silent
-csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_methods = when_on_single_line:warning
+csharp_style_expression_bodied_constructors = when_on_single_line:warning
+csharp_style_expression_bodied_operators = when_on_single_line:warning
+csharp_style_expression_bodied_properties = when_on_single_line:warning
+csharp_style_expression_bodied_indexers = when_on_single_line:warning
 csharp_space_around_binary_operators = before_and_after
-csharp_style_expression_bodied_accessors = true:silent
-csharp_style_expression_bodied_local_functions = false:silent
-csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_accessors = when_on_single_line:warning
+csharp_style_expression_bodied_local_functions = when_on_single_line:warning
+csharp_style_expression_bodied_lambdas = when_on_single_line:warning
 csharp_style_throw_expression = true:suggestion
 csharp_style_prefer_null_check_over_type_check = true:suggestion
-csharp_prefer_simple_default_expression = true:suggestion
-csharp_style_prefer_local_over_anonymous_function = true:suggestion
-csharp_style_prefer_index_operator = true:suggestion
-csharp_style_prefer_range_operator = true:suggestion
+csharp_prefer_simple_default_expression = true:warning
+csharp_style_prefer_local_over_anonymous_function = true:warning
+csharp_style_prefer_index_operator = true:warning
+csharp_style_prefer_range_operator = true:warning
 csharp_style_implicit_object_creation_when_type_is_apparent = false:suggestion
 csharp_style_prefer_tuple_swap = true:suggestion
-csharp_style_prefer_utf8_string_literals = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
-csharp_style_deconstructed_variable_declaration = true:suggestion
-csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_prefer_utf8_string_literals = false:suggestion
+csharp_style_inlined_variable_declaration = true:warning
+csharp_style_deconstructed_variable_declaration = true:warning
+csharp_style_unused_value_assignment_preference = discard_variable:warning
 csharp_style_unused_value_expression_statement_preference = discard_variable:silent
 csharp_prefer_static_local_function = true:suggestion
 csharp_style_prefer_readonly_struct = true:suggestion
 csharp_style_allow_embedded_statements_on_same_line_experimental = true:silent
 csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true:silent
 csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent
-csharp_style_conditional_delegate_call = true:suggestion
-csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:warning
+csharp_style_prefer_switch_expression = true:warning
 csharp_style_prefer_pattern_matching = true:silent
 csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_prefer_not_pattern = true:warning
 csharp_style_prefer_extended_property_pattern = true:suggestion
 csharp_style_var_for_built_in_types = false:silent
 csharp_style_var_when_type_is_apparent = false:silent
@@ -140,20 +140,20 @@ dotnet_naming_style.pascal_case.word_separator =
 dotnet_naming_style.pascal_case.capitalization = pascal_case
 
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
-dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_coalesce_expression = true:warning
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_object_initializer = true:suggestion
+dotnet_style_null_propagation = true:warning
+dotnet_style_object_initializer = true:warning
 dotnet_style_prefer_auto_properties = true:silent
 dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
+dotnet_style_collection_initializer = true:warning
 dotnet_style_prefer_conditional_expression_over_assignment = true:silent
 dotnet_style_prefer_conditional_expression_over_return = true:silent
 dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_compound_assignment = true:suggestion
-dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:warning
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
+dotnet_style_prefer_compound_assignment = true:warning
+dotnet_style_prefer_simplified_interpolation = true:warning
 dotnet_style_namespace_match_folder = true:suggestion
 dotnet_style_readonly_field = true:suggestion
 dotnet_style_predefined_type_for_locals_parameters_members = true:silent
@@ -171,3 +171,40 @@ dotnet_style_qualification_for_property = false:silent
 dotnet_style_qualification_for_method = false:silent
 dotnet_style_qualification_for_event = false:silent
 dotnet_sort_system_directives_first = true
+
+# Define the 'private_fields' symbol group:
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+# Define the 'private_static_fields' symbol group
+dotnet_naming_symbols.private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_fields.required_modifiers = static
+
+# Define the 'underscored' naming style
+dotnet_naming_style.underscored.capitalization = camel_case
+dotnet_naming_style.underscored.required_prefix = _
+
+# Define the 'private_fields_underscored' naming rule
+dotnet_naming_rule.private_fields_underscored.symbols = private_fields
+dotnet_naming_rule.private_fields_underscored.style = underscored
+dotnet_naming_rule.private_fields_underscored.severity = suggestion
+
+# Define the 'private_static_fields_none' naming rule
+dotnet_naming_rule.private_static_fields_none.symbols = private_static_fields
+dotnet_naming_rule.private_static_fields_none.style = underscored
+dotnet_naming_rule.private_static_fields_none.severity = none
+
+# Make code style diagnostic messages warnings so dotnet format can fix them
+# This list is specific to messages that can be automatically fixed and have been tested
+# These IDE/CA values are from the .NET Roslyn notices in Visual Studio
+dotnet_diagnostic.IDE0005.severity = warning # Using directive is unnecessary.
+dotnet_diagnostic.IDE0051.severity = warning # Private member is unused
+dotnet_diagnostic.IDE0220.severity = warning # Add an explicit cast to make intent clearer, as it may fail at runtime
+dotnet_diagnostic.IDE0250.severity = warning # Struct can be made 'readonly'
+dotnet_diagnostic.IDE1005.severity = warning # Delegate invocation can be simplified.
+dotnet_diagnostic.CA1822.severity = warning # Member does not access instance data and can be marked as static
+dotnet_diagnostic.CA1825.severity = warning # Avoid unnecessary zero-length array allocations. Use Array.Empty() instead
+dotnet_diagnostic.CA1829.severity = warning # Use the Count or Length property instead of Enumerable.Count()
+dotnet_diagnostic.CA1834.severity = warning # Use 'StringBuilder.Append(char)' instead of 'StringBuilder.Append(string)'
+dotnet_diagnostic.CA2016.severity = warning # Forward the 'token' parameter to the async method

--- a/.lintstagedrc.yml
+++ b/.lintstagedrc.yml
@@ -1,2 +1,2 @@
 "*.{ts,js,json,css,scss,less,html,md,yml}": "prettier --write"
-"*.cs": "dotnet csharpier"
+"*.cs": ["dotnet format analyzers --include", "dotnet format style --include", "dotnet csharpier"]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "angularKarmaTestExplorer.angularProcessArguments": ["--sourceMap=true"],
   "angularKarmaTestExplorer.karmaConfFilePath": "src/karma.conf.js",
   "angularKarmaTestExplorer.projectRootPath": "src/SIL.XForge.Scripture/ClientApp",
+  "csharp.format.enable": true,
   "cSpell.words": [
     "appbuilder",
     "backout",
@@ -75,6 +76,9 @@
     }
   ],
   "liveSassCompile.settings.generateMap": false,
+  "omnisharp.enableEditorConfigSupport": true,
+  "omnisharp.enableRoslynAnalyzers": true,
+  "omnisharp.organizeImportsOnFormat": true,
   "python.formatting.provider": "black",
   "typescript.tsdk": "./src/SIL.XForge.Scripture/ClientApp/node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true

--- a/README.md
+++ b/README.md
@@ -619,6 +619,8 @@ C# can be formatted from the repo root by running
 ```bash
 dotnet tool install csharpier
 dotnet csharpier .
+dotnet format style
+dotnet format analyzers
 ```
 
 ## Cleaning

--- a/src/Help/UpdateHelp/Program.cs
+++ b/src/Help/UpdateHelp/Program.cs
@@ -8,486 +8,475 @@ using System.Xml.Linq;
 using System.Xml.XPath;
 using HtmlAgilityPack;
 
-namespace UpdateHelp
+namespace UpdateHelp;
+
+class Program
 {
-    class Program
+    /// <summary>
+    /// Updates RoboHelp 2019 files translated from en to the target language.
+    /// Currently only HTML files are translated in Crowdin. Use the HTML files to:
+    ///     Update idata files
+    ///     Update TOC files
+    ///     Replace search with Google Search
+    ///     Remove unused buttons and inputs
+    /// </summary>
+    /// <example>
+    /// Assumes the user has ~/src/web-sf-helps/src/en/ folder and AWS console app setup locally
+    /// Pull the latest help from AWS S3:
+    /// <code>
+    ///     cd ~/src/web-sf-helps/src/en/
+    ///     aws s3 sync s3://help.scriptureforge.org/en . --exact-timestamps
+    /// </code>
+    /// If changes exist, this means the English helps have been updated and the changed HTML files
+    ///     will need to be uploaded to Crowdin
+    ///
+    /// Delete the contents of <c>targetDir</c> except for the Google search console file (google<number>.html)
+    ///     where targetDir is the target language folder e.g. /es/
+    /// Copy /en/ to <c>targetDir</c> folder
+    /// Copy Google search console site verification HTML file to <c>targetDir</c> folder
+    ///     if it does not already exist in <c>targetDir</c>
+    /// Copy translated target HTML files and menu_[target].json from Crowdin to the <c>targetDir</c> folder
+    /// Run this program, <c>dotnet run es write</c> (change 'es' for a different language)
+    /// Push to help AWS S3:
+    /// <code>
+    ///     cd ~/src/web-sf-helps/src/es/
+    ///     aws s3 sync . s3://help.scriptureforge.org/es
+    /// </code>
+    /// </example>
+    static void Main(string[] args)
     {
-        /// <summary>
-        /// Updates RoboHelp 2019 files translated from en to the target language.
-        /// Currently only HTML files are translated in Crowdin. Use the HTML files to:
-        ///     Update idata files
-        ///     Update TOC files
-        ///     Replace search with Google Search
-        ///     Remove unused buttons and inputs
-        /// </summary>
-        /// <example>
-        /// Assumes the user has ~/src/web-sf-helps/src/en/ folder and AWS console app setup locally
-        /// Pull the latest help from AWS S3:
-        /// <code>
-        ///     cd ~/src/web-sf-helps/src/en/
-        ///     aws s3 sync s3://help.scriptureforge.org/en . --exact-timestamps
-        /// </code>
-        /// If changes exist, this means the English helps have been updated and the changed HTML files
-        ///     will need to be uploaded to Crowdin
-        ///
-        /// Delete the contents of <c>targetDir</c> except for the Google search console file (google<number>.html)
-        ///     where targetDir is the target language folder e.g. /es/
-        /// Copy /en/ to <c>targetDir</c> folder
-        /// Copy Google search console site verification HTML file to <c>targetDir</c> folder
-        ///     if it does not already exist in <c>targetDir</c>
-        /// Copy translated target HTML files and menu_[target].json from Crowdin to the <c>targetDir</c> folder
-        /// Run this program, <c>dotnet run es write</c> (change 'es' for a different language)
-        /// Push to help AWS S3:
-        /// <code>
-        ///     cd ~/src/web-sf-helps/src/es/
-        ///     aws s3 sync . s3://help.scriptureforge.org/es
-        /// </code>
-        /// </example>
-        static void Main(string[] args)
+        string target = args.Length >= 1 ? args[0] : "es";
+        bool doWrite = ((args.Length >= 2 ? args[1] : "") == "write");
+
+        string userDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        string helpDir = Path.Combine(userDir, "src", "web-sf-helps", "src");
+        string source = "en";
+        string sourceDir = Path.Combine(helpDir, source);
+        string sourceWhxDir = Path.Combine(sourceDir, "whxdata");
+        string parentFolderOfThisFile = Path.GetDirectoryName(Directory.GetCurrentDirectory());
+        string sourceMenuJsonPath = Path.Combine(parentFolderOfThisFile, $"menu_{source}.json");
+        string targetDir = Path.Combine(helpDir, target);
+        string targetWhxDir = Path.Combine(targetDir, "whxdata");
+        string targetMenuJsonPath = Path.Combine(targetDir, $"menu_{target}.json");
+
+        // See https://programmablesearchengine.google.com/ to create an engine for each language.
+        // For the new language, copy existing setup from another language, including these 2 settings:
+        // - Look and feel > Layout > Two column
+        // - Search features > Advanced > Websearch Settings > Link Target > "rh_default_topic_frame_name"
+        // Copy the search engine ID for the new language into the dictionary below.
+        // Create a property for the language in https://search.google.com/search-console,
+        // download verification HTML file to targetDir folder and verify site.
+        var searchEngineIDs = new Dictionary<string, string>()
         {
-            string target = args.Length >= 1 ? args[0] : "es";
-            bool doWrite = ((args.Length >= 2 ? args[1] : "") == "write");
+            { "es", "9f727aa1dd179dd6d" },
+            { "fr", "7da597faaebed6cc7" },
+            { "pt_BR", "40bf11d4080246d99" }
+        };
 
-            string userDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            string helpDir = Path.Combine(userDir, "src", "web-sf-helps", "src");
-            string source = "en";
-            string sourceDir = Path.Combine(helpDir, source);
-            string sourceWhxDir = Path.Combine(sourceDir, "whxdata");
-            string parentFolderOfThisFile = Path.GetDirectoryName(Directory.GetCurrentDirectory());
-            string sourceMenuJsonPath = Path.Combine(parentFolderOfThisFile, $"menu_{source}.json");
-            string targetDir = Path.Combine(helpDir, target);
-            string targetWhxDir = Path.Combine(targetDir, "whxdata");
-            string targetMenuJsonPath = Path.Combine(targetDir, $"menu_{target}.json");
+        Console.WriteLine("Update Help files.\n");
 
-            // See https://programmablesearchengine.google.com/ to create an engine for each language.
-            // For the new language, copy existing setup from another language, including these 2 settings:
-            // - Look and feel > Layout > Two column
-            // - Search features > Advanced > Websearch Settings > Link Target > "rh_default_topic_frame_name"
-            // Copy the search engine ID for the new language into the dictionary below.
-            // Create a property for the language in https://search.google.com/search-console,
-            // download verification HTML file to targetDir folder and verify site.
-            var searchEngineIDs = new Dictionary<string, string>()
-            {
-                { "es", "9f727aa1dd179dd6d" },
-                { "fr", "7da597faaebed6cc7" },
-                { "pt_BR", "40bf11d4080246d99" }
-            };
+        ExitIfNoFolder(helpDir);
+        ExitIfNoFolder(sourceDir);
+        ExitIfNoFolder(sourceWhxDir);
+        ExitIfNoFile(sourceMenuJsonPath);
+        ExitIfNoFolder(targetDir);
+        ExitIfNoFolder(targetWhxDir);
+        ExitIfNoFile(targetMenuJsonPath);
+        if (!doWrite)
+            TestModeWarning();
 
-            Console.WriteLine("Update Help files.\n");
+        Dictionary<string, string> translations = ExtractHtmlTranslations(sourceDir, targetDir);
+        AddMenuTranslations(translations, sourceMenuJsonPath, targetMenuJsonPath);
 
-            ExitIfNoFolder(helpDir);
-            ExitIfNoFolder(sourceDir);
-            ExitIfNoFolder(sourceWhxDir);
-            ExitIfNoFile(sourceMenuJsonPath);
-            ExitIfNoFolder(targetDir);
-            ExitIfNoFolder(targetWhxDir);
-            ExitIfNoFile(targetMenuJsonPath);
-            if (!doWrite)
-                TestModeWarning();
+        UpdateIdataFiles(sourceWhxDir, targetWhxDir, translations, doWrite);
+        UpdateTocFiles(sourceWhxDir, targetWhxDir, translations, doWrite);
 
-            Dictionary<string, string> translations = ExtractHtmlTranslations(sourceDir, targetDir);
-            AddMenuTranslations(translations, sourceMenuJsonPath, targetMenuJsonPath);
+        bool canReplaceSearch = searchEngineIDs.TryGetValue(target, out string searchEngineID);
+        if (canReplaceSearch)
+            ReplaceSearch(targetDir, searchEngineID, doWrite);
+        RemoveUnusedButtonsAndSearch(targetDir, !canReplaceSearch, doWrite);
 
-            UpdateIdataFiles(sourceWhxDir, targetWhxDir, translations, doWrite);
-            UpdateTocFiles(sourceWhxDir, targetWhxDir, translations, doWrite);
+        Console.WriteLine("\nFinished Help Update.");
+    }
 
-            bool canReplaceSearch = searchEngineIDs.TryGetValue(target, out string searchEngineID);
-            if (canReplaceSearch)
-                ReplaceSearch(targetDir, searchEngineID, doWrite);
-            RemoveUnusedButtonsAndSearch(targetDir, !canReplaceSearch, doWrite);
-
-            Console.WriteLine("\nFinished Help Update.");
+    static void ExitIfNoFolder(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            Console.WriteLine($"Required folder doesn't exist: {path}");
+            Environment.Exit(1);
         }
+    }
 
-        static void ExitIfNoFolder(string path)
+    static void ExitIfNoFile(string path)
+    {
+        if (!File.Exists(path))
         {
-            if (!Directory.Exists(path))
+            Console.WriteLine($"Required file doesn't exist: {path}");
+            Environment.Exit(1);
+        }
+    }
+
+    static void TestModeWarning()
+    {
+        ConsoleColor savedForegroundColor = Console.ForegroundColor;
+        Console.ForegroundColor = ConsoleColor.Red;
+        Console.Write("Test Mode ONLY");
+        Console.ForegroundColor = savedForegroundColor;
+        Console.WriteLine(" - no files are changed. Run `UpdateHelp <language> write` to change files.\n");
+    }
+
+    /// <summary>
+    /// Extract translations from all HTML files.
+    /// </summary>
+    static Dictionary<string, string> ExtractHtmlTranslations(string sourcePath, string targetPath)
+    {
+        var result = new Dictionary<string, string>();
+        var sourceFileToTitles = new Dictionary<string, string>();
+        var sourceFileToHeadings = new Dictionary<string, string>();
+        try
+        {
+            string[] sourceFiles = Directory.GetFiles(sourcePath, "*.htm", SearchOption.AllDirectories);
+            Console.WriteLine($"There are {sourceFiles.Length} HTML source files.");
+            foreach (string file in sourceFiles)
             {
-                Console.WriteLine($"Required folder doesn't exist: {path}");
-                Environment.Exit(1);
+                string relativeFile = Path.GetRelativePath(sourcePath, file);
+                string sourceTitle = GetHtmlTitle(file);
+                if (sourceTitle != "")
+                    sourceFileToTitles.Add(relativeFile, sourceTitle);
+                string sourceHeading = GetHtmlHeading(file);
+                if (sourceHeading != "")
+                    sourceFileToHeadings.Add(relativeFile, sourceHeading);
+            }
+
+            string[] targetFiles = Directory.GetFiles(targetPath, "*.htm", SearchOption.AllDirectories);
+            foreach (string file in targetFiles)
+            {
+                if (file.EndsWith("index1.htm"))
+                    continue;
+                string relativeFile = Path.GetRelativePath(targetPath, file);
+                string targetTitle = GetHtmlTitle(file);
+                if (targetTitle != "" && sourceFileToTitles.TryGetValue(relativeFile, out string sourceTitle))
+                    result.Add(sourceTitle, targetTitle);
+                string targetHeading = GetHtmlHeading(file);
+                if (targetHeading != "" && sourceFileToHeadings.TryGetValue(relativeFile, out string sourceHeading))
+                    result.TryAdd(sourceHeading, targetHeading);
             }
         }
-
-        static void ExitIfNoFile(string path)
+        catch (Exception e)
         {
-            if (!File.Exists(path))
-            {
-                Console.WriteLine($"Required file doesn't exist: {path}");
-                Environment.Exit(1);
-            }
+            Console.WriteLine($"The ExtractTranslations process failed: {e}");
         }
 
-        static void TestModeWarning()
+        return result;
+    }
+
+    /// <summary>
+    /// Add menu translations from menu_[target].json file.
+    /// </summary>
+    static void AddMenuTranslations(
+        Dictionary<string, string> translations,
+        string sourceMenuPath,
+        string targetMenuPath
+    )
+    {
+        string sourceMenuJson = File.ReadAllText(sourceMenuPath);
+        string targetMenuJson = File.ReadAllText(targetMenuPath);
+        using JsonDocument sourceMenuDoc = JsonDocument.Parse(sourceMenuJson);
+        using JsonDocument targetMenuDoc = JsonDocument.Parse(targetMenuJson);
+        var sourceMenuItems = new Dictionary<string, string>();
+        foreach (JsonProperty property in sourceMenuDoc.RootElement.EnumerateObject())
+            ExtractJsonStringsAndKeys(property.Name, property.Value, sourceMenuItems);
+        var targetMenuItems = new Dictionary<string, string>();
+        foreach (JsonProperty property in targetMenuDoc.RootElement.EnumerateObject())
+            ExtractJsonStringsAndKeys(property.Name, property.Value, targetMenuItems);
+        foreach (var targetMenuItem in targetMenuItems)
+            if (sourceMenuItems.TryGetValue(targetMenuItem.Key, out string sourceMenuItem))
+                translations.TryAdd(sourceMenuItem, targetMenuItem.Value);
+    }
+
+    /// <summary>
+    /// Recursively extract the strings and associated keys from the JSON element.
+    /// </summary>
+    static void ExtractJsonStringsAndKeys(string key, JsonElement element, Dictionary<string, string> items)
+    {
+        if (element.ValueKind == JsonValueKind.String)
+            items.Add(key, element.GetString());
+        else if (element.ValueKind == JsonValueKind.Object)
+            foreach (JsonProperty property in element.EnumerateObject())
+                ExtractJsonStringsAndKeys(property.Name, property.Value, items);
+    }
+
+    /// <summary>
+    /// Get the heading text from HTML file.
+    /// </summary>
+    static string GetHtmlHeading(string file)
+    {
+        string result = "";
+        var doc = new HtmlDocument();
+        doc.Load(file);
+        HtmlNode heading =
+            doc.DocumentNode.SelectSingleNode("//body/h1") ?? doc.DocumentNode.SelectSingleNode("//body/h2");
+
+        if (heading != null)
         {
-            ConsoleColor savedForegroundColor = Console.ForegroundColor;
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.Write("Test Mode ONLY");
-            Console.ForegroundColor = savedForegroundColor;
-            Console.WriteLine(" - no files are changed. Run `UpdateHelp <language> write` to change files.\n");
+            result = heading.InnerText ?? "";
+            result = result.Replace("\n", "");
+            result = result.Replace("  ", " ");
+            result = result.Trim();
         }
 
-        /// <summary>
-        /// Extract translations from all HTML files.
-        /// </summary>
-        static Dictionary<string, string> ExtractHtmlTranslations(string sourcePath, string targetPath)
+        return result;
+    }
+
+    /// <summary>
+    /// Get the title text from HTML file.
+    /// </summary>
+    static string GetHtmlTitle(string file)
+    {
+        string result = "";
+        var doc = new HtmlDocument();
+        doc.Load(file);
+        HtmlNode title = doc.DocumentNode.SelectSingleNode("//title");
+
+        if (title != null)
         {
-            var result = new Dictionary<string, string>();
-            var sourceFileToTitles = new Dictionary<string, string>();
-            var sourceFileToHeadings = new Dictionary<string, string>();
-            try
+            result = title.InnerText ?? "";
+            result = result.Replace("\n", "");
+            result = result.Replace("  ", " ");
+            result = result.Trim();
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Find all idata???.js files, extract the containing XML, and parse and extract the topics.
+    /// Replace translated topic names in all idata???.js and idata???.new.js files.
+    /// </summary>
+    static void UpdateIdataFiles(
+        string sourcePath,
+        string targetPath,
+        Dictionary<string, string> translations,
+        bool doWrite
+    )
+    {
+        try
+        {
+            string[] files = Directory.GetFiles(sourcePath, "idata???.js");
+            Console.WriteLine($"There are {files.Length} idata source files.");
+            static string topicTextInIdata(string topicName) => $"<topic name=\\\"{topicName}\\\"";
+            static string topicTextInIdataNew(string topicName) => $"\"type\":\"topic\",\"name\":\"{topicName}\"";
+            var topicUrlsByName = new Dictionary<string, string>();
+            foreach (string file in files)
             {
-                string[] sourceFiles = Directory.GetFiles(sourcePath, "*.htm", SearchOption.AllDirectories);
-                Console.WriteLine($"There are {sourceFiles.Length} HTML source files.");
-                foreach (string file in sourceFiles)
+                XDocument doc = XDocument.Parse(GetBufferXmlFromFile(file));
+                ExtractXmlElementAttributes(doc, "topic", "name", "url", topicUrlsByName);
+                if (doWrite)
                 {
-                    string relativeFile = Path.GetRelativePath(sourcePath, file);
-                    string sourceTitle = GetHtmlTitle(file);
-                    if (sourceTitle != "")
-                        sourceFileToTitles.Add(relativeFile, sourceTitle);
-                    string sourceHeading = GetHtmlHeading(file);
-                    if (sourceHeading != "")
-                        sourceFileToHeadings.Add(relativeFile, sourceHeading);
-                }
-
-                string[] targetFiles = Directory.GetFiles(targetPath, "*.htm", SearchOption.AllDirectories);
-                foreach (string file in targetFiles)
-                {
-                    if (file.EndsWith("index1.htm"))
-                        continue;
-                    string relativeFile = Path.GetRelativePath(targetPath, file);
-                    string targetTitle = GetHtmlTitle(file);
-                    if (targetTitle != "" && sourceFileToTitles.TryGetValue(relativeFile, out string sourceTitle))
-                        result.Add(sourceTitle, targetTitle);
-                    string targetHeading = GetHtmlHeading(file);
-                    if (targetHeading != "" && sourceFileToHeadings.TryGetValue(relativeFile, out string sourceHeading))
-                        result.TryAdd(sourceHeading, targetHeading);
-                }
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine($"The ExtractTranslations process failed: {e.ToString()}");
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Add menu translations from menu_[target].json file.
-        /// </summary>
-        static void AddMenuTranslations(
-            Dictionary<string, string> translations,
-            string sourceMenuPath,
-            string targetMenuPath
-        )
-        {
-            string sourceMenuJson = File.ReadAllText(sourceMenuPath);
-            string targetMenuJson = File.ReadAllText(targetMenuPath);
-            using (JsonDocument sourceMenuDoc = JsonDocument.Parse(sourceMenuJson))
-            using (JsonDocument targetMenuDoc = JsonDocument.Parse(targetMenuJson))
-            {
-                var sourceMenuItems = new Dictionary<string, string>();
-                foreach (JsonProperty property in sourceMenuDoc.RootElement.EnumerateObject())
-                    ExtractJsonStringsAndKeys(property.Name, property.Value, sourceMenuItems);
-                var targetMenuItems = new Dictionary<string, string>();
-                foreach (JsonProperty property in targetMenuDoc.RootElement.EnumerateObject())
-                    ExtractJsonStringsAndKeys(property.Name, property.Value, targetMenuItems);
-                foreach (var targetMenuItem in targetMenuItems)
-                    if (sourceMenuItems.TryGetValue(targetMenuItem.Key, out string sourceMenuItem))
-                        translations.TryAdd(sourceMenuItem, targetMenuItem.Value);
-            }
-        }
-
-        /// <summary>
-        /// Recursively extract the strings and associated keys from the JSON element.
-        /// </summary>
-        static void ExtractJsonStringsAndKeys(string key, JsonElement element, Dictionary<string, string> items)
-        {
-            if (element.ValueKind == JsonValueKind.String)
-                items.Add(key, element.GetString());
-            else if (element.ValueKind == JsonValueKind.Object)
-                foreach (JsonProperty property in element.EnumerateObject())
-                    ExtractJsonStringsAndKeys(property.Name, property.Value, items);
-        }
-
-        /// <summary>
-        /// Get the heading text from HTML file.
-        /// </summary>
-        static string GetHtmlHeading(string file)
-        {
-            string result = "";
-            var doc = new HtmlDocument();
-            doc.Load(file);
-            HtmlNode heading =
-                doc.DocumentNode.SelectSingleNode("//body/h1") ?? doc.DocumentNode.SelectSingleNode("//body/h2");
-
-            if (heading != null)
-            {
-                result = heading.InnerText ?? "";
-                result = result.Replace("\n", "");
-                result = result.Replace("  ", " ");
-                result = result.Trim();
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Get the title text from HTML file.
-        /// </summary>
-        static string GetHtmlTitle(string file)
-        {
-            string result = "";
-            var doc = new HtmlDocument();
-            doc.Load(file);
-            HtmlNode title = doc.DocumentNode.SelectSingleNode("//title");
-
-            if (title != null)
-            {
-                result = title.InnerText ?? "";
-                result = result.Replace("\n", "");
-                result = result.Replace("  ", " ");
-                result = result.Trim();
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Find all idata???.js files, extract the containing XML, and parse and extract the topics.
-        /// Replace translated topic names in all idata???.js and idata???.new.js files.
-        /// </summary>
-        static void UpdateIdataFiles(
-            string sourcePath,
-            string targetPath,
-            Dictionary<string, string> translations,
-            bool doWrite
-        )
-        {
-            try
-            {
-                string[] files = Directory.GetFiles(sourcePath, "idata???.js");
-                Console.WriteLine($"There are {files.Length} idata source files.");
-                Func<string, string> topicTextInIdata = topicName => $"<topic name=\\\"{topicName}\\\"";
-                Func<string, string> topicTextInIdataNew = topicName => $"\"type\":\"topic\",\"name\":\"{topicName}\"";
-                var topicUrlsByName = new Dictionary<string, string>();
-                foreach (string file in files)
-                {
-                    XDocument doc = XDocument.Parse(GetBufferXmlFromFile(file));
-                    ExtractXmlElementAttributes(doc, "topic", "name", "url", topicUrlsByName);
-                    if (doWrite)
-                    {
-                        string idataFilePath = Path.Combine(targetPath, Path.GetFileName(file));
-                        ReplaceTranslationsInFile(idataFilePath, topicTextInIdata, topicUrlsByName.Keys, translations);
-                        string idataNewFilePath = Path.Combine(
-                            targetPath,
-                            Path.GetFileNameWithoutExtension(file) + ".new" + Path.GetExtension(file)
-                        );
-                        ReplaceTranslationsInFile(
-                            idataNewFilePath,
-                            topicTextInIdataNew,
-                            topicUrlsByName.Keys,
-                            translations
-                        );
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine($"The UpdateIdataFiles process failed: {e.ToString()}");
-            }
-        }
-
-        /// <summary>
-        /// Find all toc???.js files, extract the containing XML, and parse and extract the books.
-        /// Replace translated book names in all toc???.js and toc???.new.js files.
-        /// </summary>
-        static void UpdateTocFiles(
-            string sourcePath,
-            string targetPath,
-            Dictionary<string, string> translations,
-            bool doWrite
-        )
-        {
-            try
-            {
-                string[] files = Directory.GetFiles(sourcePath, "toc???.js");
-                Console.WriteLine($"There are {files.Length} toc source files.");
-                Func<string, string> bookTextInToc = bookName =>
-                    $"<book name=\\\"{SecurityElement.Escape(bookName)}\\\"";
-                Func<string, string> bookTextInTocNew = bookName =>
-                    $"\"name\":\"{HttpUtility.JavaScriptStringEncode(bookName)}\",\"type\":\"book\"";
-                Func<string, string> itemTextInToc = itemName =>
-                    $"<item name=\\\"{SecurityElement.Escape(itemName)}\\\"";
-                Func<string, string> itemTextInTocNew = itemName =>
-                    $"\"name\":\"{HttpUtility.JavaScriptStringEncode(itemName)}\",\"type\":\"item\"";
-                var bookSrcsByName = new Dictionary<string, string>();
-                var itemUrlsByName = new Dictionary<string, string>();
-                foreach (string file in files)
-                {
-                    XDocument doc = XDocument.Parse(GetBufferXmlFromFile(file));
-                    ExtractXmlElementAttributes(doc, "book", "name", "src", bookSrcsByName);
-                    ExtractXmlElementAttributes(doc, "item", "name", "url", itemUrlsByName);
-                    if (doWrite)
-                    {
-                        string tocFilePath = Path.Combine(targetPath, Path.GetFileName(file));
-                        ReplaceTranslationsInFile(tocFilePath, bookTextInToc, bookSrcsByName.Keys, translations);
-                        ReplaceTranslationsInFile(tocFilePath, itemTextInToc, itemUrlsByName.Keys, translations);
-                        string tocNewFilePath = Path.Combine(
-                            targetPath,
-                            Path.GetFileNameWithoutExtension(file) + ".new" + Path.GetExtension(file)
-                        );
-                        ReplaceTranslationsInFile(tocNewFilePath, bookTextInTocNew, bookSrcsByName.Keys, translations);
-                        ReplaceTranslationsInFile(tocNewFilePath, itemTextInTocNew, itemUrlsByName.Keys, translations);
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine($"The UpdateTocFiles process failed: {e.ToString()}");
-            }
-        }
-
-        /// <summary>
-        /// Replace search with Google Programmable Search in target index.htm.
-        /// </summary>
-        static void ReplaceSearch(string targetPath, string searchEngineID, bool doWrite)
-        {
-            string file = Path.Combine(targetPath, "index.htm");
-            var doc = new HtmlDocument();
-            doc.Load(file);
-            HtmlNode head = doc.DocumentNode.SelectSingleNode("//head");
-            HtmlNode searchBarDiv = doc.DocumentNode.SelectSingleNode("//div[@class='searchbar left-pane']");
-            HtmlNode searchInputDiv = doc.DocumentNode.SelectSingleNode("//div[@class='search-input']");
-            HtmlNode searchResultsDiv = doc.DocumentNode.SelectSingleNode("//div[@class='searchresults left-pane']");
-
-            HtmlNode node = HtmlNode.CreateNode(
-                "<style>body.media-desktop div.searchresults.search-sidebar " + "a.gs-title { color: #1155CC; }</style>"
-            );
-            if (head.FirstChild.Name == "style")
-                head.FirstChild.Remove();
-            head.PrependChild(node);
-
-            node = HtmlNode.CreateNode(
-                $"<script async src=\"https://cse.google.com/cse.js?cx={searchEngineID}\"></script>"
-            );
-            if (searchBarDiv.FirstChild.Name == "script")
-                searchBarDiv.FirstChild.Remove();
-            searchBarDiv.PrependChild(node);
-
-            searchInputDiv.RemoveAllChildren();
-            node = HtmlNode.CreateNode("<div style=\"margin: 10px\"><div class=\"gcse-searchbox\"></div></div>");
-            searchInputDiv.AppendChild(node);
-
-            searchResultsDiv.RemoveAllChildren();
-            searchResultsDiv.AppendChild(HtmlNode.CreateNode("<div class=\"gcse-searchresults\"></div>"));
-
-            if (doWrite)
-                doc.Save(file);
-        }
-
-        /// <summary>
-        /// Remove unused buttons (idx/glo/filter/?fts) and extra search field for desktop from target index.htm.
-        /// </summary>
-        static void RemoveUnusedButtonsAndSearch(string targetPath, bool removeSearchButton, bool doWrite)
-        {
-            string file = Path.Combine(targetPath, "index.htm");
-            var doc = new HtmlDocument();
-            doc.Load(file);
-            HtmlNode idxButton = doc.DocumentNode.SelectSingleNode("//a[@class='idx']");
-            HtmlNode gloButton = doc.DocumentNode.SelectSingleNode("//a[@class='glo']");
-            HtmlNode filterButton = doc.DocumentNode.SelectSingleNode("//a[@class='filter']");
-            HtmlNode searchButton = doc.DocumentNode.SelectSingleNode("//a[@class='fts']");
-            HtmlNode searchbarExtraInput = doc.DocumentNode.SelectSingleNode("//div[@class='searchbar-extra']");
-            if (idxButton != null)
-                idxButton.Remove();
-            if (gloButton != null)
-                gloButton.Remove();
-            if (filterButton != null)
-                filterButton.Remove();
-            if (removeSearchButton && searchButton != null)
-                searchButton.Remove();
-            if (searchbarExtraInput != null)
-                searchbarExtraInput.Remove();
-
-            if (doWrite)
-                doc.Save(file);
-        }
-
-        /// <summary>
-        /// Get the containing XML in idata???.js or toc???.js, etc file.
-        /// </summary>
-        static string GetBufferXmlFromFile(string file)
-        {
-            string result = "";
-            try
-            {
-                using (var sr = new StreamReader(file))
-                {
-                    string end = "\";";
-                    string start = "gXMLBuffer =\"";
-                    result = sr.ReadToEnd();
-                    if (result.EndsWith(end))
-                        result = result.Remove(result.Length - end.Length);
-                    if (result.StartsWith(start))
-                        result = result.Substring(start.Length);
-                    result = result.Replace("\\\"", "\"");
-                }
-            }
-            catch (IOException e)
-            {
-                Console.WriteLine("The XML Buffer file could not be read:");
-                Console.WriteLine(e.Message);
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Extract 2 specified attributes on a particular element from XML.
-        /// </summary>
-        static void ExtractXmlElementAttributes(
-            XDocument doc,
-            string elementName,
-            string attr1Name,
-            string att2Name,
-            Dictionary<string, string> attr2ByAttr1
-        )
-        {
-            IEnumerable<XElement> elementList = doc.XPathSelectElements($"//{elementName}");
-            foreach (XElement element in elementList)
-            {
-                string attr1 = element.Attribute(attr1Name).Value;
-                string attr2 = element.Attribute(att2Name).Value;
-                if (attr2ByAttr1.TryGetValue(attr1, out string savedAttr2))
-                {
-                    if (savedAttr2 == attr2)
-                        return;
-                    throw new Exception(
-                        $"Same {elementName} '{attr1Name}' ({attr1}) but different '{att2Name}' "
-                            + $"({savedAttr2} {attr2})"
+                    string idataFilePath = Path.Combine(targetPath, Path.GetFileName(file));
+                    ReplaceTranslationsInFile(idataFilePath, topicTextInIdata, topicUrlsByName.Keys, translations);
+                    string idataNewFilePath = Path.Combine(
+                        targetPath,
+                        Path.GetFileNameWithoutExtension(file) + ".new" + Path.GetExtension(file)
+                    );
+                    ReplaceTranslationsInFile(
+                        idataNewFilePath,
+                        topicTextInIdataNew,
+                        topicUrlsByName.Keys,
+                        translations
                     );
                 }
-                attr2ByAttr1.Add(attr1, attr2);
             }
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"The UpdateIdataFiles process failed: {e}");
+        }
+    }
+
+    /// <summary>
+    /// Find all toc???.js files, extract the containing XML, and parse and extract the books.
+    /// Replace translated book names in all toc???.js and toc???.new.js files.
+    /// </summary>
+    static void UpdateTocFiles(
+        string sourcePath,
+        string targetPath,
+        Dictionary<string, string> translations,
+        bool doWrite
+    )
+    {
+        try
+        {
+            string[] files = Directory.GetFiles(sourcePath, "toc???.js");
+            Console.WriteLine($"There are {files.Length} toc source files.");
+            static string bookTextInToc(string bookName) => $"<book name=\\\"{SecurityElement.Escape(bookName)}\\\"";
+            static string bookTextInTocNew(string bookName) =>
+                $"\"name\":\"{HttpUtility.JavaScriptStringEncode(bookName)}\",\"type\":\"book\"";
+            static string itemTextInToc(string itemName) => $"<item name=\\\"{SecurityElement.Escape(itemName)}\\\"";
+            static string itemTextInTocNew(string itemName) =>
+                $"\"name\":\"{HttpUtility.JavaScriptStringEncode(itemName)}\",\"type\":\"item\"";
+            var bookSrcsByName = new Dictionary<string, string>();
+            var itemUrlsByName = new Dictionary<string, string>();
+            foreach (string file in files)
+            {
+                XDocument doc = XDocument.Parse(GetBufferXmlFromFile(file));
+                ExtractXmlElementAttributes(doc, "book", "name", "src", bookSrcsByName);
+                ExtractXmlElementAttributes(doc, "item", "name", "url", itemUrlsByName);
+                if (doWrite)
+                {
+                    string tocFilePath = Path.Combine(targetPath, Path.GetFileName(file));
+                    ReplaceTranslationsInFile(tocFilePath, bookTextInToc, bookSrcsByName.Keys, translations);
+                    ReplaceTranslationsInFile(tocFilePath, itemTextInToc, itemUrlsByName.Keys, translations);
+                    string tocNewFilePath = Path.Combine(
+                        targetPath,
+                        Path.GetFileNameWithoutExtension(file) + ".new" + Path.GetExtension(file)
+                    );
+                    ReplaceTranslationsInFile(tocNewFilePath, bookTextInTocNew, bookSrcsByName.Keys, translations);
+                    ReplaceTranslationsInFile(tocNewFilePath, itemTextInTocNew, itemUrlsByName.Keys, translations);
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"The UpdateTocFiles process failed: {e}");
+        }
+    }
+
+    /// <summary>
+    /// Replace search with Google Programmable Search in target index.htm.
+    /// </summary>
+    static void ReplaceSearch(string targetPath, string searchEngineID, bool doWrite)
+    {
+        string file = Path.Combine(targetPath, "index.htm");
+        var doc = new HtmlDocument();
+        doc.Load(file);
+        HtmlNode head = doc.DocumentNode.SelectSingleNode("//head");
+        HtmlNode searchBarDiv = doc.DocumentNode.SelectSingleNode("//div[@class='searchbar left-pane']");
+        HtmlNode searchInputDiv = doc.DocumentNode.SelectSingleNode("//div[@class='search-input']");
+        HtmlNode searchResultsDiv = doc.DocumentNode.SelectSingleNode("//div[@class='searchresults left-pane']");
+
+        HtmlNode node = HtmlNode.CreateNode(
+            "<style>body.media-desktop div.searchresults.search-sidebar " + "a.gs-title { color: #1155CC; }</style>"
+        );
+        if (head.FirstChild.Name == "style")
+            head.FirstChild.Remove();
+        head.PrependChild(node);
+
+        node = HtmlNode.CreateNode(
+            $"<script async src=\"https://cse.google.com/cse.js?cx={searchEngineID}\"></script>"
+        );
+        if (searchBarDiv.FirstChild.Name == "script")
+            searchBarDiv.FirstChild.Remove();
+        searchBarDiv.PrependChild(node);
+
+        searchInputDiv.RemoveAllChildren();
+        node = HtmlNode.CreateNode("<div style=\"margin: 10px\"><div class=\"gcse-searchbox\"></div></div>");
+        searchInputDiv.AppendChild(node);
+
+        searchResultsDiv.RemoveAllChildren();
+        searchResultsDiv.AppendChild(HtmlNode.CreateNode("<div class=\"gcse-searchresults\"></div>"));
+
+        if (doWrite)
+            doc.Save(file);
+    }
+
+    /// <summary>
+    /// Remove unused buttons (idx/glo/filter/?fts) and extra search field for desktop from target index.htm.
+    /// </summary>
+    static void RemoveUnusedButtonsAndSearch(string targetPath, bool removeSearchButton, bool doWrite)
+    {
+        string file = Path.Combine(targetPath, "index.htm");
+        var doc = new HtmlDocument();
+        doc.Load(file);
+        HtmlNode idxButton = doc.DocumentNode.SelectSingleNode("//a[@class='idx']");
+        HtmlNode gloButton = doc.DocumentNode.SelectSingleNode("//a[@class='glo']");
+        HtmlNode filterButton = doc.DocumentNode.SelectSingleNode("//a[@class='filter']");
+        HtmlNode searchButton = doc.DocumentNode.SelectSingleNode("//a[@class='fts']");
+        HtmlNode searchbarExtraInput = doc.DocumentNode.SelectSingleNode("//div[@class='searchbar-extra']");
+        idxButton?.Remove();
+        gloButton?.Remove();
+        filterButton?.Remove();
+        if (removeSearchButton && searchButton != null)
+            searchButton.Remove();
+        searchbarExtraInput?.Remove();
+
+        if (doWrite)
+            doc.Save(file);
+    }
+
+    /// <summary>
+    /// Get the containing XML in idata???.js or toc???.js, etc file.
+    /// </summary>
+    static string GetBufferXmlFromFile(string file)
+    {
+        string result = "";
+        try
+        {
+            using var sr = new StreamReader(file);
+            string end = "\";";
+            string start = "gXMLBuffer =\"";
+            result = sr.ReadToEnd();
+            if (result.EndsWith(end))
+                result = result.Remove(result.Length - end.Length);
+            if (result.StartsWith(start))
+                result = result[start.Length..];
+            result = result.Replace("\\\"", "\"");
+        }
+        catch (IOException e)
+        {
+            Console.WriteLine("The XML Buffer file could not be read:");
+            Console.WriteLine(e.Message);
         }
 
-        /// <summary>
-        /// Replace translatable text in the specified file using the expression function.
-        /// </summary>
-        static void ReplaceTranslationsInFile(
-            string filePath,
-            Func<string, string> textExpression,
-            Dictionary<string, string>.KeyCollection sources,
-            Dictionary<string, string> translations
-        )
+        return result;
+    }
+
+    /// <summary>
+    /// Extract 2 specified attributes on a particular element from XML.
+    /// </summary>
+    static void ExtractXmlElementAttributes(
+        XDocument doc,
+        string elementName,
+        string attr1Name,
+        string att2Name,
+        Dictionary<string, string> attr2ByAttr1
+    )
+    {
+        IEnumerable<XElement> elementList = doc.XPathSelectElements($"//{elementName}");
+        foreach (XElement element in elementList)
         {
-            string text = File.ReadAllText(filePath);
-            foreach (string source in sources)
+            string attr1 = element.Attribute(attr1Name).Value;
+            string attr2 = element.Attribute(att2Name).Value;
+            if (attr2ByAttr1.TryGetValue(attr1, out string savedAttr2))
             {
-                if (translations.TryGetValue(source, out string translation))
-                    text = text.Replace(textExpression(source), textExpression(translation));
+                if (savedAttr2 == attr2)
+                    return;
+                throw new Exception(
+                    $"Same {elementName} '{attr1Name}' ({attr1}) but different '{att2Name}' "
+                        + $"({savedAttr2} {attr2})"
+                );
             }
-            File.WriteAllText(filePath, text);
+            attr2ByAttr1.Add(attr1, attr2);
         }
+    }
+
+    /// <summary>
+    /// Replace translatable text in the specified file using the expression function.
+    /// </summary>
+    static void ReplaceTranslationsInFile(
+        string filePath,
+        Func<string, string> textExpression,
+        Dictionary<string, string>.KeyCollection sources,
+        Dictionary<string, string> translations
+    )
+    {
+        string text = File.ReadAllText(filePath);
+        foreach (string source in sources)
+        {
+            if (translations.TryGetValue(source, out string translation))
+                text = text.Replace(textExpression(source), textExpression(translation));
+        }
+        File.WriteAllText(filePath, text);
     }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/.husky/pre-commit
+++ b/src/SIL.XForge.Scripture/ClientApp/.husky/pre-commit
@@ -4,4 +4,4 @@
 # Run npx in ClientApp.
 cd src/SIL.XForge.Scripture/ClientApp
 # But specify a working directory to lint-staged to work from the root of the repository.
-npx --no-install lint-staged --cwd ../../..
+npx --no-install lint-staged --relative --cwd ../../..

--- a/src/SIL.XForge.Scripture/Controllers/LanguageController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/LanguageController.cs
@@ -3,29 +3,28 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Mvc;
 
-namespace SIL.XForge.Scripture.Controllers
+namespace SIL.XForge.Scripture.Controllers;
+
+[Route("language-api")]
+[ApiController]
+public class LanguageController : ControllerBase
 {
-    [Route("language-api")]
-    [ApiController]
-    public class LanguageController : ControllerBase
+    [HttpPost]
+    public IActionResult SetLanguage([FromForm] string culture, [FromForm] string returnUrl)
     {
-        [HttpPost]
-        public IActionResult SetLanguage([FromForm] string culture, [FromForm] string returnUrl)
-        {
-            if (string.IsNullOrEmpty(culture))
-                throw new ArgumentException("culture cannot be empty", culture);
-            if (string.IsNullOrEmpty(returnUrl))
-                throw new ArgumentException("return url must be specified", returnUrl);
+        if (string.IsNullOrEmpty(culture))
+            throw new ArgumentException("culture cannot be empty", culture);
+        if (string.IsNullOrEmpty(returnUrl))
+            throw new ArgumentException("return url must be specified", returnUrl);
 
-            var cookieName = CookieRequestCultureProvider.DefaultCookieName;
-            var cookieValue = CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture));
-            Response.Cookies.Append(
-                cookieName,
-                cookieValue,
-                new CookieOptions { Expires = DateTimeOffset.UtcNow.AddYears(1) }
-            );
+        var cookieName = CookieRequestCultureProvider.DefaultCookieName;
+        var cookieValue = CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture));
+        Response.Cookies.Append(
+            cookieName,
+            cookieValue,
+            new CookieOptions { Expires = DateTimeOffset.UtcNow.AddYears(1) }
+        );
 
-            return LocalRedirect(returnUrl);
-        }
+        return LocalRedirect(returnUrl);
     }
 }

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -9,272 +9,268 @@ using SIL.XForge.Scripture.Models;
 using SIL.XForge.Scripture.Services;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Controllers
+namespace SIL.XForge.Scripture.Controllers;
+
+[Route(MachineApi.Namespace)]
+[ApiController]
+[Authorize]
+public class MachineApiController : ControllerBase
 {
-    [Route(MachineApi.Namespace)]
-    [ApiController]
-    [Authorize]
-    public class MachineApiController : ControllerBase
+    private const string MachineApiUnavailable = "Machine API is unavailable";
+    private readonly IExceptionHandler _exceptionHandler;
+    private readonly IMachineApiService _machineApiService;
+    private readonly IUserAccessor _userAccessor;
+
+    public MachineApiController(
+        IExceptionHandler exceptionHandler,
+        IMachineApiService machineApiService,
+        IUserAccessor userAccessor
+    )
     {
-        private const string MachineApiUnavailable = "Machine API is unavailable";
-        private readonly IExceptionHandler _exceptionHandler;
-        private readonly IMachineApiService _machineApiService;
-        private readonly IUserAccessor _userAccessor;
+        _machineApiService = machineApiService;
+        _userAccessor = userAccessor;
+        _exceptionHandler = exceptionHandler;
+        _exceptionHandler.RecordUserIdForException(_userAccessor.UserId);
+    }
 
-        public MachineApiController(
-            IExceptionHandler exceptionHandler,
-            IMachineApiService machineApiService,
-            IUserAccessor userAccessor
-        )
+    [HttpGet(MachineApi.GetBuild)]
+    public async Task<ActionResult<BuildDto?>> GetBuildAsync(
+        string sfProjectId,
+        string? buildId,
+        [FromQuery] int? minRevision,
+        CancellationToken cancellationToken
+    )
+    {
+        try
         {
-            _machineApiService = machineApiService;
-            _userAccessor = userAccessor;
-            _exceptionHandler = exceptionHandler;
-            _exceptionHandler.RecordUserIdForException(_userAccessor.UserId);
-        }
-
-        [HttpGet(MachineApi.GetBuild)]
-        public async Task<ActionResult<BuildDto?>> GetBuildAsync(
-            string sfProjectId,
-            string? buildId,
-            [FromQuery] int? minRevision,
-            CancellationToken cancellationToken
-        )
-        {
-            try
+            BuildDto? build;
+            if (string.IsNullOrWhiteSpace(buildId))
             {
-                BuildDto? build;
-                if (string.IsNullOrWhiteSpace(buildId))
-                {
-                    build = await _machineApiService.GetCurrentBuildAsync(
-                        _userAccessor.UserId,
-                        sfProjectId,
-                        minRevision,
-                        cancellationToken
-                    );
-                }
-                else
-                {
-                    build = await _machineApiService.GetBuildAsync(
-                        _userAccessor.UserId,
-                        sfProjectId,
-                        buildId,
-                        minRevision,
-                        cancellationToken
-                    );
-                }
-
-                // A null means no build is running
-                if (build is null)
-                {
-                    return NoContent();
-                }
-
-                return Ok(build);
-            }
-            catch (BrokenCircuitException e)
-            {
-                _exceptionHandler.ReportException(e);
-                return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
-            }
-            catch (DataNotFoundException)
-            {
-                return NotFound();
-            }
-            catch (ForbiddenException)
-            {
-                return Forbid();
-            }
-        }
-
-        [HttpGet(MachineApi.GetEngine)]
-        public async Task<ActionResult<EngineDto>> GetEngineAsync(
-            string sfProjectId,
-            CancellationToken cancellationToken
-        )
-        {
-            try
-            {
-                EngineDto engine = await _machineApiService.GetEngineAsync(
+                build = await _machineApiService.GetCurrentBuildAsync(
                     _userAccessor.UserId,
                     sfProjectId,
+                    minRevision,
                     cancellationToken
                 );
-                return Ok(engine);
             }
-            catch (BrokenCircuitException e)
+            else
             {
-                _exceptionHandler.ReportException(e);
-                return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
-            }
-            catch (DataNotFoundException)
-            {
-                return NotFound();
-            }
-            catch (ForbiddenException)
-            {
-                return Forbid();
-            }
-        }
-
-        [HttpPost(MachineApi.GetWordGraph)]
-        public async Task<ActionResult<WordGraphDto>> GetWordGraphAsync(
-            string sfProjectId,
-            [FromBody] string[] segment,
-            CancellationToken cancellationToken
-        )
-        {
-            try
-            {
-                WordGraphDto wordGraph = await _machineApiService.GetWordGraphAsync(
+                build = await _machineApiService.GetBuildAsync(
                     _userAccessor.UserId,
                     sfProjectId,
-                    segment,
+                    buildId,
+                    minRevision,
                     cancellationToken
                 );
-                return Ok(wordGraph);
             }
-            catch (BrokenCircuitException e)
-            {
-                _exceptionHandler.ReportException(e);
-                return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
-            }
-            catch (DataNotFoundException)
-            {
-                return NotFound();
-            }
-            catch (ForbiddenException)
-            {
-                return Forbid();
-            }
-        }
 
-        [HttpPost(MachineApi.StartBuild)]
-        public async Task<ActionResult<BuildDto>> StartBuildAsync(
-            [FromBody] string sfProjectId,
-            CancellationToken cancellationToken
-        )
-        {
-            try
+            // A null means no build is running
+            if (build is null)
             {
-                BuildDto build = await _machineApiService.StartBuildAsync(
-                    _userAccessor.UserId,
-                    sfProjectId,
-                    cancellationToken
-                );
-                return Ok(build);
+                return NoContent();
             }
-            catch (BrokenCircuitException e)
-            {
-                _exceptionHandler.ReportException(e);
-                return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
-            }
-            catch (DataNotFoundException)
-            {
-                return NotFound();
-            }
-            catch (ForbiddenException)
-            {
-                return Forbid();
-            }
-        }
 
-        [HttpPost(MachineApi.TrainSegment)]
-        public async Task<ActionResult> TrainSegmentAsync(
-            string sfProjectId,
-            [FromBody] SegmentPairDto segmentPair,
-            CancellationToken cancellationToken
-        )
-        {
-            try
-            {
-                await _machineApiService.TrainSegmentAsync(
-                    _userAccessor.UserId,
-                    sfProjectId,
-                    segmentPair,
-                    cancellationToken
-                );
-                return Ok();
-            }
-            catch (BrokenCircuitException e)
-            {
-                _exceptionHandler.ReportException(e);
-                return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
-            }
-            catch (DataNotFoundException)
-            {
-                return NotFound();
-            }
-            catch (ForbiddenException)
-            {
-                return Forbid();
-            }
+            return Ok(build);
         }
-
-        [HttpPost(MachineApi.Translate)]
-        public async Task<ActionResult<TranslationResultDto>> TranslateAsync(
-            string sfProjectId,
-            [FromBody] string[] segment,
-            CancellationToken cancellationToken
-        )
+        catch (BrokenCircuitException e)
         {
-            try
-            {
-                TranslationResultDto translationResult = await _machineApiService.TranslateAsync(
-                    _userAccessor.UserId,
-                    sfProjectId,
-                    segment,
-                    cancellationToken
-                );
-                return Ok(translationResult);
-            }
-            catch (BrokenCircuitException e)
-            {
-                _exceptionHandler.ReportException(e);
-                return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
-            }
-            catch (DataNotFoundException)
-            {
-                return NotFound();
-            }
-            catch (ForbiddenException)
-            {
-                return Forbid();
-            }
+            _exceptionHandler.ReportException(e);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
         }
-
-        [HttpPost(MachineApi.TranslateN)]
-        public async Task<ActionResult<TranslationResultDto[]>> TranslateNAsync(
-            string sfProjectId,
-            int n,
-            [FromBody] string[] segment,
-            CancellationToken cancellationToken
-        )
+        catch (DataNotFoundException)
         {
-            try
-            {
-                TranslationResultDto[] translationResults = await _machineApiService.TranslateNAsync(
-                    _userAccessor.UserId,
-                    sfProjectId,
-                    n,
-                    segment,
-                    cancellationToken
-                );
-                return Ok(translationResults);
-            }
-            catch (BrokenCircuitException e)
-            {
-                _exceptionHandler.ReportException(e);
-                return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
-            }
-            catch (DataNotFoundException)
-            {
-                return NotFound();
-            }
-            catch (ForbiddenException)
-            {
-                return Forbid();
-            }
+            return NotFound();
+        }
+        catch (ForbiddenException)
+        {
+            return Forbid();
+        }
+    }
+
+    [HttpGet(MachineApi.GetEngine)]
+    public async Task<ActionResult<EngineDto>> GetEngineAsync(string sfProjectId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            EngineDto engine = await _machineApiService.GetEngineAsync(
+                _userAccessor.UserId,
+                sfProjectId,
+                cancellationToken
+            );
+            return Ok(engine);
+        }
+        catch (BrokenCircuitException e)
+        {
+            _exceptionHandler.ReportException(e);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
+        }
+        catch (DataNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (ForbiddenException)
+        {
+            return Forbid();
+        }
+    }
+
+    [HttpPost(MachineApi.GetWordGraph)]
+    public async Task<ActionResult<WordGraphDto>> GetWordGraphAsync(
+        string sfProjectId,
+        [FromBody] string[] segment,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            WordGraphDto wordGraph = await _machineApiService.GetWordGraphAsync(
+                _userAccessor.UserId,
+                sfProjectId,
+                segment,
+                cancellationToken
+            );
+            return Ok(wordGraph);
+        }
+        catch (BrokenCircuitException e)
+        {
+            _exceptionHandler.ReportException(e);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
+        }
+        catch (DataNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (ForbiddenException)
+        {
+            return Forbid();
+        }
+    }
+
+    [HttpPost(MachineApi.StartBuild)]
+    public async Task<ActionResult<BuildDto>> StartBuildAsync(
+        [FromBody] string sfProjectId,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            BuildDto build = await _machineApiService.StartBuildAsync(
+                _userAccessor.UserId,
+                sfProjectId,
+                cancellationToken
+            );
+            return Ok(build);
+        }
+        catch (BrokenCircuitException e)
+        {
+            _exceptionHandler.ReportException(e);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
+        }
+        catch (DataNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (ForbiddenException)
+        {
+            return Forbid();
+        }
+    }
+
+    [HttpPost(MachineApi.TrainSegment)]
+    public async Task<ActionResult> TrainSegmentAsync(
+        string sfProjectId,
+        [FromBody] SegmentPairDto segmentPair,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            await _machineApiService.TrainSegmentAsync(
+                _userAccessor.UserId,
+                sfProjectId,
+                segmentPair,
+                cancellationToken
+            );
+            return Ok();
+        }
+        catch (BrokenCircuitException e)
+        {
+            _exceptionHandler.ReportException(e);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
+        }
+        catch (DataNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (ForbiddenException)
+        {
+            return Forbid();
+        }
+    }
+
+    [HttpPost(MachineApi.Translate)]
+    public async Task<ActionResult<TranslationResultDto>> TranslateAsync(
+        string sfProjectId,
+        [FromBody] string[] segment,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            TranslationResultDto translationResult = await _machineApiService.TranslateAsync(
+                _userAccessor.UserId,
+                sfProjectId,
+                segment,
+                cancellationToken
+            );
+            return Ok(translationResult);
+        }
+        catch (BrokenCircuitException e)
+        {
+            _exceptionHandler.ReportException(e);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
+        }
+        catch (DataNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (ForbiddenException)
+        {
+            return Forbid();
+        }
+    }
+
+    [HttpPost(MachineApi.TranslateN)]
+    public async Task<ActionResult<TranslationResultDto[]>> TranslateNAsync(
+        string sfProjectId,
+        int n,
+        [FromBody] string[] segment,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            TranslationResultDto[] translationResults = await _machineApiService.TranslateNAsync(
+                _userAccessor.UserId,
+                sfProjectId,
+                n,
+                segment,
+                cancellationToken
+            );
+            return Ok(translationResults);
+        }
+        catch (BrokenCircuitException e)
+        {
+            _exceptionHandler.ReportException(e);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
+        }
+        catch (DataNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (ForbiddenException)
+        {
+            return Forbid();
         }
     }
 }

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -7,599 +7,582 @@ using SIL.XForge.Scripture.Models;
 using SIL.XForge.Scripture.Services;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Controllers
+namespace SIL.XForge.Scripture.Controllers;
+
+/// <summary>
+/// This controller contains project-related JSON-RPC commands.
+///
+/// Many of the commands in this class could be moved to an abstract base class defined in <see cref="SIL.XForge"/>
+/// assembly. Unfortunately, the <see cref="EdjCase.JsonRpc.Router"/> library does not support methods defined in
+/// base classes.
+/// </summary>
+public class SFProjectsRpcController : RpcControllerBase
 {
-    /// <summary>
-    /// This controller contains project-related JSON-RPC commands.
-    ///
-    /// Many of the commands in this class could be moved to an abstract base class defined in <see cref="SIL.XForge"/>
-    /// assembly. Unfortunately, the <see cref="EdjCase.JsonRpc.Router"/> library does not support methods defined in
-    /// base classes.
-    /// </summary>
-    public class SFProjectsRpcController : RpcControllerBase
+    internal const string AlreadyProjectMemberResponse = "alreadyProjectMember";
+
+    private readonly IExceptionHandler _exceptionHandler;
+    private readonly ISFProjectService _projectService;
+
+    public SFProjectsRpcController(
+        IUserAccessor userAccessor,
+        ISFProjectService projectService,
+        IExceptionHandler exceptionHandler
+    )
+        : base(userAccessor, exceptionHandler)
     {
-        internal const string AlreadyProjectMemberResponse = "alreadyProjectMember";
+        _exceptionHandler = exceptionHandler;
+        _projectService = projectService;
+    }
 
-        private readonly IExceptionHandler _exceptionHandler;
-        private readonly ISFProjectService _projectService;
-
-        public SFProjectsRpcController(
-            IUserAccessor userAccessor,
-            ISFProjectService projectService,
-            IExceptionHandler exceptionHandler
-        ) : base(userAccessor, exceptionHandler)
+    public async Task<IRpcMethodResult> Create(SFProjectCreateSettings settings)
+    {
+        try
         {
-            _exceptionHandler = exceptionHandler;
-            _projectService = projectService;
+            string projectId = await _projectService.CreateProjectAsync(UserId, settings);
+            return Ok(projectId);
         }
-
-        public async Task<IRpcMethodResult> Create(SFProjectCreateSettings settings)
+        catch (ForbiddenException)
         {
-            try
-            {
-                string projectId = await _projectService.CreateProjectAsync(UserId, settings);
-                return Ok(projectId);
-            }
-            catch (ForbiddenException)
-            {
-                return ForbiddenError();
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (InvalidOperationException e)
-            {
-                return InvalidParamsError(e.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string>
-                    {
-                        { "method", "Create" },
-                        { "ParatextId", settings?.ParatextId },
-                        { "SourceParatextId", settings?.SourceParatextId },
-                        { "CheckingEnabled", settings?.CheckingEnabled.ToString() },
-                        { "TranslationSuggestionsEnabled", settings?.TranslationSuggestionsEnabled.ToString() },
-                    }
-                );
-                throw;
-            }
+            return ForbiddenError();
         }
-
-        public async Task<IRpcMethodResult> Delete(string projectId)
+        catch (DataNotFoundException dnfe)
         {
-            try
-            {
-                await _projectService.DeleteProjectAsync(UserId, projectId);
+            return NotFoundError(dnfe.Message);
+        }
+        catch (InvalidOperationException e)
+        {
+            return InvalidParamsError(e.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string>
+                {
+                    { "method", "Create" },
+                    { "ParatextId", settings?.ParatextId },
+                    { "SourceParatextId", settings?.SourceParatextId },
+                    { "CheckingEnabled", settings?.CheckingEnabled.ToString() },
+                    { "TranslationSuggestionsEnabled", settings?.TranslationSuggestionsEnabled.ToString() },
+                }
+            );
+            throw;
+        }
+    }
+
+    public async Task<IRpcMethodResult> Delete(string projectId)
+    {
+        try
+        {
+            await _projectService.DeleteProjectAsync(UserId, projectId);
+            return Ok();
+        }
+        catch (ForbiddenException)
+        {
+            return ForbiddenError();
+        }
+        catch (DataNotFoundException dnfe)
+        {
+            return NotFoundError(dnfe.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string> { { "method", "Delete" }, { "projectId", projectId }, }
+            );
+            throw;
+        }
+    }
+
+    public async Task<IRpcMethodResult> UpdateSettings(string projectId, SFProjectSettings settings)
+    {
+        try
+        {
+            await _projectService.UpdateSettingsAsync(UserId, projectId, settings);
+            return Ok();
+        }
+        catch (ForbiddenException)
+        {
+            return ForbiddenError();
+        }
+        catch (DataNotFoundException dnfe)
+        {
+            return NotFoundError(dnfe.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string>
+                {
+                    { "method", "UpdateSettings" },
+                    { "projectId", projectId },
+                    { "CheckingShareLevel", settings?.CheckingShareLevel },
+                    { "CheckingAnswerExport", settings?.CheckingAnswerExport },
+                    { "SourceParatextId", settings?.SourceParatextId },
+                    { "TranslateShareLevel", settings?.TranslateShareLevel },
+                    { "CheckingEnabled", settings?.CheckingEnabled?.ToString() },
+                    { "CheckingShareEnabled", settings?.CheckingShareEnabled?.ToString() },
+                    { "TranslateShareEnabled", settings?.TranslateShareEnabled?.ToString() },
+                    { "TranslationSuggestionsEnabled", settings?.TranslationSuggestionsEnabled?.ToString() },
+                    { "UsersSeeEachOthersResponses", settings?.UsersSeeEachOthersResponses?.ToString() },
+                }
+            );
+            throw;
+        }
+    }
+
+    public async Task<IRpcMethodResult> AddUser(string projectId, string projectRole)
+    {
+        try
+        {
+            await _projectService.AddUserAsync(UserId, projectId, projectRole);
+            return Ok();
+        }
+        catch (ForbiddenException)
+        {
+            return ForbiddenError();
+        }
+        catch (DataNotFoundException dnfe)
+        {
+            return NotFoundError(dnfe.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string>
+                {
+                    { "method", "AddUser" },
+                    { "projectId", projectId },
+                    { "projectRole", projectRole },
+                }
+            );
+            throw;
+        }
+    }
+
+    public async Task<IRpcMethodResult> AddUser(string projectId) => await this.AddUser(projectId, null);
+
+    public async Task<IRpcMethodResult> RemoveUser(string projectId, string projectUserId)
+    {
+        try
+        {
+            await _projectService.RemoveUserAsync(UserId, projectId, projectUserId);
+            return Ok();
+        }
+        catch (ForbiddenException)
+        {
+            return ForbiddenError();
+        }
+        catch (DataNotFoundException dnfe)
+        {
+            return NotFoundError(dnfe.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string>
+                {
+                    { "method", "RemoveUser" },
+                    { "projectId", projectId },
+                    { "projectUserId", projectUserId },
+                }
+            );
+            throw;
+        }
+    }
+
+    public async Task<IRpcMethodResult> GetProjectRole(string projectId)
+    {
+        try
+        {
+            string role = await _projectService.GetProjectRoleAsync(UserId, projectId);
+            return Ok(role);
+        }
+        catch (DataNotFoundException dnfe)
+        {
+            return NotFoundError(dnfe.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string> { { "method", "GetProjectRole" }, { "projectId", projectId }, }
+            );
+            throw;
+        }
+    }
+
+    public async Task<IRpcMethodResult> UpdateRole(string projectId, string projectRole)
+    {
+        try
+        {
+            await _projectService.UpdateRoleAsync(UserId, SystemRole, projectId, projectRole);
+            return Ok();
+        }
+        catch (ForbiddenException)
+        {
+            return ForbiddenError();
+        }
+        catch (DataNotFoundException dnfe)
+        {
+            return NotFoundError(dnfe.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string>
+                {
+                    { "method", "UpdateRole" },
+                    { "projectId", projectId },
+                    { "projectRole", projectRole },
+                }
+            );
+            throw;
+        }
+    }
+
+    public async Task<IRpcMethodResult> Invite(string projectId, string email, string locale, string role)
+    {
+        try
+        {
+            if (await _projectService.InviteAsync(UserId, projectId, email, locale, role))
                 return Ok();
-            }
-            catch (ForbiddenException)
-            {
-                return ForbiddenError();
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string> { { "method", "Delete" }, { "projectId", projectId }, }
-                );
-                throw;
-            }
+            return Ok(AlreadyProjectMemberResponse);
         }
-
-        public async Task<IRpcMethodResult> UpdateSettings(string projectId, SFProjectSettings settings)
+        catch (ForbiddenException)
         {
-            try
-            {
-                await _projectService.UpdateSettingsAsync(UserId, projectId, settings);
-                return Ok();
-            }
-            catch (ForbiddenException)
-            {
-                return ForbiddenError();
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string>
-                    {
-                        { "method", "UpdateSettings" },
-                        { "projectId", projectId },
-                        { "CheckingShareLevel", settings?.CheckingShareLevel },
-                        { "CheckingAnswerExport", settings?.CheckingAnswerExport },
-                        { "SourceParatextId", settings?.SourceParatextId },
-                        { "TranslateShareLevel", settings?.TranslateShareLevel },
-                        { "CheckingEnabled", settings?.CheckingEnabled?.ToString() },
-                        { "CheckingShareEnabled", settings?.CheckingShareEnabled?.ToString() },
-                        { "TranslateShareEnabled", settings?.TranslateShareEnabled?.ToString() },
-                        { "TranslationSuggestionsEnabled", settings?.TranslationSuggestionsEnabled?.ToString() },
-                        { "UsersSeeEachOthersResponses", settings?.UsersSeeEachOthersResponses?.ToString() },
-                    }
-                );
-                throw;
-            }
+            return ForbiddenError();
         }
-
-        public async Task<IRpcMethodResult> AddUser(string projectId, string projectRole)
+        catch (DataNotFoundException dnfe)
         {
-            try
-            {
-                await _projectService.AddUserAsync(UserId, projectId, projectRole);
-                return Ok();
-            }
-            catch (ForbiddenException)
-            {
-                return ForbiddenError();
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string>
-                    {
-                        { "method", "AddUser" },
-                        { "projectId", projectId },
-                        { "projectRole", projectRole },
-                    }
-                );
-                throw;
-            }
+            return NotFoundError(dnfe.Message);
         }
-
-        public async Task<IRpcMethodResult> AddUser(string projectId)
+        catch (Exception)
         {
-            return await this.AddUser(projectId, null);
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string>
+                {
+                    { "method", "Invite" },
+                    { "projectId", projectId },
+                    // Exclude email as it is PII
+                    { "locale", locale },
+                    { "role", role },
+                }
+            );
+            throw;
         }
+    }
 
-        public async Task<IRpcMethodResult> RemoveUser(string projectId, string projectUserId)
+    public async Task<IRpcMethodResult> UninviteUser(string projectId, string emailToUninvite)
+    {
+        try
         {
-            try
-            {
-                await _projectService.RemoveUserAsync(UserId, projectId, projectUserId);
-                return Ok();
-            }
-            catch (ForbiddenException)
-            {
-                return ForbiddenError();
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string>
-                    {
-                        { "method", "RemoveUser" },
-                        { "projectId", projectId },
-                        { "projectUserId", projectUserId },
-                    }
-                );
-                throw;
-            }
+            await _projectService.UninviteUserAsync(UserId, projectId, emailToUninvite);
+            return Ok();
         }
-
-        public async Task<IRpcMethodResult> GetProjectRole(string projectId)
+        catch (ForbiddenException)
         {
-            try
-            {
-                string role = await _projectService.GetProjectRoleAsync(UserId, projectId);
-                return Ok(role);
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string> { { "method", "GetProjectRole" }, { "projectId", projectId }, }
-                );
-                throw;
-            }
+            return ForbiddenError();
         }
-
-        public async Task<IRpcMethodResult> UpdateRole(string projectId, string projectRole)
+        catch (DataNotFoundException dnfe)
         {
-            try
-            {
-                await _projectService.UpdateRoleAsync(UserId, SystemRole, projectId, projectRole);
-                return Ok();
-            }
-            catch (ForbiddenException)
-            {
-                return ForbiddenError();
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string>
-                    {
-                        { "method", "UpdateRole" },
-                        { "projectId", projectId },
-                        { "projectRole", projectRole },
-                    }
-                );
-                throw;
-            }
+            return NotFoundError(dnfe.Message);
         }
-
-        public async Task<IRpcMethodResult> Invite(string projectId, string email, string locale, string role)
+        catch (Exception)
         {
-            try
-            {
-                if (await _projectService.InviteAsync(UserId, projectId, email, locale, role))
-                    return Ok();
-                return Ok(AlreadyProjectMemberResponse);
-            }
-            catch (ForbiddenException)
-            {
-                return ForbiddenError();
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string>
-                    {
-                        { "method", "Invite" },
-                        { "projectId", projectId },
-                        // Exclude email as it is PII
-                        { "locale", locale },
-                        { "role", role },
-                    }
-                );
-                throw;
-            }
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string> { { "method", "UninviteUser" }, { "projectId", projectId }, }
+            );
+            throw;
         }
+    }
 
-        public async Task<IRpcMethodResult> UninviteUser(string projectId, string emailToUninvite)
+    public async Task<IRpcMethodResult> IsAlreadyInvited(string projectId, string email)
+    {
+        try
         {
-            try
-            {
-                await _projectService.UninviteUserAsync(UserId, projectId, emailToUninvite);
-                return Ok();
-            }
-            catch (ForbiddenException)
-            {
-                return ForbiddenError();
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string> { { "method", "UninviteUser" }, { "projectId", projectId }, }
-                );
-                throw;
-            }
+            return Ok(await _projectService.IsAlreadyInvitedAsync(UserId, projectId, email));
         }
-
-        public async Task<IRpcMethodResult> IsAlreadyInvited(string projectId, string email)
+        catch (ForbiddenException)
         {
-            try
-            {
-                return Ok(await _projectService.IsAlreadyInvitedAsync(UserId, projectId, email));
-            }
-            catch (ForbiddenException)
-            {
-                return ForbiddenError();
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string> { { "method", "IsAlreadyInvited" }, { "projectId", projectId }, }
-                );
-                throw;
-            }
+            return ForbiddenError();
         }
-
-        public async Task<IRpcMethodResult> InvitedUsers(string projectId)
+        catch (DataNotFoundException dnfe)
         {
-            try
-            {
-                return Ok(await _projectService.InvitedUsersAsync(UserId, projectId));
-            }
-            catch (ForbiddenException)
-            {
-                return ForbiddenError();
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string> { { "method", "InvitedUsers" }, { "projectId", projectId }, }
-                );
-                throw;
-            }
+            return NotFoundError(dnfe.Message);
         }
-
-        public async Task<IRpcMethodResult> CheckLinkSharing(string projectId, string shareKey)
+        catch (Exception)
         {
-            try
-            {
-                await _projectService.CheckLinkSharingAsync(UserId, projectId, shareKey);
-                return Ok();
-            }
-            catch (ForbiddenException)
-            {
-                return ForbiddenError();
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string> { { "method", "CheckLinkSharing" }, { "projectId", projectId }, }
-                );
-                throw;
-            }
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string> { { "method", "IsAlreadyInvited" }, { "projectId", projectId }, }
+            );
+            throw;
         }
+    }
 
-        public async Task<IRpcMethodResult> CheckLinkSharing(string projectId)
+    public async Task<IRpcMethodResult> InvitedUsers(string projectId)
+    {
+        try
         {
-            return await CheckLinkSharing(projectId, null);
+            return Ok(await _projectService.InvitedUsersAsync(UserId, projectId));
         }
-
-        public IRpcMethodResult IsSourceProject(string projectId)
+        catch (ForbiddenException)
         {
-            return Ok(_projectService.IsSourceProject(projectId));
+            return ForbiddenError();
         }
-
-        public async Task<IRpcMethodResult> LinkSharingKey(string projectId, string role)
+        catch (DataNotFoundException dnfe)
         {
-            try
-            {
-                return Ok(await _projectService.GetLinkSharingKeyAsync(UserId, projectId, role));
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string>
-                    {
-                        { "method", "LinkSharingKey" },
-                        { "projectId", projectId },
-                        { "role", role },
-                    }
-                );
-                throw;
-            }
+            return NotFoundError(dnfe.Message);
         }
-
-        public async Task<IRpcMethodResult> AddTranslateMetrics(string projectId, TranslateMetrics metrics)
+        catch (Exception)
         {
-            try
-            {
-                await _projectService.AddTranslateMetricsAsync(UserId, projectId, metrics);
-                return Ok();
-            }
-            catch (ForbiddenException)
-            {
-                return ForbiddenError();
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string>
-                    {
-                        { "method", "AddTranslateMetrics" },
-                        { "metricsId", metrics.Id },
-                        { "projectId", projectId },
-                    }
-                );
-                throw;
-            }
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string> { { "method", "InvitedUsers" }, { "projectId", projectId }, }
+            );
+            throw;
         }
+    }
 
-        public async Task<IRpcMethodResult> Sync(string projectId)
+    public async Task<IRpcMethodResult> CheckLinkSharing(string projectId, string shareKey)
+    {
+        try
         {
-            try
-            {
-                await _projectService.SyncAsync(UserId, projectId);
-                return Ok();
-            }
-            catch (ForbiddenException)
-            {
-                return ForbiddenError();
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string> { { "method", "Sync" }, { "projectId", projectId }, }
-                );
-                throw;
-            }
+            await _projectService.CheckLinkSharingAsync(UserId, projectId, shareKey);
+            return Ok();
         }
-
-        public async Task<IRpcMethodResult> CancelSync(string projectId)
+        catch (ForbiddenException)
         {
-            try
-            {
-                await _projectService.CancelSyncAsync(UserId, projectId);
-                return Ok();
-            }
-            catch (ForbiddenException)
-            {
-                return ForbiddenError();
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string> { { "method", "CancelSync" }, { "projectId", projectId }, }
-                );
-                throw;
-            }
+            return ForbiddenError();
         }
-
-        public async Task<IRpcMethodResult> DeleteAudio(string projectId, string ownerId, string dataId)
+        catch (DataNotFoundException dnfe)
         {
-            try
-            {
-                await _projectService.DeleteAudioAsync(UserId, projectId, ownerId, dataId);
-                return Ok();
-            }
-            catch (ForbiddenException)
-            {
-                return ForbiddenError();
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (FormatException fe)
-            {
-                return InvalidParamsError(fe.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string>
-                    {
-                        { "method", "DeleteAudio" },
-                        { "projectId", projectId },
-                        { "ownerId", ownerId },
-                        { "dataId", dataId },
-                    }
-                );
-                throw;
-            }
+            return NotFoundError(dnfe.Message);
         }
-
-        public async Task<IRpcMethodResult> SetSyncDisabled(string projectId, bool isDisabled)
+        catch (Exception)
         {
-            try
-            {
-                await _projectService.SetSyncDisabledAsync(UserId, SystemRole, projectId, isDisabled);
-                return Ok();
-            }
-            catch (ForbiddenException)
-            {
-                return ForbiddenError();
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string>
-                    {
-                        { "method", "SetSyncDisabled" },
-                        { "projectId", projectId },
-                        { "isDisabled", isDisabled.ToString() },
-                    }
-                );
-                throw;
-            }
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string> { { "method", "CheckLinkSharing" }, { "projectId", projectId }, }
+            );
+            throw;
         }
+    }
 
-        public async Task<IRpcMethodResult> TransceleratorQuestions(string projectId)
+    public async Task<IRpcMethodResult> CheckLinkSharing(string projectId) => await CheckLinkSharing(projectId, null);
+
+    public IRpcMethodResult IsSourceProject(string projectId) => Ok(_projectService.IsSourceProject(projectId));
+
+    public async Task<IRpcMethodResult> LinkSharingKey(string projectId, string role)
+    {
+        try
         {
-            try
-            {
-                return Ok(await _projectService.TransceleratorQuestions(UserId, projectId));
-            }
-            catch (ForbiddenException)
-            {
-                return ForbiddenError();
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string>
-                    {
-                        { "method", "TransceleratorQuestions" },
-                        { "projectId", projectId },
-                    }
-                );
-                throw;
-            }
+            return Ok(await _projectService.GetLinkSharingKeyAsync(UserId, projectId, role));
         }
-
-        public async Task<IRpcMethodResult> SetUserProjectPermissions(
-            string projectId,
-            string userId,
-            string[] permissions
-        )
+        catch (DataNotFoundException dnfe)
         {
-            try
-            {
-                await _projectService.SetUserProjectPermissions(UserId, projectId, userId, permissions);
-                return Ok();
-            }
-            catch (ForbiddenException)
-            {
-                return ForbiddenError();
-            }
-            catch (DataNotFoundException dnfe)
-            {
-                return NotFoundError(dnfe.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string>
-                    {
-                        { "method", "SetUserProjectPermissions" },
-                        { "projectId", projectId },
-                        { "userId", userId },
-                        { "permissions", string.Join(',', permissions) },
-                    }
-                );
-                throw;
-            }
+            return NotFoundError(dnfe.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string>
+                {
+                    { "method", "LinkSharingKey" },
+                    { "projectId", projectId },
+                    { "role", role },
+                }
+            );
+            throw;
+        }
+    }
+
+    public async Task<IRpcMethodResult> AddTranslateMetrics(string projectId, TranslateMetrics metrics)
+    {
+        try
+        {
+            await _projectService.AddTranslateMetricsAsync(UserId, projectId, metrics);
+            return Ok();
+        }
+        catch (ForbiddenException)
+        {
+            return ForbiddenError();
+        }
+        catch (DataNotFoundException dnfe)
+        {
+            return NotFoundError(dnfe.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string>
+                {
+                    { "method", "AddTranslateMetrics" },
+                    { "metricsId", metrics.Id },
+                    { "projectId", projectId },
+                }
+            );
+            throw;
+        }
+    }
+
+    public async Task<IRpcMethodResult> Sync(string projectId)
+    {
+        try
+        {
+            await _projectService.SyncAsync(UserId, projectId);
+            return Ok();
+        }
+        catch (ForbiddenException)
+        {
+            return ForbiddenError();
+        }
+        catch (DataNotFoundException dnfe)
+        {
+            return NotFoundError(dnfe.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string> { { "method", "Sync" }, { "projectId", projectId }, }
+            );
+            throw;
+        }
+    }
+
+    public async Task<IRpcMethodResult> CancelSync(string projectId)
+    {
+        try
+        {
+            await _projectService.CancelSyncAsync(UserId, projectId);
+            return Ok();
+        }
+        catch (ForbiddenException)
+        {
+            return ForbiddenError();
+        }
+        catch (DataNotFoundException dnfe)
+        {
+            return NotFoundError(dnfe.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string> { { "method", "CancelSync" }, { "projectId", projectId }, }
+            );
+            throw;
+        }
+    }
+
+    public async Task<IRpcMethodResult> DeleteAudio(string projectId, string ownerId, string dataId)
+    {
+        try
+        {
+            await _projectService.DeleteAudioAsync(UserId, projectId, ownerId, dataId);
+            return Ok();
+        }
+        catch (ForbiddenException)
+        {
+            return ForbiddenError();
+        }
+        catch (DataNotFoundException dnfe)
+        {
+            return NotFoundError(dnfe.Message);
+        }
+        catch (FormatException fe)
+        {
+            return InvalidParamsError(fe.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string>
+                {
+                    { "method", "DeleteAudio" },
+                    { "projectId", projectId },
+                    { "ownerId", ownerId },
+                    { "dataId", dataId },
+                }
+            );
+            throw;
+        }
+    }
+
+    public async Task<IRpcMethodResult> SetSyncDisabled(string projectId, bool isDisabled)
+    {
+        try
+        {
+            await _projectService.SetSyncDisabledAsync(UserId, SystemRole, projectId, isDisabled);
+            return Ok();
+        }
+        catch (ForbiddenException)
+        {
+            return ForbiddenError();
+        }
+        catch (DataNotFoundException dnfe)
+        {
+            return NotFoundError(dnfe.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string>
+                {
+                    { "method", "SetSyncDisabled" },
+                    { "projectId", projectId },
+                    { "isDisabled", isDisabled.ToString() },
+                }
+            );
+            throw;
+        }
+    }
+
+    public async Task<IRpcMethodResult> TransceleratorQuestions(string projectId)
+    {
+        try
+        {
+            return Ok(await _projectService.TransceleratorQuestions(UserId, projectId));
+        }
+        catch (ForbiddenException)
+        {
+            return ForbiddenError();
+        }
+        catch (DataNotFoundException dnfe)
+        {
+            return NotFoundError(dnfe.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string> { { "method", "TransceleratorQuestions" }, { "projectId", projectId }, }
+            );
+            throw;
+        }
+    }
+
+    public async Task<IRpcMethodResult> SetUserProjectPermissions(string projectId, string userId, string[] permissions)
+    {
+        try
+        {
+            await _projectService.SetUserProjectPermissions(UserId, projectId, userId, permissions);
+            return Ok();
+        }
+        catch (ForbiddenException)
+        {
+            return ForbiddenError();
+        }
+        catch (DataNotFoundException dnfe)
+        {
+            return NotFoundError(dnfe.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string>
+                {
+                    { "method", "SetUserProjectPermissions" },
+                    { "projectId", projectId },
+                    { "userId", userId },
+                    { "permissions", string.Join(',', permissions) },
+                }
+            );
+            throw;
         }
     }
 }

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
@@ -8,75 +8,74 @@ using Microsoft.AspNetCore.Mvc;
 using SIL.XForge.Scripture.Services;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Controllers
+namespace SIL.XForge.Scripture.Controllers;
+
+/// <summary>
+/// This controller contains upload endpoints.
+/// </summary>
+[Authorize]
+[Route(UrlConstants.CommandApiNamespace + "/" + UrlConstants.Projects)]
+public class SFProjectsUploadController : ControllerBase
 {
-    /// <summary>
-    /// This controller contains upload endpoints.
-    /// </summary>
-    [Authorize]
-    [Route(UrlConstants.CommandApiNamespace + "/" + UrlConstants.Projects)]
-    public class SFProjectsUploadController : ControllerBase
+    private readonly IExceptionHandler _exceptionHandler;
+    private readonly IUserAccessor _userAccessor;
+    private readonly ISFProjectService _projectService;
+
+    public SFProjectsUploadController(
+        IUserAccessor userAccessor,
+        ISFProjectService projectService,
+        IExceptionHandler exceptionHandler
+    )
     {
-        private readonly IExceptionHandler _exceptionHandler;
-        private readonly IUserAccessor _userAccessor;
-        private readonly ISFProjectService _projectService;
+        _userAccessor = userAccessor;
+        _projectService = projectService;
+        _exceptionHandler = exceptionHandler;
+        _exceptionHandler.RecordUserIdForException(_userAccessor.UserId);
+    }
 
-        public SFProjectsUploadController(
-            IUserAccessor userAccessor,
-            ISFProjectService projectService,
-            IExceptionHandler exceptionHandler
-        )
+    [HttpPost("audio")]
+    [RequestSizeLimit(100_000_000)]
+    public async Task<IActionResult> UploadAudioAsync(
+        [FromForm] string projectId,
+        [FromForm] string dataId,
+        [FromForm] IFormFile file
+    )
+    {
+        try
         {
-            _userAccessor = userAccessor;
-            _projectService = projectService;
-            _exceptionHandler = exceptionHandler;
-            _exceptionHandler.RecordUserIdForException(_userAccessor.UserId);
+            await using Stream stream = file.OpenReadStream();
+            Uri uri = await _projectService.SaveAudioAsync(
+                _userAccessor.UserId,
+                projectId,
+                dataId,
+                Path.GetExtension(file.FileName),
+                stream
+            );
+            return Created(uri.PathAndQuery, Path.GetFileName(uri.AbsolutePath));
         }
-
-        [HttpPost("audio")]
-        [RequestSizeLimit(100_000_000)]
-        public async Task<IActionResult> UploadAudioAsync(
-            [FromForm] string projectId,
-            [FromForm] string dataId,
-            [FromForm] IFormFile file
-        )
+        catch (ForbiddenException)
         {
-            try
-            {
-                await using Stream stream = file.OpenReadStream();
-                Uri uri = await _projectService.SaveAudioAsync(
-                    _userAccessor.UserId,
-                    projectId,
-                    dataId,
-                    Path.GetExtension(file.FileName),
-                    stream
-                );
-                return Created(uri.PathAndQuery, Path.GetFileName(uri.AbsolutePath));
-            }
-            catch (ForbiddenException)
-            {
-                return Forbid();
-            }
-            catch (DataNotFoundException)
-            {
-                return NotFound();
-            }
-            catch (FormatException)
-            {
-                return BadRequest();
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string>
-                    {
-                        { "method", "UploadAudioAsync" },
-                        { "projectId", projectId },
-                        { "dataId", dataId },
-                    }
-                );
-                throw;
-            }
+            return Forbid();
+        }
+        catch (DataNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (FormatException)
+        {
+            return BadRequest();
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string>
+                {
+                    { "method", "UploadAudioAsync" },
+                    { "projectId", projectId },
+                    { "dataId", dataId },
+                }
+            );
+            throw;
         }
     }
 }

--- a/src/SIL.XForge.Scripture/DataAccess/SFDataAccessApplicationBuilderExtensions.cs
+++ b/src/SIL.XForge.Scripture/DataAccess/SFDataAccessApplicationBuilderExtensions.cs
@@ -1,16 +1,15 @@
 using SIL.XForge.Scripture.Models;
 
-namespace Microsoft.AspNetCore.Builder
-{
-    public static class SFDataAccessApplicationBuilderExtensions
-    {
-        public static void UseSFDataAccess(this IApplicationBuilder app)
-        {
-            app.UseDataAccess();
+namespace Microsoft.AspNetCore.Builder;
 
-            app.InitRepository<TranslateMetrics>();
-            app.InitRepository<SFProjectSecret>();
-            app.InitRepository<SyncMetrics>();
-        }
+public static class SFDataAccessApplicationBuilderExtensions
+{
+    public static void UseSFDataAccess(this IApplicationBuilder app)
+    {
+        app.UseDataAccess();
+
+        app.InitRepository<TranslateMetrics>();
+        app.InitRepository<SFProjectSecret>();
+        app.InitRepository<SyncMetrics>();
     }
 }

--- a/src/SIL.XForge.Scripture/DataAccess/SFDataAccessServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/DataAccess/SFDataAccessServiceCollectionExtensions.cs
@@ -2,23 +2,22 @@ using Microsoft.Extensions.Configuration;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Scripture.Models;
 
-namespace Microsoft.Extensions.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class SFDataAccessServiceCollectionExtensions
 {
-    public static class SFDataAccessServiceCollectionExtensions
+    public static IServiceCollection AddSFDataAccess(this IServiceCollection services, IConfiguration configuration)
     {
-        public static IServiceCollection AddSFDataAccess(this IServiceCollection services, IConfiguration configuration)
-        {
-            services.AddDataAccess(configuration);
+        services.AddDataAccess(configuration);
 
-            DataAccessClassMap.RegisterClass<ParatextUserProfile>(
-                cm => cm.GetMemberMap(c => c.SFUserId).SetElementName("sfUserId")
-            );
+        DataAccessClassMap.RegisterClass<ParatextUserProfile>(
+            cm => cm.GetMemberMap(c => c.SFUserId).SetElementName("sfUserId")
+        );
 
-            services.AddMongoRepository<TranslateMetrics>("translate_metrics", cm => cm.MapIdProperty(tm => tm.Id));
-            services.AddMongoRepository<SFProjectSecret>("sf_project_secrets");
-            services.AddMongoRepository<SyncMetrics>("sync_metrics", cm => cm.MapIdProperty(sm => sm.Id));
+        services.AddMongoRepository<TranslateMetrics>("translate_metrics", cm => cm.MapIdProperty(tm => tm.Id));
+        services.AddMongoRepository<SFProjectSecret>("sf_project_secrets");
+        services.AddMongoRepository<SyncMetrics>("sync_metrics", cm => cm.MapIdProperty(sm => sm.Id));
 
-            return services;
-        }
+        return services;
     }
 }

--- a/src/SIL.XForge.Scripture/Models/Answer.cs
+++ b/src/SIL.XForge.Scripture/Models/Answer.cs
@@ -1,14 +1,13 @@
 using System.Collections.Generic;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public class Answer : Comment
 {
-    public class Answer : Comment
-    {
-        public VerseRefData VerseRef { get; set; }
-        public string ScriptureText { get; set; }
-        public string AudioUrl { get; set; }
-        public List<Like> Likes { get; set; } = new List<Like>();
-        public List<Comment> Comments { get; set; } = new List<Comment>();
-        public string Status { get; set; } = AnswerStatus.None;
-    }
+    public VerseRefData VerseRef { get; set; }
+    public string ScriptureText { get; set; }
+    public string AudioUrl { get; set; }
+    public List<Like> Likes { get; set; } = new List<Like>();
+    public List<Comment> Comments { get; set; } = new List<Comment>();
+    public string Status { get; set; } = AnswerStatus.None;
 }

--- a/src/SIL.XForge.Scripture/Models/AnswerStatus.cs
+++ b/src/SIL.XForge.Scripture/Models/AnswerStatus.cs
@@ -1,15 +1,14 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>The status of an community checking answer.</summary>
+public static class AnswerStatus
 {
-    /// <summary>The status of an community checking answer.</summary>
-    public static class AnswerStatus
-    {
-        /// <summary>No status.</summary>
-        public const string None = "";
+    /// <summary>No status.</summary>
+    public const string None = "";
 
-        /// <summary>Answer has been resolved.</summary>
-        public const string Resolved = "resolve";
+    /// <summary>Answer has been resolved.</summary>
+    public const string Resolved = "resolve";
 
-        /// <summary>Answer can be exported during a sync if configured on the project.</summary>
-        public const string Exportable = "export";
-    }
+    /// <summary>Answer can be exported during a sync if configured on the project.</summary>
+    public const string Exportable = "export";
 }

--- a/src/SIL.XForge.Scripture/Models/Chapter.cs
+++ b/src/SIL.XForge.Scripture/Models/Chapter.cs
@@ -1,16 +1,15 @@
 using System.Collections.Generic;
 
-namespace SIL.XForge.Scripture.Models
-{
-    public class Chapter
-    {
-        public int Number { get; set; }
-        public int LastVerse { get; set; }
+namespace SIL.XForge.Scripture.Models;
 
-        /// <summary>Whether the chapter's USX conforms to the usx-sf SF USX
-        /// schema, which is a subset of the USX schema. If not, it will not
-        /// be editable in SF.</summary>
-        public bool IsValid { get; set; }
-        public Dictionary<string, string> Permissions { get; set; } = new Dictionary<string, string>();
-    }
+public class Chapter
+{
+    public int Number { get; set; }
+    public int LastVerse { get; set; }
+
+    /// <summary>Whether the chapter's USX conforms to the usx-sf SF USX
+    /// schema, which is a subset of the USX schema. If not, it will not
+    /// be editable in SF.</summary>
+    public bool IsValid { get; set; }
+    public Dictionary<string, string> Permissions { get; set; } = new Dictionary<string, string>();
 }

--- a/src/SIL.XForge.Scripture/Models/CheckingAnswerExport.cs
+++ b/src/SIL.XForge.Scripture/Models/CheckingAnswerExport.cs
@@ -1,15 +1,14 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>Determine what community checking answers should be synced to Paratext.</summary>
+public static class CheckingAnswerExport
 {
-    /// <summary>Determine what community checking answers should be synced to Paratext.</summary>
-    public static class CheckingAnswerExport
-    {
-        /// <summary>Export all answers.</summary>
-        public const string All = "all";
+    /// <summary>Export all answers.</summary>
+    public const string All = "all";
 
-        /// <summary>Export only answers with status set to export.</summary>
-        public const string MarkedForExport = "marked_for_export";
+    /// <summary>Export only answers with status set to export.</summary>
+    public const string MarkedForExport = "marked_for_export";
 
-        /// <summary>Do not export any answers.</summary>
-        public const string None = "none";
-    }
+    /// <summary>Do not export any answers.</summary>
+    public const string None = "none";
 }

--- a/src/SIL.XForge.Scripture/Models/CheckingConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/CheckingConfig.cs
@@ -1,11 +1,10 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public class CheckingConfig
 {
-    public class CheckingConfig
-    {
-        public bool CheckingEnabled { get; set; }
-        public bool UsersSeeEachOthersResponses { get; set; } = true;
-        public bool ShareEnabled { get; set; } = false;
-        public string ShareLevel { get; set; } = CheckingShareLevel.Specific;
-        public string AnswerExportMethod { get; set; } = CheckingAnswerExport.All;
-    }
+    public bool CheckingEnabled { get; set; }
+    public bool UsersSeeEachOthersResponses { get; set; } = true;
+    public bool ShareEnabled { get; set; } = false;
+    public string ShareLevel { get; set; } = CheckingShareLevel.Specific;
+    public string AnswerExportMethod { get; set; } = CheckingAnswerExport.All;
 }

--- a/src/SIL.XForge.Scripture/Models/CheckingShareLevel.cs
+++ b/src/SIL.XForge.Scripture/Models/CheckingShareLevel.cs
@@ -1,12 +1,11 @@
-namespace SIL.XForge.Scripture.Models
-{
-    /// <summary>Type of sharing for community checking.</summary>
-    public static class CheckingShareLevel
-    {
-        /// <summary>Anyone can access the project via a share URL.</summary>
-        public const string Anyone = "anyone";
+namespace SIL.XForge.Scripture.Models;
 
-        /// <summary>Invited people can only access the project via an invitation URL unique to them.</summary>
-        public const string Specific = "specific";
-    }
+/// <summary>Type of sharing for community checking.</summary>
+public static class CheckingShareLevel
+{
+    /// <summary>Anyone can access the project via a share URL.</summary>
+    public const string Anyone = "anyone";
+
+    /// <summary>Invited people can only access the project via an invitation URL unique to them.</summary>
+    public const string Specific = "specific";
 }

--- a/src/SIL.XForge.Scripture/Models/Comment.cs
+++ b/src/SIL.XForge.Scripture/Models/Comment.cs
@@ -1,20 +1,19 @@
 using System;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Scripture.Models
-{
-    public class Comment : IOwnedData
-    {
-        public string DataId { get; set; }
-        public string OwnerRef { get; set; }
+namespace SIL.XForge.Scripture.Models;
 
-        /// <summary>
-        /// The OpaqueUserId of a ParatextUserProfile. It is used to correlate comments between PT and SF. It may refer
-        /// to a SF user who synchronized the comment.
-        /// </summary>
-        public string SyncUserRef { get; set; }
-        public string Text { get; set; }
-        public DateTime DateModified { get; set; }
-        public DateTime DateCreated { get; set; }
-    }
+public class Comment : IOwnedData
+{
+    public string DataId { get; set; }
+    public string OwnerRef { get; set; }
+
+    /// <summary>
+    /// The OpaqueUserId of a ParatextUserProfile. It is used to correlate comments between PT and SF. It may refer
+    /// to a SF user who synchronized the comment.
+    /// </summary>
+    public string SyncUserRef { get; set; }
+    public string Text { get; set; }
+    public DateTime DateModified { get; set; }
+    public DateTime DateCreated { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/FeatureFlags.cs
+++ b/src/SIL.XForge.Scripture/Models/FeatureFlags.cs
@@ -1,11 +1,10 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// Definitions for feature flags set in the FeatureManagement configuration section.
+/// </summary>
+public static class FeatureFlags
 {
-    /// <summary>
-    /// Definitions for feature flags set in the FeatureManagement configuration section.
-    /// </summary>
-    public static class FeatureFlags
-    {
-        public const string MachineApi = "MachineApi";
-        public const string MachineInProcess = "MachineInProcess";
-    }
+    public const string MachineApi = "MachineApi";
+    public const string MachineInProcess = "MachineInProcess";
 }

--- a/src/SIL.XForge.Scripture/Models/InviteeStatus.cs
+++ b/src/SIL.XForge.Scripture/Models/InviteeStatus.cs
@@ -1,9 +1,8 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public class InviteeStatus
 {
-    public class InviteeStatus
-    {
-        public string Email { get; set; }
-        public string Role { get; set; }
-        public bool Expired { get; set; }
-    }
+    public string Email { get; set; }
+    public string Role { get; set; }
+    public bool Expired { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/Like.cs
+++ b/src/SIL.XForge.Scripture/Models/Like.cs
@@ -1,7 +1,6 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public class Like
 {
-    public class Like
-    {
-        public string OwnerRef { get; set; }
-    }
+    public string OwnerRef { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/MachineApi.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApi.cs
@@ -1,30 +1,29 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// Machine API URL strings and helper methods.
+/// </summary>
+public static class MachineApi
 {
-    /// <summary>
-    /// Machine API URL strings and helper methods.
-    /// </summary>
-    public static class MachineApi
+    public const string Namespace = "machine-api/v2";
+    public const string StartBuild = "translation/builds";
+    public const string GetBuild = "translation/builds/{locatorType}:{sfProjectId}.{buildId?}";
+    public const string GetEngine = "translation/engines/project:{sfProjectId}";
+    public const string GetWordGraph = "translation/engines/project:{sfProjectId}/actions/getWordGraph";
+    public const string TrainSegment = "translation/engines/project:{sfProjectId}/actions/trainSegment";
+    public const string Translate = "translation/engines/project:{sfProjectId}/actions/translate";
+    public const string TranslateN = "translation/engines/project:{sfProjectId}/actions/translate/{n}";
+
+    public static string GetBuildHref(string sfProjectId, string buildId)
     {
-        public const string Namespace = "machine-api/v2";
-        public const string StartBuild = "translation/builds";
-        public const string GetBuild = "translation/builds/{locatorType}:{sfProjectId}.{buildId?}";
-        public const string GetEngine = "translation/engines/project:{sfProjectId}";
-        public const string GetWordGraph = "translation/engines/project:{sfProjectId}/actions/getWordGraph";
-        public const string TrainSegment = "translation/engines/project:{sfProjectId}/actions/trainSegment";
-        public const string Translate = "translation/engines/project:{sfProjectId}/actions/translate";
-        public const string TranslateN = "translation/engines/project:{sfProjectId}/actions/translate/{n}";
-
-        public static string GetBuildHref(string sfProjectId, string buildId)
-        {
-            // The {locatorType} parameter is required to maintain compatibility with the v1 machine-api and machine.js
-            string buildHref = GetBuild
-                .Replace("{sfProjectId}", sfProjectId)
-                .Replace("{buildId?}", buildId)
-                .Replace("{locatorType}", "id");
-            return $"{Namespace}/{buildHref}";
-        }
-
-        public static string GetEngineHref(string sfProjectId) =>
-            $"{Namespace}/{GetEngine.Replace("{sfProjectId}", sfProjectId)}";
+        // The {locatorType} parameter is required to maintain compatibility with the v1 machine-api and machine.js
+        string buildHref = GetBuild
+            .Replace("{sfProjectId}", sfProjectId)
+            .Replace("{buildId?}", buildId)
+            .Replace("{locatorType}", "id");
+        return $"{Namespace}/{buildHref}";
     }
+
+    public static string GetEngineHref(string sfProjectId) =>
+        $"{Namespace}/{GetEngine.Replace("{sfProjectId}", sfProjectId)}";
 }

--- a/src/SIL.XForge.Scripture/Models/MachineApiCorpusFile.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApiCorpusFile.cs
@@ -1,18 +1,17 @@
 using SIL.Machine.WebApi;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// The details of a corpus file from the Machine API.
+/// </summary>
+/// <remarks>
+/// TODO: When Machine > 2.5.X, change any code that uses this to use DataFileDto
+/// </remarks>
+public class MachineApiCorpusFile : ResourceDto
 {
-    /// <summary>
-    /// The details of a corpus file from the Machine API.
-    /// </summary>
-    /// <remarks>
-    /// TODO: When Machine > 2.5.X, change any code that uses this to use DataFileDto
-    /// </remarks>
-    public class MachineApiCorpusFile : ResourceDto
-    {
-        public ResourceDto? Corpus { get; set; }
-        public string Name { get; set; } = string.Empty;
-        public string LanguageTag { get; set; } = string.Empty;
-        public string TextId { get; set; } = string.Empty;
-    }
+    public ResourceDto? Corpus { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string LanguageTag { get; set; } = string.Empty;
+    public string TextId { get; set; } = string.Empty;
 }

--- a/src/SIL.XForge.Scripture/Models/MachineApiTranslationEngine.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApiTranslationEngine.cs
@@ -1,25 +1,24 @@
 using SIL.Machine.WebApi;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// The details of a translation engine from the Machine API.
+/// </summary>
+/// <remarks>
+/// TODO: When Machine > 2.5.X, change any code that uses this to use TranslationEngineDto
+/// </remarks>
+public class MachineApiTranslationEngine : ResourceDto
 {
-    /// <summary>
-    /// The details of a translation engine from the Machine API.
-    /// </summary>
-    /// <remarks>
-    /// TODO: When Machine > 2.5.X, change any code that uses this to use TranslationEngineDto
-    /// </remarks>
-    public class MachineApiTranslationEngine : ResourceDto
-    {
-        public string Name { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
 
-        public string SourceLanguageTag { get; set; } = string.Empty;
+    public string SourceLanguageTag { get; set; } = string.Empty;
 
-        public string TargetLanguageTag { get; set; } = string.Empty;
+    public string TargetLanguageTag { get; set; } = string.Empty;
 
-        public string Type { get; set; } = string.Empty;
-        public bool IsBuilding { get; set; }
-        public int ModelRevision { get; set; }
-        public double Confidence { get; set; }
-        public int CorpusSize { get; set; }
-    }
+    public string Type { get; set; } = string.Empty;
+    public bool IsBuilding { get; set; }
+    public int ModelRevision { get; set; }
+    public double Confidence { get; set; }
+    public int CorpusSize { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/MachineCorpus.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineCorpus.cs
@@ -1,18 +1,17 @@
-namespace SIL.XForge.Scripture.Models
-{
-    using System.Collections.Generic;
+using System.Collections.Generic;
 
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// Machine API Corpus Data.
+/// </summary>
+public class MachineCorpus
+{
     /// <summary>
-    /// Machine API Corpus Data.
+    /// Gets or sets the files uploaded to the Machine API.
     /// </summary>
-    public class MachineCorpus
-    {
-        /// <summary>
-        /// Gets or sets the files uploaded to the Machine API.
-        /// </summary>
-        /// <value>
-        /// The machine corpus files.
-        /// </value>
-        public List<MachineCorpusFile> Files { get; set; } = new List<MachineCorpusFile>();
-    }
+    /// <value>
+    /// The machine corpus files.
+    /// </value>
+    public List<MachineCorpusFile> Files { get; set; } = new List<MachineCorpusFile>();
 }

--- a/src/SIL.XForge.Scripture/Models/MachineCorpusFile.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineCorpusFile.cs
@@ -1,17 +1,16 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// The details of a corpus file stored on the Machine API.
+/// </summary>
+public class MachineCorpusFile
 {
     /// <summary>
-    /// The details of a corpus file stored on the Machine API.
+    /// The MD5 Hash of the corpus file's contents.
+    /// This is used to see if the file has changed since its last upload to the Machine API.
     /// </summary>
-    public class MachineCorpusFile
-    {
-        /// <summary>
-        /// The MD5 Hash of the corpus file's contents.
-        /// This is used to see if the file has changed since its last upload to the Machine API.
-        /// </summary>
-        public string FileChecksum { get; set; } = string.Empty;
-        public string FileId { get; set; } = string.Empty;
-        public string LanguageTag { get; set; } = string.Empty;
-        public string TextId { get; set; } = string.Empty;
-    }
+    public string FileChecksum { get; set; } = string.Empty;
+    public string FileId { get; set; } = string.Empty;
+    public string LanguageTag { get; set; } = string.Empty;
+    public string TextId { get; set; } = string.Empty;
 }

--- a/src/SIL.XForge.Scripture/Models/MachineData.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineData.cs
@@ -1,32 +1,31 @@
 using System.Collections.Generic;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// Machine API Data
+/// </summary>
+public class MachineData
 {
     /// <summary>
-    /// Machine API Data
+    /// Gets or sets the Machine API Translation Engine Id for the project.
     /// </summary>
-    public class MachineData
-    {
-        /// <summary>
-        /// Gets or sets the Machine API Translation Engine Id for the project.
-        /// </summary>
-        /// <value>
-        /// The Translation Engine Id.
-        /// </value>
-        /// <remarks>
-        /// The user should not interact with the translation engine directly by ID.
-        /// </remarks>
-        public string TranslationEngineId { get; set; } = string.Empty;
+    /// <value>
+    /// The Translation Engine Id.
+    /// </value>
+    /// <remarks>
+    /// The user should not interact with the translation engine directly by ID.
+    /// </remarks>
+    public string TranslationEngineId { get; set; } = string.Empty;
 
-        /// <summary>
-        /// Gets or sets the corpora uploaded to the Machine API.
-        /// </summary>
-        /// <value>
-        /// The machine corpora.
-        /// </value>
-        /// <remarks>
-        /// The dictionary key is the corpus ID.
-        /// </remarks>
-        public Dictionary<string, MachineCorpus> Corpora { get; set; } = new Dictionary<string, MachineCorpus>();
-    }
+    /// <summary>
+    /// Gets or sets the corpora uploaded to the Machine API.
+    /// </summary>
+    /// <value>
+    /// The machine corpora.
+    /// </value>
+    /// <remarks>
+    /// The dictionary key is the corpus ID.
+    /// </remarks>
+    public Dictionary<string, MachineCorpus> Corpora { get; set; } = new Dictionary<string, MachineCorpus>();
 }

--- a/src/SIL.XForge.Scripture/Models/Note.cs
+++ b/src/SIL.XForge.Scripture/Models/Note.cs
@@ -1,45 +1,44 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>Represents a project note.</summary>
+public class Note : Comment
 {
-    /// <summary>Represents a project note.</summary>
-    public class Note : Comment
-    {
-        public string ThreadId { get; set; }
+    public string ThreadId { get; set; }
 
-        /// <summary>Type of note, such as "" for a normal note, or "conflict" for a conflict note.</summary>
-        public string Type { get; set; }
+    /// <summary>Type of note, such as "" for a normal note, or "conflict" for a conflict note.</summary>
+    public string Type { get; set; }
 
-        /// <summary>
-        /// Type of conflict, if a conflict note. For example, "verseText". If it is not a conflict note, this
-        /// may read "unknownConflictType".
-        /// </summary>
-        public string ConflictType { get; set; }
-        public string ExtUserId { get; set; }
-        public bool Deleted { get; set; }
-        public string Status { get; set; }
-        public int? TagId { get; set; }
-        public string Reattached { get; set; }
+    /// <summary>
+    /// Type of conflict, if a conflict note. For example, "verseText". If it is not a conflict note, this
+    /// may read "unknownConflictType".
+    /// </summary>
+    public string ConflictType { get; set; }
+    public string ExtUserId { get; set; }
+    public bool Deleted { get; set; }
+    public string Status { get; set; }
+    public int? TagId { get; set; }
+    public string Reattached { get; set; }
 
-        /// <summary>
-        /// Who this note is assigned to. This may be a <see cref="ParatextUserProfile" /> OpaqueUserId,
-        /// or a category such as team or unassigned.
-        /// </summary>
-        public string Assignment { get; set; }
+    /// <summary>
+    /// Who this note is assigned to. This may be a <see cref="ParatextUserProfile" /> OpaqueUserId,
+    /// or a category such as team or unassigned.
+    /// </summary>
+    public string Assignment { get; set; }
 
-        /// <summary>
-        /// Content of note. Contains XML. Corresponds to `Contents` element, which is not always present in the
-        /// Notes XML file.
-        /// </summary>
-        public string Content { get; set; }
+    /// <summary>
+    /// Content of note. Contains XML. Corresponds to `Contents` element, which is not always present in the
+    /// Notes XML file.
+    /// </summary>
+    public string Content { get; set; }
 
-        /// <summary>
-        /// Change difference accepted from a conflict, if any. Contains encoded XML. Not always present, in
-        /// Notes XML file.
-        /// </summary>
-        public string AcceptedChangeXml { get; set; }
+    /// <summary>
+    /// Change difference accepted from a conflict, if any. Contains encoded XML. Not always present, in
+    /// Notes XML file.
+    /// </summary>
+    public string AcceptedChangeXml { get; set; }
 
-        /// <summary>The default value for ConflictType in Paratext is "unknownConflictType", which is present
-        /// in Note XML files when the note is not a conflict note. However, this is not one of the values of
-        /// the NoteConflictType enum.</summary>
-        public readonly static string NoConflictType = "unknownConflictType";
-    }
+    /// <summary>The default value for ConflictType in Paratext is "unknownConflictType", which is present
+    /// in Note XML files when the note is not a conflict note. However, this is not one of the values of
+    /// the NoteConflictType enum.</summary>
+    public readonly static string NoConflictType = "unknownConflictType";
 }

--- a/src/SIL.XForge.Scripture/Models/NoteSyncMetricInfo.cs
+++ b/src/SIL.XForge.Scripture/Models/NoteSyncMetricInfo.cs
@@ -1,34 +1,31 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// Information on the operations performed when syncing the notes subsystem.
+/// </summary>
+/// <remarks>This is to be used with <see cref="SyncMetrics"/>.</remarks>
+public record NoteSyncMetricInfo : SyncMetricInfo
 {
-    /// <summary>
-    /// Information on the operations performed when syncing the notes subsystem.
-    /// </summary>
-    /// <remarks>This is to be used with <see cref="SyncMetrics"/>.</remarks>
-    public record NoteSyncMetricInfo : SyncMetricInfo
+    public NoteSyncMetricInfo() { }
+
+    public NoteSyncMetricInfo(int added, int deleted, int updated, int removed)
+        : base(added, deleted, updated) => Removed = removed;
+
+    public int Removed { get; set; }
+
+    public static NoteSyncMetricInfo operator +(NoteSyncMetricInfo a, NoteSyncMetricInfo b)
     {
-        public NoteSyncMetricInfo() { }
-
-        public NoteSyncMetricInfo(int added, int deleted, int updated, int removed) : base(added, deleted, updated)
+        if (a is null || b is null)
         {
-            Removed = removed;
+            return a ?? b;
         }
 
-        public int Removed { get; set; }
-
-        public static NoteSyncMetricInfo operator +(NoteSyncMetricInfo a, NoteSyncMetricInfo b)
+        return new NoteSyncMetricInfo
         {
-            if (a is null || b is null)
-            {
-                return a ?? b;
-            }
-
-            return new NoteSyncMetricInfo
-            {
-                Added = a.Added + b.Added,
-                Deleted = a.Deleted + b.Deleted,
-                Updated = a.Updated + b.Updated,
-                Removed = a.Removed + b.Removed,
-            };
-        }
+            Added = a.Added + b.Added,
+            Deleted = a.Deleted + b.Deleted,
+            Updated = a.Updated + b.Updated,
+            Removed = a.Removed + b.Removed,
+        };
     }
 }

--- a/src/SIL.XForge.Scripture/Models/NoteTag.cs
+++ b/src/SIL.XForge.Scripture/Models/NoteTag.cs
@@ -1,14 +1,13 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public class NoteTag
 {
-    public class NoteTag
-    {
-        public const string defaultTagIcon = "01flag1";
-        public const string sfNoteTagIcon = "06star2";
-        public const string sfNoteTagName = "Scripture Forge Note";
-        public const int notSetId = 0;
-        public int TagId { get; set; }
-        public string Icon { get; set; }
-        public string Name { get; set; }
-        public bool CreatorResolve { get; set; }
-    }
+    public const string defaultTagIcon = "01flag1";
+    public const string sfNoteTagIcon = "06star2";
+    public const string sfNoteTagName = "Scripture Forge Note";
+    public const int notSetId = 0;
+    public int TagId { get; set; }
+    public string Icon { get; set; }
+    public string Name { get; set; }
+    public bool CreatorResolve { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/NoteThread.cs
+++ b/src/SIL.XForge.Scripture/Models/NoteThread.cs
@@ -1,31 +1,27 @@
 using System.Collections.Generic;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public class NoteThread : ProjectData
 {
-    public class NoteThread : ProjectData
-    {
-        public static string GetDocId(string sfProjectId, string threadId)
-        {
-            return $"{sfProjectId}:{threadId}";
-        }
+    public static string GetDocId(string sfProjectId, string threadId) => $"{sfProjectId}:{threadId}";
 
-        /// <summary>Thread id. Not to be confused with the doc id.</summary>
-        public string DataId { get; set; }
-        public VerseRefData VerseRef { get; set; }
-        public List<Note> Notes { get; set; } = new List<Note>();
-        public string OriginalSelectedText { get; set; }
-        public string OriginalContextBefore { get; set; }
-        public string OriginalContextAfter { get; set; }
-        public TextAnchor Position { get; set; }
-        public string ParatextUser { get; set; }
-        public bool? PublishedToSF { get; set; }
-        public string Status { get; set; }
+    /// <summary>Thread id. Not to be confused with the doc id.</summary>
+    public string DataId { get; set; }
+    public VerseRefData VerseRef { get; set; }
+    public List<Note> Notes { get; set; } = new List<Note>();
+    public string OriginalSelectedText { get; set; }
+    public string OriginalContextBefore { get; set; }
+    public string OriginalContextAfter { get; set; }
+    public TextAnchor Position { get; set; }
+    public string ParatextUser { get; set; }
+    public bool? PublishedToSF { get; set; }
+    public string Status { get; set; }
 
-        /// <summary>
-        /// Who this note thread is assigned to. This may be a <see cref="ParatextUserProfile" /> OpaqueUserId,
-        /// or a category such as team or unassigned.
-        /// </summary>
-        public string Assignment { get; set; }
-    }
+    /// <summary>
+    /// Who this note thread is assigned to. This may be a <see cref="ParatextUserProfile" /> OpaqueUserId,
+    /// or a category such as team or unassigned.
+    /// </summary>
+    public string Assignment { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/NoteThreadChange.cs
+++ b/src/SIL.XForge.Scripture/Models/NoteThreadChange.cs
@@ -1,90 +1,87 @@
 using System.Collections.Generic;
-using Paratext.Data.ProjectComments;
-using PtxUtils;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public enum ChangeType
 {
-    public enum ChangeType
+    Added,
+    Updated,
+    Deleted,
+    None
+}
+
+/// <summary>
+/// Represents changes in a Paratext CommentThread.
+/// </summary>
+public class NoteThreadChange
+{
+    public string ThreadId { get; set; }
+    public string VerseRefStr { get; set; }
+    public string SelectedText { get; set; }
+    public string ContextBefore { get; set; }
+    public string ContextAfter { get; set; }
+    public TextAnchor Position { get; set; }
+    public string Status { get; set; }
+    public string Assignment { get; set; }
+
+    /// <summary> True if the thread has been permanently removed. </summary>
+    public bool ThreadRemoved { get; set; }
+    public bool ThreadUpdated { get; set; }
+    public List<Note> NotesAdded { get; set; } = new List<Note>();
+    public List<Note> NotesUpdated { get; set; } = new List<Note>();
+    public List<Note> NotesDeleted { get; set; } = new List<Note>();
+
+    /// <summary> IDs for notes that have been permanently removed. </summary>
+    public List<string> NoteIdsRemoved { get; set; } = new List<string>();
+
+    public bool HasChange
     {
-        Added,
-        Updated,
-        Deleted,
-        None
+        get
+        {
+            return NotesAdded.Count > 0
+                || NotesUpdated.Count > 0
+                || NotesDeleted.Count > 0
+                || NoteIdsRemoved.Count > 0
+                || ThreadRemoved
+                || ThreadUpdated
+                || Position != null;
+        }
     }
 
-    /// <summary>
-    /// Represents changes in a Paratext CommentThread.
-    /// </summary>
-    public class NoteThreadChange
+    public NoteThreadChange(
+        string threadId,
+        string verseRef,
+        string selectedText,
+        string contextBefore,
+        string contextAfter,
+        string status,
+        string assignment
+    )
     {
-        public string ThreadId { get; set; }
-        public string VerseRefStr { get; set; }
-        public string SelectedText { get; set; }
-        public string ContextBefore { get; set; }
-        public string ContextAfter { get; set; }
-        public TextAnchor Position { get; set; }
-        public string Status { get; set; }
-        public string Assignment { get; set; }
+        ThreadId = threadId;
+        VerseRefStr = verseRef;
+        SelectedText = selectedText;
+        ContextBefore = contextBefore;
+        ContextAfter = contextAfter;
+        Assignment = assignment;
+        Status = status;
+    }
 
-        /// <summary> True if the thread has been permanently removed. </summary>
-        public bool ThreadRemoved { get; set; }
-        public bool ThreadUpdated { get; set; }
-        public List<Note> NotesAdded { get; set; } = new List<Note>();
-        public List<Note> NotesUpdated { get; set; } = new List<Note>();
-        public List<Note> NotesDeleted { get; set; } = new List<Note>();
-
-        /// <summary> IDs for notes that have been permanently removed. </summary>
-        public List<string> NoteIdsRemoved { get; set; } = new List<string>();
-
-        public bool HasChange
+    public void AddChange(Note changedNote, ChangeType type)
+    {
+        switch (type)
         {
-            get
-            {
-                return NotesAdded.Count > 0
-                    || NotesUpdated.Count > 0
-                    || NotesDeleted.Count > 0
-                    || NoteIdsRemoved.Count > 0
-                    || ThreadRemoved
-                    || ThreadUpdated
-                    || Position != null;
-            }
-        }
-
-        public NoteThreadChange(
-            string threadId,
-            string verseRef,
-            string selectedText,
-            string contextBefore,
-            string contextAfter,
-            string status,
-            string assignment
-        )
-        {
-            ThreadId = threadId;
-            VerseRefStr = verseRef;
-            SelectedText = selectedText;
-            ContextBefore = contextBefore;
-            ContextAfter = contextAfter;
-            Assignment = assignment;
-            Status = status;
-        }
-
-        public void AddChange(Note changedNote, ChangeType type)
-        {
-            switch (type)
-            {
-                case ChangeType.Added:
-                    NotesAdded.Add(changedNote);
-                    break;
-                case ChangeType.Updated:
-                    NotesUpdated.Add(changedNote);
-                    break;
-                case ChangeType.Deleted:
-                    NotesDeleted.Add(changedNote);
-                    break;
-                default:
-                    break;
-            }
+            case ChangeType.Added:
+                NotesAdded.Add(changedNote);
+                break;
+            case ChangeType.Updated:
+                NotesUpdated.Add(changedNote);
+                break;
+            case ChangeType.Deleted:
+                NotesDeleted.Add(changedNote);
+                break;
+            default:
+                break;
         }
     }
 }

--- a/src/SIL.XForge.Scripture/Models/ParatextProject.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextProject.cs
@@ -1,51 +1,50 @@
 using System.Text;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>Description of a project on the Paratext server.</summary>
+public class ParatextProject
 {
-    /// <summary>Description of a project on the Paratext server.</summary>
-    public class ParatextProject
+    /// <summary> Id of PT project on Paratext servers. </summary>
+    public string ParatextId { get; set; }
+    public string Name { get; set; }
+    public string ShortName { get; set; }
+    public string LanguageTag { get; set; }
+
+    /// <summary> Id of corresponding SF project. </summary>
+    public string? ProjectId { get; set; }
+
+    /// <summary>
+    /// If the requesting user has access to the PT project, but not yet to a corresponding SF project, and has
+    /// permission to connect a SF project to the PT project. The SF project may or may not yet already exist.
+    /// </summary>
+    public bool IsConnectable { get; set; }
+
+    /// <summary>
+    /// If the requesting user has access to both the PT project and the corresponding SF project.
+    /// </summary>
+    public bool IsConnected { get; set; }
+
+    /// <summary> Descriptive string of object's properties, for debugging. </summary>
+    public override string ToString()
     {
-        /// <summary> Id of PT project on Paratext servers. </summary>
-        public string ParatextId { get; set; }
-        public string Name { get; set; }
-        public string ShortName { get; set; }
-        public string LanguageTag { get; set; }
-
-        /// <summary> Id of corresponding SF project. </summary>
-        public string? ProjectId { get; set; }
-
-        /// <summary>
-        /// If the requesting user has access to the PT project, but not yet to a corresponding SF project, and has
-        /// permission to connect a SF project to the PT project. The SF project may or may not yet already exist.
-        /// </summary>
-        public bool IsConnectable { get; set; }
-
-        /// <summary>
-        /// If the requesting user has access to both the PT project and the corresponding SF project.
-        /// </summary>
-        public bool IsConnected { get; set; }
-
-        /// <summary> Descriptive string of object's properties, for debugging. </summary>
-        public override string ToString()
-        {
-            StringBuilder message = new StringBuilder();
-            foreach (
-                string? item in new string?[]
-                {
-                    ParatextId,
-                    Name,
-                    ShortName,
-                    LanguageTag,
-                    ProjectId,
-                    IsConnectable.ToString(),
-                    IsConnected.ToString()
-                }
-            )
+        StringBuilder message = new StringBuilder();
+        foreach (
+            string? item in new string?[]
             {
-                message.Append(item);
-                message.Append(',');
+                ParatextId,
+                Name,
+                ShortName,
+                LanguageTag,
+                ProjectId,
+                IsConnectable.ToString(),
+                IsConnected.ToString()
             }
-            return message.ToString();
+        )
+        {
+            message.Append(item);
+            message.Append(',');
         }
+        return message.ToString();
     }
 }

--- a/src/SIL.XForge.Scripture/Models/ParatextResource.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextResource.cs
@@ -3,116 +3,115 @@ using System.Globalization;
 using System.Text;
 using SIL.XForge.Scripture.Services;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// A Paratext Resource.
+/// </summary>
+/// <seealso cref="SIL.XForge.Scripture.Models.ParatextProject" />
+public class ParatextResource : ParatextProject
 {
     /// <summary>
-    /// A Paratext Resource.
+    /// Gets or sets the latest available revision.
     /// </summary>
-    /// <seealso cref="SIL.XForge.Scripture.Models.ParatextProject" />
-    public class ParatextResource : ParatextProject
+    /// <value>
+    /// The latest available revision.
+    /// </value>
+    public int AvailableRevision { get; set; }
+
+    /// <summary>
+    /// Gets or sets the installed revision.
+    /// </summary>
+    /// <value>
+    /// The installed revision.
+    /// </value>
+    /// <remarks>
+    /// This is used to determine if we need to update our local copy of the resource.
+    /// </remarks>
+    public int InstalledRevision { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this resource is installed.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if this resource is installed locally; otherwise, <c>false</c>.
+    /// </value>
+    /// <remarks>
+    /// This is used to determine if we need to install a local copy of the resource.
+    /// </remarks>
+    public bool IsInstalled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the installable resource.
+    /// </summary>
+    /// <value>
+    /// The installable resource.
+    /// </value>
+    /// <remarks>
+    /// This is used solely for synchronization, and can be null if not appropriate.
+    /// </remarks>
+    internal SFInstallableDblResource? InstallableResource { get; set; }
+
+    /// <summary>
+    /// Gets or sets the created timestamp.
+    /// </summary>
+    /// <value>
+    /// The created timestamp.
+    /// </value>
+    /// <remarks>
+    /// This is used to see if this is newer, if the manifest checksum is different.
+    /// </remarks>
+    public DateTime CreatedTimestamp { get; set; }
+
+    /// <summary>
+    /// Gets or sets the manifest checksum.
+    /// </summary>
+    /// <value>
+    /// The manifest checksum.
+    /// </value>
+    /// <remarks>
+    /// This is used to see if the manifest has changed.
+    /// </remarks>
+    public string ManifestChecksum { get; set; }
+
+    /// <summary>
+    /// Gets or sets the permissions checksum.
+    /// </summary>
+    /// <value>
+    /// The permissions checksum.
+    /// </value>
+    /// <remarks>
+    /// This is used to see if the permissions have changed.
+    /// </remarks>
+    public string PermissionsChecksum { get; set; }
+
+    /// <inheritdoc/>
+    public override string ToString()
     {
-        /// <summary>
-        /// Gets or sets the latest available revision.
-        /// </summary>
-        /// <value>
-        /// The latest available revision.
-        /// </value>
-        public int AvailableRevision { get; set; }
-
-        /// <summary>
-        /// Gets or sets the installed revision.
-        /// </summary>
-        /// <value>
-        /// The installed revision.
-        /// </value>
-        /// <remarks>
-        /// This is used to determine if we need to update our local copy of the resource.
-        /// </remarks>
-        public int InstalledRevision { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether this resource is installed.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if this resource is installed locally; otherwise, <c>false</c>.
-        /// </value>
-        /// <remarks>
-        /// This is used to determine if we need to install a local copy of the resource.
-        /// </remarks>
-        public bool IsInstalled { get; set; }
-
-        /// <summary>
-        /// Gets or sets the installable resource.
-        /// </summary>
-        /// <value>
-        /// The installable resource.
-        /// </value>
-        /// <remarks>
-        /// This is used solely for synchronization, and can be null if not appropriate.
-        /// </remarks>
-        internal SFInstallableDblResource? InstallableResource { get; set; }
-
-        /// <summary>
-        /// Gets or sets the created timestamp.
-        /// </summary>
-        /// <value>
-        /// The created timestamp.
-        /// </value>
-        /// <remarks>
-        /// This is used to see if this is newer, if the manifest checksum is different.
-        /// </remarks>
-        public DateTime CreatedTimestamp { get; set; }
-
-        /// <summary>
-        /// Gets or sets the manifest checksum.
-        /// </summary>
-        /// <value>
-        /// The manifest checksum.
-        /// </value>
-        /// <remarks>
-        /// This is used to see if the manifest has changed.
-        /// </remarks>
-        public string ManifestChecksum { get; set; }
-
-        /// <summary>
-        /// Gets or sets the permissions checksum.
-        /// </summary>
-        /// <value>
-        /// The permissions checksum.
-        /// </value>
-        /// <remarks>
-        /// This is used to see if the permissions have changed.
-        /// </remarks>
-        public string PermissionsChecksum { get; set; }
-
-        /// <inheritdoc/>
-        public override string ToString()
-        {
-            StringBuilder message = new StringBuilder();
-            foreach (
-                string? item in new string?[]
-                {
-                    ParatextId,
-                    Name,
-                    ShortName,
-                    LanguageTag,
-                    ProjectId,
-                    IsConnectable.ToString(),
-                    IsConnected.ToString(),
-                    IsInstalled.ToString(),
-                    AvailableRevision.ToString(),
-                    InstalledRevision.ToString(),
-                    CreatedTimestamp.ToString(CultureInfo.CurrentCulture),
-                    ManifestChecksum,
-                    PermissionsChecksum
-                }
-            )
+        StringBuilder message = new StringBuilder();
+        foreach (
+            string? item in new string?[]
             {
-                message.Append(item);
-                message.Append(',');
+                ParatextId,
+                Name,
+                ShortName,
+                LanguageTag,
+                ProjectId,
+                IsConnectable.ToString(),
+                IsConnected.ToString(),
+                IsInstalled.ToString(),
+                AvailableRevision.ToString(),
+                InstalledRevision.ToString(),
+                CreatedTimestamp.ToString(CultureInfo.CurrentCulture),
+                ManifestChecksum,
+                PermissionsChecksum
             }
-
-            return message.ToString();
+        )
+        {
+            message.Append(item);
+            message.Append(',');
         }
+
+        return message.ToString();
     }
 }

--- a/src/SIL.XForge.Scripture/Models/ParatextSettings.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextSettings.cs
@@ -1,21 +1,20 @@
 using System.Collections.Generic;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public class ParatextSettings
 {
-    public class ParatextSettings
-    {
-        /// <summary> The full name of the project from the local repository. </summary>
-        public string FullName { get; set; }
+    /// <summary> The full name of the project from the local repository. </summary>
+    public string FullName { get; set; }
 
-        /// <summary> Whether a specific project is in a right to left language. </summary>
-        public bool IsRightToLeft { get; set; }
+    /// <summary> Whether a specific project is in a right to left language. </summary>
+    public bool IsRightToLeft { get; set; }
 
-        /// <summary> Indicates if the text in the project is editable. </summary>
-        public bool Editable { get; set; }
-        public int DefaultFontSize { get; set; }
-        public string DefaultFont { get; set; }
+    /// <summary> Indicates if the text in the project is editable. </summary>
+    public bool Editable { get; set; }
+    public int DefaultFontSize { get; set; }
+    public string DefaultFont { get; set; }
 
-        /// <summary> The tag icon used by default for note threads created in SF. </summary>
-        public IEnumerable<NoteTag> NoteTags { get; set; }
-    }
+    /// <summary> The tag icon used by default for note threads created in SF. </summary>
+    public IEnumerable<NoteTag> NoteTags { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/ParatextUserProfile.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextUserProfile.cs
@@ -1,17 +1,16 @@
-namespace SIL.XForge.Scripture.Models
-{
-    /// <summary>
-    /// Describes a Paratext user on a project (those with and without an SF account)
-    /// </summary>
-    public class ParatextUserProfile
-    {
-        /// <summary> The user's Paratext username </summary>
-        public string Username { get; set; }
+namespace SIL.XForge.Scripture.Models;
 
-        /// <summary>
-        /// A unique id that can be used to associate a project component (e.g. a note) to this paratext user
-        /// </summary>
-        public string OpaqueUserId { get; set; }
-        public string SFUserId { get; set; }
-    }
+/// <summary>
+/// Describes a Paratext user on a project (those with and without an SF account)
+/// </summary>
+public class ParatextUserProfile
+{
+    /// <summary> The user's Paratext username </summary>
+    public string Username { get; set; }
+
+    /// <summary>
+    /// A unique id that can be used to associate a project component (e.g. a note) to this paratext user
+    /// </summary>
+    public string OpaqueUserId { get; set; }
+    public string SFUserId { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/ProgressState.cs
+++ b/src/SIL.XForge.Scripture/Models/ProgressState.cs
@@ -1,10 +1,9 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public class ProgressState
 {
-    public class ProgressState
-    {
-        public static readonly ProgressState Completed = new ProgressState { ProgressValue = 1.0 };
-        public static readonly ProgressState NotStarted = new ProgressState { ProgressValue = 0.0 };
-        public string? ProgressString { get; set; }
-        public double ProgressValue { get; set; }
-    }
+    public static readonly ProgressState Completed = new ProgressState { ProgressValue = 1.0 };
+    public static readonly ProgressState NotStarted = new ProgressState { ProgressValue = 0.0 };
+    public string? ProgressString { get; set; }
+    public double ProgressValue { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/Question.cs
+++ b/src/SIL.XForge.Scripture/Models/Question.cs
@@ -2,19 +2,18 @@ using System;
 using System.Collections.Generic;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public class Question : ProjectData
 {
-    public class Question : ProjectData
-    {
-        public string DataId { get; set; }
-        public VerseRefData VerseRef { get; set; }
-        public string Text { get; set; }
-        public string AudioUrl { get; set; }
-        public List<Answer> Answers { get; set; } = new List<Answer>();
-        public bool IsArchived { get; set; }
-        public DateTime? DateArchived { get; set; }
-        public DateTime DateModified { get; set; }
-        public DateTime DateCreated { get; set; }
-        public string TransceleratorQuestionId { get; set; }
-    }
+    public string DataId { get; set; }
+    public VerseRefData VerseRef { get; set; }
+    public string Text { get; set; }
+    public string AudioUrl { get; set; }
+    public List<Answer> Answers { get; set; } = new List<Answer>();
+    public bool IsArchived { get; set; }
+    public DateTime? DateArchived { get; set; }
+    public DateTime DateModified { get; set; }
+    public DateTime DateCreated { get; set; }
+    public string TransceleratorQuestionId { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/RazorPageSettings.cs
+++ b/src/SIL.XForge.Scripture/Models/RazorPageSettings.cs
@@ -1,9 +1,8 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>Various settings to be used Razor pages</summary>
+public class RazorPageSettings
 {
-    /// <summary>Various settings to be used Razor pages</summary>
-    public class RazorPageSettings
-    {
-        public string ProductVersion { get; set; }
-        public string BugsnagConfig { get; set; }
-    }
+    public string ProductVersion { get; set; }
+    public string BugsnagConfig { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/ResourceConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/ResourceConfig.cs
@@ -1,15 +1,14 @@
-namespace SIL.XForge.Scripture.Models
-{
-    using System;
+using System;
 
-    /// <summary>
-    /// Contains configuration information for Paratext resources.
-    /// </summary>
-    public class ResourceConfig
-    {
-        public DateTime CreatedTimestamp { get; set; }
-        public string ManifestChecksum { get; set; }
-        public string PermissionsChecksum { get; set; }
-        public int Revision { get; set; }
-    }
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// Contains configuration information for Paratext resources.
+/// </summary>
+public class ResourceConfig
+{
+    public DateTime CreatedTimestamp { get; set; }
+    public string ManifestChecksum { get; set; }
+    public string PermissionsChecksum { get; set; }
+    public int Revision { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/SFParatextUser.cs
+++ b/src/SIL.XForge.Scripture/Models/SFParatextUser.cs
@@ -1,12 +1,12 @@
 using Paratext.Data.Users;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// SF customization of ParatextUser
+/// </summary>
+public class SFParatextUser : ParatextUser
 {
-    /// <summary>
-    /// SF customization of ParatextUser
-    /// </summary>
-    public class SFParatextUser : ParatextUser
-    {
-        public SFParatextUser(string ptUsername) : base(ptUsername, true) { }
-    }
+    public SFParatextUser(string ptUsername)
+        : base(ptUsername, true) { }
 }

--- a/src/SIL.XForge.Scripture/Models/SFProject.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProject.cs
@@ -1,28 +1,27 @@
 using System.Collections.Generic;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Scripture.Models
-{
-    /// <summary>Description of an SF project.</summary>
-    public class SFProject : Project
-    {
-        public string ParatextId { get; set; }
-        public string ShortName { get; set; }
-        public WritingSystem WritingSystem { get; set; } = new WritingSystem();
-        public bool? IsRightToLeft { get; set; }
-        public TranslateConfig TranslateConfig { get; set; } = new TranslateConfig();
-        public CheckingConfig CheckingConfig { get; set; } = new CheckingConfig();
-        public ResourceConfig ResourceConfig { get; set; }
-        public List<TextInfo> Texts { get; set; } = new List<TextInfo>();
-        public Sync Sync { get; set; } = new Sync();
+namespace SIL.XForge.Scripture.Models;
 
-        /// <summary>
-        /// Paratext users on this SF project that are associated with a project component (e.g. a note)
-        /// </summary>
-        public List<ParatextUserProfile> ParatextUsers { get; set; } = new List<ParatextUserProfile>();
-        public bool Editable { get; set; } = true;
-        public int? DefaultFontSize { get; set; }
-        public string DefaultFont { get; set; }
-        public List<NoteTag> NoteTags { get; set; } = new List<NoteTag>();
-    }
+/// <summary>Description of an SF project.</summary>
+public class SFProject : Project
+{
+    public string ParatextId { get; set; }
+    public string ShortName { get; set; }
+    public WritingSystem WritingSystem { get; set; } = new WritingSystem();
+    public bool? IsRightToLeft { get; set; }
+    public TranslateConfig TranslateConfig { get; set; } = new TranslateConfig();
+    public CheckingConfig CheckingConfig { get; set; } = new CheckingConfig();
+    public ResourceConfig ResourceConfig { get; set; }
+    public List<TextInfo> Texts { get; set; } = new List<TextInfo>();
+    public Sync Sync { get; set; } = new Sync();
+
+    /// <summary>
+    /// Paratext users on this SF project that are associated with a project component (e.g. a note)
+    /// </summary>
+    public List<ParatextUserProfile> ParatextUsers { get; set; } = new List<ParatextUserProfile>();
+    public bool Editable { get; set; } = true;
+    public int? DefaultFontSize { get; set; }
+    public string DefaultFont { get; set; }
+    public List<NoteTag> NoteTags { get; set; } = new List<NoteTag>();
 }

--- a/src/SIL.XForge.Scripture/Models/SFProjectCreateSettings.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectCreateSettings.cs
@@ -1,11 +1,10 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public class SFProjectCreateSettings
 {
-    public class SFProjectCreateSettings
-    {
-        public string ParatextId { get; set; }
-        public bool TranslationSuggestionsEnabled { get; set; }
-        public string SourceParatextId { get; set; }
-        public bool CheckingEnabled { get; set; }
-        public string AnswerExportMethod { get; set; } = CheckingAnswerExport.MarkedForExport;
-    }
+    public string ParatextId { get; set; }
+    public bool TranslationSuggestionsEnabled { get; set; }
+    public string SourceParatextId { get; set; }
+    public bool CheckingEnabled { get; set; }
+    public string AnswerExportMethod { get; set; } = CheckingAnswerExport.MarkedForExport;
 }

--- a/src/SIL.XForge.Scripture/Models/SFProjectRole.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectRole.cs
@@ -1,29 +1,27 @@
-namespace SIL.XForge.Scripture.Models
-{
-    public static class SFProjectRole
-    {
-        public const string Administrator = "pt_administrator";
-        public const string Translator = "pt_translator";
-        public const string Consultant = "pt_consultant";
-        public const string PTObserver = "pt_observer";
-        public const string Read = "pt_read";
-        public const string WriteNote = "pt_write_note";
-        public const string Reviewer = "sf_reviewer";
-        public const string CommunityChecker = "sf_community_checker";
-        public const string SFObserver = "sf_observer";
+namespace SIL.XForge.Scripture.Models;
 
-        public static bool IsParatextRole(string role)
+public static class SFProjectRole
+{
+    public const string Administrator = "pt_administrator";
+    public const string Translator = "pt_translator";
+    public const string Consultant = "pt_consultant";
+    public const string PTObserver = "pt_observer";
+    public const string Read = "pt_read";
+    public const string WriteNote = "pt_write_note";
+    public const string Reviewer = "sf_reviewer";
+    public const string CommunityChecker = "sf_community_checker";
+    public const string SFObserver = "sf_observer";
+
+    public static bool IsParatextRole(string role)
+    {
+        return role switch
         {
-            switch (role)
-            {
-                case SFProjectRole.Administrator:
-                case SFProjectRole.Translator:
-                case SFProjectRole.Consultant:
-                case SFProjectRole.PTObserver:
-                    return true;
-                default:
-                    return false;
-            }
-        }
+            SFProjectRole.Administrator
+            or SFProjectRole.Translator
+            or SFProjectRole.Consultant
+            or SFProjectRole.PTObserver
+                => true,
+            _ => false,
+        };
     }
 }

--- a/src/SIL.XForge.Scripture/Models/SFProjectSecret.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectSecret.cs
@@ -1,37 +1,36 @@
 using System.Collections.Generic;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public class SFProjectSecret : ProjectSecret
 {
-    public class SFProjectSecret : ProjectSecret
-    {
-        /// <summary>
-        /// The queued or active Hangfire Job Ids for the project.
-        /// </summary>
-        /// <value>
-        /// The Hangfire Job Ids.
-        /// </value>
-        /// <remarks>
-        /// The <see cref="List{T}.Count">Count</see> should correspond to <see cref="Sync.QueuedCount" />.
-        /// </remarks>
-        public List<string> JobIds { get; set; } = new List<string>();
+    /// <summary>
+    /// The queued or active Hangfire Job Ids for the project.
+    /// </summary>
+    /// <value>
+    /// The Hangfire Job Ids.
+    /// </value>
+    /// <remarks>
+    /// The <see cref="List{T}.Count">Count</see> should correspond to <see cref="Sync.QueuedCount" />.
+    /// </remarks>
+    public List<string> JobIds { get; set; } = new List<string>();
 
-        /// <summary>
-        /// The queued or active SyncMetrics Ids for the project.
-        /// </summary>
-        /// <value>
-        /// The SyncMetrics Ids.
-        /// </value>
-        /// <remarks>
-        /// This functions in a similar way to <see cref="JobIds"/>,
-        /// so that we can mark the <see cref="SyncMetrics"/> as cancelled.
-        /// </remarks>
-        public List<string> SyncMetricsIds { get; set; } = new List<string>();
+    /// <summary>
+    /// The queued or active SyncMetrics Ids for the project.
+    /// </summary>
+    /// <value>
+    /// The SyncMetrics Ids.
+    /// </value>
+    /// <remarks>
+    /// This functions in a similar way to <see cref="JobIds"/>,
+    /// so that we can mark the <see cref="SyncMetrics"/> as cancelled.
+    /// </remarks>
+    public List<string> SyncMetricsIds { get; set; } = new List<string>();
 
-        /// <summary>
-        /// Gets or sets the Machine API data.
-        /// </summary>
-        /// <value>The Machine API data.</value>
-        public MachineData? MachineData { get; set; }
-    }
+    /// <summary>
+    /// Gets or sets the Machine API data.
+    /// </summary>
+    /// <value>The Machine API data.</value>
+    public MachineData? MachineData { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/SFProjectSettings.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectSettings.cs
@@ -1,23 +1,22 @@
-namespace SIL.XForge.Scripture.Models
-{
-    /// <summary>
-    /// This class represents the project settings that can be updated using
-    /// <see cref="SIL.XForge.Scripture.Controllers.SFProjectsRpcController.UpdateSettings"/>.
-    /// </summary>
-    public class SFProjectSettings
-    {
-        // translate settings
-        public bool? TranslationSuggestionsEnabled { get; set; }
-        public string SourceParatextId { get; set; }
-        public bool? TranslateShareEnabled { get; set; }
-        public string TranslateShareLevel { get; set; }
+namespace SIL.XForge.Scripture.Models;
 
-        // checking settings
-        public bool? CheckingEnabled { get; set; }
-        public bool? UsersSeeEachOthersResponses { get; set; }
-        public bool? DownloadAudioFiles { get; set; }
-        public bool? CheckingShareEnabled { get; set; }
-        public string CheckingShareLevel { get; set; }
-        public string CheckingAnswerExport { get; set; }
-    }
+/// <summary>
+/// This class represents the project settings that can be updated using
+/// <see cref="SIL.XForge.Scripture.Controllers.SFProjectsRpcController.UpdateSettings"/>.
+/// </summary>
+public class SFProjectSettings
+{
+    // translate settings
+    public bool? TranslationSuggestionsEnabled { get; set; }
+    public string SourceParatextId { get; set; }
+    public bool? TranslateShareEnabled { get; set; }
+    public string TranslateShareLevel { get; set; }
+
+    // checking settings
+    public bool? CheckingEnabled { get; set; }
+    public bool? UsersSeeEachOthersResponses { get; set; }
+    public bool? DownloadAudioFiles { get; set; }
+    public bool? CheckingShareEnabled { get; set; }
+    public string CheckingShareLevel { get; set; }
+    public string CheckingAnswerExport { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/SFProjectUserConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectUserConfig.cs
@@ -1,34 +1,30 @@
 using System.Collections.Generic;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public class SFProjectUserConfig : ProjectData
 {
-    public class SFProjectUserConfig : ProjectData
-    {
-        public static string GetDocId(string projectId, string userId)
-        {
-            return $"{projectId}:{userId}";
-        }
+    public static string GetDocId(string projectId, string userId) => $"{projectId}:{userId}";
 
-        public string SelectedTask { get; set; }
-        public int? SelectedBookNum { get; set; }
-        public int? SelectedChapterNum { get; set; }
+    public string SelectedTask { get; set; }
+    public int? SelectedBookNum { get; set; }
+    public int? SelectedChapterNum { get; set; }
 
-        // translate
-        public bool IsTargetTextRight { get; set; } = true;
-        public double ConfidenceThreshold { get; set; } = 0.2;
-        public int NumSuggestions { get; set; } = 1;
-        public bool TranslationSuggestionsEnabled { get; set; } = true;
-        public string SelectedSegment { get; set; } = "";
-        public int? SelectedSegmentChecksum { get; set; }
+    // translate
+    public bool IsTargetTextRight { get; set; } = true;
+    public double ConfidenceThreshold { get; set; } = 0.2;
+    public int NumSuggestions { get; set; } = 1;
+    public bool TranslationSuggestionsEnabled { get; set; } = true;
+    public string SelectedSegment { get; set; } = "";
+    public int? SelectedSegmentChecksum { get; set; }
 
-        /// <summary>Ids of notes (not threads) which the user has read.</summary>
-        public List<string> NoteRefsRead { get; set; } = new List<string>();
+    /// <summary>Ids of notes (not threads) which the user has read.</summary>
+    public List<string> NoteRefsRead { get; set; } = new List<string>();
 
-        // checking
-        public List<string> QuestionRefsRead { get; set; } = new List<string>();
-        public List<string> AnswerRefsRead { get; set; } = new List<string>();
-        public List<string> CommentRefsRead { get; set; } = new List<string>();
-        public string SelectedQuestionRef { get; set; }
-    }
+    // checking
+    public List<string> QuestionRefsRead { get; set; } = new List<string>();
+    public List<string> AnswerRefsRead { get; set; } = new List<string>();
+    public List<string> CommentRefsRead { get; set; } = new List<string>();
+    public string SelectedQuestionRef { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/Sync.cs
+++ b/src/SIL.XForge.Scripture/Models/Sync.cs
@@ -1,37 +1,36 @@
 using System;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public class Sync
 {
-    public class Sync
-    {
-        public int QueuedCount { get; set; }
-        public bool? LastSyncSuccessful { get; set; }
-        public DateTime? DateLastSuccessfulSync { get; set; }
+    public int QueuedCount { get; set; }
+    public bool? LastSyncSuccessful { get; set; }
+    public DateTime? DateLastSuccessfulSync { get; set; }
 
-        /// <summary>
-        /// The SF project was last successfully synchronized with PT project data at this repository
-        /// commit on the PT project send/receive server.
-        /// </summary>
-        public string? SyncedToRepositoryVersion { get; set; }
+    /// <summary>
+    /// The SF project was last successfully synchronized with PT project data at this repository
+    /// commit on the PT project send/receive server.
+    /// </summary>
+    public string? SyncedToRepositoryVersion { get; set; }
 
-        /// <summary>
-        /// If the local PT repo has been imported into SF DB.
-        /// <br />
-        /// More specifically:<br />
-        /// True if the the local PT project repository's commit that
-        /// is the most recent commit from the last push or pull with the PT SR server (see
-        /// <see cref="HgWrapper.GetLastPublicRevision()"/>), has a commit id that matches
-        /// <see cref="SyncedToRepositoryVersion"/>, meaning a sync brought the SF DB up to date by absorbing the
-        /// contents of the local PT project hg repository at that commit id.<br />
-        /// The SF DB may have been modified since then. And the *remote* PT SR server hg repository may have received
-        /// more information since then. And the most recent attempt to sync may or may not have been successful. But
-        /// this property can still be true in those situations.
-        /// <br />
-        /// False if the local PT repo's <see cref="HgWrapper.GetLastPublicRevision()"/> does not match
-        /// <see cref="SyncedToRepositoryVersion"/>. This situation may arise from crashing during sync, with no
-        /// successful local PT repo rollback, in which case the local PT repo would have been changed, but we have no
-        /// record of successfully importing all local PT repo data into SF DB at the new commit id.
-        /// </summary>
-        public bool? DataInSync { get; set; }
-    }
+    /// <summary>
+    /// If the local PT repo has been imported into SF DB.
+    /// <br />
+    /// More specifically:<br />
+    /// True if the the local PT project repository's commit that
+    /// is the most recent commit from the last push or pull with the PT SR server (see
+    /// <see cref="HgWrapper.GetLastPublicRevision()"/>), has a commit id that matches
+    /// <see cref="SyncedToRepositoryVersion"/>, meaning a sync brought the SF DB up to date by absorbing the
+    /// contents of the local PT project hg repository at that commit id.<br />
+    /// The SF DB may have been modified since then. And the *remote* PT SR server hg repository may have received
+    /// more information since then. And the most recent attempt to sync may or may not have been successful. But
+    /// this property can still be true in those situations.
+    /// <br />
+    /// False if the local PT repo's <see cref="HgWrapper.GetLastPublicRevision()"/> does not match
+    /// <see cref="SyncedToRepositoryVersion"/>. This situation may arise from crashing during sync, with no
+    /// successful local PT repo rollback, in which case the local PT repo would have been changed, but we have no
+    /// record of successfully importing all local PT repo data into SF DB at the new commit id.
+    /// </summary>
+    public bool? DataInSync { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/SyncMetricInfo.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncMetricInfo.cs
@@ -1,37 +1,36 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// Information on the operations performed when syncing a subsystem.
+/// </summary>
+/// <remarks>This is to be used with <see cref="SyncMetrics"/>.</remarks>
+public record SyncMetricInfo
 {
-    /// <summary>
-    /// Information on the operations performed when syncing a subsystem.
-    /// </summary>
-    /// <remarks>This is to be used with <see cref="SyncMetrics"/>.</remarks>
-    public record SyncMetricInfo
+    public SyncMetricInfo() { }
+
+    public SyncMetricInfo(int added, int deleted, int updated)
     {
-        public SyncMetricInfo() { }
+        Added = added;
+        Deleted = deleted;
+        Updated = updated;
+    }
 
-        public SyncMetricInfo(int added, int deleted, int updated)
+    public int Added { get; set; }
+    public int Deleted { get; set; }
+    public int Updated { get; set; }
+
+    public static SyncMetricInfo operator +(SyncMetricInfo a, SyncMetricInfo b)
+    {
+        if (a is null || b is null)
         {
-            Added = added;
-            Deleted = deleted;
-            Updated = updated;
+            return a ?? b;
         }
 
-        public int Added { get; set; }
-        public int Deleted { get; set; }
-        public int Updated { get; set; }
-
-        public static SyncMetricInfo operator +(SyncMetricInfo a, SyncMetricInfo b)
+        return new SyncMetricInfo
         {
-            if (a is null || b is null)
-            {
-                return a ?? b;
-            }
-
-            return new SyncMetricInfo
-            {
-                Added = a.Added + b.Added,
-                Deleted = a.Deleted + b.Deleted,
-                Updated = a.Updated + b.Updated,
-            };
-        }
+            Added = a.Added + b.Added,
+            Deleted = a.Deleted + b.Deleted,
+            Updated = a.Updated + b.Updated,
+        };
     }
 }

--- a/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
@@ -2,40 +2,39 @@ using System;
 using System.Collections.Generic;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// Information on each sync performed.
+/// </summary>
+public class SyncMetrics : IIdentifiable
 {
+    // Sync Details
+    public DateTime? DateFinished { get; set; }
+    public DateTime DateQueued { get; set; }
+    public DateTime? DateStarted { get; set; }
+    public string Id { get; set; }
+    public string ErrorDetails { get; set; }
+    public string RequiresId { get; set; }
+    public string ProjectRef { get; set; }
+    public SyncStatus Status { get; set; }
+    public string UserRef { get; set; }
+
+    // Sync Statistics
+    public SyncMetricInfo Books { get; set; } = new SyncMetricInfo();
+    public NoteSyncMetricInfo Notes { get; set; } = new NoteSyncMetricInfo();
+    public SyncMetricInfo NoteThreads { get; set; } = new SyncMetricInfo();
+    public SyncMetricInfo ParatextBooks { get; set; } = new SyncMetricInfo();
+    public SyncMetricInfo ParatextNotes { get; set; } = new SyncMetricInfo();
+    public SyncMetricInfo Questions { get; set; } = new SyncMetricInfo();
+    public bool RepositoryBackupCreated { get; set; }
+    public bool RepositoryRestoredFromBackup { get; set; }
+    public SyncMetricInfo ResourceUsers { get; set; } = new SyncMetricInfo();
+    public SyncMetricInfo TextDocs { get; set; } = new SyncMetricInfo();
+    public SyncMetricInfo Users { get; set; } = new SyncMetricInfo();
+
     /// <summary>
-    /// Information on each sync performed.
+    /// The log messages from <see cref="Services.ParatextSyncRunner"/>.
     /// </summary>
-    public class SyncMetrics : IIdentifiable
-    {
-        // Sync Details
-        public DateTime? DateFinished { get; set; }
-        public DateTime DateQueued { get; set; }
-        public DateTime? DateStarted { get; set; }
-        public string Id { get; set; }
-        public string ErrorDetails { get; set; }
-        public string RequiresId { get; set; }
-        public string ProjectRef { get; set; }
-        public SyncStatus Status { get; set; }
-        public string UserRef { get; set; }
-
-        // Sync Statistics
-        public SyncMetricInfo Books { get; set; } = new SyncMetricInfo();
-        public NoteSyncMetricInfo Notes { get; set; } = new NoteSyncMetricInfo();
-        public SyncMetricInfo NoteThreads { get; set; } = new SyncMetricInfo();
-        public SyncMetricInfo ParatextBooks { get; set; } = new SyncMetricInfo();
-        public SyncMetricInfo ParatextNotes { get; set; } = new SyncMetricInfo();
-        public SyncMetricInfo Questions { get; set; } = new SyncMetricInfo();
-        public bool RepositoryBackupCreated { get; set; }
-        public bool RepositoryRestoredFromBackup { get; set; }
-        public SyncMetricInfo ResourceUsers { get; set; } = new SyncMetricInfo();
-        public SyncMetricInfo TextDocs { get; set; } = new SyncMetricInfo();
-        public SyncMetricInfo Users { get; set; } = new SyncMetricInfo();
-
-        /// <summary>
-        /// The log messages from <see cref="Services.ParatextSyncRunner"/>.
-        /// </summary>
-        public List<string> Log { get; set; } = new List<string>();
-    }
+    public List<string> Log { get; set; } = new List<string>();
 }

--- a/src/SIL.XForge.Scripture/Models/SyncStatus.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncStatus.cs
@@ -1,14 +1,13 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// The status of a sync for the <see cref="SyncMetrics"/>.
+/// </summary>
+public enum SyncStatus
 {
-    /// <summary>
-    /// The status of a sync for the <see cref="SyncMetrics"/>.
-    /// </summary>
-    public enum SyncStatus
-    {
-        Queued,
-        Running,
-        Successful,
-        Cancelled,
-        Failed,
-    }
+    Queued,
+    Running,
+    Successful,
+    Cancelled,
+    Failed,
 }

--- a/src/SIL.XForge.Scripture/Models/TextAnchor.cs
+++ b/src/SIL.XForge.Scripture/Models/TextAnchor.cs
@@ -1,38 +1,36 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// Text-only position of a series of characters relative to the start of a verse. The position uses zero-based
+/// indexing, and should correspond to the SF DB "insert" strings of a given verse.
+/// The position does not take into account quill editor text between segments, quill embeds, USFM markup, or other
+/// formatting.
+/// For example, in the following USFM verse:
+///     \v 1 Praise the \nd Lord\nd*, all you nations:
+///     \q2 laud him, all you peoples.
+///     \q
+/// (1) "Praise" has Start 0 and Length 6.
+/// (2) "all you peoples" has Start 43 and Length 15. (43 == "Praise the ".Length + "Lord".Length + ",
+///     all you nations:".Length + "laud him, ".Length)
+/// </summary>
+public class TextAnchor
 {
-    /// <summary>
-    /// Text-only position of a series of characters relative to the start of a verse. The position uses zero-based
-    /// indexing, and should correspond to the SF DB "insert" strings of a given verse.
-    /// The position does not take into account quill editor text between segments, quill embeds, USFM markup, or other
-    /// formatting.
-    /// For example, in the following USFM verse:
-    ///     \v 1 Praise the \nd Lord\nd*, all you nations:
-    ///     \q2 laud him, all you peoples.
-    ///     \q
-    /// (1) "Praise" has Start 0 and Length 6.
-    /// (2) "all you peoples" has Start 43 and Length 15. (43 == "Praise the ".Length + "Lord".Length + ",
-    ///     all you nations:".Length + "laud him, ".Length)
-    /// </summary>
-    public class TextAnchor
+    public int Start { get; set; } = 0;
+    public int Length { get; set; } = 0;
+
+    public override bool Equals(object other)
     {
-        public int Start { get; set; } = 0;
-        public int Length { get; set; } = 0;
+        if (other is not TextAnchor compared)
+            return false;
+        return Start == compared.Start && Length == compared.Length;
+    }
 
-        public override bool Equals(object other)
-        {
-            TextAnchor compared = other as TextAnchor;
-            if (compared == null)
-                return false;
-            return Start == compared.Start && Length == compared.Length;
-        }
-
-        public override int GetHashCode()
-        {
-            // Do NOT insert Text Anchor objects into a hash collection since this
-            // hash code is calculated using mutable properties
-            int primeA = 5557;
-            int primeB = 7577;
-            return Start * primeA + Length * primeB;
-        }
+    public override int GetHashCode()
+    {
+        // Do NOT insert Text Anchor objects into a hash collection since this
+        // hash code is calculated using mutable properties
+        int primeA = 5557;
+        int primeB = 7577;
+        return Start * primeA + Length * primeB;
     }
 }

--- a/src/SIL.XForge.Scripture/Models/TextData.cs
+++ b/src/SIL.XForge.Scripture/Models/TextData.cs
@@ -4,23 +4,21 @@ using SIL.Scripture;
 using SIL.XForge.Models;
 using SIL.XForge.Realtime.RichText;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public class TextData : Delta, IIdentifiable
 {
-    public class TextData : Delta, IIdentifiable
-    {
-        public static string GetTextDocId(string projectId, int book, int chapter)
-        {
-            return $"{projectId}:{Canon.BookNumberToId(book)}:{chapter}:target";
-        }
+    public static string GetTextDocId(string projectId, int book, int chapter) =>
+        $"{projectId}:{Canon.BookNumberToId(book)}:{chapter}:target";
 
-        public TextData() { }
+    public TextData() { }
 
-        public TextData(Delta delta) : base(delta) { }
+    public TextData(Delta delta)
+        : base(delta) { }
 
-        [JsonIgnore]
-        public string Id { get; set; }
+    [JsonIgnore]
+    public string Id { get; set; }
 
-        [JsonIgnore]
-        public Dictionary<string, object> ExtraElements { get; set; }
-    }
+    [JsonIgnore]
+    public Dictionary<string, object> ExtraElements { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/TextInfo.cs
+++ b/src/SIL.XForge.Scripture/Models/TextInfo.cs
@@ -1,12 +1,11 @@
 using System.Collections.Generic;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public class TextInfo
 {
-    public class TextInfo
-    {
-        public int BookNum { get; set; }
-        public bool HasSource { get; set; }
-        public List<Chapter> Chapters { get; set; } = new List<Chapter>();
-        public Dictionary<string, string> Permissions { get; set; } = new Dictionary<string, string>();
-    }
+    public int BookNum { get; set; }
+    public bool HasSource { get; set; }
+    public List<Chapter> Chapters { get; set; } = new List<Chapter>();
+    public Dictionary<string, string> Permissions { get; set; } = new Dictionary<string, string>();
 }

--- a/src/SIL.XForge.Scripture/Models/TextInfoPermission.cs
+++ b/src/SIL.XForge.Scripture/Models/TextInfoPermission.cs
@@ -1,9 +1,8 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public static class TextInfoPermission
 {
-    public static class TextInfoPermission
-    {
-        public const string Write = "write";
-        public const string Read = "read";
-        public const string None = "none";
-    }
+    public const string Write = "write";
+    public const string Read = "read";
+    public const string None = "none";
 }

--- a/src/SIL.XForge.Scripture/Models/TransceleratorQuestion.cs
+++ b/src/SIL.XForge.Scripture/Models/TransceleratorQuestion.cs
@@ -1,13 +1,12 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public class TransceleratorQuestion
 {
-    public class TransceleratorQuestion
-    {
-        public string Book { get; set; }
-        public string StartChapter { get; set; }
-        public string StartVerse { get; set; }
-        public string EndChapter { get; set; }
-        public string EndVerse { get; set; }
-        public string Text { get; set; }
-        public string Id { get; set; }
-    }
+    public string Book { get; set; }
+    public string StartChapter { get; set; }
+    public string StartVerse { get; set; }
+    public string EndChapter { get; set; }
+    public string EndVerse { get; set; }
+    public string Text { get; set; }
+    public string Id { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/TranslateConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/TranslateConfig.cs
@@ -1,11 +1,10 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public class TranslateConfig
 {
-    public class TranslateConfig
-    {
-        public bool TranslationSuggestionsEnabled { get; set; }
-        public TranslateSource Source { get; set; }
-        public bool ShareEnabled { get; set; } = false;
-        public string ShareLevel { get; set; } = TranslateShareLevel.Specific;
-        public int? DefaultNoteTagId { get; set; }
-    }
+    public bool TranslationSuggestionsEnabled { get; set; }
+    public TranslateSource Source { get; set; }
+    public bool ShareEnabled { get; set; } = false;
+    public string ShareLevel { get; set; } = TranslateShareLevel.Specific;
+    public int? DefaultNoteTagId { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/TranslateMetrics.cs
+++ b/src/SIL.XForge.Scripture/Models/TranslateMetrics.cs
@@ -1,39 +1,38 @@
 using System;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// Usage information for a short amount of user activity in the editor component.
+/// </summary>
+public class TranslateMetrics : IIdentifiable
 {
-    /// <summary>
-    /// Usage information for a short amount of user activity in the editor component.
-    /// </summary>
-    public class TranslateMetrics : IIdentifiable
-    {
-        public string Id { get; set; }
-        public string Type { get; set; }
-        public string SessionId { get; set; }
-        public string UserRef { get; set; }
-        public string ProjectRef { get; set; }
-        public int BookNum { get; set; }
-        public int ChapterNum { get; set; }
-        public DateTime Timestamp { get; set; }
+    public string Id { get; set; }
+    public string Type { get; set; }
+    public string SessionId { get; set; }
+    public string UserRef { get; set; }
+    public string ProjectRef { get; set; }
+    public int BookNum { get; set; }
+    public int ChapterNum { get; set; }
+    public DateTime Timestamp { get; set; }
 
-        // editing metrics
-        public string Segment { get; set; }
-        public int? SourceWordCount { get; set; }
-        public int? TargetWordCount { get; set; }
-        public int? KeyBackspaceCount { get; set; }
-        public int? KeyDeleteCount { get; set; }
-        public int? KeyCharacterCount { get; set; }
-        public int? ProductiveCharacterCount { get; set; }
-        public int? SuggestionAcceptedCount { get; set; }
-        public int? SuggestionTotalCount { get; set; }
+    // editing metrics
+    public string Segment { get; set; }
+    public int? SourceWordCount { get; set; }
+    public int? TargetWordCount { get; set; }
+    public int? KeyBackspaceCount { get; set; }
+    public int? KeyDeleteCount { get; set; }
+    public int? KeyCharacterCount { get; set; }
+    public int? ProductiveCharacterCount { get; set; }
+    public int? SuggestionAcceptedCount { get; set; }
+    public int? SuggestionTotalCount { get; set; }
 
-        /// <remarks>In milliseconds.</remarks>
-        public int? TimeEditActive { get; set; }
-        public string EditEndEvent { get; set; }
+    /// <remarks>In milliseconds.</remarks>
+    public int? TimeEditActive { get; set; }
+    public string EditEndEvent { get; set; }
 
-        // navigation metrics
-        public int? KeyNavigationCount { get; set; }
-        public int? MouseClickCount { get; set; }
-    }
+    // navigation metrics
+    public int? KeyNavigationCount { get; set; }
+    public int? MouseClickCount { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/TranslateShareLevel.cs
+++ b/src/SIL.XForge.Scripture/Models/TranslateShareLevel.cs
@@ -1,12 +1,11 @@
-namespace SIL.XForge.Scripture.Models
-{
-    /// <summary>Type of sharing for translate tool.</summary>
-    public static class TranslateShareLevel
-    {
-        /// <summary>Anyone can access the project via a share URL.</summary>
-        public const string Anyone = "anyone";
+namespace SIL.XForge.Scripture.Models;
 
-        /// <summary>Invited people can only access the project via an invitation URL unique to them.</summary>
-        public const string Specific = "specific";
-    }
+/// <summary>Type of sharing for translate tool.</summary>
+public static class TranslateShareLevel
+{
+    /// <summary>Anyone can access the project via a share URL.</summary>
+    public const string Anyone = "anyone";
+
+    /// <summary>Invited people can only access the project via an invitation URL unique to them.</summary>
+    public const string Specific = "specific";
 }

--- a/src/SIL.XForge.Scripture/Models/TranslateSource.cs
+++ b/src/SIL.XForge.Scripture/Models/TranslateSource.cs
@@ -1,33 +1,32 @@
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Scripture.Models
-{
-    public class TranslateSource
-    {
-        /// <summary>
-        /// Gets or sets the paratext identifier.
-        /// </summary>
-        /// <value>
-        /// The paratext identifier.
-        /// </value>
-        /// <remarks>
-        /// Only use this if <see cref="TranslateConfig.TranslationSuggestionsEnabled" /> is set to <c>true.</c>
-        /// </remarks>
-        public string ParatextId { get; set; }
+namespace SIL.XForge.Scripture.Models;
 
-        /// <summary>
-        /// Gets or sets the project reference.
-        /// </summary>
-        /// <value>
-        /// The project reference.
-        /// </value>
-        /// <remarks>
-        /// Only use this if <see cref="TranslateConfig.TranslationSuggestionsEnabled" /> is set to <c>true.</c>
-        /// </remarks>
-        public string ProjectRef { get; set; }
-        public string Name { get; set; }
-        public string ShortName { get; set; }
-        public WritingSystem WritingSystem { get; set; } = new WritingSystem();
-        public bool? IsRightToLeft { get; set; }
-    }
+public class TranslateSource
+{
+    /// <summary>
+    /// Gets or sets the paratext identifier.
+    /// </summary>
+    /// <value>
+    /// The paratext identifier.
+    /// </value>
+    /// <remarks>
+    /// Only use this if <see cref="TranslateConfig.TranslationSuggestionsEnabled" /> is set to <c>true.</c>
+    /// </remarks>
+    public string ParatextId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the project reference.
+    /// </summary>
+    /// <value>
+    /// The project reference.
+    /// </value>
+    /// <remarks>
+    /// Only use this if <see cref="TranslateConfig.TranslationSuggestionsEnabled" /> is set to <c>true.</c>
+    /// </remarks>
+    public string ProjectRef { get; set; }
+    public string Name { get; set; }
+    public string ShortName { get; set; }
+    public WritingSystem WritingSystem { get; set; } = new WritingSystem();
+    public bool? IsRightToLeft { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/VerseRefData.cs
+++ b/src/SIL.XForge.Scripture/Models/VerseRefData.cs
@@ -1,58 +1,54 @@
 using SIL.Scripture;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public class VerseRefData
 {
-    public class VerseRefData
+    private static void ParseVerseNumber(string vNum, out int number, out string segment)
     {
-        private static void ParseVerseNumber(string vNum, out int number, out string segment)
+        int j;
+        for (j = 0; j < vNum.Length && char.IsDigit(vNum[j]); ++j) { }
+
+        number = 0;
+        if (j > 0)
         {
-            int j;
-            for (j = 0; j < vNum.Length && char.IsDigit(vNum[j]); ++j) { }
-
-            number = 0;
-            if (j > 0)
-            {
-                string num = vNum.Substring(0, j);
-                int.TryParse(num, out number); // Can't fail, we have already validated digits
-            }
-
-            segment = vNum.Substring(j);
+            string num = vNum[..j];
+            int.TryParse(num, out number); // Can't fail, we have already validated digits
         }
 
-        public VerseRefData() { }
-
-        public VerseRefData(int bookNum, int chapterNum, int verseNum)
-        {
-            BookNum = bookNum;
-            ChapterNum = chapterNum;
-            VerseNum = verseNum;
-        }
-
-        public VerseRefData(int bookNum, int chapterNum, string verse)
-        {
-            BookNum = bookNum;
-            ChapterNum = chapterNum;
-            Verse = verse;
-            ParseVerseNumber(verse, out int verseNum, out _);
-            VerseNum = verseNum;
-        }
-
-        public int BookNum { get; set; }
-        public int ChapterNum { get; set; }
-        public int VerseNum { get; set; }
-        public string Verse { get; set; }
-
-        public VerseRef ToVerseRef()
-        {
-            var verseRef = new VerseRef(BookNum, ChapterNum, VerseNum, VerseRef.defaultVersification);
-            if (Verse != null)
-                verseRef.Verse = Verse;
-            return verseRef;
-        }
-
-        public override string ToString()
-        {
-            return ToVerseRef().ToString();
-        }
+        segment = vNum[j..];
     }
+
+    public VerseRefData() { }
+
+    public VerseRefData(int bookNum, int chapterNum, int verseNum)
+    {
+        BookNum = bookNum;
+        ChapterNum = chapterNum;
+        VerseNum = verseNum;
+    }
+
+    public VerseRefData(int bookNum, int chapterNum, string verse)
+    {
+        BookNum = bookNum;
+        ChapterNum = chapterNum;
+        Verse = verse;
+        ParseVerseNumber(verse, out int verseNum, out _);
+        VerseNum = verseNum;
+    }
+
+    public int BookNum { get; set; }
+    public int ChapterNum { get; set; }
+    public int VerseNum { get; set; }
+    public string Verse { get; set; }
+
+    public VerseRef ToVerseRef()
+    {
+        var verseRef = new VerseRef(BookNum, ChapterNum, VerseNum, VerseRef.defaultVersification);
+        if (Verse != null)
+            verseRef.Verse = Verse;
+        return verseRef;
+    }
+
+    public override string ToString() => ToVerseRef().ToString();
 }

--- a/src/SIL.XForge.Scripture/Pages/Index.cshtml.cs
+++ b/src/SIL.XForge.Scripture/Pages/Index.cshtml.cs
@@ -4,26 +4,25 @@ using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using SIL.XForge.Configuration;
 
-namespace SIL.XForge.Scripture.Pages
+namespace SIL.XForge.Scripture.Pages;
+
+public class IndexModel : PageModel
 {
-    public class IndexModel : PageModel
+    public IStringLocalizer Localizer { get; }
+
+    private readonly IOptions<AuthOptions> _authOptions;
+
+    public IndexModel(IOptions<AuthOptions> authOptions, IStringLocalizerFactory localizerFactory)
     {
-        public IStringLocalizer Localizer { get; }
+        _authOptions = authOptions;
+        Localizer = localizerFactory.Create("Pages.Index", Assembly.GetExecutingAssembly().GetName().Name);
+    }
 
-        private readonly IOptions<AuthOptions> _authOptions;
-
-        public IndexModel(IOptions<AuthOptions> authOptions, IStringLocalizerFactory localizerFactory)
-        {
-            _authOptions = authOptions;
-            Localizer = localizerFactory.Create("Pages.Index", Assembly.GetExecutingAssembly().GetName().Name);
-        }
-
-        public void OnGet()
-        {
-            ViewData["Domain"] = _authOptions.Value.Domain;
-            ViewData["ClientId"] = _authOptions.Value.FrontendClientId;
-            ViewData["Audience"] = _authOptions.Value.Audience;
-            ViewData["Scope"] = _authOptions.Value.Scope;
-        }
+    public void OnGet()
+    {
+        ViewData["Domain"] = _authOptions.Value.Domain;
+        ViewData["ClientId"] = _authOptions.Value.FrontendClientId;
+        ViewData["Audience"] = _authOptions.Value.Audience;
+        ViewData["Scope"] = _authOptions.Value.Scope;
     }
 }

--- a/src/SIL.XForge.Scripture/Pages/LearnMore.cshtml.cs
+++ b/src/SIL.XForge.Scripture/Pages/LearnMore.cshtml.cs
@@ -5,24 +5,23 @@ using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using SIL.XForge.Configuration;
 
-namespace SIL.XForge.Scripture.Pages
+namespace SIL.XForge.Scripture.Pages;
+
+public class LearnMoreModel : PageModel
 {
-    public class LearnMoreModel : PageModel
+    public IStringLocalizer Localizer { get; }
+
+    private readonly IOptions<SiteOptions> _siteOptions;
+
+    public LearnMoreModel(IOptions<SiteOptions> siteOptions, IStringLocalizerFactory localizerFactory)
     {
-        public IStringLocalizer Localizer { get; }
+        _siteOptions = siteOptions;
+        Localizer = localizerFactory.Create("Pages.LearnMore", Assembly.GetExecutingAssembly().GetName().Name);
+    }
 
-        private readonly IOptions<SiteOptions> _siteOptions;
-
-        public LearnMoreModel(IOptions<SiteOptions> siteOptions, IStringLocalizerFactory localizerFactory)
-        {
-            _siteOptions = siteOptions;
-            Localizer = localizerFactory.Create("Pages.LearnMore", Assembly.GetExecutingAssembly().GetName().Name);
-        }
-
-        public void OnGet()
-        {
-            ViewData["Scheme"] = _siteOptions.Value.Origin.Scheme;
-            ViewData["Origin"] = HttpUtility.UrlEncode(_siteOptions.Value.Origin.ToString());
-        }
+    public void OnGet()
+    {
+        ViewData["Scheme"] = _siteOptions.Value.Origin.Scheme;
+        ViewData["Origin"] = HttpUtility.UrlEncode(_siteOptions.Value.Origin.ToString());
     }
 }

--- a/src/SIL.XForge.Scripture/Pages/Status/Error.cs
+++ b/src/SIL.XForge.Scripture/Pages/Status/Error.cs
@@ -4,26 +4,25 @@ using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using SIL.XForge.Configuration;
 
-namespace SIL.XForge.Scripture.Pages
+namespace SIL.XForge.Scripture.Pages;
+
+public class ErrorModel : PageModel
 {
-    public class ErrorModel : PageModel
+    public IStringLocalizer Localizer { get; }
+    public int ErrorStatusCode { get; set; }
+    public bool RedirectToHome { get; set; }
+    private readonly IOptions<SiteOptions> _siteOptions;
+
+    public ErrorModel(IOptions<SiteOptions> siteOptions, IStringLocalizerFactory localizerFactory)
     {
-        public IStringLocalizer Localizer { get; }
-        public int ErrorStatusCode { get; set; }
-        public bool RedirectToHome { get; set; }
-        private readonly IOptions<SiteOptions> _siteOptions;
+        _siteOptions = siteOptions;
+        Localizer = localizerFactory.Create("Pages.NotFound", Assembly.GetExecutingAssembly().GetName().Name);
+    }
 
-        public ErrorModel(IOptions<SiteOptions> siteOptions, IStringLocalizerFactory localizerFactory)
-        {
-            _siteOptions = siteOptions;
-            Localizer = localizerFactory.Create("Pages.NotFound", Assembly.GetExecutingAssembly().GetName().Name);
-        }
-
-        public void OnGet(int code)
-        {
-            ViewData["Origin"] = _siteOptions.Value.Origin.ToString();
-            ErrorStatusCode = code;
-            RedirectToHome = ErrorStatusCode == 404;
-        }
+    public void OnGet(int code)
+    {
+        ViewData["Origin"] = _siteOptions.Value.Origin.ToString();
+        ErrorStatusCode = code;
+        RedirectToHome = ErrorStatusCode == 404;
     }
 }

--- a/src/SIL.XForge.Scripture/Program.cs
+++ b/src/SIL.XForge.Scripture/Program.cs
@@ -2,49 +2,45 @@ using System.IO;
 using System.Reflection;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 
-namespace SIL.XForge.Scripture
+namespace SIL.XForge.Scripture;
+
+public class Program
 {
-    public class Program
+    public static void Main(string[] args) => CreateWebHostBuilder(args).Build().Run();
+
+    public static IWebHostBuilder CreateWebHostBuilder(string[] args)
     {
-        public static void Main(string[] args)
-        {
-            CreateWebHostBuilder(args).Build().Run();
-        }
+        IWebHostBuilder builder = WebHost.CreateDefaultBuilder(args);
+        string environment = builder.GetSetting("environment");
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args)
-        {
-            IWebHostBuilder builder = WebHost.CreateDefaultBuilder(args);
-            string environment = builder.GetSetting("environment");
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("hosting.json", true, true)
+            .AddJsonFile($"hosting.{environment}.json", true, true)
+            .Build();
 
-            IConfigurationRoot configuration = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("hosting.json", true, true)
-                .AddJsonFile($"hosting.{environment}.json", true, true)
-                .Build();
-
-            return builder
-                .ConfigureAppConfiguration(
-                    (context, config) =>
+        return builder
+            .ConfigureAppConfiguration(
+                (context, config) =>
+                {
+                    IWebHostEnvironment env = context.HostingEnvironment;
+                    if (env.IsDevelopment() || env.IsEnvironment("Testing"))
+                        config.AddJsonFile("appsettings.user.json", true);
+                    else
+                        config.AddJsonFile("secrets.json", true, true);
+                    // Manually read in secrets for development-related environments that aren't specifically "Development".
+                    if (env.IsEnvironment("Testing"))
                     {
-                        IWebHostEnvironment env = context.HostingEnvironment;
-                        if (env.IsDevelopment() || env.IsEnvironment("Testing"))
-                            config.AddJsonFile("appsettings.user.json", true);
-                        else
-                            config.AddJsonFile("secrets.json", true, true);
-                        // Manually read in secrets for development-related environments that aren't specifically "Development".
-                        if (env.IsEnvironment("Testing"))
-                        {
-                            var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
-                            if (appAssembly != null)
-                                config.AddUserSecrets(appAssembly, true);
-                        }
+                        var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
+                        if (appAssembly != null)
+                            config.AddUserSecrets(appAssembly, true);
                     }
-                )
-                .UseConfiguration(configuration)
-                .UseStartup<Startup>();
-        }
+                }
+            )
+            .UseConfiguration(configuration)
+            .UseStartup<Startup>();
     }
 }

--- a/src/SIL.XForge.Scripture/Realtime/SFMemoryRealtimeService.cs
+++ b/src/SIL.XForge.Scripture/Realtime/SFMemoryRealtimeService.cs
@@ -3,14 +3,13 @@ using SIL.XForge.DataAccess;
 using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
 
-namespace SIL.XForge.Scripture.Realtime
+namespace SIL.XForge.Scripture.Realtime;
+
+public class SFMemoryRealtimeService : MemoryRealtimeService
 {
-    public class SFMemoryRealtimeService : MemoryRealtimeService
+    public override async Task DeleteProjectAsync(string projectId)
     {
-        public override async Task DeleteProjectAsync(string projectId)
-        {
-            await GetRepository<SFProject>().DeleteAsync(projectId);
-            await GetRepository<SFProjectUserConfig>().DeleteAllAsync(puc => puc.Id.StartsWith(projectId));
-        }
+        await GetRepository<SFProject>().DeleteAsync(projectId);
+        await GetRepository<SFProjectUserConfig>().DeleteAllAsync(puc => puc.Id.StartsWith(projectId));
     }
 }

--- a/src/SIL.XForge.Scripture/Realtime/SFRealtimeServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Realtime/SFRealtimeServiceCollectionExtensions.cs
@@ -4,45 +4,44 @@ using SIL.XForge.Configuration;
 using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
 
-namespace Microsoft.Extensions.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// This class is used to add the SF real-time server to the DI container.
+/// </summary>
+public static class SFRealtimeServiceCollectionExtensions
 {
-    /// <summary>
-    /// This class is used to add the SF real-time server to the DI container.
-    /// </summary>
-    public static class SFRealtimeServiceCollectionExtensions
+    public static IServiceCollection AddSFRealtimeServer(
+        this IServiceCollection services,
+        ILoggerFactory loggerFactory,
+        IConfiguration configuration,
+        string? nodeOptions = null,
+        bool migrationsDisabled = false
+    )
     {
-        public static IServiceCollection AddSFRealtimeServer(
-            this IServiceCollection services,
-            ILoggerFactory loggerFactory,
-            IConfiguration configuration,
-            string? nodeOptions = null,
-            bool migrationsDisabled = false
-        )
-        {
-            services.AddRealtimeServer(
-                loggerFactory,
-                configuration,
-                o =>
-                {
-                    o.AppModuleName = "scriptureforge";
-                    o.MigrationsDisabled = migrationsDisabled;
-                    o.ProjectDoc = new DocConfig("sf_projects", typeof(SFProject));
-                    o.ProjectDataDocs.AddRange(
-                        new[]
-                        {
-                            new DocConfig("sf_project_user_configs", typeof(SFProjectUserConfig)),
-                            new DocConfig("texts", typeof(TextData), OTType.RichText),
-                            new DocConfig("questions", typeof(Question)),
-                            new DocConfig("note_threads", typeof(NoteThread))
-                        }
-                    );
-                    o.UserDataDocs.AddRange(
-                        new[] { new DocConfig("sf_project_user_configs", typeof(SFProjectUserConfig)) }
-                    );
-                },
-                nodeOptions
-            );
-            return services;
-        }
+        services.AddRealtimeServer(
+            loggerFactory,
+            configuration,
+            o =>
+            {
+                o.AppModuleName = "scriptureforge";
+                o.MigrationsDisabled = migrationsDisabled;
+                o.ProjectDoc = new DocConfig("sf_projects", typeof(SFProject));
+                o.ProjectDataDocs.AddRange(
+                    new[]
+                    {
+                        new DocConfig("sf_project_user_configs", typeof(SFProjectUserConfig)),
+                        new DocConfig("texts", typeof(TextData), OTType.RichText),
+                        new DocConfig("questions", typeof(Question)),
+                        new DocConfig("note_threads", typeof(NoteThread))
+                    }
+                );
+                o.UserDataDocs.AddRange(
+                    new[] { new DocConfig("sf_project_user_configs", typeof(SFProjectUserConfig)) }
+                );
+            },
+            nodeOptions
+        );
+        return services;
     }
 }

--- a/src/SIL.XForge.Scripture/Services/DeltaUsxExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxExtensions.cs
@@ -1,57 +1,56 @@
 using Newtonsoft.Json.Linq;
 using SIL.XForge.Realtime.RichText;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public static class DeltaUsxExtensions
 {
-    public static class DeltaUsxExtensions
+    public static Delta InsertPara(this Delta delta, JObject paraAttributes, JObject attributes = null)
     {
-        public static Delta InsertPara(this Delta delta, JObject paraAttributes, JObject attributes = null)
-        {
-            attributes = (JObject)attributes?.DeepClone() ?? new JObject();
-            attributes.Add(new JProperty("para", paraAttributes));
-            return delta.Insert("\n", attributes);
-        }
+        attributes = (JObject)attributes?.DeepClone() ?? new JObject();
+        attributes.Add(new JProperty("para", paraAttributes));
+        return delta.Insert("\n", attributes);
+    }
 
-        public static Delta InsertText(this Delta delta, string text, string segRef = null, JObject attributes = null)
-        {
-            if (segRef != null)
-            {
-                attributes = (JObject)attributes?.DeepClone() ?? new JObject();
-                attributes.Add(new JProperty("segment", segRef));
-            }
-            return delta.Insert(text, attributes);
-        }
-
-        public static Delta InsertBlank(this Delta delta, string segRef)
-        {
-            var attrs = new JObject(new JProperty("segment", segRef));
-            return delta.Insert(new { blank = true }, attrs);
-        }
-
-        public static Delta InsertEmpty(this Delta delta, string segRef, JObject attributes = null)
+    public static Delta InsertText(this Delta delta, string text, string segRef = null, JObject attributes = null)
+    {
+        if (segRef != null)
         {
             attributes = (JObject)attributes?.DeepClone() ?? new JObject();
             attributes.Add(new JProperty("segment", segRef));
-            return delta.Insert(new { empty = true }, attributes);
         }
+        return delta.Insert(text, attributes);
+    }
 
-        public static Delta InsertEmbed(
-            this Delta delta,
-            string type,
-            JObject obj,
-            string segRef = null,
-            JObject attributes = null
-        )
+    public static Delta InsertBlank(this Delta delta, string segRef)
+    {
+        var attrs = new JObject(new JProperty("segment", segRef));
+        return delta.Insert(new { blank = true }, attrs);
+    }
+
+    public static Delta InsertEmpty(this Delta delta, string segRef, JObject attributes = null)
+    {
+        attributes = (JObject)attributes?.DeepClone() ?? new JObject();
+        attributes.Add(new JProperty("segment", segRef));
+        return delta.Insert(new { empty = true }, attributes);
+    }
+
+    public static Delta InsertEmbed(
+        this Delta delta,
+        string type,
+        JObject obj,
+        string segRef = null,
+        JObject attributes = null
+    )
+    {
+        var embed = new JObject(new JProperty(type, obj));
+
+        if (segRef != null)
         {
-            var embed = new JObject(new JProperty(type, obj));
-
-            if (segRef != null)
-            {
-                attributes = (JObject)attributes?.DeepClone() ?? new JObject();
-                attributes.Add(new JProperty("segment", segRef));
-            }
-
-            return delta.Insert(embed, attributes);
+            attributes = (JObject)attributes?.DeepClone() ?? new JObject();
+            attributes.Add(new JProperty("segment", segRef));
         }
+
+        return delta.Insert(embed, attributes);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
@@ -8,867 +8,805 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using SIL.XForge.Realtime.RichText;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public class DeltaUsxMapper : IDeltaUsxMapper
 {
-    public class DeltaUsxMapper : IDeltaUsxMapper
+    private static readonly XmlSchemaSet Schemas = CreateSchemaSet();
+
+    private static XmlSchemaSet CreateSchemaSet()
     {
-        private static readonly XmlSchemaSet Schemas = CreateSchemaSet();
+        var schemas = new XmlSchemaSet();
+        schemas.Add("", "usx-sf.xsd");
+        schemas.Compile();
+        return schemas;
+    }
 
-        private static XmlSchemaSet CreateSchemaSet()
+    private static readonly HashSet<string> ParagraphPoetryListStyles = new HashSet<string>
+    {
+        // Paragraphs
+        "p",
+        "m",
+        "po",
+        "pr",
+        "cls",
+        "pmo",
+        "pm",
+        "pmc",
+        "pmr",
+        "pi",
+        "mi",
+        "pc",
+        "ph",
+        "lit",
+        // Poetry
+        "q",
+        "qr",
+        "qc",
+        "qa",
+        "qm",
+        "qd",
+        // Lists
+        "lh",
+        "li",
+        "lf",
+        "lim"
+    };
+
+    private IGuidService GuidService;
+    private ILogger<DeltaUsxMapper> Logger;
+    private readonly IExceptionHandler ExceptionHandler;
+
+    private class ParseState
+    {
+        public string CurRef { get; set; }
+        public string CurChapter { get; set; }
+        public bool CurChapterIsValid { get; set; } = true;
+        public int TableIndex { get; set; }
+        public bool ImpliedParagraph { get; set; }
+        public int LastVerse { get; set; }
+        public string LastVerseStr
         {
-            var schemas = new XmlSchemaSet();
-            schemas.Add("", "usx-sf.xsd");
-            schemas.Compile();
-            return schemas;
-        }
-
-        private static readonly HashSet<string> ParagraphPoetryListStyles = new HashSet<string>
-        {
-            // Paragraphs
-            "p",
-            "m",
-            "po",
-            "pr",
-            "cls",
-            "pmo",
-            "pm",
-            "pmc",
-            "pmr",
-            "pi",
-            "mi",
-            "pc",
-            "ph",
-            "lit",
-            // Poetry
-            "q",
-            "qr",
-            "qc",
-            "qa",
-            "qm",
-            "qd",
-            // Lists
-            "lh",
-            "li",
-            "lf",
-            "lim"
-        };
-
-        private IGuidService GuidService;
-        private ILogger<DeltaUsxMapper> Logger;
-        private readonly IExceptionHandler ExceptionHandler;
-
-        private class ParseState
-        {
-            public string CurRef { get; set; }
-            public string CurChapter { get; set; }
-            public bool CurChapterIsValid { get; set; } = true;
-            public int TableIndex { get; set; }
-            public bool ImpliedParagraph { get; set; }
-            public int LastVerse { get; set; }
-            public string LastVerseStr
+            set
             {
-                set
+                if (value != null)
                 {
-                    if (value != null)
-                    {
-                        int lastVerse = LastVerse;
-                        int dashIndex = value.IndexOf('-');
-                        if (dashIndex != -1)
-                            value = value.Substring(dashIndex + 1);
-                        if (
-                            int.TryParse(
-                                value,
-                                System.Globalization.NumberStyles.Integer,
-                                CultureInfo.InvariantCulture,
-                                out int _lastVerse
-                            )
+                    int lastVerse = LastVerse;
+                    int dashIndex = value.IndexOf('-');
+                    if (dashIndex != -1)
+                        value = value[(dashIndex + 1)..];
+                    if (
+                        int.TryParse(
+                            value,
+                            System.Globalization.NumberStyles.Integer,
+                            CultureInfo.InvariantCulture,
+                            out int _lastVerse
                         )
-                            lastVerse = _lastVerse;
-                        LastVerse = lastVerse;
-                    }
+                    )
+                        lastVerse = _lastVerse;
+                    LastVerse = lastVerse;
                 }
             }
         }
+    }
 
-        public DeltaUsxMapper(
-            IGuidService guidService,
-            ILogger<DeltaUsxMapper> logger,
-            IExceptionHandler exceptionHandler
-        )
-        {
-            GuidService = guidService;
-            Logger = logger;
-            ExceptionHandler = exceptionHandler;
-        }
+    public DeltaUsxMapper(IGuidService guidService, ILogger<DeltaUsxMapper> logger, IExceptionHandler exceptionHandler)
+    {
+        GuidService = guidService;
+        Logger = logger;
+        ExceptionHandler = exceptionHandler;
+    }
 
-        public static bool CanParaContainVerseText(string style)
-        {
-            // an empty style indicates an improperly formatted paragraph which could contain verse text
-            if (style == string.Empty)
-                return true;
-            if (char.IsDigit(style[style.Length - 1]))
-                style = style.Substring(0, style.Length - 1);
-            // paragraph, poetry, and list styles are the only types of valid paras that can contain verse text
-            return ParagraphPoetryListStyles.Contains(style);
-        }
+    public static bool CanParaContainVerseText(string style)
+    {
+        // an empty style indicates an improperly formatted paragraph which could contain verse text
+        if (style == string.Empty)
+            return true;
+        if (char.IsDigit(style[^1]))
+            style = style[..^1];
+        // paragraph, poetry, and list styles are the only types of valid paras that can contain verse text
+        return ParagraphPoetryListStyles.Contains(style);
+    }
 
-        /// <summary>
-        /// Create list of ChapterDelta objects from USX.
-        ///
-        /// PT Data Access gives USX with chapters for each chapter that is
-        /// present in its project content. It will skip over chapters that are
-        /// not present in its project content. If there are no chapters present
-        /// in the project content, PT Data Access will return USX with no explicit
-        /// chapters.
-        ///
-        /// ToChapterDeltas will return a ChapterDelta for each chapter in
-        /// USX. If there are no explicit chapters in USX, return a single
-        /// ChapterDelta with a non-null Delta with an empty Ops list. This
-        /// is because every book has at least one chapter. The book
-        /// introduction is part of an implicit first chapter, even if there
-        /// are no explicit chapters.
-        /// </summary>
-        public IEnumerable<ChapterDelta> ToChapterDeltas(XDocument usxDoc)
-        {
-            var invalidNodes = new HashSet<XNode>();
-            usxDoc.Validate(
-                Schemas,
-                (o, e) =>
-                {
-                    XNode node;
-                    var attr = o as XAttribute;
-                    if (attr != null)
-                        node = attr.Parent;
-                    else
-                        node = (XNode)o;
-                    invalidNodes.Add(node);
-                },
-                true
-            );
-            var chapterDeltas = new List<ChapterDelta>();
-            var chapterDelta = new Delta();
-            var nextIds = new Dictionary<string, int>();
-            var state = new ParseState();
-            foreach (XNode node in usxDoc.Element("usx").Nodes())
+    /// <summary>
+    /// Create list of ChapterDelta objects from USX.
+    ///
+    /// PT Data Access gives USX with chapters for each chapter that is
+    /// present in its project content. It will skip over chapters that are
+    /// not present in its project content. If there are no chapters present
+    /// in the project content, PT Data Access will return USX with no explicit
+    /// chapters.
+    ///
+    /// ToChapterDeltas will return a ChapterDelta for each chapter in
+    /// USX. If there are no explicit chapters in USX, return a single
+    /// ChapterDelta with a non-null Delta with an empty Ops list. This
+    /// is because every book has at least one chapter. The book
+    /// introduction is part of an implicit first chapter, even if there
+    /// are no explicit chapters.
+    /// </summary>
+    public IEnumerable<ChapterDelta> ToChapterDeltas(XDocument usxDoc)
+    {
+        var invalidNodes = new HashSet<XNode>();
+        usxDoc.Validate(
+            Schemas,
+            (o, e) =>
             {
-                switch (node)
-                {
-                    case XElement elem:
-                        switch (elem.Name.LocalName)
-                        {
-                            case "book":
-                                break;
-
-                            case "para":
-                                if (state.ImpliedParagraph)
-                                {
-                                    chapterDelta.Insert('\n');
-                                    state.ImpliedParagraph = false;
-                                }
-                                var style = (string)elem.Attribute("style");
-                                bool canContainVerseText = CanParaContainVerseText(style);
-                                if (canContainVerseText)
-                                {
-                                    if (state.CurRef != null)
-                                    {
-                                        int slashIndex = state.CurRef.IndexOf("/", StringComparison.Ordinal);
-                                        if (slashIndex != -1)
-                                            state.CurRef = state.CurRef.Substring(0, slashIndex);
-                                        state.CurRef = GetParagraphRef(
-                                            nextIds,
-                                            state.CurRef,
-                                            state.CurRef + "/" + style
-                                        );
-                                    }
-                                    else
-                                    {
-                                        state.CurRef = GetParagraphRef(nextIds, style, style);
-                                    }
-                                }
-                                else if (style == "b")
-                                {
-                                    // insert the line break and continue processing with the current verse ref
-                                    ProcessChildNodes(elem, chapterDelta, invalidNodes);
-                                    InsertPara(elem, chapterDelta, invalidNodes, state);
-                                    break;
-                                }
-                                else
-                                {
-                                    state.CurRef = GetParagraphRef(nextIds, style, style);
-                                }
-                                ProcessChildNodes(elem, chapterDelta, invalidNodes, state);
-                                SegmentEnded(chapterDelta, state.CurRef);
-                                if (!canContainVerseText)
-                                    state.CurRef = null;
-                                InsertPara(elem, chapterDelta, invalidNodes, state);
-                                break;
-
-                            case "chapter":
-                                if (state.CurChapter != null)
-                                {
-                                    ChapterEnded(chapterDeltas, chapterDelta, state);
-                                    nextIds.Clear();
-                                    chapterDelta = new Delta();
-                                    state.CurChapterIsValid = true;
-                                }
-                                state.CurRef = null;
-                                state.LastVerse = 0;
-                                state.CurChapter = (string)elem.Attribute("number");
-                                chapterDelta.InsertEmbed(
-                                    "chapter",
-                                    GetAttributes(elem),
-                                    attributes: AddInvalidBlockAttribute(invalidNodes, elem)
-                                );
-                                break;
-
-                            // according to the USX schema, a verse can only occur within a paragraph, but Paratext 8.0
-                            // can still generate USX with verses at the top-level
-                            case "verse":
-                                ProcessChildNode(elem, chapterDelta, invalidNodes, state);
-                                state.ImpliedParagraph = true;
-                                break;
-
-                            default:
-                                ProcessChildNode(elem, chapterDelta, invalidNodes, state);
-                                break;
-                        }
-                        if (elem.GetSchemaInfo().Validity != XmlSchemaValidity.Valid)
-                            state.CurChapterIsValid = false;
-                        break;
-
-                    case XText text:
-                        chapterDelta.InsertText(
-                            text.Value,
-                            state.CurRef,
-                            AddInvalidInlineAttribute(invalidNodes, text)
-                        );
-                        state.ImpliedParagraph = true;
-                        break;
-                }
-            }
-            if (state.CurChapter == null)
-                state.CurChapter = "1";
-            ChapterEnded(chapterDeltas, chapterDelta, state);
-            return chapterDeltas;
-        }
-
-        private void ProcessChildNodes(XElement parentElem, Delta newDelta, HashSet<XNode> invalidNodes)
-        {
-            ProcessChildNodes(parentElem, newDelta, invalidNodes, new ParseState());
-        }
-
-        private void ProcessChildNodes(
-            XElement parentElem,
-            Delta newDelta,
-            HashSet<XNode> invalidNodes,
-            ParseState state,
-            JObject attributes = null
-        )
-        {
-            foreach (XNode node in parentElem.Nodes())
-                ProcessChildNode(node, newDelta, invalidNodes, state, attributes);
-        }
-
-        private void ProcessChildNode(
-            XNode node,
-            Delta newDelta,
-            HashSet<XNode> invalidNodes,
-            ParseState state,
-            JObject attributes = null
-        )
+                XNode node;
+                if (o is XAttribute attr)
+                    node = attr.Parent;
+                else
+                    node = (XNode)o;
+                invalidNodes.Add(node);
+            },
+            true
+        );
+        var chapterDeltas = new List<ChapterDelta>();
+        var chapterDelta = new Delta();
+        var nextIds = new Dictionary<string, int>();
+        var state = new ParseState();
+        foreach (XNode node in usxDoc.Element("usx").Nodes())
         {
             switch (node)
             {
                 case XElement elem:
                     switch (elem.Name.LocalName)
                     {
+                        case "book":
+                            break;
+
                         case "para":
-                            ProcessChildNodes(elem, newDelta, invalidNodes);
-                            InsertPara(elem, newDelta, invalidNodes, state);
-                            break;
-
-                        case "verse":
-                            state.LastVerseStr = (string)elem.Attribute("number");
-                            InsertVerse(elem, newDelta, invalidNodes, state);
-                            break;
-
-                        case "ref":
-                            var newRefAttributes = (JObject)attributes?.DeepClone() ?? new JObject();
-                            newRefAttributes.Add(new JProperty(elem.Name.LocalName, GetAttributes(elem)));
-                            newRefAttributes = AddInvalidInlineAttribute(invalidNodes, elem, newRefAttributes);
-                            newDelta.InsertText(elem.Value, state.CurRef, newRefAttributes);
-                            break;
-
-                        case "char":
-                            var newChildAttributes = (JObject)attributes?.DeepClone() ?? new JObject();
-                            JToken existingCharAttrs = newChildAttributes["char"];
-                            JObject newCharAttrs = GetAttributes(elem);
-                            if (!newCharAttrs.ContainsKey("cid"))
-                                newCharAttrs.Add("cid", GuidService.Generate());
-
-                            if (existingCharAttrs == null)
-                                newChildAttributes.Add(new JProperty(elem.Name.LocalName, newCharAttrs));
-                            else
+                            if (state.ImpliedParagraph)
                             {
-                                switch (existingCharAttrs)
+                                chapterDelta.Insert('\n');
+                                state.ImpliedParagraph = false;
+                            }
+                            var style = (string)elem.Attribute("style");
+                            bool canContainVerseText = CanParaContainVerseText(style);
+                            if (canContainVerseText)
+                            {
+                                if (state.CurRef != null)
                                 {
-                                    case JArray array:
-                                        array.Add(newCharAttrs);
-                                        break;
-                                    case JObject obj:
-                                        newChildAttributes[elem.Name.LocalName] = new JArray(obj, newCharAttrs);
-                                        break;
+                                    int slashIndex = state.CurRef.IndexOf("/", StringComparison.Ordinal);
+                                    if (slashIndex != -1)
+                                        state.CurRef = state.CurRef[..slashIndex];
+                                    state.CurRef = GetParagraphRef(nextIds, state.CurRef, state.CurRef + "/" + style);
+                                }
+                                else
+                                {
+                                    state.CurRef = GetParagraphRef(nextIds, style, style);
                                 }
                             }
-                            newChildAttributes = AddInvalidInlineAttribute(invalidNodes, elem, newChildAttributes);
-                            if (!elem.Nodes().Any() && elem.Value == "")
-                                newDelta.InsertEmpty(state.CurRef, newChildAttributes);
+                            else if (style == "b")
+                            {
+                                // insert the line break and continue processing with the current verse ref
+                                ProcessChildNodes(elem, chapterDelta, invalidNodes);
+                                InsertPara(elem, chapterDelta, invalidNodes, state);
+                                break;
+                            }
                             else
-                                ProcessChildNodes(elem, newDelta, invalidNodes, state, newChildAttributes);
+                            {
+                                state.CurRef = GetParagraphRef(nextIds, style, style);
+                            }
+                            ProcessChildNodes(elem, chapterDelta, invalidNodes, state);
+                            SegmentEnded(chapterDelta, state.CurRef);
+                            if (!canContainVerseText)
+                                state.CurRef = null;
+                            InsertPara(elem, chapterDelta, invalidNodes, state);
                             break;
 
-                        case "table":
-                            state.TableIndex++;
-                            JObject tableAttributes = GetAttributes(elem);
-                            tableAttributes.Add(new JProperty("id", $"table_{state.TableIndex}"));
-                            int rowIndex = 1;
-                            foreach (XElement row in elem.Elements("row"))
+                        case "chapter":
+                            if (state.CurChapter != null)
                             {
-                                var rowAttributes = new JObject(
-                                    new JProperty("id", $"row_{state.TableIndex}_{rowIndex}")
-                                );
-                                int cellIndex = 1;
-                                foreach (XElement cell in row.Elements())
-                                {
-                                    state.CurRef = $"cell_{state.TableIndex}_{rowIndex}_{cellIndex}";
-                                    ProcessChildNode(cell, newDelta, invalidNodes, state);
-                                    SegmentEnded(newDelta, state.CurRef);
-                                    var attrs = new JObject(
-                                        new JProperty("table", tableAttributes),
-                                        new JProperty("row", rowAttributes)
-                                    );
-                                    if (cell.Name.LocalName == "cell")
-                                        attrs.Add(new JProperty("cell", GetAttributes(cell)));
-                                    attrs = AddInvalidBlockAttribute(invalidNodes, elem, attrs);
-                                    attrs = AddInvalidBlockAttribute(invalidNodes, row, attrs);
-                                    attrs = AddInvalidBlockAttribute(invalidNodes, cell, attrs);
-                                    newDelta.Insert("\n", attrs);
-                                    cellIndex++;
-                                }
-                                rowIndex++;
+                                ChapterEnded(chapterDeltas, chapterDelta, state);
+                                nextIds.Clear();
+                                chapterDelta = new Delta();
+                                state.CurChapterIsValid = true;
                             }
                             state.CurRef = null;
+                            state.LastVerse = 0;
+                            state.CurChapter = (string)elem.Attribute("number");
+                            chapterDelta.InsertEmbed(
+                                "chapter",
+                                GetAttributes(elem),
+                                attributes: AddInvalidBlockAttribute(invalidNodes, elem)
+                            );
                             break;
 
-                        case "cell":
-                            ProcessChildNodes(elem, newDelta, invalidNodes, state);
+                        // according to the USX schema, a verse can only occur within a paragraph, but Paratext 8.0
+                        // can still generate USX with verses at the top-level
+                        case "verse":
+                            ProcessChildNode(elem, chapterDelta, invalidNodes, state);
+                            state.ImpliedParagraph = true;
                             break;
 
                         default:
-                            InsertEmbed(elem, newDelta, invalidNodes, state.CurRef, attributes);
+                            ProcessChildNode(elem, chapterDelta, invalidNodes, state);
                             break;
                     }
+                    if (elem.GetSchemaInfo().Validity != XmlSchemaValidity.Valid)
+                        state.CurChapterIsValid = false;
                     break;
 
                 case XText text:
-                    newDelta.InsertText(
-                        text.Value,
-                        state.CurRef,
-                        AddInvalidInlineAttribute(invalidNodes, text, attributes)
-                    );
+                    chapterDelta.InsertText(text.Value, state.CurRef, AddInvalidInlineAttribute(invalidNodes, text));
+                    state.ImpliedParagraph = true;
                     break;
             }
         }
+        state.CurChapter ??= "1";
+        ChapterEnded(chapterDeltas, chapterDelta, state);
+        return chapterDeltas;
+    }
 
-        private void ChapterEnded(List<ChapterDelta> chapterDeltas, Delta chapterDelta, ParseState state)
+    private void ProcessChildNodes(XElement parentElem, Delta newDelta, HashSet<XNode> invalidNodes) =>
+        ProcessChildNodes(parentElem, newDelta, invalidNodes, new ParseState());
+
+    private void ProcessChildNodes(
+        XElement parentElem,
+        Delta newDelta,
+        HashSet<XNode> invalidNodes,
+        ParseState state,
+        JObject attributes = null
+    )
+    {
+        foreach (XNode node in parentElem.Nodes())
+            ProcessChildNode(node, newDelta, invalidNodes, state, attributes);
+    }
+
+    private void ProcessChildNode(
+        XNode node,
+        Delta newDelta,
+        HashSet<XNode> invalidNodes,
+        ParseState state,
+        JObject attributes = null
+    )
+    {
+        switch (node)
         {
-            if (state.ImpliedParagraph)
-            {
-                SegmentEnded(chapterDelta, state.CurRef);
-                chapterDelta.Insert('\n');
-                state.ImpliedParagraph = false;
-            }
-            if (!int.TryParse(state.CurChapter, out int chapterNum))
-                return;
+            case XElement elem:
+                switch (elem.Name.LocalName)
+                {
+                    case "para":
+                        ProcessChildNodes(elem, newDelta, invalidNodes);
+                        InsertPara(elem, newDelta, invalidNodes, state);
+                        break;
 
-            chapterDeltas.Add(new ChapterDelta(chapterNum, state.LastVerse, state.CurChapterIsValid, chapterDelta));
+                    case "verse":
+                        state.LastVerseStr = (string)elem.Attribute("number");
+                        InsertVerse(elem, newDelta, invalidNodes, state);
+                        break;
+
+                    case "ref":
+                        var newRefAttributes = (JObject)attributes?.DeepClone() ?? new JObject();
+                        newRefAttributes.Add(new JProperty(elem.Name.LocalName, GetAttributes(elem)));
+                        newRefAttributes = AddInvalidInlineAttribute(invalidNodes, elem, newRefAttributes);
+                        newDelta.InsertText(elem.Value, state.CurRef, newRefAttributes);
+                        break;
+
+                    case "char":
+                        var newChildAttributes = (JObject)attributes?.DeepClone() ?? new JObject();
+                        JToken existingCharAttrs = newChildAttributes["char"];
+                        JObject newCharAttrs = GetAttributes(elem);
+                        if (!newCharAttrs.ContainsKey("cid"))
+                            newCharAttrs.Add("cid", GuidService.Generate());
+
+                        if (existingCharAttrs == null)
+                            newChildAttributes.Add(new JProperty(elem.Name.LocalName, newCharAttrs));
+                        else
+                        {
+                            switch (existingCharAttrs)
+                            {
+                                case JArray array:
+                                    array.Add(newCharAttrs);
+                                    break;
+                                case JObject obj:
+                                    newChildAttributes[elem.Name.LocalName] = new JArray(obj, newCharAttrs);
+                                    break;
+                            }
+                        }
+                        newChildAttributes = AddInvalidInlineAttribute(invalidNodes, elem, newChildAttributes);
+                        if (!elem.Nodes().Any() && elem.Value == "")
+                            newDelta.InsertEmpty(state.CurRef, newChildAttributes);
+                        else
+                            ProcessChildNodes(elem, newDelta, invalidNodes, state, newChildAttributes);
+                        break;
+
+                    case "table":
+                        state.TableIndex++;
+                        JObject tableAttributes = GetAttributes(elem);
+                        tableAttributes.Add(new JProperty("id", $"table_{state.TableIndex}"));
+                        int rowIndex = 1;
+                        foreach (XElement row in elem.Elements("row"))
+                        {
+                            var rowAttributes = new JObject(new JProperty("id", $"row_{state.TableIndex}_{rowIndex}"));
+                            int cellIndex = 1;
+                            foreach (XElement cell in row.Elements())
+                            {
+                                state.CurRef = $"cell_{state.TableIndex}_{rowIndex}_{cellIndex}";
+                                ProcessChildNode(cell, newDelta, invalidNodes, state);
+                                SegmentEnded(newDelta, state.CurRef);
+                                var attrs = new JObject(
+                                    new JProperty("table", tableAttributes),
+                                    new JProperty("row", rowAttributes)
+                                );
+                                if (cell.Name.LocalName == "cell")
+                                    attrs.Add(new JProperty("cell", GetAttributes(cell)));
+                                attrs = AddInvalidBlockAttribute(invalidNodes, elem, attrs);
+                                attrs = AddInvalidBlockAttribute(invalidNodes, row, attrs);
+                                attrs = AddInvalidBlockAttribute(invalidNodes, cell, attrs);
+                                newDelta.Insert("\n", attrs);
+                                cellIndex++;
+                            }
+                            rowIndex++;
+                        }
+                        state.CurRef = null;
+                        break;
+
+                    case "cell":
+                        ProcessChildNodes(elem, newDelta, invalidNodes, state);
+                        break;
+
+                    default:
+                        InsertEmbed(elem, newDelta, invalidNodes, state.CurRef, attributes);
+                        break;
+                }
+                break;
+
+            case XText text:
+                newDelta.InsertText(
+                    text.Value,
+                    state.CurRef,
+                    AddInvalidInlineAttribute(invalidNodes, text, attributes)
+                );
+                break;
         }
+    }
 
-        private static void InsertVerse(XElement elem, Delta newDelta, HashSet<XNode> invalidNodes, ParseState state)
+    private static void ChapterEnded(List<ChapterDelta> chapterDeltas, Delta chapterDelta, ParseState state)
+    {
+        if (state.ImpliedParagraph)
         {
-            var verse = (string)elem.Attribute("number");
-            SegmentEnded(newDelta, state.CurRef);
-            state.CurRef = $"verse_{state.CurChapter}_{verse}";
-            newDelta.InsertEmbed(
-                "verse",
-                GetAttributes(elem),
-                attributes: AddInvalidInlineAttribute(invalidNodes, elem)
-            );
+            SegmentEnded(chapterDelta, state.CurRef);
+            chapterDelta.Insert('\n');
+            state.ImpliedParagraph = false;
         }
+        if (!int.TryParse(state.CurChapter, out int chapterNum))
+            return;
 
-        private void InsertEmbed(
-            XElement elem,
-            Delta newDelta,
-            HashSet<XNode> invalidNodes,
-            string curRef,
-            JObject attributes
-        )
+        chapterDeltas.Add(new ChapterDelta(chapterNum, state.LastVerse, state.CurChapterIsValid, chapterDelta));
+    }
+
+    private static void InsertVerse(XElement elem, Delta newDelta, HashSet<XNode> invalidNodes, ParseState state)
+    {
+        var verse = (string)elem.Attribute("number");
+        SegmentEnded(newDelta, state.CurRef);
+        state.CurRef = $"verse_{state.CurChapter}_{verse}";
+        newDelta.InsertEmbed("verse", GetAttributes(elem), attributes: AddInvalidInlineAttribute(invalidNodes, elem));
+    }
+
+    private void InsertEmbed(
+        XElement elem,
+        Delta newDelta,
+        HashSet<XNode> invalidNodes,
+        string curRef,
+        JObject attributes
+    )
+    {
+        JObject obj = GetAttributes(elem);
+        var contents = new Delta();
+        ProcessChildNodes(elem, contents, invalidNodes);
+        if (contents.Ops.Count > 0)
         {
-            JObject obj = GetAttributes(elem);
-            var contents = new Delta();
-            ProcessChildNodes(elem, contents, invalidNodes);
-            if (contents.Ops.Count > 0)
-            {
-                obj.Add(new JProperty("contents", new JObject(new JProperty("ops", new JArray(contents.Ops)))));
-            }
-            newDelta.InsertEmbed(
-                elem.Name.LocalName,
-                obj,
-                curRef,
-                AddInvalidInlineAttribute(invalidNodes, elem, attributes)
-            );
+            obj.Add(new JProperty("contents", new JObject(new JProperty("ops", new JArray(contents.Ops)))));
         }
+        newDelta.InsertEmbed(
+            elem.Name.LocalName,
+            obj,
+            curRef,
+            AddInvalidInlineAttribute(invalidNodes, elem, attributes)
+        );
+    }
 
-        private static void InsertPara(XElement elem, Delta newDelta, HashSet<XNode> invalidNodes, ParseState state)
+    private static void InsertPara(XElement elem, Delta newDelta, HashSet<XNode> invalidNodes, ParseState state)
+    {
+        string style = elem.Attribute("style")?.Value;
+        bool canContainVerseText = CanParaContainVerseText(style);
+        if (!canContainVerseText && elem.Descendants("verse").Any())
         {
-            string style = elem.Attribute("style")?.Value;
-            bool canContainVerseText = CanParaContainVerseText(style);
-            if (!canContainVerseText && elem.Descendants("verse").Any())
-            {
-                invalidNodes.Add(elem);
-                state.CurChapterIsValid = false;
-            }
-            newDelta.InsertPara(GetAttributes(elem), AddInvalidBlockAttribute(invalidNodes, elem));
+            invalidNodes.Add(elem);
+            state.CurChapterIsValid = false;
         }
+        newDelta.InsertPara(GetAttributes(elem), AddInvalidBlockAttribute(invalidNodes, elem));
+    }
 
-        private static void SegmentEnded(Delta newDelta, string segRef)
+    private static void SegmentEnded(Delta newDelta, string segRef)
+    {
+        if (segRef == null)
+            return;
+
+        if (newDelta.Ops.Count == 0)
         {
-            if (segRef == null)
-                return;
-
-            if (newDelta.Ops.Count == 0)
+            newDelta.InsertBlank(segRef);
+        }
+        else
+        {
+            JToken lastOp = newDelta.Ops[^1];
+            string lastOpText = "";
+            if (lastOp[Delta.InsertType].Type == JTokenType.String)
+                lastOpText = (string)lastOp[Delta.InsertType];
+            var embed = lastOp[Delta.InsertType] as JObject;
+            var attrs = (JObject)lastOp[Delta.Attributes];
+            if (
+                (embed != null && (embed["verse"] != null || embed["chapter"] != null))
+                || (attrs != null && (attrs["para"] != null || attrs["table"] != null))
+                || lastOpText.EndsWith('\n')
+            )
             {
                 newDelta.InsertBlank(segRef);
             }
-            else
-            {
-                JToken lastOp = newDelta.Ops[newDelta.Ops.Count - 1];
-                string lastOpText = "";
-                if (lastOp[Delta.InsertType].Type == JTokenType.String)
-                    lastOpText = (string)lastOp[Delta.InsertType];
-                var embed = lastOp[Delta.InsertType] as JObject;
-                var attrs = (JObject)lastOp[Delta.Attributes];
-                if (
-                    (embed != null && (embed["verse"] != null || embed["chapter"] != null))
-                    || (attrs != null && (attrs["para"] != null || attrs["table"] != null))
-                    || lastOpText.EndsWith('\n')
-                )
-                {
-                    newDelta.InsertBlank(segRef);
-                }
-            }
         }
+    }
 
-        private static string GetParagraphRef(Dictionary<string, int> nextIds, string key, string prefix)
+    private static string GetParagraphRef(Dictionary<string, int> nextIds, string key, string prefix)
+    {
+        if (!nextIds.ContainsKey(key))
+            nextIds[key] = 1;
+        return prefix + "_" + nextIds[key]++;
+    }
+
+    private static JObject GetAttributes(XElement elem)
+    {
+        var obj = new JObject();
+        foreach (XAttribute attribute in elem.Attributes())
+            obj.Add(new JProperty(attribute.Name.LocalName, attribute.Value));
+        return obj;
+    }
+
+    private static JObject AddInvalidInlineAttribute(HashSet<XNode> invalidNodes, XNode node, JObject attributes = null)
+    {
+        if (invalidNodes.Contains(node))
         {
-            if (!nextIds.ContainsKey(key))
-                nextIds[key] = 1;
-            return prefix + "_" + nextIds[key]++;
+            attributes = (JObject)attributes?.DeepClone() ?? new JObject();
+            attributes["invalid-inline"] = true;
         }
+        return attributes;
+    }
 
-        private static JObject GetAttributes(XElement elem)
+    private static JObject AddInvalidBlockAttribute(HashSet<XNode> invalidNodes, XNode node, JObject attributes = null)
+    {
+        if (invalidNodes.Contains(node))
         {
-            var obj = new JObject();
-            foreach (XAttribute attribute in elem.Attributes())
-                obj.Add(new JProperty(attribute.Name.LocalName, attribute.Value));
-            return obj;
+            attributes = (JObject)attributes?.DeepClone() ?? new JObject();
+            attributes["invalid-block"] = true;
         }
+        return attributes;
+    }
 
-        private static JObject AddInvalidInlineAttribute(
-            HashSet<XNode> invalidNodes,
-            XNode node,
-            JObject attributes = null
-        )
+    /// <summary>
+    /// It may be that this method is taking USX, leaving alone all chapters not specified and valid in
+    /// chapterDeltas, and then replacing all chapters in the USX, that are in chapterDeltas and valid, with
+    /// the data from the chapterDeltas.
+    /// </summary>
+    public XDocument ToUsx(XDocument oldUsxDoc, IEnumerable<ChapterDelta> chapterDeltas)
+    {
+        var newUsxDoc = new XDocument(oldUsxDoc);
+        int curChapter = 1;
+        bool isFirstChapterFound = false;
+        ChapterDelta[] chapterDeltaArray = chapterDeltas.ToArray();
+        int i = 0;
+        try
         {
-            if (invalidNodes.Contains(node))
-            {
-                attributes = (JObject)attributes?.DeepClone() ?? new JObject();
-                attributes["invalid-inline"] = true;
-            }
-            return attributes;
-        }
-
-        private static JObject AddInvalidBlockAttribute(
-            HashSet<XNode> invalidNodes,
-            XNode node,
-            JObject attributes = null
-        )
-        {
-            if (invalidNodes.Contains(node))
-            {
-                attributes = (JObject)attributes?.DeepClone() ?? new JObject();
-                attributes["invalid-block"] = true;
-            }
-            return attributes;
-        }
-
-        /// <summary>
-        /// It may be that this method is taking USX, leaving alone all chapters not specified and valid in
-        /// chapterDeltas, and then replacing all chapters in the USX, that are in chapterDeltas and valid, with
-        /// the data from the chapterDeltas.
-        /// </summary>
-        public XDocument ToUsx(XDocument oldUsxDoc, IEnumerable<ChapterDelta> chapterDeltas)
-        {
-            var newUsxDoc = new XDocument(oldUsxDoc);
-            int curChapter = 1;
-            bool isFirstChapterFound = false;
-            ChapterDelta[] chapterDeltaArray = chapterDeltas.ToArray();
-            int i = 0;
-            try
-            {
-                if (chapterDeltaArray.Length == 1 && chapterDeltaArray[0]?.Delta.Ops.Count == 0)
-                {
-                    int usxChapterCount = oldUsxDoc.Root.Nodes().Count((XNode node) => IsElement(node, "chapter"));
-                    // The chapterDeltas indicate this may be a book in the SF DB with no chapters, but the USX
-                    // indicates that we should have known there were chapters and previously recorded them in
-                    // the SF DB.
-                    if (usxChapterCount > 0)
-                    {
-                        string errorExplanation =
-                            "ToUsx() received a chapterDeltas with no real chapters "
-                            + $"(just one 'chapter' with a Delta.Ops.Count of 0), and USX with {usxChapterCount} "
-                            + "chapters. This may indicate corrupt data in the SF DB. Handling by ignoring "
-                            + "chapterDeltas and returning the input USX.";
-                        Logger.LogWarning(errorExplanation);
-                        // Report to bugsnag, but don't throw.
-                        var report = new ArgumentException(errorExplanation);
-                        ExceptionHandler.ReportException(report);
-                    }
-                    return oldUsxDoc;
-                }
-                foreach (XNode curNode in newUsxDoc.Root.Nodes().ToArray())
-                {
-                    if (IsElement(curNode, "chapter"))
-                    {
-                        if (isFirstChapterFound)
-                        {
-                            ChapterDelta chapterDelta = chapterDeltaArray[i];
-                            if (chapterDelta.Number == curChapter)
-                            {
-                                if (chapterDelta.IsValid)
-                                    curNode.AddBeforeSelf(ProcessDelta(chapterDelta.Delta));
-                                i++;
-                            }
-                            var numberStr = (string)((XElement)curNode).Attribute("number");
-                            if (int.TryParse(numberStr, out int number))
-                                curChapter = number;
-                        }
-                        else
-                        {
-                            isFirstChapterFound = true;
-                        }
-                    }
-
-                    if (
-                        chapterDeltaArray[i].Number == curChapter
-                        && chapterDeltaArray[i].IsValid
-                        && !IsElement(curNode, "book")
-                    )
-                    {
-                        curNode.Remove();
-                    }
-                }
-
-                if (chapterDeltaArray[i].Number == curChapter && chapterDeltaArray[i].IsValid)
-                    newUsxDoc.Root.Add(ProcessDelta(chapterDeltaArray[i].Delta));
-                return newUsxDoc;
-            }
-            catch (Exception e)
+            if (chapterDeltaArray.Length == 1 && chapterDeltaArray[0]?.Delta.Ops.Count == 0)
             {
                 int usxChapterCount = oldUsxDoc.Root.Nodes().Count((XNode node) => IsElement(node, "chapter"));
-                string errorExplanation =
-                    $"ToUsx() had a problem ({e.Message}). SF DB corruption can cause "
-                    + "IndexOutOfRangeException to be thrown here. Rethrowing. Diagnostic info: "
-                    + $"chapterDeltas length is {chapterDeltaArray.Length}, "
-                    + $"The first chapterDeltas Delta.Ops.Count is "
-                    + $"{chapterDeltaArray.ElementAtOrDefault(0)?.Delta.Ops.Count}, "
-                    + $"The input oldUsxDoc has this many chapter elements: {usxChapterCount}, "
-                    + $"i is {i}, isFirstChapterFound is {isFirstChapterFound}.";
-                throw new Exception(errorExplanation, e);
+                // The chapterDeltas indicate this may be a book in the SF DB with no chapters, but the USX
+                // indicates that we should have known there were chapters and previously recorded them in
+                // the SF DB.
+                if (usxChapterCount > 0)
+                {
+                    string errorExplanation =
+                        "ToUsx() received a chapterDeltas with no real chapters "
+                        + $"(just one 'chapter' with a Delta.Ops.Count of 0), and USX with {usxChapterCount} "
+                        + "chapters. This may indicate corrupt data in the SF DB. Handling by ignoring "
+                        + "chapterDeltas and returning the input USX.";
+                    Logger.LogWarning(errorExplanation);
+                    // Report to bugsnag, but don't throw.
+                    var report = new ArgumentException(errorExplanation);
+                    ExceptionHandler.ReportException(report);
+                }
+                return oldUsxDoc;
             }
-        }
-
-        private IEnumerable<XNode> ProcessDelta(Delta delta)
-        {
-            var content = new List<XNode>();
-            var curCharAttrs = new List<JObject>();
-            var childNodes = new Stack<List<XNode>>();
-            childNodes.Push(new List<XNode>());
-            JObject curTableAttrs = null;
-            JObject curRowAttrs = null;
-            foreach (JToken op in delta.Ops)
+            foreach (XNode curNode in newUsxDoc.Root.Nodes().ToArray())
             {
-                if (op.OpType() != Delta.InsertType)
-                    throw new ArgumentException("The delta is not a document.", nameof(delta));
-
-                var attrs = (JObject)op[Delta.Attributes];
-                if (curCharAttrs.Count > 0 && (attrs == null || attrs["char"] == null))
+                if (IsElement(curNode, "chapter"))
                 {
-                    while (curCharAttrs.Count > 0)
-                        CharEnded(childNodes, curCharAttrs);
-                }
-                else if (attrs != null && attrs["char"] != null)
-                {
-                    List<JObject> charAttrs = GetCharAttributes(attrs["char"]);
-                    while (curCharAttrs.Count > 0 && !CharAttributesMatch(curCharAttrs, charAttrs))
-                        CharEnded(childNodes, curCharAttrs);
-                    curCharAttrs = charAttrs;
-                    while (childNodes.Count < curCharAttrs.Count + 1)
-                        childNodes.Push(new List<XNode>());
-                }
-
-                if (op[Delta.InsertType].Type == JTokenType.String)
-                {
-                    var text = (string)op[Delta.InsertType];
-                    if (curTableAttrs != null && (attrs == null || attrs["table"] == null) && text == "\n")
+                    if (isFirstChapterFound)
                     {
-                        List<XNode> nextBlockNodes = RowEnded(childNodes, ref curRowAttrs);
-                        TableEnded(content, childNodes, ref curTableAttrs);
-                        childNodes.Peek().AddRange(nextBlockNodes);
-                    }
-                    else if (attrs != null && attrs["table"] != null)
-                    {
-                        var cellAttrs = (JObject)attrs["cell"];
-                        XElement cellElem;
-                        if (cellAttrs != null)
-                            cellElem = CreateContainerElement("cell", cellAttrs, childNodes.Peek());
-                        else
-                            cellElem = (XElement)childNodes.Peek().Single();
-                        childNodes.Pop();
-
-                        var tableAttrs = (JObject)attrs["table"];
-                        var rowAttrs = (JObject)attrs["row"];
-                        if (curTableAttrs != null)
+                        ChapterDelta chapterDelta = chapterDeltaArray[i];
+                        if (chapterDelta.Number == curChapter)
                         {
-                            if ((string)rowAttrs["id"] != (string)curRowAttrs["id"])
-                                RowEnded(childNodes, ref curRowAttrs);
-                            if ((string)tableAttrs["id"] != (string)curTableAttrs["id"])
-                                TableEnded(content, childNodes, ref curTableAttrs);
+                            if (chapterDelta.IsValid)
+                                curNode.AddBeforeSelf(ProcessDelta(chapterDelta.Delta));
+                            i++;
                         }
-
-                        while (childNodes.Count < 2)
-                            childNodes.Push(new List<XNode>());
-                        childNodes.Peek().Add(cellElem);
-                        childNodes.Push(new List<XNode>());
-
-                        curTableAttrs = tableAttrs;
-                        curRowAttrs = rowAttrs;
-                    }
-
-                    if (attrs == null)
-                    {
-                        if (text.Length > 1 && text.EndsWith('\n'))
-                        {
-                            // Combine implied paragraphs since USX only supports one (not expecting more than one tho).
-                            string[] impliedParagraphs = text.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-                            childNodes.Peek().Add(new XText(string.Join("", impliedParagraphs)));
-                            text = "\n";
-                        }
-
-                        if (text == "\n")
-                        {
-                            content.AddRange(childNodes.Peek());
-                            childNodes.Peek().Clear();
-                            continue;
-                        }
-                        childNodes.Peek().Add(new XText(text));
+                        var numberStr = (string)((XElement)curNode).Attribute("number");
+                        if (int.TryParse(numberStr, out int number))
+                            curChapter = number;
                     }
                     else
                     {
-                        // text blots
-                        foreach (JProperty prop in attrs.Properties())
-                        {
-                            switch (prop.Name)
-                            {
-                                case "para":
-                                    // end of a para block
-                                    for (int j = 0; j < text.Length; j++)
-                                        content.Add(CreateContainerElement("para", prop.Value, childNodes.Peek()));
-                                    childNodes.Peek().Clear();
-                                    break;
-
-                                case "ref":
-                                    XElement refElem = CreateContainerElement("ref", prop.Value, text);
-                                    childNodes.Peek().Add(refElem);
-                                    break;
-
-                                case "char":
-                                    if (attrs["ref"] == null)
-                                        childNodes.Peek().Add(new XText(text));
-                                    break;
-
-                                case "segment":
-                                    if (attrs.Count == 1)
-                                        childNodes.Peek().Add(new XText(text));
-                                    break;
-                            }
-                        }
+                        isFirstChapterFound = true;
                     }
+                }
+
+                if (
+                    chapterDeltaArray[i].Number == curChapter
+                    && chapterDeltaArray[i].IsValid
+                    && !IsElement(curNode, "book")
+                )
+                {
+                    curNode.Remove();
+                }
+            }
+
+            if (chapterDeltaArray[i].Number == curChapter && chapterDeltaArray[i].IsValid)
+                newUsxDoc.Root.Add(ProcessDelta(chapterDeltaArray[i].Delta));
+            return newUsxDoc;
+        }
+        catch (Exception e)
+        {
+            int usxChapterCount = oldUsxDoc.Root.Nodes().Count((XNode node) => IsElement(node, "chapter"));
+            string errorExplanation =
+                $"ToUsx() had a problem ({e.Message}). SF DB corruption can cause "
+                + "IndexOutOfRangeException to be thrown here. Rethrowing. Diagnostic info: "
+                + $"chapterDeltas length is {chapterDeltaArray.Length}, "
+                + $"The first chapterDeltas Delta.Ops.Count is "
+                + $"{chapterDeltaArray.ElementAtOrDefault(0)?.Delta.Ops.Count}, "
+                + $"The input oldUsxDoc has this many chapter elements: {usxChapterCount}, "
+                + $"i is {i}, isFirstChapterFound is {isFirstChapterFound}.";
+            throw new Exception(errorExplanation, e);
+        }
+    }
+
+    private IEnumerable<XNode> ProcessDelta(Delta delta)
+    {
+        var content = new List<XNode>();
+        var curCharAttrs = new List<JObject>();
+        var childNodes = new Stack<List<XNode>>();
+        childNodes.Push(new List<XNode>());
+        JObject curTableAttrs = null;
+        JObject curRowAttrs = null;
+        foreach (JToken op in delta.Ops)
+        {
+            if (op.OpType() != Delta.InsertType)
+                throw new ArgumentException("The delta is not a document.", nameof(delta));
+
+            var attrs = (JObject)op[Delta.Attributes];
+            if (curCharAttrs.Count > 0 && (attrs == null || attrs["char"] == null))
+            {
+                while (curCharAttrs.Count > 0)
+                    CharEnded(childNodes, curCharAttrs);
+            }
+            else if (attrs != null && attrs["char"] != null)
+            {
+                List<JObject> charAttrs = GetCharAttributes(attrs["char"]);
+                while (curCharAttrs.Count > 0 && !CharAttributesMatch(curCharAttrs, charAttrs))
+                    CharEnded(childNodes, curCharAttrs);
+                curCharAttrs = charAttrs;
+                while (childNodes.Count < curCharAttrs.Count + 1)
+                    childNodes.Push(new List<XNode>());
+            }
+
+            if (op[Delta.InsertType].Type == JTokenType.String)
+            {
+                var text = (string)op[Delta.InsertType];
+                if (curTableAttrs != null && (attrs == null || attrs["table"] == null) && text == "\n")
+                {
+                    List<XNode> nextBlockNodes = RowEnded(childNodes, ref curRowAttrs);
+                    TableEnded(content, childNodes, ref curTableAttrs);
+                    childNodes.Peek().AddRange(nextBlockNodes);
+                }
+                else if (attrs != null && attrs["table"] != null)
+                {
+                    var cellAttrs = (JObject)attrs["cell"];
+                    XElement cellElem;
+                    if (cellAttrs != null)
+                        cellElem = CreateContainerElement("cell", cellAttrs, childNodes.Peek());
+                    else
+                        cellElem = (XElement)childNodes.Peek().Single();
+                    childNodes.Pop();
+
+                    var tableAttrs = (JObject)attrs["table"];
+                    var rowAttrs = (JObject)attrs["row"];
+                    if (curTableAttrs != null)
+                    {
+                        if ((string)rowAttrs["id"] != (string)curRowAttrs["id"])
+                            RowEnded(childNodes, ref curRowAttrs);
+                        if ((string)tableAttrs["id"] != (string)curTableAttrs["id"])
+                            TableEnded(content, childNodes, ref curTableAttrs);
+                    }
+
+                    while (childNodes.Count < 2)
+                        childNodes.Push(new List<XNode>());
+                    childNodes.Peek().Add(cellElem);
+                    childNodes.Push(new List<XNode>());
+
+                    curTableAttrs = tableAttrs;
+                    curRowAttrs = rowAttrs;
+                }
+
+                if (attrs == null)
+                {
+                    if (text.Length > 1 && text.EndsWith('\n'))
+                    {
+                        // Combine implied paragraphs since USX only supports one (not expecting more than one tho).
+                        string[] impliedParagraphs = text.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+                        childNodes.Peek().Add(new XText(string.Join("", impliedParagraphs)));
+                        text = "\n";
+                    }
+
+                    if (text == "\n")
+                    {
+                        content.AddRange(childNodes.Peek());
+                        childNodes.Peek().Clear();
+                        continue;
+                    }
+                    childNodes.Peek().Add(new XText(text));
                 }
                 else
                 {
-                    // embeds
-                    var obj = (JObject)op[Delta.InsertType];
-                    foreach (JProperty prop in obj.Properties())
+                    // text blots
+                    foreach (JProperty prop in attrs.Properties())
                     {
                         switch (prop.Name)
                         {
-                            case "chapter":
-                                XElement chapterElem = new XElement("chapter");
-                                AddAttributes(chapterElem, prop.Value);
-                                content.Add(chapterElem);
+                            case "para":
+                                // end of a para block
+                                for (int j = 0; j < text.Length; j++)
+                                    content.Add(CreateContainerElement("para", prop.Value, childNodes.Peek()));
+                                childNodes.Peek().Clear();
                                 break;
 
-                            case "blank":
-                            case "empty":
-                                // ignore blank and empty embeds
+                            case "ref":
+                                XElement refElem = CreateContainerElement("ref", prop.Value, text);
+                                childNodes.Peek().Add(refElem);
                                 break;
 
-                            default:
-                                XElement embedElem = new XElement(prop.Name);
-                                AddAttributes(embedElem, prop.Value);
-                                if (prop.Value["contents"] != null)
-                                {
-                                    var contentsDelta = new Delta(prop.Value["contents"]["ops"].Children());
-                                    embedElem.Add(ProcessDelta(contentsDelta));
-                                }
-                                childNodes.Peek().Add(embedElem);
+                            case "char":
+                                if (attrs["ref"] == null)
+                                    childNodes.Peek().Add(new XText(text));
+                                break;
+
+                            case "segment":
+                                if (attrs.Count == 1)
+                                    childNodes.Peek().Add(new XText(text));
                                 break;
                         }
                     }
                 }
             }
-            while (curCharAttrs.Count > 0)
-                CharEnded(childNodes, curCharAttrs);
-            if (curTableAttrs != null)
+            else
             {
-                RowEnded(childNodes, ref curRowAttrs);
-                TableEnded(content, childNodes, ref curTableAttrs);
-            }
-            content.AddRange(childNodes.Pop());
-            return content;
-        }
+                // embeds
+                var obj = (JObject)op[Delta.InsertType];
+                foreach (JProperty prop in obj.Properties())
+                {
+                    switch (prop.Name)
+                    {
+                        case "chapter":
+                            XElement chapterElem = new XElement("chapter");
+                            AddAttributes(chapterElem, prop.Value);
+                            content.Add(chapterElem);
+                            break;
 
-        private static bool CharAttributesMatch(List<JObject> curCharAttrs, List<JObject> charAttrs)
+                        case "blank":
+                        case "empty":
+                            // ignore blank and empty embeds
+                            break;
+
+                        default:
+                            XElement embedElem = new XElement(prop.Name);
+                            AddAttributes(embedElem, prop.Value);
+                            if (prop.Value["contents"] != null)
+                            {
+                                var contentsDelta = new Delta(prop.Value["contents"]["ops"].Children());
+                                embedElem.Add(ProcessDelta(contentsDelta));
+                            }
+                            childNodes.Peek().Add(embedElem);
+                            break;
+                    }
+                }
+            }
+        }
+        while (curCharAttrs.Count > 0)
+            CharEnded(childNodes, curCharAttrs);
+        if (curTableAttrs != null)
         {
-            if (curCharAttrs.Count > charAttrs.Count)
+            RowEnded(childNodes, ref curRowAttrs);
+            TableEnded(content, childNodes, ref curTableAttrs);
+        }
+        content.AddRange(childNodes.Pop());
+        return content;
+    }
+
+    private static bool CharAttributesMatch(List<JObject> curCharAttrs, List<JObject> charAttrs)
+    {
+        if (curCharAttrs.Count > charAttrs.Count)
+            return false;
+
+        for (int i = 0; i < curCharAttrs.Count; i++)
+        {
+            if (!JToken.DeepEquals(curCharAttrs[i], charAttrs[i]))
                 return false;
-
-            for (int i = 0; i < curCharAttrs.Count; i++)
-            {
-                if (!JToken.DeepEquals(curCharAttrs[i], charAttrs[i]))
-                    return false;
-            }
-            return true;
         }
+        return true;
+    }
 
-        private static List<JObject> GetCharAttributes(JToken charAttrs)
+    private static List<JObject> GetCharAttributes(JToken charAttrs)
+    {
+        return charAttrs switch
         {
-            switch (charAttrs)
-            {
-                case JArray array:
-                    return new List<JObject>(array.Children<JObject>());
+            JArray array => new List<JObject>(array.Children<JObject>()),
+            JObject obj => new List<JObject> { obj },
+            _ => new List<JObject>(),
+        };
+    }
 
-                case JObject obj:
-                    return new List<JObject> { obj };
-            }
-            return new List<JObject>();
-        }
+    private static XElement CreateContainerElement(string name, JToken attributes, object content = null)
+    {
+        var elem = new XElement(name);
+        AddAttributes(elem, attributes);
+        if (content != null)
+            elem.Add(content);
+        return elem;
+    }
 
-        private static JObject RemoveCharAttributes(ref JToken curChar)
+    private static void AddAttributes(XElement elem, JToken attributes)
+    {
+        var attrsObj = (JObject)attributes;
+        foreach (JProperty prop in attrsObj.Properties())
         {
-            JObject charAttrs = null;
-            switch (curChar)
-            {
-                case JArray array:
-                    charAttrs = (JObject)array.Last;
-                    array.Remove(charAttrs);
-                    if (array.Count == 1)
-                        curChar = array.First;
-                    break;
-
-                case JObject obj:
-                    charAttrs = obj;
-                    curChar = null;
-                    break;
-            }
-            return charAttrs;
-        }
-
-        private static XElement CreateContainerElement(string name, JToken attributes, object content = null)
-        {
-            var elem = new XElement(name);
-            AddAttributes(elem, attributes);
-            if (content != null)
-                elem.Add(content);
-            return elem;
-        }
-
-        private static void AddAttributes(XElement elem, JToken attributes)
-        {
-            var attrsObj = (JObject)attributes;
-            foreach (JProperty prop in attrsObj.Properties())
-            {
-                if (prop.Value.Type != JTokenType.String || prop.Name == "id" || prop.Name == "invalid")
-                    continue;
-                elem.Add(new XAttribute(prop.Name, (string)prop.Value));
-            }
-        }
-
-        private static void CharEnded(Stack<List<XNode>> childNodes, List<JObject> curCharAttrs)
-        {
-            JObject charAttrs = curCharAttrs[curCharAttrs.Count - 1];
-            curCharAttrs.RemoveAt(curCharAttrs.Count - 1);
-            if (charAttrs.ContainsKey("cid"))
-            {
-                charAttrs = (JObject)charAttrs.DeepClone();
-                charAttrs.Property("cid").Remove();
-            }
-            XElement charElem = CreateContainerElement("char", charAttrs, childNodes.Peek());
-            childNodes.Pop();
-            childNodes.Peek().Add(charElem);
-        }
-
-        private static List<XNode> RowEnded(Stack<List<XNode>> childNodes, ref JObject curRowAttrs)
-        {
-            if (childNodes.Count > 3)
-                throw new InvalidOperationException("A table is not valid in the current location.");
-
-            List<XNode> nextBlockNodes = null;
-            if (childNodes.Count == 3)
-                nextBlockNodes = childNodes.Pop();
-            XElement rowElem = CreateContainerElement(
-                "row",
-                new JObject(new JProperty("style", "tr")),
-                childNodes.Peek()
-            );
-            childNodes.Pop();
-            childNodes.Peek().Add(rowElem);
-            curRowAttrs = null;
-            return nextBlockNodes;
-        }
-
-        private static void TableEnded(List<XNode> content, Stack<List<XNode>> childNodes, ref JObject curTableAttrs)
-        {
-            content.Add(CreateContainerElement("table", curTableAttrs, childNodes.Peek()));
-            childNodes.Peek().Clear();
-            curTableAttrs = null;
-        }
-
-        private static bool IsElement(XNode node, string name)
-        {
-            var elem = node as XElement;
-            return elem != null && elem.Name.LocalName == name;
+            if (prop.Value.Type != JTokenType.String || prop.Name == "id" || prop.Name == "invalid")
+                continue;
+            elem.Add(new XAttribute(prop.Name, (string)prop.Value));
         }
     }
+
+    private static void CharEnded(Stack<List<XNode>> childNodes, List<JObject> curCharAttrs)
+    {
+        JObject charAttrs = curCharAttrs[^1];
+        curCharAttrs.RemoveAt(curCharAttrs.Count - 1);
+        if (charAttrs.ContainsKey("cid"))
+        {
+            charAttrs = (JObject)charAttrs.DeepClone();
+            charAttrs.Property("cid").Remove();
+        }
+        XElement charElem = CreateContainerElement("char", charAttrs, childNodes.Peek());
+        childNodes.Pop();
+        childNodes.Peek().Add(charElem);
+    }
+
+    private static List<XNode> RowEnded(Stack<List<XNode>> childNodes, ref JObject curRowAttrs)
+    {
+        if (childNodes.Count > 3)
+            throw new InvalidOperationException("A table is not valid in the current location.");
+
+        List<XNode> nextBlockNodes = null;
+        if (childNodes.Count == 3)
+            nextBlockNodes = childNodes.Pop();
+        XElement rowElem = CreateContainerElement("row", new JObject(new JProperty("style", "tr")), childNodes.Peek());
+        childNodes.Pop();
+        childNodes.Peek().Add(rowElem);
+        curRowAttrs = null;
+        return nextBlockNodes;
+    }
+
+    private static void TableEnded(List<XNode> content, Stack<List<XNode>> childNodes, ref JObject curTableAttrs)
+    {
+        content.Add(CreateContainerElement("table", curTableAttrs, childNodes.Peek()));
+        childNodes.Peek().Clear();
+        curTableAttrs = null;
+    }
+
+    private static bool IsElement(XNode node, string name) => node is XElement elem && elem.Name.LocalName == name;
 }

--- a/src/SIL.XForge.Scripture/Services/DictionaryComparer.cs
+++ b/src/SIL.XForge.Scripture/Services/DictionaryComparer.cs
@@ -2,30 +2,29 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public class DictionaryComparer<TKey, TValue> : IEqualityComparer<Dictionary<TKey, TValue>>
 {
-    public class DictionaryComparer<TKey, TValue> : IEqualityComparer<Dictionary<TKey, TValue>>
+    public bool Equals(Dictionary<TKey, TValue> x, Dictionary<TKey, TValue> y)
     {
-        public bool Equals(Dictionary<TKey, TValue> x, Dictionary<TKey, TValue> y)
-        {
-            return (x ?? new Dictionary<TKey, TValue>())
-                .OrderBy(p => p.Key)
-                .SequenceEqual((y ?? new Dictionary<TKey, TValue>()).OrderBy(p => p.Key));
-        }
+        return (x ?? new Dictionary<TKey, TValue>())
+            .OrderBy(p => p.Key)
+            .SequenceEqual((y ?? new Dictionary<TKey, TValue>()).OrderBy(p => p.Key));
+    }
 
-        public int GetHashCode(Dictionary<TKey, TValue> obj)
+    public int GetHashCode(Dictionary<TKey, TValue> obj)
+    {
+        int hash = 0;
+        if (obj != null)
         {
-            int hash = 0;
-            if (obj != null)
+            foreach (KeyValuePair<TKey, TValue> element in obj)
             {
-                foreach (KeyValuePair<TKey, TValue> element in obj)
-                {
-                    hash ^= element.Key.GetHashCode();
-                    hash ^= element.Value.GetHashCode();
-                }
+                hash ^= element.Key.GetHashCode();
+                hash ^= element.Value.GetHashCode();
             }
-
-            return hash;
         }
+
+        return hash;
     }
 }

--- a/src/SIL.XForge.Scripture/Services/DotNetCoreAlert.cs
+++ b/src/SIL.XForge.Scripture/Services/DotNetCoreAlert.cs
@@ -2,35 +2,29 @@ using System.ComponentModel;
 using Microsoft.Extensions.Logging;
 using PtxUtils;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary> Simple alert implementation for Paratext Data to use when running in dotnet core. </summary>
+class DotNetCoreAlert : PtxUtils.Alert
 {
-    /// <summary> Simple alert implementation for Paratext Data to use when running in dotnet core. </summary>
-    class DotNetCoreAlert : PtxUtils.Alert
+    private readonly ILogger _logger;
+
+    public DotNetCoreAlert(ILogger logger) => _logger = logger;
+
+    protected override AlertResult ShowInternal(
+        IComponent owner,
+        string text,
+        string caption,
+        AlertButtons alertButtons,
+        AlertLevel alertLevel,
+        AlertDefaultButton defaultButton,
+        bool showInTaskbar
+    )
     {
-        private readonly ILogger _logger;
-
-        public DotNetCoreAlert(ILogger logger)
-        {
-            _logger = logger;
-        }
-
-        protected override AlertResult ShowInternal(
-            IComponent owner,
-            string text,
-            string caption,
-            AlertButtons alertButtons,
-            AlertLevel alertLevel,
-            AlertDefaultButton defaultButton,
-            bool showInTaskbar
-        )
-        {
-            _logger.LogInformation($"Alert: {text} : {caption}");
-            return AlertResult.Positive;
-        }
-
-        protected override void ShowLaterInternal(string text, string caption, AlertLevel alertLevel)
-        {
-            _logger.LogInformation($"Async Alert: {text} : {caption}");
-        }
+        _logger.LogInformation($"Alert: {text} : {caption}");
+        return AlertResult.Positive;
     }
+
+    protected override void ShowLaterInternal(string text, string caption, AlertLevel alertLevel) =>
+        _logger.LogInformation($"Async Alert: {text} : {caption}");
 }

--- a/src/SIL.XForge.Scripture/Services/DotNetCoreRegistry.cs
+++ b/src/SIL.XForge.Scripture/Services/DotNetCoreRegistry.cs
@@ -1,73 +1,40 @@
 using Microsoft.Win32;
 using PtxUtils;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary> Dummy registry implementation for Paratext Data to use when running in dotnet core. </summary>
+class DotNetCoreRegistry : RegistryU
 {
-    /// <summary> Dummy registry implementation for Paratext Data to use when running in dotnet core. </summary>
-    class DotNetCoreRegistry : RegistryU
+    protected override bool ValueExistsInternal(string registryPath) => false;
+
+    protected override bool KeyExistsInternal(string registryPath) => false;
+
+    protected override bool KeyExistsInternal(RegistryKey key, string subKey) => false;
+
+    protected override bool RegEntryExistsInternal(RegistryKey key, string subKey, string regEntry, out object value)
     {
-        protected override bool ValueExistsInternal(string registryPath)
-        {
-            return false;
-        }
-
-        protected override bool KeyExistsInternal(string registryPath)
-        {
-            return false;
-        }
-
-        protected override bool KeyExistsInternal(RegistryKey key, string subKey)
-        {
-            return false;
-        }
-
-        protected override bool RegEntryExistsInternal(
-            RegistryKey key,
-            string subKey,
-            string regEntry,
-            out object value
-        )
-        {
-            value = null;
-            return false;
-        }
-
-        protected override object GetValInternal(string baseKey, string subKey, string key)
-        {
-            return null;
-        }
-
-        protected override object GetValInternal(string registryPath)
-        {
-            return null;
-        }
-
-        protected override object GetValIfExistsInternal(string registryPath)
-        {
-            return null;
-        }
-
-        protected override string GetStringInternal(string basekey, string path, string key)
-        {
-            return null;
-        }
-
-        protected override string GetStringInternal(string registryPath)
-        {
-            return null;
-        }
-
-        protected override void DelKeyInternal(string baseKey, string subKey) { }
-
-        protected override void DelKeyInternal(string registryPath) { }
-
-        protected override void SetValInternal(string baseKey, string subKey, string key, object theValue) { }
-
-        protected override void SetValInternal(string registryPath, object theValue) { }
-
-        protected override bool HasWritePermissionInternal(string registryPath)
-        {
-            return false;
-        }
+        value = null;
+        return false;
     }
+
+    protected override object GetValInternal(string baseKey, string subKey, string key) => null;
+
+    protected override object GetValInternal(string registryPath) => null;
+
+    protected override object GetValIfExistsInternal(string registryPath) => null;
+
+    protected override string GetStringInternal(string basekey, string path, string key) => null;
+
+    protected override string GetStringInternal(string registryPath) => null;
+
+    protected override void DelKeyInternal(string baseKey, string subKey) { }
+
+    protected override void DelKeyInternal(string registryPath) { }
+
+    protected override void SetValInternal(string baseKey, string subKey, string key, object theValue) { }
+
+    protected override void SetValInternal(string registryPath, object theValue) { }
+
+    protected override bool HasWritePermissionInternal(string registryPath) => false;
 }

--- a/src/SIL.XForge.Scripture/Services/GuidService.cs
+++ b/src/SIL.XForge.Scripture/Services/GuidService.cs
@@ -1,21 +1,14 @@
 using System;
 using MongoDB.Bson;
 
-namespace SIL.XForge.Scripture.Services
-{
-    /// <summary>
-    /// This class is injected to allow testing.
-    /// </summary>
-    public class GuidService : IGuidService
-    {
-        public string Generate()
-        {
-            return Guid.NewGuid().ToString();
-        }
+namespace SIL.XForge.Scripture.Services;
 
-        public string NewObjectId()
-        {
-            return ObjectId.GenerateNewId().ToString();
-        }
-    }
+/// <summary>
+/// This class is injected to allow testing.
+/// </summary>
+public class GuidService : IGuidService
+{
+    public string Generate() => Guid.NewGuid().ToString();
+
+    public string NewObjectId() => ObjectId.GenerateNewId().ToString();
 }

--- a/src/SIL.XForge.Scripture/Services/HgWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/HgWrapper.cs
@@ -4,121 +4,106 @@ using System.IO;
 using System.Linq;
 using Paratext.Data.Repository;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary> A wrapper for the <see cref="Hg" /> class for calling Mercurial. </summary>
+public class HgWrapper : IHgWrapper
 {
-    /// <summary> A wrapper for the <see cref="Hg" /> class for calling Mercurial. </summary>
-    public class HgWrapper : IHgWrapper
+    public static string RunCommand(string repository, string cmd)
     {
-        public static string RunCommand(string repository, string cmd)
-        {
-            if (Hg.Default == null)
-                throw new InvalidOperationException("Hg default has not been set.");
-            return Hg.Default.RunCommand(repository, cmd).StdOut;
-        }
-
-        public static byte[] Bundle(string repository, params string[] heads)
-        {
-            if (Hg.Default == null)
-                throw new InvalidOperationException("Hg default has not been set.");
-            return Hg.Default.Bundle(repository, heads);
-        }
-
-        public static string[] Pull(string repository, byte[] bundle)
-        {
-            if (Hg.Default == null)
-                throw new InvalidOperationException("Hg default has not been set.");
-            return Hg.Default.Pull(repository, bundle, true);
-        }
-
-        /// <summary>
-        /// Backups the repository.
-        /// </summary>
-        /// <param name="repository">The repository.</param>
-        /// <param name="backupFile">The backup file to create. This string must be encoded correctly.</param>
-        public void BackupRepository(string repository, string backupFile)
-        {
-            RunCommand(repository, $"bundle -a --type v2 \"{backupFile}\"");
-        }
-
-        /// <summary>
-        /// Get the most recent revision id of the commit from the last push or pull with the PT send/receive server.
-        /// </summary>
-        /// <param name="repository">The full path to the repository directory.</param>
-        /// <returns>
-        /// The Mercurial revision identifier.
-        /// </returns>
-        public string GetLastPublicRevision(string repository)
-        {
-            string ids = RunCommand(repository, "log --rev \"public()\" --template \"{node}\n\"");
-            string revision = ids.Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries).LastOrDefault()?.Trim();
-            return revision;
-        }
-
-        /// <summary>
-        /// Returns the currently checked out revision of an hg repository.
-        /// </summary>
-        public string GetRepoRevision(string repositoryPath)
-        {
-            string rev = RunCommand(repositoryPath, "log --limit 1 --rev . --template {node}");
-            if (string.IsNullOrWhiteSpace(rev))
-            {
-                throw new InvalidDataException($"Unable to determine repo revision for hg repo at {repositoryPath}");
-            }
-            return rev;
-        }
-
-        /// <summary>
-        /// Restores the repository.
-        /// </summary>
-        /// <param name="destination">The destination to restore to.</param>
-        /// <param name="backupFile">The backup file to restore from. This string must be encoded correctly.</param>
-        public void RestoreRepository(string destination, string backupFile)
-        {
-            if (Hg.Default == null)
-                throw new InvalidOperationException("Hg default has not been set.");
-
-            Hg.Default.Init(destination);
-            Hg.Default.Unbundle(destination, backupFile);
-            Hg.Default.Update(destination);
-        }
-
-        /// <summary>
-        /// Mark all changesets available on the PT server public.
-        /// </summary>
-        /// <param name="repository">The repository.</param>
-        public void MarkSharedChangeSetsPublic(string repository)
-        {
-            RunCommand(repository, "phase -p -r 'tip'");
-        }
-
-        /// <summary> Set the default Mercurial installation. Must be called for all other methods to work. </summary>
-        public void SetDefault(Hg hgDefault)
-        {
-            Hg.Default = hgDefault;
-
-            // This allows SF to intercept some Hg commands involving registration codes
-            Hg.DefaultRunnerCreationFunc = (installPathArg, repositoryArg, mergePathArg) =>
-                new SFHgRunner(installPathArg, repositoryArg, mergePathArg);
-        }
-
-        public void Init(string repository)
-        {
-            Hg.Default.Init(repository);
-        }
-
-        public void Update(string repository)
-        {
-            Hg.Default.Update(repository);
-        }
-
-        /// <summary>
-        /// Set a hg repo's files to a particular revision in history. Similar to running
-        /// `git checkout --force --detach COMMITTISH`
-        /// Changes to tracked files will be discarded. Untracked files are left in place without being cleaned up.
-        /// </summary>
-        public void Update(string repositoryPath, string rev)
-        {
-            Hg.Default.Update(repositoryPath, rev);
-        }
+        if (Hg.Default == null)
+            throw new InvalidOperationException("Hg default has not been set.");
+        return Hg.Default.RunCommand(repository, cmd).StdOut;
     }
+
+    public static byte[] Bundle(string repository, params string[] heads)
+    {
+        if (Hg.Default == null)
+            throw new InvalidOperationException("Hg default has not been set.");
+        return Hg.Default.Bundle(repository, heads);
+    }
+
+    public static string[] Pull(string repository, byte[] bundle)
+    {
+        if (Hg.Default == null)
+            throw new InvalidOperationException("Hg default has not been set.");
+        return Hg.Default.Pull(repository, bundle, true);
+    }
+
+    /// <summary>
+    /// Backups the repository.
+    /// </summary>
+    /// <param name="repository">The repository.</param>
+    /// <param name="backupFile">The backup file to create. This string must be encoded correctly.</param>
+    public void BackupRepository(string repository, string backupFile) =>
+        RunCommand(repository, $"bundle -a --type v2 \"{backupFile}\"");
+
+    /// <summary>
+    /// Get the most recent revision id of the commit from the last push or pull with the PT send/receive server.
+    /// </summary>
+    /// <param name="repository">The full path to the repository directory.</param>
+    /// <returns>
+    /// The Mercurial revision identifier.
+    /// </returns>
+    public string GetLastPublicRevision(string repository)
+    {
+        string ids = RunCommand(repository, "log --rev \"public()\" --template \"{node}\n\"");
+        string revision = ids.Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries).LastOrDefault()?.Trim();
+        return revision;
+    }
+
+    /// <summary>
+    /// Returns the currently checked out revision of an hg repository.
+    /// </summary>
+    public string GetRepoRevision(string repositoryPath)
+    {
+        string rev = RunCommand(repositoryPath, "log --limit 1 --rev . --template {node}");
+        if (string.IsNullOrWhiteSpace(rev))
+        {
+            throw new InvalidDataException($"Unable to determine repo revision for hg repo at {repositoryPath}");
+        }
+        return rev;
+    }
+
+    /// <summary>
+    /// Restores the repository.
+    /// </summary>
+    /// <param name="destination">The destination to restore to.</param>
+    /// <param name="backupFile">The backup file to restore from. This string must be encoded correctly.</param>
+    public void RestoreRepository(string destination, string backupFile)
+    {
+        if (Hg.Default == null)
+            throw new InvalidOperationException("Hg default has not been set.");
+
+        Hg.Default.Init(destination);
+        Hg.Default.Unbundle(destination, backupFile);
+        Hg.Default.Update(destination);
+    }
+
+    /// <summary>
+    /// Mark all changesets available on the PT server public.
+    /// </summary>
+    /// <param name="repository">The repository.</param>
+    public void MarkSharedChangeSetsPublic(string repository) => RunCommand(repository, "phase -p -r 'tip'");
+
+    /// <summary> Set the default Mercurial installation. Must be called for all other methods to work. </summary>
+    public void SetDefault(Hg hgDefault)
+    {
+        Hg.Default = hgDefault;
+
+        // This allows SF to intercept some Hg commands involving registration codes
+        Hg.DefaultRunnerCreationFunc = (installPathArg, repositoryArg, mergePathArg) =>
+            new SFHgRunner(installPathArg, repositoryArg, mergePathArg);
+    }
+
+    public void Init(string repository) => Hg.Default.Init(repository);
+
+    public void Update(string repository) => Hg.Default.Update(repository);
+
+    /// <summary>
+    /// Set a hg repo's files to a particular revision in history. Similar to running
+    /// `git checkout --force --detach COMMITTISH`
+    /// Changes to tracked files will be discarded. Untracked files are left in place without being cleaned up.
+    /// </summary>
+    public void Update(string repositoryPath, string rev) => Hg.Default.Update(repositoryPath, rev);
 }

--- a/src/SIL.XForge.Scripture/Services/IDeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/IDeltaUsxMapper.cs
@@ -2,27 +2,26 @@ using System.Collections.Generic;
 using System.Xml.Linq;
 using SIL.XForge.Realtime.RichText;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public class ChapterDelta
 {
-    public class ChapterDelta
+    public ChapterDelta(int number, int lastVerse, bool isValid, Delta delta)
     {
-        public ChapterDelta(int number, int lastVerse, bool isValid, Delta delta)
-        {
-            Number = number;
-            LastVerse = lastVerse;
-            IsValid = isValid;
-            Delta = delta;
-        }
-
-        public int Number { get; }
-        public int LastVerse { get; }
-        public bool IsValid { get; }
-        public Delta Delta { get; }
+        Number = number;
+        LastVerse = lastVerse;
+        IsValid = isValid;
+        Delta = delta;
     }
 
-    public interface IDeltaUsxMapper
-    {
-        IEnumerable<ChapterDelta> ToChapterDeltas(XDocument usxDoc);
-        XDocument ToUsx(XDocument oldUsxDoc, IEnumerable<ChapterDelta> chapterDeltas);
-    }
+    public int Number { get; }
+    public int LastVerse { get; }
+    public bool IsValid { get; }
+    public Delta Delta { get; }
+}
+
+public interface IDeltaUsxMapper
+{
+    IEnumerable<ChapterDelta> ToChapterDeltas(XDocument usxDoc);
+    XDocument ToUsx(XDocument oldUsxDoc, IEnumerable<ChapterDelta> chapterDeltas);
 }

--- a/src/SIL.XForge.Scripture/Services/IGuidService.cs
+++ b/src/SIL.XForge.Scripture/Services/IGuidService.cs
@@ -1,8 +1,7 @@
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public interface IGuidService
 {
-    public interface IGuidService
-    {
-        string Generate();
-        string NewObjectId();
-    }
+    string Generate();
+    string NewObjectId();
 }

--- a/src/SIL.XForge.Scripture/Services/IHgWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/IHgWrapper.cs
@@ -1,17 +1,16 @@
 using Paratext.Data.Repository;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public interface IHgWrapper
 {
-    public interface IHgWrapper
-    {
-        void SetDefault(Hg hgDefault);
-        void Init(string repository);
-        void Update(string repository);
-        void Update(string repository, string rev);
-        void BackupRepository(string repository, string backupFile);
-        void RestoreRepository(string destination, string backupFile);
-        string GetLastPublicRevision(string repository);
-        string GetRepoRevision(string repositoryPath);
-        void MarkSharedChangeSetsPublic(string repository);
-    }
+    void SetDefault(Hg hgDefault);
+    void Init(string repository);
+    void Update(string repository);
+    void Update(string repository, string rev);
+    void BackupRepository(string repository, string backupFile);
+    void RestoreRepository(string destination, string backupFile);
+    string GetLastPublicRevision(string repository);
+    string GetRepoRevision(string repositoryPath);
+    void MarkSharedChangeSetsPublic(string repository);
 }

--- a/src/SIL.XForge.Scripture/Services/IInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/IInternetSharedRepositorySource.cs
@@ -2,18 +2,17 @@ using System.Collections.Generic;
 using Paratext.Data.RegistryServerAccess;
 using Paratext.Data.Repository;
 
-namespace SIL.XForge.Scripture.Services
-{
-    public interface IInternetSharedRepositorySource
-    {
-        IEnumerable<SharedRepository> GetRepositories();
-        IEnumerable<ProjectMetadata> GetProjectsMetaData();
-        string[] Pull(string repository, SharedRepository pullRepo);
-        void RefreshToken(string jwtToken);
-        void UnlockRemoteRepository(SharedRepository sharedRepo);
-        bool CanUserAuthenticateToPTArchives();
+namespace SIL.XForge.Scripture.Services;
 
-        /// <summary> Access as a particular class. </summary>
-        InternetSharedRepositorySource AsInternetSharedRepositorySource();
-    }
+public interface IInternetSharedRepositorySource
+{
+    IEnumerable<SharedRepository> GetRepositories();
+    IEnumerable<ProjectMetadata> GetProjectsMetaData();
+    string[] Pull(string repository, SharedRepository pullRepo);
+    void RefreshToken(string jwtToken);
+    void UnlockRemoteRepository(SharedRepository sharedRepo);
+    bool CanUserAuthenticateToPTArchives();
+
+    /// <summary> Access as a particular class. </summary>
+    InternetSharedRepositorySource AsInternetSharedRepositorySource();
 }

--- a/src/SIL.XForge.Scripture/Services/IInternetSharedRepositorySourceProvider.cs
+++ b/src/SIL.XForge.Scripture/Services/IInternetSharedRepositorySourceProvider.cs
@@ -1,13 +1,12 @@
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public interface IInternetSharedRepositorySourceProvider
 {
-    public interface IInternetSharedRepositorySourceProvider
-    {
-        IInternetSharedRepositorySource GetSource(
-            UserSecret userSecret,
-            string sendReceiveServerUri,
-            string registryServerUri
-        );
-    }
+    IInternetSharedRepositorySource GetSource(
+        UserSecret userSecret,
+        string sendReceiveServerUri,
+        string registryServerUri
+    );
 }

--- a/src/SIL.XForge.Scripture/Services/IJwtTokenHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/IJwtTokenHelper.cs
@@ -4,17 +4,16 @@ using System.Threading.Tasks;
 using SIL.XForge.Configuration;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public interface IJwtTokenHelper
 {
-    public interface IJwtTokenHelper
-    {
-        string? GetParatextUsername(UserSecret userSecret);
-        string GetJwtTokenFromUserSecret(UserSecret userSecret);
-        Task<Tokens> RefreshAccessTokenAsync(
-            ParatextOptions options,
-            Tokens paratextTokens,
-            HttpClient client,
-            CancellationToken token
-        );
-    }
+    string? GetParatextUsername(UserSecret userSecret);
+    string GetJwtTokenFromUserSecret(UserSecret userSecret);
+    Task<Tokens> RefreshAccessTokenAsync(
+        ParatextOptions options,
+        Tokens paratextTokens,
+        HttpClient client,
+        CancellationToken token
+    );
 }

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -3,49 +3,48 @@ using System.Threading;
 using System.Threading.Tasks;
 using SIL.Machine.WebApi;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public interface IMachineApiService
 {
-    public interface IMachineApiService
-    {
-        Task<BuildDto?> GetBuildAsync(
-            string curUserId,
-            string sfProjectId,
-            string buildId,
-            long? minRevision,
-            CancellationToken cancellationToken
-        );
-        Task<BuildDto?> GetCurrentBuildAsync(
-            string curUserId,
-            string sfProjectId,
-            long? minRevision,
-            CancellationToken cancellationToken
-        );
-        Task<EngineDto> GetEngineAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
-        Task<WordGraphDto> GetWordGraphAsync(
-            string curUserId,
-            string sfProjectId,
-            IReadOnlyList<string> segment,
-            CancellationToken cancellationToken
-        );
-        Task<BuildDto> StartBuildAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
-        Task TrainSegmentAsync(
-            string curUserId,
-            string sfProjectId,
-            SegmentPairDto segmentPair,
-            CancellationToken cancellationToken
-        );
-        Task<TranslationResultDto> TranslateAsync(
-            string curUserId,
-            string sfProjectId,
-            IReadOnlyList<string> segment,
-            CancellationToken cancellationToken
-        );
-        Task<TranslationResultDto[]> TranslateNAsync(
-            string curUserId,
-            string sfProjectId,
-            int n,
-            IReadOnlyList<string> segment,
-            CancellationToken cancellationToken
-        );
-    }
+    Task<BuildDto?> GetBuildAsync(
+        string curUserId,
+        string sfProjectId,
+        string buildId,
+        long? minRevision,
+        CancellationToken cancellationToken
+    );
+    Task<BuildDto?> GetCurrentBuildAsync(
+        string curUserId,
+        string sfProjectId,
+        long? minRevision,
+        CancellationToken cancellationToken
+    );
+    Task<EngineDto> GetEngineAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
+    Task<WordGraphDto> GetWordGraphAsync(
+        string curUserId,
+        string sfProjectId,
+        IReadOnlyList<string> segment,
+        CancellationToken cancellationToken
+    );
+    Task<BuildDto> StartBuildAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
+    Task TrainSegmentAsync(
+        string curUserId,
+        string sfProjectId,
+        SegmentPairDto segmentPair,
+        CancellationToken cancellationToken
+    );
+    Task<TranslationResultDto> TranslateAsync(
+        string curUserId,
+        string sfProjectId,
+        IReadOnlyList<string> segment,
+        CancellationToken cancellationToken
+    );
+    Task<TranslationResultDto[]> TranslateNAsync(
+        string curUserId,
+        string sfProjectId,
+        int n,
+        IReadOnlyList<string> segment,
+        CancellationToken cancellationToken
+    );
 }

--- a/src/SIL.XForge.Scripture/Services/IMachineBuildService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineBuildService.cs
@@ -1,23 +1,22 @@
-using System.Threading.Tasks;
 using System.Threading;
+using System.Threading.Tasks;
 using SIL.Machine.WebApi;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public interface IMachineBuildService
 {
-    public interface IMachineBuildService
-    {
-        Task CancelCurrentBuildAsync(string translationEngineId, CancellationToken cancellationToken);
-        Task<BuildDto?> GetBuildAsync(
-            string translationEngineId,
-            string buildId,
-            long? minRevision,
-            CancellationToken cancellationToken
-        );
-        Task<BuildDto?> GetCurrentBuildAsync(
-            string translationEngineId,
-            long? minRevision,
-            CancellationToken cancellationToken
-        );
-        Task<BuildDto> StartBuildAsync(string translationEngineId, CancellationToken cancellationToken);
-    }
+    Task CancelCurrentBuildAsync(string translationEngineId, CancellationToken cancellationToken);
+    Task<BuildDto?> GetBuildAsync(
+        string translationEngineId,
+        string buildId,
+        long? minRevision,
+        CancellationToken cancellationToken
+    );
+    Task<BuildDto?> GetCurrentBuildAsync(
+        string translationEngineId,
+        long? minRevision,
+        CancellationToken cancellationToken
+    );
+    Task<BuildDto> StartBuildAsync(string translationEngineId, CancellationToken cancellationToken);
 }

--- a/src/SIL.XForge.Scripture/Services/IMachineCorporaService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineCorporaService.cs
@@ -1,39 +1,38 @@
-using SIL.XForge.Scripture.Models;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using SIL.XForge.Scripture.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public interface IMachineCorporaService
 {
-    public interface IMachineCorporaService
-    {
-        Task AddCorpusToTranslationEngineAsync(
-            string translationEngineId,
-            string corpusId,
-            bool pretranslate,
-            CancellationToken cancellationToken
-        );
-        Task<string> CreateCorpusAsync(string name, bool paratext, CancellationToken cancellationToken);
-        Task DeleteCorpusAsync(string corpusId, CancellationToken cancellationToken);
-        Task DeleteCorpusFileAsync(string corpusId, string fileId, CancellationToken cancellationToken);
-        Task<IList<MachineApiCorpusFile>> GetCorpusFilesAsync(string corpusId, CancellationToken cancellationToken);
-        Task RemoveCorpusFromTranslationEngineAsync(
-            string translationEngineId,
-            string corpusId,
-            CancellationToken cancellationToken
-        );
-        Task<string> UploadCorpusTextAsync(
-            string corpusId,
-            string languageTag,
-            string textId,
-            string text,
-            CancellationToken cancellationToken
-        );
-        Task<string> UploadParatextCorpusAsync(
-            string corpusId,
-            string languageTag,
-            string path,
-            CancellationToken cancellationToken
-        );
-    }
+    Task AddCorpusToTranslationEngineAsync(
+        string translationEngineId,
+        string corpusId,
+        bool pretranslate,
+        CancellationToken cancellationToken
+    );
+    Task<string> CreateCorpusAsync(string name, bool paratext, CancellationToken cancellationToken);
+    Task DeleteCorpusAsync(string corpusId, CancellationToken cancellationToken);
+    Task DeleteCorpusFileAsync(string corpusId, string fileId, CancellationToken cancellationToken);
+    Task<IList<MachineApiCorpusFile>> GetCorpusFilesAsync(string corpusId, CancellationToken cancellationToken);
+    Task RemoveCorpusFromTranslationEngineAsync(
+        string translationEngineId,
+        string corpusId,
+        CancellationToken cancellationToken
+    );
+    Task<string> UploadCorpusTextAsync(
+        string corpusId,
+        string languageTag,
+        string textId,
+        string text,
+        CancellationToken cancellationToken
+    );
+    Task<string> UploadParatextCorpusAsync(
+        string corpusId,
+        string languageTag,
+        string path,
+        CancellationToken cancellationToken
+    );
 }

--- a/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
@@ -1,13 +1,12 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public interface IMachineProjectService
 {
-    public interface IMachineProjectService
-    {
-        Task AddProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
-        Task BuildProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
-        Task RemoveProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
-        Task<bool> SyncProjectCorporaAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
-    }
+    Task AddProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
+    Task BuildProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
+    Task RemoveProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
+    Task<bool> SyncProjectCorporaAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
 }

--- a/src/SIL.XForge.Scripture/Services/IMachineTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineTranslationService.cs
@@ -4,42 +4,37 @@ using System.Threading.Tasks;
 using SIL.Machine.WebApi;
 using SIL.XForge.Scripture.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public interface IMachineTranslationService
 {
-    public interface IMachineTranslationService
-    {
-        Task<string> CreateTranslationEngineAsync(
-            string name,
-            string sourceLanguageTag,
-            string targetLanguageTag,
-            bool smtTransfer,
-            CancellationToken cancellationToken
-        );
-        Task DeleteTranslationEngineAsync(string translationEngineId, CancellationToken cancellationToken);
-        Task<MachineApiTranslationEngine> GetTranslationEngineAsync(
-            string translationEngineId,
-            CancellationToken cancellationToken
-        );
-        Task<WordGraphDto> GetWordGraphAsync(
-            string translationEngineId,
-            IEnumerable<string> segment,
-            CancellationToken cancellationToken
-        );
-        Task TrainSegmentAsync(
-            string translationEngineId,
-            SegmentPairDto segmentPair,
-            CancellationToken cancellationToken
-        );
-        Task<TranslationResultDto> TranslateAsync(
-            string translationEngineId,
-            IEnumerable<string> segment,
-            CancellationToken cancellationToken
-        );
-        Task<TranslationResultDto[]> TranslateNAsync(
-            string translationEngineId,
-            int n,
-            IEnumerable<string> segment,
-            CancellationToken cancellationToken
-        );
-    }
+    Task<string> CreateTranslationEngineAsync(
+        string name,
+        string sourceLanguageTag,
+        string targetLanguageTag,
+        bool smtTransfer,
+        CancellationToken cancellationToken
+    );
+    Task DeleteTranslationEngineAsync(string translationEngineId, CancellationToken cancellationToken);
+    Task<MachineApiTranslationEngine> GetTranslationEngineAsync(
+        string translationEngineId,
+        CancellationToken cancellationToken
+    );
+    Task<WordGraphDto> GetWordGraphAsync(
+        string translationEngineId,
+        IEnumerable<string> segment,
+        CancellationToken cancellationToken
+    );
+    Task TrainSegmentAsync(string translationEngineId, SegmentPairDto segmentPair, CancellationToken cancellationToken);
+    Task<TranslationResultDto> TranslateAsync(
+        string translationEngineId,
+        IEnumerable<string> segment,
+        CancellationToken cancellationToken
+    );
+    Task<TranslationResultDto[]> TranslateNAsync(
+        string translationEngineId,
+        int n,
+        IEnumerable<string> segment,
+        CancellationToken cancellationToken
+    );
 }

--- a/src/SIL.XForge.Scripture/Services/INotifier.cs
+++ b/src/SIL.XForge.Scripture/Services/INotifier.cs
@@ -1,11 +1,10 @@
 using System.Threading.Tasks;
 using SIL.XForge.Scripture.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public interface INotifier
 {
-    public interface INotifier
-    {
-        Task NotifySyncProgress(string sfProjectId, ProgressState progressState);
-        Task SubscribeToProject(string projectId);
-    }
+    Task NotifySyncProgress(string sfProjectId, ProgressState progressState);
+    Task SubscribeToProject(string projectId);
 }

--- a/src/SIL.XForge.Scripture/Services/IParatextDataHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextDataHelper.cs
@@ -1,9 +1,8 @@
 using Paratext.Data;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public interface IParatextDataHelper
 {
-    public interface IParatextDataHelper
-    {
-        void CommitVersionedText(ScrText scrText, string comment);
-    }
+    void CommitVersionedText(ScrText scrText, string comment);
 }

--- a/src/SIL.XForge.Scripture/Services/IParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextNotesMapper.cs
@@ -6,23 +6,22 @@ using SIL.XForge.Models;
 using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public interface IParatextNotesMapper
 {
-    public interface IParatextNotesMapper
-    {
-        Task InitAsync(
-            UserSecret currentUserSecret,
-            SFProjectSecret projectSecret,
-            List<User> ptUsers,
-            SFProject project,
-            CancellationToken token
-        );
-        Task<XElement> GetNotesChangelistAsync(
-            XElement oldNotesElem,
-            IEnumerable<IDocument<Question>> questionsDocs,
-            Dictionary<string, ParatextUserProfile> ptProjectUsers,
-            Dictionary<string, string> userRoles,
-            string answerExportMethod
-        );
-    }
+    Task InitAsync(
+        UserSecret currentUserSecret,
+        SFProjectSecret projectSecret,
+        List<User> ptUsers,
+        SFProject project,
+        CancellationToken token
+    );
+    Task<XElement> GetNotesChangelistAsync(
+        XElement oldNotesElem,
+        IEnumerable<IDocument<Question>> questionsDocs,
+        Dictionary<string, ParatextUserProfile> ptProjectUsers,
+        Dictionary<string, string> userRoles,
+        string answerExportMethod
+    );
 }

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -8,83 +8,82 @@ using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Utils;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public interface IParatextService
 {
-    public interface IParatextService
-    {
-        void Init();
-        Task<bool> CanUserAuthenticateToPTRegistryAsync(UserSecret userSecret);
-        Task<bool> CanUserAuthenticateToPTArchivesAsync(string userSFId);
-        Task<IReadOnlyList<ParatextProject>> GetProjectsAsync(UserSecret userSecret);
-        string? GetParatextUsername(UserSecret userSecret);
-        Task<Attempt<string>> TryGetProjectRoleAsync(UserSecret userSecret, string paratextId, CancellationToken token);
-        Task<IReadOnlyDictionary<string, string>> GetProjectRolesAsync(
-            UserSecret userSecret,
-            SFProject project,
-            CancellationToken token
-        );
-        ParatextSettings? GetParatextSettings(UserSecret userSecret, string paratextId);
+    void Init();
+    Task<bool> CanUserAuthenticateToPTRegistryAsync(UserSecret userSecret);
+    Task<bool> CanUserAuthenticateToPTArchivesAsync(string userSFId);
+    Task<IReadOnlyList<ParatextProject>> GetProjectsAsync(UserSecret userSecret);
+    string? GetParatextUsername(UserSecret userSecret);
+    Task<Attempt<string>> TryGetProjectRoleAsync(UserSecret userSecret, string paratextId, CancellationToken token);
+    Task<IReadOnlyDictionary<string, string>> GetProjectRolesAsync(
+        UserSecret userSecret,
+        SFProject project,
+        CancellationToken token
+    );
+    ParatextSettings? GetParatextSettings(UserSecret userSecret, string paratextId);
 
-        Task<IReadOnlyList<ParatextResource>> GetResourcesAsync(string userId);
-        bool IsResource(string paratextId);
-        Task<string> GetResourcePermissionAsync(string paratextId, string userId, CancellationToken token);
-        Task<IReadOnlyDictionary<string, string>> GetParatextUsernameMappingAsync(
-            UserSecret userSecret,
-            SFProject project,
-            CancellationToken token
-        );
-        Task<Dictionary<string, string>> GetPermissionsAsync(
-            UserSecret userSecret,
-            SFProject project,
-            IReadOnlyDictionary<string, string> ptUsernameMapping,
-            int book = 0,
-            int chapter = 0,
-            CancellationToken token = default
-        );
-        bool ResourceDocsNeedUpdating(SFProject project, ParatextResource resource);
+    Task<IReadOnlyList<ParatextResource>> GetResourcesAsync(string userId);
+    bool IsResource(string paratextId);
+    Task<string> GetResourcePermissionAsync(string paratextId, string userId, CancellationToken token);
+    Task<IReadOnlyDictionary<string, string>> GetParatextUsernameMappingAsync(
+        UserSecret userSecret,
+        SFProject project,
+        CancellationToken token
+    );
+    Task<Dictionary<string, string>> GetPermissionsAsync(
+        UserSecret userSecret,
+        SFProject project,
+        IReadOnlyDictionary<string, string> ptUsernameMapping,
+        int book = 0,
+        int chapter = 0,
+        CancellationToken token = default
+    );
+    bool ResourceDocsNeedUpdating(SFProject project, ParatextResource resource);
 
-        IReadOnlyList<int> GetBookList(UserSecret userSecret, string paratextId);
-        string GetBookText(UserSecret userSecret, string paratextId, int bookNum);
-        Task<int> PutBookText(
-            UserSecret userSecret,
-            string paratextId,
-            int bookNum,
-            XDocument usx,
-            Dictionary<int, string> chapterAuthors = null
-        );
-        string GetNotes(UserSecret userSecret, string paratextId, int bookNum);
-        SyncMetricInfo PutNotes(UserSecret userSecret, string paratextId, XElement notesElement);
-        Task<SyncMetricInfo> UpdateParatextCommentsAsync(
-            UserSecret userSecret,
-            string paratextId,
-            int bookNum,
-            IEnumerable<IDocument<NoteThread>> noteThreadDocs,
-            Dictionary<string, ParatextUserProfile> ptProjectUsers,
-            int sfNoteTagId
-        );
-        IEnumerable<NoteThreadChange> GetNoteThreadChanges(
-            UserSecret userSecret,
-            string paratextId,
-            int bookNum,
-            IEnumerable<IDocument<NoteThread>> noteThreadDocs,
-            Dictionary<int, ChapterDelta> chapterDeltas,
-            Dictionary<string, ParatextUserProfile> ptProjectUsers
-        );
-        int UpdateCommentTag(UserSecret userSecret, string paratextId, NoteTag noteTag);
-        string? GetLatestSharedVersion(UserSecret userSecret, string paratextId);
-        string GetRepoRevision(UserSecret userSecret, string paratextId);
-        void SetRepoToRevision(UserSecret userSecret, string paratextId, string desiredRevision);
-        bool BackupExists(UserSecret userSecret, string paratextId);
-        bool BackupRepository(UserSecret userSecret, string paratextId);
-        bool RestoreRepository(UserSecret userSecret, string paratextId);
-        bool LocalProjectDirExists(string paratextId);
-        string GetLanguageId(UserSecret userSecret, string paratextId);
+    IReadOnlyList<int> GetBookList(UserSecret userSecret, string paratextId);
+    string GetBookText(UserSecret userSecret, string paratextId, int bookNum);
+    Task<int> PutBookText(
+        UserSecret userSecret,
+        string paratextId,
+        int bookNum,
+        XDocument usx,
+        Dictionary<int, string> chapterAuthors = null
+    );
+    string GetNotes(UserSecret userSecret, string paratextId, int bookNum);
+    SyncMetricInfo PutNotes(UserSecret userSecret, string paratextId, XElement notesElement);
+    Task<SyncMetricInfo> UpdateParatextCommentsAsync(
+        UserSecret userSecret,
+        string paratextId,
+        int bookNum,
+        IEnumerable<IDocument<NoteThread>> noteThreadDocs,
+        Dictionary<string, ParatextUserProfile> ptProjectUsers,
+        int sfNoteTagId
+    );
+    IEnumerable<NoteThreadChange> GetNoteThreadChanges(
+        UserSecret userSecret,
+        string paratextId,
+        int bookNum,
+        IEnumerable<IDocument<NoteThread>> noteThreadDocs,
+        Dictionary<int, ChapterDelta> chapterDeltas,
+        Dictionary<string, ParatextUserProfile> ptProjectUsers
+    );
+    int UpdateCommentTag(UserSecret userSecret, string paratextId, NoteTag noteTag);
+    string? GetLatestSharedVersion(UserSecret userSecret, string paratextId);
+    string GetRepoRevision(UserSecret userSecret, string paratextId);
+    void SetRepoToRevision(UserSecret userSecret, string paratextId, string desiredRevision);
+    bool BackupExists(UserSecret userSecret, string paratextId);
+    bool BackupRepository(UserSecret userSecret, string paratextId);
+    bool RestoreRepository(UserSecret userSecret, string paratextId);
+    bool LocalProjectDirExists(string paratextId);
+    string GetLanguageId(UserSecret userSecret, string paratextId);
 
-        Task<ParatextProject> SendReceiveAsync(
-            UserSecret userSecret,
-            string paratextId,
-            IProgress<ProgressState> progress = null,
-            CancellationToken token = default
-        );
-    }
+    Task<ParatextProject> SendReceiveAsync(
+        UserSecret userSecret,
+        string paratextId,
+        IProgress<ProgressState> progress = null,
+        CancellationToken token = default
+    );
 }

--- a/src/SIL.XForge.Scripture/Services/IParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextSyncRunner.cs
@@ -1,10 +1,9 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public interface IParatextSyncRunner
 {
-    public interface IParatextSyncRunner
-    {
-        Task RunAsync(string projectId, string userId, string syncMetricsId, bool trainEngine, CancellationToken token);
-    }
+    Task RunAsync(string projectId, string userId, string syncMetricsId, bool trainEngine, CancellationToken token);
 }

--- a/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -6,26 +5,25 @@ using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public interface ISFProjectService : IProjectService
 {
-    public interface ISFProjectService : IProjectService
-    {
-        Task<string> CreateProjectAsync(string curUserId, SFProjectCreateSettings settings);
-        Task<string> CreateResourceProjectAsync(string curUserId, string paratextId);
-        Task DeleteProjectAsync(string curUserId, string projectId);
-        Task UpdateSettingsAsync(string curUserId, string projectId, SFProjectSettings settings);
-        Task AddTranslateMetricsAsync(string curUserId, string projectId, TranslateMetrics metrics);
-        Task SyncAsync(string curUserId, string projectId);
-        Task CancelSyncAsync(string curUserId, string projectId);
-        Task<bool> InviteAsync(string curUserId, string projectId, string email, string locale, string role);
-        Task<string> GetLinkSharingKeyAsync(string curUserId, string projectId, string role);
-        Task<bool> IsAlreadyInvitedAsync(string curUserId, string projectId, string email);
-        Task UninviteUserAsync(string curUserId, string projectId, string email);
-        Task CheckLinkSharingAsync(string curUserId, string projectId, string shareKey = null);
-        Task<IReadOnlyList<InviteeStatus>> InvitedUsersAsync(string curUserId, string projectId);
-        bool IsSourceProject(string projectId);
-        Task<IEnumerable<TransceleratorQuestion>> TransceleratorQuestions(string curUserId, string projectId);
-        Task UpdatePermissionsAsync(string curUserId, IDocument<SFProject> projectDoc, CancellationToken token);
-        Task EnsureWritingSystemTagIsSetAsync(string curUserId, string projectId);
-    }
+    Task<string> CreateProjectAsync(string curUserId, SFProjectCreateSettings settings);
+    Task<string> CreateResourceProjectAsync(string curUserId, string paratextId);
+    Task DeleteProjectAsync(string curUserId, string projectId);
+    Task UpdateSettingsAsync(string curUserId, string projectId, SFProjectSettings settings);
+    Task AddTranslateMetricsAsync(string curUserId, string projectId, TranslateMetrics metrics);
+    Task SyncAsync(string curUserId, string projectId);
+    Task CancelSyncAsync(string curUserId, string projectId);
+    Task<bool> InviteAsync(string curUserId, string projectId, string email, string locale, string role);
+    Task<string> GetLinkSharingKeyAsync(string curUserId, string projectId, string role);
+    Task<bool> IsAlreadyInvitedAsync(string curUserId, string projectId, string email);
+    Task UninviteUserAsync(string curUserId, string projectId, string email);
+    Task CheckLinkSharingAsync(string curUserId, string projectId, string shareKey = null);
+    Task<IReadOnlyList<InviteeStatus>> InvitedUsersAsync(string curUserId, string projectId);
+    bool IsSourceProject(string projectId);
+    Task<IEnumerable<TransceleratorQuestion>> TransceleratorQuestions(string curUserId, string projectId);
+    Task UpdatePermissionsAsync(string curUserId, IDocument<SFProject> projectDoc, CancellationToken token);
+    Task EnsureWritingSystemTagIsSetAsync(string curUserId, string projectId);
 }

--- a/src/SIL.XForge.Scripture/Services/ISFRestClient.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFRestClient.cs
@@ -1,30 +1,26 @@
 using Paratext.Data;
 using static Paratext.Data.RESTClient;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// The Scripture Forge implementation of <see cref="IRESTClient" />.
+/// </summary>
+/// <seealso cref="Paratext.Data.IRESTClient" />
+public interface ISFRestClient : IRESTClient
 {
     /// <summary>
-    /// The Scripture Forge implementation of <see cref="IRESTClient" />.
+    /// Encode a HEAD cgi call with query vars.
     /// </summary>
-    /// <seealso cref="Paratext.Data.IRESTClient" />
-    public interface ISFRestClient : IRESTClient
-    {
-        /// <summary>
-        /// Encode a HEAD cgi call with query vars.
-        /// </summary>
-        /// <param name="cgiCall">The CGI URL path (to be appended to BaseUri)
-        /// Do not include ? or query variable pairs</param>
-        /// <param name="queryvars">An even number of unencoded strings, paired
-        /// like so: "varname1", "value1", "varname2", "val2"</param>
-        /// <returns>
-        /// The web response as a string.
-        /// </returns>
-        /// <remarks>
-        /// A default implementation is included for convenience.
-        /// </remarks>
-        public string Head(string cgiCall, params string[] queryvars)
-        {
-            return Head(new CgiCallOptions(), cgiCall, queryvars);
-        }
-    }
+    /// <param name="cgiCall">The CGI URL path (to be appended to BaseUri)
+    /// Do not include ? or query variable pairs</param>
+    /// <param name="queryvars">An even number of unencoded strings, paired
+    /// like so: "varname1", "value1", "varname2", "val2"</param>
+    /// <returns>
+    /// The web response as a string.
+    /// </returns>
+    /// <remarks>
+    /// A default implementation is included for convenience.
+    /// </remarks>
+    public string Head(string cgiCall, params string[] queryvars) => Head(new CgiCallOptions(), cgiCall, queryvars);
 }

--- a/src/SIL.XForge.Scripture/Services/ISFRestClientFactory.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFRestClientFactory.cs
@@ -1,18 +1,17 @@
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// The Scripture Forge Rest Client Factory Interface.
+/// </summary>
+public interface ISFRestClientFactory
 {
     /// <summary>
-    /// The Scripture Forge Rest Client Factory Interface.
+    /// Creates the rest client.
     /// </summary>
-    public interface ISFRestClientFactory
-    {
-        /// <summary>
-        /// Creates the rest client.
-        /// </summary>
-        /// <param name="baseUri">The base URI.</param>
-        /// <param name="userSecret">The user secret.</param>
-        /// <returns>The rest client.</returns>
-        ISFRestClient Create(string baseUri, UserSecret userSecret);
-    }
+    /// <param name="baseUri">The base URI.</param>
+    /// <param name="userSecret">The user secret.</param>
+    /// <returns>The rest client.</returns>
+    ISFRestClient Create(string baseUri, UserSecret userSecret);
 }

--- a/src/SIL.XForge.Scripture/Services/IScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/IScrTextCollection.cs
@@ -1,10 +1,9 @@
 using Paratext.Data;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public interface IScrTextCollection
 {
-    public interface IScrTextCollection
-    {
-        void Initialize(string settingsDir = null);
-        ScrText? FindById(string username, string projectId);
-    }
+    void Initialize(string settingsDir = null);
+    ScrText? FindById(string username, string projectId);
 }

--- a/src/SIL.XForge.Scripture/Services/ISharingLogicWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/ISharingLogicWrapper.cs
@@ -2,16 +2,15 @@ using System;
 using System.Collections.Generic;
 using Paratext.Data.Repository;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public interface ISharingLogicWrapper
 {
-    public interface ISharingLogicWrapper
-    {
-        bool ShareChanges(
-            List<SharedProject> sharedProjects,
-            SharedRepositorySource source,
-            out List<SendReceiveResult> results,
-            IList<SharedProject> reviewProjects
-        );
-        bool HandleErrors(Action action, bool throwExceptions = false);
-    }
+    bool ShareChanges(
+        List<SharedProject> sharedProjects,
+        SharedRepositorySource source,
+        out List<SendReceiveResult> results,
+        IList<SharedProject> reviewProjects
+    );
+    bool HandleErrors(Action action, bool throwExceptions = false);
 }

--- a/src/SIL.XForge.Scripture/Services/ISyncService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISyncService.cs
@@ -1,10 +1,9 @@
 using System.Threading.Tasks;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public interface ISyncService
 {
-    public interface ISyncService
-    {
-        Task SyncAsync(string curUserId, string projectId, bool trainEngine);
-        Task CancelSyncAsync(string curUserId, string projectId);
-    }
+    Task SyncAsync(string curUserId, string projectId, bool trainEngine);
+    Task CancelSyncAsync(string curUserId, string projectId);
 }

--- a/src/SIL.XForge.Scripture/Services/ITransceleratorService.cs
+++ b/src/SIL.XForge.Scripture/Services/ITransceleratorService.cs
@@ -1,11 +1,9 @@
-using System;
 using System.Collections.Generic;
 using SIL.XForge.Scripture.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public interface ITransceleratorService
 {
-    public interface ITransceleratorService
-    {
-        IEnumerable<TransceleratorQuestion> Questions(string paratextId);
-    }
+    IEnumerable<TransceleratorQuestion> Questions(string paratextId);
 }

--- a/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
@@ -3,197 +3,185 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using Paratext;
+using Paratext.Data;
+using Paratext.Data.RegistryServerAccess;
 using Paratext.Data.Repository;
 using Paratext.Data.Users;
-using Paratext.Data.RegistryServerAccess;
-using Paratext.Data;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary> An internet shared repository source that networks using JWT authenticated REST clients. </summary>
+public class JwtInternetSharedRepositorySource : InternetSharedRepositorySource, IInternetSharedRepositorySource
 {
-    /// <summary> An internet shared repository source that networks using JWT authenticated REST clients. </summary>
-    public class JwtInternetSharedRepositorySource : InternetSharedRepositorySource, IInternetSharedRepositorySource
+    private readonly JwtRestClient _registryClient;
+    private readonly IHgWrapper _hgWrapper;
+
+    public JwtInternetSharedRepositorySource(
+        string accessToken,
+        JwtRestClient registryClient,
+        IHgWrapper hgWrapper,
+        ParatextUser authenticationPtUser,
+        string srServerUri
+    )
+        : base(authenticationPtUser, srServerUri)
     {
-        private readonly JwtRestClient _registryClient;
-        private readonly IHgWrapper _hgWrapper;
+        _registryClient = registryClient;
+        _hgWrapper = hgWrapper;
+        SetToken(accessToken);
+    }
 
-        public JwtInternetSharedRepositorySource(
-            string accessToken,
-            JwtRestClient registryClient,
-            IHgWrapper hgWrapper,
-            ParatextUser authenticationPtUser,
-            string srServerUri
-        ) : base(authenticationPtUser, srServerUri)
+    public void RefreshToken(string jwtToken)
+    {
+        if (_registryClient.JwtToken == jwtToken)
+            return;
+        SetToken(jwtToken);
+    }
+
+    public InternetSharedRepositorySource AsInternetSharedRepositorySource() => this;
+
+    public bool CanUserAuthenticateToPTArchives()
+    {
+        try
         {
-            _registryClient = registryClient;
-            _hgWrapper = hgWrapper;
-            SetToken(accessToken);
+            GetClient().Get("listrepos");
+            return true;
+        }
+        catch (Paratext.Data.HttpException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Uses the a REST client to pull from the Paratext send/receive server. This overrides the base implementation
+    /// to avoid needing the current user's Paratext registration code to get the base revision.
+    /// </summary>
+    public override string[] Pull(string repository, SharedRepository pullRepo)
+    {
+        string baseRev = _hgWrapper.GetLastPublicRevision(repository);
+
+        // Get bundle
+        string guid = Guid.NewGuid().ToString();
+        List<string> query = new List<string>
+        {
+            "guid",
+            guid,
+            "proj",
+            pullRepo.ScrTextName,
+            "projid",
+            pullRepo.SendReceiveId.Id,
+            "type",
+            "zstd-v2"
+        };
+        if (baseRev != null)
+        {
+            query.Add("base1");
+            query.Add(baseRev);
         }
 
-        public void RefreshToken(string jwtToken)
-        {
-            if (_registryClient.JwtToken == jwtToken)
-                return;
-            SetToken(jwtToken);
-        }
+        byte[] bundle = client.GetStreaming("pullbundle", query.ToArray());
+        // Finish bundle
+        client.Get("pullbundlefinish", "guid", guid);
+        if (bundle.Length == 0)
+            return Array.Empty<string>();
 
-        public InternetSharedRepositorySource AsInternetSharedRepositorySource()
-        {
-            return this;
-        }
+        // Use bundle
+        string[] changeSets = HgWrapper.Pull(repository, bundle);
 
-        public bool CanUserAuthenticateToPTArchives()
-        {
-            try
-            {
-                GetClient().Get("listrepos");
-                return true;
-            }
-            catch (Paratext.Data.HttpException)
-            {
-                return false;
-            }
-        }
+        _hgWrapper.MarkSharedChangeSetsPublic(repository);
+        return changeSets;
+    }
 
-        /// <summary>
-        /// Uses the a REST client to pull from the Paratext send/receive server. This overrides the base implementation
-        /// to avoid needing the current user's Paratext registration code to get the base revision.
-        /// </summary>
-        public override string[] Pull(string repository, SharedRepository pullRepo)
-        {
-            string baseRev = _hgWrapper.GetLastPublicRevision(repository);
+    /// <summary>
+    /// Uses the a REST client to push to the Paratext send/receive server. This overrides the base implementation
+    /// to avoid needing the current user's Paratext registration code to get the base revision.
+    /// </summary>
+    public override void Push(string repository, SharedRepository pushRepo)
+    {
+        string baseRev = _hgWrapper.GetLastPublicRevision(repository);
 
-            // Get bundle
-            string guid = Guid.NewGuid().ToString();
-            List<string> query = new List<string>
-            {
-                "guid",
-                guid,
-                "proj",
-                pullRepo.ScrTextName,
-                "projid",
-                pullRepo.SendReceiveId.Id,
-                "type",
-                "zstd-v2"
-            };
-            if (baseRev != null)
-            {
-                query.Add("base1");
-                query.Add(baseRev);
-            }
+        // Create bundle
+        byte[] bundle = HgWrapper.Bundle(repository, baseRev);
+        if (bundle.Length == 0)
+            return;
 
-            byte[] bundle = client.GetStreaming("pullbundle", query.ToArray());
-            // Finish bundle
-            client.Get("pullbundlefinish", "guid", guid);
-            if (bundle.Length == 0)
-                return new string[0];
+        // Send bundle
+        string guid = Guid.NewGuid().ToString();
+        client.PostStreaming(
+            bundle,
+            "pushbundle",
+            "guid",
+            guid,
+            "proj",
+            pushRepo.ScrTextName,
+            "projid",
+            pushRepo.SendReceiveId.Id,
+            "registered",
+            "yes",
+            "userschanged",
+            "no"
+        );
 
-            // Use bundle
-            string[] changeSets = HgWrapper.Pull(repository, bundle);
+        _hgWrapper.MarkSharedChangeSetsPublic(repository);
+    }
 
-            _hgWrapper.MarkSharedChangeSetsPublic(repository);
-            return changeSets;
-        }
+    /// <summary>
+    /// This looks like it would be important, but it doesn't seem to matter what it returns, to synchronize.
+    /// </summary>
+    public override string GetHgUri(SharedRepository sharedRepository) => string.Empty;
 
-        /// <summary>
-        /// Uses the a REST client to push to the Paratext send/receive server. This overrides the base implementation
-        /// to avoid needing the current user's Paratext registration code to get the base revision.
-        /// </summary>
-        public override void Push(string repository, SharedRepository pushRepo)
-        {
-            string baseRev = _hgWrapper.GetLastPublicRevision(repository);
+    /// <summary>
+    /// Retrieve a list of <see cref="SharedRepository" />.
+    /// </summary>
+    public override IEnumerable<SharedRepository> GetRepositories() => GetRepositories(GetLicensesForUserProjects());
 
-            // Create bundle
-            byte[] bundle = HgWrapper.Bundle(repository, baseRev);
-            if (bundle.Length == 0)
-                return;
+    /// <summary>
+    /// Gets the metadata information for all projects that the current user is on.
+    /// Sourced from <see cref="RegistryServer" />.
+    /// </summary>
+    public IEnumerable<ProjectMetadata> GetProjectsMetaData()
+    {
+        JArray projects = GetJsonArray("my/projects");
+        return projects?.Select(p => new ProjectMetadata((JObject)p)).ToList();
+    }
 
-            // Send bundle
-            string guid = Guid.NewGuid().ToString();
-            client.PostStreaming(
-                bundle,
-                "pushbundle",
-                "guid",
-                guid,
-                "proj",
-                pushRepo.ScrTextName,
-                "projid",
-                pushRepo.SendReceiveId.Id,
-                "registered",
-                "yes",
-                "userschanged",
-                "no"
-            );
+    /// <summary>Gets the client.</summary>
+    /// <remarks>Helps unit tests</remarks>
+    public virtual RESTClient GetClient() => client;
 
-            _hgWrapper.MarkSharedChangeSetsPublic(repository);
-        }
-
-        /// <summary>
-        /// This looks like it would be important, but it doesn't seem to matter what it returns, to synchronize.
-        /// </summary>
-        public override string GetHgUri(SharedRepository sharedRepository)
-        {
-            return string.Empty;
-        }
-
-        /// <summary>
-        /// Retrieve a list of <see cref="SharedRepository" />.
-        /// </summary>
-        public override IEnumerable<SharedRepository> GetRepositories()
-        {
-            return GetRepositories(GetLicensesForUserProjects());
-        }
-
-        /// <summary>
-        /// Gets the metadata information for all projects that the current user is on.
-        /// Sourced from <see cref="RegistryServer" />.
-        /// </summary>
-        public IEnumerable<ProjectMetadata> GetProjectsMetaData()
-        {
-            JArray projects = GetJsonArray("my/projects");
-            return projects == null ? null : projects.Select(p => new ProjectMetadata((JObject)p)).ToList();
-        }
-
-        /// <summary>Gets the client.</summary>
-        /// <remarks>Helps unit tests</remarks>
-        public virtual RESTClient GetClient()
-        {
-            return client;
-        }
-
-        /// <summary>
-        /// Gets the licenses for all projects the current user is a member of.
-        /// Sourced from <see cref="RegistryServer" />.
-        /// </summary>
-        private List<ProjectLicense> GetLicensesForUserProjects()
-        {
-            JArray licenses = GetJsonArray("my/licenses");
-            if (licenses == null)
-                return null;
-            List<ProjectLicense> result = new List<ProjectLicense>();
-            foreach (JObject license in licenses)
-            {
-                var projLicense = new ProjectLicense(license);
-                if (projLicense.IsInvalid || projLicense.IsExpired)
-                    continue;
-                result.Add(projLicense);
-            }
-            return result;
-        }
-
-        private JArray GetJsonArray(string cgiCall)
-        {
-            string projectData = _registryClient.Get(cgiCall);
-            if (!string.IsNullOrEmpty(projectData) && !projectData.Equals("null", StringComparison.OrdinalIgnoreCase))
-                return JArray.Parse(projectData);
+    /// <summary>
+    /// Gets the licenses for all projects the current user is a member of.
+    /// Sourced from <see cref="RegistryServer" />.
+    /// </summary>
+    private List<ProjectLicense> GetLicensesForUserProjects()
+    {
+        JArray licenses = GetJsonArray("my/licenses");
+        if (licenses == null)
             return null;
-        }
-
-        private void SetToken(string jwtToken)
+        List<ProjectLicense> result = new List<ProjectLicense>();
+        foreach (JObject license in licenses.Cast<JObject>())
         {
-            client.JwtToken = jwtToken;
-            // RestClient only uses the jwtToken if authentication is null;
-            ReflectionHelperLite.SetField(client, "authentication", null);
-            _registryClient.JwtToken = jwtToken;
+            var projLicense = new ProjectLicense(license);
+            if (projLicense.IsInvalid || projLicense.IsExpired)
+                continue;
+            result.Add(projLicense);
         }
+        return result;
+    }
+
+    private JArray GetJsonArray(string cgiCall)
+    {
+        string projectData = _registryClient.Get(cgiCall);
+        if (!string.IsNullOrEmpty(projectData) && !projectData.Equals("null", StringComparison.OrdinalIgnoreCase))
+            return JArray.Parse(projectData);
+        return null;
+    }
+
+    private void SetToken(string jwtToken)
+    {
+        client.JwtToken = jwtToken;
+        // RestClient only uses the jwtToken if authentication is null;
+        ReflectionHelperLite.SetField(client, "authentication", null);
+        _registryClient.JwtToken = jwtToken;
     }
 }

--- a/src/SIL.XForge.Scripture/Services/JwtRestClient.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtRestClient.cs
@@ -1,18 +1,18 @@
 using Paratext;
 using Paratext.Data;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary> A REST client using a JWT token to authenticate. </summary>
+public class JwtRestClient : RESTClient, ISFRestClient
 {
-    /// <summary> A REST client using a JWT token to authenticate. </summary>
-    public class JwtRestClient : RESTClient, ISFRestClient
+    public JwtRestClient(string baseUri, string applicationName, string jwtToken)
+        : base(baseUri, null)
     {
-        public JwtRestClient(string baseUri, string applicationName, string jwtToken) : base(baseUri, null)
-        {
-            this.JwtToken = jwtToken;
-            ReflectionHelperLite.SetField(this, "authentication", null);
-            string location = System.Reflection.Assembly.GetEntryAssembly().Location;
-            string version = System.Diagnostics.FileVersionInfo.GetVersionInfo(location).ProductVersion ?? "1.0";
-            OverrideApplicationAgent = applicationName.Replace(" ", "") + "/" + version;
-        }
+        this.JwtToken = jwtToken;
+        ReflectionHelperLite.SetField(this, "authentication", null);
+        string location = System.Reflection.Assembly.GetEntryAssembly().Location;
+        string version = System.Diagnostics.FileVersionInfo.GetVersionInfo(location).ProductVersion ?? "1.0";
+        OverrideApplicationAgent = applicationName.Replace(" ", "") + "/" + version;
     }
 }

--- a/src/SIL.XForge.Scripture/Services/JwtTokenHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtTokenHelper.cs
@@ -10,72 +10,64 @@ using Newtonsoft.Json.Linq;
 using SIL.XForge.Configuration;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary> Helper methods to access information involving JWT tokens </summary>
+public class JwtTokenHelper : IJwtTokenHelper
 {
-    /// <summary> Helper methods to access information involving JWT tokens </summary>
-    public class JwtTokenHelper : IJwtTokenHelper
+    private readonly IExceptionHandler _exceptionHandler;
+
+    public JwtTokenHelper(IExceptionHandler exceptionHandler) => _exceptionHandler = exceptionHandler;
+
+    /// <summary> Get the Paratext username from the access token stored in the UserSecret. </summary>
+    public string? GetParatextUsername(UserSecret userSecret)
     {
-        private readonly IExceptionHandler _exceptionHandler;
-
-        public JwtTokenHelper(IExceptionHandler exceptionHandler)
+        if (userSecret == null || userSecret.ParatextTokens == null || userSecret.ParatextTokens.AccessToken == null)
         {
-            _exceptionHandler = exceptionHandler;
+            return null;
         }
+        var accessToken = new JwtSecurityToken(userSecret.ParatextTokens.AccessToken);
+        Claim usernameClaim = accessToken.Claims.FirstOrDefault(c => c.Type == "username");
+        return usernameClaim?.Value;
+    }
 
-        /// <summary> Get the Paratext username from the access token stored in the UserSecret. </summary>
-        public string? GetParatextUsername(UserSecret userSecret)
+    /// <summary> Get the JWT token that a REST client can use to authenticate. </summary>
+    public string GetJwtTokenFromUserSecret(UserSecret userSecret)
+    {
+        var jwtToken = userSecret.ParatextTokens.AccessToken;
+        if (jwtToken?.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) ?? false)
+            jwtToken = jwtToken["Bearer ".Length..].Trim();
+        return jwtToken;
+    }
+
+    /// <summary> Refresh the Paratext access token if expired with the given HttpClient. </summary>
+    public async Task<Tokens> RefreshAccessTokenAsync(
+        ParatextOptions options,
+        Tokens paratextTokens,
+        HttpClient client,
+        CancellationToken token
+    )
+    {
+        bool expired = !paratextTokens.ValidateLifetime();
+        if (!expired)
+            return paratextTokens;
+        using var request = new HttpRequestMessage(HttpMethod.Post, "api8/token");
+        var requestObj = new JObject(
+            new JProperty("grant_type", "refresh_token"),
+            new JProperty("client_id", options.ClientId),
+            new JProperty("client_secret", options.ClientSecret),
+            new JProperty("refresh_token", paratextTokens.RefreshToken)
+        );
+        request.Content = new StringContent(requestObj.ToString(), Encoding.Default, "application/json");
+        HttpResponseMessage response = await client.SendAsync(request, token);
+        await _exceptionHandler.EnsureSuccessStatusCode(response);
+
+        string responseJson = await response.Content.ReadAsStringAsync(token);
+        JObject responseObj = JObject.Parse(responseJson);
+        return new Tokens
         {
-            if (
-                userSecret == null || userSecret.ParatextTokens == null || userSecret.ParatextTokens.AccessToken == null
-            )
-            {
-                return null;
-            }
-            var accessToken = new JwtSecurityToken(userSecret.ParatextTokens.AccessToken);
-            Claim usernameClaim = accessToken.Claims.FirstOrDefault(c => c.Type == "username");
-            return usernameClaim?.Value;
-        }
-
-        /// <summary> Get the JWT token that a REST client can use to authenticate. </summary>
-        public string GetJwtTokenFromUserSecret(UserSecret userSecret)
-        {
-            var jwtToken = userSecret.ParatextTokens.AccessToken;
-            if (jwtToken?.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) ?? false)
-                jwtToken = jwtToken.Substring("Bearer ".Length).Trim();
-            return jwtToken;
-        }
-
-        /// <summary> Refresh the Paratext access token if expired with the given HttpClient. </summary>
-        public async Task<Tokens> RefreshAccessTokenAsync(
-            ParatextOptions options,
-            Tokens paratextTokens,
-            HttpClient client,
-            CancellationToken token
-        )
-        {
-            bool expired = !paratextTokens.ValidateLifetime();
-            if (!expired)
-                return paratextTokens;
-            using (var request = new HttpRequestMessage(HttpMethod.Post, "api8/token"))
-            {
-                var requestObj = new JObject(
-                    new JProperty("grant_type", "refresh_token"),
-                    new JProperty("client_id", options.ClientId),
-                    new JProperty("client_secret", options.ClientSecret),
-                    new JProperty("refresh_token", paratextTokens.RefreshToken)
-                );
-                request.Content = new StringContent(requestObj.ToString(), Encoding.Default, "application/json");
-                HttpResponseMessage response = await client.SendAsync(request, token);
-                await _exceptionHandler.EnsureSuccessStatusCode(response);
-
-                string responseJson = await response.Content.ReadAsStringAsync();
-                JObject responseObj = JObject.Parse(responseJson);
-                return new Tokens
-                {
-                    AccessToken = (string)responseObj["access_token"],
-                    RefreshToken = (string)responseObj["refresh_token"]
-                };
-            }
-        }
+            AccessToken = (string)responseObj["access_token"],
+            RefreshToken = (string)responseObj["refresh_token"]
+        };
     }
 }

--- a/src/SIL.XForge.Scripture/Services/LazyScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/LazyScrTextCollection.cs
@@ -6,86 +6,82 @@ using Paratext.Data.ProjectSettingsAccess;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// A class that can be used to get a ScrText without using a cache. This class is not
+/// related by inheritance or type to ScrTextCollection.
+/// </summary>
+public class LazyScrTextCollection : IScrTextCollection
 {
-    /// <summary>
-    /// A class that can be used to get a ScrText without using a cache. This class is not
-    /// related by inheritance or type to ScrTextCollection.
-    /// </summary>
-    public class LazyScrTextCollection : IScrTextCollection
+    public LazyScrTextCollection() => FileSystemService = new FileSystemService();
+
+    /// <summary> Path of directory containing projects. </summary>
+    public string SettingsDirectory { get; set; }
+    internal IFileSystemService FileSystemService { get; set; }
+
+    /// <summary> Set the directory to the folder containing Paratext projects. </summary>
+    public void Initialize(string projectsPath)
     {
-        public LazyScrTextCollection()
-        {
-            FileSystemService = new FileSystemService();
-        }
+        SettingsDirectory = projectsPath;
+        // Initialize so that Paratext.Data can find settings files
+        ScrTextCollection.Implementation = new SFScrTextCollection();
+        ScrTextCollection.Initialize(projectsPath);
+    }
 
-        /// <summary> Path of directory containing projects. </summary>
-        public string SettingsDirectory { get; set; }
-        internal IFileSystemService FileSystemService { get; set; }
-
-        /// <summary> Set the directory to the folder containing Paratext projects. </summary>
-        public void Initialize(string projectsPath)
-        {
-            SettingsDirectory = projectsPath;
-            // Initialize so that Paratext.Data can find settings files
-            ScrTextCollection.Implementation = new SFScrTextCollection();
-            ScrTextCollection.Initialize(projectsPath);
-        }
-
-        /// <summary>
-        /// Get a ScrText for a given user from the data for a paratext project with the target project ID and type.
-        /// </summary>
-        /// <param name="ptUsername"> The username of the user retrieving the ScrText. </param>
-        /// <param name="projectId"> The ID of the target project. </param>
-        public ScrText? FindById(string ptUsername, string projectId)
-        {
-            if (projectId == null)
-                return null;
-            string baseProjectPath = Path.Combine(SettingsDirectory, projectId);
-            if (!FileSystemService.DirectoryExists(baseProjectPath))
-                return null;
-
-            string fullProjectPath = Path.Combine(baseProjectPath, "target");
-            string settingsFile = Path.Combine(fullProjectPath, ProjectSettings.fileName);
-            if (!FileSystemService.FileExists(settingsFile))
-            {
-                // If this is an older project (most likely a resource), there will be an SSF file
-                settingsFile = FileSystemService.EnumerateFiles(fullProjectPath, "*.ssf").FirstOrDefault();
-
-                // We couldn't find the xml or ssf file
-                if (settingsFile == null)
-                {
-                    return null;
-                }
-            }
-
-            string name = GetNameFromSettings(settingsFile);
-            if (name != null)
-            {
-                ScrText scrText = CreateScrText(
-                    ptUsername,
-                    new ProjectName() { ProjectPath = fullProjectPath, ShortName = name }
-                );
-
-                // return the object
-                return scrText;
-            }
-
+    /// <summary>
+    /// Get a ScrText for a given user from the data for a paratext project with the target project ID and type.
+    /// </summary>
+    /// <param name="ptUsername"> The username of the user retrieving the ScrText. </param>
+    /// <param name="projectId"> The ID of the target project. </param>
+    public ScrText? FindById(string ptUsername, string projectId)
+    {
+        if (projectId == null)
             return null;
+        string baseProjectPath = Path.Combine(SettingsDirectory, projectId);
+        if (!FileSystemService.DirectoryExists(baseProjectPath))
+            return null;
+
+        string fullProjectPath = Path.Combine(baseProjectPath, "target");
+        string settingsFile = Path.Combine(fullProjectPath, ProjectSettings.fileName);
+        if (!FileSystemService.FileExists(settingsFile))
+        {
+            // If this is an older project (most likely a resource), there will be an SSF file
+            settingsFile = FileSystemService.EnumerateFiles(fullProjectPath, "*.ssf").FirstOrDefault();
+
+            // We couldn't find the xml or ssf file
+            if (settingsFile == null)
+            {
+                return null;
+            }
         }
 
-        protected virtual ScrText CreateScrText(string ptUsername, ProjectName projectName)
+        string name = GetNameFromSettings(settingsFile);
+        if (name != null)
         {
-            var associatedUser = new SFParatextUser(ptUsername);
-            return new ScrText(projectName, associatedUser);
+            ScrText scrText = CreateScrText(
+                ptUsername,
+                new ProjectName() { ProjectPath = fullProjectPath, ShortName = name }
+            );
+
+            // return the object
+            return scrText;
         }
 
-        private string GetNameFromSettings(string settingsFilePath)
-        {
-            string contents = FileSystemService.FileReadText(settingsFilePath);
-            XElement root = XElement.Parse(contents);
-            XElement nameElem = root.Element("Name");
-            return nameElem == null || nameElem.Value == "" ? null : nameElem.Value;
-        }
+        return null;
+    }
+
+    protected virtual ScrText CreateScrText(string ptUsername, ProjectName projectName)
+    {
+        var associatedUser = new SFParatextUser(ptUsername);
+        return new ScrText(projectName, associatedUser);
+    }
+
+    private string GetNameFromSettings(string settingsFilePath)
+    {
+        string contents = FileSystemService.FileReadText(settingsFilePath);
+        XElement root = XElement.Parse(contents);
+        XElement nameElem = root.Element("Name");
+        return nameElem == null || nameElem.Value == "" ? null : nameElem.Value;
     }
 }

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -20,728 +20,714 @@ using SIL.XForge.Scripture.Models;
 using SIL.XForge.Services;
 using SIL.XForge.Utils;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// The Machine API service for use with <see cref="Controllers.MachineApiController"/>.
+/// </summary>
+public class MachineApiService : IMachineApiService
 {
-    /// <summary>
-    /// The Machine API service for use with <see cref="Controllers.MachineApiController"/>.
-    /// </summary>
-    public class MachineApiService : IMachineApiService
+    private readonly IBuildRepository _builds;
+    private readonly IEngineRepository _engines;
+    private readonly IOptions<EngineOptions> _engineOptions;
+    private readonly IEngineService _engineService;
+    private readonly IExceptionHandler _exceptionHandler;
+    private readonly IFeatureManager _featureManager;
+    private readonly IMachineBuildService _machineBuildService;
+    private readonly IMachineProjectService _machineProjectService;
+    private readonly IMachineTranslationService _machineTranslationService;
+    private readonly DataAccess.IRepository<SFProjectSecret> _projectSecrets;
+    private readonly IRealtimeService _realtimeService;
+
+    public MachineApiService(
+        IBuildRepository builds,
+        IEngineRepository engines,
+        IOptions<EngineOptions> engineOptions,
+        IEngineService engineService,
+        IExceptionHandler exceptionHandler,
+        IFeatureManager featureManager,
+        IMachineBuildService machineBuildService,
+        IMachineProjectService machineProjectService,
+        IMachineTranslationService machineTranslationService,
+        DataAccess.IRepository<SFProjectSecret> projectSecrets,
+        IRealtimeService realtimeService
+    )
     {
-        private readonly IBuildRepository _builds;
-        private readonly IEngineRepository _engines;
-        private readonly IOptions<EngineOptions> _engineOptions;
-        private readonly IEngineService _engineService;
-        private readonly IExceptionHandler _exceptionHandler;
-        private readonly IFeatureManager _featureManager;
-        private readonly IMachineBuildService _machineBuildService;
-        private readonly IMachineProjectService _machineProjectService;
-        private readonly IMachineTranslationService _machineTranslationService;
-        private readonly DataAccess.IRepository<SFProjectSecret> _projectSecrets;
-        private readonly IRealtimeService _realtimeService;
+        // In Process Machine Dependencies
+        _builds = builds;
+        _engines = engines;
+        _engineOptions = engineOptions;
+        _engineService = engineService;
 
-        public MachineApiService(
-            IBuildRepository builds,
-            IEngineRepository engines,
-            IOptions<EngineOptions> engineOptions,
-            IEngineService engineService,
-            IExceptionHandler exceptionHandler,
-            IFeatureManager featureManager,
-            IMachineBuildService machineBuildService,
-            IMachineProjectService machineProjectService,
-            IMachineTranslationService machineTranslationService,
-            DataAccess.IRepository<SFProjectSecret> projectSecrets,
-            IRealtimeService realtimeService
-        )
+        // Shared Dependencies
+        _exceptionHandler = exceptionHandler;
+        _featureManager = featureManager;
+
+        // Machine API Dependencies
+        _machineBuildService = machineBuildService;
+        _machineProjectService = machineProjectService;
+        _machineTranslationService = machineTranslationService;
+        _projectSecrets = projectSecrets;
+        _realtimeService = realtimeService;
+    }
+
+    public async Task<BuildDto?> GetBuildAsync(
+        string curUserId,
+        string sfProjectId,
+        string buildId,
+        long? minRevision,
+        CancellationToken cancellationToken
+    )
+    {
+        BuildDto? buildDto;
+
+        // Ensure that the user has permission
+        await EnsurePermissionAsync(curUserId, sfProjectId);
+
+        // Execute the In Process Machine instance, if it is enabled
+        // We can only use In Process or the API - not both or unnecessary delays will result
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
         {
-            // In Process Machine Dependencies
-            _builds = builds;
-            _engines = engines;
-            _engineOptions = engineOptions;
-            _engineService = engineService;
-
-            // Shared Dependencies
-            _exceptionHandler = exceptionHandler;
-            _featureManager = featureManager;
-
-            // Machine API Dependencies
-            _machineBuildService = machineBuildService;
-            _machineProjectService = machineProjectService;
-            _machineTranslationService = machineTranslationService;
-            _projectSecrets = projectSecrets;
-            _realtimeService = realtimeService;
+            buildDto = await GetInProcessBuildAsync(BuildLocatorType.Id, buildId, minRevision, cancellationToken);
         }
-
-        public async Task<BuildDto?> GetBuildAsync(
-            string curUserId,
-            string sfProjectId,
-            string buildId,
-            long? minRevision,
-            CancellationToken cancellationToken
-        )
+        else if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
         {
-            BuildDto? buildDto;
-
-            // Ensure that the user has permission
-            await EnsurePermissionAsync(curUserId, sfProjectId);
-
-            // Execute the In Process Machine instance, if it is enabled
-            // We can only use In Process or the API - not both or unnecessary delays will result
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-            {
-                buildDto = await GetInProcessBuildAsync(BuildLocatorType.Id, buildId, minRevision, cancellationToken);
-            }
-            else if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
-            {
-                // Execute the Machine API, if it is enabled
-                string translationEngineId = await GetTranslationIdAsync(sfProjectId);
-                if (string.IsNullOrWhiteSpace(translationEngineId))
-                {
-                    throw new DataNotFoundException("The translation engine is not configured");
-                }
-
-                buildDto = await _machineBuildService.GetBuildAsync(
-                    translationEngineId,
-                    buildId,
-                    minRevision,
-                    cancellationToken
-                );
-            }
-            else
-            {
-                // No feature flags enabled, notify the user
-                throw new DataNotFoundException("No Machine learning engine is enabled");
-            }
-
-            // Make sure the DTO conforms to the machine-api V2 URLs
-            if (buildDto is not null)
-            {
-                UpdateDto(buildDto, sfProjectId);
-            }
-
-            return buildDto;
-        }
-
-        public async Task<BuildDto?> GetCurrentBuildAsync(
-            string curUserId,
-            string sfProjectId,
-            long? minRevision,
-            CancellationToken cancellationToken
-        )
-        {
-            BuildDto? buildDto;
-
-            // Ensure that the user has permission
-            await EnsurePermissionAsync(curUserId, sfProjectId);
-
-            // We can only use In Process or the API - not both or unnecessary delays will result
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-            {
-                // Execute the In Process Machine instance, if it is enabled
-                Engine engine = await GetInProcessEngineAsync(sfProjectId, cancellationToken);
-                buildDto = await GetInProcessBuildAsync(
-                    BuildLocatorType.Engine,
-                    engine.Id,
-                    minRevision,
-                    cancellationToken
-                );
-            }
-            else if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
-            {
-                // Otherwise, execute the Machine API, if it is enabled
-                string translationEngineId = await GetTranslationIdAsync(sfProjectId);
-                if (string.IsNullOrWhiteSpace(translationEngineId))
-                {
-                    throw new DataNotFoundException("The translation engine is not configured");
-                }
-
-                buildDto = await _machineBuildService.GetCurrentBuildAsync(
-                    translationEngineId,
-                    minRevision,
-                    cancellationToken
-                );
-            }
-            else
-            {
-                // No feature flags enabled, notify the user
-                throw new DataNotFoundException("No Machine learning engine is enabled");
-            }
-
-            // Make sure the DTO conforms to the machine-api V2 URLs
-            if (buildDto is not null)
-            {
-                UpdateDto(buildDto, sfProjectId);
-            }
-
-            return buildDto;
-        }
-
-        public async Task<EngineDto> GetEngineAsync(
-            string curUserId,
-            string sfProjectId,
-            CancellationToken cancellationToken
-        )
-        {
-            EngineDto? engineDto = null;
-
-            // Ensure that the user has permission
-            await EnsurePermissionAsync(curUserId, sfProjectId);
-
             // Execute the Machine API, if it is enabled
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
-            {
-                string translationEngineId = await GetTranslationIdAsync(sfProjectId);
-                if (!string.IsNullOrWhiteSpace(translationEngineId))
-                {
-                    try
-                    {
-                        MachineApiTranslationEngine translationEngine =
-                            await _machineTranslationService.GetTranslationEngineAsync(
-                                translationEngineId,
-                                cancellationToken
-                            );
-                        engineDto = CreateDto(translationEngine);
-                    }
-                    catch (BrokenCircuitException e)
-                    {
-                        // We do not want to throw the error if we are returning from In Process API below
-                        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-                        {
-                            _exceptionHandler.ReportException(e);
-                        }
-                        else
-                        {
-                            throw;
-                        }
-                    }
-                }
-                else if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-                {
-                    // Only throw the exception if the In Process instance will not be called below
-                    throw new DataNotFoundException("The translation engine is not configured");
-                }
-            }
-
-            // Execute the In Process Machine instance, if it is enabled
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-            {
-                Engine engine = await GetInProcessEngineAsync(sfProjectId, cancellationToken);
-                engineDto = CreateDto(engine);
-            }
-
-            // This will be null if the Machine API is down, or if all feature flags are false
-            if (engineDto is null)
-            {
-                throw new DataNotFoundException("No translation engine could be retrieved");
-            }
-
-            // Make sure the DTO conforms to the machine-api V2 URLs
-            return UpdateDto(engineDto, sfProjectId);
-        }
-
-        public async Task<WordGraphDto> GetWordGraphAsync(
-            string curUserId,
-            string sfProjectId,
-            IReadOnlyList<string> segment,
-            CancellationToken cancellationToken
-        )
-        {
-            WordGraphDto? wordGraphDto = null;
-
-            // Ensure that the user has permission
-            await EnsurePermissionAsync(curUserId, sfProjectId);
-
-            // Execute the Machine API, if it is enabled
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
-            {
-                string translationEngineId = await GetTranslationIdAsync(sfProjectId);
-                if (!string.IsNullOrWhiteSpace(translationEngineId))
-                {
-                    try
-                    {
-                        wordGraphDto = await _machineTranslationService.GetWordGraphAsync(
-                            translationEngineId,
-                            segment,
-                            cancellationToken
-                        );
-                    }
-                    catch (BrokenCircuitException e)
-                    {
-                        // We do not want to throw the error if we are returning from In Process API below
-                        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-                        {
-                            _exceptionHandler.ReportException(e);
-                        }
-                        else
-                        {
-                            throw;
-                        }
-                    }
-                }
-                else if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-                {
-                    // Only throw the exception if the In Process instance will not be called below
-                    throw new DataNotFoundException("The translation engine is not configured");
-                }
-            }
-
-            // Execute the In Process Machine instance, if it is enabled
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-            {
-                Engine engine = await GetInProcessEngineAsync(sfProjectId, cancellationToken);
-                WordGraph wordGraph = await _engineService.GetWordGraphAsync(engine.Id, segment);
-                wordGraphDto = CreateDto(wordGraph);
-            }
-
-            // This will be null if the Machine API is down, or if all feature flags are false
-            if (wordGraphDto is null)
-            {
-                throw new DataNotFoundException("No translation engine could be retrieved");
-            }
-
-            return wordGraphDto;
-        }
-
-        public async Task<BuildDto> StartBuildAsync(
-            string curUserId,
-            string sfProjectId,
-            CancellationToken cancellationToken
-        )
-        {
-            BuildDto? buildDto = null;
-
-            // Ensure that the user has permission
-            await EnsurePermissionAsync(curUserId, sfProjectId);
-
-            // Execute the Machine API, if it is enabled
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
-            {
-                string translationEngineId = await GetTranslationIdAsync(sfProjectId);
-                if (!string.IsNullOrWhiteSpace(translationEngineId))
-                {
-                    try
-                    {
-                        // We do not need the success boolean result, as we will still rebuild if no files have changed
-                        _ = await _machineProjectService.SyncProjectCorporaAsync(
-                            curUserId,
-                            sfProjectId,
-                            cancellationToken
-                        );
-                        buildDto = await _machineBuildService.StartBuildAsync(translationEngineId, cancellationToken);
-                    }
-                    catch (BrokenCircuitException e)
-                    {
-                        // We do not want to throw the error if we are returning from In Process API below
-                        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-                        {
-                            _exceptionHandler.ReportException(e);
-                        }
-                        else
-                        {
-                            throw;
-                        }
-                    }
-                }
-                else if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-                {
-                    // Only throw the exception if the In Process instance will not be called below
-                    throw new DataNotFoundException("The translation engine is not configured");
-                }
-            }
-
-            // Execute the In Process Machine instance, if it is enabled
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-            {
-                Engine engine = await GetInProcessEngineAsync(sfProjectId, cancellationToken);
-                Build build = await _engineService.StartBuildAsync(engine.Id);
-                buildDto = CreateDto(build);
-            }
-
-            // This will be null if the Machine API is down, or if all feature flags are false
-            if (buildDto is null)
-            {
-                throw new DataNotFoundException("No translation engine could be retrieved");
-            }
-
-            return UpdateDto(buildDto, sfProjectId);
-        }
-
-        public async Task TrainSegmentAsync(
-            string curUserId,
-            string sfProjectId,
-            SegmentPairDto segmentPair,
-            CancellationToken cancellationToken
-        )
-        {
-            // Ensure that the user has permission
-            await EnsurePermissionAsync(curUserId, sfProjectId);
-
-            // Execute the Machine API, if it is enabled
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
-            {
-                string translationEngineId = await GetTranslationIdAsync(sfProjectId);
-                if (!string.IsNullOrWhiteSpace(translationEngineId))
-                {
-                    try
-                    {
-                        await _machineTranslationService.TrainSegmentAsync(
-                            translationEngineId,
-                            segmentPair,
-                            cancellationToken
-                        );
-                    }
-                    catch (BrokenCircuitException e)
-                    {
-                        // We do not want to throw the error if we are returning from In Process API below
-                        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-                        {
-                            _exceptionHandler.ReportException(e);
-                        }
-                        else
-                        {
-                            throw;
-                        }
-                    }
-                }
-                else if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-                {
-                    // Only throw the exception if the In Process instance will not be called below
-                    throw new DataNotFoundException("The translation engine is not configured");
-                }
-            }
-
-            // Execute the In Process Machine instance, if it is enabled
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-            {
-                Engine engine = await GetInProcessEngineAsync(sfProjectId, cancellationToken);
-                await _engineService.TrainSegmentAsync(
-                    engine.Id,
-                    segmentPair.SourceSegment,
-                    segmentPair.TargetSegment,
-                    segmentPair.SentenceStart
-                );
-            }
-        }
-
-        public async Task<TranslationResultDto> TranslateAsync(
-            string curUserId,
-            string sfProjectId,
-            IReadOnlyList<string> segment,
-            CancellationToken cancellationToken
-        )
-        {
-            TranslationResultDto? translationResultDto = null;
-
-            // Ensure that the user has permission
-            await EnsurePermissionAsync(curUserId, sfProjectId);
-
-            // Execute the Machine API, if it is enabled
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
-            {
-                string translationEngineId = await GetTranslationIdAsync(sfProjectId);
-                if (!string.IsNullOrWhiteSpace(translationEngineId))
-                {
-                    try
-                    {
-                        translationResultDto = await _machineTranslationService.TranslateAsync(
-                            translationEngineId,
-                            segment,
-                            cancellationToken
-                        );
-                    }
-                    catch (BrokenCircuitException e)
-                    {
-                        // We do not want to throw the error if we are returning from In Process API below
-                        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-                        {
-                            _exceptionHandler.ReportException(e);
-                        }
-                        else
-                        {
-                            throw;
-                        }
-                    }
-                }
-                else if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-                {
-                    // Only throw the exception if the In Process instance will not be called below
-                    throw new DataNotFoundException("The translation engine is not configured");
-                }
-            }
-
-            // Execute the In Process Machine instance, if it is enabled
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-            {
-                Engine engine = await GetInProcessEngineAsync(sfProjectId, cancellationToken);
-                TranslationResult translationResult = await _engineService.TranslateAsync(engine.Id, segment);
-                translationResultDto = CreateDto(translationResult);
-            }
-
-            // This will be null if the Machine API is down, or if all feature flags are false
-            if (translationResultDto is null)
-            {
-                throw new DataNotFoundException("No translation engine could be retrieved");
-            }
-
-            return translationResultDto;
-        }
-
-        public async Task<TranslationResultDto[]> TranslateNAsync(
-            string curUserId,
-            string sfProjectId,
-            int n,
-            IReadOnlyList<string> segment,
-            CancellationToken cancellationToken
-        )
-        {
-            TranslationResultDto[] translationResultsDto = Array.Empty<TranslationResultDto>();
-
-            // Ensure that the user has permission
-            await EnsurePermissionAsync(curUserId, sfProjectId);
-
-            // Execute the Machine API, if it is enabled
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
-            {
-                string translationEngineId = await GetTranslationIdAsync(sfProjectId);
-                if (!string.IsNullOrWhiteSpace(translationEngineId))
-                {
-                    try
-                    {
-                        translationResultsDto = await _machineTranslationService.TranslateNAsync(
-                            translationEngineId,
-                            n,
-                            segment,
-                            cancellationToken
-                        );
-                    }
-                    catch (BrokenCircuitException e)
-                    {
-                        // We do not want to throw the error if we are returning from In Process API below
-                        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-                        {
-                            _exceptionHandler.ReportException(e);
-                        }
-                        else
-                        {
-                            throw;
-                        }
-                    }
-                }
-                else if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-                {
-                    // Only throw the exception if the In Process instance will not be called below
-                    throw new DataNotFoundException("The translation engine is not configured");
-                }
-            }
-
-            // Execute the In Process Machine instance, if it is enabled
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-            {
-                Engine engine = await GetInProcessEngineAsync(sfProjectId, cancellationToken);
-                IEnumerable<TranslationResult> translationResults = await _engineService.TranslateAsync(
-                    engine.Id,
-                    n,
-                    segment
-                );
-                translationResultsDto = translationResults.Select(CreateDto).ToArray();
-            }
-
-            return translationResultsDto;
-        }
-
-        private static BuildDto CreateDto(Build build) =>
-            new BuildDto
-            {
-                Id = build.Id,
-                Revision = build.Revision,
-                PercentCompleted = build.PercentCompleted,
-                Message = build.Message,
-                State = build.State,
-            };
-
-        private static EngineDto CreateDto(MachineApiTranslationEngine translationEngine) =>
-            new EngineDto
-            {
-                Confidence = translationEngine.Confidence,
-                IsShared = false,
-                SourceLanguageTag = translationEngine.SourceLanguageTag,
-                TargetLanguageTag = translationEngine.TargetLanguageTag,
-                TrainedSegmentCount = translationEngine.CorpusSize,
-            };
-
-        private static EngineDto CreateDto(Engine engine) =>
-            new EngineDto
-            {
-                Confidence = engine.Confidence,
-                IsShared = false,
-                SourceLanguageTag = engine.SourceLanguageTag,
-                TargetLanguageTag = engine.TargetLanguageTag,
-                TrainedSegmentCount = engine.TrainedSegmentCount,
-            };
-
-        private static PhraseDto CreateDto(Phrase phrase) =>
-            new PhraseDto
-            {
-                SourceSegmentRange = CreateDto(phrase.SourceSegmentRange),
-                TargetSegmentCut = phrase.TargetSegmentCut,
-                Confidence = phrase.Confidence,
-            };
-
-        private static RangeDto CreateDto(Range<int> range) => new RangeDto { Start = range.Start, End = range.End };
-
-        private static TranslationResultDto CreateDto(TranslationResult translationResult) =>
-            new TranslationResultDto
-            {
-                Target = translationResult.TargetSegment.ToArray(),
-                Confidences = translationResult.WordConfidences.Select(c => (float)c).ToArray(),
-                Sources = translationResult.WordSources.ToArray(),
-                Alignment = CreateDto(translationResult.Alignment),
-                Phrases = translationResult.Phrases.Select(CreateDto).ToArray(),
-            };
-
-        private static WordGraphDto CreateDto(WordGraph wordGraph) =>
-            new WordGraphDto
-            {
-                InitialStateScore = (float)wordGraph.InitialStateScore,
-                FinalStates = wordGraph.FinalStates.ToArray(),
-                Arcs = wordGraph.Arcs.Select(CreateDto).ToArray(),
-            };
-
-        private static WordGraphArcDto CreateDto(WordGraphArc arc) =>
-            new WordGraphArcDto
-            {
-                PrevState = arc.PrevState,
-                NextState = arc.NextState,
-                Score = (float)arc.Score,
-                Words = arc.Words.ToArray(),
-                Confidences = arc.WordConfidences.Select(c => (float)c).ToArray(),
-                SourceSegmentRange = CreateDto(arc.SourceSegmentRange),
-                Sources = arc.WordSources.ToArray(),
-                Alignment = CreateDto(arc.Alignment),
-            };
-
-        private static AlignedWordPairDto[] CreateDto(WordAlignmentMatrix matrix)
-        {
-            var wordPairs = new List<AlignedWordPairDto>();
-            for (int i = 0; i < matrix.RowCount; i++)
-            {
-                for (int j = 0; j < matrix.ColumnCount; j++)
-                {
-                    if (matrix[i, j])
-                    {
-                        wordPairs.Add(new AlignedWordPairDto { SourceIndex = i, TargetIndex = j });
-                    }
-                }
-            }
-
-            return wordPairs.ToArray();
-        }
-
-        private static BuildDto UpdateDto(BuildDto buildDto, string sfProjectId)
-        {
-            buildDto.Href = MachineApi.GetBuildHref(sfProjectId, buildDto.Id);
-            buildDto.Engine = new ResourceDto { Href = MachineApi.GetEngineHref(sfProjectId), Id = sfProjectId };
-
-            // We use this special ID format so that the DTO ID can be an optional URL parameter
-            buildDto.Id = $"{sfProjectId}.{buildDto.Id}";
-            return buildDto;
-        }
-
-        private static EngineDto UpdateDto(EngineDto engineDto, string sfProjectId)
-        {
-            engineDto.Href = MachineApi.GetEngineHref(sfProjectId);
-            engineDto.Id = sfProjectId;
-            engineDto.Projects = new[]
-            {
-                new ResourceDto { Href = MachineApi.GetEngineHref(sfProjectId), Id = sfProjectId },
-            };
-            return engineDto;
-        }
-
-        private async Task EnsurePermissionAsync(string curUserId, string sfProjectId)
-        {
-            // Load the project from the realtime service
-            Attempt<SFProject> attempt = await _realtimeService.TryGetSnapshotAsync<SFProject>(sfProjectId);
-            if (!attempt.TryResult(out SFProject project))
-            {
-                throw new DataNotFoundException("The project does not exist.");
-            }
-
-            // Check for permission
-            if (
-                !(
-                    project.UserRoles.TryGetValue(curUserId, out string role)
-                    && role is SFProjectRole.Administrator or SFProjectRole.Translator
-                )
-            )
-            {
-                throw new ForbiddenException();
-            }
-        }
-
-        private async Task<BuildDto?> GetInProcessBuildAsync(
-            BuildLocatorType locatorType,
-            string locator,
-            long? minRevision,
-            CancellationToken cancellationToken
-        )
-        {
-            BuildDto? buildDto = null;
-            Build? build;
-            if (minRevision is not null)
-            {
-                EntityChange<Build> change = await _builds
-                    .GetNewerRevisionAsync(locatorType, locator, minRevision.Value, cancellationToken)
-                    .Timeout(_engineOptions.Value.BuildLongPollTimeout, cancellationToken);
-                build = change.Entity;
-                if (change.Type == EntityChangeType.Delete)
-                {
-                    throw new DataNotFoundException("Entity Deleted");
-                }
-            }
-            else
-            {
-                build = await _builds.GetByLocatorAsync(locatorType, locator, cancellationToken);
-            }
-
-            if (build is not null)
-            {
-                buildDto = CreateDto(build);
-            }
-
-            return buildDto;
-        }
-
-        private async Task<Engine> GetInProcessEngineAsync(string sfProjectId, CancellationToken cancellationToken)
-        {
-            Engine? engine = await _engines.GetByLocatorAsync(
-                EngineLocatorType.Project,
-                sfProjectId,
-                cancellationToken
-            );
-            if (engine is null)
-            {
-                throw new DataNotFoundException("The engine does not exist.");
-            }
-
-            return engine;
-        }
-
-        private async Task<string> GetTranslationIdAsync(string sfProjectId)
-        {
-            // Load the project secret, so we can get the translation engine ID
-            if (!(await _projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret))
-            {
-                return string.Empty;
-            }
-
-            // Ensure we have a translation engine ID
-            string? translationEngineId = projectSecret.MachineData?.TranslationEngineId;
+            string translationEngineId = await GetTranslationIdAsync(sfProjectId);
             if (string.IsNullOrWhiteSpace(translationEngineId))
             {
-                return string.Empty;
+                throw new DataNotFoundException("The translation engine is not configured");
             }
 
-            return translationEngineId;
+            buildDto = await _machineBuildService.GetBuildAsync(
+                translationEngineId,
+                buildId,
+                minRevision,
+                cancellationToken
+            );
         }
+        else
+        {
+            // No feature flags enabled, notify the user
+            throw new DataNotFoundException("No Machine learning engine is enabled");
+        }
+
+        // Make sure the DTO conforms to the machine-api V2 URLs
+        if (buildDto is not null)
+        {
+            UpdateDto(buildDto, sfProjectId);
+        }
+
+        return buildDto;
+    }
+
+    public async Task<BuildDto?> GetCurrentBuildAsync(
+        string curUserId,
+        string sfProjectId,
+        long? minRevision,
+        CancellationToken cancellationToken
+    )
+    {
+        BuildDto? buildDto;
+
+        // Ensure that the user has permission
+        await EnsurePermissionAsync(curUserId, sfProjectId);
+
+        // We can only use In Process or the API - not both or unnecessary delays will result
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+        {
+            // Execute the In Process Machine instance, if it is enabled
+            Engine engine = await GetInProcessEngineAsync(sfProjectId, cancellationToken);
+            buildDto = await GetInProcessBuildAsync(BuildLocatorType.Engine, engine.Id, minRevision, cancellationToken);
+        }
+        else if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
+        {
+            // Otherwise, execute the Machine API, if it is enabled
+            string translationEngineId = await GetTranslationIdAsync(sfProjectId);
+            if (string.IsNullOrWhiteSpace(translationEngineId))
+            {
+                throw new DataNotFoundException("The translation engine is not configured");
+            }
+
+            buildDto = await _machineBuildService.GetCurrentBuildAsync(
+                translationEngineId,
+                minRevision,
+                cancellationToken
+            );
+        }
+        else
+        {
+            // No feature flags enabled, notify the user
+            throw new DataNotFoundException("No Machine learning engine is enabled");
+        }
+
+        // Make sure the DTO conforms to the machine-api V2 URLs
+        if (buildDto is not null)
+        {
+            UpdateDto(buildDto, sfProjectId);
+        }
+
+        return buildDto;
+    }
+
+    public async Task<EngineDto> GetEngineAsync(
+        string curUserId,
+        string sfProjectId,
+        CancellationToken cancellationToken
+    )
+    {
+        EngineDto? engineDto = null;
+
+        // Ensure that the user has permission
+        await EnsurePermissionAsync(curUserId, sfProjectId);
+
+        // Execute the Machine API, if it is enabled
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
+        {
+            string translationEngineId = await GetTranslationIdAsync(sfProjectId);
+            if (!string.IsNullOrWhiteSpace(translationEngineId))
+            {
+                try
+                {
+                    MachineApiTranslationEngine translationEngine =
+                        await _machineTranslationService.GetTranslationEngineAsync(
+                            translationEngineId,
+                            cancellationToken
+                        );
+                    engineDto = CreateDto(translationEngine);
+                }
+                catch (BrokenCircuitException e)
+                {
+                    // We do not want to throw the error if we are returning from In Process API below
+                    if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+                    {
+                        _exceptionHandler.ReportException(e);
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+            }
+            else if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+            {
+                // Only throw the exception if the In Process instance will not be called below
+                throw new DataNotFoundException("The translation engine is not configured");
+            }
+        }
+
+        // Execute the In Process Machine instance, if it is enabled
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+        {
+            Engine engine = await GetInProcessEngineAsync(sfProjectId, cancellationToken);
+            engineDto = CreateDto(engine);
+        }
+
+        // This will be null if the Machine API is down, or if all feature flags are false
+        if (engineDto is null)
+        {
+            throw new DataNotFoundException("No translation engine could be retrieved");
+        }
+
+        // Make sure the DTO conforms to the machine-api V2 URLs
+        return UpdateDto(engineDto, sfProjectId);
+    }
+
+    public async Task<WordGraphDto> GetWordGraphAsync(
+        string curUserId,
+        string sfProjectId,
+        IReadOnlyList<string> segment,
+        CancellationToken cancellationToken
+    )
+    {
+        WordGraphDto? wordGraphDto = null;
+
+        // Ensure that the user has permission
+        await EnsurePermissionAsync(curUserId, sfProjectId);
+
+        // Execute the Machine API, if it is enabled
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
+        {
+            string translationEngineId = await GetTranslationIdAsync(sfProjectId);
+            if (!string.IsNullOrWhiteSpace(translationEngineId))
+            {
+                try
+                {
+                    wordGraphDto = await _machineTranslationService.GetWordGraphAsync(
+                        translationEngineId,
+                        segment,
+                        cancellationToken
+                    );
+                }
+                catch (BrokenCircuitException e)
+                {
+                    // We do not want to throw the error if we are returning from In Process API below
+                    if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+                    {
+                        _exceptionHandler.ReportException(e);
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+            }
+            else if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+            {
+                // Only throw the exception if the In Process instance will not be called below
+                throw new DataNotFoundException("The translation engine is not configured");
+            }
+        }
+
+        // Execute the In Process Machine instance, if it is enabled
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+        {
+            Engine engine = await GetInProcessEngineAsync(sfProjectId, cancellationToken);
+            WordGraph wordGraph = await _engineService.GetWordGraphAsync(engine.Id, segment);
+            wordGraphDto = CreateDto(wordGraph);
+        }
+
+        // This will be null if the Machine API is down, or if all feature flags are false
+        if (wordGraphDto is null)
+        {
+            throw new DataNotFoundException("No translation engine could be retrieved");
+        }
+
+        return wordGraphDto;
+    }
+
+    public async Task<BuildDto> StartBuildAsync(
+        string curUserId,
+        string sfProjectId,
+        CancellationToken cancellationToken
+    )
+    {
+        BuildDto? buildDto = null;
+
+        // Ensure that the user has permission
+        await EnsurePermissionAsync(curUserId, sfProjectId);
+
+        // Execute the Machine API, if it is enabled
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
+        {
+            string translationEngineId = await GetTranslationIdAsync(sfProjectId);
+            if (!string.IsNullOrWhiteSpace(translationEngineId))
+            {
+                try
+                {
+                    // We do not need the success boolean result, as we will still rebuild if no files have changed
+                    _ = await _machineProjectService.SyncProjectCorporaAsync(curUserId, sfProjectId, cancellationToken);
+                    buildDto = await _machineBuildService.StartBuildAsync(translationEngineId, cancellationToken);
+                }
+                catch (BrokenCircuitException e)
+                {
+                    // We do not want to throw the error if we are returning from In Process API below
+                    if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+                    {
+                        _exceptionHandler.ReportException(e);
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+            }
+            else if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+            {
+                // Only throw the exception if the In Process instance will not be called below
+                throw new DataNotFoundException("The translation engine is not configured");
+            }
+        }
+
+        // Execute the In Process Machine instance, if it is enabled
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+        {
+            Engine engine = await GetInProcessEngineAsync(sfProjectId, cancellationToken);
+            Build build = await _engineService.StartBuildAsync(engine.Id);
+            buildDto = CreateDto(build);
+        }
+
+        // This will be null if the Machine API is down, or if all feature flags are false
+        if (buildDto is null)
+        {
+            throw new DataNotFoundException("No translation engine could be retrieved");
+        }
+
+        return UpdateDto(buildDto, sfProjectId);
+    }
+
+    public async Task TrainSegmentAsync(
+        string curUserId,
+        string sfProjectId,
+        SegmentPairDto segmentPair,
+        CancellationToken cancellationToken
+    )
+    {
+        // Ensure that the user has permission
+        await EnsurePermissionAsync(curUserId, sfProjectId);
+
+        // Execute the Machine API, if it is enabled
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
+        {
+            string translationEngineId = await GetTranslationIdAsync(sfProjectId);
+            if (!string.IsNullOrWhiteSpace(translationEngineId))
+            {
+                try
+                {
+                    await _machineTranslationService.TrainSegmentAsync(
+                        translationEngineId,
+                        segmentPair,
+                        cancellationToken
+                    );
+                }
+                catch (BrokenCircuitException e)
+                {
+                    // We do not want to throw the error if we are returning from In Process API below
+                    if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+                    {
+                        _exceptionHandler.ReportException(e);
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+            }
+            else if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+            {
+                // Only throw the exception if the In Process instance will not be called below
+                throw new DataNotFoundException("The translation engine is not configured");
+            }
+        }
+
+        // Execute the In Process Machine instance, if it is enabled
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+        {
+            Engine engine = await GetInProcessEngineAsync(sfProjectId, cancellationToken);
+            await _engineService.TrainSegmentAsync(
+                engine.Id,
+                segmentPair.SourceSegment,
+                segmentPair.TargetSegment,
+                segmentPair.SentenceStart
+            );
+        }
+    }
+
+    public async Task<TranslationResultDto> TranslateAsync(
+        string curUserId,
+        string sfProjectId,
+        IReadOnlyList<string> segment,
+        CancellationToken cancellationToken
+    )
+    {
+        TranslationResultDto? translationResultDto = null;
+
+        // Ensure that the user has permission
+        await EnsurePermissionAsync(curUserId, sfProjectId);
+
+        // Execute the Machine API, if it is enabled
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
+        {
+            string translationEngineId = await GetTranslationIdAsync(sfProjectId);
+            if (!string.IsNullOrWhiteSpace(translationEngineId))
+            {
+                try
+                {
+                    translationResultDto = await _machineTranslationService.TranslateAsync(
+                        translationEngineId,
+                        segment,
+                        cancellationToken
+                    );
+                }
+                catch (BrokenCircuitException e)
+                {
+                    // We do not want to throw the error if we are returning from In Process API below
+                    if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+                    {
+                        _exceptionHandler.ReportException(e);
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+            }
+            else if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+            {
+                // Only throw the exception if the In Process instance will not be called below
+                throw new DataNotFoundException("The translation engine is not configured");
+            }
+        }
+
+        // Execute the In Process Machine instance, if it is enabled
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+        {
+            Engine engine = await GetInProcessEngineAsync(sfProjectId, cancellationToken);
+            TranslationResult translationResult = await _engineService.TranslateAsync(engine.Id, segment);
+            translationResultDto = CreateDto(translationResult);
+        }
+
+        // This will be null if the Machine API is down, or if all feature flags are false
+        if (translationResultDto is null)
+        {
+            throw new DataNotFoundException("No translation engine could be retrieved");
+        }
+
+        return translationResultDto;
+    }
+
+    public async Task<TranslationResultDto[]> TranslateNAsync(
+        string curUserId,
+        string sfProjectId,
+        int n,
+        IReadOnlyList<string> segment,
+        CancellationToken cancellationToken
+    )
+    {
+        TranslationResultDto[] translationResultsDto = Array.Empty<TranslationResultDto>();
+
+        // Ensure that the user has permission
+        await EnsurePermissionAsync(curUserId, sfProjectId);
+
+        // Execute the Machine API, if it is enabled
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
+        {
+            string translationEngineId = await GetTranslationIdAsync(sfProjectId);
+            if (!string.IsNullOrWhiteSpace(translationEngineId))
+            {
+                try
+                {
+                    translationResultsDto = await _machineTranslationService.TranslateNAsync(
+                        translationEngineId,
+                        n,
+                        segment,
+                        cancellationToken
+                    );
+                }
+                catch (BrokenCircuitException e)
+                {
+                    // We do not want to throw the error if we are returning from In Process API below
+                    if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+                    {
+                        _exceptionHandler.ReportException(e);
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+            }
+            else if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+            {
+                // Only throw the exception if the In Process instance will not be called below
+                throw new DataNotFoundException("The translation engine is not configured");
+            }
+        }
+
+        // Execute the In Process Machine instance, if it is enabled
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+        {
+            Engine engine = await GetInProcessEngineAsync(sfProjectId, cancellationToken);
+            IEnumerable<TranslationResult> translationResults = await _engineService.TranslateAsync(
+                engine.Id,
+                n,
+                segment
+            );
+            translationResultsDto = translationResults.Select(CreateDto).ToArray();
+        }
+
+        return translationResultsDto;
+    }
+
+    private static BuildDto CreateDto(Build build) =>
+        new BuildDto
+        {
+            Id = build.Id,
+            Revision = build.Revision,
+            PercentCompleted = build.PercentCompleted,
+            Message = build.Message,
+            State = build.State,
+        };
+
+    private static EngineDto CreateDto(MachineApiTranslationEngine translationEngine) =>
+        new EngineDto
+        {
+            Confidence = translationEngine.Confidence,
+            IsShared = false,
+            SourceLanguageTag = translationEngine.SourceLanguageTag,
+            TargetLanguageTag = translationEngine.TargetLanguageTag,
+            TrainedSegmentCount = translationEngine.CorpusSize,
+        };
+
+    private static EngineDto CreateDto(Engine engine) =>
+        new EngineDto
+        {
+            Confidence = engine.Confidence,
+            IsShared = false,
+            SourceLanguageTag = engine.SourceLanguageTag,
+            TargetLanguageTag = engine.TargetLanguageTag,
+            TrainedSegmentCount = engine.TrainedSegmentCount,
+        };
+
+    private static PhraseDto CreateDto(Phrase phrase) =>
+        new PhraseDto
+        {
+            SourceSegmentRange = CreateDto(phrase.SourceSegmentRange),
+            TargetSegmentCut = phrase.TargetSegmentCut,
+            Confidence = phrase.Confidence,
+        };
+
+    private static RangeDto CreateDto(Range<int> range) => new RangeDto { Start = range.Start, End = range.End };
+
+    private static TranslationResultDto CreateDto(TranslationResult translationResult) =>
+        new TranslationResultDto
+        {
+            Target = translationResult.TargetSegment.ToArray(),
+            Confidences = translationResult.WordConfidences.Select(c => (float)c).ToArray(),
+            Sources = translationResult.WordSources.ToArray(),
+            Alignment = CreateDto(translationResult.Alignment),
+            Phrases = translationResult.Phrases.Select(CreateDto).ToArray(),
+        };
+
+    private static WordGraphDto CreateDto(WordGraph wordGraph) =>
+        new WordGraphDto
+        {
+            InitialStateScore = (float)wordGraph.InitialStateScore,
+            FinalStates = wordGraph.FinalStates.ToArray(),
+            Arcs = wordGraph.Arcs.Select(CreateDto).ToArray(),
+        };
+
+    private static WordGraphArcDto CreateDto(WordGraphArc arc) =>
+        new WordGraphArcDto
+        {
+            PrevState = arc.PrevState,
+            NextState = arc.NextState,
+            Score = (float)arc.Score,
+            Words = arc.Words.ToArray(),
+            Confidences = arc.WordConfidences.Select(c => (float)c).ToArray(),
+            SourceSegmentRange = CreateDto(arc.SourceSegmentRange),
+            Sources = arc.WordSources.ToArray(),
+            Alignment = CreateDto(arc.Alignment),
+        };
+
+    private static AlignedWordPairDto[] CreateDto(WordAlignmentMatrix matrix)
+    {
+        var wordPairs = new List<AlignedWordPairDto>();
+        for (int i = 0; i < matrix.RowCount; i++)
+        {
+            for (int j = 0; j < matrix.ColumnCount; j++)
+            {
+                if (matrix[i, j])
+                {
+                    wordPairs.Add(new AlignedWordPairDto { SourceIndex = i, TargetIndex = j });
+                }
+            }
+        }
+
+        return wordPairs.ToArray();
+    }
+
+    private static BuildDto UpdateDto(BuildDto buildDto, string sfProjectId)
+    {
+        buildDto.Href = MachineApi.GetBuildHref(sfProjectId, buildDto.Id);
+        buildDto.Engine = new ResourceDto { Href = MachineApi.GetEngineHref(sfProjectId), Id = sfProjectId };
+
+        // We use this special ID format so that the DTO ID can be an optional URL parameter
+        buildDto.Id = $"{sfProjectId}.{buildDto.Id}";
+        return buildDto;
+    }
+
+    private static EngineDto UpdateDto(EngineDto engineDto, string sfProjectId)
+    {
+        engineDto.Href = MachineApi.GetEngineHref(sfProjectId);
+        engineDto.Id = sfProjectId;
+        engineDto.Projects = new[]
+        {
+            new ResourceDto { Href = MachineApi.GetEngineHref(sfProjectId), Id = sfProjectId },
+        };
+        return engineDto;
+    }
+
+    private async Task EnsurePermissionAsync(string curUserId, string sfProjectId)
+    {
+        // Load the project from the realtime service
+        Attempt<SFProject> attempt = await _realtimeService.TryGetSnapshotAsync<SFProject>(sfProjectId);
+        if (!attempt.TryResult(out SFProject project))
+        {
+            throw new DataNotFoundException("The project does not exist.");
+        }
+
+        // Check for permission
+        if (
+            !(
+                project.UserRoles.TryGetValue(curUserId, out string role)
+                && role is SFProjectRole.Administrator or SFProjectRole.Translator
+            )
+        )
+        {
+            throw new ForbiddenException();
+        }
+    }
+
+    private async Task<BuildDto?> GetInProcessBuildAsync(
+        BuildLocatorType locatorType,
+        string locator,
+        long? minRevision,
+        CancellationToken cancellationToken
+    )
+    {
+        BuildDto? buildDto = null;
+        Build? build;
+        if (minRevision is not null)
+        {
+            EntityChange<Build> change = await _builds
+                .GetNewerRevisionAsync(locatorType, locator, minRevision.Value, cancellationToken)
+                .Timeout(_engineOptions.Value.BuildLongPollTimeout, cancellationToken);
+            build = change.Entity;
+            if (change.Type == EntityChangeType.Delete)
+            {
+                throw new DataNotFoundException("Entity Deleted");
+            }
+        }
+        else
+        {
+            build = await _builds.GetByLocatorAsync(locatorType, locator, cancellationToken);
+        }
+
+        if (build is not null)
+        {
+            buildDto = CreateDto(build);
+        }
+
+        return buildDto;
+    }
+
+    private async Task<Engine> GetInProcessEngineAsync(string sfProjectId, CancellationToken cancellationToken)
+    {
+        Engine? engine = await _engines.GetByLocatorAsync(EngineLocatorType.Project, sfProjectId, cancellationToken);
+        if (engine is null)
+        {
+            throw new DataNotFoundException("The engine does not exist.");
+        }
+
+        return engine;
+    }
+
+    private async Task<string> GetTranslationIdAsync(string sfProjectId)
+    {
+        // Load the project secret, so we can get the translation engine ID
+        if (!(await _projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret))
+        {
+            return string.Empty;
+        }
+
+        // Ensure we have a translation engine ID
+        string? translationEngineId = projectSecret.MachineData?.TranslationEngineId;
+        if (string.IsNullOrWhiteSpace(translationEngineId))
+        {
+            return string.Empty;
+        }
+
+        return translationEngineId;
     }
 }

--- a/src/SIL.XForge.Scripture/Services/MachineBuildService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineBuildService.cs
@@ -8,136 +8,132 @@ using System.Threading.Tasks;
 using SIL.Machine.WebApi;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// Provides an interface to the Build endpoints of the Machine API Translation Engine.
+/// </summary>
+public class MachineBuildService : MachineServiceBase, IMachineBuildService
 {
-    /// <summary>
-    /// Provides an interface to the Build endpoints of the Machine API Translation Engine.
-    /// </summary>
-    public class MachineBuildService : MachineServiceBase, IMachineBuildService
+    private readonly IExceptionHandler _exceptionHandler;
+
+    public MachineBuildService(IExceptionHandler exceptionHandler, IHttpClientFactory httpClientFactory)
+        : base(httpClientFactory) => _exceptionHandler = exceptionHandler;
+
+    public async Task CancelCurrentBuildAsync(string translationEngineId, CancellationToken cancellationToken)
     {
-        private readonly IExceptionHandler _exceptionHandler;
+        ValidateId(translationEngineId);
 
-        public MachineBuildService(IExceptionHandler exceptionHandler, IHttpClientFactory httpClientFactory)
-            : base(httpClientFactory)
+        string requestUri = $"translation-engines/{translationEngineId}/current-build/cancel";
+        using var response = await MachineClient.PostAsync(requestUri, content: null, cancellationToken);
+
+        // A 200 HTTP status code is returned whether there is a job currently running or not
+        await _exceptionHandler.EnsureSuccessStatusCode(response);
+    }
+
+    public async Task<BuildDto?> GetBuildAsync(
+        string translationEngineId,
+        string buildId,
+        long? minRevision,
+        CancellationToken cancellationToken
+    )
+    {
+        ValidateId(translationEngineId);
+        ValidateId(buildId);
+
+        string requestUri = $"translation-engines/{translationEngineId}/builds/{buildId}";
+        return await GetBuildAsync(requestUri, minRevision, cancellationToken);
+    }
+
+    public async Task<BuildDto?> GetCurrentBuildAsync(
+        string translationEngineId,
+        long? minRevision,
+        CancellationToken cancellationToken
+    )
+    {
+        ValidateId(translationEngineId);
+
+        string requestUri = $"translation-engines/{translationEngineId}/current-build";
+        return await GetBuildAsync(requestUri, minRevision, cancellationToken);
+    }
+
+    public async Task<BuildDto> StartBuildAsync(string translationEngineId, CancellationToken cancellationToken)
+    {
+        ValidateId(translationEngineId);
+
+        string requestUri = $"translation-engines/{translationEngineId}/builds";
+        using var response = await MachineClient.PostAsync(requestUri, content: null, cancellationToken);
+        await _exceptionHandler.EnsureSuccessStatusCode(response);
+
+        // Return the build job information
+        try
         {
-            _exceptionHandler = exceptionHandler;
-        }
-
-        public async Task CancelCurrentBuildAsync(string translationEngineId, CancellationToken cancellationToken)
-        {
-            ValidateId(translationEngineId);
-
-            string requestUri = $"translation-engines/{translationEngineId}/current-build/cancel";
-            using var response = await MachineClient.PostAsync(requestUri, content: null, cancellationToken);
-
-            // A 200 HTTP status code is returned whether there is a job currently running or not
-            await _exceptionHandler.EnsureSuccessStatusCode(response);
-        }
-
-        public async Task<BuildDto?> GetBuildAsync(
-            string translationEngineId,
-            string buildId,
-            long? minRevision,
-            CancellationToken cancellationToken
-        )
-        {
-            ValidateId(translationEngineId);
-            ValidateId(buildId);
-
-            string requestUri = $"translation-engines/{translationEngineId}/builds/{buildId}";
-            return await GetBuildAsync(requestUri, minRevision, cancellationToken);
-        }
-
-        public async Task<BuildDto?> GetCurrentBuildAsync(
-            string translationEngineId,
-            long? minRevision,
-            CancellationToken cancellationToken
-        )
-        {
-            ValidateId(translationEngineId);
-
-            string requestUri = $"translation-engines/{translationEngineId}/current-build";
-            return await GetBuildAsync(requestUri, minRevision, cancellationToken);
-        }
-
-        public async Task<BuildDto> StartBuildAsync(string translationEngineId, CancellationToken cancellationToken)
-        {
-            ValidateId(translationEngineId);
-
-            string requestUri = $"translation-engines/{translationEngineId}/builds";
-            using var response = await MachineClient.PostAsync(requestUri, content: null, cancellationToken);
-            await _exceptionHandler.EnsureSuccessStatusCode(response);
-
-            // Return the build job information
-            try
+            BuildDto? build = await response.Content.ReadFromJsonAsync<BuildDto>(Options, cancellationToken);
+            if (build is null)
             {
-                BuildDto? build = await response.Content.ReadFromJsonAsync<BuildDto>(Options, cancellationToken);
-                if (build is null)
-                {
-                    throw new InvalidDataException();
-                }
+                throw new InvalidDataException();
+            }
 
+            // The Machine 2.5.12 DTO requires this to be uppercase
+            // Upgrading to a later version changes this to an enum
+            // When this occurs, remove this line
+            build.State = build.State.ToUpperInvariant();
+
+            return build;
+        }
+        catch (Exception e)
+        {
+            throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
+        }
+    }
+
+    private async Task<BuildDto?> GetBuildAsync(
+        string requestUri,
+        long? minRevision,
+        CancellationToken cancellationToken
+    )
+    {
+        if (minRevision.HasValue)
+        {
+            requestUri += $"?minRevision={minRevision}";
+        }
+
+        using var response = await MachineClient.GetAsync(requestUri, cancellationToken);
+
+        // A 408 HTTP status code is returned if there is no build started/running within the timeout period
+        if (response.StatusCode == HttpStatusCode.RequestTimeout)
+        {
+            // This is equivalent to 204 in the V1 API and represents EntityChangeType.None
+            return null;
+        }
+
+        // No body is returned on a 204 HTTP status code
+        if (response.StatusCode == HttpStatusCode.NoContent)
+        {
+            // This is equivalent to 404 in the V1 API and represents EntityChangeType.Delete
+            throw new DataNotFoundException("Entity Deleted");
+        }
+
+        // Ensure we have a 2XX HTTP status code
+        await _exceptionHandler.EnsureSuccessStatusCode(response);
+
+        // Return the build job information
+        try
+        {
+            BuildDto? build = await response.Content.ReadFromJsonAsync<BuildDto>(Options, cancellationToken);
+            if (build is not null)
+            {
                 // The Machine 2.5.12 DTO requires this to be uppercase
                 // Upgrading to a later version changes this to an enum
-                // When this occurs, remove this line
+                // When this occurs, remove this block
                 build.State = build.State.ToUpperInvariant();
+            }
 
-                return build;
-            }
-            catch (Exception e)
-            {
-                throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
-            }
+            return build;
         }
-
-        private async Task<BuildDto?> GetBuildAsync(
-            string requestUri,
-            long? minRevision,
-            CancellationToken cancellationToken
-        )
+        catch (Exception e)
         {
-            if (minRevision.HasValue)
-            {
-                requestUri += $"?minRevision={minRevision}";
-            }
-
-            using var response = await MachineClient.GetAsync(requestUri, cancellationToken);
-
-            // A 408 HTTP status code is returned if there is no build started/running within the timeout period
-            if (response.StatusCode == HttpStatusCode.RequestTimeout)
-            {
-                // This is equivalent to 204 in the V1 API and represents EntityChangeType.None
-                return null;
-            }
-
-            // No body is returned on a 204 HTTP status code
-            if (response.StatusCode == HttpStatusCode.NoContent)
-            {
-                // This is equivalent to 404 in the V1 API and represents EntityChangeType.Delete
-                throw new DataNotFoundException("Entity Deleted");
-            }
-
-            // Ensure we have a 2XX HTTP status code
-            await _exceptionHandler.EnsureSuccessStatusCode(response);
-
-            // Return the build job information
-            try
-            {
-                BuildDto? build = await response.Content.ReadFromJsonAsync<BuildDto>(Options, cancellationToken);
-                if (build is not null)
-                {
-                    // The Machine 2.5.12 DTO requires this to be uppercase
-                    // Upgrading to a later version changes this to an enum
-                    // When this occurs, remove this block
-                    build.State = build.State.ToUpperInvariant();
-                }
-
-                return build;
-            }
-            catch (Exception e)
-            {
-                throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
-            }
+            throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
         }
     }
 }

--- a/src/SIL.XForge.Scripture/Services/MachineCorporaService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineCorporaService.cs
@@ -11,339 +11,336 @@ using System.Threading.Tasks;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// The Machine Corpora service.
+/// </summary>
+/// <remarks>
+/// This should only be called from <see cref="MachineProjectService"/>,
+/// and exists to allow proper unit testing of the Machine API integration.
+/// TODO: When Machine > 2.5.X, change all object usage to the appropriate corpus DTO
+/// </remarks>
+public class MachineCorporaService : MachineServiceBase, IMachineCorporaService
 {
-    /// <summary>
-    /// The Machine Corpora service.
-    /// </summary>
-    /// <remarks>
-    /// This should only be called from <see cref="MachineProjectService"/>,
-    /// and exists to allow proper unit testing of the Machine API integration.
-    /// TODO: When Machine > 2.5.X, change all object usage to the appropriate corpus DTO
-    /// </remarks>
-    public class MachineCorporaService : MachineServiceBase, IMachineCorporaService
+    private readonly IExceptionHandler _exceptionHandler;
+    private readonly IFileSystemService _fileSystemService;
+
+    public MachineCorporaService(
+        IExceptionHandler exceptionHandler,
+        IFileSystemService fileSystemService,
+        IHttpClientFactory httpClientFactory
+    )
+        : base(httpClientFactory)
     {
-        private readonly IExceptionHandler _exceptionHandler;
-        private readonly IFileSystemService _fileSystemService;
+        _exceptionHandler = exceptionHandler;
+        _fileSystemService = fileSystemService;
+    }
 
-        public MachineCorporaService(
-            IExceptionHandler exceptionHandler,
-            IFileSystemService fileSystemService,
-            IHttpClientFactory httpClientFactory
-        ) : base(httpClientFactory)
-        {
-            _exceptionHandler = exceptionHandler;
-            _fileSystemService = fileSystemService;
-        }
+    /// <summary>
+    /// Adds a corpus to a translation engine.
+    /// </summary>
+    /// <param name="translationEngineId">The translation engine identifier.</param>
+    /// <param name="corpusId">The corpus identifier</param>
+    /// <param name="pretranslate">
+    /// If <c>true</c>, enable pre-translation.
+    /// This is only to be enabled with Nmt translation engine types.
+    /// </param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The asynchronous task.</returns>
+    /// <exception cref="HttpRequestException">
+    /// An error occurred adding the corpus to the translation engine.
+    /// </exception>
+    /// <remarks>Pre-translation is not currently used by Scripture Forge.</remarks>
+    public async Task AddCorpusToTranslationEngineAsync(
+        string translationEngineId,
+        string corpusId,
+        bool pretranslate,
+        CancellationToken cancellationToken
+    )
+    {
+        // Add the corpus to the Machine API
+        ValidateId(translationEngineId);
+        ValidateId(corpusId);
+        string requestUri = $"translation-engines/{translationEngineId}/corpora";
+        using var response = await MachineClient.PostAsJsonAsync(
+            requestUri,
+            new { corpusId, pretranslate },
+            cancellationToken
+        );
+        await _exceptionHandler.EnsureSuccessStatusCode(response);
 
-        /// <summary>
-        /// Adds a corpus to a translation engine.
-        /// </summary>
-        /// <param name="translationEngineId">The translation engine identifier.</param>
-        /// <param name="corpusId">The corpus identifier</param>
-        /// <param name="pretranslate">
-        /// If <c>true</c>, enable pre-translation.
-        /// This is only to be enabled with Nmt translation engine types.
-        /// </param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The asynchronous task.</returns>
-        /// <exception cref="HttpRequestException">
-        /// An error occurred adding the corpus to the translation engine.
-        /// </exception>
-        /// <remarks>Pre-translation is not currently used by Scripture Forge.</remarks>
-        public async Task AddCorpusToTranslationEngineAsync(
-            string translationEngineId,
-            string corpusId,
-            bool pretranslate,
-            CancellationToken cancellationToken
-        )
+        try
         {
-            // Add the corpus to the Machine API
-            ValidateId(translationEngineId);
-            ValidateId(corpusId);
-            string requestUri = $"translation-engines/{translationEngineId}/corpora";
-            using var response = await MachineClient.PostAsJsonAsync(
-                requestUri,
-                new { corpusId, pretranslate },
+            var corpus = await ReadAnonymousObjectFromJsonAsync(
+                response,
+                new { corpus = new { id = string.Empty } },
+                Options,
                 cancellationToken
             );
-            await _exceptionHandler.EnsureSuccessStatusCode(response);
-
-            try
+            if (corpus?.corpus.id != corpusId)
             {
-                var corpus = await ReadAnonymousObjectFromJsonAsync(
-                    response,
-                    new { corpus = new { id = string.Empty } },
-                    Options,
-                    cancellationToken
-                );
-                if (corpus?.corpus.id != corpusId)
-                {
-                    throw new DataNotFoundException("The corpus could not be added to the translation");
-                }
-            }
-            catch (Exception e)
-            {
-                throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
+                throw new DataNotFoundException("The corpus could not be added to the translation");
             }
         }
-
-        /// <summary>
-        /// Creates a corpus.
-        /// </summary>
-        /// <param name="name">The corpus name.</param>
-        /// <param name="paratext">
-        /// If <c>true</c>, texts will be uploaded using <see cref="UploadParatextCorpusAsync"/>;
-        /// otherwise, upload texts via <see cref="UploadCorpusTextAsync"/>.
-        /// </param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The new corpus identifier.</returns>
-        /// <exception cref="HttpRequestException">An error occurred creating the corpus.</exception>
-        /// <remarks>The Paratext file upload is not currently used by Scripture Forge.</remarks>
-        public async Task<string> CreateCorpusAsync(string name, bool paratext, CancellationToken cancellationToken)
+        catch (Exception e)
         {
-            // Add the corpus to the Machine API
-            const string requestUri = "corpora";
-            using var response = await MachineClient.PostAsJsonAsync(
-                requestUri,
-                new
-                {
-                    name,
-                    format = paratext ? "Paratext" : "Text",
-                    type = "Text",
-                },
+            throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
+        }
+    }
+
+    /// <summary>
+    /// Creates a corpus.
+    /// </summary>
+    /// <param name="name">The corpus name.</param>
+    /// <param name="paratext">
+    /// If <c>true</c>, texts will be uploaded using <see cref="UploadParatextCorpusAsync"/>;
+    /// otherwise, upload texts via <see cref="UploadCorpusTextAsync"/>.
+    /// </param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The new corpus identifier.</returns>
+    /// <exception cref="HttpRequestException">An error occurred creating the corpus.</exception>
+    /// <remarks>The Paratext file upload is not currently used by Scripture Forge.</remarks>
+    public async Task<string> CreateCorpusAsync(string name, bool paratext, CancellationToken cancellationToken)
+    {
+        // Add the corpus to the Machine API
+        const string requestUri = "corpora";
+        using var response = await MachineClient.PostAsJsonAsync(
+            requestUri,
+            new
+            {
+                name,
+                format = paratext ? "Paratext" : "Text",
+                type = "Text",
+            },
+            cancellationToken
+        );
+        await _exceptionHandler.EnsureSuccessStatusCode(response);
+
+        try
+        {
+            var corpus = await ReadAnonymousObjectFromJsonAsync(
+                response,
+                new { id = string.Empty },
+                Options,
                 cancellationToken
             );
-            await _exceptionHandler.EnsureSuccessStatusCode(response);
+            return corpus?.id ?? string.Empty;
+        }
+        catch (Exception e)
+        {
+            throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
+        }
+    }
 
-            try
+    /// <summary>
+    /// Deletes a corpus.
+    /// </summary>
+    /// <param name="corpusId">The corpus identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The asynchronous task.</returns>
+    /// <remarks>
+    /// The corpus files should be deleted using <see cref="DeleteCorpusFileAsync"/> before this method is executed.
+    /// </remarks>
+    public async Task DeleteCorpusAsync(string corpusId, CancellationToken cancellationToken)
+    {
+        // Delete the corpus from the Machine API
+        ValidateId(corpusId);
+        string requestUri = $"corpora/{corpusId}";
+        using var response = await MachineClient.DeleteAsync(requestUri, cancellationToken);
+        await _exceptionHandler.EnsureSuccessStatusCode(response);
+    }
+
+    /// <summary>
+    /// Deletes a corpus file.
+    /// </summary>
+    /// <param name="corpusId">The corpus identifier.</param>
+    /// <param name="fileId">The file identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The asynchronous task.</returns>
+    public async Task DeleteCorpusFileAsync(string corpusId, string fileId, CancellationToken cancellationToken)
+    {
+        // Delete the corpus file from the Machine API
+        ValidateId(corpusId);
+        ValidateId(fileId);
+        string requestUri = $"corpora/{corpusId}/files/{fileId}";
+        using var response = await MachineClient.DeleteAsync(requestUri, cancellationToken);
+        await _exceptionHandler.EnsureSuccessStatusCode(response);
+    }
+
+    /// <summary>
+    /// Gets the files in a corpus.
+    /// </summary>
+    /// <param name="corpusId">The corpus identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A collection of the files in the corpus.</returns>
+    /// <exception cref="HttpRequestException">An error occurred retrieving the files.</exception>
+    public async Task<IList<MachineApiCorpusFile>> GetCorpusFilesAsync(
+        string corpusId,
+        CancellationToken cancellationToken
+    )
+    {
+        // Get the corpus files from the Machine API
+        ValidateId(corpusId);
+        string requestUri = $"corpora/{corpusId}/files";
+        using var response = await MachineClient.GetAsync(requestUri, cancellationToken);
+        await _exceptionHandler.EnsureSuccessStatusCode(response);
+
+        try
+        {
+            return await response.Content.ReadFromJsonAsync<MachineApiCorpusFile[]>(Options, cancellationToken)
+                ?? Array.Empty<MachineApiCorpusFile>();
+        }
+        catch (Exception e)
+        {
+            throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
+        }
+    }
+
+    /// <summary>
+    /// Removes a corpus from a translation engine.
+    /// </summary>
+    /// <param name="translationEngineId">The translation engine identifier.</param>
+    /// <param name="corpusId">The corpus identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The asynchronous task.</returns>
+    /// <remarks>This method does not delete the corpus.</remarks>
+    public async Task RemoveCorpusFromTranslationEngineAsync(
+        string translationEngineId,
+        string corpusId,
+        CancellationToken cancellationToken
+    )
+    {
+        // Remove the corpus from the translation engine on the Machine API
+        ValidateId(translationEngineId);
+        ValidateId(corpusId);
+        string requestUri = $"translation-engines/{translationEngineId}/corpora/{corpusId}";
+        using var response = await MachineClient.DeleteAsync(requestUri, cancellationToken);
+        await _exceptionHandler.EnsureSuccessStatusCode(response);
+    }
+
+    /// <summary>
+    /// Uploads a text file to a corpus.
+    /// </summary>
+    /// <param name="corpusId">The corpus identifier.</param>
+    /// <param name="languageTag">The language tag.</param>
+    /// <param name="textId">The text identifier.</param>
+    /// <param name="text">The text file data.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The file identifier.</returns>
+    /// <exception cref="HttpRequestException">An error occurred uploading the text file.</exception>
+    /// <remarks>
+    /// The text file is created by the <see cref="MachineProjectService"/>
+    /// using the <see cref="SFTextCorpusFactory"/>.
+    /// </remarks>
+    public async Task<string> UploadCorpusTextAsync(
+        string corpusId,
+        string languageTag,
+        string textId,
+        string text,
+        CancellationToken cancellationToken
+    )
+    {
+        // Validate input
+        ValidateId(corpusId);
+
+        // Upload the text file
+        using var content = new MultipartFormDataContent();
+        byte[] byteArray = Encoding.UTF8.GetBytes(text);
+        await using var memoryStream = new MemoryStream(byteArray);
+        using var fileContent = new StreamContent(memoryStream);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/plain") { CharSet = Encoding.UTF8.WebName, };
+        string fileName = string.Join("_", textId.Split(Path.GetInvalidFileNameChars()));
+        content.Add(fileContent, "file", $"{fileName}.txt");
+        content.Add(new StringContent(languageTag), "languageTag");
+        content.Add(new StringContent(textId), "textId");
+
+        string requestUri = $"corpora/{corpusId}/files";
+        var response = await MachineClient.PostAsync(requestUri, content, cancellationToken);
+        await _exceptionHandler.EnsureSuccessStatusCode(response);
+
+        try
+        {
+            var file = await ReadAnonymousObjectFromJsonAsync(
+                response,
+                new { id = string.Empty },
+                Options,
+                cancellationToken
+            );
+            return file?.id ?? string.Empty;
+        }
+        catch (Exception e)
+        {
+            throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
+        }
+    }
+
+    /// <summary>
+    /// Uploads a Paratext project directory to a corpus.
+    /// </summary>
+    /// <param name="corpusId">The corpus identifier.</param>
+    /// <param name="languageTag">The language tag.</param>
+    /// <param name="path">The path to the Paratext project.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The file identifier.</returns>
+    /// <exception cref="DirectoryNotFoundException">The Paratext project directory does not exist.</exception>
+    /// <exception cref="HttpRequestException">An error occurred uploading the Paratext project.</exception>
+    /// <remarks>This is not currently used by Scripture Forge.</remarks>
+    public async Task<string> UploadParatextCorpusAsync(
+        string corpusId,
+        string languageTag,
+        string path,
+        CancellationToken cancellationToken
+    )
+    {
+        // Validate input
+        ValidateId(corpusId);
+
+        // Ensure that the path exists
+        if (!_fileSystemService.DirectoryExists(path))
+        {
+            throw new DirectoryNotFoundException($"The following directory could not be found: {path}");
+        }
+
+        // Create the zip file from the directory in memory
+        await using var memoryStream = new MemoryStream();
+        using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, true))
+        {
+            // Do not convert the ZipArchive using statement above into a using declaration,
+            // otherwise the ZipArchive disposal will crash after the MemoryStream disposal.
+            foreach (string filePath in _fileSystemService.EnumerateFiles(path))
             {
-                var corpus = await ReadAnonymousObjectFromJsonAsync(
-                    response,
-                    new { id = string.Empty },
-                    Options,
-                    cancellationToken
-                );
-                return corpus?.id ?? string.Empty;
-            }
-            catch (Exception e)
-            {
-                throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
+                await using Stream fileStream = _fileSystemService.OpenFile(filePath, FileMode.Open);
+                ZipArchiveEntry entry = archive.CreateEntry(Path.GetFileName(filePath));
+                await using Stream entryStream = entry.Open();
+                await fileStream.CopyToAsync(entryStream, cancellationToken);
             }
         }
 
-        /// <summary>
-        /// Deletes a corpus.
-        /// </summary>
-        /// <param name="corpusId">The corpus identifier.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The asynchronous task.</returns>
-        /// <remarks>
-        /// The corpus files should be deleted using <see cref="DeleteCorpusFileAsync"/> before this method is executed.
-        /// </remarks>
-        public async Task DeleteCorpusAsync(string corpusId, CancellationToken cancellationToken)
+        // Upload the zip file
+        using var content = new MultipartFormDataContent();
+        using var fileContent = new StreamContent(memoryStream);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/zip");
+        content.Add(fileContent, "file", $"{Path.GetDirectoryName(path)}.zip");
+        content.Add(new StringContent(languageTag), "languageTag");
+
+        string requestUri = $"corpora/{corpusId}/files";
+        var response = await MachineClient.PostAsync(requestUri, content, cancellationToken);
+        await _exceptionHandler.EnsureSuccessStatusCode(response);
+
+        try
         {
-            // Delete the corpus from the Machine API
-            ValidateId(corpusId);
-            string requestUri = $"corpora/{corpusId}";
-            using var response = await MachineClient.DeleteAsync(requestUri, cancellationToken);
-            await _exceptionHandler.EnsureSuccessStatusCode(response);
+            var file = await ReadAnonymousObjectFromJsonAsync(
+                response,
+                new { id = string.Empty },
+                Options,
+                cancellationToken
+            );
+            return file?.id ?? string.Empty;
         }
-
-        /// <summary>
-        /// Deletes a corpus file.
-        /// </summary>
-        /// <param name="corpusId">The corpus identifier.</param>
-        /// <param name="fileId">The file identifier.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The asynchronous task.</returns>
-        public async Task DeleteCorpusFileAsync(string corpusId, string fileId, CancellationToken cancellationToken)
+        catch (Exception e)
         {
-            // Delete the corpus file from the Machine API
-            ValidateId(corpusId);
-            ValidateId(fileId);
-            string requestUri = $"corpora/{corpusId}/files/{fileId}";
-            using var response = await MachineClient.DeleteAsync(requestUri, cancellationToken);
-            await _exceptionHandler.EnsureSuccessStatusCode(response);
-        }
-
-        /// <summary>
-        /// Gets the files in a corpus.
-        /// </summary>
-        /// <param name="corpusId">The corpus identifier.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>A collection of the files in the corpus.</returns>
-        /// <exception cref="HttpRequestException">An error occurred retrieving the files.</exception>
-        public async Task<IList<MachineApiCorpusFile>> GetCorpusFilesAsync(
-            string corpusId,
-            CancellationToken cancellationToken
-        )
-        {
-            // Get the corpus files from the Machine API
-            ValidateId(corpusId);
-            string requestUri = $"corpora/{corpusId}/files";
-            using var response = await MachineClient.GetAsync(requestUri, cancellationToken);
-            await _exceptionHandler.EnsureSuccessStatusCode(response);
-
-            try
-            {
-                return await response.Content.ReadFromJsonAsync<MachineApiCorpusFile[]>(Options, cancellationToken)
-                    ?? Array.Empty<MachineApiCorpusFile>();
-            }
-            catch (Exception e)
-            {
-                throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
-            }
-        }
-
-        /// <summary>
-        /// Removes a corpus from a translation engine.
-        /// </summary>
-        /// <param name="translationEngineId">The translation engine identifier.</param>
-        /// <param name="corpusId">The corpus identifier.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The asynchronous task.</returns>
-        /// <remarks>This method does not delete the corpus.</remarks>
-        public async Task RemoveCorpusFromTranslationEngineAsync(
-            string translationEngineId,
-            string corpusId,
-            CancellationToken cancellationToken
-        )
-        {
-            // Remove the corpus from the translation engine on the Machine API
-            ValidateId(translationEngineId);
-            ValidateId(corpusId);
-            string requestUri = $"translation-engines/{translationEngineId}/corpora/{corpusId}";
-            using var response = await MachineClient.DeleteAsync(requestUri, cancellationToken);
-            await _exceptionHandler.EnsureSuccessStatusCode(response);
-        }
-
-        /// <summary>
-        /// Uploads a text file to a corpus.
-        /// </summary>
-        /// <param name="corpusId">The corpus identifier.</param>
-        /// <param name="languageTag">The language tag.</param>
-        /// <param name="textId">The text identifier.</param>
-        /// <param name="text">The text file data.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The file identifier.</returns>
-        /// <exception cref="HttpRequestException">An error occurred uploading the text file.</exception>
-        /// <remarks>
-        /// The text file is created by the <see cref="MachineProjectService"/>
-        /// using the <see cref="SFTextCorpusFactory"/>.
-        /// </remarks>
-        public async Task<string> UploadCorpusTextAsync(
-            string corpusId,
-            string languageTag,
-            string textId,
-            string text,
-            CancellationToken cancellationToken
-        )
-        {
-            // Validate input
-            ValidateId(corpusId);
-
-            // Upload the text file
-            using var content = new MultipartFormDataContent();
-            byte[] byteArray = Encoding.UTF8.GetBytes(text);
-            await using var memoryStream = new MemoryStream(byteArray);
-            using var fileContent = new StreamContent(memoryStream);
-            fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/plain")
-            {
-                CharSet = Encoding.UTF8.WebName,
-            };
-            string fileName = string.Join("_", textId.Split(Path.GetInvalidFileNameChars()));
-            content.Add(fileContent, "file", $"{fileName}.txt");
-            content.Add(new StringContent(languageTag), "languageTag");
-            content.Add(new StringContent(textId), "textId");
-
-            string requestUri = $"corpora/{corpusId}/files";
-            var response = await MachineClient.PostAsync(requestUri, content, cancellationToken);
-            await _exceptionHandler.EnsureSuccessStatusCode(response);
-
-            try
-            {
-                var file = await ReadAnonymousObjectFromJsonAsync(
-                    response,
-                    new { id = string.Empty },
-                    Options,
-                    cancellationToken
-                );
-                return file?.id ?? string.Empty;
-            }
-            catch (Exception e)
-            {
-                throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
-            }
-        }
-
-        /// <summary>
-        /// Uploads a Paratext project directory to a corpus.
-        /// </summary>
-        /// <param name="corpusId">The corpus identifier.</param>
-        /// <param name="languageTag">The language tag.</param>
-        /// <param name="path">The path to the Paratext project.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The file identifier.</returns>
-        /// <exception cref="DirectoryNotFoundException">The Paratext project directory does not exist.</exception>
-        /// <exception cref="HttpRequestException">An error occurred uploading the Paratext project.</exception>
-        /// <remarks>This is not currently used by Scripture Forge.</remarks>
-        public async Task<string> UploadParatextCorpusAsync(
-            string corpusId,
-            string languageTag,
-            string path,
-            CancellationToken cancellationToken
-        )
-        {
-            // Validate input
-            ValidateId(corpusId);
-
-            // Ensure that the path exists
-            if (!_fileSystemService.DirectoryExists(path))
-            {
-                throw new DirectoryNotFoundException($"The following directory could not be found: {path}");
-            }
-
-            // Create the zip file from the directory in memory
-            await using var memoryStream = new MemoryStream();
-            using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, true))
-            {
-                // Do not convert the ZipArchive using statement above into a using declaration,
-                // otherwise the ZipArchive disposal will crash after the MemoryStream disposal.
-                foreach (string filePath in _fileSystemService.EnumerateFiles(path))
-                {
-                    await using Stream fileStream = _fileSystemService.OpenFile(filePath, FileMode.Open);
-                    ZipArchiveEntry entry = archive.CreateEntry(Path.GetFileName(filePath));
-                    await using Stream entryStream = entry.Open();
-                    await fileStream.CopyToAsync(entryStream, cancellationToken);
-                }
-            }
-
-            // Upload the zip file
-            using var content = new MultipartFormDataContent();
-            using var fileContent = new StreamContent(memoryStream);
-            fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/zip");
-            content.Add(fileContent, "file", $"{Path.GetDirectoryName(path)}.zip");
-            content.Add(new StringContent(languageTag), "languageTag");
-
-            string requestUri = $"corpora/{corpusId}/files";
-            var response = await MachineClient.PostAsync(requestUri, content, cancellationToken);
-            await _exceptionHandler.EnsureSuccessStatusCode(response);
-
-            try
-            {
-                var file = await ReadAnonymousObjectFromJsonAsync(
-                    response,
-                    new { id = string.Empty },
-                    Options,
-                    cancellationToken
-                );
-                return file?.id ?? string.Empty;
-            }
-            catch (Exception e)
-            {
-                throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
-            }
+            throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
         }
     }
 }

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -19,646 +19,631 @@ using SIL.XForge.Services;
 using SIL.XForge.Utils;
 using Project = SIL.Machine.WebApi.Models.Project;
 
-namespace SIL.XForge.Scripture.Services
-{
-    /// <summary>
-    /// Provides functionality to add, remove, and build Machine projects in both
-    /// the In-Process Machine and Machine API implementations.
-    /// </summary>
-    public class MachineProjectService : IMachineProjectService
-    {
-        private readonly IEngineService _engineService;
-        private readonly IFeatureManager _featureManager;
-        private readonly ILogger<MachineProjectService> _logger;
-        private readonly IMachineBuildService _machineBuildService;
-        private readonly IMachineCorporaService _machineCorporaService;
-        private readonly IMachineTranslationService _machineTranslationService;
-        private readonly IParatextService _paratextService;
-        private readonly IRepository<SFProjectSecret> _projectSecrets;
-        private readonly IRealtimeService _realtimeService;
-        private readonly ITextCorpusFactory _textCorpusFactory;
-        private readonly IRepository<UserSecret> _userSecrets;
+namespace SIL.XForge.Scripture.Services;
 
-        public MachineProjectService(
-            IEngineService engineService,
-            IFeatureManager featureManager,
-            ILogger<MachineProjectService> logger,
-            IMachineBuildService machineBuildService,
-            IMachineCorporaService machineCorporaService,
-            IMachineTranslationService machineTranslationService,
-            IParatextService paratextService,
-            IRepository<SFProjectSecret> projectSecrets,
-            IRealtimeService realtimeService,
-            ITextCorpusFactory textCorpusFactory,
-            IRepository<UserSecret> userSecrets
-        )
+/// <summary>
+/// Provides functionality to add, remove, and build Machine projects in both
+/// the In-Process Machine and Machine API implementations.
+/// </summary>
+public class MachineProjectService : IMachineProjectService
+{
+    private readonly IEngineService _engineService;
+    private readonly IFeatureManager _featureManager;
+    private readonly ILogger<MachineProjectService> _logger;
+    private readonly IMachineBuildService _machineBuildService;
+    private readonly IMachineCorporaService _machineCorporaService;
+    private readonly IMachineTranslationService _machineTranslationService;
+    private readonly IParatextService _paratextService;
+    private readonly IRepository<SFProjectSecret> _projectSecrets;
+    private readonly IRealtimeService _realtimeService;
+    private readonly ITextCorpusFactory _textCorpusFactory;
+    private readonly IRepository<UserSecret> _userSecrets;
+
+    public MachineProjectService(
+        IEngineService engineService,
+        IFeatureManager featureManager,
+        ILogger<MachineProjectService> logger,
+        IMachineBuildService machineBuildService,
+        IMachineCorporaService machineCorporaService,
+        IMachineTranslationService machineTranslationService,
+        IParatextService paratextService,
+        IRepository<SFProjectSecret> projectSecrets,
+        IRealtimeService realtimeService,
+        ITextCorpusFactory textCorpusFactory,
+        IRepository<UserSecret> userSecrets
+    )
+    {
+        _engineService = engineService;
+        _featureManager = featureManager;
+        _logger = logger;
+        _machineBuildService = machineBuildService;
+        _machineCorporaService = machineCorporaService;
+        _machineTranslationService = machineTranslationService;
+        _paratextService = paratextService;
+        _projectSecrets = projectSecrets;
+        _realtimeService = realtimeService;
+        _textCorpusFactory = textCorpusFactory;
+        _userSecrets = userSecrets;
+    }
+
+    public async Task AddProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken)
+    {
+        // Load the project from the realtime service
+        Attempt<SFProject> attempt = await _realtimeService.TryGetSnapshotAsync<SFProject>(sfProjectId);
+        if (!attempt.TryResult(out SFProject project))
         {
-            _engineService = engineService;
-            _featureManager = featureManager;
-            _logger = logger;
-            _machineBuildService = machineBuildService;
-            _machineCorporaService = machineCorporaService;
-            _machineTranslationService = machineTranslationService;
-            _paratextService = paratextService;
-            _projectSecrets = projectSecrets;
-            _realtimeService = realtimeService;
-            _textCorpusFactory = textCorpusFactory;
-            _userSecrets = userSecrets;
+            throw new DataNotFoundException("The project does not exist.");
         }
 
-        public async Task AddProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken)
+        // Add the project to the in process Machine instance
+        var machineProject = new Project
         {
+            Id = sfProjectId,
+            SourceLanguageTag = project.TranslateConfig.Source.WritingSystem.Tag,
+            TargetLanguageTag = project.WritingSystem.Tag,
+        };
+
+        // Only add to the In Process instance if it is enabled
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+        {
+            await _engineService.AddProjectAsync(machineProject);
+        }
+
+        // Ensure that the Machine API feature flag is enabled
+        if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
+        {
+            _logger.LogInformation("Machine API feature flag is not enabled");
+            return;
+        }
+
+        // We may not have the source language tag or target language tag if either is a back translation
+        // If that is the case, we will create the translation engine on first sync by running this method again
+        // After ensuring that the source and target language tags are present
+        if (
+            !string.IsNullOrWhiteSpace(machineProject.SourceLanguageTag)
+            && !string.IsNullOrWhiteSpace(machineProject.TargetLanguageTag)
+        )
+        {
+            // We do not need the returned project secret
+            _ = await CreateMachineApiProjectAsync(project, cancellationToken);
+        }
+    }
+
+    public async Task BuildProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken)
+    {
+        // Build the project with the In Process Machine instance
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+        {
+            await _engineService.StartBuildByProjectIdAsync(sfProjectId);
+        }
+
+        // Ensure that the Machine API feature flag is enabled
+        if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
+        {
+            _logger.LogInformation("Machine API feature flag is not enabled");
+            return;
+        }
+
+        // Load the target project secrets, so we can get the translation engine ID
+        if (!(await _projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret))
+        {
+            throw new ArgumentException("The project secret cannot be found.");
+        }
+
+        // Ensure we have a translation engine id
+        if (string.IsNullOrWhiteSpace(projectSecret.MachineData?.TranslationEngineId))
+        {
+            // We do not have one, likely because the translation is a back translation
+            // We can only get the language tags for back translations from the ScrText,
+            // which is not present until after the first sync (not from the Registry).
+
             // Load the project from the realtime service
-            Attempt<SFProject> attempt = await _realtimeService.TryGetSnapshotAsync<SFProject>(sfProjectId);
-            if (!attempt.TryResult(out SFProject project))
+            using IConnection conn = await _realtimeService.ConnectAsync(curUserId);
+            IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(sfProjectId);
+            if (!projectDoc.IsLoaded)
             {
                 throw new DataNotFoundException("The project does not exist.");
             }
 
-            // Add the project to the in process Machine instance
-            var machineProject = new Project
-            {
-                Id = sfProjectId,
-                SourceLanguageTag = project.TranslateConfig.Source.WritingSystem.Tag,
-                TargetLanguageTag = project.WritingSystem.Tag,
-            };
-
-            // Only add to the In Process instance if it is enabled
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-            {
-                await _engineService.AddProjectAsync(machineProject);
-            }
-
-            // Ensure that the Machine API feature flag is enabled
-            if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
-            {
-                _logger.LogInformation("Machine API feature flag is not enabled");
-                return;
-            }
-
-            // We may not have the source language tag or target language tag if either is a back translation
-            // If that is the case, we will create the translation engine on first sync by running this method again
-            // After ensuring that the source and target language tags are present
+            // If the source or target writing system tag is missing, get them from the ScrText
             if (
-                !string.IsNullOrWhiteSpace(machineProject.SourceLanguageTag)
-                && !string.IsNullOrWhiteSpace(machineProject.TargetLanguageTag)
+                string.IsNullOrWhiteSpace(projectDoc.Data.WritingSystem.Tag)
+                || string.IsNullOrWhiteSpace(projectDoc.Data.TranslateConfig.Source.WritingSystem.Tag)
             )
             {
-                // We do not need the returned project secret
-                _ = await CreateMachineApiProjectAsync(project, cancellationToken);
+                // Get the user secret
+                Attempt<UserSecret> userSecretAttempt = await _userSecrets.TryGetAsync(curUserId);
+                if (!userSecretAttempt.TryResult(out UserSecret userSecret))
+                    throw new DataNotFoundException("The user does not exist.");
+
+                // Update the target writing system tag
+                if (string.IsNullOrWhiteSpace(projectDoc.Data.WritingSystem.Tag))
+                {
+                    string targetLanguageTag = _paratextService.GetLanguageId(userSecret, projectDoc.Data.ParatextId);
+                    if (!string.IsNullOrEmpty(targetLanguageTag))
+                    {
+                        await projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.WritingSystem.Tag, targetLanguageTag));
+                    }
+                }
+
+                // Update the source writing system tag
+                if (string.IsNullOrWhiteSpace(projectDoc.Data.TranslateConfig.Source.WritingSystem.Tag))
+                {
+                    string sourceLanguageTag = _paratextService.GetLanguageId(
+                        userSecret,
+                        projectDoc.Data.TranslateConfig.Source.ParatextId
+                    );
+                    if (!string.IsNullOrEmpty(sourceLanguageTag))
+                    {
+                        await projectDoc.SubmitJson0OpAsync(
+                            op => op.Set(p => p.TranslateConfig.Source.WritingSystem.Tag, sourceLanguageTag)
+                        );
+                    }
+                }
             }
+
+            // Create the Machine API project
+            // The returned project secret will have the translation engine id
+            projectSecret = await CreateMachineApiProjectAsync(projectDoc.Data, cancellationToken);
         }
 
-        public async Task BuildProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken)
+        // Sync the corpus
+        if (await SyncProjectCorporaAsync(curUserId, sfProjectId, cancellationToken))
         {
-            // Build the project with the In Process Machine instance
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-            {
-                await _engineService.StartBuildByProjectIdAsync(sfProjectId);
-            }
+            // If the corpus was updated, start the build
+            // We do not need the build ID for tracking as we use GetCurrentBuildAsync for that
+            _ = await _machineBuildService.StartBuildAsync(
+                projectSecret.MachineData!.TranslationEngineId,
+                cancellationToken
+            );
+        }
+    }
 
-            // Ensure that the Machine API feature flag is enabled
-            if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
-            {
-                _logger.LogInformation("Machine API feature flag is not enabled");
-                return;
-            }
-
-            // Load the target project secrets, so we can get the translation engine ID
-            if (!(await _projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret))
-            {
-                throw new ArgumentException("The project secret cannot be found.");
-            }
-
-            // Ensure we have a translation engine id
-            if (string.IsNullOrWhiteSpace(projectSecret.MachineData?.TranslationEngineId))
-            {
-                // We do not have one, likely because the translation is a back translation
-                // We can only get the language tags for back translations from the ScrText,
-                // which is not present until after the first sync (not from the Registry).
-
-                // Load the project from the realtime service
-                using IConnection conn = await _realtimeService.ConnectAsync(curUserId);
-                IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(sfProjectId);
-                if (!projectDoc.IsLoaded)
-                {
-                    throw new DataNotFoundException("The project does not exist.");
-                }
-
-                // If the source or target writing system tag is missing, get them from the ScrText
-                if (
-                    string.IsNullOrWhiteSpace(projectDoc.Data.WritingSystem.Tag)
-                    || string.IsNullOrWhiteSpace(projectDoc.Data.TranslateConfig.Source.WritingSystem.Tag)
-                )
-                {
-                    // Get the user secret
-                    Attempt<UserSecret> userSecretAttempt = await _userSecrets.TryGetAsync(curUserId);
-                    if (!userSecretAttempt.TryResult(out UserSecret userSecret))
-                        throw new DataNotFoundException("The user does not exist.");
-
-                    // Update the target writing system tag
-                    if (string.IsNullOrWhiteSpace(projectDoc.Data.WritingSystem.Tag))
-                    {
-                        string targetLanguageTag = _paratextService.GetLanguageId(
-                            userSecret,
-                            projectDoc.Data.ParatextId
-                        );
-                        if (!string.IsNullOrEmpty(targetLanguageTag))
-                        {
-                            await projectDoc.SubmitJson0OpAsync(op =>
-                            {
-                                op.Set(p => p.WritingSystem.Tag, targetLanguageTag);
-                            });
-                        }
-                    }
-
-                    // Update the source writing system tag
-                    if (string.IsNullOrWhiteSpace(projectDoc.Data.TranslateConfig.Source.WritingSystem.Tag))
-                    {
-                        string sourceLanguageTag = _paratextService.GetLanguageId(
-                            userSecret,
-                            projectDoc.Data.TranslateConfig.Source.ParatextId
-                        );
-                        if (!string.IsNullOrEmpty(sourceLanguageTag))
-                        {
-                            await projectDoc.SubmitJson0OpAsync(op =>
-                            {
-                                op.Set(p => p.TranslateConfig.Source.WritingSystem.Tag, sourceLanguageTag);
-                            });
-                        }
-                    }
-                }
-
-                // Create the Machine API project
-                // The returned project secret will have the translation engine id
-                projectSecret = await CreateMachineApiProjectAsync(projectDoc.Data, cancellationToken);
-            }
-
-            // Sync the corpus
-            if (await SyncProjectCorporaAsync(curUserId, sfProjectId, cancellationToken))
-            {
-                // If the corpus was updated, start the build
-                // We do not need the build ID for tracking as we use GetCurrentBuildAsync for that
-                _ = await _machineBuildService.StartBuildAsync(
-                    projectSecret.MachineData!.TranslationEngineId,
-                    cancellationToken
-                );
-            }
+    public async Task RemoveProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken)
+    {
+        // Remove the project from the In Process Machine instance
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+        {
+            await _engineService.RemoveProjectAsync(sfProjectId);
         }
 
-        public async Task RemoveProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken)
+        // Ensure that the Machine API feature flag is enabled
+        if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
         {
-            // Remove the project from the In Process Machine instance
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
-            {
-                await _engineService.RemoveProjectAsync(sfProjectId);
-            }
+            _logger.LogInformation("Machine API feature flag is not enabled");
+            return;
+        }
 
-            // Ensure that the Machine API feature flag is enabled
-            if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
-            {
-                _logger.LogInformation("Machine API feature flag is not enabled");
-                return;
-            }
+        // Load the target project secrets, so we can get the translation engine ID
+        if (!(await _projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret))
+        {
+            throw new ArgumentException("The project secret cannot be found.");
+        }
 
-            // Load the target project secrets, so we can get the translation engine ID
-            if (!(await _projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret))
-            {
-                throw new ArgumentException("The project secret cannot be found.");
-            }
+        // Ensure we have a translation engine id
+        if (string.IsNullOrWhiteSpace(projectSecret.MachineData?.TranslationEngineId))
+        {
+            _logger.LogInformation($"No Translation Engine Id specified for project {sfProjectId}");
+            return;
+        }
 
-            // Ensure we have a translation engine id
-            if (string.IsNullOrWhiteSpace(projectSecret.MachineData?.TranslationEngineId))
+        // Remove the corpus files
+        foreach ((string corpusId, _) in projectSecret.MachineData.Corpora)
+        {
+            foreach (string fileId in projectSecret.MachineData.Corpora[corpusId].Files.Select(f => f.FileId))
             {
-                _logger.LogInformation($"No Translation Engine Id specified for project {sfProjectId}");
-                return;
-            }
-
-            // Remove the corpus files
-            foreach ((string corpusId, _) in projectSecret.MachineData.Corpora)
-            {
-                foreach (string fileId in projectSecret.MachineData.Corpora[corpusId].Files.Select(f => f.FileId))
-                {
-                    try
-                    {
-                        await _machineCorporaService.DeleteCorpusFileAsync(corpusId, fileId, cancellationToken);
-                    }
-                    catch (HttpRequestException e)
-                    {
-                        // A 404 means that the file does not exist
-                        string message;
-                        if (e.StatusCode == HttpStatusCode.NotFound)
-                        {
-                            message =
-                                $"Corpora file {fileId} in corpus {corpusId} for project {sfProjectId}"
-                                + " was missing or already deleted.";
-                            _logger.LogInformation(message);
-                        }
-                        else
-                        {
-                            message =
-                                $"Ignored exception while deleting file {fileId} in corpus {corpusId}"
-                                + $" for project {sfProjectId}.";
-                            _logger.LogError(e, message);
-                        }
-                    }
-                }
-
-                // Remove the corpus from the translation engine
-                string translationEngineId = projectSecret.MachineData.TranslationEngineId;
                 try
                 {
-                    await _machineCorporaService.RemoveCorpusFromTranslationEngineAsync(
-                        translationEngineId,
-                        corpusId,
-                        cancellationToken
-                    );
+                    await _machineCorporaService.DeleteCorpusFileAsync(corpusId, fileId, cancellationToken);
                 }
                 catch (HttpRequestException e)
                 {
-                    // A 404 means that the translation engine does not exist
+                    // A 404 means that the file does not exist
                     string message;
                     if (e.StatusCode == HttpStatusCode.NotFound)
                     {
                         message =
-                            $"Translation Engine {translationEngineId} for project {sfProjectId}"
+                            $"Corpora file {fileId} in corpus {corpusId} for project {sfProjectId}"
                             + " was missing or already deleted.";
                         _logger.LogInformation(message);
                     }
                     else
                     {
                         message =
-                            $"Ignored exception while deleting translation engine {translationEngineId}"
+                            $"Ignored exception while deleting file {fileId} in corpus {corpusId}"
                             + $" for project {sfProjectId}.";
                         _logger.LogError(e, message);
                     }
                 }
+            }
 
-                // Delete the corpus
-                try
+            // Remove the corpus from the translation engine
+            string translationEngineId = projectSecret.MachineData.TranslationEngineId;
+            try
+            {
+                await _machineCorporaService.RemoveCorpusFromTranslationEngineAsync(
+                    translationEngineId,
+                    corpusId,
+                    cancellationToken
+                );
+            }
+            catch (HttpRequestException e)
+            {
+                // A 404 means that the translation engine does not exist
+                string message;
+                if (e.StatusCode == HttpStatusCode.NotFound)
                 {
-                    await _machineCorporaService.DeleteCorpusAsync(corpusId, cancellationToken);
+                    message =
+                        $"Translation Engine {translationEngineId} for project {sfProjectId}"
+                        + " was missing or already deleted.";
+                    _logger.LogInformation(message);
                 }
-                catch (HttpRequestException e)
+                else
                 {
-                    // A 404 means that the corpus does not exist
-                    string message;
-                    if (e.StatusCode == HttpStatusCode.NotFound)
-                    {
-                        message = $"Corpus {corpusId} for project {sfProjectId} was missing or already deleted.";
-                        _logger.LogInformation(message);
-                    }
-                    else
-                    {
-                        message = $"Ignored exception while deleting corpus {corpusId} for project {sfProjectId}.";
-                        _logger.LogError(e, message);
-                    }
+                    message =
+                        $"Ignored exception while deleting translation engine {translationEngineId}"
+                        + $" for project {sfProjectId}.";
+                    _logger.LogError(e, message);
                 }
             }
 
-            // Remove the project from the Machine API
-            await _machineTranslationService.DeleteTranslationEngineAsync(
-                projectSecret.MachineData.TranslationEngineId,
-                cancellationToken
-            );
+            // Delete the corpus
+            try
+            {
+                await _machineCorporaService.DeleteCorpusAsync(corpusId, cancellationToken);
+            }
+            catch (HttpRequestException e)
+            {
+                // A 404 means that the corpus does not exist
+                string message;
+                if (e.StatusCode == HttpStatusCode.NotFound)
+                {
+                    message = $"Corpus {corpusId} for project {sfProjectId} was missing or already deleted.";
+                    _logger.LogInformation(message);
+                }
+                else
+                {
+                    message = $"Ignored exception while deleting corpus {corpusId} for project {sfProjectId}.";
+                    _logger.LogError(e, message);
+                }
+            }
         }
 
-        /// <summary>
-        /// Syncs the project corpora from MongoDB to the Machine API via <see cref="SFTextCorpusFactory"/>
-        /// </summary>
-        /// <param name="curUserId">The current user identifier.</param>
-        /// <param name="sfProjectId">The project identifier.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns><c>true</c> if the project corpora and its files were updated; otherwise, <c>false</c>.</returns>
-        /// <exception cref="DataNotFoundException">The project does not exist.</exception>
-        /// <exception cref="ArgumentException">One of the arguments was an invalid identifier.</exception>
-        /// <remarks>
-        /// Notes:
-        ///  - If the corpus was updated, then you should start the Build with <see cref="MachineBuildService"/>.
-        ///  - If the Machine API feature flag is disabled, false is returned and an information message logged.
-        ///  - If a corpus is not configured on the Machine API, one is created and recorded in the project secret.
-        /// </remarks>
-        public async Task<bool> SyncProjectCorporaAsync(
-            string curUserId,
-            string sfProjectId,
-            CancellationToken cancellationToken
-        )
+        // Remove the project from the Machine API
+        await _machineTranslationService.DeleteTranslationEngineAsync(
+            projectSecret.MachineData.TranslationEngineId,
+            cancellationToken
+        );
+    }
+
+    /// <summary>
+    /// Syncs the project corpora from MongoDB to the Machine API via <see cref="SFTextCorpusFactory"/>
+    /// </summary>
+    /// <param name="curUserId">The current user identifier.</param>
+    /// <param name="sfProjectId">The project identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns><c>true</c> if the project corpora and its files were updated; otherwise, <c>false</c>.</returns>
+    /// <exception cref="DataNotFoundException">The project does not exist.</exception>
+    /// <exception cref="ArgumentException">One of the arguments was an invalid identifier.</exception>
+    /// <remarks>
+    /// Notes:
+    ///  - If the corpus was updated, then you should start the Build with <see cref="MachineBuildService"/>.
+    ///  - If the Machine API feature flag is disabled, false is returned and an information message logged.
+    ///  - If a corpus is not configured on the Machine API, one is created and recorded in the project secret.
+    /// </remarks>
+    public async Task<bool> SyncProjectCorporaAsync(
+        string curUserId,
+        string sfProjectId,
+        CancellationToken cancellationToken
+    )
+    {
+        // Used to return whether or not the corpus was updated
+        bool corpusUpdated = false;
+
+        // Ensure that the Machine API feature flag is enabled
+        if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
         {
-            // Used to return whether or not the corpus was updated
-            bool corpusUpdated = false;
+            _logger.LogInformation("Machine API feature flag is not enabled");
+            return false;
+        }
 
-            // Ensure that the Machine API feature flag is enabled
-            if (!await _featureManager.IsEnabledAsync(FeatureFlags.MachineApi))
+        // Load the project from the realtime service
+        Attempt<SFProject> attempt = await _realtimeService.TryGetSnapshotAsync<SFProject>(sfProjectId);
+        if (!attempt.TryResult(out SFProject project))
+        {
+            throw new DataNotFoundException("The project does not exist.");
+        }
+
+        // Load the project secrets, so we can get the corpus files
+        if (!(await _projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret))
+        {
+            throw new ArgumentException("The project secret cannot be found.");
+        }
+
+        // Ensure we have a translation engine ID
+        if (string.IsNullOrWhiteSpace(projectSecret.MachineData?.TranslationEngineId))
+        {
+            throw new ArgumentException("The translation engine ID cannot be found.");
+        }
+
+        // Ensure that there is a corpus
+        string corpusId;
+        if (string.IsNullOrWhiteSpace(projectSecret.MachineData.Corpora.Keys.FirstOrDefault()))
+        {
+            corpusId = await _machineCorporaService.CreateCorpusAsync(sfProjectId, paratext: false, cancellationToken);
+            await _machineCorporaService.AddCorpusToTranslationEngineAsync(
+                projectSecret.MachineData.TranslationEngineId,
+                corpusId,
+                pretranslate: false,
+                cancellationToken
+            );
+
+            // Store the Corpus ID
+            projectSecret = await _projectSecrets.UpdateAsync(
+                sfProjectId,
+                u =>
+                    u.Set(
+                        p => p.MachineData.Corpora[corpusId],
+                        new MachineCorpus { Files = new List<MachineCorpusFile>() }
+                    )
+            );
+        }
+        else
+        {
+            corpusId = projectSecret.MachineData.Corpora.Keys.First();
+        }
+
+        // Get the corpus files on the server
+        IList<MachineApiCorpusFile> serverCorpusFiles = await _machineCorporaService.GetCorpusFilesAsync(
+            corpusId,
+            cancellationToken
+        );
+
+        // Reuse the SFTextCorpusFactory implementation
+        ITextCorpus? textCorpus = await _textCorpusFactory.CreateAsync(new[] { sfProjectId }, TextCorpusType.Source);
+        corpusUpdated |= await SyncTextCorpusAsync(
+            corpusId,
+            project,
+            projectSecret,
+            textCorpus,
+            TextCorpusType.Source,
+            serverCorpusFiles,
+            cancellationToken
+        );
+
+        textCorpus = await _textCorpusFactory.CreateAsync(new[] { sfProjectId }, TextCorpusType.Target);
+        corpusUpdated |= await SyncTextCorpusAsync(
+            corpusId,
+            project,
+            projectSecret,
+            textCorpus,
+            TextCorpusType.Target,
+            serverCorpusFiles,
+            cancellationToken
+        );
+
+        return corpusUpdated;
+    }
+
+    /// <summary>
+    /// Gets the segments from the text with Unix/Linux line endings.
+    /// </summary>
+    /// <param name="text">The IText</param>
+    /// <returns>The text file data to be uploaded to the Machine API.</returns>
+    private static string GetTextFileData(IText text)
+    {
+        var sb = new StringBuilder();
+        foreach (TextSegment segment in text.GetSegments().Where(s => !s.IsEmpty))
+        {
+            string key;
+            if (segment.SegmentRef is TextSegmentRef textSegmentRef)
             {
-                _logger.LogInformation("Machine API feature flag is not enabled");
-                return false;
-            }
-
-            // Load the project from the realtime service
-            Attempt<SFProject> attempt = await _realtimeService.TryGetSnapshotAsync<SFProject>(sfProjectId);
-            if (!attempt.TryResult(out SFProject project))
-            {
-                throw new DataNotFoundException("The project does not exist.");
-            }
-
-            // Load the project secrets, so we can get the corpus files
-            if (!(await _projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret))
-            {
-                throw new ArgumentException("The project secret cannot be found.");
-            }
-
-            // Ensure we have a translation engine ID
-            if (string.IsNullOrWhiteSpace(projectSecret.MachineData?.TranslationEngineId))
-            {
-                throw new ArgumentException("The translation engine ID cannot be found.");
-            }
-
-            // Ensure that there is a corpus
-            string corpusId;
-            if (string.IsNullOrWhiteSpace(projectSecret.MachineData.Corpora.Keys.FirstOrDefault()))
-            {
-                corpusId = await _machineCorporaService.CreateCorpusAsync(
-                    sfProjectId,
-                    paratext: false,
-                    cancellationToken
-                );
-                await _machineCorporaService.AddCorpusToTranslationEngineAsync(
-                    projectSecret.MachineData.TranslationEngineId,
-                    corpusId,
-                    pretranslate: false,
-                    cancellationToken
-                );
-
-                // Store the Corpus ID
-                projectSecret = await _projectSecrets.UpdateAsync(
-                    sfProjectId,
-                    u =>
-                        u.Set(
-                            p => p.MachineData.Corpora[corpusId],
-                            new MachineCorpus { Files = new List<MachineCorpusFile>() }
-                        )
+                // We pad the verse number so the string based key comparisons in Machine will be accurate
+                key = string.Join(
+                    '_',
+                    textSegmentRef.Keys.Select(k => int.TryParse(k, out int _) ? k.PadLeft(3, '0') : k)
                 );
             }
             else
             {
-                corpusId = projectSecret.MachineData.Corpora.Keys.First();
+                key = (string)segment.SegmentRef;
             }
 
-            // Get the corpus files on the server
-            IList<MachineApiCorpusFile> serverCorpusFiles = await _machineCorporaService.GetCorpusFilesAsync(
-                corpusId,
-                cancellationToken
-            );
-
-            // Reuse the SFTextCorpusFactory implementation
-            ITextCorpus? textCorpus = await _textCorpusFactory.CreateAsync(
-                new[] { sfProjectId },
-                TextCorpusType.Source
-            );
-            corpusUpdated |= await SyncTextCorpusAsync(
-                corpusId,
-                project,
-                projectSecret,
-                textCorpus,
-                TextCorpusType.Source,
-                serverCorpusFiles,
-                cancellationToken
-            );
-
-            textCorpus = await _textCorpusFactory.CreateAsync(new[] { sfProjectId }, TextCorpusType.Target);
-            corpusUpdated |= await SyncTextCorpusAsync(
-                corpusId,
-                project,
-                projectSecret,
-                textCorpus,
-                TextCorpusType.Target,
-                serverCorpusFiles,
-                cancellationToken
-            );
-
-            return corpusUpdated;
-        }
-
-        /// <summary>
-        /// Gets the segments from the text with Unix/Linux line endings.
-        /// </summary>
-        /// <param name="text">The IText</param>
-        /// <returns>The text file data to be uploaded to the Machine API.</returns>
-        private static string GetTextFileData(IText text)
-        {
-            var sb = new StringBuilder();
-            foreach (TextSegment segment in text.GetSegments().Where(s => !s.IsEmpty))
+            // Strip characters from the key that will corrupt the line
+            sb.Append(key.Replace('\n', '_').Replace('\t', '_'));
+            sb.Append('\t');
+            sb.Append(string.Join(' ', segment.Segment));
+            sb.Append('\t');
+            if (segment.IsSentenceStart)
             {
-                string key;
-                if (segment.SegmentRef is TextSegmentRef textSegmentRef)
-                {
-                    // We pad the verse number so the string based key comparisons in Machine will be accurate
-                    key = string.Join(
-                        '_',
-                        textSegmentRef.Keys.Select(k => int.TryParse(k, out int _) ? k.PadLeft(3, '0') : k)
-                    );
-                }
-                else
-                {
-                    key = (string)segment.SegmentRef;
-                }
-
-                // Strip characters from the key that will corrupt the line
-                sb.Append(key.Replace('\n', '_').Replace('\t', '_'));
-                sb.Append('\t');
-                sb.Append(string.Join(' ', segment.Segment));
-                sb.Append('\t');
-                if (segment.IsSentenceStart)
-                {
-                    sb.Append("ss,");
-                }
-
-                if (segment.IsInRange)
-                {
-                    sb.Append("ir,");
-                }
-
-                if (segment.IsRangeStart)
-                {
-                    sb.Append("rs,");
-                }
-
-                // Strip the last comma, or the tab if there are no flags
-                sb.Length--;
-
-                // Append the Unix EOL to ensure consistency as this text data is uploaded to the Machine API
-                sb.Append('\n');
+                sb.Append("ss,");
             }
 
-            return sb.ToString();
-        }
-
-        /// <summary>
-        /// Creates a project in the Machine API.
-        /// </summary>
-        /// <param name="sfProject">The Scripture Forge project</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The asynchronous task.</returns>
-        /// <exception cref="ArgumentException">The translation engine could not be created.</exception>
-        private async Task<SFProjectSecret> CreateMachineApiProjectAsync(
-            SFProject sfProject,
-            CancellationToken cancellationToken
-        )
-        {
-            // Add the project to the Machine API
-            string translationEngineId = await _machineTranslationService.CreateTranslationEngineAsync(
-                name: sfProject.Id,
-                sourceLanguageTag: sfProject.TranslateConfig.Source.WritingSystem.Tag,
-                targetLanguageTag: sfProject.WritingSystem.Tag,
-                smtTransfer: true,
-                cancellationToken
-            );
-            if (string.IsNullOrWhiteSpace(translationEngineId))
+            if (segment.IsInRange)
             {
-                throw new ArgumentException("Translation Engine ID from the Machine API is missing.");
+                sb.Append("ir,");
             }
 
-            // Store the Translation Engine ID
-            return await _projectSecrets.UpdateAsync(
-                sfProject.Id,
-                u => u.Set(p => p.MachineData, new MachineData { TranslationEngineId = translationEngineId })
-            );
+            if (segment.IsRangeStart)
+            {
+                sb.Append("rs,");
+            }
+
+            // Strip the last comma, or the tab if there are no flags
+            sb.Length--;
+
+            // Append the Unix EOL to ensure consistency as this text data is uploaded to the Machine API
+            sb.Append('\n');
         }
 
-        /// <summary>
-        /// Syncs an <see cref="ITextCorpus"/> with a corpus on the Machine APU, creating and updating corpus
-        /// files on the corpus as necessary, and recording the details in the <see cref="projectSecret"/>.
-        /// </summary>
-        /// <param name="corpusId">The corpus identifier.</param>
-        /// <param name="project">The project.</param>
-        /// <param name="projectSecret">The project secret.</param>
-        /// <param name="textCorpus">The text corpus created by <see cref="SFTextCorpusFactory"/>.</param>
-        /// <param name="type">The type can be either Source or Target.</param>
-        /// <param name="serverCorpusFiles">The corpus files already on the server, from the Machine API.</param>
-        /// <param name="cancellationToken"></param>
-        /// <returns><c>true</c> if the corpus was created or updated; otherwise, <c>false</c>.</returns>
-        /// <remarks>
-        /// The project secret is updated with the corpus file details added or updated on the Machine API.
-        /// </remarks>
-        private async Task<bool> SyncTextCorpusAsync(
-            string corpusId,
-            SFProject project,
-            SFProjectSecret projectSecret,
-            ITextCorpus? textCorpus,
-            TextCorpusType type,
-            IList<MachineApiCorpusFile> serverCorpusFiles,
-            CancellationToken cancellationToken
-        )
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Creates a project in the Machine API.
+    /// </summary>
+    /// <param name="sfProject">The Scripture Forge project</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The asynchronous task.</returns>
+    /// <exception cref="ArgumentException">The translation engine could not be created.</exception>
+    private async Task<SFProjectSecret> CreateMachineApiProjectAsync(
+        SFProject sfProject,
+        CancellationToken cancellationToken
+    )
+    {
+        // Add the project to the Machine API
+        string translationEngineId = await _machineTranslationService.CreateTranslationEngineAsync(
+            name: sfProject.Id,
+            sourceLanguageTag: sfProject.TranslateConfig.Source.WritingSystem.Tag,
+            targetLanguageTag: sfProject.WritingSystem.Tag,
+            smtTransfer: true,
+            cancellationToken
+        );
+        if (string.IsNullOrWhiteSpace(translationEngineId))
         {
-            // Used to return whether or not the corpus files were created or updated
-            bool corpusUpdated = false;
+            throw new ArgumentException("Translation Engine ID from the Machine API is missing.");
+        }
 
-            // Get the language tag
-            string languageTag =
-                type == TextCorpusType.Target
-                    ? project.WritingSystem.Tag
-                    : project.TranslateConfig.Source.WritingSystem.Tag;
+        // Store the Translation Engine ID
+        return await _projectSecrets.UpdateAsync(
+            sfProject.Id,
+            u => u.Set(p => p.MachineData, new MachineData { TranslationEngineId = translationEngineId })
+        );
+    }
 
-            // Get the files we have already synced
-            List<MachineCorpusFile> previousCorpusFiles =
-                projectSecret.MachineData?.Corpora[corpusId].Files ?? new List<MachineCorpusFile>();
+    /// <summary>
+    /// Syncs an <see cref="ITextCorpus"/> with a corpus on the Machine APU, creating and updating corpus
+    /// files on the corpus as necessary, and recording the details in the <see cref="projectSecret"/>.
+    /// </summary>
+    /// <param name="corpusId">The corpus identifier.</param>
+    /// <param name="project">The project.</param>
+    /// <param name="projectSecret">The project secret.</param>
+    /// <param name="textCorpus">The text corpus created by <see cref="SFTextCorpusFactory"/>.</param>
+    /// <param name="type">The type can be either Source or Target.</param>
+    /// <param name="serverCorpusFiles">The corpus files already on the server, from the Machine API.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns><c>true</c> if the corpus was created or updated; otherwise, <c>false</c>.</returns>
+    /// <remarks>
+    /// The project secret is updated with the corpus file details added or updated on the Machine API.
+    /// </remarks>
+    private async Task<bool> SyncTextCorpusAsync(
+        string corpusId,
+        SFProject project,
+        SFProjectSecret projectSecret,
+        ITextCorpus? textCorpus,
+        TextCorpusType type,
+        IList<MachineApiCorpusFile> serverCorpusFiles,
+        CancellationToken cancellationToken
+    )
+    {
+        // Used to return whether or not the corpus files were created or updated
+        bool corpusUpdated = false;
 
-            // Sync each text
-            foreach (IText text in textCorpus?.Texts ?? Array.Empty<IText>())
+        // Get the language tag
+        string languageTag =
+            type == TextCorpusType.Target
+                ? project.WritingSystem.Tag
+                : project.TranslateConfig.Source.WritingSystem.Tag;
+
+        // Get the files we have already synced
+        List<MachineCorpusFile> previousCorpusFiles =
+            projectSecret.MachineData?.Corpora[corpusId].Files ?? new List<MachineCorpusFile>();
+
+        // Sync each text
+        foreach (IText text in textCorpus?.Texts ?? Array.Empty<IText>())
+        {
+            string textFileData = GetTextFileData(text);
+            if (!string.IsNullOrWhiteSpace(textFileData))
             {
-                string textFileData = GetTextFileData(text);
-                if (!string.IsNullOrWhiteSpace(textFileData))
+                // Remove the project id from the start of the text id (if present)
+                string textId = text.Id.StartsWith($"{project.Id}_") ? text.Id[(project.Id.Length + 1)..] : text.Id;
+
+                // If the writing system is the same, we need to differentiate the texts.
+                // Note that if the writing system is different, the same text id is required for source and target
+                // texts to allow them to be aligned in the ParallelTextCorpus
+                if (project.WritingSystem.Tag == project.TranslateConfig.Source.WritingSystem.Tag)
                 {
-                    // Remove the project id from the start of the text id (if present)
-                    string textId = text.Id.StartsWith($"{project.Id}_") ? text.Id[(project.Id.Length + 1)..] : text.Id;
+                    textId = $"{text.Id}_{type.ToString().ToLowerInvariant()}";
+                }
 
-                    // If the writing system is the same, we need to differentiate the texts.
-                    // Note that if the writing system is different, the same text id is required for source and target
-                    // texts to allow them to be aligned in the ParallelTextCorpus
-                    if (project.WritingSystem.Tag == project.TranslateConfig.Source.WritingSystem.Tag)
+                // See if the corpus exists, and delete it if it does
+                bool uploadText = false;
+                string checksum = StringUtils.ComputeMd5Hash(textFileData);
+                MachineCorpusFile? previousCorpusFile = previousCorpusFiles.FirstOrDefault(
+                    c => c.TextId == textId && c.LanguageTag == languageTag
+                );
+                if (previousCorpusFile is null)
+                {
+                    uploadText = true;
+                }
+                else if (previousCorpusFile.FileChecksum != checksum)
+                {
+                    // Only delete the file if it is present in the Machine API
+                    if (serverCorpusFiles.Any(c => c.Id == previousCorpusFile.FileId))
                     {
-                        textId = $"{text.Id}_{type.ToString().ToLowerInvariant()}";
-                    }
-
-                    // See if the corpus exists, and delete it if it does
-                    bool uploadText = false;
-                    string checksum = StringUtils.ComputeMd5Hash(textFileData);
-                    MachineCorpusFile? previousCorpusFile = previousCorpusFiles.FirstOrDefault(
-                        c => c.TextId == textId && c.LanguageTag == languageTag
-                    );
-                    if (previousCorpusFile is null)
-                    {
-                        uploadText = true;
-                    }
-                    else if (previousCorpusFile.FileChecksum != checksum)
-                    {
-                        // Only delete the file if it is present in the Machine API
-                        if (serverCorpusFiles.Any(c => c.Id == previousCorpusFile.FileId))
-                        {
-                            await _machineCorporaService.DeleteCorpusFileAsync(
-                                corpusId,
-                                previousCorpusFile.FileId,
-                                cancellationToken
-                            );
-                        }
-
-                        uploadText = true;
-                    }
-
-                    // Upload the file if it is not there, or has changed
-                    if (uploadText)
-                    {
-                        string fileId = await _machineCorporaService.UploadCorpusTextAsync(
+                        await _machineCorporaService.DeleteCorpusFileAsync(
                             corpusId,
-                            languageTag,
-                            textId,
-                            textFileData,
+                            previousCorpusFile.FileId,
                             cancellationToken
                         );
-
-                        // Record the fileId and checksum, matching the text id
-                        // We coalesce to -1, as FindIndex returns -1 if not found
-                        int index =
-                            projectSecret.MachineData?.Corpora[corpusId].Files.FindIndex(
-                                f => f.TextId == textId && f.LanguageTag == languageTag
-                            ) ?? -1;
-
-                        if (previousCorpusFile is null || index == -1)
-                        {
-                            // Add the file information to the project secret
-                            projectSecret = await _projectSecrets.UpdateAsync(
-                                projectSecret,
-                                u =>
-                                    u.Add(
-                                        p => p.MachineData.Corpora[corpusId].Files,
-                                        new MachineCorpusFile
-                                        {
-                                            FileChecksum = checksum,
-                                            FileId = fileId,
-                                            LanguageTag = languageTag,
-                                            TextId = textId,
-                                        }
-                                    )
-                            );
-                        }
-                        else
-                        {
-                            // Update the file information in the project secret
-                            projectSecret = await _projectSecrets.UpdateAsync(
-                                projectSecret,
-                                u =>
-                                    u.Set(p => p.MachineData.Corpora[corpusId].Files[index].FileChecksum, checksum)
-                                        .Set(p => p.MachineData.Corpora[corpusId].Files[index].FileId, fileId)
-                                        .Set(p => p.MachineData.Corpora[corpusId].Files[index].LanguageTag, languageTag)
-                            );
-                        }
-
-                        corpusUpdated = true;
                     }
+
+                    uploadText = true;
+                }
+
+                // Upload the file if it is not there, or has changed
+                if (uploadText)
+                {
+                    string fileId = await _machineCorporaService.UploadCorpusTextAsync(
+                        corpusId,
+                        languageTag,
+                        textId,
+                        textFileData,
+                        cancellationToken
+                    );
+
+                    // Record the fileId and checksum, matching the text id
+                    // We coalesce to -1, as FindIndex returns -1 if not found
+                    int index =
+                        projectSecret.MachineData?.Corpora[corpusId].Files.FindIndex(
+                            f => f.TextId == textId && f.LanguageTag == languageTag
+                        ) ?? -1;
+
+                    if (previousCorpusFile is null || index == -1)
+                    {
+                        // Add the file information to the project secret
+                        projectSecret = await _projectSecrets.UpdateAsync(
+                            projectSecret,
+                            u =>
+                                u.Add(
+                                    p => p.MachineData.Corpora[corpusId].Files,
+                                    new MachineCorpusFile
+                                    {
+                                        FileChecksum = checksum,
+                                        FileId = fileId,
+                                        LanguageTag = languageTag,
+                                        TextId = textId,
+                                    }
+                                )
+                        );
+                    }
+                    else
+                    {
+                        // Update the file information in the project secret
+                        projectSecret = await _projectSecrets.UpdateAsync(
+                            projectSecret,
+                            u =>
+                                u.Set(p => p.MachineData.Corpora[corpusId].Files[index].FileChecksum, checksum)
+                                    .Set(p => p.MachineData.Corpora[corpusId].Files[index].FileId, fileId)
+                                    .Set(p => p.MachineData.Corpora[corpusId].Files[index].LanguageTag, languageTag)
+                        );
+                    }
+
+                    corpusUpdated = true;
                 }
             }
-
-            return corpusUpdated;
         }
+
+        return corpusUpdated;
     }
 }

--- a/src/SIL.XForge.Scripture/Services/MachineServiceBase.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineServiceBase.cs
@@ -8,53 +8,49 @@ using System.Threading;
 using System.Threading.Tasks;
 using SIL.ObjectModel;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// Shared functionality and configuration for Machine Services that access the Machine API.
+/// </summary>
+public abstract class MachineServiceBase : DisposableBase
 {
-    /// <summary>
-    /// Shared functionality and configuration for Machine Services that access the Machine API.
-    /// </summary>
-    public abstract class MachineServiceBase : DisposableBase
+    public const string ClientName = "machine_api";
+
+    protected HttpClient MachineClient { get; }
+    protected JsonSerializerOptions Options { get; }
+
+    protected MachineServiceBase(IHttpClientFactory httpClientFactory)
     {
-        public const string ClientName = "machine_api";
+        MachineClient = httpClientFactory.CreateClient(ClientName);
+        Options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        Options.Converters.Add(new JsonStringEnumConverter());
+    }
 
-        protected HttpClient MachineClient { get; }
-        protected JsonSerializerOptions Options { get; }
+    protected static async Task<T> ReadAnonymousObjectFromJsonAsync<T>(
+        HttpResponseMessage response,
+        T _,
+        JsonSerializerOptions options,
+        CancellationToken cancellationToken
+    ) => await response.Content.ReadFromJsonAsync<T>(options, cancellationToken);
 
-        protected MachineServiceBase(IHttpClientFactory httpClientFactory)
+    protected override void DisposeManagedResources() => MachineClient.Dispose();
+
+    /// <summary>
+    /// Validates an identifier for passing via a URL segment to the Machine API.
+    /// </summary>
+    /// <param name="id">The identifier.</param>
+    /// <exception cref="ArgumentException"></exception>
+    /// <remarks>
+    /// Calling this method on an ID string ensures that the ID can be included in a URL to a Machine API endpoint,
+    /// without risk of URL injection. This identifier will usually be a 24 character MongoDB generated identifier.
+    /// Length is not verified - the Machine API will return an error for an incorrect/missing ID.
+    /// </remarks>
+    protected void ValidateId(string id)
+    {
+        if (!Regex.IsMatch(id, "^[a-zA-Z0-9]+$"))
         {
-            MachineClient = httpClientFactory.CreateClient(ClientName);
-            Options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-            Options.Converters.Add(new JsonStringEnumConverter());
-        }
-
-        protected static async Task<T> ReadAnonymousObjectFromJsonAsync<T>(
-            HttpResponseMessage response,
-            T _,
-            JsonSerializerOptions options,
-            CancellationToken cancellationToken
-        ) => await response.Content.ReadFromJsonAsync<T>(options, cancellationToken);
-
-        protected override void DisposeManagedResources()
-        {
-            MachineClient.Dispose();
-        }
-
-        /// <summary>
-        /// Validates an identifier for passing via a URL segment to the Machine API.
-        /// </summary>
-        /// <param name="id">The identifier.</param>
-        /// <exception cref="ArgumentException"></exception>
-        /// <remarks>
-        /// Calling this method on an ID string ensures that the ID can be included in a URL to a Machine API endpoint,
-        /// without risk of URL injection. This identifier will usually be a 24 character MongoDB generated identifier.
-        /// Length is not verified - the Machine API will return an error for an incorrect/missing ID.
-        /// </remarks>
-        protected void ValidateId(string id)
-        {
-            if (!Regex.IsMatch(id, "^[a-zA-Z0-9]+$"))
-            {
-                throw new ArgumentException($"Invalid Identifier: {id}");
-            }
+            throw new ArgumentException($"Invalid Identifier: {id}");
         }
     }
 }

--- a/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
@@ -13,91 +13,87 @@ using SIL.Machine.WebApi.Services;
 using SIL.XForge.Configuration;
 using SIL.XForge.Scripture.Services;
 
-namespace Microsoft.Extensions.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class MachineServiceCollectionExtensions
 {
-    public static class MachineServiceCollectionExtensions
+    public static IServiceCollection AddSFMachine(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IWebHostEnvironment env
+    )
     {
-        public static IServiceCollection AddSFMachine(
-            this IServiceCollection services,
-            IConfiguration configuration,
-            IWebHostEnvironment env
-        )
-        {
-            var siteOptions = configuration.GetOptions<SiteOptions>();
-            var dataAccessOptions = configuration.GetOptions<DataAccessOptions>();
-            services
-                .AddMachine(config =>
-                {
-                    config.AuthenticationSchemes = new[] { JwtBearerDefaults.AuthenticationScheme };
-                    config.Namespace = "machine-api/v1";
-                })
-                .AddEngineOptions(o => o.EnginesDir = Path.Combine(siteOptions.SiteDir, "engines"))
-                .AddMongoDataAccess(o =>
-                {
-                    o.ConnectionString = dataAccessOptions.ConnectionString;
-                    o.MachineDatabaseName = "xforge_machine";
-                })
-                .AddTextCorpus<SFTextCorpusFactory>();
-            services.AddSingleton<IAuthorizationHandler, MachineAuthorizationHandler>();
-            services.AddSingleton<IBuildHandler, SFBuildHandler>();
-
-            // Setup the Machine API
-            var machineOptions = configuration.GetOptions<MachineOptions>();
-            services.AddAccessTokenManagement(options =>
+        var siteOptions = configuration.GetOptions<SiteOptions>();
+        var dataAccessOptions = configuration.GetOptions<DataAccessOptions>();
+        services
+            .AddMachine(config =>
             {
-                options.Client.Clients.Add(
-                    MachineServiceBase.ClientName,
-                    new ClientCredentialsTokenRequest
-                    {
-                        Address = machineOptions.TokenUrl,
-                        ClientId = machineOptions.ClientId,
-                        ClientSecret = machineOptions.ClientSecret,
-                        Parameters = new Parameters { { "audience", machineOptions.Audience } },
-                    }
-                );
-            });
-            services
-                .AddClientAccessTokenHttpClient(
-                    MachineServiceBase.ClientName,
-                    configureClient: client =>
-                    {
-                        client.BaseAddress = new Uri(machineOptions.ApiServer);
-                    }
-                )
-                .ConfigurePrimaryHttpMessageHandler(() =>
+                config.AuthenticationSchemes = new[] { JwtBearerDefaults.AuthenticationScheme };
+                config.Namespace = "machine-api/v1";
+            })
+            .AddEngineOptions(o => o.EnginesDir = Path.Combine(siteOptions.SiteDir, "engines"))
+            .AddMongoDataAccess(o =>
+            {
+                o.ConnectionString = dataAccessOptions.ConnectionString;
+                o.MachineDatabaseName = "xforge_machine";
+            })
+            .AddTextCorpus<SFTextCorpusFactory>();
+        services.AddSingleton<IAuthorizationHandler, MachineAuthorizationHandler>();
+        services.AddSingleton<IBuildHandler, SFBuildHandler>();
+
+        // Setup the Machine API
+        var machineOptions = configuration.GetOptions<MachineOptions>();
+        services.AddAccessTokenManagement(options =>
+        {
+            options.Client.Clients.Add(
+                MachineServiceBase.ClientName,
+                new ClientCredentialsTokenRequest
                 {
-                    var handler = new HttpClientHandler();
-                    if (env.IsDevelopment() || env.IsEnvironment("Testing"))
-                    {
-                        handler.ServerCertificateCustomValidationCallback =
-                            HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
-                    }
+                    Address = machineOptions.TokenUrl,
+                    ClientId = machineOptions.ClientId,
+                    ClientSecret = machineOptions.ClientSecret,
+                    Parameters = new Parameters { { "audience", machineOptions.Audience } },
+                }
+            );
+        });
+        services
+            .AddClientAccessTokenHttpClient(
+                MachineServiceBase.ClientName,
+                configureClient: client => client.BaseAddress = new Uri(machineOptions.ApiServer)
+            )
+            .ConfigurePrimaryHttpMessageHandler(() =>
+            {
+                var handler = new HttpClientHandler();
+                if (env.IsDevelopment() || env.IsEnvironment("Testing"))
+                {
+                    handler.ServerCertificateCustomValidationCallback =
+                        HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+                }
 
-                    return handler;
-                });
-            services
-                .AddHttpClient(MachineServiceBase.ClientName)
-                .SetHandlerLifetime(TimeSpan.FromMinutes(5))
-                .AddPolicyHandler(GetRetryPolicy())
-                .AddPolicyHandler(GetCircuitBreakerPolicy());
-            services.AddSingleton<IMachineApiService, MachineApiService>();
-            services.AddSingleton<IMachineBuildService, MachineBuildService>();
-            services.AddSingleton<IMachineCorporaService, MachineCorporaService>();
-            services.AddSingleton<IMachineProjectService, MachineProjectService>();
-            services.AddSingleton<IMachineTranslationService, MachineTranslationService>();
-            return services;
-        }
-
-        private static IAsyncPolicy<HttpResponseMessage> GetRetryPolicy() =>
-            Policy<HttpResponseMessage>
-                .Handle<HttpRequestException>()
-                .OrResult(r => r.StatusCode >= HttpStatusCode.InternalServerError)
-                .WaitAndRetryAsync(6, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
-
-        private static IAsyncPolicy<HttpResponseMessage> GetCircuitBreakerPolicy() =>
-            Policy<HttpResponseMessage>
-                .Handle<HttpRequestException>()
-                .OrResult(r => r.StatusCode >= HttpStatusCode.InternalServerError)
-                .CircuitBreakerAsync(5, TimeSpan.FromSeconds(30));
+                return handler;
+            });
+        services
+            .AddHttpClient(MachineServiceBase.ClientName)
+            .SetHandlerLifetime(TimeSpan.FromMinutes(5))
+            .AddPolicyHandler(GetRetryPolicy())
+            .AddPolicyHandler(GetCircuitBreakerPolicy());
+        services.AddSingleton<IMachineApiService, MachineApiService>();
+        services.AddSingleton<IMachineBuildService, MachineBuildService>();
+        services.AddSingleton<IMachineCorporaService, MachineCorporaService>();
+        services.AddSingleton<IMachineProjectService, MachineProjectService>();
+        services.AddSingleton<IMachineTranslationService, MachineTranslationService>();
+        return services;
     }
+
+    private static IAsyncPolicy<HttpResponseMessage> GetRetryPolicy() =>
+        Policy<HttpResponseMessage>
+            .Handle<HttpRequestException>()
+            .OrResult(r => r.StatusCode >= HttpStatusCode.InternalServerError)
+            .WaitAndRetryAsync(6, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
+
+    private static IAsyncPolicy<HttpResponseMessage> GetCircuitBreakerPolicy() =>
+        Policy<HttpResponseMessage>
+            .Handle<HttpRequestException>()
+            .OrResult(r => r.StatusCode >= HttpStatusCode.InternalServerError)
+            .CircuitBreakerAsync(5, TimeSpan.FromSeconds(30));
 }

--- a/src/SIL.XForge.Scripture/Services/MachineTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineTranslationService.cs
@@ -7,177 +7,171 @@ using System.Threading.Tasks;
 using SIL.Machine.WebApi;
 using SIL.XForge.Scripture.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// Provides an interface to the non-build endpoints of the Machine API Translation Engine.
+/// These include project creation, deletion, and translation related methods.
+/// </summary>
+public class MachineTranslationService : MachineServiceBase, IMachineTranslationService
 {
-    /// <summary>
-    /// Provides an interface to the non-build endpoints of the Machine API Translation Engine.
-    /// These include project creation, deletion, and translation related methods.
-    /// </summary>
-    public class MachineTranslationService : MachineServiceBase, IMachineTranslationService
+    private readonly IExceptionHandler _exceptionHandler;
+
+    public MachineTranslationService(IExceptionHandler exceptionHandler, IHttpClientFactory httpClientFactory)
+        : base(httpClientFactory) => _exceptionHandler = exceptionHandler;
+
+    public async Task<string> CreateTranslationEngineAsync(
+        string name,
+        string sourceLanguageTag,
+        string targetLanguageTag,
+        bool smtTransfer,
+        CancellationToken cancellationToken
+    )
     {
-        private readonly IExceptionHandler _exceptionHandler;
+        // TODO: When Machine > 2.5.X, change the anonymous object to TranslationEngineConfigDto
+        const string requestUri = "translation-engines";
+        using var response = await MachineClient.PostAsJsonAsync(
+            requestUri,
+            new
+            {
+                name,
+                sourceLanguageTag,
+                targetLanguageTag,
+                type = smtTransfer ? "SmtTransfer" : "Nmt",
+            },
+            cancellationToken
+        );
+        await _exceptionHandler.EnsureSuccessStatusCode(response);
 
-        public MachineTranslationService(IExceptionHandler exceptionHandler, IHttpClientFactory httpClientFactory)
-            : base(httpClientFactory)
+        try
         {
-            _exceptionHandler = exceptionHandler;
-        }
-
-        public async Task<string> CreateTranslationEngineAsync(
-            string name,
-            string sourceLanguageTag,
-            string targetLanguageTag,
-            bool smtTransfer,
-            CancellationToken cancellationToken
-        )
-        {
-            // TODO: When Machine > 2.5.X, change the anonymous object to TranslationEngineConfigDto
-            const string requestUri = "translation-engines";
-            using var response = await MachineClient.PostAsJsonAsync(
-                requestUri,
-                new
-                {
-                    name,
-                    sourceLanguageTag,
-                    targetLanguageTag,
-                    type = smtTransfer ? "SmtTransfer" : "Nmt",
-                },
+            var translationEngine = await ReadAnonymousObjectFromJsonAsync(
+                response,
+                new { id = string.Empty },
+                Options,
                 cancellationToken
             );
-            await _exceptionHandler.EnsureSuccessStatusCode(response);
-
-            try
-            {
-                var translationEngine = await ReadAnonymousObjectFromJsonAsync(
-                    response,
-                    new { id = string.Empty },
-                    Options,
-                    cancellationToken
-                );
-                return translationEngine?.id ?? string.Empty;
-            }
-            catch (Exception e)
-            {
-                throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
-            }
+            return translationEngine?.id ?? string.Empty;
         }
-
-        public async Task DeleteTranslationEngineAsync(string translationEngineId, CancellationToken cancellationToken)
+        catch (Exception e)
         {
-            // Delete the translation engine from the Machine API
-            ValidateId(translationEngineId);
-            string requestUri = $"translation-engines/{translationEngineId}";
-            using var response = await MachineClient.DeleteAsync(requestUri, cancellationToken);
-            await _exceptionHandler.EnsureSuccessStatusCode(response);
+            throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
         }
+    }
 
-        public async Task<MachineApiTranslationEngine> GetTranslationEngineAsync(
-            string translationEngineId,
-            CancellationToken cancellationToken
-        )
+    public async Task DeleteTranslationEngineAsync(string translationEngineId, CancellationToken cancellationToken)
+    {
+        // Delete the translation engine from the Machine API
+        ValidateId(translationEngineId);
+        string requestUri = $"translation-engines/{translationEngineId}";
+        using var response = await MachineClient.DeleteAsync(requestUri, cancellationToken);
+        await _exceptionHandler.EnsureSuccessStatusCode(response);
+    }
+
+    public async Task<MachineApiTranslationEngine> GetTranslationEngineAsync(
+        string translationEngineId,
+        CancellationToken cancellationToken
+    )
+    {
+        ValidateId(translationEngineId);
+
+        string requestUri = $"translation-engines/{translationEngineId}";
+        using var response = await MachineClient.GetAsync(requestUri, cancellationToken);
+        await _exceptionHandler.EnsureSuccessStatusCode(response);
+
+        // Return the translation engine
+        try
         {
-            ValidateId(translationEngineId);
-
-            string requestUri = $"translation-engines/{translationEngineId}";
-            using var response = await MachineClient.GetAsync(requestUri, cancellationToken);
-            await _exceptionHandler.EnsureSuccessStatusCode(response);
-
-            // Return the translation engine
-            try
-            {
-                return (
-                    await response.Content.ReadFromJsonAsync<MachineApiTranslationEngine>(Options, cancellationToken)
-                )!;
-            }
-            catch (Exception e)
-            {
-                throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
-            }
+            return (await response.Content.ReadFromJsonAsync<MachineApiTranslationEngine>(Options, cancellationToken))!;
         }
-
-        public async Task<WordGraphDto> GetWordGraphAsync(
-            string translationEngineId,
-            IEnumerable<string> segment,
-            CancellationToken cancellationToken
-        )
+        catch (Exception e)
         {
-            ValidateId(translationEngineId);
-
-            string requestUri = $"translation-engines/{translationEngineId}/get-word-graph";
-            using var response = await MachineClient.PostAsJsonAsync(requestUri, segment, cancellationToken);
-            await _exceptionHandler.EnsureSuccessStatusCode(response);
-
-            // Return the word graph
-            try
-            {
-                return (await response.Content.ReadFromJsonAsync<WordGraphDto>(Options, cancellationToken))!;
-            }
-            catch (Exception e)
-            {
-                throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
-            }
+            throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
         }
+    }
 
-        public async Task TrainSegmentAsync(
-            string translationEngineId,
-            SegmentPairDto segmentPair,
-            CancellationToken cancellationToken
-        )
+    public async Task<WordGraphDto> GetWordGraphAsync(
+        string translationEngineId,
+        IEnumerable<string> segment,
+        CancellationToken cancellationToken
+    )
+    {
+        ValidateId(translationEngineId);
+
+        string requestUri = $"translation-engines/{translationEngineId}/get-word-graph";
+        using var response = await MachineClient.PostAsJsonAsync(requestUri, segment, cancellationToken);
+        await _exceptionHandler.EnsureSuccessStatusCode(response);
+
+        // Return the word graph
+        try
         {
-            ValidateId(translationEngineId);
-
-            string requestUri = $"translation-engines/{translationEngineId}/train-segment";
-            using var response = await MachineClient.PostAsJsonAsync(requestUri, segmentPair, cancellationToken);
-
-            // No body is returned on success
-            await _exceptionHandler.EnsureSuccessStatusCode(response);
+            return (await response.Content.ReadFromJsonAsync<WordGraphDto>(Options, cancellationToken))!;
         }
-
-        public async Task<TranslationResultDto> TranslateAsync(
-            string translationEngineId,
-            IEnumerable<string> segment,
-            CancellationToken cancellationToken
-        )
+        catch (Exception e)
         {
-            ValidateId(translationEngineId);
-
-            string requestUri = $"translation-engines/{translationEngineId}/translate";
-            using var response = await MachineClient.PostAsJsonAsync(requestUri, segment, cancellationToken);
-            await _exceptionHandler.EnsureSuccessStatusCode(response);
-
-            // Return the translation result
-            try
-            {
-                return (await response.Content.ReadFromJsonAsync<TranslationResultDto>(Options, cancellationToken))!;
-            }
-            catch (Exception e)
-            {
-                throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
-            }
+            throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
         }
+    }
 
-        public async Task<TranslationResultDto[]> TranslateNAsync(
-            string translationEngineId,
-            int n,
-            IEnumerable<string> segment,
-            CancellationToken cancellationToken
-        )
+    public async Task TrainSegmentAsync(
+        string translationEngineId,
+        SegmentPairDto segmentPair,
+        CancellationToken cancellationToken
+    )
+    {
+        ValidateId(translationEngineId);
+
+        string requestUri = $"translation-engines/{translationEngineId}/train-segment";
+        using var response = await MachineClient.PostAsJsonAsync(requestUri, segmentPair, cancellationToken);
+
+        // No body is returned on success
+        await _exceptionHandler.EnsureSuccessStatusCode(response);
+    }
+
+    public async Task<TranslationResultDto> TranslateAsync(
+        string translationEngineId,
+        IEnumerable<string> segment,
+        CancellationToken cancellationToken
+    )
+    {
+        ValidateId(translationEngineId);
+
+        string requestUri = $"translation-engines/{translationEngineId}/translate";
+        using var response = await MachineClient.PostAsJsonAsync(requestUri, segment, cancellationToken);
+        await _exceptionHandler.EnsureSuccessStatusCode(response);
+
+        // Return the translation result
+        try
         {
-            ValidateId(translationEngineId);
+            return (await response.Content.ReadFromJsonAsync<TranslationResultDto>(Options, cancellationToken))!;
+        }
+        catch (Exception e)
+        {
+            throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
+        }
+    }
 
-            string requestUri = $"translation-engines/{translationEngineId}/translate/{n}";
-            using var response = await MachineClient.PostAsJsonAsync(requestUri, segment, cancellationToken);
-            await _exceptionHandler.EnsureSuccessStatusCode(response);
+    public async Task<TranslationResultDto[]> TranslateNAsync(
+        string translationEngineId,
+        int n,
+        IEnumerable<string> segment,
+        CancellationToken cancellationToken
+    )
+    {
+        ValidateId(translationEngineId);
 
-            // Return the translation results
-            try
-            {
-                return (await response.Content.ReadFromJsonAsync<TranslationResultDto[]>(Options, cancellationToken))!;
-            }
-            catch (Exception e)
-            {
-                throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
-            }
+        string requestUri = $"translation-engines/{translationEngineId}/translate/{n}";
+        using var response = await MachineClient.PostAsJsonAsync(requestUri, segment, cancellationToken);
+        await _exceptionHandler.EnsureSuccessStatusCode(response);
+
+        // Return the translation results
+        try
+        {
+            return (await response.Content.ReadFromJsonAsync<TranslationResultDto[]>(Options, cancellationToken))!;
+        }
+        catch (Exception e)
+        {
+            throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response), e);
         }
     }
 }

--- a/src/SIL.XForge.Scripture/Services/MutexAttribute.cs
+++ b/src/SIL.XForge.Scripture/Services/MutexAttribute.cs
@@ -5,178 +5,165 @@ using Hangfire.Common;
 using Hangfire.States;
 using Hangfire.Storage;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// Represents a background job filter that helps to disable concurrent execution
+/// without causing worker to wait as in <see cref="Hangfire.DisableConcurrentExecutionAttribute"/>.
+///
+/// Source: https://gist.github.com/odinserj/4a3bf40606c4da9183588a5a325dfb99
+/// </summary>
+public class MutexAttribute : JobFilterAttribute, IElectStateFilter, IApplyStateFilter
 {
-    /// <summary>
-    /// Represents a background job filter that helps to disable concurrent execution
-    /// without causing worker to wait as in <see cref="Hangfire.DisableConcurrentExecutionAttribute"/>.
-    ///
-    /// Source: https://gist.github.com/odinserj/4a3bf40606c4da9183588a5a325dfb99
-    /// </summary>
-    public class MutexAttribute : JobFilterAttribute, IElectStateFilter, IApplyStateFilter
+    private static readonly TimeSpan DistributedLockTimeout = TimeSpan.FromMinutes(1);
+
+    private readonly string _resource;
+
+    public MutexAttribute(string resource)
     {
-        private static readonly TimeSpan DistributedLockTimeout = TimeSpan.FromMinutes(1);
+        _resource = resource;
+        RetryInSeconds = 15;
+    }
 
-        private readonly string _resource;
+    public int RetryInSeconds { get; set; }
+    public int MaxAttempts { get; set; }
 
-        public MutexAttribute(string resource)
+    public void OnStateElection(ElectStateContext context)
+    {
+        // We are intercepting transitions to the Processed state, that is performed by
+        // a worker just before processing a job. During the state election phase we can
+        // change the target state to another one, causing a worker not to process the
+        // backgorund job.
+        if (context.CandidateState.Name != ProcessingState.StateName || context.BackgroundJob.Job == null)
         {
-            _resource = resource;
-            RetryInSeconds = 15;
+            return;
         }
 
-        public int RetryInSeconds { get; set; }
-        public int MaxAttempts { get; set; }
-
-        public void OnStateElection(ElectStateContext context)
+        // This filter requires an extended set of storage operations. It's supported
+        // by all the official storages, and many of the community-based ones.
+        if (context.Connection is not JobStorageConnection storageConnection)
         {
-            // We are intercepting transitions to the Processed state, that is performed by
-            // a worker just before processing a job. During the state election phase we can
-            // change the target state to another one, causing a worker not to process the
-            // backgorund job.
-            if (context.CandidateState.Name != ProcessingState.StateName || context.BackgroundJob.Job == null)
-            {
-                return;
-            }
-
-            // This filter requires an extended set of storage operations. It's supported
-            // by all the official storages, and many of the community-based ones.
-            var storageConnection = context.Connection as JobStorageConnection;
-            if (storageConnection == null)
-            {
-                throw new NotSupportedException(
-                    "This version of storage doesn't support extended methods. Please try to update to the latest version."
-                );
-            }
-
-            string blockedBy;
-
-            try
-            {
-                // Distributed lock is needed here only to prevent a race condition, when another
-                // worker picks up a background job with the same resource between GET and SET
-                // operations.
-                // There will be no race condition, when two or more workers pick up background job
-                // with the same id, because state transitions are protected with distributed lock
-                // themselves.
-                using (AcquireDistributedSetLock(context.Connection, context.BackgroundJob.Job.Args))
-                {
-                    // Resource set contains a background job id that acquired a mutex for the resource.
-                    // We are getting only one element to see what background job blocked the invocation.
-                    var range = storageConnection.GetRangeFromSet(GetResourceKey(context.BackgroundJob.Job.Args), 0, 0);
-
-                    blockedBy = range.Count > 0 ? range[0] : null;
-
-                    // We should permit an invocation only when the set is empty, or if current background
-                    // job is already owns a resource. This may happen, when the localTransaction succeeded,
-                    // but outer transaction was failed.
-                    if (blockedBy == null || blockedBy == context.BackgroundJob.Id)
-                    {
-                        // We need to commit the changes inside a distributed lock, otherwise it's
-                        // useless. So we create a local transaction instead of using the
-                        // context.Transaction property.
-                        var localTransaction = context.Connection.CreateWriteTransaction();
-
-                        // Add the current background job identifier to a resource set. This means
-                        // that resource is owned by the current background job. Identifier will be
-                        // removed only on failed state, or in one of final states (succeeded or
-                        // deleted).
-                        localTransaction.AddToSet(
-                            GetResourceKey(context.BackgroundJob.Job.Args),
-                            context.BackgroundJob.Id
-                        );
-                        localTransaction.Commit();
-
-                        // Invocation is permitted, and we did all the required things.
-                        return;
-                    }
-                }
-            }
-            catch (DistributedLockTimeoutException)
-            {
-                // We weren't able to acquire a distributed lock within a specified window. This may
-                // be caused by network delays, storage outages or abandoned locks in some storages.
-                // Since it is required to expire abandoned locks after some time, we can simply
-                // postpone the invocation.
-                context.CandidateState = new ScheduledState(TimeSpan.FromSeconds(RetryInSeconds))
-                {
-                    Reason = "Couldn't acquire a distributed lock for mutex: timeout exceeded"
-                };
-
-                return;
-            }
-
-            // Background job execution is blocked. We should change the target state either to
-            // the Scheduled or to the Deleted one, depending on current retry attempt number.
-            var currentAttempt = context.GetJobParameter<int>("MutexAttempt") + 1;
-            context.SetJobParameter("MutexAttempt", currentAttempt);
-
-            context.CandidateState =
-                MaxAttempts == 0 || currentAttempt <= MaxAttempts
-                    ? CreateScheduledState(blockedBy, currentAttempt)
-                    : CreateDeletedState(blockedBy);
+            throw new NotSupportedException(
+                "This version of storage doesn't support extended methods. Please try to update to the latest version."
+            );
         }
 
-        public void OnStateApplied(ApplyStateContext context, IWriteOnlyTransaction transaction)
-        {
-            if (context.BackgroundJob.Job == null)
-                return;
+        string blockedBy;
 
-            if (context.OldStateName == ProcessingState.StateName)
+        try
+        {
+            // Distributed lock is needed here only to prevent a race condition, when another
+            // worker picks up a background job with the same resource between GET and SET
+            // operations.
+            // There will be no race condition, when two or more workers pick up background job
+            // with the same id, because state transitions are protected with distributed lock
+            // themselves.
+            using (AcquireDistributedSetLock(context.Connection, context.BackgroundJob.Job.Args))
             {
-                using (AcquireDistributedSetLock(context.Connection, context.BackgroundJob.Job.Args))
+                // Resource set contains a background job id that acquired a mutex for the resource.
+                // We are getting only one element to see what background job blocked the invocation.
+                var range = storageConnection.GetRangeFromSet(GetResourceKey(context.BackgroundJob.Job.Args), 0, 0);
+
+                blockedBy = range.Count > 0 ? range[0] : null;
+
+                // We should permit an invocation only when the set is empty, or if current background
+                // job is already owns a resource. This may happen, when the localTransaction succeeded,
+                // but outer transaction was failed.
+                if (blockedBy == null || blockedBy == context.BackgroundJob.Id)
                 {
+                    // We need to commit the changes inside a distributed lock, otherwise it's
+                    // useless. So we create a local transaction instead of using the
+                    // context.Transaction property.
                     var localTransaction = context.Connection.CreateWriteTransaction();
-                    localTransaction.RemoveFromSet(
-                        GetResourceKey(context.BackgroundJob.Job.Args),
-                        context.BackgroundJob.Id
-                    );
 
+                    // Add the current background job identifier to a resource set. This means
+                    // that resource is owned by the current background job. Identifier will be
+                    // removed only on failed state, or in one of final states (succeeded or
+                    // deleted).
+                    localTransaction.AddToSet(GetResourceKey(context.BackgroundJob.Job.Args), context.BackgroundJob.Id);
                     localTransaction.Commit();
+
+                    // Invocation is permitted, and we did all the required things.
+                    return;
                 }
             }
         }
-
-        public void OnStateUnapplied(ApplyStateContext context, IWriteOnlyTransaction transaction) { }
-
-        private static DeletedState CreateDeletedState(string blockedBy)
+        catch (DistributedLockTimeoutException)
         {
-            return new DeletedState
+            // We weren't able to acquire a distributed lock within a specified window. This may
+            // be caused by network delays, storage outages or abandoned locks in some storages.
+            // Since it is required to expire abandoned locks after some time, we can simply
+            // postpone the invocation.
+            context.CandidateState = new ScheduledState(TimeSpan.FromSeconds(RetryInSeconds))
             {
-                Reason = $"Execution was blocked by background job {blockedBy}, all attempts exhausted"
+                Reason = "Couldn't acquire a distributed lock for mutex: timeout exceeded"
             };
+
+            return;
         }
 
-        private IState CreateScheduledState(string blockedBy, int currentAttempt)
-        {
-            var reason = $"Execution is blocked by background job {blockedBy}, retry attempt: {currentAttempt}";
+        // Background job execution is blocked. We should change the target state either to
+        // the Scheduled or to the Deleted one, depending on current retry attempt number.
+        var currentAttempt = context.GetJobParameter<int>("MutexAttempt") + 1;
+        context.SetJobParameter("MutexAttempt", currentAttempt);
 
-            if (MaxAttempts > 0)
+        context.CandidateState =
+            MaxAttempts == 0 || currentAttempt <= MaxAttempts
+                ? CreateScheduledState(blockedBy, currentAttempt)
+                : CreateDeletedState(blockedBy);
+    }
+
+    public void OnStateApplied(ApplyStateContext context, IWriteOnlyTransaction transaction)
+    {
+        if (context.BackgroundJob.Job == null)
+            return;
+
+        if (context.OldStateName == ProcessingState.StateName)
+        {
+            using (AcquireDistributedSetLock(context.Connection, context.BackgroundJob.Job.Args))
             {
-                reason += $"/{MaxAttempts}";
+                var localTransaction = context.Connection.CreateWriteTransaction();
+                localTransaction.RemoveFromSet(
+                    GetResourceKey(context.BackgroundJob.Job.Args),
+                    context.BackgroundJob.Id
+                );
+
+                localTransaction.Commit();
             }
-
-            return new ScheduledState(TimeSpan.FromSeconds(RetryInSeconds)) { Reason = reason };
-        }
-
-        private IDisposable AcquireDistributedSetLock(IStorageConnection connection, IEnumerable<object> args)
-        {
-            return connection.AcquireDistributedLock(GetDistributedLockKey(args), DistributedLockTimeout);
-        }
-
-        private string GetDistributedLockKey(IEnumerable<object> args)
-        {
-            return $"extension:job-mutex:lock:{GetKeyFormat(args, _resource)}";
-        }
-
-        private string GetResourceKey(IEnumerable<object> args)
-        {
-            return $"extension:job-mutex:set:{GetKeyFormat(args, _resource)}";
-        }
-
-        private static string GetKeyFormat(IEnumerable<object> args, string keyFormat)
-        {
-            return String.Format(keyFormat, args.ToArray());
         }
     }
+
+    public void OnStateUnapplied(ApplyStateContext context, IWriteOnlyTransaction transaction) { }
+
+    private static DeletedState CreateDeletedState(string blockedBy)
+    {
+        return new DeletedState
+        {
+            Reason = $"Execution was blocked by background job {blockedBy}, all attempts exhausted"
+        };
+    }
+
+    private IState CreateScheduledState(string blockedBy, int currentAttempt)
+    {
+        var reason = $"Execution is blocked by background job {blockedBy}, retry attempt: {currentAttempt}";
+
+        if (MaxAttempts > 0)
+        {
+            reason += $"/{MaxAttempts}";
+        }
+
+        return new ScheduledState(TimeSpan.FromSeconds(RetryInSeconds)) { Reason = reason };
+    }
+
+    private IDisposable AcquireDistributedSetLock(IStorageConnection connection, IEnumerable<object> args) =>
+        connection.AcquireDistributedLock(GetDistributedLockKey(args), DistributedLockTimeout);
+
+    private string GetDistributedLockKey(IEnumerable<object> args) =>
+        $"extension:job-mutex:lock:{GetKeyFormat(args, _resource)}";
+
+    private string GetResourceKey(IEnumerable<object> args) =>
+        $"extension:job-mutex:set:{GetKeyFormat(args, _resource)}";
+
+    private static string GetKeyFormat(IEnumerable<object> args, string keyFormat) =>
+        String.Format(keyFormat, args.ToArray());
 }

--- a/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
+++ b/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
@@ -8,242 +8,239 @@ using Paratext.Data.ProjectComments;
 using Paratext.Data.Users;
 using SIL.Xml;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// Formats CommentThreads to and from XML.
+/// </summary>
+/// <remarks>
+/// This file is copied from Paratext DataAccessServer, with the following alterations:
+///  * ParseNotes takes an XElement for input rather than a String
+///  * Additional null checking
+///  * Code reformatting
+/// </remarks>
+public static class NotesFormatter
 {
+    private const string NotesSchemaVersion = "1.1";
+
+    #region Public methods
     /// <summary>
-    /// Formats CommentThreads to and from XML.
+    /// Formats the specified CommentThreads as XML.
     /// </summary>
-    /// <remarks>
-    /// This file is copied from Paratext DataAccessServer, with the following alterations:
-    ///  * ParseNotes takes an XElement for input rather than a String
-    ///  * Additional null checking
-    ///  * Code reformatting
-    /// </remarks>
-    public static class NotesFormatter
+    public static string FormatNotes(IEnumerable<CommentThread> threads)
     {
-        private const string NotesSchemaVersion = "1.1";
-
-        #region Public methods
-        /// <summary>
-        /// Formats the specified CommentThreads as XML.
-        /// </summary>
-        public static string FormatNotes(IEnumerable<CommentThread> threads)
-        {
-            XElement topElem = new XElement("notes");
-            topElem.Add(new XAttribute("version", NotesSchemaVersion));
-            foreach (CommentThread thread in threads.Where(t => t.ActiveComments.Any()))
-                topElem.Add(FormatThread(thread));
-            return topElem.ToString();
-        }
-
-        /// <summary>
-        /// Parses the XML into a nested list of Comments - each inner list is the data for a thread.
-        /// </summary>
-        /// <param name="noteXml">The Note XML Element</param>
-        /// <param name="ptUser">ParatextUser to use when creating any new Comments.</param>
-        /// <returns>Nested list of comments</returns>
-        /// <remarks>
-        /// This code assumes that the XML passes the validation of the notes XML schema.
-        /// This is the inverse of <see cref="FormatNotes"/>, except the thread type is not parsed from the XML.
-        /// </remarks>
-        public static List<List<Comment>> ParseNotes(XElement noteXml, ParatextUser ptUser)
-        {
-            return noteXml.Elements("thread").Select(threadElem => ParseThread(threadElem, ptUser)).ToList();
-        }
-
-        #endregion
-
-        #region Private helper methods for formatting
-        private static XElement FormatThread(CommentThread thread)
-        {
-            XElement threadElem = new XElement("thread");
-            threadElem.Add(new XAttribute("id", thread.Id));
-            if (thread.Type == NoteType.Conflict)
-                threadElem.Add(new XAttribute("type", "conflict"));
-            threadElem.Add(FormatSelection(thread.ScriptureSelection));
-            foreach (Comment comment in thread.ActiveComments)
-                threadElem.Add(FormatComment(comment));
-
-            return threadElem;
-        }
-
-        private static XElement FormatComment(Comment comment)
-        {
-            XElement commentElem = new XElement("comment");
-            commentElem.Add(new XAttribute("user", comment.User));
-            commentElem.Add(new XAttribute("date", comment.Date));
-            if (comment.ExternalUser is not null)
-                commentElem.Add(new XAttribute("extUser", comment.ExternalUser));
-            if (comment.Deleted)
-                commentElem.Add(new XAttribute("deleted", "true"));
-            commentElem.Add(FormatContent(comment.Contents));
-            return commentElem;
-        }
-
-        private static XElement FormatContent(XmlElement? commentContents)
-        {
-            XElement contentElem = new XElement("content");
-            if (commentContents is null)
-                contentElem.Add(new XElement("p", string.Empty));
-            else
-            {
-                foreach (XmlNode node in commentContents.ChildNodes)
-                    if (node.Name == "p")
-                        contentElem.Add(FormatParagraph(node));
-                    else if (node.NodeType == XmlNodeType.Text && node.Value is not null)
-                        contentElem.Add(new XText(node.Value));
-            }
-
-            return contentElem;
-        }
-
-        private static XElement FormatParagraph(XmlNode paraNode)
-        {
-            XElement paraElem = new XElement("p");
-            if (paraNode.ChildNodes.Count == 1)
-                paraElem.Value = paraNode.InnerText;
-            else
-            {
-                foreach (XmlNode node in paraNode.ChildNodes)
-                {
-                    if (node.NodeType == XmlNodeType.Text)
-                    {
-                        paraElem.Add(new XText(node.InnerText));
-                    }
-                    else if (node.Name is "bold" or "italic")
-                    {
-                        XElement spanElem = new XElement("span");
-                        spanElem.Add(new XAttribute("style", node.Name));
-                        spanElem.Value = node.InnerText;
-                        paraElem.Add(spanElem);
-                    }
-                    else if (node.Name == "language")
-                    {
-                        XElement langElem = new XElement("lang");
-                        langElem.Add(new XAttribute("name", node.GetStringAttribute("name")));
-                        langElem.Value = node.InnerText;
-                        paraElem.Add(langElem);
-                    }
-                }
-            }
-
-            return paraElem;
-        }
-
-        private static XElement FormatSelection(ScriptureSelection selection)
-        {
-            XElement selElem = new XElement("selection");
-            selElem.Add(new XAttribute("verseRef", selection.VerseRef.ToString()));
-            selElem.Add(new XAttribute("startPos", selection.StartPosition.ToString()));
-            selElem.Add(new XAttribute("selectedText", selection.SelectedText));
-            if (!string.IsNullOrEmpty(selection.ContextBefore))
-                selElem.Add(new XAttribute("beforeContext", selection.ContextBefore));
-            if (!string.IsNullOrEmpty(selection.ContextAfter))
-                selElem.Add(new XAttribute("afterContext", selection.ContextAfter));
-
-            return selElem;
-        }
-        #endregion
-
-        #region Private helper methods for parsing
-        private static List<Comment> ParseThread(XElement threadElem, ParatextUser ptUser)
-        {
-            List<Comment> result = new List<Comment>();
-            Comment comment = null;
-            foreach (var commentElem in threadElem.Elements("comment"))
-            {
-                if (comment is null)
-                {
-                    comment = new Comment(ptUser);
-                    XAttribute threadId = threadElem.Attribute("id");
-                    if (threadId is not null)
-                        comment.Thread = threadId.Value;
-                    ParseSelection(threadElem.Element("selection"), comment);
-                }
-                else
-                {
-                    comment = (Comment)comment.Clone();
-                }
-                result.Add(comment);
-                ParseComment(commentElem, comment);
-            }
-
-            return result;
-        }
-
-        private static void ParseComment(XElement commentElem, Comment comment)
-        {
-            comment.User = commentElem.Attribute("user")?.Value;
-            string commentDate = commentElem.Attribute("date")?.Value;
-            if (commentDate is not null)
-                comment.Date = commentDate;
-            comment.ExternalUser = commentElem.Attribute("extUser")?.Value;
-            comment.Deleted = commentElem.Attribute("deleted")?.Value == "true";
-            ParseContents(commentElem.Element("content"), comment);
-        }
-
-        private static void ParseContents(XElement? contentElem, Comment comment)
-        {
-            string contents;
-            if (contentElem is null)
-            {
-                contents = string.Empty;
-            }
-            else if (contentElem.FirstNode?.NodeType == XmlNodeType.Text)
-            {
-                contents = ((XText)contentElem.FirstNode).Value;
-            }
-            else
-            {
-                StringBuilder sb = new StringBuilder();
-                foreach (var paraElem in contentElem.Elements("p"))
-                    ParseParagraph(paraElem, sb);
-                contents = sb.ToString();
-            }
-
-            comment.AddTextToContent(string.Empty, false);
-            comment.Contents.InnerXml = contents;
-        }
-
-        private static void ParseParagraph(XElement paraElem, StringBuilder sb)
-        {
-            sb.Append("<p>");
-            foreach (var node in paraElem.Nodes())
-            {
-                if (node is XText text)
-                    sb.Append(text.Value);
-                else
-                {
-                    XElement elem = (XElement)node;
-                    if (elem.Name == "span")
-                    {
-                        string style = elem.Attribute("style")?.Value ?? "bold";
-                        sb.Append($"<{style}>");
-                        sb.Append(elem.GetInnerText());
-                        sb.Append($"</{style}>");
-                    }
-                    else if (elem.Name == "lang")
-                    {
-                        string name = elem.Attribute("name")?.Value ?? "en";
-                        sb.Append($"<language name=\"{name}\">");
-                        sb.Append(elem.GetInnerText());
-                        sb.Append("</language>");
-                    }
-                }
-            }
-            sb.Append("</p>");
-        }
-
-        private static void ParseSelection(XElement? selElem, Comment comment)
-        {
-            if (selElem is null)
-                return;
-            comment.SelectedText = selElem.Attribute("selectedText")?.Value ?? string.Empty;
-            comment.VerseRefStr = selElem.Attribute("verseRef")?.Value;
-            comment.StartPosition = int.Parse(selElem.Attribute("startPos")?.Value ?? "0");
-            comment.ContextBefore = selElem.Attribute("beforeContext")?.Value ?? string.Empty;
-            comment.ContextAfter = selElem.Attribute("afterContext")?.Value ?? string.Empty;
-        }
-        #endregion
+        XElement topElem = new XElement("notes");
+        topElem.Add(new XAttribute("version", NotesSchemaVersion));
+        foreach (CommentThread thread in threads.Where(t => t.ActiveComments.Any()))
+            topElem.Add(FormatThread(thread));
+        return topElem.ToString();
     }
+
+    /// <summary>
+    /// Parses the XML into a nested list of Comments - each inner list is the data for a thread.
+    /// </summary>
+    /// <param name="noteXml">The Note XML Element</param>
+    /// <param name="ptUser">ParatextUser to use when creating any new Comments.</param>
+    /// <returns>Nested list of comments</returns>
+    /// <remarks>
+    /// This code assumes that the XML passes the validation of the notes XML schema.
+    /// This is the inverse of <see cref="FormatNotes"/>, except the thread type is not parsed from the XML.
+    /// </remarks>
+    public static List<List<Comment>> ParseNotes(XElement noteXml, ParatextUser ptUser) =>
+        noteXml.Elements("thread").Select(threadElem => ParseThread(threadElem, ptUser)).ToList();
+
+    #endregion
+
+    #region Private helper methods for formatting
+    private static XElement FormatThread(CommentThread thread)
+    {
+        XElement threadElem = new XElement("thread");
+        threadElem.Add(new XAttribute("id", thread.Id));
+        if (thread.Type == NoteType.Conflict)
+            threadElem.Add(new XAttribute("type", "conflict"));
+        threadElem.Add(FormatSelection(thread.ScriptureSelection));
+        foreach (Comment comment in thread.ActiveComments)
+            threadElem.Add(FormatComment(comment));
+
+        return threadElem;
+    }
+
+    private static XElement FormatComment(Comment comment)
+    {
+        XElement commentElem = new XElement("comment");
+        commentElem.Add(new XAttribute("user", comment.User));
+        commentElem.Add(new XAttribute("date", comment.Date));
+        if (comment.ExternalUser is not null)
+            commentElem.Add(new XAttribute("extUser", comment.ExternalUser));
+        if (comment.Deleted)
+            commentElem.Add(new XAttribute("deleted", "true"));
+        commentElem.Add(FormatContent(comment.Contents));
+        return commentElem;
+    }
+
+    private static XElement FormatContent(XmlElement? commentContents)
+    {
+        XElement contentElem = new XElement("content");
+        if (commentContents is null)
+            contentElem.Add(new XElement("p", string.Empty));
+        else
+        {
+            foreach (XmlNode node in commentContents.ChildNodes)
+                if (node.Name == "p")
+                    contentElem.Add(FormatParagraph(node));
+                else if (node.NodeType == XmlNodeType.Text && node.Value is not null)
+                    contentElem.Add(new XText(node.Value));
+        }
+
+        return contentElem;
+    }
+
+    private static XElement FormatParagraph(XmlNode paraNode)
+    {
+        XElement paraElem = new XElement("p");
+        if (paraNode.ChildNodes.Count == 1)
+            paraElem.Value = paraNode.InnerText;
+        else
+        {
+            foreach (XmlNode node in paraNode.ChildNodes)
+            {
+                if (node.NodeType == XmlNodeType.Text)
+                {
+                    paraElem.Add(new XText(node.InnerText));
+                }
+                else if (node.Name is "bold" or "italic")
+                {
+                    XElement spanElem = new XElement("span");
+                    spanElem.Add(new XAttribute("style", node.Name));
+                    spanElem.Value = node.InnerText;
+                    paraElem.Add(spanElem);
+                }
+                else if (node.Name == "language")
+                {
+                    XElement langElem = new XElement("lang");
+                    langElem.Add(new XAttribute("name", node.GetStringAttribute("name")));
+                    langElem.Value = node.InnerText;
+                    paraElem.Add(langElem);
+                }
+            }
+        }
+
+        return paraElem;
+    }
+
+    private static XElement FormatSelection(ScriptureSelection selection)
+    {
+        XElement selElem = new XElement("selection");
+        selElem.Add(new XAttribute("verseRef", selection.VerseRef.ToString()));
+        selElem.Add(new XAttribute("startPos", selection.StartPosition.ToString()));
+        selElem.Add(new XAttribute("selectedText", selection.SelectedText));
+        if (!string.IsNullOrEmpty(selection.ContextBefore))
+            selElem.Add(new XAttribute("beforeContext", selection.ContextBefore));
+        if (!string.IsNullOrEmpty(selection.ContextAfter))
+            selElem.Add(new XAttribute("afterContext", selection.ContextAfter));
+
+        return selElem;
+    }
+    #endregion
+
+    #region Private helper methods for parsing
+    private static List<Comment> ParseThread(XElement threadElem, ParatextUser ptUser)
+    {
+        List<Comment> result = new List<Comment>();
+        Comment comment = null;
+        foreach (var commentElem in threadElem.Elements("comment"))
+        {
+            if (comment is null)
+            {
+                comment = new Comment(ptUser);
+                XAttribute threadId = threadElem.Attribute("id");
+                if (threadId is not null)
+                    comment.Thread = threadId.Value;
+                ParseSelection(threadElem.Element("selection"), comment);
+            }
+            else
+            {
+                comment = (Comment)comment.Clone();
+            }
+            result.Add(comment);
+            ParseComment(commentElem, comment);
+        }
+
+        return result;
+    }
+
+    private static void ParseComment(XElement commentElem, Comment comment)
+    {
+        comment.User = commentElem.Attribute("user")?.Value;
+        string commentDate = commentElem.Attribute("date")?.Value;
+        if (commentDate is not null)
+            comment.Date = commentDate;
+        comment.ExternalUser = commentElem.Attribute("extUser")?.Value;
+        comment.Deleted = commentElem.Attribute("deleted")?.Value == "true";
+        ParseContents(commentElem.Element("content"), comment);
+    }
+
+    private static void ParseContents(XElement? contentElem, Comment comment)
+    {
+        string contents;
+        if (contentElem is null)
+        {
+            contents = string.Empty;
+        }
+        else if (contentElem.FirstNode?.NodeType == XmlNodeType.Text)
+        {
+            contents = ((XText)contentElem.FirstNode).Value;
+        }
+        else
+        {
+            StringBuilder sb = new StringBuilder();
+            foreach (var paraElem in contentElem.Elements("p"))
+                ParseParagraph(paraElem, sb);
+            contents = sb.ToString();
+        }
+
+        comment.AddTextToContent(string.Empty, false);
+        comment.Contents.InnerXml = contents;
+    }
+
+    private static void ParseParagraph(XElement paraElem, StringBuilder sb)
+    {
+        sb.Append("<p>");
+        foreach (var node in paraElem.Nodes())
+        {
+            if (node is XText text)
+                sb.Append(text.Value);
+            else
+            {
+                XElement elem = (XElement)node;
+                if (elem.Name == "span")
+                {
+                    string style = elem.Attribute("style")?.Value ?? "bold";
+                    sb.Append($"<{style}>");
+                    sb.Append(elem.GetInnerText());
+                    sb.Append($"</{style}>");
+                }
+                else if (elem.Name == "lang")
+                {
+                    string name = elem.Attribute("name")?.Value ?? "en";
+                    sb.Append($"<language name=\"{name}\">");
+                    sb.Append(elem.GetInnerText());
+                    sb.Append("</language>");
+                }
+            }
+        }
+        sb.Append("</p>");
+    }
+
+    private static void ParseSelection(XElement? selElem, Comment comment)
+    {
+        if (selElem is null)
+            return;
+        comment.SelectedText = selElem.Attribute("selectedText")?.Value ?? string.Empty;
+        comment.VerseRefStr = selElem.Attribute("verseRef")?.Value;
+        comment.StartPosition = int.Parse(selElem.Attribute("startPos")?.Value ?? "0");
+        comment.ContextBefore = selElem.Attribute("beforeContext")?.Value ?? string.Empty;
+        comment.ContextAfter = selElem.Attribute("afterContext")?.Value ?? string.Empty;
+    }
+    #endregion
 }

--- a/src/SIL.XForge.Scripture/Services/NotificationHub.cs
+++ b/src/SIL.XForge.Scripture/Services/NotificationHub.cs
@@ -3,30 +3,29 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using SIL.XForge.Scripture.Models;
 
-namespace SIL.XForge.Scripture.Services
-{
-    [Authorize]
-    public class NotificationHub : Hub<INotifier>, INotifier
-    {
-        /// <summary>
-        /// Notifies subscribers to a project of sync progress.
-        /// </summary>
-        /// <param name="projectId">The Scripture Forge project identifier.</param>
-        /// <param name="progressState">
-        /// The progress state, including a string value (Paratext only - not used in SF), or percentage value.
-        /// </param>
-        /// <returns>The asynchronous task.</returns>
-        public async Task NotifySyncProgress(string projectId, ProgressState progressState) =>
-            await Clients.Group(projectId).NotifySyncProgress(projectId, progressState);
+namespace SIL.XForge.Scripture.Services;
 
-        /// <summary>
-        /// Subscribe to notifications for a project.
-        ///
-        /// This is called from the frontend via <c>project-notification.service.ts</c>.
-        /// </summary>
-        /// <param name="projectId">The Scripture Forge project identifier.</param>
-        /// <returns>The asynchronous task.</returns>
-        public async Task SubscribeToProject(string projectId) =>
-            await Groups.AddToGroupAsync(Context.ConnectionId, projectId);
-    }
+[Authorize]
+public class NotificationHub : Hub<INotifier>, INotifier
+{
+    /// <summary>
+    /// Notifies subscribers to a project of sync progress.
+    /// </summary>
+    /// <param name="projectId">The Scripture Forge project identifier.</param>
+    /// <param name="progressState">
+    /// The progress state, including a string value (Paratext only - not used in SF), or percentage value.
+    /// </param>
+    /// <returns>The asynchronous task.</returns>
+    public async Task NotifySyncProgress(string projectId, ProgressState progressState) =>
+        await Clients.Group(projectId).NotifySyncProgress(projectId, progressState);
+
+    /// <summary>
+    /// Subscribe to notifications for a project.
+    ///
+    /// This is called from the frontend via <c>project-notification.service.ts</c>.
+    /// </summary>
+    /// <param name="projectId">The Scripture Forge project identifier.</param>
+    /// <returns>The asynchronous task.</returns>
+    public async Task SubscribeToProject(string projectId) =>
+        await Groups.AddToGroupAsync(Context.ConnectionId, projectId);
 }

--- a/src/SIL.XForge.Scripture/Services/NotificationHubExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/NotificationHubExtensions.cs
@@ -2,14 +2,13 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using SIL.XForge.Scripture.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public static class NotificationHubExtensions
 {
-    public static class NotificationHubExtensions
-    {
-        public static Task NotifySyncProgress(
-            this IHubContext<NotificationHub, INotifier> hubContext,
-            string projectId,
-            ProgressState progressState
-        ) => hubContext.Clients.Groups(projectId).NotifySyncProgress(projectId, progressState);
-    }
+    public static Task NotifySyncProgress(
+        this IHubContext<NotificationHub, INotifier> hubContext,
+        string projectId,
+        ProgressState progressState
+    ) => hubContext.Clients.Groups(projectId).NotifySyncProgress(projectId, progressState);
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextDataHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextDataHelper.cs
@@ -1,15 +1,14 @@
 using Paratext.Data;
 using Paratext.Data.Repository;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary> Provides methods calls to Paratext Data. Can be mocked in tests. </summary>
+public class ParatextDataHelper : IParatextDataHelper
 {
-    /// <summary> Provides methods calls to Paratext Data. Can be mocked in tests. </summary>
-    public class ParatextDataHelper : IParatextDataHelper
+    public void CommitVersionedText(ScrText scrText, string comment)
     {
-        public void CommitVersionedText(ScrText scrText, string comment)
-        {
-            VersionedText vText = VersioningManager.Get(scrText);
-            vText.Commit(comment, null, false);
-        }
+        VersionedText vText = VersioningManager.Get(scrText);
+        vText.Commit(comment, null, false);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
@@ -11,398 +11,392 @@ using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
 using SIL.XForge.Realtime;
 using SIL.XForge.Realtime.Json0;
-using SIL.XForge.Services;
 using SIL.XForge.Scripture.Models;
+using SIL.XForge.Services;
 using SIL.XForge.Utils;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// This class is used to produce two types of changes:
+/// (1) The Paratext notes changelist in XML used to update the Paratext project on the Scripture Forge sync folder.
+/// (2) The Paratext note thread changes from the Paratext project used to update the Scripture Forge database.
+/// This class ensures that the mapping between answers/comments and PT notes remains stable over time by recording
+/// the PT user for each answer/comment. In order to not expose the actual PT usernames in the questions and
+/// comments data, the PT user for a answer/comment is recorded as an opaque id. This class maintains the mapping
+/// of ids to PT usernames in the project entity.
+/// </summary>
+public class ParatextNotesMapper : IParatextNotesMapper
 {
-    /// <summary>
-    /// This class is used to produce two types of changes:
-    /// (1) The Paratext notes changelist in XML used to update the Paratext project on the Scripture Forge sync folder.
-    /// (2) The Paratext note thread changes from the Paratext project used to update the Scripture Forge database.
-    /// This class ensures that the mapping between answers/comments and PT notes remains stable over time by recording
-    /// the PT user for each answer/comment. In order to not expose the actual PT usernames in the questions and
-    /// comments data, the PT user for a answer/comment is recorded as an opaque id. This class maintains the mapping
-    /// of ids to PT usernames in the project entity.
-    /// </summary>
-    public class ParatextNotesMapper : IParatextNotesMapper
+    private readonly IRepository<UserSecret> _userSecrets;
+    private readonly IParatextService _paratextService;
+    private readonly IUserService _userService;
+    private readonly IStringLocalizer<SharedResource> _localizer;
+    private readonly IOptions<SiteOptions> _siteOptions;
+    private UserSecret _currentUserSecret;
+    private string _currentParatextUsername;
+    private SFProjectSecret _projectSecret;
+    private IGuidService _guidService;
+    private HashSet<string> _ptProjectUsersWhoCanWriteNotes;
+
+    public ParatextNotesMapper(
+        IRepository<UserSecret> userSecrets,
+        IParatextService paratextService,
+        IUserService userService,
+        IStringLocalizer<SharedResource> localizer,
+        IOptions<SiteOptions> siteOptions,
+        IGuidService guidService
+    )
     {
-        private readonly IRepository<UserSecret> _userSecrets;
-        private readonly IParatextService _paratextService;
-        private readonly IUserService _userService;
-        private readonly IStringLocalizer<SharedResource> _localizer;
-        private readonly IOptions<SiteOptions> _siteOptions;
-        private UserSecret _currentUserSecret;
-        private string _currentParatextUsername;
-        private SFProjectSecret _projectSecret;
-        private IGuidService _guidService;
-        private HashSet<string> _ptProjectUsersWhoCanWriteNotes;
+        _userSecrets = userSecrets;
+        _paratextService = paratextService;
+        _userService = userService;
+        _localizer = localizer;
+        _siteOptions = siteOptions;
+        _guidService = guidService;
+    }
 
-        public ParatextNotesMapper(
-            IRepository<UserSecret> userSecrets,
-            IParatextService paratextService,
-            IUserService userService,
-            IStringLocalizer<SharedResource> localizer,
-            IOptions<SiteOptions> siteOptions,
-            IGuidService guidService
-        )
+    public async Task InitAsync(
+        UserSecret currentUserSecret,
+        SFProjectSecret projectSecret,
+        List<User> ptUsers,
+        SFProject project,
+        CancellationToken token
+    )
+    {
+        _currentUserSecret = currentUserSecret;
+        _currentParatextUsername = _paratextService.GetParatextUsername(currentUserSecret);
+        _projectSecret = projectSecret;
+        _ptProjectUsersWhoCanWriteNotes = new HashSet<string>();
+        IReadOnlyDictionary<string, string> roles = await _paratextService.GetProjectRolesAsync(
+            currentUserSecret,
+            project,
+            token
+        );
+        var ptRolesCanWriteNote = new HashSet<string>
         {
-            _userSecrets = userSecrets;
-            _paratextService = paratextService;
-            _userService = userService;
-            _localizer = localizer;
-            _siteOptions = siteOptions;
-            _guidService = guidService;
+            SFProjectRole.Administrator,
+            SFProjectRole.Translator,
+            SFProjectRole.Consultant,
+            SFProjectRole.WriteNote
+        };
+        foreach (User user in ptUsers)
+        {
+            // Populate the list with all Paratext users belonging to the project and who can write notes
+            if (roles.TryGetValue(user.ParatextId, out string role) && ptRolesCanWriteNote.Contains(role))
+                _ptProjectUsersWhoCanWriteNotes.Add(user.Id);
         }
+    }
 
-        public async Task InitAsync(
-            UserSecret currentUserSecret,
-            SFProjectSecret projectSecret,
-            List<User> ptUsers,
-            SFProject project,
-            CancellationToken token
-        )
+    public async Task<XElement> GetNotesChangelistAsync(
+        XElement oldNotesElem,
+        IEnumerable<IDocument<Question>> questionsDocs,
+        Dictionary<string, ParatextUserProfile> ptProjectUsers,
+        Dictionary<string, string> userRoles,
+        string answerExportMethod
+    )
+    {
+        // Usernames of SF community checker users. Paratext users are mapped to null.
+        Dictionary<string, string> checkerUsernames = new Dictionary<string, string>();
+        var version = (string)oldNotesElem.Attribute("version");
+        Dictionary<string, XElement> oldCommentElems = GetOldCommentElements(oldNotesElem, ptProjectUsers);
+
+        var notesElem = new XElement("notes", new XAttribute("version", version));
+        if (answerExportMethod != CheckingAnswerExport.None)
         {
-            _currentUserSecret = currentUserSecret;
-            _currentParatextUsername = _paratextService.GetParatextUsername(currentUserSecret);
-            _projectSecret = projectSecret;
-            _ptProjectUsersWhoCanWriteNotes = new HashSet<string>();
-            IReadOnlyDictionary<string, string> roles = await _paratextService.GetProjectRolesAsync(
-                currentUserSecret,
-                project,
-                token
-            );
-            var ptRolesCanWriteNote = new HashSet<string>
+            foreach (IDocument<Question> questionDoc in questionsDocs)
             {
-                SFProjectRole.Administrator,
-                SFProjectRole.Translator,
-                SFProjectRole.Consultant,
-                SFProjectRole.WriteNote
-            };
-            foreach (User user in ptUsers)
-            {
-                // Populate the list with all Paratext users belonging to the project and who can write notes
-                if (roles.TryGetValue(user.ParatextId, out string role) && ptRolesCanWriteNote.Contains(role))
-                    _ptProjectUsersWhoCanWriteNotes.Add(user.Id);
-            }
-        }
-
-        public async Task<XElement> GetNotesChangelistAsync(
-            XElement oldNotesElem,
-            IEnumerable<IDocument<Question>> questionsDocs,
-            Dictionary<string, ParatextUserProfile> ptProjectUsers,
-            Dictionary<string, string> userRoles,
-            string answerExportMethod
-        )
-        {
-            // Usernames of SF community checker users. Paratext users are mapped to null.
-            Dictionary<string, string> checkerUsernames = new Dictionary<string, string>();
-            var version = (string)oldNotesElem.Attribute("version");
-            Dictionary<string, XElement> oldCommentElems = GetOldCommentElements(oldNotesElem, ptProjectUsers);
-
-            var notesElem = new XElement("notes", new XAttribute("version", version));
-            if (answerExportMethod != CheckingAnswerExport.None)
-            {
-                foreach (IDocument<Question> questionDoc in questionsDocs)
+                var answerSyncUserIds = new List<(int, string)>();
+                var commentSyncUserIds = new List<(int, int, string)>();
+                Question question = questionDoc.Data;
+                for (int j = 0; j < question.Answers.Count; j++)
                 {
-                    var answerSyncUserIds = new List<(int, string)>();
-                    var commentSyncUserIds = new List<(int, int, string)>();
-                    Question question = questionDoc.Data;
-                    for (int j = 0; j < question.Answers.Count; j++)
+                    Answer answer = question.Answers[j];
+                    if (answer.Status != AnswerStatus.Exportable && answerExportMethod != CheckingAnswerExport.All)
                     {
-                        Answer answer = question.Answers[j];
-                        if (answer.Status != AnswerStatus.Exportable && answerExportMethod != CheckingAnswerExport.All)
-                        {
-                            continue;
-                        }
-                        string threadId = $"ANSWER_{answer.DataId}";
-                        var threadElem = new XElement(
-                            "thread",
-                            new XAttribute("id", threadId),
-                            new XElement(
-                                "selection",
-                                new XAttribute("verseRef", question.VerseRef.ToString()),
-                                new XAttribute("startPos", 0),
-                                new XAttribute("selectedText", "")
-                            )
-                        );
-                        var answerPrefixContents = new List<object>();
+                        continue;
+                    }
+                    string threadId = $"ANSWER_{answer.DataId}";
+                    var threadElem = new XElement(
+                        "thread",
+                        new XAttribute("id", threadId),
+                        new XElement(
+                            "selection",
+                            new XAttribute("verseRef", question.VerseRef.ToString()),
+                            new XAttribute("startPos", 0),
+                            new XAttribute("selectedText", "")
+                        )
+                    );
+                    var answerPrefixContents = new List<object>();
 
-                        // Questions that have empty texts will show in Paratext notes that it is audio-only
-                        string qText = string.IsNullOrEmpty(question.Text)
-                            ? _localizer[SharedResource.Keys.AudioOnlyQuestion, _siteOptions.Value.Name]
-                            : question.Text;
-                        answerPrefixContents.Add(new XElement("span", new XAttribute("style", "bold"), qText));
-                        if (!string.IsNullOrEmpty(answer.ScriptureText))
-                        {
-                            string scriptureRef = answer.VerseRef.ToString();
-                            string scriptureText = $"{answer.ScriptureText.Trim()} ({scriptureRef})";
-                            answerPrefixContents.Add(
-                                new XElement("span", new XAttribute("style", "italic"), scriptureText)
-                            );
-                        }
-                        string username = await TryGetCommunityCheckerUsername(
-                            answer.OwnerRef,
+                    // Questions that have empty texts will show in Paratext notes that it is audio-only
+                    string qText = string.IsNullOrEmpty(question.Text)
+                        ? _localizer[SharedResource.Keys.AudioOnlyQuestion, _siteOptions.Value.Name]
+                        : question.Text;
+                    answerPrefixContents.Add(new XElement("span", new XAttribute("style", "bold"), qText));
+                    if (!string.IsNullOrEmpty(answer.ScriptureText))
+                    {
+                        string scriptureRef = answer.VerseRef.ToString();
+                        string scriptureText = $"{answer.ScriptureText.Trim()} ({scriptureRef})";
+                        answerPrefixContents.Add(
+                            new XElement("span", new XAttribute("style", "italic"), scriptureText)
+                        );
+                    }
+                    string username = await TryGetCommunityCheckerUsername(
+                        answer.OwnerRef,
+                        userRoles,
+                        checkerUsernames
+                    );
+                    if (!string.IsNullOrEmpty(username))
+                        answerPrefixContents.Add($"[{username} - {_siteOptions.Value.Name}]");
+
+                    string answerSyncUserId = await AddCommentIfChangedAsync(
+                        oldCommentElems,
+                        threadElem,
+                        answer,
+                        ptProjectUsers,
+                        answerPrefixContents
+                    );
+                    if (answer.SyncUserRef == null)
+                        answerSyncUserIds.Add((j, answerSyncUserId));
+
+                    for (int k = 0; k < answer.Comments.Count; k++)
+                    {
+                        Comment comment = answer.Comments[k];
+                        var commentPrefixContents = new List<object>();
+                        string commentUsername = await TryGetCommunityCheckerUsername(
+                            comment.OwnerRef,
                             userRoles,
                             checkerUsernames
                         );
-                        if (!string.IsNullOrEmpty(username))
-                            answerPrefixContents.Add($"[{username} - {_siteOptions.Value.Name}]");
-
-                        string answerSyncUserId = await AddCommentIfChangedAsync(
+                        if (!string.IsNullOrEmpty(commentUsername))
+                            commentPrefixContents.Add($"[{commentUsername} - {_siteOptions.Value.Name}]");
+                        string commentSyncUserId = await AddCommentIfChangedAsync(
                             oldCommentElems,
                             threadElem,
-                            answer,
+                            comment,
                             ptProjectUsers,
-                            answerPrefixContents
+                            commentPrefixContents
                         );
-                        if (answer.SyncUserRef == null)
-                            answerSyncUserIds.Add((j, answerSyncUserId));
-
-                        for (int k = 0; k < answer.Comments.Count; k++)
-                        {
-                            Comment comment = answer.Comments[k];
-                            var commentPrefixContents = new List<object>();
-                            string commentUsername = await TryGetCommunityCheckerUsername(
-                                comment.OwnerRef,
-                                userRoles,
-                                checkerUsernames
-                            );
-                            if (!string.IsNullOrEmpty(commentUsername))
-                                commentPrefixContents.Add($"[{commentUsername} - {_siteOptions.Value.Name}]");
-                            string commentSyncUserId = await AddCommentIfChangedAsync(
-                                oldCommentElems,
-                                threadElem,
-                                comment,
-                                ptProjectUsers,
-                                commentPrefixContents
-                            );
-                            if (comment.SyncUserRef == null)
-                                commentSyncUserIds.Add((j, k, commentSyncUserId));
-                        }
-                        if (threadElem.Elements("comment").Any())
-                            notesElem.Add(threadElem);
+                        if (comment.SyncUserRef == null)
+                            commentSyncUserIds.Add((j, k, commentSyncUserId));
                     }
-                    // set SyncUserRef property on answers and comments that need it
-                    await questionDoc.SubmitJson0OpAsync(op =>
-                    {
-                        foreach ((int aIndex, string syncUserId) in answerSyncUserIds)
-                            op.Set(q => q.Answers[aIndex].SyncUserRef, syncUserId);
-
-                        foreach ((int aIndex, int cIndex, string syncUserId) in commentSyncUserIds)
-                            op.Set(q => q.Answers[aIndex].Comments[cIndex].SyncUserRef, syncUserId);
-                    });
+                    if (threadElem.Elements("comment").Any())
+                        notesElem.Add(threadElem);
                 }
-            }
-
-            AddDeletedNotes(notesElem, oldCommentElems.Values);
-            return notesElem;
-        }
-
-        /// <summar>
-        /// Get the Paratext Comment elements from a project that are associated with Community Checking answers.
-        /// </summary>
-        private Dictionary<string, XElement> GetOldCommentElements(
-            XElement ptNotesElement,
-            Dictionary<string, ParatextUserProfile> ptProjectUsers
-        )
-        {
-            var oldCommentElems = new Dictionary<string, XElement>();
-            // collect already pushed Paratext notes
-            foreach (XElement threadElem in ptNotesElement.Elements("thread"))
-            {
-                var threadId = (string)threadElem.Attribute("id");
-                if (threadId.StartsWith("ANSWER_"))
+                // set SyncUserRef property on answers and comments that need it
+                await questionDoc.SubmitJson0OpAsync(op =>
                 {
-                    foreach (XElement commentElem in threadElem.Elements("comment"))
-                    {
-                        var deleted = (bool?)commentElem.Attribute("deleted") ?? false;
-                        if (!deleted)
-                        {
-                            string key = GetCommentKey(threadId, commentElem, ptProjectUsers);
-                            oldCommentElems[key] = commentElem;
-                        }
-                    }
-                }
+                    foreach ((int aIndex, string syncUserId) in answerSyncUserIds)
+                        op.Set(q => q.Answers[aIndex].SyncUserRef, syncUserId);
+
+                    foreach ((int aIndex, int cIndex, string syncUserId) in commentSyncUserIds)
+                        op.Set(q => q.Answers[aIndex].Comments[cIndex].SyncUserRef, syncUserId);
+                });
             }
-            return oldCommentElems;
         }
 
-        private async Task<string> AddCommentIfChangedAsync(
-            Dictionary<string, XElement> oldCommentElems,
-            XElement threadElem,
-            Comment comment,
-            Dictionary<string, ParatextUserProfile> ptProjectUsers,
-            IReadOnlyList<object> prefixContent = null
-        )
+        AddDeletedNotes(notesElem, oldCommentElems.Values);
+        return notesElem;
+    }
+
+    /// <summar>
+    /// Get the Paratext Comment elements from a project that are associated with Community Checking answers.
+    /// </summary>
+    private Dictionary<string, XElement> GetOldCommentElements(
+        XElement ptNotesElement,
+        Dictionary<string, ParatextUserProfile> ptProjectUsers
+    )
+    {
+        var oldCommentElems = new Dictionary<string, XElement>();
+        // collect already pushed Paratext notes
+        foreach (XElement threadElem in ptNotesElement.Elements("thread"))
         {
-            (string syncUserId, string user, bool canWritePTNoteOnProject) = await GetSyncUserAsync(
-                comment.SyncUserRef,
-                comment.OwnerRef,
-                ptProjectUsers
-            );
-
-            var commentElem = new XElement("comment");
-            commentElem.Add(new XAttribute("user", user));
-            // if the user is not a Paratext user on the project, then set external user id
-            if (!canWritePTNoteOnProject)
-                commentElem.Add(new XAttribute("extUser", comment.OwnerRef));
-            commentElem.Add(new XAttribute("date", FormatCommentDate(comment.DateCreated)));
-            var contentElem = new XElement("content");
-            // Responses that have empty texts will show in Paratext notes that it is audio-only
-            string responseText = string.IsNullOrEmpty(comment.Text)
-                ? _localizer[SharedResource.Keys.AudioOnlyResponse, _siteOptions.Value.Name]
-                : comment.Text;
-            if (prefixContent == null || prefixContent.Count == 0)
-            {
-                contentElem.Add(responseText);
-            }
-            else
-            {
-                foreach (object paraContent in prefixContent)
-                    contentElem.Add(new XElement("p", paraContent));
-                contentElem.Add(new XElement("p", responseText));
-            }
-            commentElem.Add(contentElem);
-
             var threadId = (string)threadElem.Attribute("id");
-            string key = GetCommentKey(threadId, commentElem, ptProjectUsers);
-            if (IsCommentNewOrChanged(oldCommentElems, key, commentElem))
-                threadElem.Add(commentElem);
-            oldCommentElems.Remove(key);
-            return syncUserId;
-        }
-
-        private void AddDeletedNotes(XElement notesElem, IEnumerable<XElement> commentsToDelete)
-        {
-            foreach (XElement oldCommentElem in commentsToDelete)
+            if (threadId.StartsWith("ANSWER_"))
             {
-                XElement oldThreadElem = oldCommentElem.Parent;
-                var threadId = (string)oldThreadElem.Attribute("id");
-                XElement threadElem = notesElem
-                    .Elements("thread")
-                    .FirstOrDefault(e => (string)e.Attribute("id") == threadId);
-                if (threadElem == null)
+                foreach (XElement commentElem in threadElem.Elements("comment"))
                 {
-                    threadElem = new XElement(oldThreadElem);
-                    threadElem.Elements("comment").Remove();
-                    notesElem.Add(threadElem);
+                    var deleted = (bool?)commentElem.Attribute("deleted") ?? false;
+                    if (!deleted)
+                    {
+                        string key = GetCommentKey(threadId, commentElem, ptProjectUsers);
+                        oldCommentElems[key] = commentElem;
+                    }
                 }
-                XElement commentElem = new XElement(oldCommentElem);
-                commentElem.SetAttributeValue("deleted", true);
-                commentElem.SetAttributeValue("versionNbr", null);
-                threadElem.Add(commentElem);
             }
         }
+        return oldCommentElems;
+    }
 
-        /// <summary>
-        /// Gets the Paratext user for a comment from the specified sync user id and owner id.
-        /// </summary>
-        private async Task<(string SyncUserId, string ParatextUsername, bool CanWritePTNoteOnProject)> GetSyncUserAsync(
-            string syncUserRef,
-            string ownerRef,
-            Dictionary<string, ParatextUserProfile> ptProjectUsers
-        )
+    private async Task<string> AddCommentIfChangedAsync(
+        Dictionary<string, XElement> oldCommentElems,
+        XElement threadElem,
+        Comment comment,
+        Dictionary<string, ParatextUserProfile> ptProjectUsers,
+        IReadOnlyList<object> prefixContent = null
+    )
+    {
+        (string syncUserId, string user, bool canWritePTNoteOnProject) = await GetSyncUserAsync(
+            comment.SyncUserRef,
+            comment.OwnerRef,
+            ptProjectUsers
+        );
+
+        var commentElem = new XElement("comment");
+        commentElem.Add(new XAttribute("user", user));
+        // if the user is not a Paratext user on the project, then set external user id
+        if (!canWritePTNoteOnProject)
+            commentElem.Add(new XAttribute("extUser", comment.OwnerRef));
+        commentElem.Add(new XAttribute("date", FormatCommentDate(comment.DateCreated)));
+        var contentElem = new XElement("content");
+        // Responses that have empty texts will show in Paratext notes that it is audio-only
+        string responseText = string.IsNullOrEmpty(comment.Text)
+            ? _localizer[SharedResource.Keys.AudioOnlyResponse, _siteOptions.Value.Name]
+            : comment.Text;
+        if (prefixContent == null || prefixContent.Count == 0)
         {
-            // if the owner is a PT user who can write notes, then get the PT username
-            string paratextUsername = null;
-            if (_ptProjectUsersWhoCanWriteNotes.Contains(ownerRef))
+            contentElem.Add(responseText);
+        }
+        else
+        {
+            foreach (object paraContent in prefixContent)
+                contentElem.Add(new XElement("p", paraContent));
+            contentElem.Add(new XElement("p", responseText));
+        }
+        commentElem.Add(contentElem);
+
+        var threadId = (string)threadElem.Attribute("id");
+        string key = GetCommentKey(threadId, commentElem, ptProjectUsers);
+        if (IsCommentNewOrChanged(oldCommentElems, key, commentElem))
+            threadElem.Add(commentElem);
+        oldCommentElems.Remove(key);
+        return syncUserId;
+    }
+
+    private static void AddDeletedNotes(XElement notesElem, IEnumerable<XElement> commentsToDelete)
+    {
+        foreach (XElement oldCommentElem in commentsToDelete)
+        {
+            XElement oldThreadElem = oldCommentElem.Parent;
+            var threadId = (string)oldThreadElem.Attribute("id");
+            XElement threadElem = notesElem
+                .Elements("thread")
+                .FirstOrDefault(e => (string)e.Attribute("id") == threadId);
+            if (threadElem == null)
             {
-                Attempt<UserSecret> attempt = await _userSecrets.TryGetAsync(ownerRef);
-                if (attempt.TryResult(out UserSecret userSecret))
-                    paratextUsername = _paratextService.GetParatextUsername(userSecret);
+                threadElem = new XElement(oldThreadElem);
+                threadElem.Elements("comment").Remove();
+                notesElem.Add(threadElem);
             }
-
-            bool canWritePTNoteOnProject = paratextUsername != null;
-
-            ParatextUserProfile ptProjectUser =
-                syncUserRef == null ? null : ptProjectUsers.Values.SingleOrDefault(s => s.OpaqueUserId == syncUserRef);
-            // check if comment has already been synced before
-            if (ptProjectUser == null)
-            {
-                // the comment has never been synced before (or syncUser is missing)
-                // if the owner is not a PT user on the project, then use the current user's PT username
-                if (paratextUsername == null)
-                    paratextUsername = _currentParatextUsername;
-                ptProjectUser = FindOrCreateParatextUser(paratextUsername, ptProjectUsers);
-            }
-            return (ptProjectUser.OpaqueUserId, ptProjectUser.Username, canWritePTNoteOnProject);
-        }
-
-        private bool IsCommentNewOrChanged(
-            Dictionary<string, XElement> oldCommentElems,
-            string key,
-            XElement commentElem
-        )
-        {
-            return !oldCommentElems.TryGetValue(key, out XElement oldCommentElem)
-                || !XNode.DeepEquals(oldCommentElem.Element("content"), commentElem.Element("content"));
-        }
-
-        private ParatextUserProfile FindOrCreateParatextUser(
-            string paratextUsername,
-            Dictionary<string, ParatextUserProfile> ptProjectUsers
-        )
-        {
-            if (!ptProjectUsers.TryGetValue(paratextUsername, out ParatextUserProfile ptProjectUser))
-            {
-                // the PT user has never been associated with a comment, so generate a new sync user id and add it
-                // to the NewSyncUsers property
-                ptProjectUser = new ParatextUserProfile
-                {
-                    OpaqueUserId = _guidService.NewObjectId(),
-                    Username = paratextUsername
-                };
-                // Add the sync user to the dictionary
-                ptProjectUsers.Add(paratextUsername, ptProjectUser);
-            }
-            return ptProjectUser;
-        }
-
-        /// <summary>
-        /// Gets the username for a community checker, or null if the user has a paratext role on the project.
-        /// </summary>
-        private async Task<string> TryGetCommunityCheckerUsername(
-            string userId,
-            Dictionary<string, string> userRoles,
-            Dictionary<string, string> checkerUsernames
-        )
-        {
-            string username;
-            if (checkerUsernames.TryGetValue(userId, out username))
-                return username;
-
-            if (userRoles.TryGetValue(userId, out string role) && SFProjectRole.IsParatextRole(role))
-            {
-                // map users with paratext roles to null
-                checkerUsernames.Add(userId, null);
-                return null;
-            }
-
-            // the user is an SF community checker
-            username = await _userService.GetUsernameFromUserId(_currentUserSecret.Id, userId);
-            checkerUsernames.Add(userId, username);
-            return username;
-        }
-
-        private string GetCommentKey(
-            string threadId,
-            XElement commentElem,
-            Dictionary<string, ParatextUserProfile> ptProjectUsers
-        )
-        {
-            var user = (string)commentElem.Attribute("user");
-            ParatextUserProfile ptProjectUser = FindOrCreateParatextUser(user, ptProjectUsers);
-            var extUser = (string)commentElem.Attribute("extUser") ?? "";
-            var date = (string)commentElem.Attribute("date");
-            return $"{threadId}|{ptProjectUser.OpaqueUserId}|{extUser}|{date}";
-        }
-
-        /// <summary> Formats a DateTime object to a string that is compatible with a Paratext Comment. </summary>
-        private string FormatCommentDate(DateTime date)
-        {
-            return new DateTimeOffset(date).ToString("o");
+            XElement commentElem = new XElement(oldCommentElem);
+            commentElem.SetAttributeValue("deleted", true);
+            commentElem.SetAttributeValue("versionNbr", null);
+            threadElem.Add(commentElem);
         }
     }
+
+    /// <summary>
+    /// Gets the Paratext user for a comment from the specified sync user id and owner id.
+    /// </summary>
+    private async Task<(string SyncUserId, string ParatextUsername, bool CanWritePTNoteOnProject)> GetSyncUserAsync(
+        string syncUserRef,
+        string ownerRef,
+        Dictionary<string, ParatextUserProfile> ptProjectUsers
+    )
+    {
+        // if the owner is a PT user who can write notes, then get the PT username
+        string paratextUsername = null;
+        if (_ptProjectUsersWhoCanWriteNotes.Contains(ownerRef))
+        {
+            Attempt<UserSecret> attempt = await _userSecrets.TryGetAsync(ownerRef);
+            if (attempt.TryResult(out UserSecret userSecret))
+                paratextUsername = _paratextService.GetParatextUsername(userSecret);
+        }
+
+        bool canWritePTNoteOnProject = paratextUsername != null;
+
+        ParatextUserProfile ptProjectUser =
+            syncUserRef == null ? null : ptProjectUsers.Values.SingleOrDefault(s => s.OpaqueUserId == syncUserRef);
+        // check if comment has already been synced before
+        if (ptProjectUser == null)
+        {
+            // the comment has never been synced before (or syncUser is missing)
+            // if the owner is not a PT user on the project, then use the current user's PT username
+            paratextUsername ??= _currentParatextUsername;
+            ptProjectUser = FindOrCreateParatextUser(paratextUsername, ptProjectUsers);
+        }
+        return (ptProjectUser.OpaqueUserId, ptProjectUser.Username, canWritePTNoteOnProject);
+    }
+
+    private static bool IsCommentNewOrChanged(
+        Dictionary<string, XElement> oldCommentElems,
+        string key,
+        XElement commentElem
+    )
+    {
+        return !oldCommentElems.TryGetValue(key, out XElement oldCommentElem)
+            || !XNode.DeepEquals(oldCommentElem.Element("content"), commentElem.Element("content"));
+    }
+
+    private ParatextUserProfile FindOrCreateParatextUser(
+        string paratextUsername,
+        Dictionary<string, ParatextUserProfile> ptProjectUsers
+    )
+    {
+        if (!ptProjectUsers.TryGetValue(paratextUsername, out ParatextUserProfile ptProjectUser))
+        {
+            // the PT user has never been associated with a comment, so generate a new sync user id and add it
+            // to the NewSyncUsers property
+            ptProjectUser = new ParatextUserProfile
+            {
+                OpaqueUserId = _guidService.NewObjectId(),
+                Username = paratextUsername
+            };
+            // Add the sync user to the dictionary
+            ptProjectUsers.Add(paratextUsername, ptProjectUser);
+        }
+        return ptProjectUser;
+    }
+
+    /// <summary>
+    /// Gets the username for a community checker, or null if the user has a paratext role on the project.
+    /// </summary>
+    private async Task<string> TryGetCommunityCheckerUsername(
+        string userId,
+        Dictionary<string, string> userRoles,
+        Dictionary<string, string> checkerUsernames
+    )
+    {
+        if (checkerUsernames.TryGetValue(userId, out string username))
+            return username;
+
+        if (userRoles.TryGetValue(userId, out string role) && SFProjectRole.IsParatextRole(role))
+        {
+            // map users with paratext roles to null
+            checkerUsernames.Add(userId, null);
+            return null;
+        }
+
+        // the user is an SF community checker
+        username = await _userService.GetUsernameFromUserId(_currentUserSecret.Id, userId);
+        checkerUsernames.Add(userId, username);
+        return username;
+    }
+
+    private string GetCommentKey(
+        string threadId,
+        XElement commentElem,
+        Dictionary<string, ParatextUserProfile> ptProjectUsers
+    )
+    {
+        var user = (string)commentElem.Attribute("user");
+        ParatextUserProfile ptProjectUser = FindOrCreateParatextUser(user, ptProjectUsers);
+        var extUser = (string)commentElem.Attribute("extUser") ?? "";
+        var date = (string)commentElem.Attribute("date");
+        return $"{threadId}|{ptProjectUser.OpaqueUserId}|{extUser}|{date}";
+    }
+
+    /// <summary> Formats a DateTime object to a string that is compatible with a Paratext Comment. </summary>
+    private static string FormatCommentDate(DateTime date) => new DateTimeOffset(date).ToString("o");
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -41,2599 +41,2529 @@ using SIL.XForge.Scripture.Models;
 using SIL.XForge.Services;
 using SIL.XForge.Utils;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// Provides interaction with Paratext libraries for data processing and exchanging data with Paratext servers.
+/// Also contains methods for interacting with the Paratext Registry web service API.
+/// </summary>
+public class ParatextService : DisposableBase, IParatextService
 {
-    /// <summary>
-    /// Provides interaction with Paratext libraries for data processing and exchanging data with Paratext servers.
-    /// Also contains methods for interacting with the Paratext Registry web service API.
-    /// </summary>
-    public class ParatextService : DisposableBase, IParatextService
+    internal HttpClient _registryClient;
+    private readonly IOptions<ParatextOptions> _paratextOptions;
+    private readonly IRepository<UserSecret> _userSecretRepository;
+    private readonly IRealtimeService _realtimeService;
+    private readonly IOptions<SiteOptions> _siteOptions;
+    private readonly IFileSystemService _fileSystemService;
+    private readonly HttpClientHandler _httpClientHandler;
+    private readonly IExceptionHandler _exceptionHandler;
+    private readonly ILogger _logger;
+    private readonly IJwtTokenHelper _jwtTokenHelper;
+    private readonly IParatextDataHelper _paratextDataHelper;
+    private readonly IGuidService _guidService;
+    private string _dblServerUri = "https://paratext.thedigitalbiblelibrary.org/";
+    private string _registryServerUri = "https://registry.paratext.org";
+    private string _sendReceiveServerUri = InternetAccess.uriProduction;
+    private readonly IInternetSharedRepositorySourceProvider _internetSharedRepositorySourceProvider;
+    private readonly ISFRestClientFactory _restClientFactory;
+
+    /// <summary> Map user IDs to semaphores </summary>
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _tokenRefreshSemaphores =
+        new ConcurrentDictionary<string, SemaphoreSlim>();
+    private readonly IHgWrapper _hgHelper;
+    private readonly IWebHostEnvironment _env;
+
+    public ParatextService(
+        IWebHostEnvironment env,
+        IOptions<ParatextOptions> paratextOptions,
+        IRepository<UserSecret> userSecretRepository,
+        IRealtimeService realtimeService,
+        IExceptionHandler exceptionHandler,
+        IOptions<SiteOptions> siteOptions,
+        IFileSystemService fileSystemService,
+        ILogger<ParatextService> logger,
+        IJwtTokenHelper jwtTokenHelper,
+        IParatextDataHelper paratextDataHelper,
+        IInternetSharedRepositorySourceProvider internetSharedRepositorySourceProvider,
+        IGuidService guidService,
+        ISFRestClientFactory restClientFactory,
+        IHgWrapper hgWrapper
+    )
     {
-        internal HttpClient _registryClient;
-        private readonly IOptions<ParatextOptions> _paratextOptions;
-        private readonly IRepository<UserSecret> _userSecretRepository;
-        private readonly IRealtimeService _realtimeService;
-        private readonly IOptions<SiteOptions> _siteOptions;
-        private readonly IFileSystemService _fileSystemService;
-        private readonly HttpClientHandler _httpClientHandler;
-        private readonly IExceptionHandler _exceptionHandler;
-        private readonly ILogger _logger;
-        private readonly IJwtTokenHelper _jwtTokenHelper;
-        private readonly IParatextDataHelper _paratextDataHelper;
-        private readonly IGuidService _guidService;
-        private string _dblServerUri = "https://paratext.thedigitalbiblelibrary.org/";
-        private string _registryServerUri = "https://registry.paratext.org";
-        private string _sendReceiveServerUri = InternetAccess.uriProduction;
-        private readonly IInternetSharedRepositorySourceProvider _internetSharedRepositorySourceProvider;
-        private readonly ISFRestClientFactory _restClientFactory;
+        _paratextOptions = paratextOptions;
+        _userSecretRepository = userSecretRepository;
+        _realtimeService = realtimeService;
+        _exceptionHandler = exceptionHandler;
+        _siteOptions = siteOptions;
+        _fileSystemService = fileSystemService;
+        _logger = logger;
+        _jwtTokenHelper = jwtTokenHelper;
+        _paratextDataHelper = paratextDataHelper;
+        _internetSharedRepositorySourceProvider = internetSharedRepositorySourceProvider;
+        _guidService = guidService;
+        _restClientFactory = restClientFactory;
+        _hgHelper = hgWrapper;
+        _env = env;
 
-        /// <summary> Map user IDs to semaphores </summary>
-        private readonly ConcurrentDictionary<string, SemaphoreSlim> _tokenRefreshSemaphores =
-            new ConcurrentDictionary<string, SemaphoreSlim>();
-        private readonly IHgWrapper _hgHelper;
-        private readonly IWebHostEnvironment _env;
-
-        public ParatextService(
-            IWebHostEnvironment env,
-            IOptions<ParatextOptions> paratextOptions,
-            IRepository<UserSecret> userSecretRepository,
-            IRealtimeService realtimeService,
-            IExceptionHandler exceptionHandler,
-            IOptions<SiteOptions> siteOptions,
-            IFileSystemService fileSystemService,
-            ILogger<ParatextService> logger,
-            IJwtTokenHelper jwtTokenHelper,
-            IParatextDataHelper paratextDataHelper,
-            IInternetSharedRepositorySourceProvider internetSharedRepositorySourceProvider,
-            IGuidService guidService,
-            ISFRestClientFactory restClientFactory,
-            IHgWrapper hgWrapper
-        )
+        _httpClientHandler = new HttpClientHandler();
+        _registryClient = new HttpClient(_httpClientHandler);
+        if (env.IsDevelopment() || env.IsEnvironment("Testing"))
         {
-            _paratextOptions = paratextOptions;
-            _userSecretRepository = userSecretRepository;
-            _realtimeService = realtimeService;
-            _exceptionHandler = exceptionHandler;
-            _siteOptions = siteOptions;
-            _fileSystemService = fileSystemService;
-            _logger = logger;
-            _jwtTokenHelper = jwtTokenHelper;
-            _paratextDataHelper = paratextDataHelper;
-            _internetSharedRepositorySourceProvider = internetSharedRepositorySourceProvider;
-            _guidService = guidService;
-            _restClientFactory = restClientFactory;
-            _hgHelper = hgWrapper;
-            _env = env;
+            _httpClientHandler.ServerCertificateCustomValidationCallback =
+                HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+            // This should be paratext-qa.thedigitalbiblelibrary.org, but it's broken as of 2021-04 and
+            // qa.thedigitalbiblelibrary.org should be just as good, at least for the time being.
+            _dblServerUri = "https://qa.thedigitalbiblelibrary.org/";
+            _registryServerUri = "https://registry-dev.paratext.org";
+            _registryClient.BaseAddress = new Uri(_registryServerUri);
+            _sendReceiveServerUri = InternetAccess.uriDevelopment;
+        }
+        else
+        {
+            _registryClient.BaseAddress = new Uri(_registryServerUri);
+        }
+        _registryClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        ScrTextCollection = new LazyScrTextCollection();
 
-            _httpClientHandler = new HttpClientHandler();
-            _registryClient = new HttpClient(_httpClientHandler);
-            if (env.IsDevelopment() || env.IsEnvironment("Testing"))
-            {
-                _httpClientHandler.ServerCertificateCustomValidationCallback =
-                    HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
-                // This should be paratext-qa.thedigitalbiblelibrary.org, but it's broken as of 2021-04 and
-                // qa.thedigitalbiblelibrary.org should be just as good, at least for the time being.
-                _dblServerUri = "https://qa.thedigitalbiblelibrary.org/";
-                _registryServerUri = "https://registry-dev.paratext.org";
-                _registryClient.BaseAddress = new Uri(_registryServerUri);
-                _sendReceiveServerUri = InternetAccess.uriDevelopment;
-            }
-            else
-            {
-                _registryClient.BaseAddress = new Uri(_registryServerUri);
-            }
-            _registryClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            ScrTextCollection = new LazyScrTextCollection();
+        SharingLogicWrapper = new SharingLogicWrapper();
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+    }
 
-            SharingLogicWrapper = new SharingLogicWrapper();
-            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+    public static string AssemblyDirectory
+    {
+        get
+        {
+            string location = Assembly.GetExecutingAssembly().Location;
+            return Path.GetDirectoryName(location);
+        }
+    }
+
+    /// <summary> Path to cloned PT project Mercurial repos. </summary>
+    public string SyncDir { get; set; }
+
+    internal IScrTextCollection ScrTextCollection { get; set; }
+    internal ISharingLogicWrapper SharingLogicWrapper { get; set; }
+
+    /// <summary> Prepare access to Paratext.Data library, authenticate, and prepare Mercurial. </summary>
+    public void Init()
+    {
+        // Uncomment to output more info to the Terminal from ParatextData.dll for investigating. Note that without
+        // Clear()ing, the output would show in Debug Console while debugging.
+        // The output is using System.Diagnostics.Trace and so is not managed by the ILogging LogLevel filtering
+        // settings.
+        // System.Diagnostics.Trace.Listeners.Add(new System.Diagnostics.TextWriterTraceListener(Console.Out));
+        // System.Diagnostics.Trace.AutoFlush = true;
+
+        // Stop ParatextData.dll Trace output from appearing on the server.
+        System.Diagnostics.Trace.Listeners.Clear();
+
+        SyncDir = Path.Combine(_siteOptions.Value.SiteDir, "sync");
+        if (!_fileSystemService.DirectoryExists(SyncDir))
+            _fileSystemService.CreateDirectory(SyncDir);
+        // Disable caching VersionedText instances since multiple repos may exist on SF server with the same GUID
+        Environment.SetEnvironmentVariable("PTD_CACHE_VERSIONED_TEXT", "DISABLED");
+        RegistryU.Implementation = new DotNetCoreRegistry();
+        Alert.Implementation = new DotNetCoreAlert(_logger);
+        ParatextDataSettings.Initialize(new PersistedParatextDataSettings());
+        PtxUtilsDataSettings.Initialize(new PersistedPtxUtilsSettings());
+        SetupMercurial();
+        WritingSystemRepository.Initialize();
+        ScrTextCollection.Initialize(SyncDir);
+        InstallStyles();
+        // Allow use of custom versification systems
+        Versification.Table.Implementation = new ParatextVersificationTable();
+    }
+
+    /// <summary>
+    /// Synchronizes the text and notes data on the SF server with the data on the Paratext server, for the PT
+    /// project referred to by paratextId. Or if paratextId refers to a DBL Resource, update the local copy of the
+    /// resource if needed.
+    /// </summary>
+    /// <returns>The project that was synced. This is returned so we can use it for other Paratext logic.</returns>
+    public async Task<ParatextProject> SendReceiveAsync(
+        UserSecret userSecret,
+        string paratextId,
+        IProgress<ProgressState> progress = null,
+        CancellationToken token = default
+    )
+    {
+        if (userSecret == null || paratextId == null)
+        {
+            throw new ArgumentNullException();
         }
 
-        public static string AssemblyDirectory
+        IInternetSharedRepositorySource source = await GetInternetSharedRepositorySource(userSecret.Id, token);
+        IEnumerable<SharedRepository> repositories = GetRepositories(
+            source,
+            $"For SF user id {userSecret.Id}, while attempting to sync PT project id {paratextId}."
+        );
+        IEnumerable<ProjectMetadata> projectsMetadata = source.GetProjectsMetaData();
+        IEnumerable<string> projectGuids = projectsMetadata.Select(pmd => pmd.ProjectGuid.Id);
+        SharedRepository sendReceiveRepository = repositories.FirstOrDefault(r => r.SendReceiveId.Id == paratextId);
+        if (TryGetProject(userSecret, sendReceiveRepository, projectsMetadata, out ParatextProject ptProject))
         {
-            get
-            {
-                string location = Assembly.GetExecutingAssembly().Location;
-                return Path.GetDirectoryName(location);
-            }
+            if (!projectGuids.Contains(paratextId))
+                _logger.LogWarning($"The project with PT ID {paratextId} did not have a full name available.");
         }
-
-        /// <summary> Path to cloned PT project Mercurial repos. </summary>
-        public string SyncDir { get; set; }
-
-        internal IScrTextCollection ScrTextCollection { get; set; }
-        internal ISharingLogicWrapper SharingLogicWrapper { get; set; }
-
-        /// <summary> Prepare access to Paratext.Data library, authenticate, and prepare Mercurial. </summary>
-        public void Init()
+        else
         {
-            // Uncomment to output more info to the Terminal from ParatextData.dll for investigating. Note that without
-            // Clear()ing, the output would show in Debug Console while debugging.
-            // The output is using System.Diagnostics.Trace and so is not managed by the ILogging LogLevel filtering
-            // settings.
-            // System.Diagnostics.Trace.Listeners.Add(new System.Diagnostics.TextWriterTraceListener(Console.Out));
-            // System.Diagnostics.Trace.AutoFlush = true;
-
-            // Stop ParatextData.dll Trace output from appearing on the server.
-            System.Diagnostics.Trace.Listeners.Clear();
-
-            SyncDir = Path.Combine(_siteOptions.Value.SiteDir, "sync");
-            if (!_fileSystemService.DirectoryExists(SyncDir))
-                _fileSystemService.CreateDirectory(SyncDir);
-            // Disable caching VersionedText instances since multiple repos may exist on SF server with the same GUID
-            Environment.SetEnvironmentVariable("PTD_CACHE_VERSIONED_TEXT", "DISABLED");
-            RegistryU.Implementation = new DotNetCoreRegistry();
-            Alert.Implementation = new DotNetCoreAlert(_logger);
-            ParatextDataSettings.Initialize(new PersistedParatextDataSettings());
-            PtxUtilsDataSettings.Initialize(new PersistedPtxUtilsSettings());
-            SetupMercurial();
-            WritingSystemRepository.Initialize();
-            ScrTextCollection.Initialize(SyncDir);
-            InstallStyles();
-            // Allow use of custom versification systems
-            Versification.Table.Implementation = new ParatextVersificationTable();
-        }
-
-        /// <summary>
-        /// Synchronizes the text and notes data on the SF server with the data on the Paratext server, for the PT
-        /// project referred to by paratextId. Or if paratextId refers to a DBL Resource, update the local copy of the
-        /// resource if needed.
-        /// </summary>
-        /// <returns>The project that was synced. This is returned so we can use it for other Paratext logic.</returns>
-        public async Task<ParatextProject> SendReceiveAsync(
-            UserSecret userSecret,
-            string paratextId,
-            IProgress<ProgressState> progress = null,
-            CancellationToken token = default
-        )
-        {
-            if (userSecret == null || paratextId == null)
-            {
-                throw new ArgumentNullException();
-            }
-
-            IInternetSharedRepositorySource source = await GetInternetSharedRepositorySource(userSecret.Id, token);
-            IEnumerable<SharedRepository> repositories = GetRepositories(
-                source,
-                $"For SF user id {userSecret.Id}, while attempting to sync PT project id {paratextId}."
+            // See if this is a resource
+            IReadOnlyList<ParatextResource> resources = await this.GetResourcesInternalAsync(
+                userSecret.Id,
+                true,
+                token
             );
-            IEnumerable<ProjectMetadata> projectsMetadata = source.GetProjectsMetaData();
-            IEnumerable<string> projectGuids = projectsMetadata.Select(pmd => pmd.ProjectGuid.Id);
-            SharedRepository sendReceiveRepository = repositories.FirstOrDefault(r => r.SendReceiveId.Id == paratextId);
-            ParatextProject ptProject;
-            if (TryGetProject(userSecret, sendReceiveRepository, projectsMetadata, out ptProject))
-            {
-                if (!projectGuids.Contains(paratextId))
-                    _logger.LogWarning($"The project with PT ID {paratextId} did not have a full name available.");
-            }
-            else
-            {
-                // See if this is a resource
-                IReadOnlyList<ParatextResource> resources = await this.GetResourcesInternalAsync(
-                    userSecret.Id,
-                    true,
-                    token
-                );
-                ptProject = resources.SingleOrDefault(r => r.ParatextId == paratextId);
-            }
-
-            if (ptProject == null)
-            {
-                throw new ArgumentException(
-                    "PT projects with the following PT ids were requested but without access or they don't exist: "
-                        + $"{paratextId}"
-                );
-            }
-            EnsureProjectReposExists(userSecret, ptProject, source);
-            if (ptProject is not ParatextResource)
-            {
-                StartProgressReporting(progress);
-
-                string username = GetParatextUsername(userSecret);
-                using ScrText scrText = ScrTextCollection.FindById(username, paratextId);
-                if (scrText == null)
-                    throw new Exception(
-                        $"Failed to fetch ScrText for PT project id {paratextId} using PT username {username}"
-                    );
-
-                SharedProject sharedProj = CreateSharedProject(
-                    paratextId,
-                    ptProject.ShortName,
-                    scrText,
-                    sendReceiveRepository
-                );
-                List<SharedProject> sharedPtProjectsToSr = new List<SharedProject> { sharedProj };
-
-                // If we are in development, unlock the repo before we begin,
-                // just in case the repo is locked.
-                if (_env.IsDevelopment())
-                {
-                    try
-                    {
-                        source.UnlockRemoteRepository(sharedProj.Repository);
-                    }
-                    catch (Paratext.Data.HttpException)
-                    {
-                        // A 403 error will be thrown if the repo is not locked
-                    }
-                }
-
-                // TODO report results
-                List<SendReceiveResult> results = Enumerable.Empty<SendReceiveResult>().ToList();
-                bool success = false;
-                bool noErrors = SharingLogicWrapper.HandleErrors(
-                    () =>
-                        success = SharingLogicWrapper.ShareChanges(
-                            sharedPtProjectsToSr,
-                            source.AsInternetSharedRepositorySource(),
-                            out results,
-                            sharedPtProjectsToSr
-                        )
-                );
-                if (results == null)
-                {
-                    _logger.LogWarning($"SendReceive results are unexpectedly null.");
-                }
-                if (results != null && results.Any(r => r == null))
-                {
-                    _logger.LogWarning($"SendReceive results unexpectedly contained a null result.");
-                }
-                string srResultDescriptions = ExplainSRResults(results);
-                _logger.LogInformation($"SendReceive results: {srResultDescriptions}");
-                if (
-                    !noErrors
-                    || !success
-                    || (results != null && results.Any(r => r != null && r.Result == SendReceiveResultEnum.Failed))
-                )
-                {
-                    string resultsInfo = ExplainSRResults(results);
-                    throw new InvalidOperationException(
-                        $"Failed: Errors occurred while performing the sync with the Paratext Server. More information: noErrors: {noErrors}. success: {success}. null results: {results == null}. results: {resultsInfo}"
-                    );
-                }
-
-                // Update the cached comment manager
-                CommentManager manager = CommentManager.Get(scrText);
-                manager.Load();
-            }
-
-            return ptProject;
+            ptProject = resources.SingleOrDefault(r => r.ParatextId == paratextId);
         }
 
-        /// <returns>
-        /// True if the user secret is able to access the PT Registry. PT Registry is a web service such as at
-        /// registry.paratext.org.
-        /// False if there is a problem with authorization or connecting to the PT Registry.
-        /// </returns>
-        public async Task<bool> CanUserAuthenticateToPTRegistryAsync(UserSecret? userSecret)
+        if (ptProject == null)
         {
-            if (userSecret == null)
+            throw new ArgumentException(
+                "PT projects with the following PT ids were requested but without access or they don't exist: "
+                    + $"{paratextId}"
+            );
+        }
+        EnsureProjectReposExists(userSecret, ptProject, source);
+        if (ptProject is not ParatextResource)
+        {
+            StartProgressReporting(progress);
+
+            string username = GetParatextUsername(userSecret);
+            using ScrText scrText = ScrTextCollection.FindById(username, paratextId);
+            if (scrText == null)
+                throw new Exception(
+                    $"Failed to fetch ScrText for PT project id {paratextId} using PT username {username}"
+                );
+
+            SharedProject sharedProj = CreateSharedProject(
+                paratextId,
+                ptProject.ShortName,
+                scrText,
+                sendReceiveRepository
+            );
+            List<SharedProject> sharedPtProjectsToSr = new List<SharedProject> { sharedProj };
+
+            // If we are in development, unlock the repo before we begin,
+            // just in case the repo is locked.
+            if (_env.IsDevelopment())
             {
-                throw new ArgumentNullException(nameof(userSecret));
+                try
+                {
+                    source.UnlockRemoteRepository(sharedProj.Repository);
+                }
+                catch (Paratext.Data.HttpException)
+                {
+                    // A 403 error will be thrown if the repo is not locked
+                }
             }
-            if (userSecret.Id == null || userSecret.ParatextTokens == null)
+
+            // TODO report results
+            List<SendReceiveResult> results = Enumerable.Empty<SendReceiveResult>().ToList();
+            bool success = false;
+            bool noErrors = SharingLogicWrapper.HandleErrors(
+                () =>
+                    success = SharingLogicWrapper.ShareChanges(
+                        sharedPtProjectsToSr,
+                        source.AsInternetSharedRepositorySource(),
+                        out results,
+                        sharedPtProjectsToSr
+                    )
+            );
+            if (results == null)
             {
-                throw new ArgumentException(nameof(userSecret));
+                _logger.LogWarning($"SendReceive results are unexpectedly null.");
             }
+            if (results != null && results.Any(r => r == null))
+            {
+                _logger.LogWarning($"SendReceive results unexpectedly contained a null result.");
+            }
+            string srResultDescriptions = ExplainSRResults(results);
+            _logger.LogInformation($"SendReceive results: {srResultDescriptions}");
+            if (
+                !noErrors
+                || !success
+                || (results != null && results.Any(r => r != null && r.Result == SendReceiveResultEnum.Failed))
+            )
+            {
+                string resultsInfo = ExplainSRResults(results);
+                throw new InvalidOperationException(
+                    $"Failed: Errors occurred while performing the sync with the Paratext Server. More information: noErrors: {noErrors}. success: {success}. null results: {results == null}. results: {resultsInfo}"
+                );
+            }
+
+            // Update the cached comment manager
+            CommentManager manager = CommentManager.Get(scrText);
+            manager.Load();
+        }
+
+        return ptProject;
+    }
+
+    /// <returns>
+    /// True if the user secret is able to access the PT Registry. PT Registry is a web service such as at
+    /// registry.paratext.org.
+    /// False if there is a problem with authorization or connecting to the PT Registry.
+    /// </returns>
+    public async Task<bool> CanUserAuthenticateToPTRegistryAsync(UserSecret? userSecret)
+    {
+        if (userSecret == null)
+        {
+            throw new ArgumentNullException(nameof(userSecret));
+        }
+        if (userSecret.Id == null || userSecret.ParatextTokens == null)
+        {
+            throw new ArgumentException(nameof(userSecret));
+        }
+        try
+        {
+            await CallApiAsync(userSecret, HttpMethod.Get, "userinfo", content: null);
+            // If the server responds with code 200, then the user is authorized.
+            // They might not have a completed registration. And they might not be
+            // an "approved translator". But they are able to authorize to PT
+            // Registry.
+            return true;
+        }
+        catch (HttpRequestException)
+        {
+            return false;
+        }
+    }
+
+    /// <returns>
+    /// True if the user secret is able to access the PT Archives. PT Archives is a service such as at
+    /// archives.paratext.org, which provides Mercurial project repositores, and may sometimes be referred to as
+    /// "the Send and Receive server".
+    /// False if there is a problem with authorization or connecting to the PT Archives.
+    /// </returns>
+    public async Task<bool> CanUserAuthenticateToPTArchivesAsync(string sfUserId)
+    {
+        if (string.IsNullOrWhiteSpace(sfUserId))
+        {
+            throw new ArgumentException(nameof(sfUserId));
+        }
+
+        IInternetSharedRepositorySource ptRepoSource = await GetInternetSharedRepositorySource(
+            sfUserId,
+            CancellationToken.None
+        );
+        return ptRepoSource.CanUserAuthenticateToPTArchives();
+    }
+
+    /// <summary> Get Paratext projects that a user has access to. </summary>
+    public async Task<IReadOnlyList<ParatextProject>> GetProjectsAsync(UserSecret userSecret)
+    {
+        IInternetSharedRepositorySource ptRepoSource = await GetInternetSharedRepositorySource(
+            userSecret.Id,
+            CancellationToken.None
+        );
+        IEnumerable<SharedRepository> remotePtProjects = GetRepositories(
+            ptRepoSource,
+            $"Using SF user id {userSecret.Id}"
+        );
+        return GetProjects(userSecret, remotePtProjects, ptRepoSource.GetProjectsMetaData());
+    }
+
+    /// <summary>Get Paratext resources that a user has access to. </summary>
+    public async Task<IReadOnlyList<ParatextResource>> GetResourcesAsync(string userId) =>
+        await this.GetResourcesInternalAsync(userId, false, CancellationToken.None);
+
+    /// <summary>
+    /// Is the PT project referred to by `paratextId` a DBL resource?
+    /// </summary>
+    public bool IsResource(string paratextId) =>
+        paratextId?.Length == SFInstallableDblResource.ResourceIdentifierLength;
+
+    /// <summary>
+    /// Determines whether the <see cref="TextData"/> for a resource project requires updating.
+    /// </summary>
+    /// <param name="project">The Scripture Forge project.</param>
+    /// <param name="resource">The Paratext resource.</param>
+    /// <returns>
+    /// <c>true</c> if the project's documents require updating; otherwise, <c>false</c>.
+    /// </returns>
+    /// <remarks>
+    /// This method is an implementation of <see cref="Paratext.Data.Archiving.InstallableResource.IsNewerThanCurrentlyInstalled" />
+    /// specifically for comparing downloaded resources with the resource data in the Mongo database.
+    /// If a non-resource project is specified, <c>true</c> is always returned.
+    /// </remarks>
+    public bool ResourceDocsNeedUpdating(SFProject project, ParatextResource resource)
+    {
+        // Ensure that we are checking a resource. We will default to true if it is not a resource.
+        if (!IsResource(project.ParatextId))
+        {
+            return true;
+        }
+
+        // If we do not have a ResourceConfig, return true, as we have not synced this data into the database
+        if (project.ResourceConfig == null)
+        {
+            _logger.LogInformation($"No resource configuration for '{project.ParatextId}' could be found.");
+            return true;
+        }
+
+        // We use the latest revision, as all this data is from the Paratext feed
+        if (resource.AvailableRevision > project.ResourceConfig.Revision)
+        {
+            return true;
+        }
+
+        if (resource.PermissionsChecksum != project.ResourceConfig.PermissionsChecksum)
+        {
+            return true;
+        }
+
+        // If the manifest is different, use the creation timestamp to ensure it is newer
+        return resource.ManifestChecksum != project.ResourceConfig.ManifestChecksum
+            && resource.CreatedTimestamp > project.ResourceConfig.CreatedTimestamp;
+    }
+
+    /// <summary>
+    /// Returns `userSecret`'s role on a PT project according to the PT Registry.
+    /// </summary>
+    public async Task<Attempt<string>> TryGetProjectRoleAsync(
+        UserSecret userSecret,
+        string paratextId,
+        CancellationToken token
+    )
+    {
+        if (userSecret == null || string.IsNullOrEmpty(paratextId))
+        {
+            return Attempt.Failure((string)null);
+        }
+        // Ensure the user has the paratext access tokens, and this is not a resource
+        if (userSecret.ParatextTokens == null || IsResource(paratextId))
+        {
+            return Attempt.Failure((string)null);
+        }
+        else if (await IsRegisteredAsync(userSecret, paratextId, token))
+        {
+            // Use the registry server
             try
             {
-                await CallApiAsync(userSecret, HttpMethod.Get, "userinfo", content: null);
-                // If the server responds with code 200, then the user is authorized.
-                // They might not have a completed registration. And they might not be
-                // an "approved translator". But they are able to authorize to PT
-                // Registry.
-                return true;
+                var accessToken = new JwtSecurityToken(userSecret.ParatextTokens.AccessToken);
+                Claim subClaim = accessToken.Claims.FirstOrDefault(c => c.Type == JwtClaimTypes.Subject);
+                // Paratext RegistryServer has methods to do this, but it is unreliable to use it in a multi-user
+                // environment so instead we call the registry API.
+                string response = await CallApiAsync(
+                    userSecret,
+                    HttpMethod.Get,
+                    $"projects/{paratextId}/members/{subClaim.Value}",
+                    null,
+                    token
+                );
+                var memberObj = JObject.Parse(response);
+                return Attempt.Success((string)memberObj["role"]);
             }
             catch (HttpRequestException)
             {
-                return false;
+                return Attempt.Failure((string)null);
             }
         }
-
-        /// <returns>
-        /// True if the user secret is able to access the PT Archives. PT Archives is a service such as at
-        /// archives.paratext.org, which provides Mercurial project repositores, and may sometimes be referred to as
-        /// "the Send and Receive server".
-        /// False if there is a problem with authorization or connecting to the PT Archives.
-        /// </returns>
-        public async Task<bool> CanUserAuthenticateToPTArchivesAsync(string sfUserId)
+        else
         {
-            if (string.IsNullOrWhiteSpace(sfUserId))
-            {
-                throw new ArgumentException(nameof(sfUserId));
-            }
-
-            IInternetSharedRepositorySource ptRepoSource = await GetInternetSharedRepositorySource(
-                sfUserId,
-                CancellationToken.None
-            );
-            return ptRepoSource.CanUserAuthenticateToPTArchives();
-        }
-
-        /// <summary> Get Paratext projects that a user has access to. </summary>
-        public async Task<IReadOnlyList<ParatextProject>> GetProjectsAsync(UserSecret userSecret)
-        {
+            // We will use the repository to get the project role for this user, as back translations inherit the
+            // base project registration, so are not in the registry.
             IInternetSharedRepositorySource ptRepoSource = await GetInternetSharedRepositorySource(
                 userSecret.Id,
                 CancellationToken.None
             );
             IEnumerable<SharedRepository> remotePtProjects = GetRepositories(
                 ptRepoSource,
-                $"Using SF user id {userSecret.Id}"
+                $"For SF user id {userSecret.Id} for unregistered PT project id {paratextId}"
             );
-            return GetProjects(userSecret, remotePtProjects, ptRepoSource.GetProjectsMetaData());
-        }
-
-        /// <summary>Get Paratext resources that a user has access to. </summary>
-        public async Task<IReadOnlyList<ParatextResource>> GetResourcesAsync(string userId)
-        {
-            return await this.GetResourcesInternalAsync(userId, false, CancellationToken.None);
-        }
-
-        /// <summary>
-        /// Is the PT project referred to by `paratextId` a DBL resource?
-        /// </summary>
-        public bool IsResource(string paratextId)
-        {
-            return paratextId?.Length == SFInstallableDblResource.ResourceIdentifierLength;
-        }
-
-        /// <summary>
-        /// Determines whether the <see cref="TextData"/> for a resource project requires updating.
-        /// </summary>
-        /// <param name="project">The Scripture Forge project.</param>
-        /// <param name="resource">The Paratext resource.</param>
-        /// <returns>
-        /// <c>true</c> if the project's documents require updating; otherwise, <c>false</c>.
-        /// </returns>
-        /// <remarks>
-        /// This method is an implementation of <see cref="Paratext.Data.Archiving.InstallableResource.IsNewerThanCurrentlyInstalled" />
-        /// specifically for comparing downloaded resources with the resource data in the Mongo database.
-        /// If a non-resource project is specified, <c>true</c> is always returned.
-        /// </remarks>
-        public bool ResourceDocsNeedUpdating(SFProject project, ParatextResource resource)
-        {
-            // Ensure that we are checking a resource. We will default to true if it is not a resource.
-            if (!IsResource(project.ParatextId))
+            string username = GetParatextUsername(userSecret);
+            string role = ConvertFromUserRole(
+                remotePtProjects
+                    .SingleOrDefault(p => p.SendReceiveId.Id == paratextId)
+                    ?.SourceUsers.Users.FirstOrDefault(u => u.UserName == username)
+                    ?.Role
+            );
+            if (string.IsNullOrEmpty(role))
             {
-                return true;
-            }
-
-            // If we do not have a ResourceConfig, return true, as we have not synced this data into the database
-            if (project.ResourceConfig == null)
-            {
-                _logger.LogInformation($"No resource configuration for '{project.ParatextId}' could be found.");
-                return true;
-            }
-
-            // We use the latest revision, as all this data is from the Paratext feed
-            if (resource.AvailableRevision > project.ResourceConfig.Revision)
-            {
-                return true;
-            }
-
-            if (resource.PermissionsChecksum != project.ResourceConfig.PermissionsChecksum)
-            {
-                return true;
-            }
-
-            // If the manifest is different, use the creation timestamp to ensure it is newer
-            return resource.ManifestChecksum != project.ResourceConfig.ManifestChecksum
-                && resource.CreatedTimestamp > project.ResourceConfig.CreatedTimestamp;
-        }
-
-        /// <summary>
-        /// Returns `userSecret`'s role on a PT project according to the PT Registry.
-        /// </summary>
-        public async Task<Attempt<string>> TryGetProjectRoleAsync(
-            UserSecret userSecret,
-            string paratextId,
-            CancellationToken token
-        )
-        {
-            if (userSecret == null || string.IsNullOrEmpty(paratextId))
-            {
-                return Attempt.Failure((string)null);
-            }
-            // Ensure the user has the paratext access tokens, and this is not a resource
-            if (userSecret.ParatextTokens == null || IsResource(paratextId))
-            {
-                return Attempt.Failure((string)null);
-            }
-            else if (await IsRegisteredAsync(userSecret, paratextId, token))
-            {
-                // Use the registry server
-                try
-                {
-                    var accessToken = new JwtSecurityToken(userSecret.ParatextTokens.AccessToken);
-                    Claim subClaim = accessToken.Claims.FirstOrDefault(c => c.Type == JwtClaimTypes.Subject);
-                    // Paratext RegistryServer has methods to do this, but it is unreliable to use it in a multi-user
-                    // environment so instead we call the registry API.
-                    string response = await CallApiAsync(
-                        userSecret,
-                        HttpMethod.Get,
-                        $"projects/{paratextId}/members/{subClaim.Value}",
-                        null,
-                        token
-                    );
-                    var memberObj = JObject.Parse(response);
-                    return Attempt.Success((string)memberObj["role"]);
-                }
-                catch (HttpRequestException)
-                {
-                    return Attempt.Failure((string)null);
-                }
+                return Attempt.Failure(role);
             }
             else
             {
-                // We will use the repository to get the project role for this user, as back translations inherit the
-                // base project registration, so are not in the registry.
-                IInternetSharedRepositorySource ptRepoSource = await GetInternetSharedRepositorySource(
-                    userSecret.Id,
-                    CancellationToken.None
-                );
-                IEnumerable<SharedRepository> remotePtProjects = GetRepositories(
-                    ptRepoSource,
-                    $"For SF user id {userSecret.Id} for unregistered PT project id {paratextId}"
-                );
-                string username = GetParatextUsername(userSecret);
-                string role = ConvertFromUserRole(
-                    remotePtProjects
-                        .SingleOrDefault(p => p.SendReceiveId.Id == paratextId)
-                        ?.SourceUsers.Users.FirstOrDefault(u => u.UserName == username)
-                        ?.Role
-                );
-                if (string.IsNullOrEmpty(role))
+                return Attempt.Success(role);
+            }
+        }
+    }
+
+    /// <summary> Get the Paratext username from the UserSecret. </summary>
+    public string? GetParatextUsername(UserSecret userSecret) => _jwtTokenHelper.GetParatextUsername(userSecret);
+
+    /// <summary>
+    /// Gets the permission a user has to access a resource, according to a DBL server.
+    /// </summary>
+    /// <param name="paratextId">The paratext resource identifier.</param>
+    /// <param name="sfUserId">The user SF identifier.</param>
+    /// <returns>
+    /// Read or None.
+    /// </returns>
+    /// <remarks>
+    /// See <see cref="TextInfoPermission" /> for permission values.
+    /// </remarks>
+    public async Task<string> GetResourcePermissionAsync(string paratextId, string sfUserId, CancellationToken token)
+    {
+        // See if the source is even a resource
+        if (!IsResource(paratextId))
+        {
+            // Default to no permissions for projects used as sources
+            return TextInfoPermission.None;
+        }
+        using ParatextAccessLock accessLock = await GetParatextAccessLock(sfUserId, token);
+        bool canRead = SFInstallableDblResource.CheckResourcePermission(
+            paratextId,
+            accessLock.UserSecret,
+            _paratextOptions.Value,
+            _restClientFactory,
+            _fileSystemService,
+            _jwtTokenHelper,
+            _exceptionHandler,
+            _dblServerUri
+        );
+        return canRead ? TextInfoPermission.Read : TextInfoPermission.None;
+    }
+
+    private static string ExplainSRResults(IEnumerable<SendReceiveResult> srResults)
+    {
+        return string.Join(
+            ";",
+            srResults?.Select(
+                (SendReceiveResult r) =>
+                    $"SR result: {r.Result}, "
+                    + $"Revisions sent: {string.Join(",", r.RevisionsSent ?? Enumerable.Empty<string>())}, "
+                    + $"Revisions received: {string.Join(",", r.RevisionsReceived ?? Enumerable.Empty<string>())}, "
+                    + $"Failure message: {r.FailureMessage}."
+            ) ?? Enumerable.Empty<string>()
+        );
+    }
+
+    private void WarnIfNonuniqueValues(Dictionary<string, string> sfUserIdToPTUsernameMap, string context)
+    {
+        IEnumerable<KeyValuePair<string, string>> recordsWithNonuniqueValues = sfUserIdToPTUsernameMap.Where(
+            (KeyValuePair<string, string> record) =>
+                sfUserIdToPTUsernameMap.Values.Count(val => val == record.Value) > 1
+        );
+        if (recordsWithNonuniqueValues.Count() > 0)
+        {
+            string display = string.Join(
+                ", ",
+                recordsWithNonuniqueValues.Select(record => $"{record.Key}: {record.Value}")
+            );
+            _logger.LogWarning(
+                $"Warning: The PT Username mapping contains multiple records with duplicate values. The following records have values that occur more than once: {display}. {context}"
+            );
+        }
+    }
+
+    /// <summary>
+    /// Queries the ParatextRegistry for the project and builds a dictionary of SF user id
+    /// to paratext user names for members of the project.
+    /// </summary>
+    /// <param name="userSecret">The user secret.</param>
+    /// <param name="project">The project - the UserRoles and ParatextId are used.</param>
+    /// <param name="token">The cancellation token.</param>
+    /// <returns>
+    /// A dictionary where the key is the SF user ID and the value is Paratext username. (May be empty)
+    /// </returns>
+    public async Task<IReadOnlyDictionary<string, string>> GetParatextUsernameMappingAsync(
+        UserSecret userSecret,
+        SFProject project,
+        CancellationToken token
+    )
+    {
+        // Skip all the work if the project is a resource. Resources don't have project members
+        if (IsResource(project.ParatextId))
+        {
+            return new Dictionary<string, string>();
+        }
+        else if (await IsRegisteredAsync(userSecret, project.ParatextId, token))
+        {
+            // Get the mapping for paratext users ids to usernames from the registry
+            string response = await CallApiAsync(
+                userSecret,
+                HttpMethod.Get,
+                $"projects/{project.ParatextId}/members",
+                null,
+                token
+            );
+            Dictionary<string, string> paratextMapping = JArray
+                .Parse(response)
+                .OfType<JObject>()
+                .Where(m => !string.IsNullOrEmpty((string)m["userId"]) && !string.IsNullOrEmpty((string)m["username"]))
+                .ToDictionary(m => (string)m["userId"], m => (string)m["username"]);
+
+            // Get the mapping of Scripture Forge user IDs to Paratext usernames
+            IQueryable<User> relevantUsers = this._realtimeService
+                .QuerySnapshots<User>()
+                .Where(u => paratextMapping.Keys.Contains(u.ParatextId));
+            string sfUserIdToPTUserIdMap = string.Join(
+                ", ",
+                relevantUsers.Select((User userItem) => userItem.Id + ": " + userItem.ParatextId).ToArray<string>()
+            );
+            Dictionary<string, string> userMapping = await relevantUsers.ToDictionaryAsync(
+                u => u.Id,
+                u => paratextMapping[u.ParatextId]
+            );
+
+            WarnIfNonuniqueValues(
+                userMapping,
+                $"This occurred while SF user id '{userSecret.Id}' was querying registered PT project id "
+                    + $"'{project.ParatextId}' (SF project id '{project.Id}').\n"
+                    + $"The project-member json info returned from the server was: {response}\n"
+                    + "The records of SF user ids and their corresponding user paratext ids that was taken from "
+                    + $"realtimeservice to further consider was: {sfUserIdToPTUserIdMap}"
+            );
+            return userMapping;
+        }
+        else
+        {
+            // Get the list of users from the repository
+            IInternetSharedRepositorySource ptRepoSource = await GetInternetSharedRepositorySource(
+                userSecret.Id,
+                CancellationToken.None
+            );
+
+            bool hasRole = project.UserRoles.TryGetValue(userSecret.Id, out string userRole);
+            string contextInformation =
+                $"For SF user id '{userSecret.Id}', "
+                + $"while interested in unregistered PT project id '{project.ParatextId}' "
+                + $"(SF project id {project.Id}). "
+                + $"On SF project, user has {(hasRole ? $"role '{userRole}'." : "no role.")}";
+
+            IEnumerable<SharedRepository> remotePtProjects = GetRepositories(ptRepoSource, contextInformation);
+            SharedRepository remotePtProject = remotePtProjects.Single(p => p.SendReceiveId.Id == project.ParatextId);
+
+            // Build a dictionary of user IDs mapped to usernames using the user secrets
+            var userMapping = new Dictionary<string, string>();
+            foreach (string userId in project.UserRoles.Keys)
+            {
+                UserSecret projectUserSecret;
+                if (userId == userSecret.Id)
                 {
-                    return Attempt.Failure(role);
+                    projectUserSecret = userSecret;
                 }
                 else
                 {
-                    return Attempt.Success(role);
+                    projectUserSecret = await _userSecretRepository.GetAsync(userId);
+                }
+
+                string projectUserName = GetParatextUsername(projectUserSecret);
+                if (remotePtProject.SourceUsers.UserNames.Contains(projectUserName))
+                {
+                    userMapping.Add(userId, projectUserName);
                 }
             }
-        }
 
-        /// <summary> Get the Paratext username from the UserSecret. </summary>
-        public string? GetParatextUsername(UserSecret userSecret)
-        {
-            return _jwtTokenHelper.GetParatextUsername(userSecret);
-        }
-
-        /// <summary>
-        /// Gets the permission a user has to access a resource, according to a DBL server.
-        /// </summary>
-        /// <param name="paratextId">The paratext resource identifier.</param>
-        /// <param name="sfUserId">The user SF identifier.</param>
-        /// <returns>
-        /// Read or None.
-        /// </returns>
-        /// <remarks>
-        /// See <see cref="TextInfoPermission" /> for permission values.
-        /// </remarks>
-        public async Task<string> GetResourcePermissionAsync(
-            string paratextId,
-            string sfUserId,
-            CancellationToken token
-        )
-        {
-            // See if the source is even a resource
-            if (!IsResource(paratextId))
-            {
-                // Default to no permissions for projects used as sources
-                return TextInfoPermission.None;
-            }
-            using (ParatextAccessLock accessLock = await GetParatextAccessLock(sfUserId, token))
-            {
-                bool canRead = SFInstallableDblResource.CheckResourcePermission(
-                    paratextId,
-                    accessLock.UserSecret,
-                    _paratextOptions.Value,
-                    _restClientFactory,
-                    _fileSystemService,
-                    _jwtTokenHelper,
-                    _exceptionHandler,
-                    _dblServerUri
-                );
-                return canRead ? TextInfoPermission.Read : TextInfoPermission.None;
-            }
-        }
-
-        private string ExplainSRResults(IEnumerable<SendReceiveResult> srResults)
-        {
-            return string.Join(
-                ";",
-                srResults?.Select(
-                    (SendReceiveResult r) =>
-                        $"SR result: {r.Result.ToString()}, "
-                        + $"Revisions sent: {string.Join(",", r.RevisionsSent ?? Enumerable.Empty<string>())}, "
-                        + $"Revisions received: {string.Join(",", r.RevisionsReceived ?? Enumerable.Empty<string>())}, "
-                        + $"Failure message: {r.FailureMessage}."
-                ) ?? Enumerable.Empty<string>()
+            WarnIfNonuniqueValues(
+                userMapping,
+                $"This occurred while SF user id '{userSecret.Id}' was querying unregistered PT project id '{project.ParatextId}' (SF project id '{project.Id}')."
             );
+            return userMapping;
         }
+    }
 
-        private void WarnIfNonuniqueValues(Dictionary<string, string> sfUserIdToPTUsernameMap, string context)
+    /// <summary>
+    /// Gets the permissions for a project or resource.
+    /// </summary>
+    /// <param name="userSecret">The user secret.</param>
+    /// <param name="sfProject">The project - the UserRoles and ParatextId are used.</param>
+    /// <param name="ptUsernameMapping">A mapping of user ID to Paratext username.</param>
+    /// <param name="book">The book number. Set to zero to check for all books.</param>
+    /// <param name="chapter">The chapter number. Set to zero to check for all books.</param>
+    /// <returns>
+    /// A dictionary of permissions where the key is the user ID and the value is the permission.
+    /// </returns>
+    /// <remarks>
+    /// See <see cref="TextInfoPermission" /> for permission values.
+    /// A dictionary is returned, as permissions can be updated.
+    /// </remarks>
+    public async Task<Dictionary<string, string>> GetPermissionsAsync(
+        UserSecret userSecret,
+        SFProject sfProject,
+        IReadOnlyDictionary<string, string> ptUsernameMapping,
+        int book = 0,
+        int chapter = 0,
+        CancellationToken token = default
+    )
+    {
+        var permissions = new Dictionary<string, string>();
+
+        if (IsResource(sfProject.ParatextId))
         {
-            IEnumerable<KeyValuePair<string, string>> recordsWithNonuniqueValues = sfUserIdToPTUsernameMap.Where(
-                (KeyValuePair<string, string> record) =>
-                    sfUserIdToPTUsernameMap.Values.Count(val => val == record.Value) > 1
-            );
-            if (recordsWithNonuniqueValues.Count() > 0)
+            foreach (string sfUserId in sfProject.UserRoles.Keys)
             {
-                string display = string.Join(
-                    ", ",
-                    recordsWithNonuniqueValues.Select(record => $"{record.Key}: {record.Value}")
-                );
-                _logger.LogWarning(
-                    $"Warning: The PT Username mapping contains multiple records with duplicate values. The following records have values that occur more than once: {display}. {context}"
-                );
+                permissions.Add(sfUserId, await this.GetResourcePermissionAsync(sfProject.ParatextId, sfUserId, token));
             }
         }
-
-        /// <summary>
-        /// Queries the ParatextRegistry for the project and builds a dictionary of SF user id
-        /// to paratext user names for members of the project.
-        /// </summary>
-        /// <param name="userSecret">The user secret.</param>
-        /// <param name="project">The project - the UserRoles and ParatextId are used.</param>
-        /// <param name="token">The cancellation token.</param>
-        /// <returns>
-        /// A dictionary where the key is the SF user ID and the value is Paratext username. (May be empty)
-        /// </returns>
-        public async Task<IReadOnlyDictionary<string, string>> GetParatextUsernameMappingAsync(
-            UserSecret userSecret,
-            SFProject project,
-            CancellationToken token
-        )
+        else
         {
-            // Skip all the work if the project is a resource. Resources don't have project members
-            if (IsResource(project.ParatextId))
+            // Get the scripture text so we can retrieve the permissions from the XML
+            using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), sfProject.ParatextId);
+
+            // Calculate the project and resource permissions
+            foreach (string uid in sfProject.UserRoles.Keys)
             {
-                return new Dictionary<string, string>();
-            }
-            else if (await IsRegisteredAsync(userSecret, project.ParatextId, token))
-            {
-                // Get the mapping for paratext users ids to usernames from the registry
-                string response = await CallApiAsync(
-                    userSecret,
-                    HttpMethod.Get,
-                    $"projects/{project.ParatextId}/members",
-                    null,
-                    token
-                );
-                Dictionary<string, string> paratextMapping = JArray
-                    .Parse(response)
-                    .OfType<JObject>()
-                    .Where(
-                        m => !string.IsNullOrEmpty((string)m["userId"]) && !string.IsNullOrEmpty((string)m["username"])
-                    )
-                    .ToDictionary(m => (string)m["userId"], m => (string)m["username"]);
-
-                // Get the mapping of Scripture Forge user IDs to Paratext usernames
-                IQueryable<User> relevantUsers = this._realtimeService
-                    .QuerySnapshots<User>()
-                    .Where(u => paratextMapping.Keys.Contains(u.ParatextId));
-                string sfUserIdToPTUserIdMap = string.Join(
-                    ", ",
-                    relevantUsers.Select((User userItem) => userItem.Id + ": " + userItem.ParatextId).ToArray<string>()
-                );
-                Dictionary<string, string> userMapping = await relevantUsers.ToDictionaryAsync(
-                    u => u.Id,
-                    u => paratextMapping[u.ParatextId]
-                );
-
-                WarnIfNonuniqueValues(
-                    userMapping,
-                    $"This occurred while SF user id '{userSecret.Id}' was querying registered PT project id "
-                        + $"'{project.ParatextId}' (SF project id '{project.Id}').\n"
-                        + $"The project-member json info returned from the server was: {response}\n"
-                        + "The records of SF user ids and their corresponding user paratext ids that was taken from "
-                        + $"realtimeservice to further consider was: {sfUserIdToPTUserIdMap}"
-                );
-                return userMapping;
-            }
-            else
-            {
-                // Get the list of users from the repository
-                IInternetSharedRepositorySource ptRepoSource = await GetInternetSharedRepositorySource(
-                    userSecret.Id,
-                    CancellationToken.None
-                );
-
-                bool hasRole = project.UserRoles.TryGetValue(userSecret.Id, out string userRole);
-                string contextInformation =
-                    $"For SF user id '{userSecret.Id}', "
-                    + $"while interested in unregistered PT project id '{project.ParatextId}' "
-                    + $"(SF project id {project.Id}). "
-                    + $"On SF project, user has {(hasRole ? $"role '{userRole}'." : "no role.")}";
-
-                IEnumerable<SharedRepository> remotePtProjects = GetRepositories(ptRepoSource, contextInformation);
-                SharedRepository remotePtProject = remotePtProjects.Single(
-                    p => p.SendReceiveId.Id == project.ParatextId
-                );
-
-                // Build a dictionary of user IDs mapped to usernames using the user secrets
-                var userMapping = new Dictionary<string, string>();
-                foreach (string userId in project.UserRoles.Keys)
+                // See if the user is in the project members list
+                if (
+                    !ptUsernameMapping.TryGetValue(uid, out string userName)
+                    || string.IsNullOrWhiteSpace(userName)
+                    || scrText.Permissions.GetRole(userName) == Paratext.Data.Users.UserRoles.None
+                )
                 {
-                    UserSecret projectUserSecret;
-                    if (userId == userSecret.Id)
-                    {
-                        projectUserSecret = userSecret;
-                    }
-                    else
-                    {
-                        projectUserSecret = await _userSecretRepository.GetAsync(userId);
-                    }
-
-                    string projectUserName = GetParatextUsername(projectUserSecret);
-                    if (remotePtProject.SourceUsers.UserNames.Contains(projectUserName))
-                    {
-                        userMapping.Add(userId, projectUserName);
-                    }
+                    permissions.Add(uid, TextInfoPermission.None);
                 }
-
-                WarnIfNonuniqueValues(
-                    userMapping,
-                    $"This occurred while SF user id '{userSecret.Id}' was querying unregistered PT project id '{project.ParatextId}' (SF project id '{project.Id}')."
-                );
-                return userMapping;
-            }
-        }
-
-        /// <summary>
-        /// Gets the permissions for a project or resource.
-        /// </summary>
-        /// <param name="userSecret">The user secret.</param>
-        /// <param name="sfProject">The project - the UserRoles and ParatextId are used.</param>
-        /// <param name="ptUsernameMapping">A mapping of user ID to Paratext username.</param>
-        /// <param name="book">The book number. Set to zero to check for all books.</param>
-        /// <param name="chapter">The chapter number. Set to zero to check for all books.</param>
-        /// <returns>
-        /// A dictionary of permissions where the key is the user ID and the value is the permission.
-        /// </returns>
-        /// <remarks>
-        /// See <see cref="TextInfoPermission" /> for permission values.
-        /// A dictionary is returned, as permissions can be updated.
-        /// </remarks>
-        public async Task<Dictionary<string, string>> GetPermissionsAsync(
-            UserSecret userSecret,
-            SFProject sfProject,
-            IReadOnlyDictionary<string, string> ptUsernameMapping,
-            int book = 0,
-            int chapter = 0,
-            CancellationToken token = default
-        )
-        {
-            var permissions = new Dictionary<string, string>();
-
-            if (IsResource(sfProject.ParatextId))
-            {
-                foreach (string sfUserId in sfProject.UserRoles.Keys)
+                else
                 {
-                    permissions.Add(
-                        sfUserId,
-                        await this.GetResourcePermissionAsync(sfProject.ParatextId, sfUserId, token)
-                    );
-                }
-            }
-            else
-            {
-                // Get the scripture text so we can retrieve the permissions from the XML
-                using ScrText scrText = ScrTextCollection.FindById(
-                    GetParatextUsername(userSecret),
-                    sfProject.ParatextId
-                );
-
-                // Calculate the project and resource permissions
-                foreach (string uid in sfProject.UserRoles.Keys)
-                {
-                    // See if the user is in the project members list
-                    if (
-                        !ptUsernameMapping.TryGetValue(uid, out string userName)
-                        || string.IsNullOrWhiteSpace(userName)
-                        || scrText.Permissions.GetRole(userName) == Paratext.Data.Users.UserRoles.None
-                    )
+                    string textInfoPermission = TextInfoPermission.Read;
+                    if (book == 0)
                     {
-                        permissions.Add(uid, TextInfoPermission.None);
-                    }
-                    else
-                    {
-                        string textInfoPermission = TextInfoPermission.Read;
-                        if (book == 0)
+                        // Project level
+                        if (scrText.Permissions.CanEditAllBooks(userName))
                         {
-                            // Project level
+                            textInfoPermission = TextInfoPermission.Write;
+                        }
+                    }
+                    else if (chapter == 0)
+                    {
+                        // Book level
+                        IEnumerable<int> editable = scrText.Permissions.GetEditableBooks(
+                            Paratext.Data.Users.PermissionSet.Merged,
+                            userName
+                        );
+                        if (editable == null || !editable.Any())
+                        {
+                            // If there are no editable book permissions, check if they can edit all books
                             if (scrText.Permissions.CanEditAllBooks(userName))
                             {
                                 textInfoPermission = TextInfoPermission.Write;
                             }
                         }
-                        else if (chapter == 0)
+                        else if (editable.Contains(book))
                         {
-                            // Book level
-                            IEnumerable<int> editable = scrText.Permissions.GetEditableBooks(
-                                Paratext.Data.Users.PermissionSet.Merged,
-                                userName
-                            );
-                            if (editable == null || !editable.Any())
-                            {
-                                // If there are no editable book permissions, check if they can edit all books
-                                if (scrText.Permissions.CanEditAllBooks(userName))
-                                {
-                                    textInfoPermission = TextInfoPermission.Write;
-                                }
-                            }
-                            else if (editable.Contains(book))
-                            {
-                                textInfoPermission = TextInfoPermission.Write;
-                            }
+                            textInfoPermission = TextInfoPermission.Write;
                         }
-                        else
-                        {
-                            // Chapter level
-                            IEnumerable<int> editable = scrText.Permissions.GetEditableChapters(
-                                book,
-                                scrText.Settings.Versification,
-                                userName,
-                                Paratext.Data.Users.PermissionSet.Merged
-                            );
-                            if (editable?.Contains(chapter) ?? false)
-                            {
-                                textInfoPermission = TextInfoPermission.Write;
-                            }
-                        }
-
-                        permissions.Add(uid, textInfoPermission);
-                    }
-                }
-            }
-
-            return permissions;
-        }
-
-        /// <summary>
-        /// Helper method to fetch repositories, and log when there is a problem. The available contextual information
-        /// varies among usages, so it is passed in via string.
-        /// </summary>
-        private IEnumerable<SharedRepository> GetRepositories(
-            IInternetSharedRepositorySource ptRepoSource,
-            string contextInformation
-        )
-        {
-            try
-            {
-                return ptRepoSource.GetRepositories();
-            }
-            catch (Paratext.Data.HttpException e)
-            {
-                string message = $"Problem fetching repositories: {contextInformation}";
-                _logger.LogWarning(e, message);
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// Gets the project roles asynchronously.
-        /// </summary>
-        /// <param name="userSecret">The user secret.</param>
-        /// <param name="project">The project - the UserRoles and ParatextId are used.</param>
-        /// <param name="token">The cancellation token.</param>
-        /// <returns>
-        /// A dictionary where the key is the PT user ID and the value is the PT role.
-        /// </returns>
-        public async Task<IReadOnlyDictionary<string, string>> GetProjectRolesAsync(
-            UserSecret userSecret,
-            SFProject project,
-            CancellationToken token
-        )
-        {
-            if (IsResource(project.ParatextId))
-            {
-                // Resources do not have roles
-                return new Dictionary<string, string>();
-            }
-            else if (await IsRegisteredAsync(userSecret, project.ParatextId, token))
-            {
-                // Paratext RegistryServer has methods to do this, but it is unreliable to use it in a multi-user
-                // environment so instead we call the registry API.
-                string response = await CallApiAsync(
-                    userSecret,
-                    HttpMethod.Get,
-                    $"projects/{project.ParatextId}/members",
-                    null,
-                    token
-                );
-                JArray? members = JArray.Parse(response);
-                if (members == null)
-                {
-                    throw new DataNotFoundException(
-                        $"Got a null list of members when parsing registry members list, for project SF id {project.Id}, using user secret id {userSecret.Id}."
-                    );
-                }
-                return members
-                    .OfType<JObject>()
-                    .Where(
-                        m => !string.IsNullOrEmpty((string?)m["userId"]) && !string.IsNullOrEmpty((string?)m["role"])
-                    )
-                    .ToDictionary(m => (string)m["userId"]!, m => (string)m["role"]!);
-            }
-            else
-            {
-                // Get the list of users from the repository
-                IInternetSharedRepositorySource ptRepoSource = await GetInternetSharedRepositorySource(
-                    userSecret.Id,
-                    CancellationToken.None
-                );
-
-                bool hasRole = project.UserRoles.TryGetValue(userSecret.Id, out string? userRole);
-                string moreInformation =
-                    $"SF user id '{userSecret.Id}', "
-                    + $"while interested in unregistered PT project id '{project.ParatextId}' "
-                    + $"(SF project id {project.Id}). "
-                    + $"On SF project, user has {(hasRole ? $"role '{userRole}'." : "no role.")}";
-
-                IEnumerable<SharedRepository> remotePtProjects = GetRepositories(
-                    ptRepoSource,
-                    $"For {moreInformation}"
-                );
-                SharedRepository? remotePtProject = remotePtProjects.SingleOrDefault(
-                    p => p.SendReceiveId.Id == project.ParatextId
-                );
-                if (remotePtProject == null)
-                {
-                    string projects = string.Join(
-                        ",",
-                        remotePtProjects.Select((SharedRepository r) => r.SendReceiveId.Id)
-                    );
-                    string message =
-                        $"Failed to find project, when looking in permissible set of repositories "
-                        + $"of PT ids '{projects}', for {moreInformation}";
-                    throw new ForbiddenException(message);
-                }
-
-                // Build a dictionary of user IDs mapped to roles using the user secrets
-                var userMapping = new Dictionary<string, string>();
-                foreach (string userId in project.UserRoles.Keys)
-                {
-                    // Reuse the userSecret if this is for the current user
-                    UserSecret projectUserSecret;
-                    if (userId == userSecret.Id)
-                    {
-                        projectUserSecret = userSecret;
                     }
                     else
                     {
-                        projectUserSecret = await _userSecretRepository.GetAsync(userId);
-                    }
-
-                    if (projectUserSecret == null)
-                    {
-                        // Skip users that we won't be able to find a PT role for.
-                        continue;
-                    }
-
-                    // Get the PT role
-                    string? projectUserName = GetParatextUsername(projectUserSecret);
-                    if (projectUserName == null)
-                    {
-                        continue;
-                    }
-
-                    if (remotePtProject.SourceUsers is null)
-                    {
-                        throw new InvalidDataException(
-                            $"Unexpected null SourceUsers when working with PT project id {remotePtProject.SendReceiveId}."
+                        // Chapter level
+                        IEnumerable<int> editable = scrText.Permissions.GetEditableChapters(
+                            book,
+                            scrText.Settings.Versification,
+                            userName,
+                            Paratext.Data.Users.PermissionSet.Merged
                         );
+                        if (editable?.Contains(chapter) ?? false)
+                        {
+                            textInfoPermission = TextInfoPermission.Write;
+                        }
                     }
-                    if (remotePtProject.SourceUsers.Users is null)
-                    {
-                        throw new InvalidDataException(
-                            $"Unexpected null SourceUsers.Users when working with PT project id {remotePtProject.SendReceiveId}."
-                        );
-                    }
-                    string role = ConvertFromUserRole(
-                        remotePtProject.SourceUsers.Users
-                            .SingleOrDefault(u =>
-                            {
-                                if (u is null)
-                                {
-                                    _logger.LogWarning(
-                                        $"An element of SourceUsers.Users was null when working with PT project id {remotePtProject.SendReceiveId}."
-                                    );
-                                }
-                                return u?.UserName == projectUserName;
-                            })
-                            ?.Role
+
+                    permissions.Add(uid, textInfoPermission);
+                }
+            }
+        }
+
+        return permissions;
+    }
+
+    /// <summary>
+    /// Helper method to fetch repositories, and log when there is a problem. The available contextual information
+    /// varies among usages, so it is passed in via string.
+    /// </summary>
+    private IEnumerable<SharedRepository> GetRepositories(
+        IInternetSharedRepositorySource ptRepoSource,
+        string contextInformation
+    )
+    {
+        try
+        {
+            return ptRepoSource.GetRepositories();
+        }
+        catch (Paratext.Data.HttpException e)
+        {
+            string message = $"Problem fetching repositories: {contextInformation}";
+            _logger.LogWarning(e, message);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Gets the project roles asynchronously.
+    /// </summary>
+    /// <param name="userSecret">The user secret.</param>
+    /// <param name="project">The project - the UserRoles and ParatextId are used.</param>
+    /// <param name="token">The cancellation token.</param>
+    /// <returns>
+    /// A dictionary where the key is the PT user ID and the value is the PT role.
+    /// </returns>
+    public async Task<IReadOnlyDictionary<string, string>> GetProjectRolesAsync(
+        UserSecret userSecret,
+        SFProject project,
+        CancellationToken token
+    )
+    {
+        if (IsResource(project.ParatextId))
+        {
+            // Resources do not have roles
+            return new Dictionary<string, string>();
+        }
+        else if (await IsRegisteredAsync(userSecret, project.ParatextId, token))
+        {
+            // Paratext RegistryServer has methods to do this, but it is unreliable to use it in a multi-user
+            // environment so instead we call the registry API.
+            string response = await CallApiAsync(
+                userSecret,
+                HttpMethod.Get,
+                $"projects/{project.ParatextId}/members",
+                null,
+                token
+            );
+            JArray? members = JArray.Parse(response);
+            if (members == null)
+            {
+                throw new DataNotFoundException(
+                    $"Got a null list of members when parsing registry members list, for project SF id {project.Id}, using user secret id {userSecret.Id}."
+                );
+            }
+            return members
+                .OfType<JObject>()
+                .Where(m => !string.IsNullOrEmpty((string?)m["userId"]) && !string.IsNullOrEmpty((string?)m["role"]))
+                .ToDictionary(m => (string)m["userId"]!, m => (string)m["role"]!);
+        }
+        else
+        {
+            // Get the list of users from the repository
+            IInternetSharedRepositorySource ptRepoSource = await GetInternetSharedRepositorySource(
+                userSecret.Id,
+                CancellationToken.None
+            );
+
+            bool hasRole = project.UserRoles.TryGetValue(userSecret.Id, out string? userRole);
+            string moreInformation =
+                $"SF user id '{userSecret.Id}', "
+                + $"while interested in unregistered PT project id '{project.ParatextId}' "
+                + $"(SF project id {project.Id}). "
+                + $"On SF project, user has {(hasRole ? $"role '{userRole}'." : "no role.")}";
+
+            IEnumerable<SharedRepository> remotePtProjects = GetRepositories(ptRepoSource, $"For {moreInformation}");
+            SharedRepository? remotePtProject = remotePtProjects.SingleOrDefault(
+                p => p.SendReceiveId.Id == project.ParatextId
+            );
+            if (remotePtProject == null)
+            {
+                string projects = string.Join(",", remotePtProjects.Select((SharedRepository r) => r.SendReceiveId.Id));
+                string message =
+                    $"Failed to find project, when looking in permissible set of repositories "
+                    + $"of PT ids '{projects}', for {moreInformation}";
+                throw new ForbiddenException(message);
+            }
+
+            // Build a dictionary of user IDs mapped to roles using the user secrets
+            var userMapping = new Dictionary<string, string>();
+            foreach (string userId in project.UserRoles.Keys)
+            {
+                // Reuse the userSecret if this is for the current user
+                UserSecret projectUserSecret;
+                if (userId == userSecret.Id)
+                {
+                    projectUserSecret = userSecret;
+                }
+                else
+                {
+                    projectUserSecret = await _userSecretRepository.GetAsync(userId);
+                }
+
+                if (projectUserSecret == null)
+                {
+                    // Skip users that we won't be able to find a PT role for.
+                    continue;
+                }
+
+                // Get the PT role
+                string? projectUserName = GetParatextUsername(projectUserSecret);
+                if (projectUserName == null)
+                {
+                    continue;
+                }
+
+                if (remotePtProject.SourceUsers is null)
+                {
+                    throw new InvalidDataException(
+                        $"Unexpected null SourceUsers when working with PT project id {remotePtProject.SendReceiveId}."
                     );
+                }
+                if (remotePtProject.SourceUsers.Users is null)
+                {
+                    throw new InvalidDataException(
+                        $"Unexpected null SourceUsers.Users when working with PT project id {remotePtProject.SendReceiveId}."
+                    );
+                }
+                string role = ConvertFromUserRole(
+                    remotePtProject.SourceUsers.Users
+                        .SingleOrDefault(u =>
+                        {
+                            if (u is null)
+                            {
+                                _logger.LogWarning(
+                                    $"An element of SourceUsers.Users was null when working with PT project id {remotePtProject.SendReceiveId}."
+                                );
+                            }
+                            return u?.UserName == projectUserName;
+                        })
+                        ?.Role
+                );
 
-                    // Get the PT user ID
-                    var accessToken = new JwtSecurityToken(projectUserSecret.ParatextTokens.AccessToken);
-                    string ptUserId = accessToken.Claims.FirstOrDefault(c => c.Type == JwtClaimTypes.Subject)?.Value;
+                // Get the PT user ID
+                var accessToken = new JwtSecurityToken(projectUserSecret.ParatextTokens.AccessToken);
+                string ptUserId = accessToken.Claims.FirstOrDefault(c => c.Type == JwtClaimTypes.Subject)?.Value;
 
-                    // Only add if we have a user ID and role
-                    if (!string.IsNullOrEmpty(ptUserId) && !string.IsNullOrEmpty(role))
+                // Only add if we have a user ID and role
+                if (!string.IsNullOrEmpty(ptUserId) && !string.IsNullOrEmpty(role))
+                {
+                    userMapping.Add(ptUserId, role);
+                }
+            }
+
+            return userMapping;
+        }
+    }
+
+    /// <summary> Gets basic settings for a Paratext project. </summary>
+    /// <returns> The Paratext project settings, or null if the project repository does not exist locally </returns>
+    public ParatextSettings? GetParatextSettings(UserSecret userSecret, string paratextId)
+    {
+        using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
+        if (scrText == null)
+            return null;
+        // Clear the cached comment tag file
+        CommentTags.ClearCacheForProject(scrText);
+        CommentTags commentTags = CommentTags.Get(scrText);
+        IEnumerable<NoteTag> noteTags = commentTags
+            .GetAllTags()
+            .Select(
+                t =>
+                    new NoteTag
                     {
-                        userMapping.Add(ptUserId, role);
+                        TagId = t.Id,
+                        Icon = t.Icon,
+                        Name = t.Name
+                    }
+            );
+
+        return new ParatextSettings
+        {
+            FullName = scrText.FullName,
+            IsRightToLeft = scrText.RightToLeft,
+            Editable = scrText.Settings.Editable,
+            DefaultFontSize = scrText.Settings.DefaultFontSize,
+            DefaultFont = scrText.Settings.DefaultFont,
+            NoteTags = noteTags
+        };
+    }
+
+    /// <summary> Get list of book numbers in PT project. </summary>
+    public IReadOnlyList<int> GetBookList(UserSecret userSecret, string paratextId)
+    {
+        using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
+        if (scrText == null)
+            return Array.Empty<int>();
+        return scrText.Settings.BooksPresentSet.SelectedBookNumbers.ToArray();
+    }
+
+    /// <summary> Get PT book text in USX, or throw if can't. </summary>
+    public string GetBookText(UserSecret userSecret, string paratextId, int bookNum)
+    {
+        using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
+        if (scrText == null)
+            throw new DataNotFoundException("Can't get access to cloned project.");
+        string usfm = scrText.GetText(bookNum);
+        return UsfmToUsx.ConvertToXmlString(scrText, bookNum, usfm, false);
+    }
+
+    /// <summary> Write up-to-date book text from mongo database to Paratext project folder. </summary>
+    /// <remarks> It is up to the caller to determine whether the project text is editable. </remarks>
+    public async Task<int> PutBookText(
+        UserSecret userSecret,
+        string paratextId,
+        int bookNum,
+        XDocument usx,
+        Dictionary<int, string> chapNumToAuthorSFUserIdMap = null
+    )
+    {
+        if (userSecret == null)
+        {
+            throw new ArgumentNullException(nameof(userSecret));
+        }
+        if (string.IsNullOrWhiteSpace(paratextId))
+        {
+            throw new ArgumentNullException(nameof(paratextId));
+        }
+
+        int booksUpdated = 0;
+        StringBuilder log = new StringBuilder(
+            $"ParatextService.PutBookText(userSecret, paratextId {paratextId}, bookNum {bookNum}, usx {usx.Root}, chapterAuthors: {(chapNumToAuthorSFUserIdMap == null ? "null" : ($"count {chapNumToAuthorSFUserIdMap.Count}"))})"
+        );
+        Dictionary<string, ScrText> scrTexts = new Dictionary<string, ScrText>();
+        try
+        {
+            log.AppendLine(
+                $"Querying userSecret (id {userSecret.Id}, tokens null: {userSecret.ParatextTokens == null}) for username."
+            );
+            string username = GetParatextUsername(userSecret);
+            log.AppendLine(
+                $"Acquired username: {(username == null ? "is null" : (username.Length == 0 ? "zero length" : "yes"))}"
+            );
+            using ScrText scrText = ScrTextCollection.FindById(username, paratextId);
+
+            // We add this here so we can dispose in the finally
+            scrTexts.Add(userSecret.Id, scrText);
+            log.AppendLine($"Imported XDocument with {usx.Elements().Count()} elements.");
+            UsxFragmenter.FindFragments(
+                scrText.ScrStylesheet(bookNum),
+                usx.CreateNavigator(),
+                XPathExpression.Compile("*[false()]"),
+                out string usfm
+            );
+            log.AppendLine($"Created usfm of {usfm}");
+            usfm = UsfmToken.NormalizeUsfm(scrText.ScrStylesheet(bookNum), usfm, false, scrText.RightToLeft, scrText);
+            log.AppendLine($"Normalized usfm to {usfm}");
+
+            if (chapNumToAuthorSFUserIdMap == null || chapNumToAuthorSFUserIdMap.Count == 0)
+            {
+                log.AppendLine($"Using current user ({userSecret.Id}) to write book {bookNum} to {scrText.Name}.");
+                // If we don't have chapter authors, update book as current user
+                WriteChapterToScrText(scrText, userSecret.Id, bookNum, 0, usfm);
+                booksUpdated++;
+            }
+            else
+            {
+                // As we have a list of chapter authors, build a dictionary of ScrTexts for each of them
+                foreach (string sfUserId in chapNumToAuthorSFUserIdMap.Values.Distinct())
+                {
+                    if (sfUserId != userSecret.Id)
+                    {
+                        // Get their user secret, so we can get their username, and create their ScrText
+                        log.AppendLine($"Fetching user secret for SF user id '{sfUserId}'.");
+                        UserSecret authorUserSecret = await _userSecretRepository.GetAsync(sfUserId);
+                        log.AppendLine(
+                            $"Received user secret: {(authorUserSecret == null ? "null" : (authorUserSecret.ParatextTokens == null ? "with null tokens" : "with tokens"))}"
+                        );
+                        log.AppendLine($"Fetching PT username from secret.");
+                        string authorUserName = GetParatextUsername(authorUserSecret);
+                        log.AppendLine(
+                            $"Received username: {(authorUserName == null ? "null" : (authorUserName.Length == 0 ? "empty" : "non-empty"))}"
+                        );
+                        log.AppendLine($"Fetching scrtext using this authorUserName for PT project.");
+                        ScrText scrTextForUser = ScrTextCollection.FindById(authorUserName, paratextId);
+                        log.AppendLine(
+                            $"Received ScrText: {(scrTextForUser == null ? "null" : (scrTextForUser.Name))}"
+                        );
+                        scrTexts.Add(sfUserId, scrTextForUser);
                     }
                 }
 
-                return userMapping;
-            }
-        }
-
-        /// <summary> Gets basic settings for a Paratext project. </summary>
-        /// <returns> The Paratext project settings, or null if the project repository does not exist locally </returns>
-        public ParatextSettings? GetParatextSettings(UserSecret userSecret, string paratextId)
-        {
-            using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
-            if (scrText == null)
-                return null;
-            // Clear the cached comment tag file
-            CommentTags.ClearCacheForProject(scrText);
-            CommentTags commentTags = CommentTags.Get(scrText);
-            IEnumerable<NoteTag> noteTags = commentTags
-                .GetAllTags()
-                .Select(
-                    t =>
-                        new NoteTag
-                        {
-                            TagId = t.Id,
-                            Icon = t.Icon,
-                            Name = t.Name
-                        }
-                );
-
-            return new ParatextSettings
-            {
-                FullName = scrText.FullName,
-                IsRightToLeft = scrText.RightToLeft,
-                Editable = scrText.Settings.Editable,
-                DefaultFontSize = scrText.Settings.DefaultFontSize,
-                DefaultFont = scrText.Settings.DefaultFont,
-                NoteTags = noteTags
-            };
-        }
-
-        /// <summary> Get list of book numbers in PT project. </summary>
-        public IReadOnlyList<int> GetBookList(UserSecret userSecret, string paratextId)
-        {
-            using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
-            if (scrText == null)
-                return Array.Empty<int>();
-            return scrText.Settings.BooksPresentSet.SelectedBookNumbers.ToArray();
-        }
-
-        /// <summary> Get PT book text in USX, or throw if can't. </summary>
-        public string GetBookText(UserSecret userSecret, string paratextId, int bookNum)
-        {
-            using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
-            if (scrText == null)
-                throw new DataNotFoundException("Can't get access to cloned project.");
-            string usfm = scrText.GetText(bookNum);
-            return UsfmToUsx.ConvertToXmlString(scrText, bookNum, usfm, false);
-        }
-
-        /// <summary> Write up-to-date book text from mongo database to Paratext project folder. </summary>
-        /// <remarks> It is up to the caller to determine whether the project text is editable. </remarks>
-        public async Task<int> PutBookText(
-            UserSecret userSecret,
-            string paratextId,
-            int bookNum,
-            XDocument usx,
-            Dictionary<int, string> chapNumToAuthorSFUserIdMap = null
-        )
-        {
-            if (userSecret == null)
-            {
-                throw new ArgumentNullException(nameof(userSecret));
-            }
-            if (string.IsNullOrWhiteSpace(paratextId))
-            {
-                throw new ArgumentNullException(nameof(paratextId));
-            }
-
-            int booksUpdated = 0;
-            StringBuilder log = new StringBuilder(
-                $"ParatextService.PutBookText(userSecret, paratextId {paratextId}, bookNum {bookNum}, usx {usx.Root}, chapterAuthors: {(chapNumToAuthorSFUserIdMap == null ? "null" : ($"count {chapNumToAuthorSFUserIdMap.Count}"))})"
-            );
-            Dictionary<string, ScrText> scrTexts = new Dictionary<string, ScrText>();
-            try
-            {
-                log.AppendLine(
-                    $"Querying userSecret (id {userSecret.Id}, tokens null: {userSecret.ParatextTokens == null}) for username."
-                );
-                string username = GetParatextUsername(userSecret);
-                log.AppendLine(
-                    $"Acquired username: {(username == null ? "is null" : (username.Length == 0 ? "zero length" : "yes"))}"
-                );
-                using ScrText scrText = ScrTextCollection.FindById(username, paratextId);
-
-                // We add this here so we can dispose in the finally
-                scrTexts.Add(userSecret.Id, scrText);
-                log.AppendLine($"Imported XDocument with {usx.Elements().Count()} elements.");
-                UsxFragmenter.FindFragments(
-                    scrText.ScrStylesheet(bookNum),
-                    usx.CreateNavigator(),
-                    XPathExpression.Compile("*[false()]"),
-                    out string usfm
-                );
-                log.AppendLine($"Created usfm of {usfm}");
-                usfm = UsfmToken.NormalizeUsfm(
-                    scrText.ScrStylesheet(bookNum),
-                    usfm,
-                    false,
-                    scrText.RightToLeft,
-                    scrText
-                );
-                log.AppendLine($"Normalized usfm to {usfm}");
-
-                if (chapNumToAuthorSFUserIdMap == null || chapNumToAuthorSFUserIdMap.Count == 0)
+                // If there is only one author, just write the book
+                if (scrTexts.Count == 1)
                 {
-                    log.AppendLine($"Using current user ({userSecret.Id}) to write book {bookNum} to {scrText.Name}.");
-                    // If we don't have chapter authors, update book as current user
-                    WriteChapterToScrText(scrText, userSecret.Id, bookNum, 0, usfm);
+                    try
+                    {
+                        ScrText target = scrTexts.Values.First();
+                        string authorSFUserId = scrTexts.Keys.First();
+                        log.AppendLine(
+                            $"Using single author (SF user id '{authorSFUserId}') to write to {target.Name} book {bookNum}."
+                        );
+                        WriteChapterToScrText(target, authorSFUserId, bookNum, 0, usfm);
+                    }
+                    catch (SafetyCheckException e)
+                    {
+                        log.AppendLine(
+                            $"There was trouble writing ({e.Message}). Trying again, but using SF user id '{userSecret.Id}' to write to {scrText.Name}"
+                        );
+                        // If the author does not have permission, attempt to run as the current user
+                        WriteChapterToScrText(scrText, userSecret.Id, bookNum, 0, usfm);
+                    }
+
                     booksUpdated++;
                 }
                 else
                 {
-                    // As we have a list of chapter authors, build a dictionary of ScrTexts for each of them
-                    foreach (string sfUserId in chapNumToAuthorSFUserIdMap.Values.Distinct())
-                    {
-                        if (sfUserId != userSecret.Id)
-                        {
-                            // Get their user secret, so we can get their username, and create their ScrText
-                            log.AppendLine($"Fetching user secret for SF user id '{sfUserId}'.");
-                            UserSecret authorUserSecret = await _userSecretRepository.GetAsync(sfUserId);
-                            log.AppendLine(
-                                $"Received user secret: {(authorUserSecret == null ? "null" : (authorUserSecret.ParatextTokens == null ? "with null tokens" : "with tokens"))}"
-                            );
-                            log.AppendLine($"Fetching PT username from secret.");
-                            string authorUserName = GetParatextUsername(authorUserSecret);
-                            log.AppendLine(
-                                $"Received username: {(authorUserName == null ? "null" : (authorUserName.Length == 0 ? "empty" : "non-empty"))}"
-                            );
-                            log.AppendLine($"Fetching scrtext using this authorUserName for PT project.");
-                            ScrText scrTextForUser = ScrTextCollection.FindById(authorUserName, paratextId);
-                            log.AppendLine(
-                                $"Received ScrText: {(scrTextForUser == null ? "null" : (scrTextForUser.Name))}"
-                            );
-                            scrTexts.Add(sfUserId, scrTextForUser);
-                        }
-                    }
+                    log.AppendLine($"There are multiple authors. Splitting USFM into chapters.");
+                    // Split the usfm into chapters
+                    List<string> chapters = ScrText.SplitIntoChapters(scrText.Name, bookNum, usfm);
+                    log.AppendLine($"Received chapters: {(chapters == null ? "null" : ($"count {chapters.Count}"))}");
 
-                    // If there is only one author, just write the book
-                    if (scrTexts.Count == 1)
+                    // Put the individual chapters
+                    foreach ((int chapterNum, string authorSFUserId) in chapNumToAuthorSFUserIdMap)
                     {
-                        try
+                        if ((chapterNum - 1) < chapters.Count)
                         {
-                            ScrText target = scrTexts.Values.First();
-                            string authorSFUserId = scrTexts.Keys.First();
-                            log.AppendLine(
-                                $"Using single author (SF user id '{authorSFUserId}') to write to {target.Name} book {bookNum}."
-                            );
-                            WriteChapterToScrText(target, authorSFUserId, bookNum, 0, usfm);
-                        }
-                        catch (SafetyCheckException e)
-                        {
-                            log.AppendLine(
-                                $"There was trouble writing ({e.Message}). Trying again, but using SF user id '{userSecret.Id}' to write to {scrText.Name}"
-                            );
-                            // If the author does not have permission, attempt to run as the current user
-                            WriteChapterToScrText(scrText, userSecret.Id, bookNum, 0, usfm);
-                        }
-
-                        booksUpdated++;
-                    }
-                    else
-                    {
-                        log.AppendLine($"There are multiple authors. Splitting USFM into chapters.");
-                        // Split the usfm into chapters
-                        List<string> chapters = ScrText.SplitIntoChapters(scrText.Name, bookNum, usfm);
-                        log.AppendLine(
-                            $"Received chapters: {(chapters == null ? "null" : ($"count {chapters.Count}"))}"
-                        );
-
-                        // Put the individual chapters
-                        foreach ((int chapterNum, string authorSFUserId) in chapNumToAuthorSFUserIdMap)
-                        {
-                            if ((chapterNum - 1) < chapters.Count)
+                            try
                             {
-                                try
-                                {
-                                    ScrText target = scrTexts[authorSFUserId];
-                                    string payloadUsfm = chapters[chapterNum - 1];
-                                    log.AppendLine(
-                                        $"Writing to {target.Name}, chapter {chapterNum}, using author SF user id {authorSFUserId}, the usfm: {payloadUsfm}"
-                                    );
-                                    // The ScrText permissions will be the same as the last sync's permissions
-                                    WriteChapterToScrText(target, authorSFUserId, bookNum, chapterNum, payloadUsfm);
-                                }
-                                catch (SafetyCheckException e)
-                                {
-                                    log.AppendLine(
-                                        $"There was trouble writing ({e.Message}). Trying again, but using SF user id '{userSecret.Id}' to write to {scrText.Name}. Also now writing the whole book, not just the single chapter."
-                                    );
-                                    // If the author does not have permission, attempt to run as the current user
-                                    WriteChapterToScrText(scrText, userSecret.Id, bookNum, 0, usfm);
-                                }
+                                ScrText target = scrTexts[authorSFUserId];
+                                string payloadUsfm = chapters[chapterNum - 1];
+                                log.AppendLine(
+                                    $"Writing to {target.Name}, chapter {chapterNum}, using author SF user id {authorSFUserId}, the usfm: {payloadUsfm}"
+                                );
+                                // The ScrText permissions will be the same as the last sync's permissions
+                                WriteChapterToScrText(target, authorSFUserId, bookNum, chapterNum, payloadUsfm);
                             }
-                            else
+                            catch (SafetyCheckException e)
                             {
-                                log.AppendLine($"Not processing erroneous chapter number '{chapterNum}'");
+                                log.AppendLine(
+                                    $"There was trouble writing ({e.Message}). Trying again, but using SF user id '{userSecret.Id}' to write to {scrText.Name}. Also now writing the whole book, not just the single chapter."
+                                );
+                                // If the author does not have permission, attempt to run as the current user
+                                WriteChapterToScrText(scrText, userSecret.Id, bookNum, 0, usfm);
                             }
                         }
-
-                        booksUpdated++;
+                        else
+                        {
+                            log.AppendLine($"Not processing erroneous chapter number '{chapterNum}'");
+                        }
                     }
+
+                    booksUpdated++;
                 }
             }
-            catch (Exception e)
+        }
+        catch (Exception e)
+        {
+            log.AppendLine($"An exception occurred while processing: {e}");
+            log.AppendLine($"ScrTexts contained {scrTexts.Count} projects.");
+            string uniqueCode = $"ParatextService.PutBookText.{DateTime.UtcNow}";
+            e.Data.Add(uniqueCode, log.ToString());
+            throw;
+        }
+        finally
+        {
+            // Dispose the ScrText objects
+            foreach (ScrText scrText in scrTexts.Values)
             {
-                log.AppendLine($"An exception occurred while processing: {e}");
-                log.AppendLine($"ScrTexts contained {scrTexts.Count} projects.");
-                string uniqueCode = $"ParatextService.PutBookText.{DateTime.UtcNow}";
-                e.Data.Add(uniqueCode, log.ToString());
-                throw;
-            }
-            finally
-            {
-                // Dispose the ScrText objects
-                foreach (ScrText scrText in scrTexts.Values)
-                {
-                    scrText?.Dispose();
-                }
-
-                // Clear the collection to release the references to the ScrTexts for GC
-                scrTexts.Clear();
+                scrText?.Dispose();
             }
 
-            return booksUpdated;
+            // Clear the collection to release the references to the ScrTexts for GC
+            scrTexts.Clear();
         }
 
-        /// <summary> Get notes from the Paratext project folder. </summary>
-        public string GetNotes(UserSecret userSecret, string paratextId, int bookNum)
-        {
-            // TODO: should return some data structure instead of XML
-            using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
-            if (scrText == null)
-                return null;
+        return booksUpdated;
+    }
 
-            CommentManager manager = CommentManager.Get(scrText);
-            var threads = manager.FindThreads(commentThread => commentThread.VerseRef.BookNum == bookNum, true);
-            return NotesFormatter.FormatNotes(threads);
-        }
+    /// <summary> Get notes from the Paratext project folder. </summary>
+    public string GetNotes(UserSecret userSecret, string paratextId, int bookNum)
+    {
+        // TODO: should return some data structure instead of XML
+        using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
+        if (scrText == null)
+            return null;
 
-        /// <summary> Write up-to-date notes from the mongo database to the Paratext project folder </summary>
-        public SyncMetricInfo PutNotes(UserSecret userSecret, string paratextId, XElement notesElement)
+        CommentManager manager = CommentManager.Get(scrText);
+        var threads = manager.FindThreads(commentThread => commentThread.VerseRef.BookNum == bookNum, true);
+        return NotesFormatter.FormatNotes(threads);
+    }
+
+    /// <summary> Write up-to-date notes from the mongo database to the Paratext project folder </summary>
+    public SyncMetricInfo PutNotes(UserSecret userSecret, string paratextId, XElement notesElement)
+    {
+        // TODO: should accept some data structure instead of XML
+        var changeList = NotesFormatter.ParseNotes(notesElement, new SFParatextUser(GetParatextUsername(userSecret)));
+        return PutCommentThreads(userSecret, paratextId, changeList);
+    }
+
+    /// <summary>
+    /// Returns a list of changes to apply to SF note threads to match the corresponding
+    /// PT comment threads for a given book.
+    /// </summary>
+    public IEnumerable<NoteThreadChange> GetNoteThreadChanges(
+        UserSecret userSecret,
+        string paratextId,
+        int bookNum,
+        IEnumerable<IDocument<NoteThread>> noteThreadDocs,
+        Dictionary<int, ChapterDelta> chapterDeltas,
+        Dictionary<string, ParatextUserProfile> ptProjectUsers
+    )
+    {
+        IEnumerable<CommentThread> commentThreads = GetCommentThreads(userSecret, paratextId, bookNum);
+        CommentTags commentTags = GetCommentTags(userSecret, paratextId);
+        List<string> matchedThreadIds = new List<string>();
+        List<NoteThreadChange> changes = new List<NoteThreadChange>();
+
+        foreach (var threadDoc in noteThreadDocs)
         {
-            // TODO: should accept some data structure instead of XML
-            var changeList = NotesFormatter.ParseNotes(
-                notesElement,
-                new SFParatextUser(GetParatextUsername(userSecret))
+            List<string> matchedCommentIds = new List<string>();
+            NoteThreadChange threadChange = new NoteThreadChange(
+                threadDoc.Data.DataId,
+                threadDoc.Data.VerseRef.ToString(),
+                threadDoc.Data.OriginalSelectedText,
+                threadDoc.Data.OriginalContextBefore,
+                threadDoc.Data.OriginalContextAfter,
+                threadDoc.Data.Status,
+                threadDoc.Data.Assignment
             );
-            return PutCommentThreads(userSecret, paratextId, changeList);
-        }
-
-        /// <summary>
-        /// Returns a list of changes to apply to SF note threads to match the corresponding
-        /// PT comment threads for a given book.
-        /// </summary>
-        public IEnumerable<NoteThreadChange> GetNoteThreadChanges(
-            UserSecret userSecret,
-            string paratextId,
-            int bookNum,
-            IEnumerable<IDocument<NoteThread>> noteThreadDocs,
-            Dictionary<int, ChapterDelta> chapterDeltas,
-            Dictionary<string, ParatextUserProfile> ptProjectUsers
-        )
-        {
-            IEnumerable<CommentThread> commentThreads = GetCommentThreads(userSecret, paratextId, bookNum);
-            CommentTags commentTags = GetCommentTags(userSecret, paratextId);
-            List<string> matchedThreadIds = new List<string>();
-            List<NoteThreadChange> changes = new List<NoteThreadChange>();
-
-            foreach (var threadDoc in noteThreadDocs)
+            // Find the corresponding comment thread
+            var existingThread = commentThreads.SingleOrDefault(ct => ct.Id == threadDoc.Data.DataId);
+            if (existingThread == null)
             {
-                List<string> matchedCommentIds = new List<string>();
-                NoteThreadChange threadChange = new NoteThreadChange(
-                    threadDoc.Data.DataId,
-                    threadDoc.Data.VerseRef.ToString(),
-                    threadDoc.Data.OriginalSelectedText,
-                    threadDoc.Data.OriginalContextBefore,
-                    threadDoc.Data.OriginalContextAfter,
-                    threadDoc.Data.Status,
-                    threadDoc.Data.Assignment
-                );
-                // Find the corresponding comment thread
-                var existingThread = commentThreads.SingleOrDefault(ct => ct.Id == threadDoc.Data.DataId);
-                if (existingThread == null)
-                {
-                    // The thread has been removed
-                    threadChange.ThreadRemoved = true;
-                    changes.Add(threadChange);
-                    continue;
-                }
-                matchedThreadIds.Add(existingThread.Id);
-                foreach (Note note in threadDoc.Data.Notes)
-                {
-                    Paratext.Data.ProjectComments.Comment matchedComment = GetMatchingCommentFromNote(
-                        note,
-                        existingThread,
-                        ptProjectUsers
-                    );
-                    if (matchedComment != null)
-                    {
-                        matchedCommentIds.Add(matchedComment.Id);
-                        Paratext.Data.ProjectComments.CommentTag commentIconTag = GetCommentTag(
-                            existingThread,
-                            matchedComment,
-                            commentTags
-                        );
-                        ChangeType changeType = GetCommentChangeType(
-                            matchedComment,
-                            note,
-                            commentIconTag,
-                            ptProjectUsers
-                        );
-                        if (changeType != ChangeType.None)
-                        {
-                            threadChange.AddChange(
-                                CreateNoteFromComment(note.DataId, matchedComment, commentIconTag, ptProjectUsers),
-                                changeType
-                            );
-                        }
-                    }
-                    else
-                        threadChange.NoteIdsRemoved.Add(note.DataId);
-                }
-                if (existingThread.Status.InternalValue != threadDoc.Data.Status)
-                {
-                    threadChange.Status = existingThread.Status.InternalValue;
-                    threadChange.ThreadUpdated = true;
-                }
-                if (GetAssignedUserRef(existingThread.AssignedUser, ptProjectUsers) != threadDoc.Data.Assignment)
-                {
-                    threadChange.Assignment = GetAssignedUserRef(existingThread.AssignedUser, ptProjectUsers);
-                    threadChange.ThreadUpdated = true;
-                }
-
-                // Add new Comments to note thread change
-                IEnumerable<string> ptCommentIds = existingThread.Comments.Select(c => c.Id);
-                IEnumerable<string> newCommentIds = ptCommentIds.Except(matchedCommentIds);
-                foreach (string commentId in newCommentIds)
-                {
-                    Paratext.Data.ProjectComments.Comment comment = existingThread.Comments.Single(
-                        c => c.Id == commentId
-                    );
-                    CommentTag commentIconTag = GetCommentTag(existingThread, comment, commentTags);
-                    threadChange.AddChange(
-                        CreateNoteFromComment(_guidService.NewObjectId(), comment, commentIconTag, ptProjectUsers),
-                        ChangeType.Added
-                    );
-                }
-                if (existingThread.Comments.Count > 0)
-                {
-                    // Get the text anchor to use for the note
-                    TextAnchor range = GetThreadTextAnchor(existingThread, chapterDeltas);
-                    if (!range.Equals(threadDoc.Data.Position))
-                        threadChange.Position = range;
-                }
-                if (threadChange.HasChange)
-                    changes.Add(threadChange);
+                // The thread has been removed
+                threadChange.ThreadRemoved = true;
+                changes.Add(threadChange);
+                continue;
             }
-
-            IEnumerable<string> ptThreadIds = commentThreads.Select(ct => ct.Id);
-            IEnumerable<string> newThreadIds = ptThreadIds.Except(matchedThreadIds);
-            foreach (string threadId in newThreadIds)
+            matchedThreadIds.Add(existingThread.Id);
+            foreach (Note note in threadDoc.Data.Notes)
             {
-                CommentThread thread = commentThreads.Single(ct => ct.Id == threadId);
-                Paratext.Data.ProjectComments.Comment info = thread.Comments[0];
-                NoteThreadChange newThread = new NoteThreadChange(
-                    threadId,
-                    info.VerseRefStr,
-                    info.SelectedText,
-                    info.ContextBefore,
-                    info.ContextAfter,
-                    info.Status.InternalValue,
-                    info.AssignedUser
-                );
-                newThread.Position = GetThreadTextAnchor(thread, chapterDeltas);
-                newThread.Status = thread.Status.InternalValue;
-                newThread.Assignment = GetAssignedUserRef(thread.AssignedUser, ptProjectUsers);
-                foreach (var comm in thread.Comments)
-                {
-                    CommentTag commentIconTag = GetCommentTag(thread, comm, commentTags);
-                    newThread.AddChange(
-                        CreateNoteFromComment(_guidService.NewObjectId(), comm, commentIconTag, ptProjectUsers),
-                        ChangeType.Added
-                    );
-                }
-                changes.Add(newThread);
-            }
-            return changes;
-        }
-
-        public async Task<SyncMetricInfo> UpdateParatextCommentsAsync(
-            UserSecret userSecret,
-            string paratextId,
-            int bookNum,
-            IEnumerable<IDocument<NoteThread>> noteThreadDocs,
-            Dictionary<string, ParatextUserProfile> ptProjectUsers,
-            int sfNoteTagId
-        )
-        {
-            string username = GetParatextUsername(userSecret);
-            IEnumerable<CommentThread> commentThreads = GetCommentThreads(userSecret, paratextId, bookNum);
-            List<List<Paratext.Data.ProjectComments.Comment>> noteThreadChangeList =
-                await SFNotesToCommentChangeListAsync(
-                    noteThreadDocs,
-                    commentThreads,
-                    username,
-                    sfNoteTagId,
+                Paratext.Data.ProjectComments.Comment matchedComment = GetMatchingCommentFromNote(
+                    note,
+                    existingThread,
                     ptProjectUsers
                 );
-
-            return PutCommentThreads(userSecret, paratextId, noteThreadChangeList);
-        }
-
-        /// <summary> Adds the comment tag to the list of comment tags if that tag does not already exist. </summary>
-        /// <returns> The id of the tag that was added. </returns>
-        public int UpdateCommentTag(UserSecret userSecret, string paratextId, NoteTag noteTag)
-        {
-            CommentTags commentTags = GetCommentTags(userSecret, paratextId);
-            if (noteTag.TagId != NoteTag.notSetId)
-            {
-                // Disallow updating existing comment tags from SF
-                throw new ArgumentException("Cannot update an existing comment tag via Scripture Forge");
+                if (matchedComment != null)
+                {
+                    matchedCommentIds.Add(matchedComment.Id);
+                    Paratext.Data.ProjectComments.CommentTag commentIconTag = GetCommentTag(
+                        existingThread,
+                        matchedComment,
+                        commentTags
+                    );
+                    ChangeType changeType = GetCommentChangeType(matchedComment, note, commentIconTag, ptProjectUsers);
+                    if (changeType != ChangeType.None)
+                    {
+                        threadChange.AddChange(
+                            CreateNoteFromComment(note.DataId, matchedComment, commentIconTag, ptProjectUsers),
+                            changeType
+                        );
+                    }
+                }
+                else
+                    threadChange.NoteIdsRemoved.Add(note.DataId);
             }
-            var newCommentTag = new CommentTag(noteTag.Name, noteTag.Icon);
-            // Check that the tag does not already exist
-            if (commentTags.FindMatchingTag(newCommentTag) == CommentTag.toDoTagId)
+            if (existingThread.Status.InternalValue != threadDoc.Data.Status)
             {
-                // The to do tag is returned as the default if a matching tag does not exist
-                commentTags.AddOrUpdate(newCommentTag);
+                threadChange.Status = existingThread.Status.InternalValue;
+                threadChange.ThreadUpdated = true;
             }
-            return commentTags.FindMatchingTag(newCommentTag);
-        }
-
-        /// <summary>
-        /// Get the most recent revision id of a commit from the last push or pull with the PT send/receive server.
-        /// </summary>
-        public string? GetLatestSharedVersion(UserSecret userSecret, string paratextId)
-        {
-            if (IsResource(paratextId))
+            if (GetAssignedUserRef(existingThread.AssignedUser, ptProjectUsers) != threadDoc.Data.Assignment)
             {
-                // Not meaningful for DBL resources, which do not have a local hg repo.
-                return null;
+                threadChange.Assignment = GetAssignedUserRef(existingThread.AssignedUser, ptProjectUsers);
+                threadChange.ThreadUpdated = true;
             }
 
-            using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
-            if (scrText != null)
+            // Add new Comments to note thread change
+            IEnumerable<string> ptCommentIds = existingThread.Comments.Select(c => c.Id);
+            IEnumerable<string> newCommentIds = ptCommentIds.Except(matchedCommentIds);
+            foreach (string commentId in newCommentIds)
             {
-                return _hgHelper.GetLastPublicRevision(scrText.Directory);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>Returns the current revision of the local hg repo for a given PT project id,
-        /// accessed using a given user.</summary>
-        public string GetRepoRevision(UserSecret userSecret, string paratextId)
-        {
-            if (IsResource(paratextId))
-            {
-                throw new InvalidOperationException("Cannot query a resource for an hg repo revision.");
-            }
-            using ScrText scrText = GetScrText(userSecret, paratextId);
-            return _hgHelper.GetRepoRevision(scrText.Directory);
-        }
-
-        /// <summary>Set a project local hg repo to a given Mercurial revision. Accessed by a given user.</summary>>
-        public void SetRepoToRevision(UserSecret userSecret, string paratextid, string desiredRevision)
-        {
-            if (IsResource(paratextid))
-            {
-                throw new InvalidOperationException("Cannot query a resource for an hg repo revision.");
-            }
-            using ScrText scrText = GetScrText(userSecret, paratextid);
-            // Act
-            _hgHelper.Update(scrText.Directory, desiredRevision);
-            // Verify
-            string currentRepoRev = GetRepoRevision(userSecret, paratextid);
-            if (currentRepoRev != desiredRevision)
-            {
-                throw new Exception(
-                    $"SetRepoToRevision failed to set repo for PT project id {paratextid} to revision {desiredRevision}, as the resulting revision is {currentRepoRev}."
+                Paratext.Data.ProjectComments.Comment comment = existingThread.Comments.Single(c => c.Id == commentId);
+                CommentTag commentIconTag = GetCommentTag(existingThread, comment, commentTags);
+                threadChange.AddChange(
+                    CreateNoteFromComment(_guidService.NewObjectId(), comment, commentIconTag, ptProjectUsers),
+                    ChangeType.Added
                 );
             }
+            if (existingThread.Comments.Count > 0)
+            {
+                // Get the text anchor to use for the note
+                TextAnchor range = GetThreadTextAnchor(existingThread, chapterDeltas);
+                if (!range.Equals(threadDoc.Data.Position))
+                    threadChange.Position = range;
+            }
+            if (threadChange.HasChange)
+                changes.Add(threadChange);
         }
 
-        /// <summary>
-        /// Checks whether a backup exists for the Paratext project repository.
-        /// </summary>
-        /// <param name="userSecret">The user secret.</param>
-        /// <param name="paratextId">The Paratext project identifier.</param>
-        /// <returns>
-        ///   <c>true</c> if the backup exists; otherwise, <c>false</c>.
-        /// </returns>
-        public bool BackupExists(UserSecret userSecret, string paratextId)
+        IEnumerable<string> ptThreadIds = commentThreads.Select(ct => ct.Id);
+        IEnumerable<string> newThreadIds = ptThreadIds.Except(matchedThreadIds);
+        foreach (string threadId in newThreadIds)
         {
-            // We do not back up resources
-            if (paratextId == null || IsResource(paratextId))
+            CommentThread thread = commentThreads.Single(ct => ct.Id == threadId);
+            Paratext.Data.ProjectComments.Comment info = thread.Comments[0];
+            NoteThreadChange newThread = new NoteThreadChange(
+                threadId,
+                info.VerseRefStr,
+                info.SelectedText,
+                info.ContextBefore,
+                info.ContextAfter,
+                info.Status.InternalValue,
+                info.AssignedUser
+            )
             {
-                return false;
-            }
-
-            // Get the scripture text
-            using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
-
-            // If we do not have a scripture text, do not back up
-            if (scrText == null)
+                Position = GetThreadTextAnchor(thread, chapterDeltas),
+                Status = thread.Status.InternalValue,
+                Assignment = GetAssignedUserRef(thread.AssignedUser, ptProjectUsers)
+            };
+            foreach (var comm in thread.Comments)
             {
-                return false;
+                CommentTag commentIconTag = GetCommentTag(thread, comm, commentTags);
+                newThread.AddChange(
+                    CreateNoteFromComment(_guidService.NewObjectId(), comm, commentIconTag, ptProjectUsers),
+                    ChangeType.Added
+                );
             }
+            changes.Add(newThread);
+        }
+        return changes;
+    }
 
-            // Use the Paratext implementation
-            return this.BackupExistsInternal(scrText);
+    public async Task<SyncMetricInfo> UpdateParatextCommentsAsync(
+        UserSecret userSecret,
+        string paratextId,
+        int bookNum,
+        IEnumerable<IDocument<NoteThread>> noteThreadDocs,
+        Dictionary<string, ParatextUserProfile> ptProjectUsers,
+        int sfNoteTagId
+    )
+    {
+        string username = GetParatextUsername(userSecret);
+        IEnumerable<CommentThread> commentThreads = GetCommentThreads(userSecret, paratextId, bookNum);
+        List<List<Paratext.Data.ProjectComments.Comment>> noteThreadChangeList = await SFNotesToCommentChangeListAsync(
+            noteThreadDocs,
+            commentThreads,
+            username,
+            sfNoteTagId,
+            ptProjectUsers
+        );
+
+        return PutCommentThreads(userSecret, paratextId, noteThreadChangeList);
+    }
+
+    /// <summary> Adds the comment tag to the list of comment tags if that tag does not already exist. </summary>
+    /// <returns> The id of the tag that was added. </returns>
+    public int UpdateCommentTag(UserSecret userSecret, string paratextId, NoteTag noteTag)
+    {
+        CommentTags commentTags = GetCommentTags(userSecret, paratextId);
+        if (noteTag.TagId != NoteTag.notSetId)
+        {
+            // Disallow updating existing comment tags from SF
+            throw new ArgumentException("Cannot update an existing comment tag via Scripture Forge");
+        }
+        var newCommentTag = new CommentTag(noteTag.Name, noteTag.Icon);
+        // Check that the tag does not already exist
+        if (commentTags.FindMatchingTag(newCommentTag) == CommentTag.toDoTagId)
+        {
+            // The to do tag is returned as the default if a matching tag does not exist
+            commentTags.AddOrUpdate(newCommentTag);
+        }
+        return commentTags.FindMatchingTag(newCommentTag);
+    }
+
+    /// <summary>
+    /// Get the most recent revision id of a commit from the last push or pull with the PT send/receive server.
+    /// </summary>
+    public string? GetLatestSharedVersion(UserSecret userSecret, string paratextId)
+    {
+        if (IsResource(paratextId))
+        {
+            // Not meaningful for DBL resources, which do not have a local hg repo.
+            return null;
         }
 
-        public bool BackupRepository(UserSecret userSecret, string paratextId)
+        using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
+        if (scrText != null)
         {
-            // We do not back up resources
-            if (paratextId == null || IsResource(paratextId))
+            return _hgHelper.GetLastPublicRevision(scrText.Directory);
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Returns the current revision of the local hg repo for a given PT project id,
+    /// accessed using a given user.</summary>
+    public string GetRepoRevision(UserSecret userSecret, string paratextId)
+    {
+        if (IsResource(paratextId))
+        {
+            throw new InvalidOperationException("Cannot query a resource for an hg repo revision.");
+        }
+        using ScrText scrText = GetScrText(userSecret, paratextId);
+        return _hgHelper.GetRepoRevision(scrText.Directory);
+    }
+
+    /// <summary>Set a project local hg repo to a given Mercurial revision. Accessed by a given user.</summary>>
+    public void SetRepoToRevision(UserSecret userSecret, string paratextid, string desiredRevision)
+    {
+        if (IsResource(paratextid))
+        {
+            throw new InvalidOperationException("Cannot query a resource for an hg repo revision.");
+        }
+        using ScrText scrText = GetScrText(userSecret, paratextid);
+        // Act
+        _hgHelper.Update(scrText.Directory, desiredRevision);
+        // Verify
+        string currentRepoRev = GetRepoRevision(userSecret, paratextid);
+        if (currentRepoRev != desiredRevision)
+        {
+            throw new Exception(
+                $"SetRepoToRevision failed to set repo for PT project id {paratextid} to revision {desiredRevision}, as the resulting revision is {currentRepoRev}."
+            );
+        }
+    }
+
+    /// <summary>
+    /// Checks whether a backup exists for the Paratext project repository.
+    /// </summary>
+    /// <param name="userSecret">The user secret.</param>
+    /// <param name="paratextId">The Paratext project identifier.</param>
+    /// <returns>
+    ///   <c>true</c> if the backup exists; otherwise, <c>false</c>.
+    /// </returns>
+    public bool BackupExists(UserSecret userSecret, string paratextId)
+    {
+        // We do not back up resources
+        if (paratextId == null || IsResource(paratextId))
+        {
+            return false;
+        }
+
+        // Get the scripture text
+        using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
+
+        // If we do not have a scripture text, do not back up
+        if (scrText == null)
+        {
+            return false;
+        }
+
+        // Use the Paratext implementation
+        return this.BackupExistsInternal(scrText);
+    }
+
+    public bool BackupRepository(UserSecret userSecret, string paratextId)
+    {
+        // We do not back up resources
+        if (paratextId == null || IsResource(paratextId))
+        {
+            if (paratextId == null)
             {
-                if (paratextId == null)
-                {
-                    _logger.LogInformation("Not backing up local PT repo for null paratextId.");
-                }
-                return false;
+                _logger.LogInformation("Not backing up local PT repo for null paratextId.");
+            }
+            return false;
+        }
+
+        // Get the scripture text
+        using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
+
+        // If we do not have a scripture text, do not back up
+        if (scrText == null)
+        {
+            _logger.LogInformation($"Not backing up local PT repo since no scrText for PTId '{paratextId}'.");
+            return false;
+        }
+
+        // VersionedText.BackupDirectories skips backup on error, and runs in a background thread.
+        // We would rather be notified of the error, and not have this run in a background thread.
+        // The following is a re-implementation of VersionedText.BackupDirectories with error trapping,
+        // and file system and Mercurial dependency injection so this method can be unit tested.
+        // Note that SharedProject.Repository.SendReceiveId is equivalent to ScrText.Guid - compare the
+        // BackupProject and RestoreProject implementations in Paratext.Data.Repository.VersionedText.
+        try
+        {
+            string directory = Path.Combine(Paratext.Data.ScrTextCollection.SettingsDirectory, "_Backups");
+            string path = Path.Combine(directory, scrText.Guid + ".bndl");
+            string tempPath = path + "_temp";
+            _fileSystemService.CreateDirectory(directory);
+
+            _hgHelper.BackupRepository(scrText.Directory, tempPath);
+            if (_fileSystemService.FileExists(path))
+            {
+                _fileSystemService.DeleteFile(path);
             }
 
-            // Get the scripture text
-            using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
+            _fileSystemService.MoveFile(tempPath, path);
+            return true;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, $"Problem backing up local PT repo for PTId '{paratextId}'.");
+            // An error has occurred, so the backup was not created
+            return false;
+        }
+    }
 
-            // If we do not have a scripture text, do not back up
-            if (scrText == null)
+    public bool RestoreRepository(UserSecret userSecret, string paratextId)
+    {
+        // We do not back up resources
+        if (paratextId == null || IsResource(paratextId))
+        {
+            if (paratextId == null)
             {
-                _logger.LogInformation($"Not backing up local PT repo since no scrText for PTId '{paratextId}'.");
-                return false;
+                _logger.LogInformation("Not restoring local PT repo for null paratextId.");
+            }
+            else if (IsResource(paratextId))
+            {
+                _logger.LogInformation("Not restoring a DBL resource.");
             }
 
-            // VersionedText.BackupDirectories skips backup on error, and runs in a background thread.
-            // We would rather be notified of the error, and not have this run in a background thread.
-            // The following is a re-implementation of VersionedText.BackupDirectories with error trapping,
-            // and file system and Mercurial dependency injection so this method can be unit tested.
-            // Note that SharedProject.Repository.SendReceiveId is equivalent to ScrText.Guid - compare the
-            // BackupProject and RestoreProject implementations in Paratext.Data.Repository.VersionedText.
+            return false;
+        }
+
+        // Get the scripture text
+        using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
+
+        // If we do not have a scripture text, do not back up
+        if (scrText == null)
+        {
+            _logger.LogInformation($"Not restoring local PT repo since no scrText for PTId '{paratextId}'.");
+            return false;
+        }
+
+        // VersionedText.RestoreProject copies files from the repository to the restored backup.
+        // We would rather not do this, as there can be files trapped in the directory, particularly
+        // if the incoming change included new books and the sync was cancelled. In addition,
+        // Mongo is the source of truth for a project's state in Scripture Forge.
+        // The following is a re-implementation of VersionedText.RestoreProject with error trapping,
+        // and file system and Mercurial dependency injection so this method can be unit tested.
+        if (this.BackupExistsInternal(scrText))
+        {
+            string source = scrText.Directory;
+            string destination = Path.Combine(
+                Paratext.Data.ScrTextCollection.SettingsDirectory,
+                "_Backups",
+                scrText.Guid.ToString()
+            );
+            string restoredDestination = destination + "_Restored";
+            string backupPath = destination + ".bndl";
+
             try
             {
-                string directory = Path.Combine(Paratext.Data.ScrTextCollection.SettingsDirectory, "_Backups");
-                string path = Path.Combine(directory, scrText.Guid + ".bndl");
-                string tempPath = path + "_temp";
-                _fileSystemService.CreateDirectory(directory);
-
-                _hgHelper.BackupRepository(scrText.Directory, tempPath);
-                if (_fileSystemService.FileExists(path))
+                if (_fileSystemService.DirectoryExists(restoredDestination))
                 {
-                    _fileSystemService.DeleteFile(path);
+                    _fileSystemService.DeleteDirectory(restoredDestination);
                 }
 
-                _fileSystemService.MoveFile(tempPath, path);
+                // Remove the backup destination, if it exists
+                if (_fileSystemService.DirectoryExists(destination))
+                {
+                    _fileSystemService.DeleteDirectory(destination);
+                }
+
+                // Move the current repository to the backup destination
+                if (source != destination)
+                {
+                    _fileSystemService.MoveDirectory(source, destination);
+                }
+
+                // Restore the Mercurial repository to a temporary destination
+                _hgHelper.RestoreRepository(restoredDestination, backupPath);
+
+                // Although the bundle stores phase information, this is compared against the repo the bundle is
+                // restored to. As the repo is new, the changesets from the bundle will be marked draft. Because
+                // the bundle contains changesets from the Paratext server, we can just mark the changesets public,
+                // as we do when pulling from the repo.
+                _hgHelper.MarkSharedChangeSetsPublic(restoredDestination);
+
+                // Now that it is ready, move it to the repository location
+                _fileSystemService.MoveDirectory(restoredDestination, source);
+
                 return true;
             }
             catch (Exception e)
             {
-                _logger.LogError(e, $"Problem backing up local PT repo for PTId '{paratextId}'.");
-                // An error has occurred, so the backup was not created
+                _logger.LogError(e, $"Problem restoring local PT repo for PTId '{paratextId}'.");
+                // On error, move the backup destination back to the repository folder
+                if (!_fileSystemService.DirectoryExists(source))
+                {
+                    _fileSystemService.MoveDirectory(destination, source);
+                }
+            }
+        }
+        else
+        {
+            _logger.LogInformation($"Not restoring local PT repo for PTId '{paratextId}' since no backup exists.");
+        }
+
+        // An error occurred, or the backup does not exist
+        return false;
+    }
+
+    /// <summary>Does a local directory exist for the project? (i.e. in /var/lib/...)</summary>
+    public bool LocalProjectDirExists(string paratextId)
+    {
+        string dir = LocalProjectDir(paratextId);
+        return _fileSystemService.DirectoryExists(dir);
+    }
+
+    /// <summary>
+    /// Gets the Language tag for a Paratext project.
+    /// </summary>
+    /// <param name="userSecret">The user secret.</param>
+    /// <param name="ptProjectId">The Project identifier</param>
+    /// <returns>The Language identifier.</returns>
+    /// <remarks>This is used to get the WritingSystem Tag for Back Translations.</remarks>
+    public string GetLanguageId(UserSecret userSecret, string ptProjectId)
+    {
+        using ScrText scrText = GetScrText(userSecret, ptProjectId);
+        return scrText.Language.Id;
+    }
+
+    protected override void DisposeManagedResources()
+    {
+        _registryClient.Dispose();
+        _httpClientHandler.Dispose();
+    }
+
+    private ScrText GetScrText(UserSecret userSecret, string paratextId)
+    {
+        string? ptUsername = GetParatextUsername(userSecret);
+        if (ptUsername == null)
+        {
+            throw new DataNotFoundException($"Failed to get username for UserSecret id {userSecret.Id}.");
+        }
+        ScrText? scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
+        if (scrText == null)
+        {
+            throw new DataNotFoundException(
+                $"Could not find project for UserSecret id {userSecret.Id}, PT project id {paratextId}"
+            );
+        }
+        return scrText;
+    }
+
+    /// <summary>
+    /// Converts from a user role to a Paratext registry user role.
+    /// </summary>
+    /// <param name="role">The role.</param>
+    /// <returns>
+    /// The Paratext Registry user role.
+    /// </returns>
+    /// <remarks>
+    /// Sourced from <see cref="RegistryServer" />.
+    /// </remarks>
+    private static string ConvertFromUserRole(UserRoles? role) =>
+        role switch
+        {
+            UserRoles.Administrator => SFProjectRole.Administrator,
+            UserRoles.Consultant => SFProjectRole.Consultant,
+            UserRoles.TeamMember => SFProjectRole.Translator,
+            UserRoles.Observer => SFProjectRole.PTObserver,
+            _ => string.Empty,
+        };
+
+    /// <summary>
+    /// Checks whether a backup exists
+    /// </summary>
+    /// <param name="scrText">The scripture text.</param>
+    /// <returns><c>true</c> if the backup exists; otherwise, <c>false</c>.</returns>
+    /// <remarks>
+    /// This is a re-implementation of <see cref="VersionedText.BackupExists(ScrText)"/>
+    /// that uses file system dependency injection so this method can be unit tested.
+    /// </remarks>
+    private bool BackupExistsInternal(ScrText scrText)
+    {
+        try
+        {
+            string path = Path.Combine(
+                Paratext.Data.ScrTextCollection.SettingsDirectory,
+                "_Backups",
+                $"{scrText.Guid}.bndl"
+            );
+            return _fileSystemService.FileExists(path);
+        }
+        catch (Exception e)
+        {
+            // An error occurred
+            _logger.LogError(
+                e,
+                $"Problem when checking if a local PT repo backup exists for scrText id '{scrText.Guid}'."
+            );
+            return false;
+        }
+    }
+
+    private IReadOnlyList<ParatextProject> GetProjects(
+        UserSecret userSecret,
+        IEnumerable<SharedRepository> remotePtProjects,
+        IEnumerable<ProjectMetadata> projectsMetadata
+    )
+    {
+        if (userSecret == null)
+            throw new ArgumentNullException();
+
+        List<ParatextProject> paratextProjects = new List<ParatextProject>();
+        IQueryable<SFProject> existingSfProjects = _realtimeService.QuerySnapshots<SFProject>();
+
+        foreach (SharedRepository remotePtProject in remotePtProjects)
+        {
+            SFProject correspondingSfProject = existingSfProjects.FirstOrDefault(
+                sfProj => sfProj.ParatextId == remotePtProject.SendReceiveId.Id
+            );
+
+            bool sfProjectExists = correspondingSfProject != null;
+            bool sfUserIsOnSfProject = correspondingSfProject?.UserRoles.ContainsKey(userSecret.Id) ?? false;
+            bool adminOnPtProject =
+                remotePtProject.SourceUsers.GetRole(GetParatextUsername(userSecret)) == UserRoles.Administrator;
+            bool ptProjectIsConnectable =
+                (sfProjectExists && !sfUserIsOnSfProject) || (!sfProjectExists && adminOnPtProject);
+
+            // On SF Live server, many users have projects without corresponding project metadata.
+            // If this happens, default to using the project's short name
+            var projectMD = projectsMetadata.SingleOrDefault(pmd => pmd.ProjectGuid == remotePtProject.SendReceiveId);
+            string fullOrShortName = projectMD == null ? remotePtProject.ScrTextName : projectMD.FullName;
+
+            paratextProjects.Add(
+                new ParatextProject
+                {
+                    ParatextId = remotePtProject.SendReceiveId.Id,
+                    Name = fullOrShortName,
+                    ShortName = remotePtProject.ScrTextName,
+                    LanguageTag = correspondingSfProject?.WritingSystem.Tag ?? projectMD?.LanguageId.Code,
+                    ProjectId = correspondingSfProject?.Id,
+                    IsConnectable = ptProjectIsConnectable,
+                    IsConnected = sfProjectExists && sfUserIsOnSfProject
+                }
+            );
+        }
+        return paratextProjects.OrderBy(project => project.Name, StringComparer.InvariantCulture).ToArray();
+    }
+
+    private bool TryGetProject(
+        UserSecret userSecret,
+        SharedRepository sharedRepository,
+        IEnumerable<ProjectMetadata> metadata,
+        out ParatextProject? ptProject
+    )
+    {
+        if (sharedRepository != null)
+        {
+            ptProject = GetProjects(userSecret, new SharedRepository[] { sharedRepository }, metadata).FirstOrDefault();
+            if (ptProject != null)
+                return true;
+        }
+        ptProject = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether the specified project is registered with the Registry.
+    /// </summary>
+    /// <param name="userSecret">The user secret.</param>
+    /// <param name="paratextId">The paratext identifier for the project.</param>
+    /// <param name="token">The cancellation token.</param>
+    /// <returns>
+    /// <c>true</c> if the specified project is registered, and the user is
+    /// authorized to view it; otherwise, <c>false</c>.
+    /// </returns>
+    internal async Task<bool> IsRegisteredAsync(UserSecret userSecret, string paratextId, CancellationToken token)
+    {
+        try
+        {
+            string registeredParatextId = await CallApiAsync(
+                userSecret,
+                HttpMethod.Get,
+                $"projects/{paratextId}/identification_systemId/paratext/text",
+                null,
+                token
+            );
+            return registeredParatextId.Trim('"') == paratextId;
+        }
+        catch (HttpRequestException error)
+        {
+            // A 404 error means the project is not registered. It can also mean
+            // the authenticated user is not authorized to view it, according to
+            // the API and as seen in practice.
+            if (error.StatusCode == HttpStatusCode.NotFound)
                 return false;
+            else
+                throw;
+        }
+    }
+
+    private void SetupMercurial()
+    {
+        // We do not yet know where hg will be installed on the server, so allow defining it in an env variable
+        string customHgPath = Environment.GetEnvironmentVariable("HG_PATH") ?? _paratextOptions.Value.HgExe;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            customHgPath = Path.GetExtension(customHgPath) != ".exe" ? customHgPath + ".exe" : customHgPath;
+        if (!File.Exists(customHgPath))
+        {
+            string msg = string.Format(
+                "Error: Could not find hg executable at {0}. Please install hg 4.7 or greater.",
+                customHgPath
+            );
+            _logger.LogError(msg);
+            throw new InvalidOperationException(msg);
+        }
+        var hgMerge = Path.Combine(AssemblyDirectory, "ParatextMerge.py");
+        _hgHelper.SetDefault(new Hg(customHgPath, hgMerge, AssemblyDirectory));
+    }
+
+    /// <summary> Copy resource files from the Assembly Directory into the sync directory. </summary>
+    private void InstallStyles()
+    {
+        string[] resources = new[] { "usfm.sty", "revisionStyle.sty", "revisionTemplate.tem", "usfm_mod.sty" };
+        foreach (string resource in resources)
+        {
+            string target = Path.Combine(SyncDir, resource);
+            string source = Path.Combine(AssemblyDirectory, resource);
+            if (!File.Exists(target))
+            {
+                _logger.LogInformation($"Installing missing {target}");
+                File.Copy(source, target, true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Ensure the target project repository exists on the local SF server, cloning if necessary.
+    /// </summary>
+    private void EnsureProjectReposExists(
+        UserSecret userSecret,
+        ParatextProject target,
+        IInternetSharedRepositorySource repositorySource
+    )
+    {
+        string username = GetParatextUsername(userSecret);
+        using ScrText scrText = ScrTextCollection.FindById(username, target.ParatextId);
+        bool targetNeedsCloned = scrText == null;
+        if (target is ParatextResource resource)
+        {
+            // If the target is a resource, install it
+            InstallResource(resource, target.ParatextId, targetNeedsCloned);
+        }
+        else if (targetNeedsCloned)
+        {
+            SharedRepository targetRepo = new SharedRepository(
+                target.ShortName,
+                HexId.FromStr(target.ParatextId),
+                RepositoryType.Shared
+            );
+            CloneProjectRepo(repositorySource, target.ParatextId, targetRepo);
+        }
+    }
+
+    /// <summary>
+    /// Installs the resource.
+    /// </summary>
+    /// <param name="resource">The resource.</param>
+    /// <param name="targetParatextId">The target paratext identifier.</param>
+    /// <param name="needsToBeCloned">If set to <c>true</c>, the resource needs to be cloned.</param>
+    /// <remarks>
+    ///   <paramref name="targetParatextId" /> is required because the resource may be a source or target.
+    /// </remarks>
+    private void InstallResource(ParatextResource resource, string targetParatextId, bool needsToBeCloned)
+    {
+        if (resource.InstallableResource != null)
+        {
+            // Install the resource if it is missing or out of date
+            if (
+                !resource.IsInstalled
+                || resource.AvailableRevision > resource.InstalledRevision
+                || resource.InstallableResource.IsNewerThanCurrentlyInstalled()
+            )
+            {
+                resource.InstallableResource.Install();
+                needsToBeCloned = true;
+            }
+
+            // Extract the resource to the source directory
+            if (needsToBeCloned)
+            {
+                string path = LocalProjectDir(targetParatextId);
+                _fileSystemService.CreateDirectory(path);
+                resource.InstallableResource.ExtractToDirectory(path);
+            }
+        }
+        else
+        {
+            _logger.LogWarning($"The installable resource is not available for {resource.ParatextId}");
+        }
+    }
+
+    /// <summary> Create a shared project object for a given project. </summary>
+    private static SharedProject CreateSharedProject(
+        string paratextId,
+        string proj,
+        ScrText scrText,
+        SharedRepository sharedRepository
+    )
+    {
+        // Previously we used the CreateSharedProject method of SharingLogic but it would
+        // result in null if the user did not have a license to the repo which happens
+        // if the project is derived from another. This ensures the SharedProject is available.
+        // We must set the ScrText property of the SharedProject to indicate that the project is available locally
+        return new SharedProject
+        {
+            ScrTextName = proj,
+            Repository = sharedRepository,
+            SendReceiveId = HexId.FromStr(paratextId),
+            ScrText = scrText,
+            Permissions = scrText.Permissions
+        };
+    }
+
+    /// <summary>Path for project directory on local filesystem. Whether or not that directory
+    /// exists. </summary>
+    private string LocalProjectDir(string paratextId)
+    {
+        // Historically, SF used both "target" and "source" projects in adjacent directories. Then
+        // moved to just using "target".
+        string subDirForMainProject = "target";
+        return Path.Combine(SyncDir, paratextId, subDirForMainProject);
+    }
+
+    private void CloneProjectRepo(IInternetSharedRepositorySource source, string paratextId, SharedRepository repo)
+    {
+        string clonePath = LocalProjectDir(paratextId);
+        if (!_fileSystemService.DirectoryExists(clonePath))
+        {
+            _fileSystemService.CreateDirectory(clonePath);
+            _hgHelper.Init(clonePath);
+        }
+        source.Pull(clonePath, repo);
+        _hgHelper.Update(clonePath);
+    }
+
+    private IEnumerable<CommentThread> GetCommentThreads(UserSecret userSecret, string paratextId, int bookNum)
+    {
+        ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
+        if (scrText == null)
+            return null;
+
+        CommentManager manager = CommentManager.Get(scrText);
+        return manager.FindThreads(
+            commentThread => commentThread.VerseRef.BookNum == bookNum && !commentThread.Id.StartsWith("ANSWER_"),
+            false
+        );
+    }
+
+    private SyncMetricInfo PutCommentThreads(
+        UserSecret userSecret,
+        string paratextId,
+        List<List<Paratext.Data.ProjectComments.Comment>> changeList
+    )
+    {
+        string username = GetParatextUsername(userSecret);
+        List<string> users = new List<string>();
+        SyncMetricInfo syncMetricInfo = new SyncMetricInfo();
+        ScrText scrText = ScrTextCollection.FindById(username, paratextId);
+        if (scrText == null)
+            throw new DataNotFoundException("Can't get access to cloned project.");
+        CommentManager manager = CommentManager.Get(scrText);
+
+        // Algorithm sourced from Paratext DataAccessServer
+        foreach (List<Paratext.Data.ProjectComments.Comment> thread in changeList)
+        {
+            CommentThread existingThread = manager.FindThread(thread[0].Thread);
+            foreach (Paratext.Data.ProjectComments.Comment comment in thread)
+            {
+                Paratext.Data.ProjectComments.Comment existingComment = existingThread?.Comments.FirstOrDefault(
+                    c => c.Id == comment.Id
+                );
+                if (existingComment == null)
+                {
+                    manager.AddComment(comment);
+                    syncMetricInfo.Added++;
+                }
+                else if (comment.Deleted)
+                {
+                    existingComment.Deleted = true;
+                    syncMetricInfo.Deleted++;
+                }
+                else
+                {
+                    existingComment.ExternalUser = comment.ExternalUser;
+                    existingComment.Contents = comment.Contents;
+                    existingComment.VersionNumber += 1;
+                    existingComment.Deleted = false;
+                    syncMetricInfo.Updated++;
+                }
+
+                if (!users.Contains(comment.User))
+                    users.Add(comment.User);
             }
         }
 
-        public bool RestoreRepository(UserSecret userSecret, string paratextId)
+        try
         {
-            // We do not back up resources
-            if (paratextId == null || IsResource(paratextId))
-            {
-                if (paratextId == null)
-                {
-                    _logger.LogInformation("Not restoring local PT repo for null paratextId.");
-                }
-                else if (IsResource(paratextId))
-                {
-                    _logger.LogInformation("Not restoring a DBL resource.");
-                }
+            foreach (string user in users)
+                manager.SaveUser(user, false);
+            _paratextDataHelper.CommitVersionedText(
+                scrText,
+                $"{syncMetricInfo.Added} notes added and "
+                    + $"{syncMetricInfo.Deleted + syncMetricInfo.Updated} notes updated or deleted in synchronize"
+            );
+            _logger.LogInformation(
+                "{0} added {1} notes, updated {2} notes and deleted {3} notes",
+                userSecret.Id,
+                syncMetricInfo.Added,
+                syncMetricInfo.Updated,
+                syncMetricInfo.Deleted
+            );
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Exception while updating notes: {0}", e.Message);
+        }
 
-                return false;
+        return syncMetricInfo;
+    }
+
+    private CommentTags? GetCommentTags(UserSecret userSecret, string paratextId)
+    {
+        string? ptUsername = GetParatextUsername(userSecret);
+        if (ptUsername == null)
+            return null;
+        ScrText? scrText = ScrTextCollection.FindById(ptUsername, paratextId);
+        return scrText == null ? null : CommentTags.Get(scrText);
+    }
+
+    private async Task<string> CallApiAsync(
+        UserSecret userSecret,
+        HttpMethod method,
+        string url,
+        string? content = null,
+        CancellationToken token = default
+    )
+    {
+        using ParatextAccessLock accessLock = await GetParatextAccessLock(userSecret.Id, token);
+        using var request = new HttpRequestMessage(method, $"api8/{url}");
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            "Bearer",
+            accessLock.UserSecret.ParatextTokens.AccessToken
+        );
+        if (content != null)
+        {
+            request.Content = new StringContent(content);
+        }
+        HttpResponseMessage response = await _registryClient.SendAsync(request, token);
+        if (response.IsSuccessStatusCode)
+        {
+            return await response.Content.ReadAsStringAsync(token);
+        }
+        else
+        {
+            throw new HttpRequestException(
+                await ExceptionHandler.CreateHttpRequestErrorMessage(response),
+                null,
+                response.StatusCode
+            );
+        }
+    }
+
+    /// <summary>
+    /// Get access to a source for PT project repositories, based on user secret.
+    /// </summary>
+    private async Task<IInternetSharedRepositorySource> GetInternetSharedRepositorySource(
+        string sfUserId,
+        CancellationToken token
+    )
+    {
+        using ParatextAccessLock accessLock = await GetParatextAccessLock(sfUserId, token);
+        return _internetSharedRepositorySourceProvider.GetSource(
+            accessLock.UserSecret,
+            _sendReceiveServerUri,
+            _registryServerUri
+        );
+    }
+
+    /// <summary>
+    /// Get Paratext resources that a user has access to.
+    /// </summary>
+    /// <param name="userSecret">The user secret.</param>
+    /// <param name="includeInstallableResource">If set to <c>true</c> include the installable resource.</param>
+    /// <returns>
+    /// The available resources.
+    /// </returns>
+    private async Task<IReadOnlyList<ParatextResource>> GetResourcesInternalAsync(
+        string sfUserId,
+        bool includeInstallableResource,
+        CancellationToken token
+    )
+    {
+        IEnumerable<SFInstallableDblResource> resources;
+        using (ParatextAccessLock accessLock = await GetParatextAccessLock(sfUserId, token))
+        {
+            resources = SFInstallableDblResource.GetInstallableDblResources(
+                accessLock.UserSecret,
+                this._paratextOptions.Value,
+                this._restClientFactory,
+                this._fileSystemService,
+                this._jwtTokenHelper,
+                _exceptionHandler,
+                this._dblServerUri
+            );
+        }
+        IReadOnlyDictionary<string, int> resourceRevisions = SFInstallableDblResource.GetInstalledResourceRevisions();
+        return resources
+            .OrderBy(r => r.FullName)
+            .Select(
+                r =>
+                    new ParatextResource
+                    {
+                        AvailableRevision = r.DBLRevision,
+                        CreatedTimestamp = r.CreatedTimestamp,
+                        InstallableResource = includeInstallableResource ? r : null,
+                        InstalledRevision = resourceRevisions.ContainsKey(r.DBLEntryUid.Id)
+                            ? resourceRevisions[r.DBLEntryUid.Id]
+                            : 0,
+                        IsConnectable = false,
+                        IsConnected = false,
+                        IsInstalled = resourceRevisions.ContainsKey(r.DBLEntryUid.Id),
+                        LanguageTag = r.LanguageID.Code,
+                        ManifestChecksum = r.ManifestChecksum,
+                        Name = r.FullName,
+                        ParatextId = r.DBLEntryUid.Id,
+                        PermissionsChecksum = r.PermissionsChecksum,
+                        ProjectId = null,
+                        ShortName = r.Name,
+                    }
+            )
+            .ToArray();
+    }
+
+    /// <summary> Get the corresponding Comment from a note. </summary>
+    private static Paratext.Data.ProjectComments.Comment GetMatchingCommentFromNote(
+        Note note,
+        CommentThread thread,
+        Dictionary<string, ParatextUserProfile> ptProjectUsers
+    )
+    {
+        ParatextUserProfile ptUser =
+            note.SyncUserRef == null
+                ? null
+                : ptProjectUsers.Values.SingleOrDefault(u => u.OpaqueUserId == note.SyncUserRef);
+        if (ptUser == null)
+            return null;
+        string date = new DateTimeOffset(note.DateCreated).ToString("o");
+        // Comment ids are generated using the Paratext username. Since we do not want to transparently
+        // store a username to a note in SF we construct the intended Comment id at runtime.
+        string commentId = string.Format("{0}/{1}/{2}", note.ThreadId, ptUser.Username, date);
+        Paratext.Data.ProjectComments.Comment matchingComment = thread.Comments.LastOrDefault(c => c.Id == commentId);
+        if (matchingComment != null)
+            return matchingComment;
+
+        // Try another method to find the comment
+        DateTime noteTime = note.DateCreated.ToUniversalTime();
+        return thread.Comments
+            .Where(c => DateTime.Equals(noteTime, DateTime.Parse(c.Date, null, DateTimeStyles.AdjustToUniversal)))
+            .LastOrDefault(c => c.User == ptUser.Username);
+    }
+
+    /// <summary>
+    /// Get the comment change lists from the up-to-date note thread docs in the Scripture Forge mongo database.
+    /// </summary>
+    private async Task<List<List<Paratext.Data.ProjectComments.Comment>>> SFNotesToCommentChangeListAsync(
+        IEnumerable<IDocument<NoteThread>> noteThreadDocs,
+        IEnumerable<CommentThread> commentThreads,
+        string defaultUsername,
+        int sfNoteTagId,
+        Dictionary<string, ParatextUserProfile> ptProjectUsers
+    )
+    {
+        List<List<Paratext.Data.ProjectComments.Comment>> changes =
+            new List<List<Paratext.Data.ProjectComments.Comment>>();
+        IEnumerable<IDocument<NoteThread>> activeThreadDocs = noteThreadDocs.Where(t => t.Data != null);
+        foreach (IDocument<NoteThread> threadDoc in activeThreadDocs)
+        {
+            List<Paratext.Data.ProjectComments.Comment> thread = new List<Paratext.Data.ProjectComments.Comment>();
+            CommentThread existingThread = commentThreads.SingleOrDefault(ct => ct.Id == threadDoc.Data.DataId);
+            List<(int, string)> threadNoteParatextUserRefs = new List<(int, string)>();
+            for (int i = 0; i < threadDoc.Data.Notes.Count; i++)
+            {
+                Note note = threadDoc.Data.Notes[i];
+                Paratext.Data.ProjectComments.Comment matchedComment =
+                    existingThread == null ? null : GetMatchingCommentFromNote(note, existingThread, ptProjectUsers);
+                if (matchedComment != null)
+                {
+                    var comment = (Paratext.Data.ProjectComments.Comment)matchedComment.Clone();
+                    bool commentUpdated = false;
+                    if (note.Content != comment.Contents?.InnerXml)
+                    {
+                        if (comment.Contents == null)
+                            comment.AddTextToContent("", false);
+                        comment.Contents.InnerXml = note.Content;
+                        commentUpdated = true;
+                    }
+                    if (note.Deleted && !comment.Deleted)
+                    {
+                        comment.Deleted = true;
+                        commentUpdated = true;
+                    }
+                    if (commentUpdated)
+                    {
+                        thread.Add(comment);
+                    }
+                }
+                else
+                {
+                    // new comment added
+                    ParatextUserProfile ptProjectUser;
+                    UserSecret userSecret = _userSecretRepository.Query().FirstOrDefault(s => s.Id == note.OwnerRef);
+                    if (userSecret == null)
+                        ptProjectUser = FindOrCreateParatextUser(defaultUsername, ptProjectUsers);
+                    else
+                        ptProjectUser = FindOrCreateParatextUser(GetParatextUsername(userSecret), ptProjectUsers);
+
+                    SFParatextUser ptUser = new SFParatextUser(ptProjectUser.Username);
+                    var comment = new Paratext.Data.ProjectComments.Comment(ptUser)
+                    {
+                        VerseRefStr = threadDoc.Data.VerseRef.ToString(),
+                        SelectedText = threadDoc.Data.OriginalSelectedText,
+                        ContextBefore = threadDoc.Data.OriginalContextBefore,
+                        ContextAfter = threadDoc.Data.OriginalContextAfter
+                    };
+                    bool isFirstComment = i == 0;
+                    PopulateCommentFromNote(note, comment, sfNoteTagId, isFirstComment);
+                    thread.Add(comment);
+                    if (note.SyncUserRef == null)
+                    {
+                        threadNoteParatextUserRefs.Add((i, ptProjectUser.OpaqueUserId));
+                    }
+                }
+            }
+            if (thread.Count > 0)
+            {
+                changes.Add(thread);
+                // Set the sync user ref on the notes in the SF Mongo DB
+                await UpdateNoteSyncUserAsync(threadDoc, threadNoteParatextUserRefs);
+            }
+        }
+        return changes;
+    }
+
+    private ChangeType GetCommentChangeType(
+        Paratext.Data.ProjectComments.Comment comment,
+        Note note,
+        Paratext.Data.ProjectComments.CommentTag commentTag,
+        Dictionary<string, ParatextUserProfile> ptProjectUsers
+    )
+    {
+        if (comment.Deleted != note.Deleted)
+            return ChangeType.Deleted;
+        // Check if fields have been updated in Paratext
+        bool statusChanged = comment.Status.InternalValue != note.Status;
+        bool typeChanged = comment.Type.InternalValue != note.Type;
+        bool conflictTypeChanged = comment.ConflictType.InternalValue != note.ConflictType;
+        bool acceptedChangeXmlChanged = comment.AcceptedChangeXmlStr != note.AcceptedChangeXml;
+        bool contentChanged = comment.Contents?.InnerXml != note.Content;
+        bool tagChanged = commentTag?.Id != note.TagId;
+        bool assignedUserChanged = GetAssignedUserRef(comment.AssignedUser, ptProjectUsers) != note.Assignment;
+        if (
+            contentChanged
+            || statusChanged
+            || tagChanged
+            || typeChanged
+            || conflictTypeChanged
+            || assignedUserChanged
+            || acceptedChangeXmlChanged
+        )
+            return ChangeType.Updated;
+        return ChangeType.None;
+    }
+
+    private void PopulateCommentFromNote(
+        Note note,
+        Paratext.Data.ProjectComments.Comment comment,
+        int sfNoteTagId,
+        bool isFirstComment
+    )
+    {
+        comment.Thread = note.ThreadId;
+        comment.Date = new DateTimeOffset(note.DateCreated).ToString("o");
+        comment.Deleted = note.Deleted;
+
+        if (!string.IsNullOrEmpty(note.Content))
+            comment.GetOrCreateCommentNode().InnerXml = note.Content;
+        if (_userSecretRepository.Query().Any(u => u.Id == note.OwnerRef))
+            comment.ExternalUser = note.OwnerRef;
+        comment.TagsAdded =
+            note.TagId == null
+                ? isFirstComment
+                    ? new[] { sfNoteTagId.ToString() }
+                    : null
+                : new[] { note.TagId.ToString() };
+    }
+
+    private Note CreateNoteFromComment(
+        string noteId,
+        Paratext.Data.ProjectComments.Comment comment,
+        CommentTag commentTag,
+        Dictionary<string, ParatextUserProfile> ptProjectUsers
+    )
+    {
+        return new Note
+        {
+            DataId = noteId,
+            ThreadId = comment.Thread,
+            Type = comment.Type.InternalValue,
+            ConflictType = comment.ConflictType.InternalValue,
+            ExtUserId = comment.ExternalUser,
+            // The owner is unknown at this point and is determined when submitting the ops to the note thread docs
+            OwnerRef = "",
+            SyncUserRef = FindOrCreateParatextUser(comment.User, ptProjectUsers)?.OpaqueUserId,
+            Content = comment.Contents?.InnerXml,
+            AcceptedChangeXml = comment.AcceptedChangeXmlStr,
+            DateCreated = DateTime.Parse(comment.Date),
+            DateModified = DateTime.Parse(comment.Date),
+            Deleted = comment.Deleted,
+            Status = comment.Status.InternalValue,
+            TagId = commentTag?.Id,
+            Reattached = comment.Reattached,
+            Assignment = GetAssignedUserRef(comment.AssignedUser, ptProjectUsers)
+        };
+    }
+
+    private string GetAssignedUserRef(string assignedPTUser, Dictionary<string, ParatextUserProfile> ptProjectUsers)
+    {
+        return assignedPTUser switch
+        {
+            Paratext.Data.ProjectComments.CommentThread.teamUser
+            or Paratext.Data.ProjectComments.CommentThread.unassignedUser
+            or null
+                => assignedPTUser,
+            _ => FindOrCreateParatextUser(assignedPTUser, ptProjectUsers).OpaqueUserId,
+        };
+    }
+
+    private static CommentTag GetCommentTag(
+        Paratext.Data.ProjectComments.CommentThread thread,
+        Paratext.Data.ProjectComments.Comment comment,
+        CommentTags commentTags
+    )
+    {
+        // Use the main to do tag as default
+        CommentTag tagInUse = commentTags.Get(CommentTag.toDoTagId);
+        CommentTag lastTodoTagUsed = null;
+        foreach (Paratext.Data.ProjectComments.Comment threadComment in thread.Comments)
+        {
+            bool tagAddedInUse = threadComment.TagsAdded != null && threadComment.TagsAdded.Length > 0;
+            if (tagAddedInUse)
+            {
+                tagInUse = commentTags.Get(int.Parse(threadComment.TagsAdded[0]));
             }
 
-            // Get the scripture text
-            using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
-
-            // If we do not have a scripture text, do not back up
-            if (scrText == null)
+            // When checking the tag for the thread and a conflict is found then use that
+            if (comment == null)
             {
-                _logger.LogInformation($"Not restoring local PT repo since no scrText for PTId '{paratextId}'.");
-                return false;
+                if (threadComment.Type == NoteType.Conflict)
+                    return CommentTag.ConflictTag;
+                continue;
             }
 
-            // VersionedText.RestoreProject copies files from the repository to the restored backup.
-            // We would rather not do this, as there can be files trapped in the directory, particularly
-            // if the incoming change included new books and the sync was cancelled. In addition,
-            // Mongo is the source of truth for a project's state in Scripture Forge.
-            // The following is a re-implementation of VersionedText.RestoreProject with error trapping,
-            // and file system and Mercurial dependency injection so this method can be unit tested.
-            if (this.BackupExistsInternal(scrText))
+            if (threadComment.Id == comment.Id)
             {
-                string source = scrText.Directory;
-                string destination = Path.Combine(
-                    Paratext.Data.ScrTextCollection.SettingsDirectory,
-                    "_Backups",
-                    scrText.Guid.ToString()
-                );
-                string restoredDestination = destination + "_Restored";
-                string backupPath = destination + ".bndl";
+                // Overwrite any tag with a conflict if needed
+                if (comment.Type == NoteType.Conflict)
+                    return CommentTag.ConflictTag;
 
+                // Ignore any repeat tag icons i.e. only use a tag if it has changed
+                if (
+                    lastTodoTagUsed != null
+                    && lastTodoTagUsed.Icon == tagInUse.Icon
+                    && (comment.Status == NoteStatus.Todo || tagAddedInUse)
+                )
+                    return null;
+
+                // Only need to use the tag when there is a status in use or a tag has been specified
+                if (comment.Status != NoteStatus.Unspecified || tagAddedInUse)
+                    return tagInUse;
+
+                return null;
+            }
+            // Keep track of the last used to do status so we can avoid any repeats
+            if (threadComment.Status == NoteStatus.Todo)
+                lastTodoTagUsed = tagInUse;
+            else if (threadComment.Status == NoteStatus.Resolved || threadComment.Status == NoteStatus.Done)
+                lastTodoTagUsed = null;
+        }
+        // If we reach this far then the request is for the last used tag which is applied to the thread
+        return tagInUse;
+    }
+
+    private static string GetVerseText(Delta delta, VerseRef verseRef)
+    {
+        string vref = string.IsNullOrEmpty(verseRef.Verse) ? verseRef.VerseNum.ToString() : verseRef.Verse;
+        return delta.TryConcatenateInserts(out string verseText, vref, DeltaUsxMapper.CanParaContainVerseText)
+            ? verseText
+            : string.Empty;
+    }
+
+    private static TextAnchor GetThreadTextAnchor(CommentThread thread, Dictionary<int, ChapterDelta> chapterDeltas)
+    {
+        Paratext.Data.ProjectComments.Comment comment =
+            thread.Comments.LastOrDefault(c => c.Reattached != null) ?? thread.Comments[0];
+        VerseRef verseRef = comment.VerseRef;
+        int startPos = comment.StartPosition;
+        string selectedText = comment.SelectedText;
+        string contextBefore = comment.ContextBefore;
+        string contextAfter = comment.ContextAfter;
+        if (comment.Reattached != null)
+        {
+            string[] reattachedParts = comment.Reattached.Split(PtxUtils.StringUtils.orcCharacter);
+            verseRef = new VerseRef(reattachedParts[0]);
+            selectedText = reattachedParts[1];
+            startPos = int.Parse(reattachedParts[2]);
+            contextBefore = reattachedParts[3];
+            contextAfter = reattachedParts[4];
+        }
+
+        if (!chapterDeltas.TryGetValue(verseRef.ChapterNum, out ChapterDelta chapterDelta) || startPos == 0)
+            return new TextAnchor();
+
+        string verseText = GetVerseText(chapterDelta.Delta, verseRef);
+        verseText = verseText.Replace("\n", "\0");
+        PtxUtils.StringUtils.MatchContexts(
+            verseText,
+            contextBefore,
+            selectedText,
+            contextAfter,
+            null,
+            ref startPos,
+            out int posJustPastLastCharacter
+        );
+        // The text anchor is relative to the text in the verse
+        return new TextAnchor { Start = startPos, Length = posJustPastLastCharacter - startPos };
+    }
+
+    private ParatextUserProfile FindOrCreateParatextUser(
+        string paratextUsername,
+        Dictionary<string, ParatextUserProfile> ptProjectUsers
+    )
+    {
+        if (string.IsNullOrEmpty(paratextUsername))
+            return null;
+        if (!ptProjectUsers.TryGetValue(paratextUsername, out ParatextUserProfile ptProjectUser))
+        {
+            ptProjectUser = new ParatextUserProfile
+            {
+                OpaqueUserId = _guidService.NewObjectId(),
+                Username = paratextUsername
+            };
+            ptProjectUsers.Add(paratextUsername, ptProjectUser);
+        }
+        return ptProjectUser;
+    }
+
+    private static async Task UpdateNoteSyncUserAsync(
+        IDocument<NoteThread> noteThreadDoc,
+        List<(int, string)> paratextUserByNoteIndex
+    )
+    {
+        await noteThreadDoc.SubmitJson0OpAsync(op =>
+        {
+            foreach ((int index, string syncuser) in paratextUserByNoteIndex)
+                op.Set(t => t.Notes[index].SyncUserRef, syncuser);
+        });
+    }
+
+    // Make sure there are no asynchronous methods called after this until the progress is completed.
+    private static void StartProgressReporting(IProgress<ProgressState>? progress)
+    {
+        if (progress == null)
+            return;
+        var progressDisplay = new SyncProgressDisplay(progress);
+        PtxUtils.Progress.Progress.Mgr.SetDisplay(progressDisplay);
+    }
+
+    private async Task<ParatextAccessLock> GetParatextAccessLock(string sfUserId, CancellationToken token)
+    {
+        SemaphoreSlim semaphore = _tokenRefreshSemaphores.GetOrAdd(sfUserId, (string key) => new SemaphoreSlim(1, 1));
+        await semaphore.WaitAsync(token);
+
+        try
+        {
+            Attempt<UserSecret> attempt = await _userSecretRepository.TryGetAsync(sfUserId);
+            if (!attempt.TryResult(out UserSecret userSecret))
+            {
+                throw new DataNotFoundException("Could not find user secrets for SF user id " + sfUserId);
+            }
+
+            if (!userSecret.ParatextTokens.ValidateLifetime())
+            {
+                Tokens refreshedUserTokens;
                 try
                 {
-                    if (_fileSystemService.DirectoryExists(restoredDestination))
-                    {
-                        _fileSystemService.DeleteDirectory(restoredDestination);
-                    }
-
-                    // Remove the backup destination, if it exists
-                    if (_fileSystemService.DirectoryExists(destination))
-                    {
-                        _fileSystemService.DeleteDirectory(destination);
-                    }
-
-                    // Move the current repository to the backup destination
-                    if (source != destination)
-                    {
-                        _fileSystemService.MoveDirectory(source, destination);
-                    }
-
-                    // Restore the Mercurial repository to a temporary destination
-                    _hgHelper.RestoreRepository(restoredDestination, backupPath);
-
-                    // Although the bundle stores phase information, this is compared against the repo the bundle is
-                    // restored to. As the repo is new, the changesets from the bundle will be marked draft. Because
-                    // the bundle contains changesets from the Paratext server, we can just mark the changesets public,
-                    // as we do when pulling from the repo.
-                    _hgHelper.MarkSharedChangeSetsPublic(restoredDestination);
-
-                    // Now that it is ready, move it to the repository location
-                    _fileSystemService.MoveDirectory(restoredDestination, source);
-
-                    return true;
+                    refreshedUserTokens = await _jwtTokenHelper.RefreshAccessTokenAsync(
+                        _paratextOptions.Value,
+                        userSecret.ParatextTokens,
+                        _registryClient,
+                        token
+                    );
                 }
-                catch (Exception e)
+                catch
                 {
-                    _logger.LogError(e, $"Problem restoring local PT repo for PTId '{paratextId}'.");
-                    // On error, move the backup destination back to the repository folder
-                    if (!_fileSystemService.DirectoryExists(source))
-                    {
-                        _fileSystemService.MoveDirectory(destination, source);
-                    }
-                }
-            }
-            else
-            {
-                _logger.LogInformation($"Not restoring local PT repo for PTId '{paratextId}' since no backup exists.");
-            }
-
-            // An error occurred, or the backup does not exist
-            return false;
-        }
-
-        /// <summary>Does a local directory exist for the project? (i.e. in /var/lib/...)</summary>
-        public bool LocalProjectDirExists(string paratextId)
-        {
-            string dir = LocalProjectDir(paratextId);
-            return _fileSystemService.DirectoryExists(dir);
-        }
-
-        /// <summary>
-        /// Gets the Language tag for a Paratext project.
-        /// </summary>
-        /// <param name="userSecret">The user secret.</param>
-        /// <param name="ptProjectId">The Project identifier</param>
-        /// <returns>The Language identifier.</returns>
-        /// <remarks>This is used to get the WritingSystem Tag for Back Translations.</remarks>
-        public string GetLanguageId(UserSecret userSecret, string ptProjectId)
-        {
-            using ScrText scrText = GetScrText(userSecret, ptProjectId);
-            return scrText.Language.Id;
-        }
-
-        protected override void DisposeManagedResources()
-        {
-            _registryClient.Dispose();
-            _httpClientHandler.Dispose();
-        }
-
-        private ScrText GetScrText(UserSecret userSecret, string paratextId)
-        {
-            string? ptUsername = GetParatextUsername(userSecret);
-            if (ptUsername == null)
-            {
-                throw new DataNotFoundException($"Failed to get username for UserSecret id {userSecret.Id}.");
-            }
-            ScrText? scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
-            if (scrText == null)
-            {
-                throw new DataNotFoundException(
-                    $"Could not find project for UserSecret id {userSecret.Id}, PT project id {paratextId}"
-                );
-            }
-            return scrText;
-        }
-
-        /// <summary>
-        /// Converts from a user role to a Paratext registry user role.
-        /// </summary>
-        /// <param name="role">The role.</param>
-        /// <returns>
-        /// The Paratext Registry user role.
-        /// </returns>
-        /// <remarks>
-        /// Sourced from <see cref="RegistryServer" />.
-        /// </remarks>
-        private static string ConvertFromUserRole(UserRoles? role) =>
-            role switch
-            {
-                UserRoles.Administrator => SFProjectRole.Administrator,
-                UserRoles.Consultant => SFProjectRole.Consultant,
-                UserRoles.TeamMember => SFProjectRole.Translator,
-                UserRoles.Observer => SFProjectRole.PTObserver,
-                _ => string.Empty,
-            };
-
-        /// <summary>
-        /// Checks whether a backup exists
-        /// </summary>
-        /// <param name="scrText">The scripture text.</param>
-        /// <returns><c>true</c> if the backup exists; otherwise, <c>false</c>.</returns>
-        /// <remarks>
-        /// This is a re-implementation of <see cref="VersionedText.BackupExists(ScrText)"/>
-        /// that uses file system dependency injection so this method can be unit tested.
-        /// </remarks>
-        private bool BackupExistsInternal(ScrText scrText)
-        {
-            try
-            {
-                string path = Path.Combine(
-                    Paratext.Data.ScrTextCollection.SettingsDirectory,
-                    "_Backups",
-                    $"{scrText.Guid}.bndl"
-                );
-                return _fileSystemService.FileExists(path);
-            }
-            catch (Exception e)
-            {
-                // An error occurred
-                _logger.LogError(
-                    e,
-                    $"Problem when checking if a local PT repo backup exists for scrText id '{scrText.Guid}'."
-                );
-                return false;
-            }
-        }
-
-        private IReadOnlyList<ParatextProject> GetProjects(
-            UserSecret userSecret,
-            IEnumerable<SharedRepository> remotePtProjects,
-            IEnumerable<ProjectMetadata> projectsMetadata
-        )
-        {
-            if (userSecret == null)
-                throw new ArgumentNullException();
-
-            List<ParatextProject> paratextProjects = new List<ParatextProject>();
-            IQueryable<SFProject> existingSfProjects = _realtimeService.QuerySnapshots<SFProject>();
-
-            foreach (SharedRepository remotePtProject in remotePtProjects)
-            {
-                SFProject correspondingSfProject = existingSfProjects.FirstOrDefault(
-                    sfProj => sfProj.ParatextId == remotePtProject.SendReceiveId.Id
-                );
-
-                bool sfProjectExists = correspondingSfProject != null;
-                bool sfUserIsOnSfProject = correspondingSfProject?.UserRoles.ContainsKey(userSecret.Id) ?? false;
-                bool adminOnPtProject =
-                    remotePtProject.SourceUsers.GetRole(GetParatextUsername(userSecret)) == UserRoles.Administrator;
-                bool ptProjectIsConnectable =
-                    (sfProjectExists && !sfUserIsOnSfProject) || (!sfProjectExists && adminOnPtProject);
-
-                // On SF Live server, many users have projects without corresponding project metadata.
-                // If this happens, default to using the project's short name
-                var projectMD = projectsMetadata.SingleOrDefault(
-                    pmd => pmd.ProjectGuid == remotePtProject.SendReceiveId
-                );
-                string fullOrShortName = projectMD == null ? remotePtProject.ScrTextName : projectMD.FullName;
-
-                paratextProjects.Add(
-                    new ParatextProject
-                    {
-                        ParatextId = remotePtProject.SendReceiveId.Id,
-                        Name = fullOrShortName,
-                        ShortName = remotePtProject.ScrTextName,
-                        LanguageTag = correspondingSfProject?.WritingSystem.Tag ?? projectMD?.LanguageId.Code,
-                        ProjectId = correspondingSfProject?.Id,
-                        IsConnectable = ptProjectIsConnectable,
-                        IsConnected = sfProjectExists && sfUserIsOnSfProject
-                    }
-                );
-            }
-            return paratextProjects.OrderBy(project => project.Name, StringComparer.InvariantCulture).ToArray();
-        }
-
-        private bool TryGetProject(
-            UserSecret userSecret,
-            SharedRepository sharedRepository,
-            IEnumerable<ProjectMetadata> metadata,
-            out ParatextProject? ptProject
-        )
-        {
-            if (sharedRepository != null)
-            {
-                ptProject = GetProjects(userSecret, new SharedRepository[] { sharedRepository }, metadata)
-                    .FirstOrDefault();
-                if (ptProject != null)
-                    return true;
-            }
-            ptProject = null;
-            return false;
-        }
-
-        /// <summary>
-        /// Determines whether the specified project is registered with the Registry.
-        /// </summary>
-        /// <param name="userSecret">The user secret.</param>
-        /// <param name="paratextId">The paratext identifier for the project.</param>
-        /// <param name="token">The cancellation token.</param>
-        /// <returns>
-        /// <c>true</c> if the specified project is registered, and the user is
-        /// authorized to view it; otherwise, <c>false</c>.
-        /// </returns>
-        internal async Task<bool> IsRegisteredAsync(UserSecret userSecret, string paratextId, CancellationToken token)
-        {
-            try
-            {
-                string registeredParatextId = await CallApiAsync(
-                    userSecret,
-                    HttpMethod.Get,
-                    $"projects/{paratextId}/identification_systemId/paratext/text",
-                    null,
-                    token
-                );
-                return registeredParatextId.Trim('"') == paratextId;
-            }
-            catch (HttpRequestException error)
-            {
-                // A 404 error means the project is not registered. It can also mean
-                // the authenticated user is not authorized to view it, according to
-                // the API and as seen in practice.
-                if (error.StatusCode == HttpStatusCode.NotFound)
-                    return false;
-                else
+                    _logger.LogWarning(
+                        $"ParatextService.GetParatextAccessLock for sfUserId {sfUserId} is throwing from call RefreshAccessTokenAsync()."
+                    );
                     throw;
-            }
-        }
-
-        private void SetupMercurial()
-        {
-            // We do not yet know where hg will be installed on the server, so allow defining it in an env variable
-            string customHgPath = Environment.GetEnvironmentVariable("HG_PATH") ?? _paratextOptions.Value.HgExe;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                customHgPath = Path.GetExtension(customHgPath) != ".exe" ? customHgPath + ".exe" : customHgPath;
-            if (!File.Exists(customHgPath))
-            {
-                string msg = string.Format(
-                    "Error: Could not find hg executable at {0}. Please install hg 4.7 or greater.",
-                    customHgPath
-                );
-                _logger.LogError(msg);
-                throw new InvalidOperationException(msg);
-            }
-            var hgMerge = Path.Combine(AssemblyDirectory, "ParatextMerge.py");
-            _hgHelper.SetDefault(new Hg(customHgPath, hgMerge, AssemblyDirectory));
-        }
-
-        /// <summary> Copy resource files from the Assembly Directory into the sync directory. </summary>
-        private void InstallStyles()
-        {
-            string[] resources = new[] { "usfm.sty", "revisionStyle.sty", "revisionTemplate.tem", "usfm_mod.sty" };
-            foreach (string resource in resources)
-            {
-                string target = Path.Combine(SyncDir, resource);
-                string source = Path.Combine(AssemblyDirectory, resource);
-                if (!File.Exists(target))
-                {
-                    _logger.LogInformation($"Installing missing {target}");
-                    File.Copy(source, target, true);
                 }
-            }
-        }
-
-        /// <summary>
-        /// Ensure the target project repository exists on the local SF server, cloning if necessary.
-        /// </summary>
-        private void EnsureProjectReposExists(
-            UserSecret userSecret,
-            ParatextProject target,
-            IInternetSharedRepositorySource repositorySource
-        )
-        {
-            string username = GetParatextUsername(userSecret);
-            using ScrText scrText = ScrTextCollection.FindById(username, target.ParatextId);
-            bool targetNeedsCloned = scrText == null;
-            if (target is ParatextResource resource)
-            {
-                // If the target is a resource, install it
-                InstallResource(resource, target.ParatextId, targetNeedsCloned);
-            }
-            else if (targetNeedsCloned)
-            {
-                SharedRepository targetRepo = new SharedRepository(
-                    target.ShortName,
-                    HexId.FromStr(target.ParatextId),
-                    RepositoryType.Shared
-                );
-                CloneProjectRepo(repositorySource, target.ParatextId, targetRepo);
-            }
-        }
-
-        /// <summary>
-        /// Installs the resource.
-        /// </summary>
-        /// <param name="resource">The resource.</param>
-        /// <param name="targetParatextId">The target paratext identifier.</param>
-        /// <param name="needsToBeCloned">If set to <c>true</c>, the resource needs to be cloned.</param>
-        /// <remarks>
-        ///   <paramref name="targetParatextId" /> is required because the resource may be a source or target.
-        /// </remarks>
-        private void InstallResource(ParatextResource resource, string targetParatextId, bool needsToBeCloned)
-        {
-            if (resource.InstallableResource != null)
-            {
-                // Install the resource if it is missing or out of date
-                if (
-                    !resource.IsInstalled
-                    || resource.AvailableRevision > resource.InstalledRevision
-                    || resource.InstallableResource.IsNewerThanCurrentlyInstalled()
-                )
-                {
-                    resource.InstallableResource.Install();
-                    needsToBeCloned = true;
-                }
-
-                // Extract the resource to the source directory
-                if (needsToBeCloned)
-                {
-                    string path = LocalProjectDir(targetParatextId);
-                    _fileSystemService.CreateDirectory(path);
-                    resource.InstallableResource.ExtractToDirectory(path);
-                }
-            }
-            else
-            {
-                _logger.LogWarning($"The installable resource is not available for {resource.ParatextId}");
-            }
-        }
-
-        /// <summary> Create a shared project object for a given project. </summary>
-        private SharedProject CreateSharedProject(
-            string paratextId,
-            string proj,
-            ScrText scrText,
-            SharedRepository sharedRepository
-        )
-        {
-            // Previously we used the CreateSharedProject method of SharingLogic but it would
-            // result in null if the user did not have a license to the repo which happens
-            // if the project is derived from another. This ensures the SharedProject is available.
-            // We must set the ScrText property of the SharedProject to indicate that the project is available locally
-            return new SharedProject
-            {
-                ScrTextName = proj,
-                Repository = sharedRepository,
-                SendReceiveId = HexId.FromStr(paratextId),
-                ScrText = scrText,
-                Permissions = scrText.Permissions
-            };
-        }
-
-        /// <summary>Path for project directory on local filesystem. Whether or not that directory
-        /// exists. </summary>
-        private string LocalProjectDir(string paratextId)
-        {
-            // Historically, SF used both "target" and "source" projects in adjacent directories. Then
-            // moved to just using "target".
-            string subDirForMainProject = "target";
-            return Path.Combine(SyncDir, paratextId, subDirForMainProject);
-        }
-
-        private void CloneProjectRepo(IInternetSharedRepositorySource source, string paratextId, SharedRepository repo)
-        {
-            string clonePath = LocalProjectDir(paratextId);
-            if (!_fileSystemService.DirectoryExists(clonePath))
-            {
-                _fileSystemService.CreateDirectory(clonePath);
-                _hgHelper.Init(clonePath);
-            }
-            source.Pull(clonePath, repo);
-            _hgHelper.Update(clonePath);
-        }
-
-        private IEnumerable<CommentThread> GetCommentThreads(UserSecret userSecret, string paratextId, int bookNum)
-        {
-            ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
-            if (scrText == null)
-                return null;
-
-            CommentManager manager = CommentManager.Get(scrText);
-            return manager.FindThreads(
-                commentThread => commentThread.VerseRef.BookNum == bookNum && !commentThread.Id.StartsWith("ANSWER_"),
-                false
-            );
-        }
-
-        private SyncMetricInfo PutCommentThreads(
-            UserSecret userSecret,
-            string paratextId,
-            List<List<Paratext.Data.ProjectComments.Comment>> changeList
-        )
-        {
-            string username = GetParatextUsername(userSecret);
-            List<string> users = new List<string>();
-            SyncMetricInfo syncMetricInfo = new SyncMetricInfo();
-            ScrText scrText = ScrTextCollection.FindById(username, paratextId);
-            if (scrText == null)
-                throw new DataNotFoundException("Can't get access to cloned project.");
-            CommentManager manager = CommentManager.Get(scrText);
-
-            // Algorithm sourced from Paratext DataAccessServer
-            foreach (List<Paratext.Data.ProjectComments.Comment> thread in changeList)
-            {
-                CommentThread existingThread = manager.FindThread(thread[0].Thread);
-                foreach (Paratext.Data.ProjectComments.Comment comment in thread)
-                {
-                    Paratext.Data.ProjectComments.Comment existingComment = existingThread?.Comments.FirstOrDefault(
-                        c => c.Id == comment.Id
-                    );
-                    if (existingComment == null)
-                    {
-                        manager.AddComment(comment);
-                        syncMetricInfo.Added++;
-                    }
-                    else if (comment.Deleted)
-                    {
-                        existingComment.Deleted = true;
-                        syncMetricInfo.Deleted++;
-                    }
-                    else
-                    {
-                        existingComment.ExternalUser = comment.ExternalUser;
-                        existingComment.Contents = comment.Contents;
-                        existingComment.VersionNumber += 1;
-                        existingComment.Deleted = false;
-                        syncMetricInfo.Updated++;
-                    }
-
-                    if (!users.Contains(comment.User))
-                        users.Add(comment.User);
-                }
-            }
-
-            try
-            {
-                foreach (string user in users)
-                    manager.SaveUser(user, false);
-                _paratextDataHelper.CommitVersionedText(
-                    scrText,
-                    $"{syncMetricInfo.Added} notes added and "
-                        + $"{syncMetricInfo.Deleted + syncMetricInfo.Updated} notes updated or deleted in synchronize"
-                );
-                _logger.LogInformation(
-                    "{0} added {1} notes, updated {2} notes and deleted {3} notes",
-                    userSecret.Id,
-                    syncMetricInfo.Added,
-                    syncMetricInfo.Updated,
-                    syncMetricInfo.Deleted
+                userSecret = await _userSecretRepository.UpdateAsync(
+                    sfUserId,
+                    b => b.Set(u => u.ParatextTokens, refreshedUserTokens)
                 );
             }
-            catch (Exception e)
-            {
-                _logger.LogError(e, "Exception while updating notes: {0}", e.Message);
-            }
-
-            return syncMetricInfo;
+            return new ParatextAccessLock(semaphore, userSecret);
         }
-
-        private CommentTags? GetCommentTags(UserSecret userSecret, string paratextId)
+        catch
         {
-            string? ptUsername = GetParatextUsername(userSecret);
-            if (ptUsername == null)
-                return null;
-            ScrText? scrText = ScrTextCollection.FindById(ptUsername, paratextId);
-            return scrText == null ? null : CommentTags.Get(scrText);
-        }
-
-        private async Task<string> CallApiAsync(
-            UserSecret userSecret,
-            HttpMethod method,
-            string url,
-            string? content = null,
-            CancellationToken token = default
-        )
-        {
-            using (ParatextAccessLock accessLock = await GetParatextAccessLock(userSecret.Id, token))
-            using (var request = new HttpRequestMessage(method, $"api8/{url}"))
-            {
-                request.Headers.Authorization = new AuthenticationHeaderValue(
-                    "Bearer",
-                    accessLock.UserSecret.ParatextTokens.AccessToken
-                );
-                if (content != null)
-                {
-                    request.Content = new StringContent(content);
-                }
-                HttpResponseMessage response = await _registryClient.SendAsync(request, token);
-                if (response.IsSuccessStatusCode)
-                {
-                    return await response.Content.ReadAsStringAsync();
-                }
-                else
-                {
-                    throw new HttpRequestException(
-                        await ExceptionHandler.CreateHttpRequestErrorMessage(response),
-                        null,
-                        response.StatusCode
-                    );
-                }
-            }
-        }
-
-        /// <summary>
-        /// Get access to a source for PT project repositories, based on user secret.
-        /// </summary>
-        private async Task<IInternetSharedRepositorySource> GetInternetSharedRepositorySource(
-            string sfUserId,
-            CancellationToken token
-        )
-        {
-            using (ParatextAccessLock accessLock = await GetParatextAccessLock(sfUserId, token))
-            {
-                return _internetSharedRepositorySourceProvider.GetSource(
-                    accessLock.UserSecret,
-                    _sendReceiveServerUri,
-                    _registryServerUri
-                );
-            }
-        }
-
-        /// <summary>
-        /// Get Paratext resources that a user has access to.
-        /// </summary>
-        /// <param name="userSecret">The user secret.</param>
-        /// <param name="includeInstallableResource">If set to <c>true</c> include the installable resource.</param>
-        /// <returns>
-        /// The available resources.
-        /// </returns>
-        private async Task<IReadOnlyList<ParatextResource>> GetResourcesInternalAsync(
-            string sfUserId,
-            bool includeInstallableResource,
-            CancellationToken token
-        )
-        {
-            IEnumerable<SFInstallableDblResource> resources;
-            using (ParatextAccessLock accessLock = await GetParatextAccessLock(sfUserId, token))
-            {
-                resources = SFInstallableDblResource.GetInstallableDblResources(
-                    accessLock.UserSecret,
-                    this._paratextOptions.Value,
-                    this._restClientFactory,
-                    this._fileSystemService,
-                    this._jwtTokenHelper,
-                    _exceptionHandler,
-                    this._dblServerUri
-                );
-            }
-            IReadOnlyDictionary<string, int> resourceRevisions =
-                SFInstallableDblResource.GetInstalledResourceRevisions();
-            return resources
-                .OrderBy(r => r.FullName)
-                .Select(
-                    r =>
-                        new ParatextResource
-                        {
-                            AvailableRevision = r.DBLRevision,
-                            CreatedTimestamp = r.CreatedTimestamp,
-                            InstallableResource = includeInstallableResource ? r : null,
-                            InstalledRevision = resourceRevisions.ContainsKey(r.DBLEntryUid.Id)
-                                ? resourceRevisions[r.DBLEntryUid.Id]
-                                : 0,
-                            IsConnectable = false,
-                            IsConnected = false,
-                            IsInstalled = resourceRevisions.ContainsKey(r.DBLEntryUid.Id),
-                            LanguageTag = r.LanguageID.Code,
-                            ManifestChecksum = r.ManifestChecksum,
-                            Name = r.FullName,
-                            ParatextId = r.DBLEntryUid.Id,
-                            PermissionsChecksum = r.PermissionsChecksum,
-                            ProjectId = null,
-                            ShortName = r.Name,
-                        }
-                )
-                .ToArray();
-        }
-
-        /// <summary> Get the corresponding Comment from a note. </summary>
-        private Paratext.Data.ProjectComments.Comment GetMatchingCommentFromNote(
-            Note note,
-            CommentThread thread,
-            Dictionary<string, ParatextUserProfile> ptProjectUsers
-        )
-        {
-            ParatextUserProfile ptUser =
-                note.SyncUserRef == null
-                    ? null
-                    : ptProjectUsers.Values.SingleOrDefault(u => u.OpaqueUserId == note.SyncUserRef);
-            if (ptUser == null)
-                return null;
-            string date = new DateTimeOffset(note.DateCreated).ToString("o");
-            // Comment ids are generated using the Paratext username. Since we do not want to transparently
-            // store a username to a note in SF we construct the intended Comment id at runtime.
-            string commentId = string.Format("{0}/{1}/{2}", note.ThreadId, ptUser.Username, date);
-            Paratext.Data.ProjectComments.Comment matchingComment = thread.Comments.LastOrDefault(
-                c => c.Id == commentId
-            );
-            if (matchingComment != null)
-                return matchingComment;
-
-            // Try another method to find the comment
-            DateTime noteTime = note.DateCreated.ToUniversalTime();
-            return thread.Comments
-                .Where(c => DateTime.Equals(noteTime, DateTime.Parse(c.Date, null, DateTimeStyles.AdjustToUniversal)))
-                .LastOrDefault(c => c.User == ptUser.Username);
-        }
-
-        /// <summary>
-        /// Get the comment change lists from the up-to-date note thread docs in the Scripture Forge mongo database.
-        /// </summary>
-        private async Task<List<List<Paratext.Data.ProjectComments.Comment>>> SFNotesToCommentChangeListAsync(
-            IEnumerable<IDocument<NoteThread>> noteThreadDocs,
-            IEnumerable<CommentThread> commentThreads,
-            string defaultUsername,
-            int sfNoteTagId,
-            Dictionary<string, ParatextUserProfile> ptProjectUsers
-        )
-        {
-            List<List<Paratext.Data.ProjectComments.Comment>> changes =
-                new List<List<Paratext.Data.ProjectComments.Comment>>();
-            IEnumerable<IDocument<NoteThread>> activeThreadDocs = noteThreadDocs.Where(t => t.Data != null);
-            foreach (IDocument<NoteThread> threadDoc in activeThreadDocs)
-            {
-                List<Paratext.Data.ProjectComments.Comment> thread = new List<Paratext.Data.ProjectComments.Comment>();
-                CommentThread existingThread = commentThreads.SingleOrDefault(ct => ct.Id == threadDoc.Data.DataId);
-                List<(int, string)> threadNoteParatextUserRefs = new List<(int, string)>();
-                for (int i = 0; i < threadDoc.Data.Notes.Count; i++)
-                {
-                    Note note = threadDoc.Data.Notes[i];
-                    Paratext.Data.ProjectComments.Comment matchedComment =
-                        existingThread == null
-                            ? null
-                            : GetMatchingCommentFromNote(note, existingThread, ptProjectUsers);
-                    if (matchedComment != null)
-                    {
-                        var comment = (Paratext.Data.ProjectComments.Comment)matchedComment.Clone();
-                        bool commentUpdated = false;
-                        if (note.Content != comment.Contents?.InnerXml)
-                        {
-                            if (comment.Contents == null)
-                                comment.AddTextToContent("", false);
-                            comment.Contents.InnerXml = note.Content;
-                            commentUpdated = true;
-                        }
-                        if (note.Deleted && !comment.Deleted)
-                        {
-                            comment.Deleted = true;
-                            commentUpdated = true;
-                        }
-                        if (commentUpdated)
-                        {
-                            thread.Add(comment);
-                        }
-                    }
-                    else
-                    {
-                        // new comment added
-                        ParatextUserProfile ptProjectUser;
-                        UserSecret userSecret = _userSecretRepository
-                            .Query()
-                            .FirstOrDefault(s => s.Id == note.OwnerRef);
-                        if (userSecret == null)
-                            ptProjectUser = FindOrCreateParatextUser(defaultUsername, ptProjectUsers);
-                        else
-                            ptProjectUser = FindOrCreateParatextUser(GetParatextUsername(userSecret), ptProjectUsers);
-
-                        SFParatextUser ptUser = new SFParatextUser(ptProjectUser.Username);
-                        var comment = new Paratext.Data.ProjectComments.Comment(ptUser)
-                        {
-                            VerseRefStr = threadDoc.Data.VerseRef.ToString(),
-                            SelectedText = threadDoc.Data.OriginalSelectedText,
-                            ContextBefore = threadDoc.Data.OriginalContextBefore,
-                            ContextAfter = threadDoc.Data.OriginalContextAfter
-                        };
-                        bool isFirstComment = i == 0;
-                        PopulateCommentFromNote(note, comment, sfNoteTagId, isFirstComment);
-                        thread.Add(comment);
-                        if (note.SyncUserRef == null)
-                        {
-                            threadNoteParatextUserRefs.Add((i, ptProjectUser.OpaqueUserId));
-                        }
-                    }
-                }
-                if (thread.Count() > 0)
-                {
-                    changes.Add(thread);
-                    // Set the sync user ref on the notes in the SF Mongo DB
-                    await UpdateNoteSyncUserAsync(threadDoc, threadNoteParatextUserRefs);
-                }
-            }
-            return changes;
-        }
-
-        private ChangeType GetCommentChangeType(
-            Paratext.Data.ProjectComments.Comment comment,
-            Note note,
-            Paratext.Data.ProjectComments.CommentTag commentTag,
-            Dictionary<string, ParatextUserProfile> ptProjectUsers
-        )
-        {
-            if (comment.Deleted != note.Deleted)
-                return ChangeType.Deleted;
-            // Check if fields have been updated in Paratext
-            bool statusChanged = comment.Status.InternalValue != note.Status;
-            bool typeChanged = comment.Type.InternalValue != note.Type;
-            bool conflictTypeChanged = comment.ConflictType.InternalValue != note.ConflictType;
-            bool acceptedChangeXmlChanged = comment.AcceptedChangeXmlStr != note.AcceptedChangeXml;
-            bool contentChanged = comment.Contents?.InnerXml != note.Content;
-            bool tagChanged = commentTag?.Id != note.TagId;
-            bool assignedUserChanged = GetAssignedUserRef(comment.AssignedUser, ptProjectUsers) != note.Assignment;
-            if (
-                contentChanged
-                || statusChanged
-                || tagChanged
-                || typeChanged
-                || conflictTypeChanged
-                || assignedUserChanged
-                || acceptedChangeXmlChanged
-            )
-                return ChangeType.Updated;
-            return ChangeType.None;
-        }
-
-        private void PopulateCommentFromNote(
-            Note note,
-            Paratext.Data.ProjectComments.Comment comment,
-            int sfNoteTagId,
-            bool isFirstComment
-        )
-        {
-            comment.Thread = note.ThreadId;
-            comment.Date = new DateTimeOffset(note.DateCreated).ToString("o");
-            comment.Deleted = note.Deleted;
-
-            if (!string.IsNullOrEmpty(note.Content))
-                comment.GetOrCreateCommentNode().InnerXml = note.Content;
-            if (_userSecretRepository.Query().Any(u => u.Id == note.OwnerRef))
-                comment.ExternalUser = note.OwnerRef;
-            comment.TagsAdded =
-                note.TagId == null
-                    ? isFirstComment
-                        ? new[] { sfNoteTagId.ToString() }
-                        : null
-                    : new[] { note.TagId.ToString() };
-        }
-
-        private Note CreateNoteFromComment(
-            string noteId,
-            Paratext.Data.ProjectComments.Comment comment,
-            CommentTag commentTag,
-            Dictionary<string, ParatextUserProfile> ptProjectUsers
-        )
-        {
-            return new Note
-            {
-                DataId = noteId,
-                ThreadId = comment.Thread,
-                Type = comment.Type.InternalValue,
-                ConflictType = comment.ConflictType.InternalValue,
-                ExtUserId = comment.ExternalUser,
-                // The owner is unknown at this point and is determined when submitting the ops to the note thread docs
-                OwnerRef = "",
-                SyncUserRef = FindOrCreateParatextUser(comment.User, ptProjectUsers)?.OpaqueUserId,
-                Content = comment.Contents?.InnerXml,
-                AcceptedChangeXml = comment.AcceptedChangeXmlStr,
-                DateCreated = DateTime.Parse(comment.Date),
-                DateModified = DateTime.Parse(comment.Date),
-                Deleted = comment.Deleted,
-                Status = comment.Status.InternalValue,
-                TagId = commentTag?.Id,
-                Reattached = comment.Reattached,
-                Assignment = GetAssignedUserRef(comment.AssignedUser, ptProjectUsers)
-            };
-        }
-
-        private string GetAssignedUserRef(string assignedPTUser, Dictionary<string, ParatextUserProfile> ptProjectUsers)
-        {
-            switch (assignedPTUser)
-            {
-                case Paratext.Data.ProjectComments.CommentThread.teamUser:
-                case Paratext.Data.ProjectComments.CommentThread.unassignedUser:
-                case null:
-                    return assignedPTUser;
-            }
-            return FindOrCreateParatextUser(assignedPTUser, ptProjectUsers).OpaqueUserId;
-        }
-
-        private CommentTag GetCommentTag(
-            Paratext.Data.ProjectComments.CommentThread thread,
-            Paratext.Data.ProjectComments.Comment comment,
-            CommentTags commentTags
-        )
-        {
-            // Use the main to do tag as default
-            CommentTag tagInUse = commentTags.Get(CommentTag.toDoTagId);
-            CommentTag lastTodoTagUsed = null;
-            foreach (Paratext.Data.ProjectComments.Comment threadComment in thread.Comments)
-            {
-                bool tagAddedInUse = threadComment.TagsAdded != null && threadComment.TagsAdded.Length > 0;
-                if (tagAddedInUse)
-                {
-                    tagInUse = commentTags.Get(int.Parse(threadComment.TagsAdded[0]));
-                }
-
-                // When checking the tag for the thread and a conflict is found then use that
-                if (comment == null)
-                {
-                    if (threadComment.Type == NoteType.Conflict)
-                        return CommentTag.ConflictTag;
-                    continue;
-                }
-
-                if (threadComment.Id == comment.Id)
-                {
-                    // Overwrite any tag with a conflict if needed
-                    if (comment.Type == NoteType.Conflict)
-                        return CommentTag.ConflictTag;
-
-                    // Ignore any repeat tag icons i.e. only use a tag if it has changed
-                    if (
-                        lastTodoTagUsed != null
-                        && lastTodoTagUsed.Icon == tagInUse.Icon
-                        && (comment.Status == NoteStatus.Todo || tagAddedInUse)
-                    )
-                        return null;
-
-                    // Only need to use the tag when there is a status in use or a tag has been specified
-                    if (comment.Status != NoteStatus.Unspecified || tagAddedInUse)
-                        return tagInUse;
-
-                    return null;
-                }
-                // Keep track of the last used to do status so we can avoid any repeats
-                if (threadComment.Status == NoteStatus.Todo)
-                    lastTodoTagUsed = tagInUse;
-                else if (threadComment.Status == NoteStatus.Resolved || threadComment.Status == NoteStatus.Done)
-                    lastTodoTagUsed = null;
-            }
-            // If we reach this far then the request is for the last used tag which is applied to the thread
-            return tagInUse;
-        }
-
-        private string GetVerseText(Delta delta, VerseRef verseRef)
-        {
-            string vref = string.IsNullOrEmpty(verseRef.Verse) ? verseRef.VerseNum.ToString() : verseRef.Verse;
-            return delta.TryConcatenateInserts(out string verseText, vref, DeltaUsxMapper.CanParaContainVerseText)
-                ? verseText
-                : string.Empty;
-        }
-
-        private TextAnchor GetThreadTextAnchor(CommentThread thread, Dictionary<int, ChapterDelta> chapterDeltas)
-        {
-            Paratext.Data.ProjectComments.Comment comment =
-                thread.Comments.LastOrDefault(c => c.Reattached != null) ?? thread.Comments[0];
-            VerseRef verseRef = comment.VerseRef;
-            int startPos = comment.StartPosition;
-            string selectedText = comment.SelectedText;
-            string contextBefore = comment.ContextBefore;
-            string contextAfter = comment.ContextAfter;
-            if (comment.Reattached != null)
-            {
-                string[] reattachedParts = comment.Reattached.Split(PtxUtils.StringUtils.orcCharacter);
-                verseRef = new VerseRef(reattachedParts[0]);
-                selectedText = reattachedParts[1];
-                startPos = int.Parse(reattachedParts[2]);
-                contextBefore = reattachedParts[3];
-                contextAfter = reattachedParts[4];
-            }
-
-            if (!chapterDeltas.TryGetValue(verseRef.ChapterNum, out ChapterDelta chapterDelta) || startPos == 0)
-                return new TextAnchor();
-
-            string verseText = GetVerseText(chapterDelta.Delta, verseRef);
-            verseText = verseText.Replace("\n", "\0");
-            PtxUtils.StringUtils.MatchContexts(
-                verseText,
-                contextBefore,
-                selectedText,
-                contextAfter,
-                null,
-                ref startPos,
-                out int posJustPastLastCharacter
-            );
-            // The text anchor is relative to the text in the verse
-            return new TextAnchor { Start = startPos, Length = posJustPastLastCharacter - startPos };
-        }
-
-        private ParatextUserProfile FindOrCreateParatextUser(
-            string paratextUsername,
-            Dictionary<string, ParatextUserProfile> ptProjectUsers
-        )
-        {
-            if (string.IsNullOrEmpty(paratextUsername))
-                return null;
-            if (!ptProjectUsers.TryGetValue(paratextUsername, out ParatextUserProfile ptProjectUser))
-            {
-                ptProjectUser = new ParatextUserProfile
-                {
-                    OpaqueUserId = _guidService.NewObjectId(),
-                    Username = paratextUsername
-                };
-                ptProjectUsers.Add(paratextUsername, ptProjectUser);
-            }
-            return ptProjectUser;
-        }
-
-        private async Task UpdateNoteSyncUserAsync(
-            IDocument<NoteThread> noteThreadDoc,
-            List<(int, string)> paratextUserByNoteIndex
-        )
-        {
-            await noteThreadDoc.SubmitJson0OpAsync(op =>
-            {
-                foreach ((int index, string syncuser) in paratextUserByNoteIndex)
-                    op.Set(t => t.Notes[index].SyncUserRef, syncuser);
-            });
-        }
-
-        // Make sure there are no asynchronous methods called after this until the progress is completed.
-        private void StartProgressReporting(IProgress<ProgressState>? progress)
-        {
-            if (progress == null)
-                return;
-            var progressDisplay = new SyncProgressDisplay(progress);
-            PtxUtils.Progress.Progress.Mgr.SetDisplay(progressDisplay);
-        }
-
-        private async Task<ParatextAccessLock> GetParatextAccessLock(string sfUserId, CancellationToken token)
-        {
-            SemaphoreSlim semaphore = _tokenRefreshSemaphores.GetOrAdd(
-                sfUserId,
-                (string key) => new SemaphoreSlim(1, 1)
-            );
-            await semaphore.WaitAsync();
-
-            try
-            {
-                Attempt<UserSecret> attempt = await _userSecretRepository.TryGetAsync(sfUserId);
-                if (!attempt.TryResult(out UserSecret userSecret))
-                {
-                    throw new DataNotFoundException("Could not find user secrets for SF user id " + sfUserId);
-                }
-
-                if (!userSecret.ParatextTokens.ValidateLifetime())
-                {
-                    Tokens refreshedUserTokens;
-                    try
-                    {
-                        refreshedUserTokens = await _jwtTokenHelper.RefreshAccessTokenAsync(
-                            _paratextOptions.Value,
-                            userSecret.ParatextTokens,
-                            _registryClient,
-                            token
-                        );
-                    }
-                    catch
-                    {
-                        _logger.LogWarning(
-                            $"ParatextService.GetParatextAccessLock for sfUserId {sfUserId} is throwing from call RefreshAccessTokenAsync()."
-                        );
-                        throw;
-                    }
-                    userSecret = await _userSecretRepository.UpdateAsync(
-                        sfUserId,
-                        b => b.Set(u => u.ParatextTokens, refreshedUserTokens)
-                    );
-                }
-                return new ParatextAccessLock(semaphore, userSecret);
-            }
-            catch
-            {
-                // If an exception is thrown between awaiting the semaphore and returning the ParatextAccessLock, the
-                // caller of the method will not get a reference to a ParatextAccessLock and can't release
-                // the semaphore.
-                semaphore.Release();
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// Writes the chapter to the <see cref="ScrText" />.
-        /// </summary>
-        /// <param name="scrText">The Scripture Text from Paratext.</param>
-        /// <param name="authorId">The user identifier for the author.</param>
-        /// <param name="bookNum">The book number.</param>
-        /// <param name="chapterNum">The chapter number. Set to 0 to write the entire book.</param>
-        /// <param name="usfm">The USFM to write.</param>
-        private void WriteChapterToScrText(ScrText scrText, string userId, int bookNum, int chapterNum, string usfm)
-        {
-            // If we don't have chapter authors, update book as current user
-            if (scrText.Permissions.AmAdministrator)
-            {
-                // if the current user is an administrator, then always allow editing the book text even if the user
-                // doesn't have permission. This will ensure that a sync by an administrator never fails.
-                scrText.Permissions.RunWithEditPermision(
-                    bookNum,
-                    () => scrText.PutText(bookNum, chapterNum, false, usfm, null)
-                );
-            }
-            else
-            {
-                scrText.PutText(bookNum, chapterNum, false, usfm, null);
-            }
-
-            if (chapterNum == 0)
-            {
-                _logger.LogInformation(
-                    "{0} updated {1} in {2}.",
-                    userId,
-                    Canon.BookNumberToEnglishName(bookNum),
-                    scrText.Name
-                );
-            }
-            else
-            {
-                _logger.LogInformation(
-                    "{0} updated chapter {1} of {2} in {3}.",
-                    userId,
-                    chapterNum,
-                    Canon.BookNumberToEnglishName(bookNum),
-                    scrText.Name
-                );
-            }
+            // If an exception is thrown between awaiting the semaphore and returning the ParatextAccessLock, the
+            // caller of the method will not get a reference to a ParatextAccessLock and can't release
+            // the semaphore.
+            semaphore.Release();
+            throw;
         }
     }
 
-    class ParatextAccessLock : DisposableBase
+    /// <summary>
+    /// Writes the chapter to the <see cref="ScrText" />.
+    /// </summary>
+    /// <param name="scrText">The Scripture Text from Paratext.</param>
+    /// <param name="authorId">The user identifier for the author.</param>
+    /// <param name="bookNum">The book number.</param>
+    /// <param name="chapterNum">The chapter number. Set to 0 to write the entire book.</param>
+    /// <param name="usfm">The USFM to write.</param>
+    private void WriteChapterToScrText(ScrText scrText, string userId, int bookNum, int chapterNum, string usfm)
     {
-        private SemaphoreSlim _userSemaphore;
-        public readonly UserSecret UserSecret;
-
-        public ParatextAccessLock(SemaphoreSlim userSemaphore, UserSecret userSecret)
+        // If we don't have chapter authors, update book as current user
+        if (scrText.Permissions.AmAdministrator)
         {
-            _userSemaphore = userSemaphore;
-            UserSecret = userSecret;
+            // if the current user is an administrator, then always allow editing the book text even if the user
+            // doesn't have permission. This will ensure that a sync by an administrator never fails.
+            scrText.Permissions.RunWithEditPermision(
+                bookNum,
+                () => scrText.PutText(bookNum, chapterNum, false, usfm, null)
+            );
+        }
+        else
+        {
+            scrText.PutText(bookNum, chapterNum, false, usfm, null);
         }
 
-        protected override void DisposeManagedResources()
+        if (chapterNum == 0)
         {
-            _userSemaphore.Release();
+            _logger.LogInformation(
+                "{0} updated {1} in {2}.",
+                userId,
+                Canon.BookNumberToEnglishName(bookNum),
+                scrText.Name
+            );
+        }
+        else
+        {
+            _logger.LogInformation(
+                "{0} updated chapter {1} of {2} in {3}.",
+                userId,
+                chapterNum,
+                Canon.BookNumberToEnglishName(bookNum),
+                scrText.Name
+            );
         }
     }
+}
+
+class ParatextAccessLock : DisposableBase
+{
+    private SemaphoreSlim _userSemaphore;
+    public readonly UserSecret UserSecret;
+
+    public ParatextAccessLock(SemaphoreSlim userSemaphore, UserSecret userSecret)
+    {
+        _userSemaphore = userSemaphore;
+        UserSecret = userSecret;
+    }
+
+    protected override void DisposeManagedResources() => _userSemaphore.Release();
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -19,1722 +19,1684 @@ using SIL.XForge.Realtime.RichText;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// This class syncs real-time text and question docs with the Paratext S/R server. This class coordinates the data
+/// flow between three sources:
+/// 1. The real-time docs stored in Mongo, the SF DB.
+/// 2. The local Paratext project repo.
+/// 3. The remote Paratext project repo, aka PT Archives, aka the Send and Receive server.
+///
+/// Algorithm:
+/// 1. The text deltas from the real-time docs are converted to USX.
+/// 2. The local repo is updated using the converted USX.
+/// 3. A note changelist is computed by diffing the the real-time question docs and the notes in the local repo.
+/// 4. The local repo is updated using the note changelist.
+/// 5. PT send/receive is performed (remote and local repos are synced).
+/// 6. Docs associated with remotely deleted books are deleted.
+/// 7. Updated USX is retrieved from the local repo.
+/// 7. The returned USX is converted back to text deltas and diffed against the current deltas.
+/// 8. The diff is submitted as an operation to the real-time text docs (chapter docs are added and deleted as
+/// needed).
+/// 9. Question docs associated with remotely deleted chapters are deleted.
+///
+/// Target and source refer to daughter and mother translation data. Not to be confused with a target or source for
+/// where data is coming from or going to when fetching or syncing.
+/// <code>
+/// Diagram showing a high-level look at the order of data being transmitted:
+/// ┌─────┐  ┌─────┐  ┌───────────┐
+/// │SF DB├─>│Local│  │PT Archives│
+/// │     │  │PT hg├─>│           │
+/// │     │  │repo │  │           │
+/// │     │  │     │<─┤           │
+/// │     │<─┤     │  │           │
+/// └─────┘  └─────┘  └───────────┘
+/// </code>
+/// </summary>
+public class ParatextSyncRunner : IParatextSyncRunner
 {
-    /// <summary>
-    /// This class syncs real-time text and question docs with the Paratext S/R server. This class coordinates the data
-    /// flow between three sources:
-    /// 1. The real-time docs stored in Mongo, the SF DB.
-    /// 2. The local Paratext project repo.
-    /// 3. The remote Paratext project repo, aka PT Archives, aka the Send and Receive server.
-    ///
-    /// Algorithm:
-    /// 1. The text deltas from the real-time docs are converted to USX.
-    /// 2. The local repo is updated using the converted USX.
-    /// 3. A note changelist is computed by diffing the the real-time question docs and the notes in the local repo.
-    /// 4. The local repo is updated using the note changelist.
-    /// 5. PT send/receive is performed (remote and local repos are synced).
-    /// 6. Docs associated with remotely deleted books are deleted.
-    /// 7. Updated USX is retrieved from the local repo.
-    /// 7. The returned USX is converted back to text deltas and diffed against the current deltas.
-    /// 8. The diff is submitted as an operation to the real-time text docs (chapter docs are added and deleted as
-    /// needed).
-    /// 9. Question docs associated with remotely deleted chapters are deleted.
-    ///
-    /// Target and source refer to daughter and mother translation data. Not to be confused with a target or source for
-    /// where data is coming from or going to when fetching or syncing.
-    /// <code>
-    /// Diagram showing a high-level look at the order of data being transmitted:
-    /// ┌─────┐  ┌─────┐  ┌───────────┐
-    /// │SF DB├─>│Local│  │PT Archives│
-    /// │     │  │PT hg├─>│           │
-    /// │     │  │repo │  │           │
-    /// │     │  │     │<─┤           │
-    /// │     │<─┤     │  │           │
-    /// └─────┘  └─────┘  └───────────┘
-    /// </code>
-    /// </summary>
-    public class ParatextSyncRunner : IParatextSyncRunner
+    private static readonly double _numberOfPhases = Enum.GetValues(typeof(SyncPhase)).Length;
+    private static readonly IEqualityComparer<List<Chapter>> _chapterListEqualityComparer =
+        SequenceEqualityComparer.Create(new ChapterEqualityComparer());
+
+    private readonly IRepository<UserSecret> _userSecrets;
+    private readonly IRepository<SFProjectSecret> _projectSecrets;
+    private readonly IRepository<SyncMetrics> _syncMetricsRepository;
+    private readonly ISFProjectService _projectService;
+    private readonly IMachineProjectService _machineProjectService;
+    private readonly IParatextService _paratextService;
+    private readonly IRealtimeService _realtimeService;
+    private readonly IDeltaUsxMapper _deltaUsxMapper;
+    private readonly IParatextNotesMapper _notesMapper;
+    private readonly ILogger<ParatextSyncRunner> _logger;
+    private readonly IHubContext<NotificationHub, INotifier> _hubContext;
+
+    private IConnection _conn;
+    private UserSecret _userSecret;
+    private IDocument<SFProject> _projectDoc;
+    private SFProjectSecret _projectSecret;
+    private SyncMetrics _syncMetrics;
+    private Dictionary<string, ParatextUserProfile> _currentPtSyncUsers;
+
+    public ParatextSyncRunner(
+        IRepository<UserSecret> userSecrets,
+        IRepository<SFProjectSecret> projectSecrets,
+        IRepository<SyncMetrics> syncMetricsRepository,
+        ISFProjectService projectService,
+        IMachineProjectService machineProjectService,
+        IParatextService paratextService,
+        IRealtimeService realtimeService,
+        IDeltaUsxMapper deltaUsxMapper,
+        IParatextNotesMapper notesMapper,
+        IHubContext<NotificationHub, INotifier> hubContext,
+        ILogger<ParatextSyncRunner> logger
+    )
     {
-        private static readonly double _numberOfPhases = Enum.GetValues(typeof(SyncPhase)).Length;
-        private static readonly IEqualityComparer<List<Chapter>> _chapterListEqualityComparer =
-            SequenceEqualityComparer.Create(new ChapterEqualityComparer());
+        _userSecrets = userSecrets;
+        _projectSecrets = projectSecrets;
+        _syncMetricsRepository = syncMetricsRepository;
+        _projectService = projectService;
+        _machineProjectService = machineProjectService;
+        _paratextService = paratextService;
+        _realtimeService = realtimeService;
+        _logger = logger;
+        _deltaUsxMapper = deltaUsxMapper;
+        _notesMapper = notesMapper;
+        _hubContext = hubContext;
+    }
 
-        private readonly IRepository<UserSecret> _userSecrets;
-        private readonly IRepository<SFProjectSecret> _projectSecrets;
-        private readonly IRepository<SyncMetrics> _syncMetricsRepository;
-        private readonly ISFProjectService _projectService;
-        private readonly IMachineProjectService _machineProjectService;
-        private readonly IParatextService _paratextService;
-        private readonly IRealtimeService _realtimeService;
-        private readonly IDeltaUsxMapper _deltaUsxMapper;
-        private readonly IParatextNotesMapper _notesMapper;
-        private readonly ILogger<ParatextSyncRunner> _logger;
-        private readonly IHubContext<NotificationHub, INotifier> _hubContext;
+    private bool TranslationSuggestionsEnabled => _projectDoc.Data.TranslateConfig.TranslationSuggestionsEnabled;
+    private bool CheckingEnabled => _projectDoc.Data.CheckingConfig.CheckingEnabled;
 
-        private IConnection _conn;
-        private UserSecret _userSecret;
-        private IDocument<SFProject> _projectDoc;
-        private SFProjectSecret _projectSecret;
-        private SyncMetrics _syncMetrics;
-        private Dictionary<string, ParatextUserProfile> _currentPtSyncUsers;
-
-        public ParatextSyncRunner(
-            IRepository<UserSecret> userSecrets,
-            IRepository<SFProjectSecret> projectSecrets,
-            IRepository<SyncMetrics> syncMetricsRepository,
-            ISFProjectService projectService,
-            IMachineProjectService machineProjectService,
-            IParatextService paratextService,
-            IRealtimeService realtimeService,
-            IDeltaUsxMapper deltaUsxMapper,
-            IParatextNotesMapper notesMapper,
-            IHubContext<NotificationHub, INotifier> hubContext,
-            ILogger<ParatextSyncRunner> logger
-        )
+    /// <summary>
+    /// Synchronize content and user permissions in SF DB with Paratext SendReceive servers and PT Registry, for
+    /// a project.
+    /// </summary>
+    /// <remarks>
+    /// Do not allow multiple sync jobs to run in parallel on the same project by creating a hangfire mutex on the
+    /// <param name="projectSFId"/> parameter, i.e. "{0}".
+    /// </remarks>
+    [Mutex("{0}")]
+    public async Task RunAsync(
+        string projectSFId,
+        string userId,
+        string syncMetricsId,
+        bool trainEngine,
+        CancellationToken token
+    )
+    {
+        // Whether or not we can rollback Paratext
+        bool canRollbackParatext = false;
+        try
         {
-            _userSecrets = userSecrets;
-            _projectSecrets = projectSecrets;
-            _syncMetricsRepository = syncMetricsRepository;
-            _projectService = projectService;
-            _machineProjectService = machineProjectService;
-            _paratextService = paratextService;
-            _realtimeService = realtimeService;
-            _logger = logger;
-            _deltaUsxMapper = deltaUsxMapper;
-            _notesMapper = notesMapper;
-            _hubContext = hubContext;
-        }
-
-        private bool TranslationSuggestionsEnabled => _projectDoc.Data.TranslateConfig.TranslationSuggestionsEnabled;
-        private bool CheckingEnabled => _projectDoc.Data.CheckingConfig.CheckingEnabled;
-
-        /// <summary>
-        /// Synchronize content and user permissions in SF DB with Paratext SendReceive servers and PT Registry, for
-        /// a project.
-        /// </summary>
-        /// <remarks>
-        /// Do not allow multiple sync jobs to run in parallel on the same project by creating a hangfire mutex on the
-        /// <param name="projectSFId"/> parameter, i.e. "{0}".
-        /// </remarks>
-        [Mutex("{0}")]
-        public async Task RunAsync(
-            string projectSFId,
-            string userId,
-            string syncMetricsId,
-            bool trainEngine,
-            CancellationToken token
-        )
-        {
-            // Whether or not we can rollback Paratext
-            bool canRollbackParatext = false;
-            try
+            if (!await InitAsync(projectSFId, userId, syncMetricsId, token))
             {
-                if (!await InitAsync(projectSFId, userId, syncMetricsId, token))
-                {
-                    await CompleteSync(false, canRollbackParatext, trainEngine, token);
-                    return;
-                }
+                await CompleteSync(false, canRollbackParatext, trainEngine, token);
+                return;
+            }
 
-                string targetParatextId = _projectDoc.Data.ParatextId;
-                string? sourceParatextId = _projectDoc.Data.TranslateConfig.Source?.ParatextId;
-                string? sourceProjectRef = _projectDoc.Data.TranslateConfig.Source?.ProjectRef;
-                Log($"RunAsync: Starting. Target PT id '{targetParatextId}', source PT id '{sourceParatextId}'.");
+            string targetParatextId = _projectDoc.Data.ParatextId;
+            string? sourceParatextId = _projectDoc.Data.TranslateConfig.Source?.ParatextId;
+            string? sourceProjectRef = _projectDoc.Data.TranslateConfig.Source?.ProjectRef;
+            Log($"RunAsync: Starting. Target PT id '{targetParatextId}', source PT id '{sourceParatextId}'.");
 
-                // Determine if we can rollback Paratext
-                canRollbackParatext = _paratextService.BackupExists(_userSecret, targetParatextId);
-                if (!canRollbackParatext)
+            // Determine if we can rollback Paratext
+            canRollbackParatext = _paratextService.BackupExists(_userSecret, targetParatextId);
+            if (!canRollbackParatext)
+            {
+                // Attempt to create a backup if we cannot rollback
+                canRollbackParatext = _paratextService.BackupRepository(_userSecret, targetParatextId);
+                _syncMetrics.RepositoryBackupCreated = canRollbackParatext;
+                if (canRollbackParatext)
                 {
-                    // Attempt to create a backup if we cannot rollback
-                    canRollbackParatext = _paratextService.BackupRepository(_userSecret, targetParatextId);
-                    _syncMetrics.RepositoryBackupCreated = canRollbackParatext;
-                    if (canRollbackParatext)
-                    {
-                        Log($"RunAsync: There wasn't already a local PT repo backup, so we made one.");
-                    }
-                    else
-                    {
-                        Log(
-                            $"RunAsync: There wasn't already a local PT repo backup, so we tried to make one but failed."
-                        );
-                    }
-                }
-
-                ReportRepoRevs();
-                await NotifySyncProgress(SyncPhase.Phase1, 50.0);
-
-                if (_paratextService.IsResource(targetParatextId))
-                {
-                    Log($"This is a resource, so not considering hg repo revisions.");
-                }
-                else if (_projectDoc.Data.Sync.SyncedToRepositoryVersion == null)
-                {
-                    Log(
-                        $"The SF DB SyncedToRepositoryVersion is null. Maybe this project is being Connected, or has not synced successfully since we started tracking this information."
-                    );
+                    Log($"RunAsync: There wasn't already a local PT repo backup, so we made one.");
                 }
                 else
                 {
-                    Log(
-                        $"Setting hg repo to last imported hg repo rev of {_projectDoc.Data.Sync.SyncedToRepositoryVersion}."
-                    );
-                    _paratextService.SetRepoToRevision(
-                        _userSecret,
-                        targetParatextId,
-                        _projectDoc.Data.Sync.SyncedToRepositoryVersion
-                    );
+                    Log($"RunAsync: There wasn't already a local PT repo backup, so we tried to make one but failed.");
                 }
-
-                var targetTextDocsByBook = new Dictionary<int, SortedList<int, IDocument<TextData>>>();
-                var questionDocsByBook = new Dictionary<int, IReadOnlyList<IDocument<Question>>>();
-
-                // Update target Paratext books and notes, if this is not a resource
-                if (!_paratextService.IsResource(targetParatextId))
-                {
-                    await GetAndUpdateParatextBooksAndNotes(
-                        SyncPhase.Phase2,
-                        targetParatextId,
-                        targetTextDocsByBook,
-                        questionDocsByBook
-                    );
-                }
-
-                // Check for cancellation
-                if (token.IsCancellationRequested)
-                {
-                    await CompleteSync(false, canRollbackParatext, trainEngine, token);
-                    return;
-                }
-
-                // Use the new progress bar
-                var progress = new SyncProgress();
-                ParatextProject paratextProject;
-                try
-                {
-                    // Create the handler
-                    progress.ProgressUpdated += SyncProgress_ProgressUpdated;
-
-                    Log($"RunAsync: Going to do ParatextData SendReceive.");
-                    // perform Paratext send/receive
-                    paratextProject = await _paratextService.SendReceiveAsync(
-                        _userSecret,
-                        targetParatextId,
-                        progress,
-                        token
-                    );
-                    Log($"RunAsync: ParatextData SendReceive finished without throwing.");
-                }
-                finally
-                {
-                    // Deregister the handler
-                    progress.ProgressUpdated -= SyncProgress_ProgressUpdated;
-                }
-
-                await NotifySyncProgress(SyncPhase.Phase4, 30.0);
-
-                // Check for cancellation
-                if (token.IsCancellationRequested)
-                {
-                    await CompleteSync(false, canRollbackParatext, trainEngine, token);
-                    return;
-                }
-
-                var targetBooks = new HashSet<int>(_paratextService.GetBookList(_userSecret, targetParatextId));
-                var sourceBooks = new HashSet<int>(_paratextService.GetBookList(_userSecret, sourceParatextId));
-                sourceBooks.IntersectWith(targetBooks);
-
-                var targetBooksToDelete = new HashSet<int>(
-                    _projectDoc.Data.Texts.Select(t => t.BookNum).Except(targetBooks)
-                );
-
-                // Check for cancellation
-                if (token.IsCancellationRequested)
-                {
-                    await CompleteSync(false, canRollbackParatext, trainEngine, token);
-                    return;
-                }
-
-                // delete all data for removed books
-                if (targetBooksToDelete.Count > 0)
-                {
-                    Log(
-                        $"RunAsync: Going to delete texts and questions,comments,answers for {targetBooksToDelete.Count} books."
-                    );
-                    // delete target books
-                    foreach (int bookNum in targetBooksToDelete)
-                    {
-                        LogMetric($"Deleting book {bookNum}");
-                        int textIndex = _projectDoc.Data.Texts.FindIndex(t => t.BookNum == bookNum);
-                        TextInfo text = _projectDoc.Data.Texts[textIndex];
-                        await _projectDoc.SubmitJson0OpAsync(op => op.Remove(pd => pd.Texts, textIndex));
-
-                        await DeleteAllTextDocsForBookAsync(text);
-                        await DeleteAllQuestionsDocsForBookAsync(text);
-                        await DeleteNoteThreadDocsInChapters(text.BookNum, text.Chapters);
-                    }
-
-                    _syncMetrics.Books.Deleted = targetBooksToDelete.Count;
-                }
-
-                await NotifySyncProgress(SyncPhase.Phase4, 60.0);
-
-                // Check for cancellation
-                if (token.IsCancellationRequested)
-                {
-                    await CompleteSync(false, canRollbackParatext, trainEngine, token);
-                    return;
-                }
-
-                // Update user resource access, if this project has a source resource
-                // The updating of a source project's permissions is done when that project is synced.
-                if (
-                    TranslationSuggestionsEnabled
-                    && !string.IsNullOrWhiteSpace(sourceParatextId)
-                    && !string.IsNullOrWhiteSpace(sourceProjectRef)
-                    && _paratextService.IsResource(sourceParatextId)
-                )
-                {
-                    LogMetric("Updating user resource access");
-
-                    // Get the resource project
-                    IDocument<SFProject> sourceProject = await _conn.FetchAsync<SFProject>(sourceProjectRef);
-                    if (sourceProject.IsLoaded)
-                    {
-                        // NOTE: The following additions/removals not included in the transaction
-
-                        // Add new PT users who are in the target project, but not the source project
-                        List<string> usersToAdd = _projectDoc.Data.UserRoles
-                            .Where(u => SFProjectRole.IsParatextRole(u.Value))
-                            .Select(u => u.Key)
-                            .Except(sourceProject.Data.UserRoles.Keys)
-                            .ToList();
-                        foreach (string uid in usersToAdd)
-                        {
-                            // As resource projects do not have administrators, we connect as the user we are to add
-                            try
-                            {
-                                await _projectService.AddUserAsync(uid, sourceProjectRef);
-                                _syncMetrics.ResourceUsers.Added++;
-                            }
-                            catch (ForbiddenException e)
-                            {
-                                // The user does not have Paratext access
-                                Log($"RunAsync: Error attempting to add a user to the resource access list: {e}");
-                            }
-                        }
-
-                        // Remove PT users who are in the target project, and no longer have access to the resource
-                        List<string> usersToCheck = _projectDoc.Data.UserRoles
-                            .Where(u => SFProjectRole.IsParatextRole(u.Value))
-                            .Select(u => u.Key)
-                            .Except(usersToAdd)
-                            .ToList();
-                        foreach (string uid in usersToCheck)
-                        {
-                            string permission = await _paratextService.GetResourcePermissionAsync(
-                                sourceParatextId,
-                                uid,
-                                token
-                            );
-                            if (permission == TextInfoPermission.None)
-                            {
-                                await _projectService.RemoveUserWithoutPermissionsCheckAsync(
-                                    uid,
-                                    sourceProjectRef,
-                                    uid
-                                );
-                                _syncMetrics.ResourceUsers.Deleted++;
-                            }
-                        }
-                    }
-                }
-
-                await NotifySyncProgress(SyncPhase.Phase4, 90.0);
-
-                bool resourceNeedsUpdating =
-                    paratextProject is ParatextResource paratextResource
-                    && _paratextService.ResourceDocsNeedUpdating(_projectDoc.Data, paratextResource);
-
-                // If a resource needs updating, retrieve the books, as they were not retrieved previously
-                if (resourceNeedsUpdating)
-                {
-                    await GetAndUpdateParatextBooksAndNotes(
-                        SyncPhase.Phase5,
-                        targetParatextId,
-                        targetTextDocsByBook,
-                        questionDocsByBook
-                    );
-                }
-
-                if (!_paratextService.IsResource(targetParatextId) || resourceNeedsUpdating)
-                {
-                    await UpdateDocsAsync(
-                        SyncPhase.Phase6,
-                        targetParatextId,
-                        targetTextDocsByBook,
-                        questionDocsByBook,
-                        targetBooks,
-                        sourceBooks,
-                        token
-                    );
-                }
-                LogMetric("Back from UpdateDocsAsync");
-                await NotifySyncProgress(SyncPhase.Phase7, 20.0);
-
-                // Check for cancellation
-                if (token.IsCancellationRequested)
-                {
-                    await CompleteSync(false, canRollbackParatext, trainEngine, token);
-                    return;
-                }
-
-                // Update the resource configuration
-                if (resourceNeedsUpdating)
-                {
-                    LogMetric("Updating resource config");
-                    await UpdateResourceConfig(paratextProject);
-                }
-
-                // We will always update permissions, even if this is a resource project
-                LogMetric("Updating permissions");
-                await _projectService.UpdatePermissionsAsync(userId, _projectDoc, token);
-
-                await NotifySyncProgress(SyncPhase.Phase7, 40.0);
-
-                // Check for cancellation
-                if (token.IsCancellationRequested)
-                {
-                    await CompleteSync(false, canRollbackParatext, trainEngine, token);
-                    return;
-                }
-
-                await CompleteSync(true, canRollbackParatext, trainEngine, token);
             }
-            catch (Exception e)
+
+            ReportRepoRevs();
+            await NotifySyncProgress(SyncPhase.Phase1, 50.0);
+
+            if (_paratextService.IsResource(targetParatextId))
             {
-                if (e is not TaskCanceledException)
-                {
-                    StringBuilder additionalInformation = new StringBuilder();
-                    foreach (var key in e.Data.Keys)
-                    {
-                        additionalInformation.AppendLine($"{key}: {e.Data[key]}");
-                    }
+                Log($"This is a resource, so not considering hg repo revisions.");
+            }
+            else if (_projectDoc.Data.Sync.SyncedToRepositoryVersion == null)
+            {
+                Log(
+                    $"The SF DB SyncedToRepositoryVersion is null. Maybe this project is being Connected, or has not synced successfully since we started tracking this information."
+                );
+            }
+            else
+            {
+                Log(
+                    $"Setting hg repo to last imported hg repo rev of {_projectDoc.Data.Sync.SyncedToRepositoryVersion}."
+                );
+                _paratextService.SetRepoToRevision(
+                    _userSecret,
+                    targetParatextId,
+                    _projectDoc.Data.Sync.SyncedToRepositoryVersion
+                );
+            }
 
-                    string message =
-                        $"Error occurred while executing Paratext sync for project with SF id '{projectSFId}'. {(additionalInformation.Length == 0 ? string.Empty : $"Additional information: {additionalInformation}")}";
-                    _syncMetrics.ErrorDetails = $"{e}{Environment.NewLine}{message}";
-                    _logger.LogError(e, message);
-                    LogMetric(message);
-                }
+            var targetTextDocsByBook = new Dictionary<int, SortedList<int, IDocument<TextData>>>();
+            var questionDocsByBook = new Dictionary<int, IReadOnlyList<IDocument<Question>>>();
 
+            // Update target Paratext books and notes, if this is not a resource
+            if (!_paratextService.IsResource(targetParatextId))
+            {
+                await GetAndUpdateParatextBooksAndNotes(
+                    SyncPhase.Phase2,
+                    targetParatextId,
+                    targetTextDocsByBook,
+                    questionDocsByBook
+                );
+            }
+
+            // Check for cancellation
+            if (token.IsCancellationRequested)
+            {
                 await CompleteSync(false, canRollbackParatext, trainEngine, token);
+                return;
+            }
+
+            // Use the new progress bar
+            var progress = new SyncProgress();
+            ParatextProject paratextProject;
+            try
+            {
+                // Create the handler
+                progress.ProgressUpdated += SyncProgress_ProgressUpdated;
+
+                Log($"RunAsync: Going to do ParatextData SendReceive.");
+                // perform Paratext send/receive
+                paratextProject = await _paratextService.SendReceiveAsync(
+                    _userSecret,
+                    targetParatextId,
+                    progress,
+                    token
+                );
+                Log($"RunAsync: ParatextData SendReceive finished without throwing.");
             }
             finally
             {
-                CloseConnection();
+                // Deregister the handler
+                progress.ProgressUpdated -= SyncProgress_ProgressUpdated;
             }
-        }
 
-        /// <summary>
-        /// Retrieves the texts and questions from the Realtime server, and updates the Paratext repository if the
-        /// project is not a Paratext resource. Both of the dictionaries <paramref name="textDocsByBook"/> and
-        /// <paramref name="questionDocsByBook"/> are populated by this method.
-        /// </summary>
-        /// <param name="syncPhase">The sync phase.</param>
-        /// <param name="paratextId">The Paratext ID.</param>
-        /// <param name="textDocsByBook">The text documents with the book number as key.</param>
-        /// <param name="questionDocsByBook">The question documents with the book number as key.</param>
-        /// <returns>The task.</returns>
-        /// <exception cref="ArgumentException">The Paratext project repository does not exist.</exception>
-        private async Task GetAndUpdateParatextBooksAndNotes(
-            SyncPhase syncPhase,
-            string paratextId,
-            Dictionary<int, SortedList<int, IDocument<TextData>>> textDocsByBook,
-            Dictionary<int, IReadOnlyList<IDocument<Question>>> questionDocsByBook
-        )
-        {
-            ParatextSettings? settings = _paratextService.GetParatextSettings(_userSecret, paratextId);
-            double i = 0.0;
-            foreach (TextInfo text in _projectDoc.Data.Texts)
+            await NotifySyncProgress(SyncPhase.Phase4, 30.0);
+
+            // Check for cancellation
+            if (token.IsCancellationRequested)
             {
-                i++;
-
-                await NotifySyncProgress(syncPhase, i / _projectDoc.Data.Texts.Count);
-
-                // We check for settings in the loop, because if there are no texts, we would expect it to be null
-                if (settings == null)
-                {
-                    throw new ArgumentException(
-                        "FAILED: Attempting to write to a project repository that does not exist."
-                    );
-                }
-
-                LogMetric($"Getting Paratext book {text.BookNum}");
-                SortedList<int, IDocument<TextData>> targetTextDocs = await FetchTextDocsAsync(text);
-                textDocsByBook[text.BookNum] = targetTextDocs;
-                if (settings.Editable && !_paratextService.IsResource(paratextId))
-                {
-                    LogMetric("Updating Paratext book");
-                    await UpdateParatextBook(text, paratextId, targetTextDocs);
-                }
-
-                IReadOnlyList<IDocument<Question>> questionDocs = await FetchQuestionDocsAsync(text);
-                questionDocsByBook[text.BookNum] = questionDocs;
-                if (!_paratextService.IsResource(paratextId))
-                {
-                    LogMetric("Updating Paratext notes");
-                    IEnumerable<IDocument<NoteThread>> noteThreadDocs = (
-                        await FetchNoteThreadDocsAsync(text.BookNum)
-                    ).Values;
-                    // Only update the note tag if there are SF note threads in the project
-                    if (noteThreadDocs.Any(d => d.Data.PublishedToSF == true))
-                        await UpdateTranslateNoteTag(paratextId);
-                    await UpdateParatextNotesAsync(text, questionDocs);
-                    // TODO: Sync Note changes back to Paratext, and record sync metric info
-                    // await _paratextService.UpdateParatextCommentsAsync(_userSecret, paratextId, text.BookNum,
-                    //     noteThreadDocs, _currentPtSyncUsers);
-                }
+                await CompleteSync(false, canRollbackParatext, trainEngine, token);
+                return;
             }
-        }
 
-        /// <summary>
-        /// Updates the resource configuration
-        /// </summary>
-        /// <param name="project">The SF project.</param>
-        /// <param name="paratextProject">The Paratext project. This should be a resource.</param>
-        /// <returns>The asynchronous task.</returns>
-        /// <remarks>Only call this if the config requires an update.</remarks>
-        private async Task UpdateResourceConfig(ParatextProject paratextProject)
-        {
-            // Update the resource configuration
-            if (paratextProject is ParatextResource paratextResource)
+            var targetBooks = new HashSet<int>(_paratextService.GetBookList(_userSecret, targetParatextId));
+            var sourceBooks = new HashSet<int>(_paratextService.GetBookList(_userSecret, sourceParatextId));
+            sourceBooks.IntersectWith(targetBooks);
+
+            var targetBooksToDelete = new HashSet<int>(
+                _projectDoc.Data.Texts.Select(t => t.BookNum).Except(targetBooks)
+            );
+
+            // Check for cancellation
+            if (token.IsCancellationRequested)
             {
-                if (_projectDoc.Data.ResourceConfig == null)
+                await CompleteSync(false, canRollbackParatext, trainEngine, token);
+                return;
+            }
+
+            // delete all data for removed books
+            if (targetBooksToDelete.Count > 0)
+            {
+                Log(
+                    $"RunAsync: Going to delete texts and questions,comments,answers for {targetBooksToDelete.Count} books."
+                );
+                // delete target books
+                foreach (int bookNum in targetBooksToDelete)
                 {
-                    // Create the resource config
-                    await _projectDoc.SubmitJson0OpAsync(
-                        op =>
-                            op.Set(
-                                pd => pd.ResourceConfig,
-                                new ResourceConfig
-                                {
-                                    CreatedTimestamp = paratextResource.CreatedTimestamp,
-                                    ManifestChecksum = paratextResource.ManifestChecksum,
-                                    PermissionsChecksum = paratextResource.PermissionsChecksum,
-                                    Revision = paratextResource.AvailableRevision,
-                                }
-                            )
-                    );
+                    LogMetric($"Deleting book {bookNum}");
+                    int textIndex = _projectDoc.Data.Texts.FindIndex(t => t.BookNum == bookNum);
+                    TextInfo text = _projectDoc.Data.Texts[textIndex];
+                    await _projectDoc.SubmitJson0OpAsync(op => op.Remove(pd => pd.Texts, textIndex));
+
+                    await DeleteAllTextDocsForBookAsync(text);
+                    await DeleteAllQuestionsDocsForBookAsync(text);
+                    await DeleteNoteThreadDocsInChapters(text.BookNum, text.Chapters);
                 }
-                else
+
+                _syncMetrics.Books.Deleted = targetBooksToDelete.Count;
+            }
+
+            await NotifySyncProgress(SyncPhase.Phase4, 60.0);
+
+            // Check for cancellation
+            if (token.IsCancellationRequested)
+            {
+                await CompleteSync(false, canRollbackParatext, trainEngine, token);
+                return;
+            }
+
+            // Update user resource access, if this project has a source resource
+            // The updating of a source project's permissions is done when that project is synced.
+            if (
+                TranslationSuggestionsEnabled
+                && !string.IsNullOrWhiteSpace(sourceParatextId)
+                && !string.IsNullOrWhiteSpace(sourceProjectRef)
+                && _paratextService.IsResource(sourceParatextId)
+            )
+            {
+                LogMetric("Updating user resource access");
+
+                // Get the resource project
+                IDocument<SFProject> sourceProject = await _conn.FetchAsync<SFProject>(sourceProjectRef);
+                if (sourceProject.IsLoaded)
                 {
-                    // Update the resource config
-                    await _projectDoc.SubmitJson0OpAsync(op =>
+                    // NOTE: The following additions/removals not included in the transaction
+
+                    // Add new PT users who are in the target project, but not the source project
+                    List<string> usersToAdd = _projectDoc.Data.UserRoles
+                        .Where(u => SFProjectRole.IsParatextRole(u.Value))
+                        .Select(u => u.Key)
+                        .Except(sourceProject.Data.UserRoles.Keys)
+                        .ToList();
+                    foreach (string uid in usersToAdd)
                     {
-                        op.Set(pd => pd.ResourceConfig.CreatedTimestamp, paratextResource.CreatedTimestamp);
-                        op.Set(pd => pd.ResourceConfig.ManifestChecksum, paratextResource.ManifestChecksum);
-                        op.Set(pd => pd.ResourceConfig.PermissionsChecksum, paratextResource.PermissionsChecksum);
-                        op.Set(pd => pd.ResourceConfig.Revision, paratextResource.AvailableRevision);
-                    });
+                        // As resource projects do not have administrators, we connect as the user we are to add
+                        try
+                        {
+                            await _projectService.AddUserAsync(uid, sourceProjectRef);
+                            _syncMetrics.ResourceUsers.Added++;
+                        }
+                        catch (ForbiddenException e)
+                        {
+                            // The user does not have Paratext access
+                            Log($"RunAsync: Error attempting to add a user to the resource access list: {e}");
+                        }
+                    }
+
+                    // Remove PT users who are in the target project, and no longer have access to the resource
+                    List<string> usersToCheck = _projectDoc.Data.UserRoles
+                        .Where(u => SFProjectRole.IsParatextRole(u.Value))
+                        .Select(u => u.Key)
+                        .Except(usersToAdd)
+                        .ToList();
+                    foreach (string uid in usersToCheck)
+                    {
+                        string permission = await _paratextService.GetResourcePermissionAsync(
+                            sourceParatextId,
+                            uid,
+                            token
+                        );
+                        if (permission == TextInfoPermission.None)
+                        {
+                            await _projectService.RemoveUserWithoutPermissionsCheckAsync(uid, sourceProjectRef, uid);
+                            _syncMetrics.ResourceUsers.Deleted++;
+                        }
+                    }
                 }
             }
-        }
 
-        private async Task PreflightAuthenticationReportAsync()
-        {
-            bool canAuthToRegistry = await _paratextService.CanUserAuthenticateToPTRegistryAsync(_userSecret);
-            bool canAuthToArchives = await _paratextService.CanUserAuthenticateToPTArchivesAsync(_userSecret.Id);
-            Log($"User can authenticate to PT Registry: {canAuthToRegistry}, to PT Archives: {canAuthToArchives}.");
-        }
+            await NotifySyncProgress(SyncPhase.Phase4, 90.0);
 
-        private async Task UpdateDocsAsync(
-            SyncPhase syncPhase,
-            string targetParatextId,
-            Dictionary<int, SortedList<int, IDocument<TextData>>> targetTextDocsByBook,
-            Dictionary<int, IReadOnlyList<IDocument<Question>>> questionDocsByBook,
-            HashSet<int> targetBooks,
-            HashSet<int> sourceBooks,
-            CancellationToken token
-        )
-        {
-            Dictionary<string, string> ptUsernamesToSFUserIds = await GetPTUsernameToSFUserIdsAsync(token);
+            bool resourceNeedsUpdating =
+                paratextProject is ParatextResource paratextResource
+                && _paratextService.ResourceDocsNeedUpdating(_projectDoc.Data, paratextResource);
 
-            // update source and target real-time docs
-            double i = 0.0;
-            foreach (int bookNum in targetBooks)
+            // If a resource needs updating, retrieve the books, as they were not retrieved previously
+            if (resourceNeedsUpdating)
             {
-                i++;
-                await NotifySyncProgress(syncPhase, i / targetBooks.Count);
-                LogMetric($"Updating text info for book {bookNum}");
-                bool hasSource = sourceBooks.Contains(bookNum);
-                int textIndex = _projectDoc.Data.Texts.FindIndex(t => t.BookNum == bookNum);
-                TextInfo text;
-                if (textIndex == -1)
+                await GetAndUpdateParatextBooksAndNotes(
+                    SyncPhase.Phase5,
+                    targetParatextId,
+                    targetTextDocsByBook,
+                    questionDocsByBook
+                );
+            }
+
+            if (!_paratextService.IsResource(targetParatextId) || resourceNeedsUpdating)
+            {
+                await UpdateDocsAsync(
+                    SyncPhase.Phase6,
+                    targetParatextId,
+                    targetTextDocsByBook,
+                    questionDocsByBook,
+                    targetBooks,
+                    sourceBooks,
+                    token
+                );
+            }
+            LogMetric("Back from UpdateDocsAsync");
+            await NotifySyncProgress(SyncPhase.Phase7, 20.0);
+
+            // Check for cancellation
+            if (token.IsCancellationRequested)
+            {
+                await CompleteSync(false, canRollbackParatext, trainEngine, token);
+                return;
+            }
+
+            // Update the resource configuration
+            if (resourceNeedsUpdating)
+            {
+                LogMetric("Updating resource config");
+                await UpdateResourceConfig(paratextProject);
+            }
+
+            // We will always update permissions, even if this is a resource project
+            LogMetric("Updating permissions");
+            await _projectService.UpdatePermissionsAsync(userId, _projectDoc, token);
+
+            await NotifySyncProgress(SyncPhase.Phase7, 40.0);
+
+            // Check for cancellation
+            if (token.IsCancellationRequested)
+            {
+                await CompleteSync(false, canRollbackParatext, trainEngine, token);
+                return;
+            }
+
+            await CompleteSync(true, canRollbackParatext, trainEngine, token);
+        }
+        catch (Exception e)
+        {
+            if (e is not TaskCanceledException)
+            {
+                StringBuilder additionalInformation = new StringBuilder();
+                foreach (var key in e.Data.Keys)
                 {
-                    text = new TextInfo { BookNum = bookNum, HasSource = hasSource };
-                    _syncMetrics.Books.Added++;
-                }
-                else
-                {
-                    text = _projectDoc.Data.Texts[textIndex];
-                    _syncMetrics.Books.Updated++;
+                    additionalInformation.AppendLine($"{key}: {e.Data[key]}");
                 }
 
-                // update target text docs
-                if (
-                    !targetTextDocsByBook.TryGetValue(
-                        text.BookNum,
-                        out SortedList<int, IDocument<TextData>> targetTextDocs
-                    )
-                )
-                {
-                    targetTextDocs = new SortedList<int, IDocument<TextData>>();
-                }
+                string message =
+                    $"Error occurred while executing Paratext sync for project with SF id '{projectSFId}'. {(additionalInformation.Length == 0 ? string.Empty : $"Additional information: {additionalInformation}")}";
+                _syncMetrics.ErrorDetails = $"{e}{Environment.NewLine}{message}";
+                _logger.LogError(e, message);
+                LogMetric(message);
+            }
 
-                LogMetric("Updating text docs");
-                List<Chapter> newSetOfChapters = await UpdateTextDocsAsync(text, targetParatextId, targetTextDocs);
+            await CompleteSync(false, canRollbackParatext, trainEngine, token);
+        }
+        finally
+        {
+            CloseConnection();
+        }
+    }
 
-                // update question docs
-                if (questionDocsByBook.TryGetValue(text.BookNum, out IReadOnlyList<IDocument<Question>> questionDocs))
-                {
-                    LogMetric("Updating question docs");
-                    await UpdateQuestionDocsAsync(questionDocs, newSetOfChapters);
-                }
+    /// <summary>
+    /// Retrieves the texts and questions from the Realtime server, and updates the Paratext repository if the
+    /// project is not a Paratext resource. Both of the dictionaries <paramref name="textDocsByBook"/> and
+    /// <paramref name="questionDocsByBook"/> are populated by this method.
+    /// </summary>
+    /// <param name="syncPhase">The sync phase.</param>
+    /// <param name="paratextId">The Paratext ID.</param>
+    /// <param name="textDocsByBook">The text documents with the book number as key.</param>
+    /// <param name="questionDocsByBook">The question documents with the book number as key.</param>
+    /// <returns>The task.</returns>
+    /// <exception cref="ArgumentException">The Paratext project repository does not exist.</exception>
+    private async Task GetAndUpdateParatextBooksAndNotes(
+        SyncPhase syncPhase,
+        string paratextId,
+        Dictionary<int, SortedList<int, IDocument<TextData>>> textDocsByBook,
+        Dictionary<int, IReadOnlyList<IDocument<Question>>> questionDocsByBook
+    )
+    {
+        ParatextSettings? settings = _paratextService.GetParatextSettings(_userSecret, paratextId);
+        double i = 0.0;
+        foreach (TextInfo text in _projectDoc.Data.Texts)
+        {
+            i++;
 
-                // update note thread docs
-                LogMetric("Updating thread docs - fetching");
-                Dictionary<string, IDocument<NoteThread>> noteThreadDocs = await FetchNoteThreadDocsAsync(text.BookNum);
-                LogMetric("Updating thread docs - get deltas");
-                Dictionary<int, ChapterDelta> chapterDeltas = GetDeltasByChapter(text, targetParatextId);
+            await NotifySyncProgress(syncPhase, i / _projectDoc.Data.Texts.Count);
 
-                LogMetric("Updating thread docs - updating");
-                await UpdateNoteThreadDocsAsync(text, noteThreadDocs, chapterDeltas, ptUsernamesToSFUserIds);
+            // We check for settings in the loop, because if there are no texts, we would expect it to be null
+            if (settings == null)
+            {
+                throw new ArgumentException("FAILED: Attempting to write to a project repository that does not exist.");
+            }
 
-                // update project metadata
-                LogMetric("Updating project metadata");
+            LogMetric($"Getting Paratext book {text.BookNum}");
+            SortedList<int, IDocument<TextData>> targetTextDocs = await FetchTextDocsAsync(text);
+            textDocsByBook[text.BookNum] = targetTextDocs;
+            if (settings.Editable && !_paratextService.IsResource(paratextId))
+            {
+                LogMetric("Updating Paratext book");
+                await UpdateParatextBook(text, paratextId, targetTextDocs);
+            }
+
+            IReadOnlyList<IDocument<Question>> questionDocs = await FetchQuestionDocsAsync(text);
+            questionDocsByBook[text.BookNum] = questionDocs;
+            if (!_paratextService.IsResource(paratextId))
+            {
+                LogMetric("Updating Paratext notes");
+                IEnumerable<IDocument<NoteThread>> noteThreadDocs = (
+                    await FetchNoteThreadDocsAsync(text.BookNum)
+                ).Values;
+                // Only update the note tag if there are SF note threads in the project
+                if (noteThreadDocs.Any(d => d.Data.PublishedToSF == true))
+                    await UpdateTranslateNoteTag(paratextId);
+                await UpdateParatextNotesAsync(text, questionDocs);
+                // TODO: Sync Note changes back to Paratext, and record sync metric info
+                // await _paratextService.UpdateParatextCommentsAsync(_userSecret, paratextId, text.BookNum,
+                //     noteThreadDocs, _currentPtSyncUsers);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Updates the resource configuration
+    /// </summary>
+    /// <param name="project">The SF project.</param>
+    /// <param name="paratextProject">The Paratext project. This should be a resource.</param>
+    /// <returns>The asynchronous task.</returns>
+    /// <remarks>Only call this if the config requires an update.</remarks>
+    private async Task UpdateResourceConfig(ParatextProject paratextProject)
+    {
+        // Update the resource configuration
+        if (paratextProject is ParatextResource paratextResource)
+        {
+            if (_projectDoc.Data.ResourceConfig == null)
+            {
+                // Create the resource config
+                await _projectDoc.SubmitJson0OpAsync(
+                    op =>
+                        op.Set(
+                            pd => pd.ResourceConfig,
+                            new ResourceConfig
+                            {
+                                CreatedTimestamp = paratextResource.CreatedTimestamp,
+                                ManifestChecksum = paratextResource.ManifestChecksum,
+                                PermissionsChecksum = paratextResource.PermissionsChecksum,
+                                Revision = paratextResource.AvailableRevision,
+                            }
+                        )
+                );
+            }
+            else
+            {
+                // Update the resource config
                 await _projectDoc.SubmitJson0OpAsync(op =>
                 {
-                    if (textIndex == -1)
-                    {
-                        // insert text info for new text
-                        text.Chapters = newSetOfChapters;
-                        op.Add(pd => pd.Texts, text);
-                    }
-                    else
-                    {
-                        // update text info
-                        op.Set(pd => pd.Texts[textIndex].Chapters, newSetOfChapters, _chapterListEqualityComparer);
-                        op.Set(pd => pd.Texts[textIndex].HasSource, hasSource);
-                    }
+                    op.Set(pd => pd.ResourceConfig.CreatedTimestamp, paratextResource.CreatedTimestamp);
+                    op.Set(pd => pd.ResourceConfig.ManifestChecksum, paratextResource.ManifestChecksum);
+                    op.Set(pd => pd.ResourceConfig.PermissionsChecksum, paratextResource.PermissionsChecksum);
+                    op.Set(pd => pd.ResourceConfig.Revision, paratextResource.AvailableRevision);
                 });
             }
         }
+    }
 
-        internal async Task<bool> InitAsync(
-            string projectSFId,
-            string userId,
-            string syncMetricsId,
-            CancellationToken token
-        )
+    private async Task PreflightAuthenticationReportAsync()
+    {
+        bool canAuthToRegistry = await _paratextService.CanUserAuthenticateToPTRegistryAsync(_userSecret);
+        bool canAuthToArchives = await _paratextService.CanUserAuthenticateToPTArchivesAsync(_userSecret.Id);
+        Log($"User can authenticate to PT Registry: {canAuthToRegistry}, to PT Archives: {canAuthToArchives}.");
+    }
+
+    private async Task UpdateDocsAsync(
+        SyncPhase syncPhase,
+        string targetParatextId,
+        Dictionary<int, SortedList<int, IDocument<TextData>>> targetTextDocsByBook,
+        Dictionary<int, IReadOnlyList<IDocument<Question>>> questionDocsByBook,
+        HashSet<int> targetBooks,
+        HashSet<int> sourceBooks,
+        CancellationToken token
+    )
+    {
+        Dictionary<string, string> ptUsernamesToSFUserIds = await GetPTUsernameToSFUserIdsAsync(token);
+
+        // update source and target real-time docs
+        double i = 0.0;
+        foreach (int bookNum in targetBooks)
         {
-            await _hubContext.NotifySyncProgress(projectSFId, ProgressState.NotStarted);
-            _logger.LogInformation($"Initializing sync for project {projectSFId} with sync metrics id {syncMetricsId}");
-            if (!(await _syncMetricsRepository.TryGetAsync(syncMetricsId)).TryResult(out _syncMetrics))
+            i++;
+            await NotifySyncProgress(syncPhase, i / targetBooks.Count);
+            LogMetric($"Updating text info for book {bookNum}");
+            bool hasSource = sourceBooks.Contains(bookNum);
+            int textIndex = _projectDoc.Data.Texts.FindIndex(t => t.BookNum == bookNum);
+            TextInfo text;
+            if (textIndex == -1)
             {
-                Log($"Could not find sync metrics.", syncMetricsId, userId);
-                return false;
+                text = new TextInfo { BookNum = bookNum, HasSource = hasSource };
+                _syncMetrics.Books.Added++;
+            }
+            else
+            {
+                text = _projectDoc.Data.Texts[textIndex];
+                _syncMetrics.Books.Updated++;
             }
 
-            _syncMetrics.DateStarted = DateTime.UtcNow;
-            _syncMetrics.Status = SyncStatus.Running;
+            // update target text docs
+            if (
+                !targetTextDocsByBook.TryGetValue(text.BookNum, out SortedList<int, IDocument<TextData>> targetTextDocs)
+            )
+            {
+                targetTextDocs = new SortedList<int, IDocument<TextData>>();
+            }
+
+            LogMetric("Updating text docs");
+            List<Chapter> newSetOfChapters = await UpdateTextDocsAsync(text, targetParatextId, targetTextDocs);
+
+            // update question docs
+            if (questionDocsByBook.TryGetValue(text.BookNum, out IReadOnlyList<IDocument<Question>> questionDocs))
+            {
+                LogMetric("Updating question docs");
+                await UpdateQuestionDocsAsync(questionDocs, newSetOfChapters);
+            }
+
+            // update note thread docs
+            LogMetric("Updating thread docs - fetching");
+            Dictionary<string, IDocument<NoteThread>> noteThreadDocs = await FetchNoteThreadDocsAsync(text.BookNum);
+            LogMetric("Updating thread docs - get deltas");
+            Dictionary<int, ChapterDelta> chapterDeltas = GetDeltasByChapter(text, targetParatextId);
+
+            LogMetric("Updating thread docs - updating");
+            await UpdateNoteThreadDocsAsync(text, noteThreadDocs, chapterDeltas, ptUsernamesToSFUserIds);
+
+            // update project metadata
+            LogMetric("Updating project metadata");
+            await _projectDoc.SubmitJson0OpAsync(op =>
+            {
+                if (textIndex == -1)
+                {
+                    // insert text info for new text
+                    text.Chapters = newSetOfChapters;
+                    op.Add(pd => pd.Texts, text);
+                }
+                else
+                {
+                    // update text info
+                    op.Set(pd => pd.Texts[textIndex].Chapters, newSetOfChapters, _chapterListEqualityComparer);
+                    op.Set(pd => pd.Texts[textIndex].HasSource, hasSource);
+                }
+            });
+        }
+    }
+
+    internal async Task<bool> InitAsync(
+        string projectSFId,
+        string userId,
+        string syncMetricsId,
+        CancellationToken token
+    )
+    {
+        await _hubContext.NotifySyncProgress(projectSFId, ProgressState.NotStarted);
+        _logger.LogInformation($"Initializing sync for project {projectSFId} with sync metrics id {syncMetricsId}");
+        if (!(await _syncMetricsRepository.TryGetAsync(syncMetricsId)).TryResult(out _syncMetrics))
+        {
+            Log($"Could not find sync metrics.", syncMetricsId, userId);
+            return false;
+        }
+
+        _syncMetrics.DateStarted = DateTime.UtcNow;
+        _syncMetrics.Status = SyncStatus.Running;
+        if (!await _syncMetricsRepository.ReplaceAsync(_syncMetrics, true))
+        {
+            Log("The sync metrics could not be updated in MongoDB");
+        }
+
+        _conn = await _realtimeService.ConnectAsync();
+        _conn.BeginTransaction();
+        _conn.ExcludePropertyFromTransaction<SFProject>(op => op.Sync.QueuedCount);
+        _conn.ExcludePropertyFromTransaction<SFProject>(op => op.Sync.DataInSync);
+        _projectDoc = await _conn.FetchAsync<SFProject>(projectSFId);
+        if (!_projectDoc.IsLoaded)
+        {
+            Log($"Project doc was not loaded.", projectSFId, userId);
+            return false;
+        }
+
+        await NotifySyncProgress(SyncPhase.Phase1, 10.0);
+
+        if (!(await _projectSecrets.TryGetAsync(projectSFId)).TryResult(out _projectSecret))
+        {
+            Log($"Could not find project secret.", projectSFId, userId);
+            return false;
+        }
+        _currentPtSyncUsers = _projectDoc.Data.ParatextUsers.ToDictionary(u => u.Username);
+
+        if (!(await _userSecrets.TryGetAsync(userId)).TryResult(out _userSecret))
+        {
+            Log($"Could not find user secret.", projectSFId, userId);
+            return false;
+        }
+
+        List<User> paratextUsers = await _realtimeService
+            .QuerySnapshots<User>()
+            .Where(u => _projectDoc.Data.UserRoles.Keys.Contains(u.Id) && u.ParatextId != null)
+            .ToListAsync();
+
+        // Report on authentication success before other attempts.
+        await PreflightAuthenticationReportAsync();
+
+        await _notesMapper.InitAsync(_userSecret, _projectSecret, paratextUsers, _projectDoc.Data, token);
+
+        await NotifySyncProgress(SyncPhase.Phase1, 20.0);
+        return true;
+    }
+
+    internal void CloseConnection() => _conn?.Dispose();
+
+    private async Task UpdateParatextBook(
+        TextInfo text,
+        string paratextId,
+        SortedList<int, IDocument<TextData>> textDocs
+    )
+    {
+        string bookText = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
+
+        // XDocument.Parse ignores whitespace added during USX generation. The unnecessary whitespace can
+        // occasionally cause inaccurate comparisons with XNode.DeepEquals, and so we must remove it.
+        var oldUsxDoc = XDocument.Parse(bookText);
+        XDocument newUsxDoc = _deltaUsxMapper.ToUsx(
+            oldUsxDoc,
+            text.Chapters
+                .OrderBy(c => c.Number)
+                .Select(c => new ChapterDelta(c.Number, c.LastVerse, c.IsValid, textDocs[c.Number].Data))
+        );
+
+        if (!XNode.DeepEquals(oldUsxDoc, newUsxDoc))
+        {
+            var chapterAuthors = await GetChapterAuthorsAsync(text, textDocs);
+            _syncMetrics.ParatextBooks.Updated += await _paratextService.PutBookText(
+                _userSecret,
+                paratextId,
+                text.BookNum,
+                newUsxDoc,
+                chapterAuthors
+            );
+        }
+    }
+
+    /// <summary>
+    /// Gets the authors for each chapter asynchronously.
+    /// </summary>
+    /// <param name="text">The text info.</param>
+    /// <param name="textDocs">The text data, as a sorted list where the key is the chapter number.</param>
+    /// <returns>
+    /// A dictionary where the key is the chapter number, and the value is the user identifier of the author.
+    /// </returns>
+    /// <remarks>
+    /// This is internal so it can be unit tested.
+    /// </remarks>
+    internal async Task<Dictionary<int, string>> GetChapterAuthorsAsync(
+        TextInfo text,
+        SortedList<int, IDocument<TextData>> textDocs
+    )
+    {
+        // Get all of the last editors for the chapters.
+        var chapterAuthors = new Dictionary<int, string>();
+        foreach (Chapter chapter in text.Chapters)
+        {
+            // This will be from 1 to number of chapters in the book
+            int chapterNum = chapter.Number;
+
+            // Attempt to find the last user who modified this chapter
+            string userSFId = null;
+            if (textDocs.TryGetValue(chapterNum, out IDocument<TextData> textDoc))
+            {
+                // The Id is the value from TextData.GetTextDocId()
+                string textId = textDoc.Id;
+                int version = textDoc.Version;
+                userSFId = await _realtimeService.GetLastModifiedUserIdAsync<TextData>(textId, version);
+
+                // Check that this user still has write permissions
+                if (
+                    string.IsNullOrEmpty(userSFId)
+                    || !chapter.Permissions.TryGetValue(userSFId, out string permission)
+                    || permission != TextInfoPermission.Write
+                )
+                {
+                    // They no longer have write access, so reset the user id, and find it below
+                    userSFId = null;
+                }
+            }
+
+            // If we do not have a record of the last user to modify this chapter
+            if (string.IsNullOrEmpty(userSFId))
+            {
+                // See if the current user has permissions
+                if (
+                    chapter.Permissions.TryGetValue(_userSecret.Id, out string permission)
+                    && permission == TextInfoPermission.Write
+                )
+                {
+                    userSFId = _userSecret.Id;
+                }
+                else
+                {
+                    // Get the first user with write permission
+                    // NOTE: As a KeyValuePair is a struct, we do not need a null-conditional (key will be null)
+                    userSFId = chapter.Permissions.FirstOrDefault(p => p.Value == TextInfoPermission.Write).Key;
+
+                    // If the userId is still null, find a project administrator, as they can escalate privilege
+                    if (string.IsNullOrEmpty(userSFId))
+                    {
+                        userSFId = _projectDoc.Data.UserRoles
+                            .FirstOrDefault(p => p.Value == SFProjectRole.Administrator)
+                            .Key;
+                    }
+                }
+            }
+
+            // Set the author for the chapter
+            chapterAuthors.Add(chapterNum, userSFId);
+        }
+
+        return chapterAuthors;
+    }
+
+    /// <summary>
+    /// Send answer-notes to Paratext. Don't send questions that have no answers.
+    /// </summary>
+    private async Task UpdateParatextNotesAsync(TextInfo text, IReadOnlyList<IDocument<Question>> questionDocs)
+    {
+        if (!CheckingEnabled)
+            return;
+
+        // TODO: need to define a data structure for notes instead of XML
+        XElement oldNotesElem;
+        string oldNotesText = _paratextService.GetNotes(_userSecret, _projectDoc.Data.ParatextId, text.BookNum);
+        if (oldNotesText != "")
+            oldNotesElem = ParseText(oldNotesText);
+        else
+            oldNotesElem = new XElement("notes", new XAttribute("version", "1.1"));
+
+        XElement notesElem = await _notesMapper.GetNotesChangelistAsync(
+            oldNotesElem,
+            questionDocs,
+            _currentPtSyncUsers,
+            _projectDoc.Data.UserRoles,
+            _projectDoc.Data.CheckingConfig.AnswerExportMethod
+        );
+        if (notesElem.Elements("thread").Any())
+        {
+            _syncMetrics.ParatextNotes += _paratextService.PutNotes(
+                _userSecret,
+                _projectDoc.Data.ParatextId,
+                notesElem
+            );
+        }
+    }
+
+    private async Task<List<Chapter>> UpdateTextDocsAsync(
+        TextInfo text,
+        string paratextId,
+        SortedList<int, IDocument<TextData>> textDocs,
+        ISet<int>? chaptersToInclude = null
+    )
+    {
+        string bookText = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
+        var usxDoc = XDocument.Parse(bookText);
+        var tasks = new List<Task>();
+        Dictionary<int, ChapterDelta> deltas = _deltaUsxMapper.ToChapterDeltas(usxDoc).ToDictionary(cd => cd.Number);
+        var chapters = new List<Chapter>();
+        List<int> chaptersToRemove = textDocs.Keys.Where(c => !deltas.ContainsKey(c)).ToList();
+        foreach (KeyValuePair<int, ChapterDelta> kvp in deltas)
+        {
+            bool addChapter = true;
+            if (textDocs.TryGetValue(kvp.Key, out IDocument<TextData> textDataDoc))
+            {
+                if (chaptersToInclude == null || chaptersToInclude.Contains(kvp.Key))
+                {
+                    Delta diffDelta = textDataDoc.Data.Diff(kvp.Value.Delta);
+                    if (diffDelta.Ops.Count > 0)
+                    {
+                        tasks.Add(textDataDoc.SubmitOpAsync(diffDelta));
+                        _syncMetrics.TextDocs.Updated++;
+                    }
+
+                    textDocs.Remove(kvp.Key);
+                }
+                else
+                {
+                    // We are not to update this chapter
+                    Chapter existingChapter = text.Chapters.FirstOrDefault(c => c.Number == kvp.Key);
+                    if (existingChapter != null)
+                    {
+                        chapters.Add(existingChapter);
+                    }
+
+                    addChapter = false;
+                }
+            }
+            else if (chaptersToInclude == null || chaptersToInclude.Contains(kvp.Key))
+            {
+                textDataDoc = GetTextDoc(text, kvp.Key);
+                async Task createText(int chapterNum, Delta delta)
+                {
+                    await textDataDoc.FetchAsync();
+                    if (textDataDoc.IsLoaded)
+                        await textDataDoc.DeleteAsync();
+                    await textDataDoc.CreateAsync(new TextData(delta));
+                }
+                tasks.Add(createText(kvp.Key, kvp.Value.Delta));
+                _syncMetrics.TextDocs.Added++;
+            }
+            else
+            {
+                addChapter = false;
+            }
+            if (addChapter)
+            {
+                chapters.Add(
+                    new Chapter
+                    {
+                        Number = kvp.Key,
+                        LastVerse = kvp.Value.LastVerse,
+                        IsValid = kvp.Value.IsValid,
+                        Permissions = { }
+                    }
+                );
+            }
+        }
+        foreach (KeyValuePair<int, IDocument<TextData>> kvp in textDocs)
+        {
+            if (chaptersToInclude == null || chaptersToInclude.Contains(kvp.Key) || chaptersToRemove.Contains(kvp.Key))
+            {
+                tasks.Add(kvp.Value.DeleteAsync());
+                _syncMetrics.TextDocs.Deleted++;
+            }
+        }
+
+        await Task.WhenAll(tasks);
+        return chapters;
+    }
+
+    private async Task UpdateQuestionDocsAsync(
+        IReadOnlyList<IDocument<Question>> questionDocs,
+        List<Chapter> newChapters
+    )
+    {
+        // handle deletion of chapters
+        var chapterNums = new HashSet<int>(newChapters.Select(c => c.Number));
+        var tasks = new List<Task>();
+        foreach (IDocument<Question> questionDoc in questionDocs)
+        {
+            if (!chapterNums.Contains(questionDoc.Data.VerseRef.ChapterNum))
+            {
+                tasks.Add(questionDoc.DeleteAsync());
+                _syncMetrics.Questions.Deleted++;
+            }
+        }
+        await Task.WhenAll(tasks);
+    }
+
+    /// <summary>
+    /// Updates ParatextNoteThread docs for a book
+    /// </summary>
+    private async Task UpdateNoteThreadDocsAsync(
+        TextInfo text,
+        Dictionary<string, IDocument<NoteThread>> noteThreadDocs,
+        Dictionary<int, ChapterDelta> chapterDeltas,
+        Dictionary<string, string> usernamesToUserIds
+    )
+    {
+        IEnumerable<NoteThreadChange> noteThreadChanges = _paratextService.GetNoteThreadChanges(
+            _userSecret,
+            _projectDoc.Data.ParatextId,
+            text.BookNum,
+            noteThreadDocs.Values,
+            chapterDeltas,
+            _currentPtSyncUsers
+        );
+        var tasks = new List<Task>();
+
+        foreach (NoteThreadChange change in noteThreadChanges)
+        {
+            // Find the thread doc if it exists
+            if (!noteThreadDocs.TryGetValue(change.ThreadId, out IDocument<NoteThread> threadDoc))
+            {
+                // Create a new ParatextNoteThread doc
+                IDocument<NoteThread> doc = GetNoteThreadDoc(change.ThreadId);
+                async Task createThreadDoc(NoteThreadChange change)
+                {
+                    VerseRef verseRef = new VerseRef();
+                    verseRef.Parse(change.VerseRefStr);
+                    VerseRefData vrd = new VerseRefData(verseRef.BookNum, verseRef.ChapterNum, verseRef.Verse);
+                    await doc.CreateAsync(
+                        new NoteThread()
+                        {
+                            DataId = change.ThreadId,
+                            ProjectRef = _projectDoc.Id,
+                            VerseRef = vrd,
+                            OriginalSelectedText = change.SelectedText,
+                            OriginalContextBefore = change.ContextBefore,
+                            OriginalContextAfter = change.ContextAfter,
+                            Position = change.Position,
+                            Status = change.Status,
+                            Assignment = change.Assignment
+                        }
+                    );
+                    await SubmitChangesOnNoteThreadDocAsync(doc, change, usernamesToUserIds);
+                }
+                tasks.Add(createThreadDoc(change));
+                _syncMetrics.NoteThreads.Added++;
+            }
+            else
+            {
+                tasks.Add(SubmitChangesOnNoteThreadDocAsync(threadDoc, change, usernamesToUserIds));
+
+                // Record thread metrics and note metrics
+                if (change.ThreadRemoved)
+                {
+                    _syncMetrics.NoteThreads.Deleted++;
+                }
+
+                if (change.ThreadUpdated)
+                {
+                    _syncMetrics.NoteThreads.Updated++;
+                }
+
+                _syncMetrics.Notes += new NoteSyncMetricInfo(
+                    added: change.NotesAdded.Count,
+                    deleted: change.NotesDeleted.Count,
+                    updated: change.NotesUpdated.Count,
+                    removed: change.NoteIdsRemoved.Count
+                );
+            }
+        }
+        await Task.WhenAll(tasks);
+    }
+
+    /// <summary>
+    /// Fetches all text docs from the database for a book.
+    /// </summary>
+    internal async Task<SortedList<int, IDocument<TextData>>> FetchTextDocsAsync(TextInfo text)
+    {
+        var textDocs = new SortedList<int, IDocument<TextData>>();
+        var tasks = new List<Task>();
+        foreach (Chapter chapter in text.Chapters)
+        {
+            IDocument<TextData> textDoc = GetTextDoc(text, chapter.Number);
+            textDocs[chapter.Number] = textDoc;
+            tasks.Add(textDoc.FetchAsync());
+        }
+        await Task.WhenAll(tasks);
+
+        // Omit items that are not actually in the database.
+        foreach (KeyValuePair<int, IDocument<TextData>> item in textDocs.ToList())
+        {
+            if (!item.Value.IsLoaded)
+            {
+                textDocs.Remove(item.Key);
+            }
+        }
+        return textDocs;
+    }
+
+    /// <summary>
+    /// Deletes all text docs from the database for a book.
+    /// </summary>
+    private async Task DeleteAllTextDocsForBookAsync(TextInfo text)
+    {
+        var tasks = new List<Task>();
+        foreach (Chapter chapter in text.Chapters)
+            tasks.Add(DeleteTextDocAsync(text, chapter.Number));
+        await Task.WhenAll(tasks);
+        _syncMetrics.TextDocs.Deleted += text.Chapters.Count;
+    }
+
+    private async Task<IReadOnlyList<IDocument<Question>>> FetchQuestionDocsAsync(TextInfo text)
+    {
+        List<string> questionDocIds = await _realtimeService
+            .QuerySnapshots<Question>()
+            .Where(q => q.ProjectRef == _projectDoc.Id && q.VerseRef.BookNum == text.BookNum)
+            .Select(q => q.Id)
+            .ToListAsync();
+        var questionDocs = new IDocument<Question>[questionDocIds.Count];
+        var tasks = new List<Task>();
+        for (int i = 0; i < questionDocIds.Count; i++)
+        {
+            async Task fetchQuestion(int index) =>
+                questionDocs[index] = await _conn.FetchAsync<Question>(questionDocIds[index]);
+            tasks.Add(fetchQuestion(i));
+        }
+        await Task.WhenAll(tasks);
+        return questionDocs;
+    }
+
+    /// <summary>
+    /// Fetch the ParatextNoteThread docs from the database and return it in a dictionary with threadId as the key.
+    /// </summary>
+    private async Task<Dictionary<string, IDocument<NoteThread>>> FetchNoteThreadDocsAsync(int bookNum)
+    {
+        List<string> noteThreadDocIds = await _realtimeService
+            .QuerySnapshots<NoteThread>()
+            .Where(pnt => pnt.ProjectRef == _projectDoc.Id && pnt.VerseRef.BookNum == bookNum)
+            .Select(pnt => pnt.Id)
+            .ToListAsync();
+        IDocument<NoteThread>[] noteThreadDocs = new IDocument<NoteThread>[noteThreadDocIds.Count];
+        var tasks = new List<Task>();
+        for (int i = 0; i < noteThreadDocIds.Count; i++)
+        {
+            async Task fetchNoteThread(int index) =>
+                noteThreadDocs[index] = await _conn.FetchAsync<NoteThread>(noteThreadDocIds[index]);
+            tasks.Add(fetchNoteThread(i));
+        }
+        await Task.WhenAll(tasks);
+        return noteThreadDocs.ToDictionary(ntd => ntd.Data.DataId);
+    }
+
+    /// <summary>
+    /// Apply the changes to a ParatextNoteThread doc.
+    /// TODO: Handle if verseRef changes
+    /// </summary>
+    private async Task SubmitChangesOnNoteThreadDocAsync(
+        IDocument<NoteThread> threadDoc,
+        NoteThreadChange change,
+        IReadOnlyDictionary<string, string> usernamesToUserIds
+    )
+    {
+        if (change.ThreadRemoved)
+        {
+            await threadDoc.DeleteAsync();
+            return;
+        }
+
+        await threadDoc.SubmitJson0OpAsync(op =>
+        {
+            // Update thread details
+            if (change.ThreadUpdated)
+            {
+                if (threadDoc.Data.Status != change.Status)
+                    op.Set(td => td.Status, change.Status);
+                if (threadDoc.Data.Assignment != change.Assignment)
+                    op.Set(td => td.Assignment, change.Assignment);
+            }
+            // Update content for updated notes
+            foreach (Note updated in change.NotesUpdated)
+            {
+                int index = threadDoc.Data.Notes.FindIndex(n => n.DataId == updated.DataId);
+                if (index >= 0)
+                {
+                    if (threadDoc.Data.Notes[index].Content != updated.Content)
+                        op.Set(td => td.Notes[index].Content, updated.Content);
+                    if (threadDoc.Data.Notes[index].Status != updated.Status)
+                        op.Set(td => td.Notes[index].Status, updated.Status);
+                    if (threadDoc.Data.Notes[index].Type != updated.Type)
+                        op.Set(td => td.Notes[index].Type, updated.Type);
+                    if (threadDoc.Data.Notes[index].ConflictType != updated.ConflictType)
+                        op.Set(td => td.Notes[index].ConflictType, updated.ConflictType);
+                    if (threadDoc.Data.Notes[index].TagId != updated.TagId)
+                        op.Set(td => td.Notes[index].TagId, updated.TagId);
+                    if (threadDoc.Data.Notes[index].Assignment != updated.Assignment)
+                        op.Set(td => td.Notes[index].Assignment, updated.Assignment);
+                    if (threadDoc.Data.Notes[index].AcceptedChangeXml != updated.AcceptedChangeXml)
+                        op.Set(td => td.Notes[index].AcceptedChangeXml, updated.AcceptedChangeXml);
+                }
+                else
+                {
+                    string message = "Unable to update note in database with id: " + updated.DataId;
+                    _logger.LogWarning(message);
+                    LogMetric(message);
+                }
+            }
+            // Delete notes
+            foreach (Note deleted in change.NotesDeleted)
+            {
+                int index = threadDoc.Data.Notes.FindIndex(n => n.DataId == deleted.DataId);
+                if (index >= 0)
+                {
+                    // The note can be easily removed by using op.Remove if that is preferred
+                    op.Set(td => td.Notes[index].Deleted, true);
+                }
+                else
+                {
+                    string message = "Unable to delete note in database with id: " + deleted.DataId;
+                    _logger.LogWarning(message);
+                    LogMetric(message);
+                }
+            }
+
+            // Add new notes, giving each note an associated SF userId if the user is also a Paratext user.
+            foreach (Note added in change.NotesAdded)
+            {
+                string ownerRef = null;
+                string username = string.IsNullOrEmpty(added.SyncUserRef)
+                    ? null
+                    : _currentPtSyncUsers.Values.Single(u => u.OpaqueUserId == added.SyncUserRef).Username;
+                if (username != null)
+                    usernamesToUserIds.TryGetValue(username, out ownerRef);
+                added.OwnerRef = string.IsNullOrEmpty(ownerRef) ? _userSecret.Id : ownerRef;
+                op.Add(td => td.Notes, added);
+            }
+
+            // Permanently removes a note
+            foreach (string removedId in change.NoteIdsRemoved)
+            {
+                int index = threadDoc.Data.Notes.FindIndex(n => n.DataId == removedId);
+                if (index >= 0)
+                    op.Remove(td => td.Notes, index);
+            }
+
+            if (change.Position != null)
+                op.Set(td => td.Position, change.Position);
+        });
+    }
+
+    private async Task UpdateTranslateNoteTag(string targetParatextId)
+    {
+        int? defaultTagId = _projectDoc.Data.TranslateConfig.DefaultNoteTagId;
+        if (defaultTagId == null)
+        {
+            var newNoteTag = new NoteTag
+            {
+                TagId = NoteTag.notSetId,
+                Icon = NoteTag.sfNoteTagIcon,
+                Name = NoteTag.sfNoteTagName
+            };
+            // Note: If we introduce a new note tag and the remote PT repo also introduces a note tag,
+            // the tag introduced here will get overwritten
+            int noteTagId = _paratextService.UpdateCommentTag(_userSecret, targetParatextId, newNoteTag);
+            await _projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.TranslateConfig.DefaultNoteTagId, noteTagId));
+        }
+    }
+
+    /// <summary>
+    /// Preserve all whitespace in data but remove whitespace at the beginning of lines and remove line endings.
+    /// </summary>
+    private static XElement ParseText(string text)
+    {
+        text = text.Trim().Replace("\r\n", "\n");
+        text = Regex.Replace(text, @"\n\s*<", "<", RegexOptions.CultureInvariant);
+        return XElement.Parse(text, LoadOptions.PreserveWhitespace);
+    }
+
+    /// <summary>
+    /// Deletes all real-time questions docs from the database for a book.
+    /// </summary>
+    private async Task DeleteAllQuestionsDocsForBookAsync(TextInfo text)
+    {
+        List<string> questionDocIds = await _realtimeService
+            .QuerySnapshots<Question>()
+            .Where(q => q.ProjectRef == _projectDoc.Id && q.VerseRef.BookNum == text.BookNum)
+            .Select(q => q.Id)
+            .ToListAsync();
+        var tasks = new List<Task>();
+        foreach (string questionId in questionDocIds)
+        {
+            async Task deleteQuestion()
+            {
+                IDocument<Question> questionDoc = await _conn.FetchAsync<Question>(questionId);
+                if (questionDoc.IsLoaded)
+                    await questionDoc.DeleteAsync();
+            }
+            tasks.Add(deleteQuestion());
+        }
+        await Task.WhenAll(tasks);
+        _syncMetrics.Questions.Deleted += questionDocIds.Count;
+    }
+
+    private async Task<List<string>> DeleteNoteThreadDocsInChapters(int bookNum, IEnumerable<Chapter> chapters)
+    {
+        IEnumerable<int> chaptersToDelete = chapters.Select(c => c.Number);
+        IEnumerable<NoteThread> threadDocs = _realtimeService
+            .QuerySnapshots<NoteThread>()
+            .Where(n => n.ProjectRef == _projectDoc.Id && n.VerseRef.BookNum == bookNum);
+        IEnumerable<string> noteThreadDocIds = threadDocs
+            .Where(nt => chaptersToDelete.Contains(nt.VerseRef.ChapterNum))
+            .Select(n => n.Id);
+        // Make a record of the note thread doc ids to return since they are removed
+        // from noteThreadDocIds after the docs are deleted.
+        List<string> deletedNoteThreadDocIds = new List<string>(noteThreadDocIds);
+
+        var tasks = new List<Task>();
+        foreach (string noteThreadDocId in noteThreadDocIds)
+        {
+            async Task deleteNoteThread()
+            {
+                IDocument<NoteThread> noteThreadDoc = await _conn.FetchAsync<NoteThread>(noteThreadDocId);
+                if (noteThreadDoc.IsLoaded)
+                    await noteThreadDoc.DeleteAsync();
+            }
+            tasks.Add(deleteNoteThread());
+        }
+
+        await Task.WhenAll(tasks);
+        _syncMetrics.NoteThreads.Deleted += deletedNoteThreadDocIds.Count;
+        return deletedNoteThreadDocIds;
+    }
+
+    private async Task CompleteSync(
+        bool successful,
+        bool canRollbackParatext,
+        bool trainEngine,
+        CancellationToken token
+    )
+    {
+        await NotifySyncProgress(SyncPhase.Phase7, 60.0);
+        if (token.IsCancellationRequested)
+        {
+            Log($"CompleteSync: There was a cancellation request.");
+        }
+        if (_projectDoc == null || _projectSecret == null)
+        {
+            Log("CompleteSync: _projectDoc or _projectSecret are null. Rolling back SF DB transaction.");
+            _conn.RollbackTransaction();
+            return;
+        }
+
+        LogMetric("Completing sync");
+        bool updateRoles = true;
+        IReadOnlyDictionary<string, string> ptUserRoles;
+        if (_paratextService.IsResource(_projectDoc.Data.ParatextId) || token.IsCancellationRequested)
+        {
+            // Do not update permissions on sync, if this is a resource project, as then,
+            // permission updates will be performed when a target project is synchronized.
+            // If the token is cancelled, do not update permissions as GetProjectRolesAsync will fail.
+            ptUserRoles = new Dictionary<string, string>();
+            updateRoles = false;
+        }
+        else
+        {
+            try
+            {
+                ptUserRoles = await _paratextService.GetProjectRolesAsync(_userSecret, _projectDoc.Data, token);
+            }
+            catch (Exception ex)
+            {
+                if (ex is HttpRequestException || ex is OperationCanceledException)
+                {
+                    Log(
+                        $"CompleteSync: Problem fetching project roles. Maybe the user does not have access to the project or cancelled the sync. ({ex})"
+                    );
+                    // This throws a 404 if the user does not have access to the project
+                    // A task cancelled exception will be thrown if the user cancels the task
+                    // Note: OperationCanceledException includes TaskCanceledException
+                    ptUserRoles = new Dictionary<string, string>();
+                    updateRoles = false;
+                }
+                else
+                {
+                    Log($"CompleteSync: Problem fetching project roles. Rethrowing: ({ex})");
+                    throw;
+                }
+            }
+        }
+
+        var userIdsToRemove = new List<string>();
+        var projectUsers = await _realtimeService
+            .QuerySnapshots<User>()
+            .Where(u => _projectDoc.Data.UserRoles.Keys.Contains(u.Id) && u.ParatextId != null)
+            .Select(u => new { UserId = u.Id, u.ParatextId })
+            .ToListAsync();
+
+        bool dataInSync = true;
+        if (!successful)
+        {
+            LogMetric("Restoring from backup");
+            bool restoreSucceeded = false;
+            // If we have failed, restore the repository, if we can
+            if (canRollbackParatext)
+            {
+                // If the restore is successful, then dataInSync will always be set to true because
+                // the restored repo can be assumed to be at the revision recorded in the project doc.
+                restoreSucceeded = _paratextService.RestoreRepository(_userSecret, _projectDoc.Data.ParatextId);
+                if (_syncMetrics != null)
+                {
+                    _syncMetrics.RepositoryRestoredFromBackup = restoreSucceeded;
+                }
+            }
+            Log(
+                $"CompleteSync: Sync was not successful. {(restoreSucceeded ? "Rolled back" : "Failed to roll back")} local PT repo."
+            );
+            if (!restoreSucceeded)
+            {
+                string repoVersion = _paratextService.GetLatestSharedVersion(_userSecret, _projectDoc.Data.ParatextId);
+                dataInSync = repoVersion == _projectDoc.Data.Sync.SyncedToRepositoryVersion;
+            }
+        }
+
+        // NOTE: This is executed outside of the transaction because it modifies "Sync.QueuedCount"
+        await _projectDoc.SubmitJson0OpAsync(op =>
+        {
+            op.Set(pd => pd.Sync.LastSyncSuccessful, successful);
+
+            // Get the latest shared revision of the local hg repo. On a failed synchronize attempt, the data
+            // is known to be out of sync if the revision does not match the corresponding revision stored
+            // on the project doc.
+            string repoVersion = _paratextService.GetLatestSharedVersion(_userSecret, _projectDoc.Data.ParatextId);
+
+            if (successful)
+            {
+                Log($"CompleteSync: Successfully synchronized to PT repo commit id '{repoVersion}'.");
+                op.Set(pd => pd.Sync.DateLastSuccessfulSync, DateTime.UtcNow);
+                op.Set(pd => pd.Sync.SyncedToRepositoryVersion, repoVersion);
+                op.Set(pd => pd.Sync.DataInSync, true);
+            }
+            else
+            {
+                Log(
+                    $"CompleteSync: Failed to synchronize. PT repo latest shared version is '{repoVersion}'. SF DB project SyncedToRepositoryVersion is '{_projectDoc.Data.Sync.SyncedToRepositoryVersion}'."
+                );
+                op.Set(pd => pd.Sync.DataInSync, dataInSync);
+            }
+            // the frontend checks the queued count to determine if the sync is complete. The ShareDB client emits
+            // an event for each individual op even if they are applied as a batch, so this needs to be set last,
+            // otherwise the info about the sync won't be set yet when the frontend determines that the sync is
+            // complete.
+            if (_projectDoc.Data.Sync.QueuedCount > 0)
+            {
+                op.Inc(pd => pd.Sync.QueuedCount, -1);
+            }
+            else
+            {
+                Log(
+                    $"CompleteSync: Warning: SF project id {_projectDoc.Id} QueuedCount is unexpectedly {_projectDoc.Data.Sync.QueuedCount}. Setting to 0 instead of decrementing."
+                );
+                op.Set(pd => pd.Sync.QueuedCount, 0);
+            }
+
+            if (updateRoles)
+            {
+                // Only update the roles if we received information from Paratext
+                foreach (var projectUser in projectUsers)
+                {
+                    if (ptUserRoles.TryGetValue(projectUser.ParatextId, out string role))
+                        op.Set(p => p.UserRoles[projectUser.UserId], role);
+                    else if (_projectDoc.Data.UserRoles[projectUser.UserId].StartsWith("pt"))
+                        userIdsToRemove.Add(projectUser.UserId);
+                }
+            }
+
+            ParatextSettings? settings = _paratextService.GetParatextSettings(_userSecret, _projectDoc.Data.ParatextId);
+            if (settings != null)
+            {
+                // See if the full name of the project needs updating
+                if (!string.IsNullOrEmpty(settings.FullName))
+                {
+                    op.Set(pd => pd.Name, settings.FullName);
+                }
+
+                // Set the right-to-left language flag
+                op.Set(pd => pd.IsRightToLeft, settings.IsRightToLeft);
+                op.Set(pd => pd.Editable, settings.Editable);
+                op.Set(pd => pd.DefaultFont, settings.DefaultFont);
+                op.Set(pd => pd.DefaultFontSize, settings.DefaultFontSize);
+                if (settings.NoteTags != null)
+                    op.Set(pd => pd.NoteTags, settings.NoteTags);
+            }
+            // The source can be null if there was an error getting a resource from the DBL
+            if (TranslationSuggestionsEnabled && _projectDoc.Data.TranslateConfig.Source != null)
+            {
+                ParatextSettings? sourceSettings = _paratextService.GetParatextSettings(
+                    _userSecret,
+                    _projectDoc.Data.TranslateConfig.Source.ParatextId
+                );
+                if (sourceSettings != null)
+                    op.Set(pd => pd.TranslateConfig.Source.IsRightToLeft, sourceSettings.IsRightToLeft);
+            }
+        });
+        await NotifySyncProgress(SyncPhase.Phase7, 80.0);
+
+        if (_syncMetrics != null)
+        {
+            _syncMetrics.Users.Deleted = userIdsToRemove.Count;
+        }
+
+        foreach (var userId in userIdsToRemove)
+            await _projectService.RemoveUserWithoutPermissionsCheckAsync(_userSecret.Id, _projectDoc.Id, userId);
+
+        // GetPTUsernameToSFUserIdsAsync will fail if the token is cancelled
+        if (!token.IsCancellationRequested)
+        {
+            Dictionary<string, string> ptUsernamesToSFUserIds = await GetPTUsernameToSFUserIdsAsync(token);
+            await _projectDoc.SubmitJson0OpAsync(op =>
+            {
+                foreach (ParatextUserProfile activePtSyncUser in _currentPtSyncUsers.Values)
+                {
+                    ParatextUserProfile existingUser = _projectDoc.Data.ParatextUsers.SingleOrDefault(
+                        u => u.Username == activePtSyncUser.Username
+                    );
+                    if (existingUser == null)
+                    {
+                        if (ptUsernamesToSFUserIds.TryGetValue(activePtSyncUser.Username, out string userId))
+                            activePtSyncUser.SFUserId = userId;
+                        op.Add(pd => pd.ParatextUsers, activePtSyncUser);
+                    }
+                    else if (
+                        existingUser.SFUserId == null
+                        && ptUsernamesToSFUserIds.TryGetValue(existingUser.Username, out string userId)
+                    )
+                    {
+                        int index = _projectDoc.Data.ParatextUsers.FindIndex(
+                            u => u.Username == activePtSyncUser.Username
+                        );
+                        op.Set(pd => pd.ParatextUsers[index].SFUserId, userId);
+                    }
+                }
+            });
+        }
+
+        // If we have an id in the job ids collection, remove the first one, and/or if we have a
+        // sync metrics id, we will remove that specific id from the project secrets.
+        if (_projectSecret.JobIds.Any() || _projectSecret.SyncMetricsIds.Contains(_syncMetrics?.Id))
+        {
+            await _projectSecrets.UpdateAsync(
+                _projectSecret.Id,
+                u =>
+                {
+                    if (_projectSecret.JobIds.Any())
+                    {
+                        u.Remove(p => p.JobIds, _projectSecret.JobIds.First());
+                    }
+
+                    if (_projectSecret.SyncMetricsIds.Contains(_syncMetrics?.Id))
+                    {
+                        u.Remove(p => p.SyncMetricsIds, _syncMetrics?.Id);
+                    }
+                }
+            );
+        }
+
+        // Commit or rollback the transaction, depending on success
+        if (successful)
+        {
+            // Write the operations to the database
+            await _conn.CommitTransactionAsync();
+
+            // The project document and text documents must be committed before we can train the model
+            bool hasSourceTextDocs = _projectDoc.Data.Texts.Any(t => t.HasSource);
+            if (TranslationSuggestionsEnabled && trainEngine && hasSourceTextDocs)
+            {
+                // Start training Machine engine
+                await _machineProjectService.BuildProjectAsync(_userSecret.Id, _projectDoc.Id, token);
+            }
+
+            // Backup the repository
+            if (!_paratextService.IsResource(_projectDoc.Data.ParatextId))
+            {
+                bool backupOutcome = _paratextService.BackupRepository(_userSecret, _projectDoc.Data.ParatextId);
+                if (_syncMetrics != null)
+                {
+                    _syncMetrics.RepositoryBackupCreated = backupOutcome;
+                }
+
+                if (!backupOutcome)
+                {
+                    Log($"CompleteSync: Failure backing up local PT repo.");
+                }
+            }
+        }
+        else
+        {
+            // Rollback the operations (the repository was restored above)
+            _conn.RollbackTransaction();
+        }
+
+        ReportRepoRevs("CompleteSync: ");
+
+        if (_syncMetrics == null)
+        {
+            Log("The sync metrics were missing, and cannot be updated");
+        }
+        else
+        {
+            // _syncMetrics will be null if InitAsync() fails
+            if (token.IsCancellationRequested)
+            {
+                _syncMetrics.Status = SyncStatus.Cancelled;
+            }
+            else if (successful)
+            {
+                _syncMetrics.Status = SyncStatus.Successful;
+            }
+            else
+            {
+                _syncMetrics.Status = SyncStatus.Failed;
+            }
+
+            _syncMetrics.DateFinished = DateTime.UtcNow;
             if (!await _syncMetricsRepository.ReplaceAsync(_syncMetrics, true))
             {
                 Log("The sync metrics could not be updated in MongoDB");
             }
-
-            _conn = await _realtimeService.ConnectAsync();
-            _conn.BeginTransaction();
-            _conn.ExcludePropertyFromTransaction<SFProject>(op => op.Sync.QueuedCount);
-            _conn.ExcludePropertyFromTransaction<SFProject>(op => op.Sync.DataInSync);
-            _projectDoc = await _conn.FetchAsync<SFProject>(projectSFId);
-            if (!_projectDoc.IsLoaded)
-            {
-                Log($"Project doc was not loaded.", projectSFId, userId);
-                return false;
-            }
-
-            await NotifySyncProgress(SyncPhase.Phase1, 10.0);
-
-            if (!(await _projectSecrets.TryGetAsync(projectSFId)).TryResult(out _projectSecret))
-            {
-                Log($"Could not find project secret.", projectSFId, userId);
-                return false;
-            }
-            _currentPtSyncUsers = _projectDoc.Data.ParatextUsers.ToDictionary(u => u.Username);
-
-            if (!(await _userSecrets.TryGetAsync(userId)).TryResult(out _userSecret))
-            {
-                Log($"Could not find user secret.", projectSFId, userId);
-                return false;
-            }
-
-            List<User> paratextUsers = await _realtimeService
-                .QuerySnapshots<User>()
-                .Where(u => _projectDoc.Data.UserRoles.Keys.Contains(u.Id) && u.ParatextId != null)
-                .ToListAsync();
-
-            // Report on authentication success before other attempts.
-            await PreflightAuthenticationReportAsync();
-
-            await _notesMapper.InitAsync(_userSecret, _projectSecret, paratextUsers, _projectDoc.Data, token);
-
-            await NotifySyncProgress(SyncPhase.Phase1, 20.0);
-            return true;
         }
 
-        internal void CloseConnection()
+        await NotifySyncProgress(SyncPhase.Phase7, 100.0);
+        Log($"CompleteSync: Finished. Sync was {(successful ? "successful" : "unsuccessful")}.");
+    }
+
+    private void ReportRepoRevs(string prefix = "")
+    {
+        string projectPTId = _projectDoc.Data.ParatextId;
+        string dbInfo =
+            $"DB Sync.SyncedToRepositoryVersion: {_projectDoc.Data.Sync.SyncedToRepositoryVersion}, DB Sync.DataInSync: {_projectDoc.Data.Sync.DataInSync}.";
+        if (_paratextService.IsResource(projectPTId))
         {
-            _conn?.Dispose();
+            Log($"{prefix}In-sync info: Is resource. {dbInfo}");
         }
-
-        private async Task UpdateParatextBook(
-            TextInfo text,
-            string paratextId,
-            SortedList<int, IDocument<TextData>> textDocs
-        )
+        else if (!_paratextService.LocalProjectDirExists(projectPTId))
         {
-            string bookText = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
-
-            // XDocument.Parse ignores whitespace added during USX generation. The unnecessary whitespace can
-            // occasionally cause inaccurate comparisons with XNode.DeepEquals, and so we must remove it.
-            var oldUsxDoc = XDocument.Parse(bookText);
-            XDocument newUsxDoc = _deltaUsxMapper.ToUsx(
-                oldUsxDoc,
-                text.Chapters
-                    .OrderBy(c => c.Number)
-                    .Select(c => new ChapterDelta(c.Number, c.LastVerse, c.IsValid, textDocs[c.Number].Data))
+            Log($"{prefix}In-sync info: No local hg repo. {dbInfo}");
+        }
+        else
+        {
+            string repoRev = _paratextService.GetRepoRevision(_userSecret, projectPTId);
+            string sharedRev = _paratextService.GetLatestSharedVersion(_userSecret, projectPTId);
+            Log(
+                $"{prefix}In-sync info: Local hg repo current rev: {repoRev}, Latest shared rev: {sharedRev}, {dbInfo}"
             );
-
-            if (!XNode.DeepEquals(oldUsxDoc, newUsxDoc))
-            {
-                var chapterAuthors = await GetChapterAuthorsAsync(text, textDocs);
-                _syncMetrics.ParatextBooks.Updated += await _paratextService.PutBookText(
-                    _userSecret,
-                    paratextId,
-                    text.BookNum,
-                    newUsxDoc,
-                    chapterAuthors
-                );
-            }
-        }
-
-        /// <summary>
-        /// Gets the authors for each chapter asynchronously.
-        /// </summary>
-        /// <param name="text">The text info.</param>
-        /// <param name="textDocs">The text data, as a sorted list where the key is the chapter number.</param>
-        /// <returns>
-        /// A dictionary where the key is the chapter number, and the value is the user identifier of the author.
-        /// </returns>
-        /// <remarks>
-        /// This is internal so it can be unit tested.
-        /// </remarks>
-        internal async Task<Dictionary<int, string>> GetChapterAuthorsAsync(
-            TextInfo text,
-            SortedList<int, IDocument<TextData>> textDocs
-        )
-        {
-            // Get all of the last editors for the chapters.
-            var chapterAuthors = new Dictionary<int, string>();
-            foreach (Chapter chapter in text.Chapters)
-            {
-                // This will be from 1 to number of chapters in the book
-                int chapterNum = chapter.Number;
-
-                // Attempt to find the last user who modified this chapter
-                string userSFId = null;
-                if (textDocs.TryGetValue(chapterNum, out IDocument<TextData> textDoc))
-                {
-                    // The Id is the value from TextData.GetTextDocId()
-                    string textId = textDoc.Id;
-                    int version = textDoc.Version;
-                    userSFId = await _realtimeService.GetLastModifiedUserIdAsync<TextData>(textId, version);
-
-                    // Check that this user still has write permissions
-                    if (
-                        string.IsNullOrEmpty(userSFId)
-                        || !chapter.Permissions.TryGetValue(userSFId, out string permission)
-                        || permission != TextInfoPermission.Write
-                    )
-                    {
-                        // They no longer have write access, so reset the user id, and find it below
-                        userSFId = null;
-                    }
-                }
-
-                // If we do not have a record of the last user to modify this chapter
-                if (string.IsNullOrEmpty(userSFId))
-                {
-                    // See if the current user has permissions
-                    if (
-                        chapter.Permissions.TryGetValue(_userSecret.Id, out string permission)
-                        && permission == TextInfoPermission.Write
-                    )
-                    {
-                        userSFId = _userSecret.Id;
-                    }
-                    else
-                    {
-                        // Get the first user with write permission
-                        // NOTE: As a KeyValuePair is a struct, we do not need a null-conditional (key will be null)
-                        userSFId = chapter.Permissions.FirstOrDefault(p => p.Value == TextInfoPermission.Write).Key;
-
-                        // If the userId is still null, find a project administrator, as they can escalate privilege
-                        if (string.IsNullOrEmpty(userSFId))
-                        {
-                            userSFId = _projectDoc.Data.UserRoles
-                                .FirstOrDefault(p => p.Value == SFProjectRole.Administrator)
-                                .Key;
-                        }
-                    }
-                }
-
-                // Set the author for the chapter
-                chapterAuthors.Add(chapterNum, userSFId);
-            }
-
-            return chapterAuthors;
-        }
-
-        /// <summary>
-        /// Send answer-notes to Paratext. Don't send questions that have no answers.
-        /// </summary>
-        private async Task UpdateParatextNotesAsync(TextInfo text, IReadOnlyList<IDocument<Question>> questionDocs)
-        {
-            if (!CheckingEnabled)
-                return;
-
-            // TODO: need to define a data structure for notes instead of XML
-            XElement oldNotesElem;
-            string oldNotesText = _paratextService.GetNotes(_userSecret, _projectDoc.Data.ParatextId, text.BookNum);
-            if (oldNotesText != "")
-                oldNotesElem = ParseText(oldNotesText);
-            else
-                oldNotesElem = new XElement("notes", new XAttribute("version", "1.1"));
-
-            XElement notesElem = await _notesMapper.GetNotesChangelistAsync(
-                oldNotesElem,
-                questionDocs,
-                _currentPtSyncUsers,
-                _projectDoc.Data.UserRoles,
-                _projectDoc.Data.CheckingConfig.AnswerExportMethod
-            );
-            if (notesElem.Elements("thread").Any())
-            {
-                _syncMetrics.ParatextNotes += _paratextService.PutNotes(
-                    _userSecret,
-                    _projectDoc.Data.ParatextId,
-                    notesElem
-                );
-            }
-        }
-
-        private async Task<List<Chapter>> UpdateTextDocsAsync(
-            TextInfo text,
-            string paratextId,
-            SortedList<int, IDocument<TextData>> textDocs,
-            ISet<int>? chaptersToInclude = null
-        )
-        {
-            string bookText = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
-            var usxDoc = XDocument.Parse(bookText);
-            var tasks = new List<Task>();
-            Dictionary<int, ChapterDelta> deltas = _deltaUsxMapper
-                .ToChapterDeltas(usxDoc)
-                .ToDictionary(cd => cd.Number);
-            var chapters = new List<Chapter>();
-            List<int> chaptersToRemove = textDocs.Keys.Where(c => !deltas.ContainsKey(c)).ToList();
-            foreach (KeyValuePair<int, ChapterDelta> kvp in deltas)
-            {
-                bool addChapter = true;
-                if (textDocs.TryGetValue(kvp.Key, out IDocument<TextData> textDataDoc))
-                {
-                    if (chaptersToInclude == null || chaptersToInclude.Contains(kvp.Key))
-                    {
-                        Delta diffDelta = textDataDoc.Data.Diff(kvp.Value.Delta);
-                        if (diffDelta.Ops.Count > 0)
-                        {
-                            tasks.Add(textDataDoc.SubmitOpAsync(diffDelta));
-                            _syncMetrics.TextDocs.Updated++;
-                        }
-
-                        textDocs.Remove(kvp.Key);
-                    }
-                    else
-                    {
-                        // We are not to update this chapter
-                        Chapter existingChapter = text.Chapters.FirstOrDefault(c => c.Number == kvp.Key);
-                        if (existingChapter != null)
-                        {
-                            chapters.Add(existingChapter);
-                        }
-
-                        addChapter = false;
-                    }
-                }
-                else if (chaptersToInclude == null || chaptersToInclude.Contains(kvp.Key))
-                {
-                    textDataDoc = GetTextDoc(text, kvp.Key);
-                    async Task createText(int chapterNum, Delta delta)
-                    {
-                        await textDataDoc.FetchAsync();
-                        if (textDataDoc.IsLoaded)
-                            await textDataDoc.DeleteAsync();
-                        await textDataDoc.CreateAsync(new TextData(delta));
-                    }
-                    tasks.Add(createText(kvp.Key, kvp.Value.Delta));
-                    _syncMetrics.TextDocs.Added++;
-                }
-                else
-                {
-                    addChapter = false;
-                }
-                if (addChapter)
-                {
-                    chapters.Add(
-                        new Chapter
-                        {
-                            Number = kvp.Key,
-                            LastVerse = kvp.Value.LastVerse,
-                            IsValid = kvp.Value.IsValid,
-                            Permissions = { }
-                        }
-                    );
-                }
-            }
-            foreach (KeyValuePair<int, IDocument<TextData>> kvp in textDocs)
-            {
-                if (
-                    chaptersToInclude == null
-                    || chaptersToInclude.Contains(kvp.Key)
-                    || chaptersToRemove.Contains(kvp.Key)
-                )
-                {
-                    tasks.Add(kvp.Value.DeleteAsync());
-                    _syncMetrics.TextDocs.Deleted++;
-                }
-            }
-
-            await Task.WhenAll(tasks);
-            return chapters;
-        }
-
-        private async Task UpdateQuestionDocsAsync(
-            IReadOnlyList<IDocument<Question>> questionDocs,
-            List<Chapter> newChapters
-        )
-        {
-            // handle deletion of chapters
-            var chapterNums = new HashSet<int>(newChapters.Select(c => c.Number));
-            var tasks = new List<Task>();
-            foreach (IDocument<Question> questionDoc in questionDocs)
-            {
-                if (!chapterNums.Contains(questionDoc.Data.VerseRef.ChapterNum))
-                {
-                    tasks.Add(questionDoc.DeleteAsync());
-                    _syncMetrics.Questions.Deleted++;
-                }
-            }
-            await Task.WhenAll(tasks);
-        }
-
-        /// <summary>
-        /// Updates ParatextNoteThread docs for a book
-        /// </summary>
-        private async Task UpdateNoteThreadDocsAsync(
-            TextInfo text,
-            Dictionary<string, IDocument<NoteThread>> noteThreadDocs,
-            Dictionary<int, ChapterDelta> chapterDeltas,
-            Dictionary<string, string> usernamesToUserIds
-        )
-        {
-            IEnumerable<NoteThreadChange> noteThreadChanges = _paratextService.GetNoteThreadChanges(
-                _userSecret,
-                _projectDoc.Data.ParatextId,
-                text.BookNum,
-                noteThreadDocs.Values,
-                chapterDeltas,
-                _currentPtSyncUsers
-            );
-            var tasks = new List<Task>();
-
-            foreach (NoteThreadChange change in noteThreadChanges)
-            {
-                // Find the thread doc if it exists
-                if (!noteThreadDocs.TryGetValue(change.ThreadId, out IDocument<NoteThread> threadDoc))
-                {
-                    // Create a new ParatextNoteThread doc
-                    IDocument<NoteThread> doc = GetNoteThreadDoc(change.ThreadId);
-                    async Task createThreadDoc(NoteThreadChange change)
-                    {
-                        VerseRef verseRef = new VerseRef();
-                        verseRef.Parse(change.VerseRefStr);
-                        VerseRefData vrd = new VerseRefData(verseRef.BookNum, verseRef.ChapterNum, verseRef.Verse);
-                        await doc.CreateAsync(
-                            new NoteThread()
-                            {
-                                DataId = change.ThreadId,
-                                ProjectRef = _projectDoc.Id,
-                                VerseRef = vrd,
-                                OriginalSelectedText = change.SelectedText,
-                                OriginalContextBefore = change.ContextBefore,
-                                OriginalContextAfter = change.ContextAfter,
-                                Position = change.Position,
-                                Status = change.Status,
-                                Assignment = change.Assignment
-                            }
-                        );
-                        await SubmitChangesOnNoteThreadDocAsync(doc, change, usernamesToUserIds);
-                    }
-                    tasks.Add(createThreadDoc(change));
-                    _syncMetrics.NoteThreads.Added++;
-                }
-                else
-                {
-                    tasks.Add(SubmitChangesOnNoteThreadDocAsync(threadDoc, change, usernamesToUserIds));
-
-                    // Record thread metrics and note metrics
-                    if (change.ThreadRemoved)
-                    {
-                        _syncMetrics.NoteThreads.Deleted++;
-                    }
-
-                    if (change.ThreadUpdated)
-                    {
-                        _syncMetrics.NoteThreads.Updated++;
-                    }
-
-                    _syncMetrics.Notes += new NoteSyncMetricInfo(
-                        added: change.NotesAdded.Count,
-                        deleted: change.NotesDeleted.Count,
-                        updated: change.NotesUpdated.Count,
-                        removed: change.NoteIdsRemoved.Count
-                    );
-                }
-            }
-            await Task.WhenAll(tasks);
-        }
-
-        /// <summary>
-        /// Fetches all text docs from the database for a book.
-        /// </summary>
-        internal async Task<SortedList<int, IDocument<TextData>>> FetchTextDocsAsync(TextInfo text)
-        {
-            var textDocs = new SortedList<int, IDocument<TextData>>();
-            var tasks = new List<Task>();
-            foreach (Chapter chapter in text.Chapters)
-            {
-                IDocument<TextData> textDoc = GetTextDoc(text, chapter.Number);
-                textDocs[chapter.Number] = textDoc;
-                tasks.Add(textDoc.FetchAsync());
-            }
-            await Task.WhenAll(tasks);
-
-            // Omit items that are not actually in the database.
-            foreach (KeyValuePair<int, IDocument<TextData>> item in textDocs.ToList())
-            {
-                if (!item.Value.IsLoaded)
-                {
-                    textDocs.Remove(item.Key);
-                }
-            }
-            return textDocs;
-        }
-
-        /// <summary>
-        /// Deletes all text docs from the database for a book.
-        /// </summary>
-        private async Task DeleteAllTextDocsForBookAsync(TextInfo text)
-        {
-            var tasks = new List<Task>();
-            foreach (Chapter chapter in text.Chapters)
-                tasks.Add(DeleteTextDocAsync(text, chapter.Number));
-            await Task.WhenAll(tasks);
-            _syncMetrics.TextDocs.Deleted += text.Chapters.Count;
-        }
-
-        private async Task<IReadOnlyList<IDocument<Question>>> FetchQuestionDocsAsync(TextInfo text)
-        {
-            List<string> questionDocIds = await _realtimeService
-                .QuerySnapshots<Question>()
-                .Where(q => q.ProjectRef == _projectDoc.Id && q.VerseRef.BookNum == text.BookNum)
-                .Select(q => q.Id)
-                .ToListAsync();
-            var questionDocs = new IDocument<Question>[questionDocIds.Count];
-            var tasks = new List<Task>();
-            for (int i = 0; i < questionDocIds.Count; i++)
-            {
-                async Task fetchQuestion(int index)
-                {
-                    questionDocs[index] = await _conn.FetchAsync<Question>(questionDocIds[index]);
-                }
-                tasks.Add(fetchQuestion(i));
-            }
-            await Task.WhenAll(tasks);
-            return questionDocs;
-        }
-
-        /// <summary>
-        /// Fetch the ParatextNoteThread docs from the database and return it in a dictionary with threadId as the key.
-        /// </summary>
-        private async Task<Dictionary<string, IDocument<NoteThread>>> FetchNoteThreadDocsAsync(int bookNum)
-        {
-            List<string> noteThreadDocIds = await _realtimeService
-                .QuerySnapshots<NoteThread>()
-                .Where(pnt => pnt.ProjectRef == _projectDoc.Id && pnt.VerseRef.BookNum == bookNum)
-                .Select(pnt => pnt.Id)
-                .ToListAsync();
-            IDocument<NoteThread>[] noteThreadDocs = new IDocument<NoteThread>[noteThreadDocIds.Count];
-            var tasks = new List<Task>();
-            for (int i = 0; i < noteThreadDocIds.Count; i++)
-            {
-                async Task fetchNoteThread(int index)
-                {
-                    noteThreadDocs[index] = await _conn.FetchAsync<NoteThread>(noteThreadDocIds[index]);
-                }
-                tasks.Add(fetchNoteThread(i));
-            }
-            await Task.WhenAll(tasks);
-            return noteThreadDocs.ToDictionary(ntd => ntd.Data.DataId);
-        }
-
-        /// <summary>
-        /// Apply the changes to a ParatextNoteThread doc.
-        /// TODO: Handle if verseRef changes
-        /// </summary>
-        private async Task SubmitChangesOnNoteThreadDocAsync(
-            IDocument<NoteThread> threadDoc,
-            NoteThreadChange change,
-            IReadOnlyDictionary<string, string> usernamesToUserIds
-        )
-        {
-            if (change.ThreadRemoved)
-            {
-                await threadDoc.DeleteAsync();
-                return;
-            }
-
-            await threadDoc.SubmitJson0OpAsync(op =>
-            {
-                // Update thread details
-                if (change.ThreadUpdated)
-                {
-                    if (threadDoc.Data.Status != change.Status)
-                        op.Set(td => td.Status, change.Status);
-                    if (threadDoc.Data.Assignment != change.Assignment)
-                        op.Set(td => td.Assignment, change.Assignment);
-                }
-                // Update content for updated notes
-                foreach (Note updated in change.NotesUpdated)
-                {
-                    int index = threadDoc.Data.Notes.FindIndex(n => n.DataId == updated.DataId);
-                    if (index >= 0)
-                    {
-                        if (threadDoc.Data.Notes[index].Content != updated.Content)
-                            op.Set(td => td.Notes[index].Content, updated.Content);
-                        if (threadDoc.Data.Notes[index].Status != updated.Status)
-                            op.Set(td => td.Notes[index].Status, updated.Status);
-                        if (threadDoc.Data.Notes[index].Type != updated.Type)
-                            op.Set(td => td.Notes[index].Type, updated.Type);
-                        if (threadDoc.Data.Notes[index].ConflictType != updated.ConflictType)
-                            op.Set(td => td.Notes[index].ConflictType, updated.ConflictType);
-                        if (threadDoc.Data.Notes[index].TagId != updated.TagId)
-                            op.Set(td => td.Notes[index].TagId, updated.TagId);
-                        if (threadDoc.Data.Notes[index].Assignment != updated.Assignment)
-                            op.Set(td => td.Notes[index].Assignment, updated.Assignment);
-                        if (threadDoc.Data.Notes[index].AcceptedChangeXml != updated.AcceptedChangeXml)
-                            op.Set(td => td.Notes[index].AcceptedChangeXml, updated.AcceptedChangeXml);
-                    }
-                    else
-                    {
-                        string message = "Unable to update note in database with id: " + updated.DataId;
-                        _logger.LogWarning(message);
-                        LogMetric(message);
-                    }
-                }
-                // Delete notes
-                foreach (Note deleted in change.NotesDeleted)
-                {
-                    int index = threadDoc.Data.Notes.FindIndex(n => n.DataId == deleted.DataId);
-                    if (index >= 0)
-                    {
-                        // The note can be easily removed by using op.Remove if that is preferred
-                        op.Set(td => td.Notes[index].Deleted, true);
-                    }
-                    else
-                    {
-                        string message = "Unable to delete note in database with id: " + deleted.DataId;
-                        _logger.LogWarning(message);
-                        LogMetric(message);
-                    }
-                }
-
-                // Add new notes, giving each note an associated SF userId if the user is also a Paratext user.
-                foreach (Note added in change.NotesAdded)
-                {
-                    string ownerRef = null;
-                    string username = string.IsNullOrEmpty(added.SyncUserRef)
-                        ? null
-                        : _currentPtSyncUsers.Values.Single(u => u.OpaqueUserId == added.SyncUserRef).Username;
-                    if (username != null)
-                        usernamesToUserIds.TryGetValue(username, out ownerRef);
-                    added.OwnerRef = string.IsNullOrEmpty(ownerRef) ? _userSecret.Id : ownerRef;
-                    op.Add(td => td.Notes, added);
-                }
-
-                // Permanently removes a note
-                foreach (string removedId in change.NoteIdsRemoved)
-                {
-                    int index = threadDoc.Data.Notes.FindIndex(n => n.DataId == removedId);
-                    if (index >= 0)
-                        op.Remove(td => td.Notes, index);
-                }
-
-                if (change.Position != null)
-                    op.Set(td => td.Position, change.Position);
-            });
-        }
-
-        private async Task UpdateTranslateNoteTag(string targetParatextId)
-        {
-            int? defaultTagId = _projectDoc.Data.TranslateConfig.DefaultNoteTagId;
-            if (defaultTagId == null)
-            {
-                var newNoteTag = new NoteTag
-                {
-                    TagId = NoteTag.notSetId,
-                    Icon = NoteTag.sfNoteTagIcon,
-                    Name = NoteTag.sfNoteTagName
-                };
-                // Note: If we introduce a new note tag and the remote PT repo also introduces a note tag,
-                // the tag introduced here will get overwritten
-                int noteTagId = _paratextService.UpdateCommentTag(_userSecret, targetParatextId, newNoteTag);
-                await _projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.TranslateConfig.DefaultNoteTagId, noteTagId));
-            }
-        }
-
-        /// <summary>
-        /// Preserve all whitespace in data but remove whitespace at the beginning of lines and remove line endings.
-        /// </summary>
-        private static XElement ParseText(string text)
-        {
-            text = text.Trim().Replace("\r\n", "\n");
-            text = Regex.Replace(text, @"\n\s*<", "<", RegexOptions.CultureInvariant);
-            return XElement.Parse(text, LoadOptions.PreserveWhitespace);
-        }
-
-        /// <summary>
-        /// Deletes all real-time questions docs from the database for a book.
-        /// </summary>
-        private async Task DeleteAllQuestionsDocsForBookAsync(TextInfo text)
-        {
-            List<string> questionDocIds = await _realtimeService
-                .QuerySnapshots<Question>()
-                .Where(q => q.ProjectRef == _projectDoc.Id && q.VerseRef.BookNum == text.BookNum)
-                .Select(q => q.Id)
-                .ToListAsync();
-            var tasks = new List<Task>();
-            foreach (string questionId in questionDocIds)
-            {
-                async Task deleteQuestion()
-                {
-                    IDocument<Question> questionDoc = await _conn.FetchAsync<Question>(questionId);
-                    if (questionDoc.IsLoaded)
-                        await questionDoc.DeleteAsync();
-                }
-                tasks.Add(deleteQuestion());
-            }
-            await Task.WhenAll(tasks);
-            _syncMetrics.Questions.Deleted += questionDocIds.Count;
-        }
-
-        private async Task<List<string>> DeleteNoteThreadDocsInChapters(int bookNum, IEnumerable<Chapter> chapters)
-        {
-            IEnumerable<int> chaptersToDelete = chapters.Select(c => c.Number);
-            IEnumerable<NoteThread> threadDocs = _realtimeService
-                .QuerySnapshots<NoteThread>()
-                .Where(n => n.ProjectRef == _projectDoc.Id && n.VerseRef.BookNum == bookNum);
-            IEnumerable<string> noteThreadDocIds = threadDocs
-                .Where(nt => chaptersToDelete.Contains(nt.VerseRef.ChapterNum))
-                .Select(n => n.Id);
-            // Make a record of the note thread doc ids to return since they are removed
-            // from noteThreadDocIds after the docs are deleted.
-            List<string> deletedNoteThreadDocIds = new List<string>(noteThreadDocIds);
-
-            var tasks = new List<Task>();
-            foreach (string noteThreadDocId in noteThreadDocIds)
-            {
-                async Task deleteNoteThread()
-                {
-                    IDocument<NoteThread> noteThreadDoc = await _conn.FetchAsync<NoteThread>(noteThreadDocId);
-                    if (noteThreadDoc.IsLoaded)
-                        await noteThreadDoc.DeleteAsync();
-                }
-                tasks.Add(deleteNoteThread());
-            }
-
-            await Task.WhenAll(tasks);
-            _syncMetrics.NoteThreads.Deleted += deletedNoteThreadDocIds.Count;
-            return deletedNoteThreadDocIds;
-        }
-
-        private async Task CompleteSync(
-            bool successful,
-            bool canRollbackParatext,
-            bool trainEngine,
-            CancellationToken token
-        )
-        {
-            await NotifySyncProgress(SyncPhase.Phase7, 60.0);
-            if (token.IsCancellationRequested)
-            {
-                Log($"CompleteSync: There was a cancellation request.");
-            }
-            if (_projectDoc == null || _projectSecret == null)
-            {
-                Log("CompleteSync: _projectDoc or _projectSecret are null. Rolling back SF DB transaction.");
-                _conn.RollbackTransaction();
-                return;
-            }
-
-            LogMetric("Completing sync");
-            bool updateRoles = true;
-            IReadOnlyDictionary<string, string> ptUserRoles;
-            if (_paratextService.IsResource(_projectDoc.Data.ParatextId) || token.IsCancellationRequested)
-            {
-                // Do not update permissions on sync, if this is a resource project, as then,
-                // permission updates will be performed when a target project is synchronized.
-                // If the token is cancelled, do not update permissions as GetProjectRolesAsync will fail.
-                ptUserRoles = new Dictionary<string, string>();
-                updateRoles = false;
-            }
-            else
-            {
-                try
-                {
-                    ptUserRoles = await _paratextService.GetProjectRolesAsync(_userSecret, _projectDoc.Data, token);
-                }
-                catch (Exception ex)
-                {
-                    if (ex is HttpRequestException || ex is OperationCanceledException)
-                    {
-                        Log(
-                            $"CompleteSync: Problem fetching project roles. Maybe the user does not have access to the project or cancelled the sync. ({ex})"
-                        );
-                        // This throws a 404 if the user does not have access to the project
-                        // A task cancelled exception will be thrown if the user cancels the task
-                        // Note: OperationCanceledException includes TaskCanceledException
-                        ptUserRoles = new Dictionary<string, string>();
-                        updateRoles = false;
-                    }
-                    else
-                    {
-                        Log($"CompleteSync: Problem fetching project roles. Rethrowing: ({ex})");
-                        throw;
-                    }
-                }
-            }
-
-            var userIdsToRemove = new List<string>();
-            var projectUsers = await _realtimeService
-                .QuerySnapshots<User>()
-                .Where(u => _projectDoc.Data.UserRoles.Keys.Contains(u.Id) && u.ParatextId != null)
-                .Select(u => new { UserId = u.Id, u.ParatextId })
-                .ToListAsync();
-
-            bool dataInSync = true;
-            if (!successful)
-            {
-                LogMetric("Restoring from backup");
-                bool restoreSucceeded = false;
-                // If we have failed, restore the repository, if we can
-                if (canRollbackParatext)
-                {
-                    // If the restore is successful, then dataInSync will always be set to true because
-                    // the restored repo can be assumed to be at the revision recorded in the project doc.
-                    restoreSucceeded = _paratextService.RestoreRepository(_userSecret, _projectDoc.Data.ParatextId);
-                    if (_syncMetrics != null)
-                    {
-                        _syncMetrics.RepositoryRestoredFromBackup = restoreSucceeded;
-                    }
-                }
-                Log(
-                    $"CompleteSync: Sync was not successful. {(restoreSucceeded ? "Rolled back" : "Failed to roll back")} local PT repo."
-                );
-                if (!restoreSucceeded)
-                {
-                    string repoVersion = _paratextService.GetLatestSharedVersion(
-                        _userSecret,
-                        _projectDoc.Data.ParatextId
-                    );
-                    dataInSync = repoVersion == _projectDoc.Data.Sync.SyncedToRepositoryVersion;
-                }
-            }
-
-            // NOTE: This is executed outside of the transaction because it modifies "Sync.QueuedCount"
-            await _projectDoc.SubmitJson0OpAsync(op =>
-            {
-                op.Set(pd => pd.Sync.LastSyncSuccessful, successful);
-
-                // Get the latest shared revision of the local hg repo. On a failed synchronize attempt, the data
-                // is known to be out of sync if the revision does not match the corresponding revision stored
-                // on the project doc.
-                string repoVersion = _paratextService.GetLatestSharedVersion(_userSecret, _projectDoc.Data.ParatextId);
-
-                if (successful)
-                {
-                    Log($"CompleteSync: Successfully synchronized to PT repo commit id '{repoVersion}'.");
-                    op.Set(pd => pd.Sync.DateLastSuccessfulSync, DateTime.UtcNow);
-                    op.Set(pd => pd.Sync.SyncedToRepositoryVersion, repoVersion);
-                    op.Set(pd => pd.Sync.DataInSync, true);
-                }
-                else
-                {
-                    Log(
-                        $"CompleteSync: Failed to synchronize. PT repo latest shared version is '{repoVersion}'. SF DB project SyncedToRepositoryVersion is '{_projectDoc.Data.Sync.SyncedToRepositoryVersion}'."
-                    );
-                    op.Set(pd => pd.Sync.DataInSync, dataInSync);
-                }
-                // the frontend checks the queued count to determine if the sync is complete. The ShareDB client emits
-                // an event for each individual op even if they are applied as a batch, so this needs to be set last,
-                // otherwise the info about the sync won't be set yet when the frontend determines that the sync is
-                // complete.
-                if (_projectDoc.Data.Sync.QueuedCount > 0)
-                {
-                    op.Inc(pd => pd.Sync.QueuedCount, -1);
-                }
-                else
-                {
-                    Log(
-                        $"CompleteSync: Warning: SF project id {_projectDoc.Id} QueuedCount is unexpectedly {_projectDoc.Data.Sync.QueuedCount}. Setting to 0 instead of decrementing."
-                    );
-                    op.Set(pd => pd.Sync.QueuedCount, 0);
-                }
-
-                if (updateRoles)
-                {
-                    // Only update the roles if we received information from Paratext
-                    foreach (var projectUser in projectUsers)
-                    {
-                        if (ptUserRoles.TryGetValue(projectUser.ParatextId, out string role))
-                            op.Set(p => p.UserRoles[projectUser.UserId], role);
-                        else if (_projectDoc.Data.UserRoles[projectUser.UserId].StartsWith("pt"))
-                            userIdsToRemove.Add(projectUser.UserId);
-                    }
-                }
-
-                ParatextSettings? settings = _paratextService.GetParatextSettings(
-                    _userSecret,
-                    _projectDoc.Data.ParatextId
-                );
-                if (settings != null)
-                {
-                    // See if the full name of the project needs updating
-                    if (!string.IsNullOrEmpty(settings.FullName))
-                    {
-                        op.Set(pd => pd.Name, settings.FullName);
-                    }
-
-                    // Set the right-to-left language flag
-                    op.Set(pd => pd.IsRightToLeft, settings.IsRightToLeft);
-                    op.Set(pd => pd.Editable, settings.Editable);
-                    op.Set(pd => pd.DefaultFont, settings.DefaultFont);
-                    op.Set(pd => pd.DefaultFontSize, settings.DefaultFontSize);
-                    if (settings.NoteTags != null)
-                        op.Set(pd => pd.NoteTags, settings.NoteTags);
-                }
-                // The source can be null if there was an error getting a resource from the DBL
-                if (TranslationSuggestionsEnabled && _projectDoc.Data.TranslateConfig.Source != null)
-                {
-                    ParatextSettings? sourceSettings = _paratextService.GetParatextSettings(
-                        _userSecret,
-                        _projectDoc.Data.TranslateConfig.Source.ParatextId
-                    );
-                    if (sourceSettings != null)
-                        op.Set(pd => pd.TranslateConfig.Source.IsRightToLeft, sourceSettings.IsRightToLeft);
-                }
-            });
-            await NotifySyncProgress(SyncPhase.Phase7, 80.0);
-
-            if (_syncMetrics != null)
-            {
-                _syncMetrics.Users.Deleted = userIdsToRemove.Count;
-            }
-
-            foreach (var userId in userIdsToRemove)
-                await _projectService.RemoveUserWithoutPermissionsCheckAsync(_userSecret.Id, _projectDoc.Id, userId);
-
-            // GetPTUsernameToSFUserIdsAsync will fail if the token is cancelled
-            if (!token.IsCancellationRequested)
-            {
-                Dictionary<string, string> ptUsernamesToSFUserIds = await GetPTUsernameToSFUserIdsAsync(token);
-                await _projectDoc.SubmitJson0OpAsync(op =>
-                {
-                    foreach (ParatextUserProfile activePtSyncUser in _currentPtSyncUsers.Values)
-                    {
-                        ParatextUserProfile existingUser = _projectDoc.Data.ParatextUsers.SingleOrDefault(
-                            u => u.Username == activePtSyncUser.Username
-                        );
-                        if (existingUser == null)
-                        {
-                            if (ptUsernamesToSFUserIds.TryGetValue(activePtSyncUser.Username, out string userId))
-                                activePtSyncUser.SFUserId = userId;
-                            op.Add(pd => pd.ParatextUsers, activePtSyncUser);
-                        }
-                        else if (
-                            existingUser.SFUserId == null
-                            && ptUsernamesToSFUserIds.TryGetValue(existingUser.Username, out string userId)
-                        )
-                        {
-                            int index = _projectDoc.Data.ParatextUsers.FindIndex(
-                                u => u.Username == activePtSyncUser.Username
-                            );
-                            op.Set(pd => pd.ParatextUsers[index].SFUserId, userId);
-                        }
-                    }
-                });
-            }
-
-            // If we have an id in the job ids collection, remove the first one, and/or if we have a
-            // sync metrics id, we will remove that specific id from the project secrets.
-            if (_projectSecret.JobIds.Any() || _projectSecret.SyncMetricsIds.Contains(_syncMetrics?.Id))
-            {
-                await _projectSecrets.UpdateAsync(
-                    _projectSecret.Id,
-                    u =>
-                    {
-                        if (_projectSecret.JobIds.Any())
-                        {
-                            u.Remove(p => p.JobIds, _projectSecret.JobIds.First());
-                        }
-
-                        if (_projectSecret.SyncMetricsIds.Contains(_syncMetrics?.Id))
-                        {
-                            u.Remove(p => p.SyncMetricsIds, _syncMetrics?.Id);
-                        }
-                    }
-                );
-            }
-
-            // Commit or rollback the transaction, depending on success
-            if (successful)
-            {
-                // Write the operations to the database
-                await _conn.CommitTransactionAsync();
-
-                // The project document and text documents must be committed before we can train the model
-                bool hasSourceTextDocs = _projectDoc.Data.Texts.Any(t => t.HasSource);
-                if (TranslationSuggestionsEnabled && trainEngine && hasSourceTextDocs)
-                {
-                    // Start training Machine engine
-                    await _machineProjectService.BuildProjectAsync(_userSecret.Id, _projectDoc.Id, token);
-                }
-
-                // Backup the repository
-                if (!_paratextService.IsResource(_projectDoc.Data.ParatextId))
-                {
-                    bool backupOutcome = _paratextService.BackupRepository(_userSecret, _projectDoc.Data.ParatextId);
-                    if (_syncMetrics != null)
-                    {
-                        _syncMetrics.RepositoryBackupCreated = backupOutcome;
-                    }
-
-                    if (!backupOutcome)
-                    {
-                        Log($"CompleteSync: Failure backing up local PT repo.");
-                    }
-                }
-            }
-            else
-            {
-                // Rollback the operations (the repository was restored above)
-                _conn.RollbackTransaction();
-            }
-
-            ReportRepoRevs("CompleteSync: ");
-
-            if (_syncMetrics == null)
-            {
-                Log("The sync metrics were missing, and cannot be updated");
-            }
-            else
-            {
-                // _syncMetrics will be null if InitAsync() fails
-                if (token.IsCancellationRequested)
-                {
-                    _syncMetrics.Status = SyncStatus.Cancelled;
-                }
-                else if (successful)
-                {
-                    _syncMetrics.Status = SyncStatus.Successful;
-                }
-                else
-                {
-                    _syncMetrics.Status = SyncStatus.Failed;
-                }
-
-                _syncMetrics.DateFinished = DateTime.UtcNow;
-                if (!await _syncMetricsRepository.ReplaceAsync(_syncMetrics, true))
-                {
-                    Log("The sync metrics could not be updated in MongoDB");
-                }
-            }
-
-            await NotifySyncProgress(SyncPhase.Phase7, 100.0);
-            Log($"CompleteSync: Finished. Sync was {(successful ? "successful" : "unsuccessful")}.");
-        }
-
-        private void ReportRepoRevs(string prefix = "")
-        {
-            string projectPTId = _projectDoc.Data.ParatextId;
-            string dbInfo =
-                $"DB Sync.SyncedToRepositoryVersion: {_projectDoc.Data.Sync.SyncedToRepositoryVersion}, DB Sync.DataInSync: {_projectDoc.Data.Sync.DataInSync}.";
-            if (_paratextService.IsResource(projectPTId))
-            {
-                Log($"{prefix}In-sync info: Is resource. {dbInfo}");
-            }
-            else if (!_paratextService.LocalProjectDirExists(projectPTId))
-            {
-                Log($"{prefix}In-sync info: No local hg repo. {dbInfo}");
-            }
-            else
-            {
-                string repoRev = _paratextService.GetRepoRevision(_userSecret, projectPTId);
-                string sharedRev = _paratextService.GetLatestSharedVersion(_userSecret, projectPTId);
-                Log(
-                    $"{prefix}In-sync info: Local hg repo current rev: {repoRev}, Latest shared rev: {sharedRev}, {dbInfo}"
-                );
-            }
-        }
-
-        private async Task<Dictionary<string, string>> GetPTUsernameToSFUserIdsAsync(CancellationToken token)
-        {
-            IReadOnlyDictionary<string, string> idsToUsernames = await _paratextService.GetParatextUsernameMappingAsync(
-                _userSecret,
-                _projectDoc.Data,
-                token
-            );
-            Dictionary<string, string> usernamesToUserIds = new Dictionary<string, string>();
-            // Swap the keys and values
-            foreach (KeyValuePair<string, string> kvp in idsToUsernames)
-                usernamesToUserIds.Add(kvp.Value, kvp.Key);
-            return usernamesToUserIds;
-        }
-
-        private IDocument<TextData> GetTextDoc(TextInfo text, int chapter)
-        {
-            return _conn.Get<TextData>(TextData.GetTextDocId(_projectDoc.Id, text.BookNum, chapter));
-        }
-
-        private async Task DeleteTextDocAsync(TextInfo text, int chapter)
-        {
-            IDocument<TextData> textDoc = GetTextDoc(text, chapter);
-            await textDoc.FetchAsync();
-            if (textDoc.IsLoaded)
-                await textDoc.DeleteAsync();
-        }
-
-        private IDocument<NoteThread> GetNoteThreadDoc(string threadId)
-        {
-            return _conn.Get<NoteThread>($"{_projectDoc.Id}:{threadId}");
-        }
-
-        private Dictionary<int, ChapterDelta> GetDeltasByChapter(TextInfo text, string paratextId)
-        {
-            string bookText = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
-            XDocument usxDoc = XDocument.Parse(bookText);
-            Dictionary<int, ChapterDelta> chapterDeltas = _deltaUsxMapper
-                .ToChapterDeltas(usxDoc)
-                .ToDictionary(cd => cd.Number);
-            return chapterDeltas;
-        }
-
-        private async void SyncProgress_ProgressUpdated(object sender, EventArgs e)
-        {
-            if (_projectDoc == null)
-            {
-                return;
-            }
-            else if (sender is SyncProgress progress)
-            {
-                await NotifySyncProgress(SyncPhase.Phase3, progress.ProgressValue);
-            }
-        }
-
-        private async Task NotifySyncProgress(SyncPhase syncPhase, double progress)
-        {
-            if (_projectDoc is not null)
-            {
-                await _hubContext.NotifySyncProgress(
-                    _projectDoc.Id,
-                    new ProgressState
-                    {
-                        // The fraction is based on the number of phases
-                        ProgressValue =
-                            1.0 / _numberOfPhases * (double)syncPhase
-                            + (progress > 1.0 ? progress / 100.0 : progress) * 1.0 / _numberOfPhases,
-                    }
-                );
-            }
-        }
-
-        /// <summary>
-        /// The sync phase.
-        /// </summary>
-        /// <remarks>
-        /// The first phase must be 0, and each succeeding phase in numeric sequence, as the integer value of the
-        /// SyncPhase enum is used to calculate the progress value in <see cref="NotifySyncProgress"/>.
-        /// </remarks>
-        private enum SyncPhase
-        {
-            Phase1 = 0, // Initial methods
-            Phase2 = 1, // Update Paratext books and notes
-            Phase3 = 2, // Paratext Sync
-            Phase4 = 3, // Deleting texts and granting resource access
-            Phase5 = 4, // Getting the resource texts
-            Phase6 = 5, // Updating texts from Paratext books
-            Phase7 = 6, // Final methods
-        }
-
-        private class ChapterEqualityComparer : IEqualityComparer<Chapter>
-        {
-            public bool Equals(Chapter x, Chapter y)
-            {
-                // We do not compare permissions, as these are modified in SFProjectService
-                return x.Number == y.Number && x.LastVerse == y.LastVerse && x.IsValid == y.IsValid;
-            }
-
-            public int GetHashCode(Chapter obj)
-            {
-                int code = 23;
-                code = code * 31 + obj.Number.GetHashCode();
-                code = code * 31 + obj.LastVerse.GetHashCode();
-                code = code * 31 + obj.IsValid.GetHashCode();
-                return code;
-            }
-        }
-
-        private void Log(string message, string? projectSFId = null, string? userId = null)
-        {
-            projectSFId ??= _projectDoc?.Id ?? "unknown";
-            userId ??= _userSecret?.Id ?? "unknown";
-            _logger.LogInformation($"SyncLog ({projectSFId} {userId}): {message}");
-            _syncMetrics.Log.Add($"{DateTime.UtcNow.ToString("u")} {message}");
-        }
-
-        private void LogMetric(string message)
-        {
-            Log(message);
         }
     }
+
+    private async Task<Dictionary<string, string>> GetPTUsernameToSFUserIdsAsync(CancellationToken token)
+    {
+        IReadOnlyDictionary<string, string> idsToUsernames = await _paratextService.GetParatextUsernameMappingAsync(
+            _userSecret,
+            _projectDoc.Data,
+            token
+        );
+        Dictionary<string, string> usernamesToUserIds = new Dictionary<string, string>();
+        // Swap the keys and values
+        foreach (KeyValuePair<string, string> kvp in idsToUsernames)
+            usernamesToUserIds.Add(kvp.Value, kvp.Key);
+        return usernamesToUserIds;
+    }
+
+    private IDocument<TextData> GetTextDoc(TextInfo text, int chapter) =>
+        _conn.Get<TextData>(TextData.GetTextDocId(_projectDoc.Id, text.BookNum, chapter));
+
+    private async Task DeleteTextDocAsync(TextInfo text, int chapter)
+    {
+        IDocument<TextData> textDoc = GetTextDoc(text, chapter);
+        await textDoc.FetchAsync();
+        if (textDoc.IsLoaded)
+            await textDoc.DeleteAsync();
+    }
+
+    private IDocument<NoteThread> GetNoteThreadDoc(string threadId) =>
+        _conn.Get<NoteThread>($"{_projectDoc.Id}:{threadId}");
+
+    private Dictionary<int, ChapterDelta> GetDeltasByChapter(TextInfo text, string paratextId)
+    {
+        string bookText = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
+        XDocument usxDoc = XDocument.Parse(bookText);
+        Dictionary<int, ChapterDelta> chapterDeltas = _deltaUsxMapper
+            .ToChapterDeltas(usxDoc)
+            .ToDictionary(cd => cd.Number);
+        return chapterDeltas;
+    }
+
+    private async void SyncProgress_ProgressUpdated(object sender, EventArgs e)
+    {
+        if (_projectDoc == null)
+        {
+            return;
+        }
+        else if (sender is SyncProgress progress)
+        {
+            await NotifySyncProgress(SyncPhase.Phase3, progress.ProgressValue);
+        }
+    }
+
+    private async Task NotifySyncProgress(SyncPhase syncPhase, double progress)
+    {
+        if (_projectDoc is not null)
+        {
+            await _hubContext.NotifySyncProgress(
+                _projectDoc.Id,
+                new ProgressState
+                {
+                    // The fraction is based on the number of phases
+                    ProgressValue =
+                        1.0 / _numberOfPhases * (double)syncPhase
+                        + (progress > 1.0 ? progress / 100.0 : progress) * 1.0 / _numberOfPhases,
+                }
+            );
+        }
+    }
+
+    /// <summary>
+    /// The sync phase.
+    /// </summary>
+    /// <remarks>
+    /// The first phase must be 0, and each succeeding phase in numeric sequence, as the integer value of the
+    /// SyncPhase enum is used to calculate the progress value in <see cref="NotifySyncProgress"/>.
+    /// </remarks>
+    private enum SyncPhase
+    {
+        Phase1 = 0, // Initial methods
+        Phase2 = 1, // Update Paratext books and notes
+        Phase3 = 2, // Paratext Sync
+        Phase4 = 3, // Deleting texts and granting resource access
+        Phase5 = 4, // Getting the resource texts
+        Phase6 = 5, // Updating texts from Paratext books
+        Phase7 = 6, // Final methods
+    }
+
+    private class ChapterEqualityComparer : IEqualityComparer<Chapter>
+    {
+        public bool Equals(Chapter x, Chapter y) =>
+            // We do not compare permissions, as these are modified in SFProjectService
+            x.Number == y.Number
+            && x.LastVerse == y.LastVerse
+            && x.IsValid == y.IsValid;
+
+        public int GetHashCode(Chapter obj)
+        {
+            int code = 23;
+            code = code * 31 + obj.Number.GetHashCode();
+            code = code * 31 + obj.LastVerse.GetHashCode();
+            code = code * 31 + obj.IsValid.GetHashCode();
+            return code;
+        }
+    }
+
+    private void Log(string message, string? projectSFId = null, string? userId = null)
+    {
+        projectSFId ??= _projectDoc?.Id ?? "unknown";
+        userId ??= _userSecret?.Id ?? "unknown";
+        _logger.LogInformation($"SyncLog ({projectSFId} {userId}): {message}");
+        _syncMetrics.Log.Add($"{DateTime.UtcNow:u} {message}");
+    }
+
+    private void LogMetric(string message) => Log(message);
 }

--- a/src/SIL.XForge.Scripture/Services/PersistedParatextDataSettings.cs
+++ b/src/SIL.XForge.Scripture/Services/PersistedParatextDataSettings.cs
@@ -1,12 +1,11 @@
 using Paratext.Data;
 using PtxUtils;
 
-namespace SIL.XForge.Scripture
-{
-    class PersistedParatextDataSettings : IParatextDataSettings
-    {
-        public SerializableStringDictionary LastRegistryDataCachedTimes { get; set; }
+namespace SIL.XForge.Scripture;
 
-        public void SafeSave() { }
-    }
+class PersistedParatextDataSettings : IParatextDataSettings
+{
+    public SerializableStringDictionary LastRegistryDataCachedTimes { get; set; }
+
+    public void SafeSave() { }
 }

--- a/src/SIL.XForge.Scripture/Services/PersistedPtxUtilsSettings.cs
+++ b/src/SIL.XForge.Scripture/Services/PersistedPtxUtilsSettings.cs
@@ -1,13 +1,12 @@
 using PtxUtils;
 
-namespace SIL.XForge.Scripture
-{
-    class PersistedPtxUtilsSettings : IPtxUtilsSettings
-    {
-        public SerializableStringDictionary MementoData { get; set; }
-        public bool UpgradeNeeded { get; set; }
-        public bool EnableFormSnapping { get; set; }
+namespace SIL.XForge.Scripture;
 
-        public void SafeSave() { }
-    }
+class PersistedPtxUtilsSettings : IPtxUtilsSettings
+{
+    public SerializableStringDictionary MementoData { get; set; }
+    public bool UpgradeNeeded { get; set; }
+    public bool EnableFormSnapping { get; set; }
+
+    public void SafeSave() { }
 }

--- a/src/SIL.XForge.Scripture/Services/SFApplicationBuilderExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/SFApplicationBuilderExtensions.cs
@@ -1,13 +1,10 @@
 using Microsoft.Extensions.DependencyInjection;
 using SIL.XForge.Scripture.Services;
 
-namespace Microsoft.AspNetCore.Builder
+namespace Microsoft.AspNetCore.Builder;
+
+public static class SFApplicationBuilderExtensions
 {
-    public static class SFApplicationBuilderExtensions
-    {
-        public static void UseSFServices(this IApplicationBuilder app)
-        {
-            app.ApplicationServices.GetService<IParatextService>().Init();
-        }
-    }
+    public static void UseSFServices(this IApplicationBuilder app) =>
+        app.ApplicationServices.GetService<IParatextService>().Init();
 }

--- a/src/SIL.XForge.Scripture/Services/SFBiblicalTermsText.cs
+++ b/src/SIL.XForge.Scripture/Services/SFBiblicalTermsText.cs
@@ -1,65 +1,61 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
-using System.Collections.Generic;
 using SIL.Machine.Corpora;
 using SIL.Machine.Tokenization;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public class SFBiblicalTermsText : IText
 {
-    public class SFBiblicalTermsText : IText
+    private IEnumerable<TextSegment> _segments;
+
+    public SFBiblicalTermsText(
+        ITokenizer<string, int, string> wordTokenizer,
+        string projectId,
+        XDocument termRenderingsDoc
+    )
     {
-        private IEnumerable<TextSegment> _segments;
+        Id = $"{projectId}_biblical_terms";
 
-        public SFBiblicalTermsText(
-            ITokenizer<string, int, string> wordTokenizer,
-            string projectId,
-            XDocument termRenderingsDoc
+        _segments = GetSegments(wordTokenizer, termRenderingsDoc).OrderBy(s => s.SegmentRef).ToArray();
+    }
+
+    public string Id { get; }
+
+    public string SortKey => Id;
+
+    public IEnumerable<TextSegment> GetSegments(bool includeText = true, IText basedOn = null) => _segments;
+
+    private IEnumerable<TextSegment> GetSegments(
+        ITokenizer<string, int, string> wordTokenizer,
+        XDocument termRenderingsDoc
+    )
+    {
+        foreach (
+            XElement termRenderingElem in termRenderingsDoc.Root
+                .Elements("TermRendering")
+                .Where(tre => !(bool)tre.Attribute("Guess"))
         )
         {
-            Id = $"{projectId}_biblical_terms";
+            var id = (string)termRenderingElem.Attribute("Id");
+            var renderingsStr = (string)termRenderingElem.Element("Renderings");
+            string[] renderings = renderingsStr.Trim().Split("||", StringSplitOptions.RemoveEmptyEntries);
 
-            _segments = GetSegments(wordTokenizer, termRenderingsDoc).OrderBy(s => s.SegmentRef).ToArray();
-        }
-
-        public string Id { get; }
-
-        public string SortKey => Id;
-
-        public IEnumerable<TextSegment> GetSegments(bool includeText = true, IText basedOn = null)
-        {
-            return _segments;
-        }
-
-        private IEnumerable<TextSegment> GetSegments(
-            ITokenizer<string, int, string> wordTokenizer,
-            XDocument termRenderingsDoc
-        )
-        {
-            foreach (
-                XElement termRenderingElem in termRenderingsDoc.Root
-                    .Elements("TermRendering")
-                    .Where(tre => !(bool)tre.Attribute("Guess"))
-            )
+            foreach (string rendering in renderings)
             {
-                var id = (string)termRenderingElem.Attribute("Id");
-                var renderingsStr = (string)termRenderingElem.Element("Renderings");
-                string[] renderings = renderingsStr.Trim().Split("||", StringSplitOptions.RemoveEmptyEntries);
-
-                foreach (string rendering in renderings)
-                {
-                    string[] segment = wordTokenizer.Tokenize(rendering.Trim()).ToArray();
-                    // Sentence placement is not essential for biblical terms. Set all to false
-                    yield return new TextSegment(
-                        Id,
-                        new TextSegmentRef(id),
-                        segment,
-                        false,
-                        false,
-                        false,
-                        segment.Count() == 0
-                    );
-                }
+                string[] segment = wordTokenizer.Tokenize(rendering.Trim()).ToArray();
+                // Sentence placement is not essential for biblical terms. Set all to false
+                yield return new TextSegment(
+                    Id,
+                    new TextSegmentRef(id),
+                    segment,
+                    false,
+                    false,
+                    false,
+                    segment.Length == 0
+                );
             }
         }
     }

--- a/src/SIL.XForge.Scripture/Services/SFBuildHandler.cs
+++ b/src/SIL.XForge.Scripture/Services/SFBuildHandler.cs
@@ -7,43 +7,37 @@ using SIL.XForge.Realtime;
 using SIL.XForge.Realtime.Json0;
 using SIL.XForge.Scripture.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// This class clears the selected segment checksums for all user configs of a project when the translation engine
+/// finishes training. The checksums need to be reset, because the engine has been trained on any text in the
+/// selected segments.
+/// </summary>
+public class SFBuildHandler : BuildHandler
 {
-    /// <summary>
-    /// This class clears the selected segment checksums for all user configs of a project when the translation engine
-    /// finishes training. The checksums need to be reset, because the engine has been trained on any text in the
-    /// selected segments.
-    /// </summary>
-    public class SFBuildHandler : BuildHandler
+    private readonly IRealtimeService _realtimeService;
+
+    public SFBuildHandler(IRealtimeService realtimeService) => _realtimeService = realtimeService;
+
+    public override async Task OnCompleted(BuildContext context)
     {
-        private readonly IRealtimeService _realtimeService;
+        await using IConnection conn = await _realtimeService.ConnectAsync();
+        IDocument<SFProject> project = await conn.FetchAsync<SFProject>(context.Engine.Projects.First());
+        if (!project.IsLoaded)
+            return;
 
-        public SFBuildHandler(IRealtimeService realtimeService)
-        {
-            _realtimeService = realtimeService;
-        }
+        var tasks = new List<Task>();
+        foreach (string userId in project.Data.UserRoles.Keys)
+            tasks.Add(ClearSelectedSegmentChecksum(conn, project.Id, userId));
+        await Task.WhenAll(tasks);
+    }
 
-        public override async Task OnCompleted(BuildContext context)
-        {
-            await using (IConnection conn = await _realtimeService.ConnectAsync())
-            {
-                IDocument<SFProject> project = await conn.FetchAsync<SFProject>(context.Engine.Projects.First());
-                if (!project.IsLoaded)
-                    return;
-
-                var tasks = new List<Task>();
-                foreach (string userId in project.Data.UserRoles.Keys)
-                    tasks.Add(ClearSelectedSegmentChecksum(conn, project.Id, userId));
-                await Task.WhenAll(tasks);
-            }
-        }
-
-        private async Task ClearSelectedSegmentChecksum(IConnection conn, string projectId, string userId)
-        {
-            IDocument<SFProjectUserConfig> config = await conn.FetchAsync<SFProjectUserConfig>(
-                SFProjectUserConfig.GetDocId(projectId, userId)
-            );
-            await config.SubmitJson0OpAsync(op => op.Unset(puc => puc.SelectedSegmentChecksum));
-        }
+    private static async Task ClearSelectedSegmentChecksum(IConnection conn, string projectId, string userId)
+    {
+        IDocument<SFProjectUserConfig> config = await conn.FetchAsync<SFProjectUserConfig>(
+            SFProjectUserConfig.GetDocId(projectId, userId)
+        );
+        await config.SubmitJson0OpAsync(op => op.Unset(puc => puc.SelectedSegmentChecksum));
     }
 }

--- a/src/SIL.XForge.Scripture/Services/SFDblRestClientFactory.cs
+++ b/src/SIL.XForge.Scripture/Services/SFDblRestClientFactory.cs
@@ -2,35 +2,34 @@ using Microsoft.Extensions.Options;
 using SIL.XForge.Configuration;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// The Scripture Forge Rest Client Factory.
+/// </summary>
+/// <seealso cref="SIL.XForge.Scripture.Services.ISFRestClientFactory" />
+public class SFDblRestClientFactory : ISFRestClientFactory
 {
     /// <summary>
-    /// The Scripture Forge Rest Client Factory.
+    /// The JWT token helper.
     /// </summary>
-    /// <seealso cref="SIL.XForge.Scripture.Services.ISFRestClientFactory" />
-    public class SFDblRestClientFactory : ISFRestClientFactory
+    private readonly IJwtTokenHelper _jwtTokenHelper;
+    private readonly IOptions<SiteOptions> _siteOptions;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SFDblRestClientFactory"/> class.
+    /// </summary>
+    /// <param name="jwtTokenHelper">The JWT token helper.</param>
+    public SFDblRestClientFactory(IJwtTokenHelper jwtTokenHelper, IOptions<SiteOptions> siteOptions)
     {
-        /// <summary>
-        /// The JWT token helper.
-        /// </summary>
-        private readonly IJwtTokenHelper _jwtTokenHelper;
-        private readonly IOptions<SiteOptions> _siteOptions;
+        _jwtTokenHelper = jwtTokenHelper;
+        _siteOptions = siteOptions;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SFDblRestClientFactory"/> class.
-        /// </summary>
-        /// <param name="jwtTokenHelper">The JWT token helper.</param>
-        public SFDblRestClientFactory(IJwtTokenHelper jwtTokenHelper, IOptions<SiteOptions> siteOptions)
-        {
-            _jwtTokenHelper = jwtTokenHelper;
-            _siteOptions = siteOptions;
-        }
-
-        /// <inheritdoc />
-        public ISFRestClient Create(string baseUri, UserSecret userSecret)
-        {
-            string jwtToken = _jwtTokenHelper.GetJwtTokenFromUserSecret(userSecret);
-            return new JwtRestClient(baseUri, _siteOptions.Value.Name, jwtToken);
-        }
+    /// <inheritdoc />
+    public ISFRestClient Create(string baseUri, UserSecret userSecret)
+    {
+        string jwtToken = _jwtTokenHelper.GetJwtTokenFromUserSecret(userSecret);
+        return new JwtRestClient(baseUri, _siteOptions.Value.Name, jwtToken);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/SFHgRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/SFHgRunner.cs
@@ -1,20 +1,19 @@
 using System.Text.RegularExpressions;
 using Paratext.Data;
 
-namespace SIL.XForge.Scripture.Services
-{
-    /// <summary> An implementation of <see cref="HgExeRunner"/> that allows intercepting Mercurial commands. </summary>
-    public class SFHgRunner : HgExeRunner
-    {
-        public SFHgRunner(string installPath, string repository, string mergePath)
-            : base(installPath, repository, mergePath) { }
+namespace SIL.XForge.Scripture.Services;
 
-        public override void RunHg(string args)
-        {
-            // Since we don't have access to the users registration code, using 'tip' seems to be a working alternative
-            args = Regex.Replace(args, @"outgoing\(.+\)", "tip");
-            args = $"{args}";
-            base.RunHg(args);
-        }
+/// <summary> An implementation of <see cref="HgExeRunner"/> that allows intercepting Mercurial commands. </summary>
+public class SFHgRunner : HgExeRunner
+{
+    public SFHgRunner(string installPath, string repository, string mergePath)
+        : base(installPath, repository, mergePath) { }
+
+    public override void RunHg(string args)
+    {
+        // Since we don't have access to the users registration code, using 'tip' seems to be a working alternative
+        args = Regex.Replace(args, @"outgoing\(.+\)", "tip");
+        args = $"{args}";
+        base.RunHg(args);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
+++ b/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
@@ -20,48 +20,818 @@ using SIL.XForge.Models;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// The Scripture Forge Installable DBL Resource Implementation.
+/// </summary>
+/// <remarks>
+/// This is a reimplementation of <see cref="Paratext.Data.Archiving.InstallableDBLResource"/>.
+/// Much of the code was copied from that class and modified to work within the ScriptureForge environment.
+/// Primary differences include:
+///  * Configuring the password provider based on the environment's <see cref="ParatextMigrationOperations"/>
+///  * A simplified Migration Provider and Password Provider implementation
+///  * Retrieving the Paratext Username from the JWT Token
+///  * A resource permission implementation that uses the DBL API
+///  * Use of the DBL API's JSON feed rather than the slower XML feed
+///  * Reimplementing the logic in the internal class InstallableDBLResource.DBLParatextApi, using the JSON API
+/// </remarks>
+public class SFInstallableDblResource : InstallableResource
 {
     /// <summary>
-    /// The Scripture Forge Installable DBL Resource Implementation.
+    /// The resource identifier length.
     /// </summary>
+    public const int ResourceIdentifierLength = 16;
+
+    /// <summary>
+    /// The DBL folder name (in the zip file).
+    /// </summary>
+    private const string DblFolderName = ".dbl";
+
+    /// <summary>
+    /// The DBL resource entries API endpoint.
+    /// </summary>
+    private const string DblResourceEntriesApiCall = "api/resource_entries";
+
+    /// <summary>
+    /// The file system service.
+    /// </summary>
+    private readonly IFileSystemService _fileSystemService;
+
+    /// <summary>
+    /// The JWT token helper.
+    /// </summary>
+    private readonly IJwtTokenHelper _jwtTokenHelper;
+
+    /// <summary>
+    /// The paratext options.
+    /// </summary>
+    private readonly ParatextOptions _paratextOptions;
+
+    /// <summary>
+    /// The rest client factory.
+    /// </summary>
+    private readonly ISFRestClientFactory _restClientFactory;
+
+    /// <summary>
+    /// The user secret.
+    /// </summary>
+    private readonly UserSecret _userSecret;
+
+    /// <summary>
+    /// The existing Scripture Text
+    /// </summary>
+    private ScrText existingScrText;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SFInstallableDblResource" /> class.
+    /// </summary>
+    /// <param name="userSecret">The user secret.</param>
+    /// <param name="paratextOptions">The paratext options.</param>
+    /// <param name="restClientFactory">The rest client factory.</param>
+    /// <param name="fileSystemService">The file system service.</param>
+    /// <param name="jwtTokenHelper">The JWT token helper.</param>
     /// <remarks>
-    /// This is a reimplementation of <see cref="Paratext.Data.Archiving.InstallableDBLResource"/>.
-    /// Much of the code was copied from that class and modified to work within the ScriptureForge environment.
-    /// Primary differences include:
-    ///  * Configuring the password provider based on the environment's <see cref="ParatextMigrationOperations"/>
-    ///  * A simplified Migration Provider and Password Provider implementation
-    ///  * Retrieving the Paratext Username from the JWT Token
-    ///  * A resource permission implementation that uses the DBL API
-    ///  * Use of the DBL API's JSON feed rather than the slower XML feed
-    ///  * Reimplementing the logic in the internal class InstallableDBLResource.DBLParatextApi, using the JSON API
+    /// This is a convenience constructor for unit tests.
     /// </remarks>
-    public class SFInstallableDblResource : InstallableResource
+    internal SFInstallableDblResource(
+        UserSecret userSecret,
+        ParatextOptions paratextOptions,
+        ISFRestClientFactory restClientFactory,
+        IFileSystemService fileSystemService,
+        IJwtTokenHelper jwtTokenHelper
+    )
+        : this(
+            userSecret,
+            paratextOptions,
+            restClientFactory,
+            fileSystemService,
+            jwtTokenHelper,
+            new ParatextProjectDeleter(),
+            new ParatextMigrationOperations(),
+            new ParatextZippedResourcePasswordProvider(paratextOptions)
+        ) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SFInstallableDblResource" /> class.
+    /// </summary>
+    /// <param name="userSecret">The user secret.</param>
+    /// <param name="paratextOptions">The paratext options.</param>
+    /// <param name="restClientFactory">The rest client factory.</param>
+    /// <param name="fileSystemService">The file system service.</param>
+    /// <param name="jwtTokenHelper">The JWT token helper.</param>
+    /// <param name="projectDeleter">The project deleter.</param>
+    /// <param name="migrationOperations">The migration operations.</param>
+    /// <param name="passwordProvider">The password provider.</param>
+    /// <exception cref="ArgumentNullException">restClientFactory</exception>
+    private SFInstallableDblResource(
+        UserSecret userSecret,
+        ParatextOptions paratextOptions,
+        ISFRestClientFactory restClientFactory,
+        IFileSystemService fileSystemService,
+        IJwtTokenHelper jwtTokenHelper,
+        IProjectDeleter projectDeleter,
+        IMigrationOperations migrationOperations,
+        IZippedResourcePasswordProvider passwordProvider
+    )
+        : base(projectDeleter, migrationOperations, passwordProvider)
+    {
+        this._userSecret = userSecret;
+        this._paratextOptions = paratextOptions;
+        this._restClientFactory = restClientFactory;
+        this._fileSystemService = fileSystemService;
+        this._jwtTokenHelper = jwtTokenHelper;
+        if (this._restClientFactory == null)
+        {
+            throw new ArgumentNullException(nameof(restClientFactory));
+        }
+        else if (this._fileSystemService == null)
+        {
+            throw new ArgumentNullException(nameof(fileSystemService));
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the DBL source URL.
+    /// </summary>
+    /// <value>
+    /// The DBL source URL.
+    /// </value>
+    /// <remarks>
+    /// This URL may or may not require authentication, depending on the resource.
+    /// </remarks>
+    public string DblSourceUrl { get; set; }
+
+    /// <summary>
+    /// Gets the existing Scripture Text.
+    /// </summary>
+    /// <value>
+    /// The existing Scripture Text.
+    /// </value>
+    /// <remarks>
+    /// This is required for <see cref="InstallableResource.IsNewerThanCurrentlyInstalled" />.
+    /// </remarks>
+    public override ScrText ExistingScrText
+    {
+        get
+        {
+            if (existingScrText == null)
+            {
+                // Generate an ExistingScrText from the p8z file on disk
+                string fileName = this.Name + ProjectFileManager.resourceFileExtension;
+                string projectPath = Path.Combine(ScrTextCollection.ResourcesDirectory, fileName);
+                if (RobustFile.Exists(projectPath))
+                {
+                    var name = new ProjectName(projectPath);
+                    if (name != null)
+                    {
+                        string userName = this._jwtTokenHelper.GetParatextUsername(this._userSecret);
+                        if (userName == null)
+                        {
+                            throw new Exception($"Failed to get a PT username for SF user id {_userSecret.Id}.");
+                        }
+                        var ptUser = new SFParatextUser(userName);
+                        var passwordProvider = new ParatextZippedResourcePasswordProvider(this._paratextOptions);
+                        existingScrText = new ResourceScrText(name, ptUser, passwordProvider);
+                    }
+                }
+            }
+
+            return existingScrText;
+        }
+    }
+
+    /// <summary>
+    /// Checks the resource permission, according to a DBL server.
+    /// </summary>
+    /// <param name="id">The identifier.</param>
+    /// <param name="userSecret">The user secret.</param>
+    /// <param name="paratextOptions">The paratext options.</param>
+    /// <param name="restClientFactory">The rest client factory.</param>
+    /// <param name="fileSystemService">The file system service.</param>
+    /// <param name="jwtTokenHelper">The JWT token helper.</param>
+    /// <param name="baseUrl">The base URL.</param>
+    /// <returns>
+    ///   <c>true</c> if the user has permission to access the resource; otherwise, <c>false</c>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">id
+    /// or
+    /// userSecret
+    /// or
+    /// restClientFactory</exception>
+    public static bool CheckResourcePermission(
+        string id,
+        UserSecret userSecret,
+        ParatextOptions paratextOptions,
+        ISFRestClientFactory restClientFactory,
+        IFileSystemService fileSystemService,
+        IJwtTokenHelper jwtTokenHelper,
+        IExceptionHandler exceptionHandler,
+        string baseUrl = null
+    )
+    {
+        // Parameter check
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            throw new ArgumentNullException(nameof(id));
+        }
+        else if (userSecret == null)
+        {
+            throw new ArgumentNullException(nameof(userSecret));
+        }
+        else if (restClientFactory == null)
+        {
+            throw new ArgumentNullException(nameof(restClientFactory));
+        }
+
+        baseUrl = string.IsNullOrWhiteSpace(baseUrl) ? InternetAccess.ParatextDBLServer : baseUrl;
+        try
+        {
+            IEnumerable<SFInstallableDblResource> resources = GetInstallableDblResources(
+                userSecret,
+                paratextOptions,
+                restClientFactory,
+                fileSystemService,
+                jwtTokenHelper,
+                exceptionHandler,
+                baseUrl,
+                id
+            );
+            return resources.Any(r => r.DBLEntryUid.Id == id);
+        }
+        catch (Exception ex)
+        {
+            // Paratext throws an HttpException instead of a WebException
+            // If you need it, the WebException is the InnerException
+            if (ex is Paratext.Data.HttpException httpException)
+            {
+                if (httpException.Response.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    // A 401 error means unauthorized (probably a bad token)
+                    return false;
+                }
+                else if (httpException.Response.StatusCode == HttpStatusCode.Forbidden)
+                {
+                    // A 403 error means no access.
+                    return false;
+                }
+                else if (httpException.Response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    // A 404 error means that the resource is not on the server
+                    return false;
+                }
+                else
+                {
+                    // Unknown status code
+                    throw;
+                }
+            }
+            else if (ex.Source == "NSubstitute")
+            {
+                // This occurs during unit tests to test whether there is permission or not
+                return false;
+            }
+            else
+            {
+                // An unknown error
+                throw;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Return a list of resources which this user is allowed to install from DBL.
+    /// If we cannot contact DBL, return an empty list.
+    /// </summary>
+    /// <param name="userSecret">The user secret.</param>
+    /// <param name="paratextOptions">The paratext options.</param>
+    /// <param name="restClientFactory">The rest client factory.</param>
+    /// <param name="fileSystemService">The file system service.</param>
+    /// <param name="jwtTokenHelper">The JWT token helper.</param>
+    /// <param name="baseUrl">The base URL.</param>
+    /// <param name="id">ID of resource to filter for (optional).</param>
+    /// <returns>The Installable Resources.</returns>
+    /// <exception cref="ArgumentNullException">restClientFactory
+    /// or
+    /// userSecret</exception>
+    /// <remarks>Tests on this method can be found in ParatextServiceTests.cs calling GetResources().</remarks>
+    public static IEnumerable<SFInstallableDblResource> GetInstallableDblResources(
+        UserSecret userSecret,
+        ParatextOptions paratextOptions,
+        ISFRestClientFactory restClientFactory,
+        IFileSystemService fileSystemService,
+        IJwtTokenHelper jwtTokenHelper,
+        IExceptionHandler exceptionHandler,
+        string baseUrl = null,
+        string id = null
+    )
+    {
+        // Parameter check (just like the constructor)
+        if (restClientFactory == null)
+        {
+            throw new ArgumentNullException(nameof(restClientFactory));
+        }
+        else if (userSecret == null)
+        {
+            throw new ArgumentNullException(nameof(userSecret));
+        }
+
+        ISFRestClient client = restClientFactory.Create(string.Empty, userSecret);
+        baseUrl = string.IsNullOrWhiteSpace(baseUrl) ? InternetAccess.ParatextDBLServer : baseUrl;
+        string response;
+        try
+        {
+            response = client.Get(BuildDblResourceListUrl(baseUrl, id));
+        }
+        catch (WebException e)
+        {
+            // If we get a temporary 401 Unauthorized response, return an empty list.
+            string errorExplanation =
+                "GetInstallableDblResources failed when attempting to inquire about"
+                + $" resources and is ignoring error {e}";
+            var report = new Exception(errorExplanation);
+            // Report to bugsnag, but don't throw.
+            exceptionHandler.ReportException(report);
+            return Enumerable.Empty<SFInstallableDblResource>();
+        }
+        IEnumerable<SFInstallableDblResource> resources = ConvertJsonResponseToInstallableDblResources(
+            baseUrl,
+            response,
+            restClientFactory,
+            fileSystemService,
+            jwtTokenHelper,
+            DateTime.Now,
+            userSecret,
+            paratextOptions,
+            new ParatextProjectDeleter(),
+            new ParatextMigrationOperations(),
+            new ParatextZippedResourcePasswordProvider(paratextOptions)
+        );
+        return resources;
+    }
+
+    /// <summary>
+    /// Extracts the resource to a directory.
+    /// </summary>
+    /// <param name="path">The path.</param>
+    /// <exception cref="ArgumentNullException">
+    /// path
+    /// or
+    /// DBLEntryUid
+    /// or
+    /// Name
+    /// </exception>
+    /// <remarks>
+    /// After the resource is extracted, it can be a source or target.
+    /// </remarks>
+    public void ExtractToDirectory(string path)
+    {
+        // Check parameters
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new ArgumentNullException(nameof(path));
+        }
+        else if (string.IsNullOrWhiteSpace(this.DBLEntryUid.Id))
+        {
+            throw new ArgumentNullException(nameof(this.DBLEntryUid.Id));
+        }
+        else if (string.IsNullOrWhiteSpace(this.Name))
+        {
+            throw new ArgumentNullException(nameof(this.Name));
+        }
+
+        string resourceFile = ScrTextCollection.GetResourcePath(
+            this.ExistingScrText,
+            this.Name,
+            this.DBLEntryUid,
+            ProjectFileManager.resourceFileExtension
+        );
+        if (RobustFile.Exists(resourceFile))
+        {
+            using var zipFile = ZipFile.Read(resourceFile);
+            zipFile.Password = this._passwordProvider?.GetPassword();
+            zipFile.ExtractAll(path, ExtractExistingFileAction.DoNotOverwrite);
+        }
+    }
+
+    /// <summary>
+    /// Download the files for this project from DBL into sourceDirectory and then
+    /// copy them to the destination directory.
+    /// Install should throw an Exception with an appropriate message if something goes wrong.
+    /// </summary>
+    /// <returns>
+    ///   <c>true</c> if fonts were installed; otherwise <c>false</c>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">DBLEntryUid
+    /// or
+    /// DBLSourceUrl
+    /// or
+    /// Name</exception>
+    public override bool Install()
+    {
+        // Easier to check parameters here than fill the temp directory with files
+        // NOTE: This is not an exhaustive list of the required parameters!
+        //       You will need to refer to InstallableResource.Install() for that.
+        if (string.IsNullOrWhiteSpace(this.DBLEntryUid.Id))
+        {
+            throw new ArgumentNullException(nameof(this.DBLEntryUid.Id));
+        }
+        else if (string.IsNullOrWhiteSpace(this.DblSourceUrl))
+        {
+            throw new ArgumentNullException(nameof(this.DblSourceUrl));
+        }
+        else if (string.IsNullOrWhiteSpace(this.Name))
+        {
+            throw new ArgumentNullException(nameof(this.Name));
+        }
+
+        sourceDirectory = this.CreateTempSourceDirectory();
+        string filePath = Path.Combine(sourceDirectory, this.Name + ProjectFileManager.resourceFileExtension);
+        if (!this.GetFile(filePath))
+        {
+            if (RobustFile.Exists(filePath))
+            {
+                // RobustFile only handles retries...
+                RobustFile.Delete(filePath);
+            }
+
+            return false;
+        }
+
+        bool result;
+        try
+        {
+            result = base.Install();
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Treat this like we couldn't get the resource from the DBL - ignore the error and continue.
+            // This maybe caused by the file already being there and in use or the SF Project directory not existing
+            result = false;
+        }
+
+        if (RobustFile.Exists(filePath))
+        {
+            RobustFile.Delete(filePath);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Gets the revision numbers for all installed resources.
+    /// </summary>
+    /// <returns>
+    /// A dictionary where the resource id is the key, and the revision is the value.
+    /// </returns>
+    internal static IReadOnlyDictionary<string, int> GetInstalledResourceRevisions()
+    {
+        // Initialize variables
+        Dictionary<string, int> resourceRevisions = new Dictionary<string, int>();
+        string resourcesDirectory;
+
+        // This can throw an error if the SettingsDirectory is not specified
+        // If that is the case, we don't need to look at the FS anyway
+        try
+        {
+            resourcesDirectory = ScrTextCollection.ResourcesDirectory;
+        }
+        catch (ArgumentNullException)
+        {
+            // Path.Combine() in ScrTextCollection will have thrown this error
+            resourcesDirectory = string.Empty;
+        }
+
+        if (!string.IsNullOrWhiteSpace(resourcesDirectory) && Directory.Exists(resourcesDirectory))
+        {
+            foreach (
+                string resourceFile in Directory.EnumerateFiles(
+                    ScrTextCollection.ResourcesDirectory,
+                    "*" + ProjectFileManager.resourceFileExtension
+                )
+            )
+            {
+                // See if this a zip file, and if it contains the correct ID
+                try
+                {
+                    // This only uses DotNetZip because ParatextData uses DotNetZip
+                    // You could use System.IO.Compression if you wanted to
+                    using var zipFile = ZipFile.Read(resourceFile);
+                    // Zip files use forward slashes, even on Windows
+                    const string idSearchPath = DblFolderName + "/id/";
+                    const string revisionSearchPath = DblFolderName + "/revision/";
+                    // These are the values that will comprise the KeyValuePair
+                    string fileId = null;
+                    int revision = 0;
+                    foreach (ZipEntry entry in zipFile)
+                    {
+                        if (
+                            string.IsNullOrWhiteSpace(fileId)
+                            && !entry.IsDirectory
+                            && entry.FileName.StartsWith(idSearchPath, StringComparison.OrdinalIgnoreCase)
+                        )
+                        {
+                            fileId = entry.FileName.Split('/', StringSplitOptions.RemoveEmptyEntries).Last();
+                        }
+                        else if (
+                            revision == 0
+                            && !entry.IsDirectory
+                            && entry.FileName.StartsWith(revisionSearchPath, StringComparison.OrdinalIgnoreCase)
+                        )
+                        {
+                            string revisionFilename = entry.FileName
+                                .Split('/', StringSplitOptions.RemoveEmptyEntries)
+                                .Last();
+                            if (!int.TryParse(revisionFilename, out revision))
+                            {
+                                // An error occurred reading the revision
+                                revision = 0;
+                            }
+                        }
+
+                        // If we have both a revision id, and a file id, then add these to the dictionary
+                        if (!string.IsNullOrWhiteSpace(fileId) && revision != 0)
+                        {
+                            break;
+                        }
+                    }
+
+                    // If we have a file id
+                    if (!string.IsNullOrWhiteSpace(fileId))
+                    {
+                        // Ensure we have a revision
+                        if (revision == 0)
+                        {
+                            revision = 1;
+                        }
+
+                        // Add the file id and revision to the dictionary
+                        if (!resourceRevisions.ContainsKey(fileId))
+                        {
+                            resourceRevisions.Add(fileId, revision);
+                        }
+                    }
+                }
+                catch (Exception)
+                {
+                    // If it is an erroneous zip file, we don't count it as a resource
+                }
+            }
+        }
+
+        return resourceRevisions.ToReadOnlyDictionary();
+    }
+
+    /// <summary>
+    /// Get the URL for listing resources, or listing a single resource (getting metadata, not the resource itself).
+    /// </summary>
+    /// <param name="baseUri">The base URI.</param>
+    /// <param name="entryUid">The entry unique identifier.</param>
+    /// <returns>
+    /// A URL to access the resource entries or specific entry if <paramref name="entryUid" /> is specified.
+    /// </returns>
+    private static string BuildDblResourceListUrl(string baseUri, string entryUid = null)
+    {
+        var uriBuilder = new UriBuilder(baseUri) { Path = DblResourceEntriesApiCall };
+        if (!string.IsNullOrWhiteSpace(entryUid))
+        {
+            uriBuilder.Query = "id=" + entryUid;
+        }
+        return uriBuilder.Uri.AbsoluteUri;
+    }
+
+    /// <summary>
+    /// Get the URL for fetching a resource.
+    /// </summary>
+    /// <param name="baseUri">The base URI.</param>
+    /// <param name="entryUid">The entry unique identifier.</param>
+    /// <returns>
+    /// A URL to access the resource.
+    /// </returns>
+    private static string BuildDblResourceEntryUrl(string baseUri, string entryUid)
+    {
+        var uriBuilder = new UriBuilder(baseUri) { Path = DblResourceEntriesApiCall + "/" + entryUid };
+        return uriBuilder.Uri.AbsoluteUri;
+    }
+
+    /// <summary>
+    /// Creates the DBL URL with username query.
+    /// </summary>
+    /// <param name="resource">The resource.</param>
+    /// <returns>
+    /// The URL.
+    /// </returns>
+    private static string CreateDblUrlWithUsernameQuery(SFInstallableDblResource resource)
+    {
+        var uriBuilder = new UriBuilder(resource.DblSourceUrl);
+        var query = HttpUtils.ParseQueryString(uriBuilder.Query);
+        uriBuilder.Query = query.ToString();
+        return uriBuilder.ToString();
+    }
+
+    /// <summary>
+    /// Converts the JSON response to a list of Installable DBL Resources.
+    /// </summary>
+    /// <param name="baseUri">The base URI.</param>
+    /// <param name="response">The response.</param>
+    /// <param name="restClientFactory">The rest client factory.</param>
+    /// <param name="fileSystemService">The file system service.</param>
+    /// <param name="jwtTokenHelper">The JWT token helper.</param>
+    /// <param name="createdTimestamp">The created timestamp.</param>
+    /// <param name="userSecret">The user secret.</param>
+    /// <param name="paratextOptions">The paratext options.</param>
+    /// <param name="projectDeleter">The project deleter.</param>
+    /// <param name="migrationOperations">The migration operations.</param>
+    /// <param name="passwordProvider">The password provider.</param>
+    /// <returns>
+    /// The Installable Resources.
+    /// </returns>
+    private static IEnumerable<SFInstallableDblResource> ConvertJsonResponseToInstallableDblResources(
+        string baseUri,
+        string response,
+        ISFRestClientFactory restClientFactory,
+        IFileSystemService fileSystemService,
+        IJwtTokenHelper jwtTokenHelper,
+        DateTime createdTimestamp,
+        UserSecret userSecret,
+        ParatextOptions paratextOptions,
+        IProjectDeleter projectDeleter,
+        IMigrationOperations migrationOperations,
+        IZippedResourcePasswordProvider passwordProvider
+    )
+    {
+        if (!string.IsNullOrWhiteSpace(response))
+        {
+            JObject jsonResources;
+            try
+            {
+                jsonResources = JObject.Parse(response);
+            }
+            catch (JsonReaderException)
+            {
+                // Ignore the exception and just return empty result
+                // This is probably caused by partial result from poor connection to DBL
+                yield break;
+            }
+            foreach (JToken jsonResource in jsonResources["resources"] as JArray ?? new JArray())
+            {
+                var name = (string)jsonResource["name"];
+                var nameCommon = (string)jsonResource["nameCommon"];
+                var fullname = (string)jsonResource["fullname"];
+                if (string.IsNullOrWhiteSpace(fullname))
+                {
+                    fullname = nameCommon;
+                }
+
+                var languageName = (string)jsonResource["languageName"];
+                var id = (string)jsonResource["id"];
+                var revision = (string)jsonResource["revision"];
+                var permissionsChecksum = (string)jsonResource["permissions-checksum"];
+                var manifestChecksum = (string)jsonResource["p8z-manifest-checksum"];
+                var languageIdLdml = (string)jsonResource["languageLDMLId"];
+                var languageIdCode = (string)jsonResource["languageCode"];
+                LanguageId languageId = migrationOperations.DetermineBestLangIdToUseForResource(
+                    languageIdLdml,
+                    languageIdCode
+                );
+                if (string.IsNullOrEmpty(languageId.Id))
+                {
+                    languageId = LanguageIdHelper.FromCommonLanguageName(languageName);
+                }
+                else
+                {
+                    languageId = LanguageId.FromEthnologueCode(languageId.Id);
+                }
+
+                string url = BuildDblResourceEntryUrl(baseUri, id);
+                var resource = new SFInstallableDblResource(
+                    userSecret,
+                    paratextOptions,
+                    restClientFactory,
+                    fileSystemService,
+                    jwtTokenHelper,
+                    projectDeleter,
+                    migrationOperations,
+                    passwordProvider
+                )
+                {
+                    DisplayName = name,
+                    Name = name,
+                    FullName = fullname,
+                    LanguageID = languageId,
+                    DblSourceUrl = url,
+                    DBLEntryUid = HexId.FromStr(id),
+                    DBLRevision = int.Parse(revision),
+                    PermissionsChecksum = permissionsChecksum,
+                    ManifestChecksum = manifestChecksum,
+                    CreatedTimestamp = createdTimestamp,
+                };
+
+                resource.LanguageName = MacroLanguageHelper.GetMacroLanguage(resource.LanguageID) ?? languageName;
+
+                yield return resource;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates the temporary source directory.
+    /// </summary>
+    /// <returns>
+    /// The temporary directory path.
+    /// </returns>
+    private string CreateTempSourceDirectory()
+    {
+        string dirName = Path.Combine(temporaryDirectoryName, Name + '_' + Path.GetRandomFileName());
+
+        // This following is an implementation of Paratext.Data.FileUtils.GetTemporaryDirectory(dirName)
+        string path = Path.Combine(Path.GetTempPath(), dirName);
+        if (!Directory.Exists(path))
+        {
+            // If we don't have the file system service, just ignore
+            this._fileSystemService?.CreateDirectory(path);
+        }
+
+        return path;
+    }
+
+    /// <summary>
+    /// Gets the file from DBL.
+    /// </summary>
+    /// <param name="filePath">The file path.</param>
+    /// <returns>
+    ///   <c>true</c>  if the file was retrieved successfully; otherwise, <c>false</c>.
+    /// </returns>
+    private bool GetFile(string filePath)
+    {
+        ISFRestClient client = this._restClientFactory.Create(string.Empty, this._userSecret);
+        string dblUrlToResource = CreateDblUrlWithUsernameQuery(this);
+        return client.GetFile(dblUrlToResource, filePath);
+    }
+
+    /// <summary>
+    /// An empty Paratext project deleter implementation.
+    /// </summary>
+    /// <seealso cref="Paratext.Data.Archiving.IProjectDeleter" />
+    private class ParatextProjectDeleter : IProjectDeleter
+    {
+        /// <inheritdoc />
+        public void DeleteProject(ScrText scrText) =>
+            throw new NotImplementedException("This method should not be used in SF context.");
+    }
+
+    /// <summary>
+    /// An empty Paratext migration options implementation.
+    /// </summary>
+    /// <seealso cref="Paratext.Data.Archiving.IMigrationOperations" />
+    private class ParatextMigrationOperations : IMigrationOperations
     {
         /// <summary>
-        /// The resource identifier length.
+        /// Initializes a new instance of the <see cref="ParatextMigrationOperations"/> class.
         /// </summary>
-        public const int ResourceIdentifierLength = 16;
+        public ParatextMigrationOperations()
+        {
+            if (!Sldr.IsInitialized)
+            {
+                // Always use offline mode in tests
+                Sldr.Initialize(true);
+            }
+        }
 
-        /// <summary>
-        /// The DBL folder name (in the zip file).
-        /// </summary>
-        private const string DblFolderName = ".dbl";
+        /// <inheritdoc />
+        public UnsupportedReason MigrateProjectIfNeeded(ScrText scrText) => UnsupportedReason.Supported;
 
-        /// <summary>
-        /// The DBL resource entries API endpoint.
-        /// </summary>
-        private const string DblResourceEntriesApiCall = "api/resource_entries";
+        /// <inheritdoc />
+        public LanguageId DetermineBestLangIdToUseForResource(string languageIdLdml, string languageIdDbl)
+        {
+            LanguageId langIdDbl = LanguageId.FromEthnologueCode(languageIdDbl);
+            if (string.IsNullOrEmpty(languageIdLdml))
+            {
+                return langIdDbl;
+            }
 
-        /// <summary>
-        /// The file system service.
-        /// </summary>
-        private readonly IFileSystemService _fileSystemService;
+            LanguageId langIdLdml = LanguageId.FromEthnologueCode(languageIdLdml);
+            if (langIdLdml.Code == langIdDbl.Code)
+            {
+                return langIdLdml;
+            }
+            else
+            {
+                return langIdDbl;
+            }
+        }
+    }
 
+    /// <summary>
+    /// An implementation of the Paratext zipped resource password provider.
+    /// </summary>
+    /// <seealso cref="Paratext.Data.ProjectFileAccess.IZippedResourcePasswordProvider" />
+    private class ParatextZippedResourcePasswordProvider : IZippedResourcePasswordProvider
+    {
         /// <summary>
-        /// The JWT token helper.
+        /// The cached password value.
         /// </summary>
-        private readonly IJwtTokenHelper _jwtTokenHelper;
+        private string cachedValue;
 
         /// <summary>
         /// The paratext options.
@@ -69,813 +839,31 @@ namespace SIL.XForge.Scripture.Services
         private readonly ParatextOptions _paratextOptions;
 
         /// <summary>
-        /// The rest client factory.
+        /// Initializes a new instance of the <see cref="ParatextZippedResourcePasswordProvider"/> class.
         /// </summary>
-        private readonly ISFRestClientFactory _restClientFactory;
-
-        /// <summary>
-        /// The user secret.
-        /// </summary>
-        private readonly UserSecret _userSecret;
-
-        /// <summary>
-        /// The existing Scripture Text
-        /// </summary>
-        private ScrText existingScrText;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SFInstallableDblResource" /> class.
-        /// </summary>
-        /// <param name="userSecret">The user secret.</param>
         /// <param name="paratextOptions">The paratext options.</param>
-        /// <param name="restClientFactory">The rest client factory.</param>
-        /// <param name="fileSystemService">The file system service.</param>
-        /// <param name="jwtTokenHelper">The JWT token helper.</param>
-        /// <remarks>
-        /// This is a convenience constructor for unit tests.
-        /// </remarks>
-        internal SFInstallableDblResource(
-            UserSecret userSecret,
-            ParatextOptions paratextOptions,
-            ISFRestClientFactory restClientFactory,
-            IFileSystemService fileSystemService,
-            IJwtTokenHelper jwtTokenHelper
-        )
-            : this(
-                userSecret,
-                paratextOptions,
-                restClientFactory,
-                fileSystemService,
-                jwtTokenHelper,
-                new ParatextProjectDeleter(),
-                new ParatextMigrationOperations(),
-                new ParatextZippedResourcePasswordProvider(paratextOptions)
-            ) { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SFInstallableDblResource" /> class.
-        /// </summary>
-        /// <param name="userSecret">The user secret.</param>
-        /// <param name="paratextOptions">The paratext options.</param>
-        /// <param name="restClientFactory">The rest client factory.</param>
-        /// <param name="fileSystemService">The file system service.</param>
-        /// <param name="jwtTokenHelper">The JWT token helper.</param>
-        /// <param name="projectDeleter">The project deleter.</param>
-        /// <param name="migrationOperations">The migration operations.</param>
-        /// <param name="passwordProvider">The password provider.</param>
-        /// <exception cref="ArgumentNullException">restClientFactory</exception>
-        private SFInstallableDblResource(
-            UserSecret userSecret,
-            ParatextOptions paratextOptions,
-            ISFRestClientFactory restClientFactory,
-            IFileSystemService fileSystemService,
-            IJwtTokenHelper jwtTokenHelper,
-            IProjectDeleter projectDeleter,
-            IMigrationOperations migrationOperations,
-            IZippedResourcePasswordProvider passwordProvider
-        ) : base(projectDeleter, migrationOperations, passwordProvider)
-        {
-            this._userSecret = userSecret;
+        internal ParatextZippedResourcePasswordProvider(ParatextOptions paratextOptions) =>
             this._paratextOptions = paratextOptions;
-            this._restClientFactory = restClientFactory;
-            this._fileSystemService = fileSystemService;
-            this._jwtTokenHelper = jwtTokenHelper;
-            if (this._restClientFactory == null)
-            {
-                throw new ArgumentNullException(nameof(restClientFactory));
-            }
-            else if (this._fileSystemService == null)
-            {
-                throw new ArgumentNullException(nameof(fileSystemService));
-            }
-        }
 
-        /// <summary>
-        /// Gets or sets the DBL source URL.
-        /// </summary>
-        /// <value>
-        /// The DBL source URL.
-        /// </value>
-        /// <remarks>
-        /// This URL may or may not require authentication, depending on the resource.
-        /// </remarks>
-        public string DblSourceUrl { get; set; }
-
-        /// <summary>
-        /// Gets the existing Scripture Text.
-        /// </summary>
-        /// <value>
-        /// The existing Scripture Text.
-        /// </value>
-        /// <remarks>
-        /// This is required for <see cref="InstallableResource.IsNewerThanCurrentlyInstalled" />.
-        /// </remarks>
-        public override ScrText ExistingScrText
+        /// <inheritdoc />
+        public string GetPassword()
         {
-            get
+            // We can handle zip files with no password (for testing)
+            if (
+                this._paratextOptions == null
+                || string.IsNullOrWhiteSpace(this._paratextOptions.ResourcePasswordBase64)
+                || string.IsNullOrWhiteSpace(this._paratextOptions.ResourcePasswordHash)
+            )
             {
-                if (existingScrText == null)
-                {
-                    // Generate an ExistingScrText from the p8z file on disk
-                    string fileName = this.Name + ProjectFileManager.resourceFileExtension;
-                    string projectPath = Path.Combine(ScrTextCollection.ResourcesDirectory, fileName);
-                    if (RobustFile.Exists(projectPath))
-                    {
-                        var name = new ProjectName(projectPath);
-                        if (name != null)
-                        {
-                            string userName = this._jwtTokenHelper.GetParatextUsername(this._userSecret);
-                            if (userName == null)
-                            {
-                                throw new Exception($"Failed to get a PT username for SF user id {_userSecret.Id}.");
-                            }
-                            var ptUser = new SFParatextUser(userName);
-                            var passwordProvider = new ParatextZippedResourcePasswordProvider(this._paratextOptions);
-                            existingScrText = new ResourceScrText(name, ptUser, passwordProvider);
-                        }
-                    }
-                }
-
-                return existingScrText;
-            }
-        }
-
-        /// <summary>
-        /// Checks the resource permission, according to a DBL server.
-        /// </summary>
-        /// <param name="id">The identifier.</param>
-        /// <param name="userSecret">The user secret.</param>
-        /// <param name="paratextOptions">The paratext options.</param>
-        /// <param name="restClientFactory">The rest client factory.</param>
-        /// <param name="fileSystemService">The file system service.</param>
-        /// <param name="jwtTokenHelper">The JWT token helper.</param>
-        /// <param name="baseUrl">The base URL.</param>
-        /// <returns>
-        ///   <c>true</c> if the user has permission to access the resource; otherwise, <c>false</c>.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">id
-        /// or
-        /// userSecret
-        /// or
-        /// restClientFactory</exception>
-        public static bool CheckResourcePermission(
-            string id,
-            UserSecret userSecret,
-            ParatextOptions paratextOptions,
-            ISFRestClientFactory restClientFactory,
-            IFileSystemService fileSystemService,
-            IJwtTokenHelper jwtTokenHelper,
-            IExceptionHandler exceptionHandler,
-            string baseUrl = null
-        )
-        {
-            // Parameter check
-            if (string.IsNullOrWhiteSpace(id))
-            {
-                throw new ArgumentNullException(nameof(id));
-            }
-            else if (userSecret == null)
-            {
-                throw new ArgumentNullException(nameof(userSecret));
-            }
-            else if (restClientFactory == null)
-            {
-                throw new ArgumentNullException(nameof(restClientFactory));
+                return string.Empty;
             }
 
-            baseUrl = string.IsNullOrWhiteSpace(baseUrl) ? InternetAccess.ParatextDBLServer : baseUrl;
-            try
-            {
-                IEnumerable<SFInstallableDblResource> resources = GetInstallableDblResources(
-                    userSecret,
-                    paratextOptions,
-                    restClientFactory,
-                    fileSystemService,
-                    jwtTokenHelper,
-                    exceptionHandler,
-                    baseUrl,
-                    id
-                );
-                return resources.Any(r => r.DBLEntryUid.Id == id);
-            }
-            catch (Exception ex)
-            {
-                // Paratext throws an HttpException instead of a WebException
-                // If you need it, the WebException is the InnerException
-                if (ex is Paratext.Data.HttpException httpException)
-                {
-                    if (httpException.Response.StatusCode == HttpStatusCode.Unauthorized)
-                    {
-                        // A 401 error means unauthorized (probably a bad token)
-                        return false;
-                    }
-                    else if (httpException.Response.StatusCode == HttpStatusCode.Forbidden)
-                    {
-                        // A 403 error means no access.
-                        return false;
-                    }
-                    else if (httpException.Response.StatusCode == HttpStatusCode.NotFound)
-                    {
-                        // A 404 error means that the resource is not on the server
-                        return false;
-                    }
-                    else
-                    {
-                        // Unknown status code
-                        throw;
-                    }
-                }
-                else if (ex.Source == "NSubstitute")
-                {
-                    // This occurs during unit tests to test whether there is permission or not
-                    return false;
-                }
-                else
-                {
-                    // An unknown error
-                    throw;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Return a list of resources which this user is allowed to install from DBL.
-        /// If we cannot contact DBL, return an empty list.
-        /// </summary>
-        /// <param name="userSecret">The user secret.</param>
-        /// <param name="paratextOptions">The paratext options.</param>
-        /// <param name="restClientFactory">The rest client factory.</param>
-        /// <param name="fileSystemService">The file system service.</param>
-        /// <param name="jwtTokenHelper">The JWT token helper.</param>
-        /// <param name="baseUrl">The base URL.</param>
-        /// <param name="id">ID of resource to filter for (optional).</param>
-        /// <returns>The Installable Resources.</returns>
-        /// <exception cref="ArgumentNullException">restClientFactory
-        /// or
-        /// userSecret</exception>
-        /// <remarks>Tests on this method can be found in ParatextServiceTests.cs calling GetResources().</remarks>
-        public static IEnumerable<SFInstallableDblResource> GetInstallableDblResources(
-            UserSecret userSecret,
-            ParatextOptions paratextOptions,
-            ISFRestClientFactory restClientFactory,
-            IFileSystemService fileSystemService,
-            IJwtTokenHelper jwtTokenHelper,
-            IExceptionHandler exceptionHandler,
-            string baseUrl = null,
-            string id = null
-        )
-        {
-            // Parameter check (just like the constructor)
-            if (restClientFactory == null)
-            {
-                throw new ArgumentNullException(nameof(restClientFactory));
-            }
-            else if (userSecret == null)
-            {
-                throw new ArgumentNullException(nameof(userSecret));
-            }
-
-            ISFRestClient client = restClientFactory.Create(string.Empty, userSecret);
-            baseUrl = string.IsNullOrWhiteSpace(baseUrl) ? InternetAccess.ParatextDBLServer : baseUrl;
-            string response = null;
-            try
-            {
-                response = client.Get(BuildDblResourceListUrl(baseUrl, id));
-            }
-            catch (WebException e)
-            {
-                // If we get a temporary 401 Unauthorized response, return an empty list.
-                string errorExplanation =
-                    "GetInstallableDblResources failed when attempting to inquire about"
-                    + $" resources and is ignoring error {e}";
-                var report = new Exception(errorExplanation);
-                // Report to bugsnag, but don't throw.
-                exceptionHandler.ReportException(report);
-                return Enumerable.Empty<SFInstallableDblResource>();
-            }
-            IEnumerable<SFInstallableDblResource> resources = ConvertJsonResponseToInstallableDblResources(
-                baseUrl,
-                response,
-                restClientFactory,
-                fileSystemService,
-                jwtTokenHelper,
-                DateTime.Now,
-                userSecret,
-                paratextOptions,
-                new ParatextProjectDeleter(),
-                new ParatextMigrationOperations(),
-                new ParatextZippedResourcePasswordProvider(paratextOptions)
+            cachedValue ??= StringUtils.DecryptStringFromBase64(
+                this._paratextOptions.ResourcePasswordBase64,
+                this._paratextOptions.ResourcePasswordHash
             );
-            return resources;
-        }
 
-        /// <summary>
-        /// Extracts the resource to a directory.
-        /// </summary>
-        /// <param name="path">The path.</param>
-        /// <exception cref="ArgumentNullException">
-        /// path
-        /// or
-        /// DBLEntryUid
-        /// or
-        /// Name
-        /// </exception>
-        /// <remarks>
-        /// After the resource is extracted, it can be a source or target.
-        /// </remarks>
-        public void ExtractToDirectory(string path)
-        {
-            // Check parameters
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                throw new ArgumentNullException(nameof(path));
-            }
-            else if (string.IsNullOrWhiteSpace(this.DBLEntryUid.Id))
-            {
-                throw new ArgumentNullException(nameof(this.DBLEntryUid.Id));
-            }
-            else if (string.IsNullOrWhiteSpace(this.Name))
-            {
-                throw new ArgumentNullException(nameof(this.Name));
-            }
-
-            string resourceFile = ScrTextCollection.GetResourcePath(
-                this.ExistingScrText,
-                this.Name,
-                this.DBLEntryUid,
-                ProjectFileManager.resourceFileExtension
-            );
-            if (RobustFile.Exists(resourceFile))
-            {
-                using var zipFile = ZipFile.Read(resourceFile);
-                zipFile.Password = this._passwordProvider?.GetPassword();
-                zipFile.ExtractAll(path, ExtractExistingFileAction.DoNotOverwrite);
-            }
-        }
-
-        /// <summary>
-        /// Download the files for this project from DBL into sourceDirectory and then
-        /// copy them to the destination directory.
-        /// Install should throw an Exception with an appropriate message if something goes wrong.
-        /// </summary>
-        /// <returns>
-        ///   <c>true</c> if fonts were installed; otherwise <c>false</c>.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">DBLEntryUid
-        /// or
-        /// DBLSourceUrl
-        /// or
-        /// Name</exception>
-        public override bool Install()
-        {
-            // Easier to check parameters here than fill the temp directory with files
-            // NOTE: This is not an exhaustive list of the required parameters!
-            //       You will need to refer to InstallableResource.Install() for that.
-            if (string.IsNullOrWhiteSpace(this.DBLEntryUid.Id))
-            {
-                throw new ArgumentNullException(nameof(this.DBLEntryUid.Id));
-            }
-            else if (string.IsNullOrWhiteSpace(this.DblSourceUrl))
-            {
-                throw new ArgumentNullException(nameof(this.DblSourceUrl));
-            }
-            else if (string.IsNullOrWhiteSpace(this.Name))
-            {
-                throw new ArgumentNullException(nameof(this.Name));
-            }
-
-            sourceDirectory = this.CreateTempSourceDirectory();
-            string filePath = Path.Combine(sourceDirectory, this.Name + ProjectFileManager.resourceFileExtension);
-            if (!this.GetFile(filePath))
-            {
-                if (RobustFile.Exists(filePath))
-                {
-                    // RobustFile only handles retries...
-                    RobustFile.Delete(filePath);
-                }
-
-                return false;
-            }
-
-            bool result;
-            try
-            {
-                result = base.Install();
-            }
-            catch (UnauthorizedAccessException)
-            {
-                // Treat this like we couldn't get the resource from the DBL - ignore the error and continue.
-                // This maybe caused by the file already being there and in use or the SF Project directory not existing
-                result = false;
-            }
-
-            if (RobustFile.Exists(filePath))
-            {
-                RobustFile.Delete(filePath);
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Gets the revision numbers for all installed resources.
-        /// </summary>
-        /// <returns>
-        /// A dictionary where the resource id is the key, and the revision is the value.
-        /// </returns>
-        internal static IReadOnlyDictionary<string, int> GetInstalledResourceRevisions()
-        {
-            // Initialize variables
-            Dictionary<string, int> resourceRevisions = new Dictionary<string, int>();
-            string resourcesDirectory;
-
-            // This can throw an error if the SettingsDirectory is not specified
-            // If that is the case, we don't need to look at the FS anyway
-            try
-            {
-                resourcesDirectory = ScrTextCollection.ResourcesDirectory;
-            }
-            catch (ArgumentNullException)
-            {
-                // Path.Combine() in ScrTextCollection will have thrown this error
-                resourcesDirectory = string.Empty;
-            }
-
-            if (!string.IsNullOrWhiteSpace(resourcesDirectory) && Directory.Exists(resourcesDirectory))
-            {
-                foreach (
-                    string resourceFile in Directory.EnumerateFiles(
-                        ScrTextCollection.ResourcesDirectory,
-                        "*" + ProjectFileManager.resourceFileExtension
-                    )
-                )
-                {
-                    // See if this a zip file, and if it contains the correct ID
-                    try
-                    {
-                        // This only uses DotNetZip because ParatextData uses DotNetZip
-                        // You could use System.IO.Compression if you wanted to
-                        using var zipFile = ZipFile.Read(resourceFile);
-                        // Zip files use forward slashes, even on Windows
-                        const string idSearchPath = DblFolderName + "/id/";
-                        const string revisionSearchPath = DblFolderName + "/revision/";
-                        // These are the values that will comprise the KeyValuePair
-                        string fileId = null;
-                        int revision = 0;
-                        foreach (ZipEntry entry in zipFile)
-                        {
-                            if (
-                                string.IsNullOrWhiteSpace(fileId)
-                                && !entry.IsDirectory
-                                && entry.FileName.StartsWith(idSearchPath, StringComparison.OrdinalIgnoreCase)
-                            )
-                            {
-                                fileId = entry.FileName.Split('/', StringSplitOptions.RemoveEmptyEntries).Last();
-                            }
-                            else if (
-                                revision == 0
-                                && !entry.IsDirectory
-                                && entry.FileName.StartsWith(revisionSearchPath, StringComparison.OrdinalIgnoreCase)
-                            )
-                            {
-                                string revisionFilename = entry.FileName
-                                    .Split('/', StringSplitOptions.RemoveEmptyEntries)
-                                    .Last();
-                                if (!int.TryParse(revisionFilename, out revision))
-                                {
-                                    // An error occurred reading the revision
-                                    revision = 0;
-                                }
-                            }
-
-                            // If we have both a revision id, and a file id, then add these to the dictionary
-                            if (!string.IsNullOrWhiteSpace(fileId) && revision != 0)
-                            {
-                                break;
-                            }
-                        }
-
-                        // If we have a file id
-                        if (!string.IsNullOrWhiteSpace(fileId))
-                        {
-                            // Ensure we have a revision
-                            if (revision == 0)
-                            {
-                                revision = 1;
-                            }
-
-                            // Add the file id and revision to the dictionary
-                            if (!resourceRevisions.ContainsKey(fileId))
-                            {
-                                resourceRevisions.Add(fileId, revision);
-                            }
-                        }
-                    }
-                    catch (Exception)
-                    {
-                        // If it is an erroneous zip file, we don't count it as a resource
-                    }
-                }
-            }
-
-            return resourceRevisions.ToReadOnlyDictionary();
-        }
-
-        /// <summary>
-        /// Get the URL for listing resources, or listing a single resource (getting metadata, not the resource itself).
-        /// </summary>
-        /// <param name="baseUri">The base URI.</param>
-        /// <param name="entryUid">The entry unique identifier.</param>
-        /// <returns>
-        /// A URL to access the resource entries or specific entry if <paramref name="entryUid" /> is specified.
-        /// </returns>
-        private static string BuildDblResourceListUrl(string baseUri, string entryUid = null)
-        {
-            var uriBuilder = new UriBuilder(baseUri);
-            uriBuilder.Path = DblResourceEntriesApiCall;
-            if (!string.IsNullOrWhiteSpace(entryUid))
-            {
-                uriBuilder.Query = "id=" + entryUid;
-            }
-            return uriBuilder.Uri.AbsoluteUri;
-        }
-
-        /// <summary>
-        /// Get the URL for fetching a resource.
-        /// </summary>
-        /// <param name="baseUri">The base URI.</param>
-        /// <param name="entryUid">The entry unique identifier.</param>
-        /// <returns>
-        /// A URL to access the resource.
-        /// </returns>
-        private static string BuildDblResourceEntryUrl(string baseUri, string entryUid)
-        {
-            var uriBuilder = new UriBuilder(baseUri);
-            uriBuilder.Path = DblResourceEntriesApiCall + "/" + entryUid;
-            return uriBuilder.Uri.AbsoluteUri;
-        }
-
-        /// <summary>
-        /// Creates the DBL URL with username query.
-        /// </summary>
-        /// <param name="resource">The resource.</param>
-        /// <returns>
-        /// The URL.
-        /// </returns>
-        private static string CreateDblUrlWithUsernameQuery(SFInstallableDblResource resource)
-        {
-            var uriBuilder = new UriBuilder(resource.DblSourceUrl);
-            var query = HttpUtils.ParseQueryString(uriBuilder.Query);
-            uriBuilder.Query = query.ToString();
-            return uriBuilder.ToString();
-        }
-
-        /// <summary>
-        /// Converts the JSON response to a list of Installable DBL Resources.
-        /// </summary>
-        /// <param name="baseUri">The base URI.</param>
-        /// <param name="response">The response.</param>
-        /// <param name="restClientFactory">The rest client factory.</param>
-        /// <param name="fileSystemService">The file system service.</param>
-        /// <param name="jwtTokenHelper">The JWT token helper.</param>
-        /// <param name="createdTimestamp">The created timestamp.</param>
-        /// <param name="userSecret">The user secret.</param>
-        /// <param name="paratextOptions">The paratext options.</param>
-        /// <param name="projectDeleter">The project deleter.</param>
-        /// <param name="migrationOperations">The migration operations.</param>
-        /// <param name="passwordProvider">The password provider.</param>
-        /// <returns>
-        /// The Installable Resources.
-        /// </returns>
-        private static IEnumerable<SFInstallableDblResource> ConvertJsonResponseToInstallableDblResources(
-            string baseUri,
-            string response,
-            ISFRestClientFactory restClientFactory,
-            IFileSystemService fileSystemService,
-            IJwtTokenHelper jwtTokenHelper,
-            DateTime createdTimestamp,
-            UserSecret userSecret,
-            ParatextOptions paratextOptions,
-            IProjectDeleter projectDeleter,
-            IMigrationOperations migrationOperations,
-            IZippedResourcePasswordProvider passwordProvider
-        )
-        {
-            if (!string.IsNullOrWhiteSpace(response))
-            {
-                JObject jsonResources;
-                try
-                {
-                    jsonResources = JObject.Parse(response);
-                }
-                catch (JsonReaderException)
-                {
-                    // Ignore the exception and just return empty result
-                    // This is probably caused by partial result from poor connection to DBL
-                    yield break;
-                }
-                foreach (JToken jsonResource in jsonResources["resources"] as JArray ?? new JArray())
-                {
-                    var name = (string)jsonResource["name"];
-                    var nameCommon = (string)jsonResource["nameCommon"];
-                    var fullname = (string)jsonResource["fullname"];
-                    if (string.IsNullOrWhiteSpace(fullname))
-                    {
-                        fullname = nameCommon;
-                    }
-
-                    var languageName = (string)jsonResource["languageName"];
-                    var id = (string)jsonResource["id"];
-                    var revision = (string)jsonResource["revision"];
-                    var permissionsChecksum = (string)jsonResource["permissions-checksum"];
-                    var manifestChecksum = (string)jsonResource["p8z-manifest-checksum"];
-                    var languageIdLdml = (string)jsonResource["languageLDMLId"];
-                    var languageIdCode = (string)jsonResource["languageCode"];
-                    LanguageId languageId = migrationOperations.DetermineBestLangIdToUseForResource(
-                        languageIdLdml,
-                        languageIdCode
-                    );
-                    if (string.IsNullOrEmpty(languageId.Id))
-                    {
-                        languageId = LanguageIdHelper.FromCommonLanguageName(languageName);
-                    }
-                    else
-                    {
-                        languageId = LanguageId.FromEthnologueCode(languageId.Id);
-                    }
-
-                    string url = BuildDblResourceEntryUrl(baseUri, id);
-                    var resource = new SFInstallableDblResource(
-                        userSecret,
-                        paratextOptions,
-                        restClientFactory,
-                        fileSystemService,
-                        jwtTokenHelper,
-                        projectDeleter,
-                        migrationOperations,
-                        passwordProvider
-                    )
-                    {
-                        DisplayName = name,
-                        Name = name,
-                        FullName = fullname,
-                        LanguageID = languageId,
-                        DblSourceUrl = url,
-                        DBLEntryUid = HexId.FromStr(id),
-                        DBLRevision = int.Parse(revision),
-                        PermissionsChecksum = permissionsChecksum,
-                        ManifestChecksum = manifestChecksum,
-                        CreatedTimestamp = createdTimestamp,
-                    };
-
-                    resource.LanguageName = MacroLanguageHelper.GetMacroLanguage(resource.LanguageID) ?? languageName;
-
-                    yield return resource;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Creates the temporary source directory.
-        /// </summary>
-        /// <returns>
-        /// The temporary directory path.
-        /// </returns>
-        private string CreateTempSourceDirectory()
-        {
-            string dirName = Path.Combine(temporaryDirectoryName, Name + '_' + Path.GetRandomFileName());
-
-            // This following is an implementation of Paratext.Data.FileUtils.GetTemporaryDirectory(dirName)
-            string path = Path.Combine(Path.GetTempPath(), dirName);
-            if (!Directory.Exists(path))
-            {
-                // If we don't have the file system service, just ignore
-                this._fileSystemService?.CreateDirectory(path);
-            }
-
-            return path;
-        }
-
-        /// <summary>
-        /// Gets the file from DBL.
-        /// </summary>
-        /// <param name="filePath">The file path.</param>
-        /// <returns>
-        ///   <c>true</c>  if the file was retrieved successfully; otherwise, <c>false</c>.
-        /// </returns>
-        private bool GetFile(string filePath)
-        {
-            ISFRestClient client = this._restClientFactory.Create(string.Empty, this._userSecret);
-            string dblUrlToResource = CreateDblUrlWithUsernameQuery(this);
-            return client.GetFile(dblUrlToResource, filePath);
-        }
-
-        /// <summary>
-        /// An empty Paratext project deleter implementation.
-        /// </summary>
-        /// <seealso cref="Paratext.Data.Archiving.IProjectDeleter" />
-        private class ParatextProjectDeleter : IProjectDeleter
-        {
-            /// <inheritdoc />
-            public void DeleteProject(ScrText scrText)
-            {
-                throw new NotImplementedException("This method should not be used in SF context.");
-            }
-        }
-
-        /// <summary>
-        /// An empty Paratext migration options implementation.
-        /// </summary>
-        /// <seealso cref="Paratext.Data.Archiving.IMigrationOperations" />
-        private class ParatextMigrationOperations : IMigrationOperations
-        {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="ParatextMigrationOperations"/> class.
-            /// </summary>
-            public ParatextMigrationOperations()
-            {
-                if (!Sldr.IsInitialized)
-                {
-                    // Always use offline mode in tests
-                    Sldr.Initialize(true);
-                }
-            }
-
-            /// <inheritdoc />
-            public UnsupportedReason MigrateProjectIfNeeded(ScrText scrText)
-            {
-                return UnsupportedReason.Supported;
-            }
-
-            /// <inheritdoc />
-            public LanguageId DetermineBestLangIdToUseForResource(string languageIdLdml, string languageIdDbl)
-            {
-                LanguageId langIdDbl = LanguageId.FromEthnologueCode(languageIdDbl);
-                if (string.IsNullOrEmpty(languageIdLdml))
-                {
-                    return langIdDbl;
-                }
-
-                LanguageId langIdLdml = LanguageId.FromEthnologueCode(languageIdLdml);
-                if (langIdLdml.Code == langIdDbl.Code)
-                {
-                    return langIdLdml;
-                }
-                else
-                {
-                    return langIdDbl;
-                }
-            }
-        }
-
-        /// <summary>
-        /// An implementation of the Paratext zipped resource password provider.
-        /// </summary>
-        /// <seealso cref="Paratext.Data.ProjectFileAccess.IZippedResourcePasswordProvider" />
-        private class ParatextZippedResourcePasswordProvider : IZippedResourcePasswordProvider
-        {
-            /// <summary>
-            /// The cached password value.
-            /// </summary>
-            private string cachedValue;
-
-            /// <summary>
-            /// The paratext options.
-            /// </summary>
-            private readonly ParatextOptions _paratextOptions;
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="ParatextZippedResourcePasswordProvider"/> class.
-            /// </summary>
-            /// <param name="paratextOptions">The paratext options.</param>
-            internal ParatextZippedResourcePasswordProvider(ParatextOptions paratextOptions)
-            {
-                this._paratextOptions = paratextOptions;
-            }
-
-            /// <inheritdoc />
-            public string GetPassword()
-            {
-                // We can handle zip files with no password (for testing)
-                if (
-                    this._paratextOptions == null
-                    || string.IsNullOrWhiteSpace(this._paratextOptions.ResourcePasswordBase64)
-                    || string.IsNullOrWhiteSpace(this._paratextOptions.ResourcePasswordHash)
-                )
-                {
-                    return string.Empty;
-                }
-
-                if (cachedValue == null)
-                {
-                    cachedValue = StringUtils.DecryptStringFromBase64(
-                        this._paratextOptions.ResourcePasswordBase64,
-                        this._paratextOptions.ResourcePasswordHash
-                    );
-                }
-
-                return cachedValue;
-            }
+            return cachedValue;
         }
     }
 }

--- a/src/SIL.XForge.Scripture/Services/SFJsonRpcApplicationBuilderExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/SFJsonRpcApplicationBuilderExtensions.cs
@@ -1,16 +1,12 @@
 using SIL.XForge;
 using SIL.XForge.Scripture.Controllers;
 
-namespace Microsoft.AspNetCore.Builder
+namespace Microsoft.AspNetCore.Builder;
+
+public static class SFJsonRpcApplicationBuilderExtensions
 {
-    public static class SFJsonRpcApplicationBuilderExtensions
-    {
-        public static void UseSFJsonRpc(this IApplicationBuilder app)
-        {
-            app.UseXFJsonRpc(options =>
-            {
-                options.AddControllerWithCustomPath<SFProjectsRpcController>(UrlConstants.Projects);
-            });
-        }
-    }
+    public static void UseSFJsonRpc(this IApplicationBuilder app) =>
+        app.UseXFJsonRpc(
+            options => options.AddControllerWithCustomPath<SFProjectsRpcController>(UrlConstants.Projects)
+        );
 }

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -18,1230 +18,1175 @@ using SIL.XForge.Scripture.Models;
 using SIL.XForge.Services;
 using SIL.XForge.Utils;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// This class manages SF projects.
+/// </summary>
+public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFProjectService
 {
-    /// <summary>
-    /// This class manages SF projects.
-    /// </summary>
-    public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFProjectService
+    internal static readonly string ProjectSettingValueUnset = "unset";
+    private static readonly IEqualityComparer<Dictionary<string, string>> _permissionDictionaryEqualityComparer =
+        new DictionaryComparer<string, string>();
+    public static readonly string ErrorAlreadyConnectedKey = "error-already-connected";
+    private readonly IMachineProjectService _machineProjectService;
+    private readonly ISyncService _syncService;
+    private readonly IParatextService _paratextService;
+    private readonly IRepository<UserSecret> _userSecrets;
+    private readonly IRepository<TranslateMetrics> _translateMetrics;
+    private readonly IEmailService _emailService;
+    private readonly ISecurityService _securityService;
+    private readonly IStringLocalizer<SharedResource> _localizer;
+    private readonly ITransceleratorService _transceleratorService;
+
+    public SFProjectService(
+        IRealtimeService realtimeService,
+        IOptions<SiteOptions> siteOptions,
+        IAudioService audioService,
+        IEmailService emailService,
+        IRepository<SFProjectSecret> projectSecrets,
+        ISecurityService securityService,
+        IFileSystemService fileSystemService,
+        IMachineProjectService machineProjectService,
+        ISyncService syncService,
+        IParatextService paratextService,
+        IRepository<UserSecret> userSecrets,
+        IRepository<TranslateMetrics> translateMetrics,
+        IStringLocalizer<SharedResource> localizer,
+        ITransceleratorService transceleratorService
+    )
+        : base(realtimeService, siteOptions, audioService, projectSecrets, fileSystemService)
     {
-        internal static readonly string ProjectSettingValueUnset = "unset";
-        private static readonly IEqualityComparer<Dictionary<string, string>> _permissionDictionaryEqualityComparer =
-            new DictionaryComparer<string, string>();
-        public static readonly string ErrorAlreadyConnectedKey = "error-already-connected";
-        private readonly IMachineProjectService _machineProjectService;
-        private readonly ISyncService _syncService;
-        private readonly IParatextService _paratextService;
-        private readonly IRepository<UserSecret> _userSecrets;
-        private readonly IRepository<TranslateMetrics> _translateMetrics;
-        private readonly IEmailService _emailService;
-        private readonly ISecurityService _securityService;
-        private readonly IStringLocalizer<SharedResource> _localizer;
-        private readonly ITransceleratorService _transceleratorService;
+        _machineProjectService = machineProjectService;
+        _syncService = syncService;
+        _paratextService = paratextService;
+        _userSecrets = userSecrets;
+        _translateMetrics = translateMetrics;
+        _emailService = emailService;
+        _securityService = securityService;
+        _localizer = localizer;
+        _transceleratorService = transceleratorService;
+    }
 
-        public SFProjectService(
-            IRealtimeService realtimeService,
-            IOptions<SiteOptions> siteOptions,
-            IAudioService audioService,
-            IEmailService emailService,
-            IRepository<SFProjectSecret> projectSecrets,
-            ISecurityService securityService,
-            IFileSystemService fileSystemService,
-            IMachineProjectService machineProjectService,
-            ISyncService syncService,
-            IParatextService paratextService,
-            IRepository<UserSecret> userSecrets,
-            IRepository<TranslateMetrics> translateMetrics,
-            IStringLocalizer<SharedResource> localizer,
-            ITransceleratorService transceleratorService
-        ) : base(realtimeService, siteOptions, audioService, projectSecrets, fileSystemService)
+    protected override string ProjectAdminRole => SFProjectRole.Administrator;
+
+    /// <summary>
+    /// Returns SF project id of created project.
+    /// </summary>
+    public async Task<string> CreateProjectAsync(string curUserId, SFProjectCreateSettings settings)
+    {
+        Attempt<UserSecret> userSecretAttempt = await _userSecrets.TryGetAsync(curUserId);
+        if (!userSecretAttempt.TryResult(out UserSecret userSecret))
+            throw new DataNotFoundException("The user does not exist.");
+
+        IReadOnlyList<ParatextProject> ptProjects = await _paratextService.GetProjectsAsync(userSecret);
+
+        ParatextProject ptProject = ptProjects.SingleOrDefault(p => p.ParatextId == settings.ParatextId);
+        if (ptProject == null)
+            throw new DataNotFoundException("The paratext project does not exist.");
+
+        var project = new SFProject
         {
-            _machineProjectService = machineProjectService;
-            _syncService = syncService;
-            _paratextService = paratextService;
-            _userSecrets = userSecrets;
-            _translateMetrics = translateMetrics;
-            _emailService = emailService;
-            _securityService = securityService;
-            _localizer = localizer;
-            _transceleratorService = transceleratorService;
-        }
-
-        protected override string ProjectAdminRole => SFProjectRole.Administrator;
-
-        /// <summary>
-        /// Returns SF project id of created project.
-        /// </summary>
-        public async Task<string> CreateProjectAsync(string curUserId, SFProjectCreateSettings settings)
-        {
-            Attempt<UserSecret> userSecretAttempt = await _userSecrets.TryGetAsync(curUserId);
-            if (!userSecretAttempt.TryResult(out UserSecret userSecret))
-                throw new DataNotFoundException("The user does not exist.");
-
-            IReadOnlyList<ParatextProject> ptProjects = await _paratextService.GetProjectsAsync(userSecret);
-
-            ParatextProject ptProject = ptProjects.SingleOrDefault(p => p.ParatextId == settings.ParatextId);
-            if (ptProject == null)
-                throw new DataNotFoundException("The paratext project does not exist.");
-
-            var project = new SFProject
+            ParatextId = settings.ParatextId,
+            Name = ptProject.Name,
+            ShortName = ptProject.ShortName,
+            WritingSystem = new WritingSystem { Tag = ptProject.LanguageTag },
+            TranslateConfig = new TranslateConfig
             {
-                ParatextId = settings.ParatextId,
-                Name = ptProject.Name,
-                ShortName = ptProject.ShortName,
-                WritingSystem = new WritingSystem { Tag = ptProject.LanguageTag },
-                TranslateConfig = new TranslateConfig
-                {
-                    TranslationSuggestionsEnabled = settings.TranslationSuggestionsEnabled
-                },
-                CheckingConfig = new CheckingConfig
-                {
-                    CheckingEnabled = settings.CheckingEnabled,
-                    AnswerExportMethod = settings.AnswerExportMethod
-                }
-            };
-            Attempt<string> attempt = await TryGetProjectRoleAsync(project, curUserId);
-            if (!attempt.TryResult(out string projectRole) || projectRole != SFProjectRole.Administrator)
-                throw new ForbiddenException();
-
-            string projectId = ObjectId.GenerateNewId().ToString();
-            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
+                TranslationSuggestionsEnabled = settings.TranslationSuggestionsEnabled
+            },
+            CheckingConfig = new CheckingConfig
             {
-                if (
-                    this.RealtimeService
-                        .QuerySnapshots<SFProject>()
-                        .Any((SFProject sfProject) => sfProject.ParatextId == project.ParatextId)
-                )
-                {
-                    throw new InvalidOperationException(ErrorAlreadyConnectedKey);
-                }
-                IDocument<SFProject> projectDoc = await conn.CreateAsync<SFProject>(projectId, project);
-                await ProjectSecrets.InsertAsync(new SFProjectSecret { Id = projectDoc.Id });
-
-                IDocument<User> userDoc = await conn.FetchAsync<User>(curUserId);
-                await AddUserToProjectAsync(conn, projectDoc, userDoc, SFProjectRole.Administrator, false);
-
-                // Add the source after the project has been created
-                // This will make the source project appear after the target, if it needs to be created
-                if (settings.SourceParatextId != null && settings.SourceParatextId != settings.ParatextId)
-                {
-                    TranslateSource source = await this.GetTranslateSourceAsync(
-                        curUserId,
-                        userSecret,
-                        settings.SourceParatextId,
-                        ptProjects
-                    );
-
-                    await projectDoc.SubmitJson0OpAsync(op =>
-                    {
-                        UpdateSetting(op, p => p.TranslateConfig.Source, source);
-                    });
-                }
-
-                if (projectDoc.Data.TranslateConfig.TranslationSuggestionsEnabled)
-                {
-                    await EnsureWritingSystemTagIsSetAsync(curUserId, projectDoc, ptProjects);
-                    await _machineProjectService.AddProjectAsync(curUserId, projectDoc.Id, CancellationToken.None);
-                }
+                CheckingEnabled = settings.CheckingEnabled,
+                AnswerExportMethod = settings.AnswerExportMethod
             }
+        };
+        Attempt<string> attempt = await TryGetProjectRoleAsync(project, curUserId);
+        if (!attempt.TryResult(out string projectRole) || projectRole != SFProjectRole.Administrator)
+            throw new ForbiddenException();
 
-            await _syncService.SyncAsync(curUserId, projectId, true);
-            return projectId;
-        }
-
-        /// <summary>
-        /// Asynchronously creates a project for a Paratext resource.
-        /// </summary>
-        /// <param name="curUserId">The current user identifier.</param>
-        /// <param name="paratextId">The paratext resource identifier.</param>
-        /// <returns>SF project id of created project</returns>
-        /// <remarks>
-        /// This method will also work for a source project that has been deleted for some reason.
-        /// </remarks>
-        /// <exception cref="DataNotFoundException">
-        /// The user does not exist.
-        /// or
-        /// The paratext project does not exist.
-        /// </exception>
-        /// <exception cref="InvalidOperationException"></exception>
-        public async Task<string> CreateResourceProjectAsync(string curUserId, string paratextId)
+        string projectId = ObjectId.GenerateNewId().ToString();
+        await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
         {
-            Attempt<UserSecret> userSecretAttempt = await _userSecrets.TryGetAsync(curUserId);
-            if (!userSecretAttempt.TryResult(out UserSecret userSecret))
-            {
-                throw new DataNotFoundException("The user does not exist.");
-            }
-
-            // We check projects first, in case it is a project
-            IReadOnlyList<ParatextProject> ptProjects = await _paratextService.GetProjectsAsync(userSecret);
-            ParatextProject ptProject = ptProjects.SingleOrDefault(p => p.ParatextId == paratextId);
-            if (ptProject == null)
-            {
-                // If it is not a project, see if there is a matching resource
-                IReadOnlyList<ParatextResource> resources = await this._paratextService.GetResourcesAsync(curUserId);
-                ptProject = resources.SingleOrDefault(r => r.ParatextId == paratextId);
-                if (ptProject == null)
-                {
-                    throw new DataNotFoundException("The paratext project or resource does not exist.");
-                }
-            }
-
-            return await CreateResourceProjectInternalAsync(curUserId, ptProject);
-        }
-
-        public async Task DeleteProjectAsync(string curUserId, string projectId)
-        {
-            // Cancel any jobs before we delete
-            await _syncService.CancelSyncAsync(curUserId, projectId);
-
-            string ptProjectId;
-            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
-            {
-                IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
-                if (!projectDoc.IsLoaded)
-                    throw new DataNotFoundException("The project does not exist.");
-                if (!IsProjectAdmin(projectDoc.Data, curUserId))
-                    throw new ForbiddenException();
-
-                ptProjectId = projectDoc.Data.ParatextId;
-                // delete the project first, so that users get notified about the deletion
-                string[] projectUserIds = projectDoc.Data.UserRoles.Keys.ToArray();
-                await projectDoc.DeleteAsync();
-                async Task removeUser(string projectUserId)
-                {
-                    IDocument<User> userDoc = await conn.FetchAsync<User>(projectUserId);
-                    await RemoveUserFromProjectAsync(conn, projectDoc, userDoc);
-                }
-                var tasks = new List<Task>();
-                foreach (string projectUserId in projectUserIds)
-                    tasks.Add(removeUser(projectUserId));
-
-                string[] referringProjects = GetProjectWithReferenceToSource(projectId);
-                async Task removeSourceReference(string projectId)
-                {
-                    IDocument<SFProject> doc = await conn.FetchAsync<SFProject>(projectId);
-                    await doc.SubmitJson0OpAsync(op => op.Unset(d => d.TranslateConfig.Source));
-                }
-                foreach (string projId in referringProjects)
-                    tasks.Add(removeSourceReference(projId));
-                await Task.WhenAll(tasks);
-            }
-
-            // The machine service requires the project secrets, so call it before removing them
-            await _machineProjectService.RemoveProjectAsync(curUserId, projectId, CancellationToken.None);
-            await ProjectSecrets.DeleteAsync(projectId);
-            await RealtimeService.DeleteProjectAsync(projectId);
-            string projectDir = Path.Combine(SiteOptions.Value.SiteDir, "sync", ptProjectId);
-            if (FileSystemService.DirectoryExists(projectDir))
-                FileSystemService.DeleteDirectory(projectDir);
-            string audioDir = GetAudioDir(projectId);
-            if (FileSystemService.DirectoryExists(audioDir))
-                FileSystemService.DeleteDirectory(audioDir);
-        }
-
-        public async Task UpdateSettingsAsync(string curUserId, string projectId, SFProjectSettings settings)
-        {
-            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
-            {
-                IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
-                if (!projectDoc.IsLoaded)
-                    throw new DataNotFoundException("The project does not exist.");
-                if (!IsProjectAdmin(projectDoc.Data, curUserId))
-                    throw new ForbiddenException();
-
-                // Get the source - any creation or permission updates are handled in GetTranslateSourceAsync
-                TranslateSource source = null;
-                bool unsetSourceProject = settings.SourceParatextId == ProjectSettingValueUnset;
-                IReadOnlyList<ParatextProject>? ptProjects = null;
-                if (settings.SourceParatextId != null && !unsetSourceProject)
-                {
-                    Attempt<UserSecret> userSecretAttempt = await _userSecrets.TryGetAsync(curUserId);
-                    if (!userSecretAttempt.TryResult(out UserSecret userSecret))
-                        throw new DataNotFoundException("The user does not exist.");
-
-                    ptProjects = await _paratextService.GetProjectsAsync(userSecret);
-                    source = await GetTranslateSourceAsync(
-                        curUserId,
-                        userSecret,
-                        settings.SourceParatextId,
-                        ptProjects,
-                        projectDoc.Data.UserRoles
-                    );
-                    if (source.ProjectRef == projectId)
-                    {
-                        // A project cannot reference itself
-                        source = null;
-                    }
-                }
-
-                bool hasExistingMachineProject = projectDoc.Data.TranslateConfig.TranslationSuggestionsEnabled;
-                await projectDoc.SubmitJson0OpAsync(op =>
-                {
-                    UpdateSetting(
-                        op,
-                        p => p.TranslateConfig.TranslationSuggestionsEnabled,
-                        settings.TranslationSuggestionsEnabled
-                    );
-                    UpdateSetting(op, p => p.TranslateConfig.Source, source, unsetSourceProject);
-                    UpdateSetting(op, p => p.TranslateConfig.ShareEnabled, settings.TranslateShareEnabled);
-                    UpdateSetting(op, p => p.TranslateConfig.ShareLevel, settings.TranslateShareLevel);
-
-                    UpdateSetting(op, p => p.CheckingConfig.CheckingEnabled, settings.CheckingEnabled);
-                    UpdateSetting(
-                        op,
-                        p => p.CheckingConfig.UsersSeeEachOthersResponses,
-                        settings.UsersSeeEachOthersResponses
-                    );
-                    UpdateSetting(op, p => p.CheckingConfig.ShareEnabled, settings.CheckingShareEnabled);
-                    UpdateSetting(op, p => p.CheckingConfig.ShareLevel, settings.CheckingShareLevel);
-                    UpdateSetting(op, p => p.CheckingConfig.AnswerExportMethod, settings.CheckingAnswerExport);
-                });
-
-                bool suggestionsEnabledSet = settings.TranslationSuggestionsEnabled != null;
-                bool sourceParatextIdSet = settings.SourceParatextId != null || unsetSourceProject;
-                bool checkingEnabledSet = settings.CheckingEnabled != null;
-                // check if a sync needs to be run
-                if (suggestionsEnabledSet || sourceParatextIdSet || checkingEnabledSet)
-                {
-                    bool trainEngine = false;
-                    if (suggestionsEnabledSet || sourceParatextIdSet)
-                    {
-                        if (
-                            projectDoc.Data.TranslateConfig.TranslationSuggestionsEnabled
-                            && projectDoc.Data.TranslateConfig.Source != null
-                        )
-                        {
-                            // translation suggestions was enabled or source project changed
-
-                            // recreate Machine project only if one existed
-                            if (hasExistingMachineProject)
-                            {
-                                await _machineProjectService.RemoveProjectAsync(
-                                    curUserId,
-                                    projectId,
-                                    CancellationToken.None
-                                );
-                            }
-
-                            await EnsureWritingSystemTagIsSetAsync(curUserId, projectDoc, ptProjects);
-                            await _machineProjectService.AddProjectAsync(curUserId, projectId, CancellationToken.None);
-                            trainEngine = true;
-                        }
-                        else if (hasExistingMachineProject)
-                        {
-                            // translation suggestions was disabled or source project set to null
-                            await _machineProjectService.RemoveProjectAsync(
-                                curUserId,
-                                projectId,
-                                CancellationToken.None
-                            );
-                        }
-                    }
-
-                    await _syncService.SyncAsync(curUserId, projectId, trainEngine);
-                }
-            }
-        }
-
-        public async Task AddTranslateMetricsAsync(string curUserId, string projectId, TranslateMetrics metrics)
-        {
-            Attempt<SFProject> attempt = await RealtimeService.TryGetSnapshotAsync<SFProject>(projectId);
-            if (!attempt.TryResult(out SFProject project))
-                throw new DataNotFoundException("The project does not exist.");
-
-            if (!project.UserRoles.ContainsKey(curUserId))
-                throw new ForbiddenException();
-
-            metrics.UserRef = curUserId;
-            metrics.ProjectRef = projectId;
-            metrics.Timestamp = DateTime.UtcNow;
-            await _translateMetrics.ReplaceAsync(metrics, true);
-        }
-
-        public async Task SyncAsync(string curUserId, string projectId)
-        {
-            Attempt<SFProject> attempt = await RealtimeService.TryGetSnapshotAsync<SFProject>(projectId);
-            if (!attempt.TryResult(out SFProject project))
-                throw new DataNotFoundException("The project does not exist.");
-
-            if (!(IsProjectAdmin(project, curUserId) || IsProjectTranslator(project, curUserId)))
-                throw new ForbiddenException();
-
-            await _syncService.SyncAsync(curUserId, projectId, false);
-        }
-
-        public async Task CancelSyncAsync(string curUserId, string projectId)
-        {
-            SFProject project = await GetProjectAsync(projectId);
-            if (!(IsProjectAdmin(project, curUserId) || IsProjectTranslator(project, curUserId)))
-                throw new ForbiddenException();
-
-            await _syncService.CancelSyncAsync(curUserId, projectId);
-        }
-
-        public async Task<bool> InviteAsync(
-            string curUserId,
-            string projectId,
-            string email,
-            string locale,
-            string role
-        )
-        {
-            SFProject project = await GetProjectAsync(projectId);
-            if (!CanUserShareRole(curUserId, project, role))
-                throw new ForbiddenException();
-
             if (
-                await RealtimeService
-                    .QuerySnapshots<User>()
-                    .AnyAsync(u => project.UserRoles.Keys.Contains(u.Id) && u.Email == email)
+                this.RealtimeService
+                    .QuerySnapshots<SFProject>()
+                    .Any((SFProject sfProject) => sfProject.ParatextId == project.ParatextId)
             )
             {
-                return false;
+                throw new InvalidOperationException(ErrorAlreadyConnectedKey);
             }
-            SiteOptions siteOptions = SiteOptions.Value;
+            IDocument<SFProject> projectDoc = await conn.CreateAsync<SFProject>(projectId, project);
+            await ProjectSecrets.InsertAsync(new SFProjectSecret { Id = projectDoc.Id });
 
-            bool isAdmin = IsProjectAdmin(project, curUserId);
-            string[] availableRoles = new Dictionary<string, bool>
+            IDocument<User> userDoc = await conn.FetchAsync<User>(curUserId);
+            await AddUserToProjectAsync(conn, projectDoc, userDoc, SFProjectRole.Administrator, false);
+
+            // Add the source after the project has been created
+            // This will make the source project appear after the target, if it needs to be created
+            if (settings.SourceParatextId != null && settings.SourceParatextId != settings.ParatextId)
             {
-                {
-                    SFProjectRole.CommunityChecker,
-                    project.CheckingConfig.CheckingEnabled && (isAdmin || project.CheckingConfig.ShareEnabled)
-                },
-                { SFProjectRole.SFObserver, project.TranslateConfig.ShareEnabled || isAdmin },
-                { SFProjectRole.Reviewer, project.TranslateConfig.ShareEnabled || isAdmin }
-            }
-                .Where(entry => entry.Value)
-                .Select(entry => entry.Key)
-                .ToArray();
-
-            if (!availableRoles.Contains(role))
-                throw new ForbiddenException();
-
-            CultureInfo.CurrentUICulture = new CultureInfo(locale);
-            // Remove the user sharekey if expired
-            await ProjectSecrets.UpdateAsync(
-                p => p.Id == projectId,
-                update =>
-                    update.RemoveAll(p => p.ShareKeys, sk => sk.Email == email && sk.ExpirationTime < DateTime.UtcNow)
-            );
-            DateTime expTime = DateTime.UtcNow.AddDays(14);
-
-            // Invite a specific person. Reuse prior code, if any.
-            SFProjectSecret projectSecret = await ProjectSecrets.UpdateAsync(
-                p => p.Id == projectId && !p.ShareKeys.Any(sk => sk.Email == email),
-                update =>
-                    update.Add(
-                        p => p.ShareKeys,
-                        new ShareKey
-                        {
-                            Email = email,
-                            Key = _securityService.GenerateKey(),
-                            ExpirationTime = expTime,
-                            ProjectRole = role
-                        }
-                    )
-            );
-            if (projectSecret == null)
-            {
-                projectSecret = await ProjectSecrets.GetAsync(projectId);
-                int index = projectSecret.ShareKeys.FindIndex(sk => sk.Email == email);
-
-                // Renew the expiration time of the valid key
-                await ProjectSecrets.UpdateAsync(
-                    p => p.Id == projectId && p.ShareKeys.Any(sk => sk.Email == email),
-                    update =>
-                        update
-                            .Set(p => p.ShareKeys[index].ExpirationTime, expTime)
-                            .Set(p => p.ShareKeys[index].ProjectRole, role)
+                TranslateSource source = await this.GetTranslateSourceAsync(
+                    curUserId,
+                    userSecret,
+                    settings.SourceParatextId,
+                    ptProjects
                 );
+
+                await projectDoc.SubmitJson0OpAsync(op => UpdateSetting(op, p => p.TranslateConfig.Source, source));
             }
-            string key = projectSecret.ShareKeys.Single(sk => sk.Email == email).Key;
-            string url = $"{siteOptions.Origin}projects/{projectId}?sharing=true&shareKey={key}&locale={locale}";
-            string linkExpires = _localizer[SharedResource.Keys.InviteLinkExpires];
 
-            User inviter = await RealtimeService.GetSnapshotAsync<User>(curUserId);
-            string subject = _localizer[SharedResource.Keys.InviteSubject, project.Name, siteOptions.Name];
-            var greeting =
-                $"<p>{_localizer[SharedResource.Keys.InviteGreeting, "<p>", inviter.Name, project.Name, siteOptions.Name, $"<a href=\"{url}\">{url}</a><p>"]}";
-            var instructions =
-                $"<p>{_localizer[SharedResource.Keys.InviteInstructions, siteOptions.Name, "<b>", "</b>"]}";
-            var pt = $"<ul><li>{_localizer[SharedResource.Keys.InvitePTOption, "<b>", "</b>", siteOptions.Name]}</li>";
-            var google =
-                $"<li>{_localizer[SharedResource.Keys.InviteGoogleOption, "<b>", "</b>", siteOptions.Name]}</li>";
-            var facebook =
-                $"<li>{_localizer[SharedResource.Keys.InviteFacebookOption, "<b>", "</b>", siteOptions.Name]}</li>";
-            var withemail =
-                $"<li>{_localizer[SharedResource.Keys.InviteEmailOption, siteOptions.Name]}</li></ul></p><p></p>";
-            var signoff = $"<p>{_localizer[SharedResource.Keys.InviteSignature, "<p>", siteOptions.Name]}</p>";
-            var emailBody = $"{greeting}{linkExpires}{instructions}{pt}{google}{facebook}{withemail}{signoff}";
-            await _emailService.SendEmailAsync(email, subject, emailBody);
-            return true;
-        }
-
-        /// <summary> Get the link sharing key for a project if it exists, otherwise create a new one. </summary>
-        public async Task<string> GetLinkSharingKeyAsync(string curUserId, string projectId, string role)
-        {
-            SFProject project = await GetProjectAsync(projectId);
-            if (!CanUserShareRole(curUserId, project, role))
-                throw new ForbiddenException();
-
-            string[] availableRoles = new Dictionary<string, bool>
+            if (projectDoc.Data.TranslateConfig.TranslationSuggestionsEnabled)
             {
-                {
-                    SFProjectRole.CommunityChecker,
-                    project.CheckingConfig.CheckingEnabled
-                        && project.CheckingConfig.ShareEnabled
-                        && project.CheckingConfig.ShareLevel == CheckingShareLevel.Anyone
-                },
-                {
-                    SFProjectRole.SFObserver,
-                    project.TranslateConfig.ShareEnabled
-                        && project.TranslateConfig.ShareLevel == TranslateShareLevel.Anyone
-                },
-                {
-                    SFProjectRole.Reviewer,
-                    project.TranslateConfig.ShareEnabled
-                        && project.TranslateConfig.ShareLevel == TranslateShareLevel.Anyone
-                }
+                await EnsureWritingSystemTagIsSetAsync(curUserId, projectDoc, ptProjects);
+                await _machineProjectService.AddProjectAsync(curUserId, projectDoc.Id, CancellationToken.None);
             }
-                .Where(entry => entry.Value)
-                .Select(entry => entry.Key)
-                .ToArray();
-
-            if (!availableRoles.Contains(role))
-                return null;
-
-            SFProjectSecret projectSecret = await ProjectSecrets.GetAsync(projectId);
-            // Link sharing keys have Email set to null and ExpirationTime set to null.
-            string key = projectSecret.ShareKeys.SingleOrDefault(sk => sk.Email == null && sk.ProjectRole == role)?.Key;
-            if (!string.IsNullOrEmpty(key))
-                return key;
-
-            // Generate a new link sharing key for the given role
-            key = _securityService.GenerateKey();
-            await ProjectSecrets.UpdateAsync(
-                p => p.Id == projectId,
-                update =>
-                    update.Add(
-                        p => p.ShareKeys,
-                        new ShareKey
-                        {
-                            Key = key,
-                            ProjectRole = role,
-                            ExpirationTime = null
-                        }
-                    )
-            );
-            return key;
         }
 
-        /// <summary>Cancel an outstanding project invitation.</summary>
-        public async Task UninviteUserAsync(string curUserId, string projectId, string emailToUninvite)
-        {
-            SFProject project = await GetProjectAsync(projectId);
-            if (!IsProjectAdmin(project, curUserId))
-                throw new ForbiddenException();
+        await _syncService.SyncAsync(curUserId, projectId, true);
+        return projectId;
+    }
 
-            if (!await IsAlreadyInvitedAsync(curUserId, projectId, emailToUninvite))
+    /// <summary>
+    /// Asynchronously creates a project for a Paratext resource.
+    /// </summary>
+    /// <param name="curUserId">The current user identifier.</param>
+    /// <param name="paratextId">The paratext resource identifier.</param>
+    /// <returns>SF project id of created project</returns>
+    /// <remarks>
+    /// This method will also work for a source project that has been deleted for some reason.
+    /// </remarks>
+    /// <exception cref="DataNotFoundException">
+    /// The user does not exist.
+    /// or
+    /// The paratext project does not exist.
+    /// </exception>
+    /// <exception cref="InvalidOperationException"></exception>
+    public async Task<string> CreateResourceProjectAsync(string curUserId, string paratextId)
+    {
+        Attempt<UserSecret> userSecretAttempt = await _userSecrets.TryGetAsync(curUserId);
+        if (!userSecretAttempt.TryResult(out UserSecret userSecret))
+        {
+            throw new DataNotFoundException("The user does not exist.");
+        }
+
+        // We check projects first, in case it is a project
+        IReadOnlyList<ParatextProject> ptProjects = await _paratextService.GetProjectsAsync(userSecret);
+        ParatextProject ptProject = ptProjects.SingleOrDefault(p => p.ParatextId == paratextId);
+        if (ptProject == null)
+        {
+            // If it is not a project, see if there is a matching resource
+            IReadOnlyList<ParatextResource> resources = await this._paratextService.GetResourcesAsync(curUserId);
+            ptProject = resources.SingleOrDefault(r => r.ParatextId == paratextId);
+            if (ptProject == null)
             {
-                // There is not an invitation for this email address
-                return;
-            }
-
-            await ProjectSecrets.UpdateAsync(
-                projectId,
-                u =>
-                {
-                    u.RemoveAll(secretSet => secretSet.ShareKeys, shareKey => shareKey.Email == (emailToUninvite));
-                }
-            );
-        }
-
-        /// <summary>Is there already a pending invitation to the project for the specified email address?</summary>
-        public async Task<bool> IsAlreadyInvitedAsync(string curUserId, string projectId, string email)
-        {
-            SFProject project = await GetProjectAsync(projectId);
-            bool sharingEnabled =
-                project.TranslateConfig.ShareEnabled
-                || (project.CheckingConfig.CheckingEnabled && project.CheckingConfig.ShareEnabled);
-            if (!IsProjectAdmin(project, curUserId) && !(IsOnProject(project, curUserId) && sharingEnabled))
-                throw new ForbiddenException();
-
-            if (email == null)
-                return false;
-            return await ProjectSecrets
-                .Query()
-                .AnyAsync(p => p.Id == projectId && p.ShareKeys.Any(sk => sk.Email == email));
-        }
-
-        /// <summary>Return list of email addresses with outstanding invitations</summary>
-        public async Task<IReadOnlyList<InviteeStatus>> InvitedUsersAsync(string curUserId, string projectId)
-        {
-            SFProject project = await GetProjectAsync(projectId);
-
-            if (!IsProjectAdmin(project, curUserId))
-                throw new ForbiddenException();
-
-            SFProjectSecret projectSecret = await ProjectSecrets.GetAsync(projectId);
-
-            DateTime now = DateTime.UtcNow;
-            return projectSecret.ShareKeys
-                .Where(s => s.Email != null)
-                .Select(
-                    sk =>
-                        new InviteeStatus
-                        {
-                            Email = sk.Email,
-                            Role = sk.ProjectRole,
-                            Expired = sk.ExpirationTime < now
-                        }
-                )
-                .ToArray();
-        }
-
-        /// <summary> Check that a share link is valid for a project and add the user to the project. </summary>
-        public async Task CheckLinkSharingAsync(string curUserId, string projectId, string shareKey)
-        {
-            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
-            {
-                IDocument<SFProject> projectDoc = await GetProjectDocAsync(projectId, conn);
-                SFProject project = projectDoc.Data;
-                if (project.UserRoles.ContainsKey(curUserId))
-                    return;
-
-                IDocument<User> userDoc = await conn.FetchAsync<User>(curUserId);
-                string projectRole;
-                // Attempt to get the role for the user from the Paratext registry
-                Attempt<string> attempt = await TryGetProjectRoleAsync(project, curUserId);
-                if (attempt.TryResult(out projectRole))
-                {
-                    // Add the user and remove the specific user share key if it exists.
-                    await AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole, true);
-                    return;
-                }
-
-                // Get the project role that is specified in the sharekey
-                Attempt<SFProjectSecret> psAttempt = await ProjectSecrets.TryGetAsync(projectId);
-                if (psAttempt.TryResult(out SFProjectSecret ps))
-                    projectRole = ps.ShareKeys.SingleOrDefault(sk => sk.Key == shareKey)?.ProjectRole;
-                // The share key was invalid
-                if (projectRole == null)
-                    throw new ForbiddenException();
-
-                string[] availableRoles = new Dictionary<string, bool>
-                {
-                    {
-                        SFProjectRole.CommunityChecker,
-                        project.CheckingConfig.CheckingEnabled
-                            && project.CheckingConfig.ShareEnabled
-                            && project.CheckingConfig.ShareLevel == CheckingShareLevel.Anyone
-                    },
-                    {
-                        SFProjectRole.SFObserver,
-                        project.TranslateConfig.ShareEnabled
-                            && project.TranslateConfig.ShareLevel == TranslateShareLevel.Anyone
-                    },
-                    {
-                        SFProjectRole.Reviewer,
-                        project.TranslateConfig.ShareEnabled
-                            && project.TranslateConfig.ShareLevel == TranslateShareLevel.Anyone
-                    }
-                }
-                    .Where(entry => entry.Value)
-                    .Select(entry => entry.Key)
-                    .ToArray();
-
-                if (availableRoles.Contains(projectRole))
-                {
-                    // Add the user and remove the specific user share key if it exists. Link sharing keys
-                    // have Email set to null and will not be removed.
-                    await AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole, true);
-                    return;
-                }
-                // Look for a valid specific user share key.
-                SFProjectSecret projectSecret = await ProjectSecrets.UpdateAsync(
-                    p =>
-                        p.Id == projectId
-                        && p.ShareKeys.Any(
-                            sk => sk.Email != null && sk.Key == shareKey && sk.ExpirationTime > DateTime.UtcNow
-                        ),
-                    update => update.RemoveAll(p => p.ShareKeys, sk => sk.Key == shareKey)
-                );
-                if (projectSecret != null)
-                {
-                    await AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole, false);
-                    return;
-                }
-                throw new ForbiddenException();
+                throw new DataNotFoundException("The paratext project or resource does not exist.");
             }
         }
 
-        /// <summary> Determine if the specified project is an active source project. </summary>
-        public bool IsSourceProject(string projectId)
-        {
-            IQueryable<SFProject> projectQuery = RealtimeService.QuerySnapshots<SFProject>();
-            return projectQuery.Any(
-                p => p.TranslateConfig.Source != null && p.TranslateConfig.Source.ProjectRef == projectId
-            );
-        }
+        return await CreateResourceProjectInternalAsync(curUserId, ptProject);
+    }
 
-        public async Task<IEnumerable<TransceleratorQuestion>> TransceleratorQuestions(
-            string curUserId,
-            string projectId
-        )
-        {
-            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
-            {
-                IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
-                if (!projectDoc.IsLoaded)
-                    throw new DataNotFoundException("The project does not exist.");
-                // TODO Checking whether the permissions contains a particular string is not a very robust way to check
-                // permissions. A rights service needs to be created in C# land.
-                if (
-                    !IsProjectAdmin(projectDoc.Data, curUserId)
-                    && !projectDoc.Data.UserPermissions[curUserId].Contains("questions.create")
-                )
-                    throw new ForbiddenException();
-                return _transceleratorService.Questions(projectDoc.Data.ParatextId);
-            }
-        }
+    public async Task DeleteProjectAsync(string curUserId, string projectId)
+    {
+        // Cancel any jobs before we delete
+        await _syncService.CancelSyncAsync(curUserId, projectId);
 
-        /// <summary>
-        /// Ensures that the <see cref="WritingSystem"/> Tag is not null.
-        /// </summary>
-        /// <param name="curUserId">The current user identifier.</param>
-        /// <param name="projectId">The project identifier.</param>
-        /// <returns>The asynchronous task.</returns>
-        /// <remarks>
-        /// This public method exists for the Machine API Migration utility.
-        /// </remarks>
-        public async Task EnsureWritingSystemTagIsSetAsync(string curUserId, string projectId)
+        string ptProjectId;
+        await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
         {
-            using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
             IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
             if (!projectDoc.IsLoaded)
-            {
                 throw new DataNotFoundException("The project does not exist.");
-            }
+            if (!IsProjectAdmin(projectDoc.Data, curUserId))
+                throw new ForbiddenException();
 
-            await EnsureWritingSystemTagIsSetAsync(curUserId, projectDoc, null);
+            ptProjectId = projectDoc.Data.ParatextId;
+            // delete the project first, so that users get notified about the deletion
+            string[] projectUserIds = projectDoc.Data.UserRoles.Keys.ToArray();
+            await projectDoc.DeleteAsync();
+            async Task removeUser(string projectUserId)
+            {
+                IDocument<User> userDoc = await conn.FetchAsync<User>(projectUserId);
+                await RemoveUserFromProjectAsync(conn, projectDoc, userDoc);
+            }
+            var tasks = new List<Task>();
+            foreach (string projectUserId in projectUserIds)
+                tasks.Add(removeUser(projectUserId));
+
+            string[] referringProjects = GetProjectWithReferenceToSource(projectId);
+            async Task removeSourceReference(string projectId)
+            {
+                IDocument<SFProject> doc = await conn.FetchAsync<SFProject>(projectId);
+                await doc.SubmitJson0OpAsync(op => op.Unset(d => d.TranslateConfig.Source));
+            }
+            foreach (string projId in referringProjects)
+                tasks.Add(removeSourceReference(projId));
+            await Task.WhenAll(tasks);
         }
 
-        protected override async Task AddUserToProjectAsync(
-            IConnection conn,
-            IDocument<SFProject> projectDoc,
-            IDocument<User> userDoc,
-            string projectRole,
-            bool removeShareKeys = true
-        )
-        {
-            await conn.CreateAsync<SFProjectUserConfig>(
-                SFProjectUserConfig.GetDocId(projectDoc.Id, userDoc.Id),
-                new SFProjectUserConfig { ProjectRef = projectDoc.Id, OwnerRef = userDoc.Id }
-            );
-            // Listeners can now assume the ProjectUserConfig is ready when the user is added.
-            await base.AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole, removeShareKeys);
+        // The machine service requires the project secrets, so call it before removing them
+        await _machineProjectService.RemoveProjectAsync(curUserId, projectId, CancellationToken.None);
+        await ProjectSecrets.DeleteAsync(projectId);
+        await RealtimeService.DeleteProjectAsync(projectId);
+        string projectDir = Path.Combine(SiteOptions.Value.SiteDir, "sync", ptProjectId);
+        if (FileSystemService.DirectoryExists(projectDir))
+            FileSystemService.DeleteDirectory(projectDir);
+        string audioDir = GetAudioDir(projectId);
+        if (FileSystemService.DirectoryExists(audioDir))
+            FileSystemService.DeleteDirectory(audioDir);
+    }
 
-            // Update book and chapter permissions on SF project/resource, but only if user
-            // has a role on the PT project or permissions to the DBL resource. These permissions are needed
-            // in order to query the PT roles and DBL permissions of other SF project/resource users.
-            if ((await TryGetProjectRoleAsync(projectDoc.Data, userDoc.Id)).Success)
-            {
-                await UpdatePermissionsAsync(userDoc.Id, projectDoc, CancellationToken.None);
-            }
+    public async Task UpdateSettingsAsync(string curUserId, string projectId, SFProjectSettings settings)
+    {
+        await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
+        IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
+        if (!projectDoc.IsLoaded)
+            throw new DataNotFoundException("The project does not exist.");
+        if (!IsProjectAdmin(projectDoc.Data, curUserId))
+            throw new ForbiddenException();
 
-            // Add to the source project, if required
-            string sourceProjectId = projectDoc.Data.TranslateConfig.Source?.ProjectRef;
-            string sourceParatextId = projectDoc.Data.TranslateConfig.Source?.ParatextId;
-            if (!string.IsNullOrWhiteSpace(sourceProjectId) && !string.IsNullOrWhiteSpace(sourceParatextId))
-            {
-                // Load the source project role from MongoDB
-                IDocument<SFProject> sourceProjectDoc = await TryGetProjectDocAsync(sourceProjectId, conn);
-                if (sourceProjectDoc == null)
-                    return;
-                if (sourceProjectDoc.IsLoaded && !sourceProjectDoc.Data.UserRoles.ContainsKey(userDoc.Id))
-                {
-                    // Not found in Mongo, so load the project role from Paratext
-                    Attempt<string> attempt = await TryGetProjectRoleAsync(sourceProjectDoc.Data, userDoc.Id);
-                    if (attempt.TryResult(out string sourceProjectRole))
-                    {
-                        // If they are in Paratext, add the user to the source project
-                        await this.AddUserToProjectAsync(
-                            conn,
-                            sourceProjectDoc,
-                            userDoc,
-                            sourceProjectRole,
-                            removeShareKeys
-                        );
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Update all user permissions on books and chapters in an SF project, from PT project permissions. For Paratext
-        /// projects, permissions are acquired from ScrText objects, and so presumably only what was received from
-        /// Paratext in the last synchronize. For Resources, permissions are fetched from a DBL server, and so permissions
-        /// may be ahead of the last sync.
-        /// Note that this method is not necessarily applying permissions for user `curUserId`, but rather using that
-        /// user to perform PT queries and set values in the SF DB.
-        /// </summary>
-        public async Task UpdatePermissionsAsync(
-            string curUserId,
-            IDocument<SFProject> projectDoc,
-            CancellationToken token
-        )
+        // Get the source - any creation or permission updates are handled in GetTranslateSourceAsync
+        TranslateSource source = null;
+        bool unsetSourceProject = settings.SourceParatextId == ProjectSettingValueUnset;
+        IReadOnlyList<ParatextProject>? ptProjects = null;
+        if (settings.SourceParatextId != null && !unsetSourceProject)
         {
             Attempt<UserSecret> userSecretAttempt = await _userSecrets.TryGetAsync(curUserId);
             if (!userSecretAttempt.TryResult(out UserSecret userSecret))
-            {
-                throw new DataNotFoundException("No matching user secrets found.");
-            }
+                throw new DataNotFoundException("The user does not exist.");
 
-            string paratextId = projectDoc.Data.ParatextId;
-            HashSet<int> booksInProject = new HashSet<int>(_paratextService.GetBookList(userSecret, paratextId));
-            IReadOnlyDictionary<string, string> ptUsernameMapping =
-                await _paratextService.GetParatextUsernameMappingAsync(userSecret, projectDoc.Data, token);
-            bool isResource = _paratextService.IsResource(paratextId);
-            // Place to collect all chapter permissions to record in the project.
-            var projectChapterPermissions =
-                new List<(int bookIndex, int chapterIndex, Dictionary<string, string> chapterPermissions)>();
-            // Place to collect all book permissions to record in the project.
-            var projectBookPermissions = new List<(int bookIndex, Dictionary<string, string> bookPermissions)>();
-
-            Dictionary<string, string> resourcePermissions = null;
-            if (isResource)
-            {
-                // Note that DBL specifies permission for a resource with granularity of the whole resource. We will
-                // write in the SF DB that whole-resource permission but on each book and chapter.
-                resourcePermissions = await _paratextService.GetPermissionsAsync(
-                    userSecret,
-                    projectDoc.Data,
-                    ptUsernameMapping,
-                    0,
-                    0,
-                    token
-                );
-            }
-
-            foreach (int bookNum in booksInProject)
-            {
-                int textIndex = projectDoc.Data.Texts.FindIndex(t => t.BookNum == bookNum);
-                if (textIndex == -1)
-                {
-                    // Project does not contain specified book.
-                    // This is expected if a user is connecting a project for the first time, as the project may not
-                    // have been synchronized yet.
-                    continue;
-                }
-                Models.TextInfo text = projectDoc.Data.Texts[textIndex];
-                List<Chapter> chapters = text.Chapters;
-                Dictionary<string, string> bookPermissions = null;
-                IEnumerable<(
-                    int bookIndex,
-                    int chapterIndex,
-                    Dictionary<string, string> chapterPermissions
-                )> chapterPermissionsInBook = null;
-
-                if (isResource)
-                {
-                    bookPermissions = resourcePermissions;
-                    // Prepare to write the same resource permission for each chapter in the book/text.
-                    chapterPermissionsInBook = chapters.Select(
-                        (Chapter chapter, int chapterIndex) => (textIndex, chapterIndex, bookPermissions)
-                    );
-                }
-                else
-                {
-                    bookPermissions = await _paratextService.GetPermissionsAsync(
-                        userSecret,
-                        projectDoc.Data,
-                        ptUsernameMapping,
-                        bookNum,
-                        0,
-                        token
-                    );
-
-                    // Get the project permissions for the chapters
-                    chapterPermissionsInBook = await Task.WhenAll(
-                        chapters.Select(
-                            async (Chapter chapter, int chapterIndex) =>
-                            {
-                                Dictionary<string, string> chapterPermissions =
-                                    await _paratextService.GetPermissionsAsync(
-                                        userSecret,
-                                        projectDoc.Data,
-                                        ptUsernameMapping,
-                                        bookNum,
-                                        chapter.Number,
-                                        token
-                                    );
-                                return (textIndex, chapterIndex, chapterPermissions);
-                            }
-                        )
-                    );
-                }
-                projectChapterPermissions.AddRange(chapterPermissionsInBook);
-                projectBookPermissions.Add((textIndex, bookPermissions));
-            }
-
-            // Update project metadata
-            await projectDoc.SubmitJson0OpAsync(op =>
-            {
-                foreach ((int bookIndex, Dictionary<string, string> bookPermissions) in projectBookPermissions)
-                {
-                    op.Set(
-                        pd => pd.Texts[bookIndex].Permissions,
-                        bookPermissions,
-                        _permissionDictionaryEqualityComparer
-                    );
-                }
-                foreach (
-                    (
-                        int bookIndex,
-                        int chapterIndex,
-                        Dictionary<string, string> chapterPermissions
-                    ) in projectChapterPermissions
-                )
-                {
-                    op.Set(
-                        pd => pd.Texts[bookIndex].Chapters[chapterIndex].Permissions,
-                        chapterPermissions,
-                        _permissionDictionaryEqualityComparer
-                    );
-                }
-            });
-        }
-
-        protected override async Task RemoveUserFromProjectAsync(
-            IConnection conn,
-            IDocument<SFProject> projectDoc,
-            IDocument<User> userDoc
-        )
-        {
-            await base.RemoveUserFromProjectAsync(conn, projectDoc, userDoc);
-            IDocument<SFProjectUserConfig> projectUserConfigDoc = await conn.FetchAsync<SFProjectUserConfig>(
-                SFProjectUserConfig.GetDocId(projectDoc.Id, userDoc.Id)
+            ptProjects = await _paratextService.GetProjectsAsync(userSecret);
+            source = await GetTranslateSourceAsync(
+                curUserId,
+                userSecret,
+                settings.SourceParatextId,
+                ptProjects,
+                projectDoc.Data.UserRoles
             );
-            await projectUserConfigDoc.DeleteAsync();
-        }
-
-        /// <summary>
-        /// Returns `userId`'s role on project or resource `project`.
-        /// The role may be the PT role from PT Registry, or a SF role.
-        /// The returned Attempt will be Success if they have a non-None role, or otherwise Failure.
-        /// </summary>
-        protected async override Task<Attempt<string>> TryGetProjectRoleAsync(SFProject project, string userId)
-        {
-            Attempt<UserSecret> userSecretAttempt = await _userSecrets.TryGetAsync(userId);
-            if (userSecretAttempt.TryResult(out UserSecret userSecret))
+            if (source.ProjectRef == projectId)
             {
-                if (_paratextService.IsResource(project.ParatextId))
-                {
-                    // If the project is a resource, get the permission from the DBL
-                    string permission = await _paratextService.GetResourcePermissionAsync(
-                        project.ParatextId,
-                        userId,
-                        CancellationToken.None
-                    );
-                    return permission switch
-                    {
-                        TextInfoPermission.None => Attempt.Failure(ProjectRole.None),
-                        TextInfoPermission.Read => Attempt.Success(SFProjectRole.PTObserver),
-                        _
-                            => throw new ArgumentException(
-                                $"Unknown resource permission: '{permission}'",
-                                nameof(permission)
-                            ),
-                    };
-                }
-                else
-                {
-                    Attempt<string> roleAttempt = await _paratextService.TryGetProjectRoleAsync(
-                        userSecret,
-                        project.ParatextId,
-                        CancellationToken.None
-                    );
-                    if (roleAttempt.TryResult(out string role))
-                    {
-                        return Attempt.Success(role);
-                    }
-                }
-            }
-
-            return Attempt.Failure(ProjectRole.None);
-        }
-
-        private async Task<IDocument<SFProject>> TryGetProjectDocAsync(string projectId, IConnection conn)
-        {
-            try
-            {
-                IDocument<SFProject> projectDoc = await base.GetProjectDocAsync(projectId, conn);
-                return projectDoc;
-            }
-            catch (DataNotFoundException)
-            {
-                return null;
+                // A project cannot reference itself
+                source = null;
             }
         }
 
-        /// <summary>
-        /// Determines whether the user is a project translator for the specified project.
-        /// </summary>
-        /// <param name="project">The project.</param>
-        /// <param name="userId">The user identifier.</param>
-        /// <returns>
-        ///   <c>true</c> if a project translator; otherwise, <c>false</c>.
-        /// </returns>
-        /// <remarks>
-        /// This only checks the local project, and is based on <see cref="ProjectService.IsProjectAdmin" />.
-        /// </remarks>
-        private static bool IsProjectTranslator(SFProject project, string userId)
+        bool hasExistingMachineProject = projectDoc.Data.TranslateConfig.TranslationSuggestionsEnabled;
+        await projectDoc.SubmitJson0OpAsync(op =>
         {
-            return project.UserRoles.TryGetValue(userId, out string role) && role == SFProjectRole.Translator;
-        }
+            UpdateSetting(
+                op,
+                p => p.TranslateConfig.TranslationSuggestionsEnabled,
+                settings.TranslationSuggestionsEnabled
+            );
+            UpdateSetting(op, p => p.TranslateConfig.Source, source, unsetSourceProject);
+            UpdateSetting(op, p => p.TranslateConfig.ShareEnabled, settings.TranslateShareEnabled);
+            UpdateSetting(op, p => p.TranslateConfig.ShareLevel, settings.TranslateShareLevel);
 
-        private static bool HasParatextRole(SFProject project, string userId)
+            UpdateSetting(op, p => p.CheckingConfig.CheckingEnabled, settings.CheckingEnabled);
+            UpdateSetting(op, p => p.CheckingConfig.UsersSeeEachOthersResponses, settings.UsersSeeEachOthersResponses);
+            UpdateSetting(op, p => p.CheckingConfig.ShareEnabled, settings.CheckingShareEnabled);
+            UpdateSetting(op, p => p.CheckingConfig.ShareLevel, settings.CheckingShareLevel);
+            UpdateSetting(op, p => p.CheckingConfig.AnswerExportMethod, settings.CheckingAnswerExport);
+        });
+
+        bool suggestionsEnabledSet = settings.TranslationSuggestionsEnabled != null;
+        bool sourceParatextIdSet = settings.SourceParatextId != null || unsetSourceProject;
+        bool checkingEnabledSet = settings.CheckingEnabled != null;
+        // check if a sync needs to be run
+        if (suggestionsEnabledSet || sourceParatextIdSet || checkingEnabledSet)
         {
-            return project.UserRoles.TryGetValue(userId, out string role) && SFProjectRole.IsParatextRole(role);
-        }
-
-        private static void UpdateSetting<T>(
-            Json0OpBuilder<SFProject> builder,
-            Expression<Func<SFProject, T>> field,
-            T setting,
-            bool forceUpdate = false
-        )
-        {
-            if (setting != null || forceUpdate)
-                builder.Set(field, setting);
-        }
-
-        /// <summary>
-        /// Asynchronously creates a Scripture Forge project from Paratext resource/project.
-        /// </summary>
-        /// <param name="curUserId">The current user identifier.</param>
-        /// <param name="ptProject">The paratext project.</param>
-        /// <returns>SF project id of created project</returns>
-        /// <remarks>
-        /// This method will also work for a source project that has been deleted for some reason.
-        /// </remarks>
-        /// <exception cref="InvalidOperationException"></exception>
-        private async Task<string> CreateResourceProjectInternalAsync(string curUserId, ParatextProject ptProject)
-        {
-            var project = new SFProject
-            {
-                ParatextId = ptProject.ParatextId,
-                Name = ptProject.Name,
-                ShortName = ptProject.ShortName,
-                WritingSystem = new WritingSystem { Tag = ptProject.LanguageTag },
-                TranslateConfig = new TranslateConfig { TranslationSuggestionsEnabled = false, Source = null },
-                CheckingConfig = new CheckingConfig { CheckingEnabled = false }
-            };
-
-            // Create the new project using the realtime service
-            string projectId = ObjectId.GenerateNewId().ToString();
-            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
+            bool trainEngine = false;
+            if (suggestionsEnabledSet || sourceParatextIdSet)
             {
                 if (
-                    this.RealtimeService
-                        .QuerySnapshots<SFProject>()
-                        .Any((SFProject sfProject) => sfProject.ParatextId == project.ParatextId)
+                    projectDoc.Data.TranslateConfig.TranslationSuggestionsEnabled
+                    && projectDoc.Data.TranslateConfig.Source != null
                 )
                 {
-                    throw new InvalidOperationException(ErrorAlreadyConnectedKey);
-                }
-                IDocument<SFProject> projectDoc = await conn.CreateAsync(projectId, project);
-                await ProjectSecrets.InsertAsync(new SFProjectSecret { Id = projectDoc.Id });
+                    // translation suggestions was enabled or source project changed
 
-                // Resource projects do not have administrators, so users are added as needed
+                    // recreate Machine project only if one existed
+                    if (hasExistingMachineProject)
+                    {
+                        await _machineProjectService.RemoveProjectAsync(curUserId, projectId, CancellationToken.None);
+                    }
+
+                    await EnsureWritingSystemTagIsSetAsync(curUserId, projectDoc, ptProjects);
+                    await _machineProjectService.AddProjectAsync(curUserId, projectId, CancellationToken.None);
+                    trainEngine = true;
+                }
+                else if (hasExistingMachineProject)
+                {
+                    // translation suggestions was disabled or source project set to null
+                    await _machineProjectService.RemoveProjectAsync(curUserId, projectId, CancellationToken.None);
+                }
             }
 
-            return projectId;
+            await _syncService.SyncAsync(curUserId, projectId, trainEngine);
         }
+    }
 
-        /// <summary>
-        /// Gets the translate source asynchronously.
-        /// </summary>
-        /// <param name="curUserId">The current user identifier.</param>
-        /// <param name="userSecret">The user secret.</param>
-        /// <param name="paratextId">The paratext identifier.</param>
-        /// <param name="ptProjects">The paratext projects.</param>
-        /// <param name="userIds">The ids and roles of the users who will need to access the source.</param>
-        /// <returns>The <see cref="TranslateSource"/> object for the specified resource.</returns>
-        /// <exception cref="DataNotFoundException">The source paratext project does not exist.</exception>
-        private async Task<TranslateSource> GetTranslateSourceAsync(
-            string curUserId,
-            UserSecret userSecret,
-            string paratextId,
-            IReadOnlyList<ParatextProject> ptProjects,
-            IReadOnlyDictionary<string, string> userRoles = null
+    public async Task AddTranslateMetricsAsync(string curUserId, string projectId, TranslateMetrics metrics)
+    {
+        Attempt<SFProject> attempt = await RealtimeService.TryGetSnapshotAsync<SFProject>(projectId);
+        if (!attempt.TryResult(out SFProject project))
+            throw new DataNotFoundException("The project does not exist.");
+
+        if (!project.UserRoles.ContainsKey(curUserId))
+            throw new ForbiddenException();
+
+        metrics.UserRef = curUserId;
+        metrics.ProjectRef = projectId;
+        metrics.Timestamp = DateTime.UtcNow;
+        await _translateMetrics.ReplaceAsync(metrics, true);
+    }
+
+    public async Task SyncAsync(string curUserId, string projectId)
+    {
+        Attempt<SFProject> attempt = await RealtimeService.TryGetSnapshotAsync<SFProject>(projectId);
+        if (!attempt.TryResult(out SFProject project))
+            throw new DataNotFoundException("The project does not exist.");
+
+        if (!(IsProjectAdmin(project, curUserId) || IsProjectTranslator(project, curUserId)))
+            throw new ForbiddenException();
+
+        await _syncService.SyncAsync(curUserId, projectId, false);
+    }
+
+    public async Task CancelSyncAsync(string curUserId, string projectId)
+    {
+        SFProject project = await GetProjectAsync(projectId);
+        if (!(IsProjectAdmin(project, curUserId) || IsProjectTranslator(project, curUserId)))
+            throw new ForbiddenException();
+
+        await _syncService.CancelSyncAsync(curUserId, projectId);
+    }
+
+    public async Task<bool> InviteAsync(string curUserId, string projectId, string email, string locale, string role)
+    {
+        SFProject project = await GetProjectAsync(projectId);
+        if (!CanUserShareRole(curUserId, project, role))
+            throw new ForbiddenException();
+
+        if (
+            await RealtimeService
+                .QuerySnapshots<User>()
+                .AnyAsync(u => project.UserRoles.Keys.Contains(u.Id) && u.Email == email)
         )
         {
-            ParatextProject sourcePTProject = ptProjects.SingleOrDefault(p => p.ParatextId == paratextId);
-            string sourceProjectRef = null;
-            if (sourcePTProject == null)
+            return false;
+        }
+        SiteOptions siteOptions = SiteOptions.Value;
+
+        bool isAdmin = IsProjectAdmin(project, curUserId);
+        string[] availableRoles = new Dictionary<string, bool>
+        {
             {
-                // If it is not a project, see if there is a matching resource
-                IReadOnlyList<ParatextResource> resources = await this._paratextService.GetResourcesAsync(curUserId);
-                sourcePTProject = resources.SingleOrDefault(r => r.ParatextId == paratextId);
-                if (sourcePTProject == null)
+                SFProjectRole.CommunityChecker,
+                project.CheckingConfig.CheckingEnabled && (isAdmin || project.CheckingConfig.ShareEnabled)
+            },
+            { SFProjectRole.SFObserver, project.TranslateConfig.ShareEnabled || isAdmin },
+            { SFProjectRole.Reviewer, project.TranslateConfig.ShareEnabled || isAdmin }
+        }
+            .Where(entry => entry.Value)
+            .Select(entry => entry.Key)
+            .ToArray();
+
+        if (!availableRoles.Contains(role))
+            throw new ForbiddenException();
+
+        CultureInfo.CurrentUICulture = new CultureInfo(locale);
+        // Remove the user sharekey if expired
+        await ProjectSecrets.UpdateAsync(
+            p => p.Id == projectId,
+            update => update.RemoveAll(p => p.ShareKeys, sk => sk.Email == email && sk.ExpirationTime < DateTime.UtcNow)
+        );
+        DateTime expTime = DateTime.UtcNow.AddDays(14);
+
+        // Invite a specific person. Reuse prior code, if any.
+        SFProjectSecret projectSecret = await ProjectSecrets.UpdateAsync(
+            p => p.Id == projectId && !p.ShareKeys.Any(sk => sk.Email == email),
+            update =>
+                update.Add(
+                    p => p.ShareKeys,
+                    new ShareKey
+                    {
+                        Email = email,
+                        Key = _securityService.GenerateKey(),
+                        ExpirationTime = expTime,
+                        ProjectRole = role
+                    }
+                )
+        );
+        if (projectSecret == null)
+        {
+            projectSecret = await ProjectSecrets.GetAsync(projectId);
+            int index = projectSecret.ShareKeys.FindIndex(sk => sk.Email == email);
+
+            // Renew the expiration time of the valid key
+            await ProjectSecrets.UpdateAsync(
+                p => p.Id == projectId && p.ShareKeys.Any(sk => sk.Email == email),
+                update =>
+                    update
+                        .Set(p => p.ShareKeys[index].ExpirationTime, expTime)
+                        .Set(p => p.ShareKeys[index].ProjectRole, role)
+            );
+        }
+        string key = projectSecret.ShareKeys.Single(sk => sk.Email == email).Key;
+        string url = $"{siteOptions.Origin}projects/{projectId}?sharing=true&shareKey={key}&locale={locale}";
+        string linkExpires = _localizer[SharedResource.Keys.InviteLinkExpires];
+
+        User inviter = await RealtimeService.GetSnapshotAsync<User>(curUserId);
+        string subject = _localizer[SharedResource.Keys.InviteSubject, project.Name, siteOptions.Name];
+        var greeting =
+            $"<p>{_localizer[SharedResource.Keys.InviteGreeting, "<p>", inviter.Name, project.Name, siteOptions.Name, $"<a href=\"{url}\">{url}</a><p>"]}";
+        var instructions = $"<p>{_localizer[SharedResource.Keys.InviteInstructions, siteOptions.Name, "<b>", "</b>"]}";
+        var pt = $"<ul><li>{_localizer[SharedResource.Keys.InvitePTOption, "<b>", "</b>", siteOptions.Name]}</li>";
+        var google = $"<li>{_localizer[SharedResource.Keys.InviteGoogleOption, "<b>", "</b>", siteOptions.Name]}</li>";
+        var facebook =
+            $"<li>{_localizer[SharedResource.Keys.InviteFacebookOption, "<b>", "</b>", siteOptions.Name]}</li>";
+        var withemail =
+            $"<li>{_localizer[SharedResource.Keys.InviteEmailOption, siteOptions.Name]}</li></ul></p><p></p>";
+        var signoff = $"<p>{_localizer[SharedResource.Keys.InviteSignature, "<p>", siteOptions.Name]}</p>";
+        var emailBody = $"{greeting}{linkExpires}{instructions}{pt}{google}{facebook}{withemail}{signoff}";
+        await _emailService.SendEmailAsync(email, subject, emailBody);
+        return true;
+    }
+
+    /// <summary> Get the link sharing key for a project if it exists, otherwise create a new one. </summary>
+    public async Task<string> GetLinkSharingKeyAsync(string curUserId, string projectId, string role)
+    {
+        SFProject project = await GetProjectAsync(projectId);
+        if (!CanUserShareRole(curUserId, project, role))
+            throw new ForbiddenException();
+
+        string[] availableRoles = new Dictionary<string, bool>
+        {
+            {
+                SFProjectRole.CommunityChecker,
+                project.CheckingConfig.CheckingEnabled
+                    && project.CheckingConfig.ShareEnabled
+                    && project.CheckingConfig.ShareLevel == CheckingShareLevel.Anyone
+            },
+            {
+                SFProjectRole.SFObserver,
+                project.TranslateConfig.ShareEnabled && project.TranslateConfig.ShareLevel == TranslateShareLevel.Anyone
+            },
+            {
+                SFProjectRole.Reviewer,
+                project.TranslateConfig.ShareEnabled && project.TranslateConfig.ShareLevel == TranslateShareLevel.Anyone
+            }
+        }
+            .Where(entry => entry.Value)
+            .Select(entry => entry.Key)
+            .ToArray();
+
+        if (!availableRoles.Contains(role))
+            return null;
+
+        SFProjectSecret projectSecret = await ProjectSecrets.GetAsync(projectId);
+        // Link sharing keys have Email set to null and ExpirationTime set to null.
+        string key = projectSecret.ShareKeys.SingleOrDefault(sk => sk.Email == null && sk.ProjectRole == role)?.Key;
+        if (!string.IsNullOrEmpty(key))
+            return key;
+
+        // Generate a new link sharing key for the given role
+        key = _securityService.GenerateKey();
+        await ProjectSecrets.UpdateAsync(
+            p => p.Id == projectId,
+            update =>
+                update.Add(
+                    p => p.ShareKeys,
+                    new ShareKey
+                    {
+                        Key = key,
+                        ProjectRole = role,
+                        ExpirationTime = null
+                    }
+                )
+        );
+        return key;
+    }
+
+    /// <summary>Cancel an outstanding project invitation.</summary>
+    public async Task UninviteUserAsync(string curUserId, string projectId, string emailToUninvite)
+    {
+        SFProject project = await GetProjectAsync(projectId);
+        if (!IsProjectAdmin(project, curUserId))
+            throw new ForbiddenException();
+
+        if (!await IsAlreadyInvitedAsync(curUserId, projectId, emailToUninvite))
+        {
+            // There is not an invitation for this email address
+            return;
+        }
+
+        await ProjectSecrets.UpdateAsync(
+            projectId,
+            u => u.RemoveAll(secretSet => secretSet.ShareKeys, shareKey => shareKey.Email == (emailToUninvite))
+        );
+    }
+
+    /// <summary>Is there already a pending invitation to the project for the specified email address?</summary>
+    public async Task<bool> IsAlreadyInvitedAsync(string curUserId, string projectId, string email)
+    {
+        SFProject project = await GetProjectAsync(projectId);
+        bool sharingEnabled =
+            project.TranslateConfig.ShareEnabled
+            || (project.CheckingConfig.CheckingEnabled && project.CheckingConfig.ShareEnabled);
+        if (!IsProjectAdmin(project, curUserId) && !(IsOnProject(project, curUserId) && sharingEnabled))
+            throw new ForbiddenException();
+
+        if (email == null)
+            return false;
+        return await ProjectSecrets
+            .Query()
+            .AnyAsync(p => p.Id == projectId && p.ShareKeys.Any(sk => sk.Email == email));
+    }
+
+    /// <summary>Return list of email addresses with outstanding invitations</summary>
+    public async Task<IReadOnlyList<InviteeStatus>> InvitedUsersAsync(string curUserId, string projectId)
+    {
+        SFProject project = await GetProjectAsync(projectId);
+
+        if (!IsProjectAdmin(project, curUserId))
+            throw new ForbiddenException();
+
+        SFProjectSecret projectSecret = await ProjectSecrets.GetAsync(projectId);
+
+        DateTime now = DateTime.UtcNow;
+        return projectSecret.ShareKeys
+            .Where(s => s.Email != null)
+            .Select(
+                sk =>
+                    new InviteeStatus
+                    {
+                        Email = sk.Email,
+                        Role = sk.ProjectRole,
+                        Expired = sk.ExpirationTime < now
+                    }
+            )
+            .ToArray();
+    }
+
+    /// <summary> Check that a share link is valid for a project and add the user to the project. </summary>
+    public async Task CheckLinkSharingAsync(string curUserId, string projectId, string shareKey)
+    {
+        await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
+        IDocument<SFProject> projectDoc = await GetProjectDocAsync(projectId, conn);
+        SFProject project = projectDoc.Data;
+        if (project.UserRoles.ContainsKey(curUserId))
+            return;
+
+        IDocument<User> userDoc = await conn.FetchAsync<User>(curUserId);
+        // Attempt to get the role for the user from the Paratext registry
+        Attempt<string> attempt = await TryGetProjectRoleAsync(project, curUserId);
+        if (attempt.TryResult(out string projectRole))
+        {
+            // Add the user and remove the specific user share key if it exists.
+            await AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole, true);
+            return;
+        }
+
+        // Get the project role that is specified in the sharekey
+        Attempt<SFProjectSecret> psAttempt = await ProjectSecrets.TryGetAsync(projectId);
+        if (psAttempt.TryResult(out SFProjectSecret ps))
+            projectRole = ps.ShareKeys.SingleOrDefault(sk => sk.Key == shareKey)?.ProjectRole;
+        // The share key was invalid
+        if (projectRole == null)
+            throw new ForbiddenException();
+
+        string[] availableRoles = new Dictionary<string, bool>
+        {
+            {
+                SFProjectRole.CommunityChecker,
+                project.CheckingConfig.CheckingEnabled
+                    && project.CheckingConfig.ShareEnabled
+                    && project.CheckingConfig.ShareLevel == CheckingShareLevel.Anyone
+            },
+            {
+                SFProjectRole.SFObserver,
+                project.TranslateConfig.ShareEnabled && project.TranslateConfig.ShareLevel == TranslateShareLevel.Anyone
+            },
+            {
+                SFProjectRole.Reviewer,
+                project.TranslateConfig.ShareEnabled && project.TranslateConfig.ShareLevel == TranslateShareLevel.Anyone
+            }
+        }
+            .Where(entry => entry.Value)
+            .Select(entry => entry.Key)
+            .ToArray();
+
+        if (availableRoles.Contains(projectRole))
+        {
+            // Add the user and remove the specific user share key if it exists. Link sharing keys
+            // have Email set to null and will not be removed.
+            await AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole, true);
+            return;
+        }
+        // Look for a valid specific user share key.
+        SFProjectSecret projectSecret = await ProjectSecrets.UpdateAsync(
+            p =>
+                p.Id == projectId
+                && p.ShareKeys.Any(sk => sk.Email != null && sk.Key == shareKey && sk.ExpirationTime > DateTime.UtcNow),
+            update => update.RemoveAll(p => p.ShareKeys, sk => sk.Key == shareKey)
+        );
+        if (projectSecret != null)
+        {
+            await AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole, false);
+            return;
+        }
+        throw new ForbiddenException();
+    }
+
+    /// <summary> Determine if the specified project is an active source project. </summary>
+    public bool IsSourceProject(string projectId)
+    {
+        IQueryable<SFProject> projectQuery = RealtimeService.QuerySnapshots<SFProject>();
+        return projectQuery.Any(
+            p => p.TranslateConfig.Source != null && p.TranslateConfig.Source.ProjectRef == projectId
+        );
+    }
+
+    public async Task<IEnumerable<TransceleratorQuestion>> TransceleratorQuestions(string curUserId, string projectId)
+    {
+        await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
+        IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
+        if (!projectDoc.IsLoaded)
+            throw new DataNotFoundException("The project does not exist.");
+        // TODO Checking whether the permissions contains a particular string is not a very robust way to check
+        // permissions. A rights service needs to be created in C# land.
+        if (
+            !IsProjectAdmin(projectDoc.Data, curUserId)
+            && !projectDoc.Data.UserPermissions[curUserId].Contains("questions.create")
+        )
+            throw new ForbiddenException();
+        return _transceleratorService.Questions(projectDoc.Data.ParatextId);
+    }
+
+    /// <summary>
+    /// Ensures that the <see cref="WritingSystem"/> Tag is not null.
+    /// </summary>
+    /// <param name="curUserId">The current user identifier.</param>
+    /// <param name="projectId">The project identifier.</param>
+    /// <returns>The asynchronous task.</returns>
+    /// <remarks>
+    /// This public method exists for the Machine API Migration utility.
+    /// </remarks>
+    public async Task EnsureWritingSystemTagIsSetAsync(string curUserId, string projectId)
+    {
+        using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
+        IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
+        if (!projectDoc.IsLoaded)
+        {
+            throw new DataNotFoundException("The project does not exist.");
+        }
+
+        await EnsureWritingSystemTagIsSetAsync(curUserId, projectDoc, null);
+    }
+
+    protected override async Task AddUserToProjectAsync(
+        IConnection conn,
+        IDocument<SFProject> projectDoc,
+        IDocument<User> userDoc,
+        string projectRole,
+        bool removeShareKeys = true
+    )
+    {
+        await conn.CreateAsync<SFProjectUserConfig>(
+            SFProjectUserConfig.GetDocId(projectDoc.Id, userDoc.Id),
+            new SFProjectUserConfig { ProjectRef = projectDoc.Id, OwnerRef = userDoc.Id }
+        );
+        // Listeners can now assume the ProjectUserConfig is ready when the user is added.
+        await base.AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole, removeShareKeys);
+
+        // Update book and chapter permissions on SF project/resource, but only if user
+        // has a role on the PT project or permissions to the DBL resource. These permissions are needed
+        // in order to query the PT roles and DBL permissions of other SF project/resource users.
+        if ((await TryGetProjectRoleAsync(projectDoc.Data, userDoc.Id)).Success)
+        {
+            await UpdatePermissionsAsync(userDoc.Id, projectDoc, CancellationToken.None);
+        }
+
+        // Add to the source project, if required
+        string sourceProjectId = projectDoc.Data.TranslateConfig.Source?.ProjectRef;
+        string sourceParatextId = projectDoc.Data.TranslateConfig.Source?.ParatextId;
+        if (!string.IsNullOrWhiteSpace(sourceProjectId) && !string.IsNullOrWhiteSpace(sourceParatextId))
+        {
+            // Load the source project role from MongoDB
+            IDocument<SFProject> sourceProjectDoc = await TryGetProjectDocAsync(sourceProjectId, conn);
+            if (sourceProjectDoc == null)
+                return;
+            if (sourceProjectDoc.IsLoaded && !sourceProjectDoc.Data.UserRoles.ContainsKey(userDoc.Id))
+            {
+                // Not found in Mongo, so load the project role from Paratext
+                Attempt<string> attempt = await TryGetProjectRoleAsync(sourceProjectDoc.Data, userDoc.Id);
+                if (attempt.TryResult(out string sourceProjectRole))
                 {
-                    throw new DataNotFoundException("The source paratext project does not exist.");
+                    // If they are in Paratext, add the user to the source project
+                    await this.AddUserToProjectAsync(
+                        conn,
+                        sourceProjectDoc,
+                        userDoc,
+                        sourceProjectRole,
+                        removeShareKeys
+                    );
                 }
             }
+        }
+    }
 
-            // Get the users who will access this source resource or project
-            IEnumerable<string> userIds = userRoles != null ? userRoles.Keys : new string[] { curUserId };
+    /// <summary>
+    /// Update all user permissions on books and chapters in an SF project, from PT project permissions. For Paratext
+    /// projects, permissions are acquired from ScrText objects, and so presumably only what was received from
+    /// Paratext in the last synchronize. For Resources, permissions are fetched from a DBL server, and so permissions
+    /// may be ahead of the last sync.
+    /// Note that this method is not necessarily applying permissions for user `curUserId`, but rather using that
+    /// user to perform PT queries and set values in the SF DB.
+    /// </summary>
+    public async Task UpdatePermissionsAsync(string curUserId, IDocument<SFProject> projectDoc, CancellationToken token)
+    {
+        Attempt<UserSecret> userSecretAttempt = await _userSecrets.TryGetAsync(curUserId);
+        if (!userSecretAttempt.TryResult(out UserSecret userSecret))
+        {
+            throw new DataNotFoundException("No matching user secrets found.");
+        }
 
-            // Get the project reference
-            SFProject sourceProject = RealtimeService
-                .QuerySnapshots<SFProject>()
-                .FirstOrDefault(p => p.ParatextId == paratextId);
-            if (sourceProject != null)
+        string paratextId = projectDoc.Data.ParatextId;
+        HashSet<int> booksInProject = new HashSet<int>(_paratextService.GetBookList(userSecret, paratextId));
+        IReadOnlyDictionary<string, string> ptUsernameMapping = await _paratextService.GetParatextUsernameMappingAsync(
+            userSecret,
+            projectDoc.Data,
+            token
+        );
+        bool isResource = _paratextService.IsResource(paratextId);
+        // Place to collect all chapter permissions to record in the project.
+        var projectChapterPermissions =
+            new List<(int bookIndex, int chapterIndex, Dictionary<string, string> chapterPermissions)>();
+        // Place to collect all book permissions to record in the project.
+        var projectBookPermissions = new List<(int bookIndex, Dictionary<string, string> bookPermissions)>();
+
+        Dictionary<string, string> resourcePermissions = null;
+        if (isResource)
+        {
+            // Note that DBL specifies permission for a resource with granularity of the whole resource. We will
+            // write in the SF DB that whole-resource permission but on each book and chapter.
+            resourcePermissions = await _paratextService.GetPermissionsAsync(
+                userSecret,
+                projectDoc.Data,
+                ptUsernameMapping,
+                0,
+                0,
+                token
+            );
+        }
+
+        foreach (int bookNum in booksInProject)
+        {
+            int textIndex = projectDoc.Data.Texts.FindIndex(t => t.BookNum == bookNum);
+            if (textIndex == -1)
             {
-                sourceProjectRef = sourceProject.Id;
+                // Project does not contain specified book.
+                // This is expected if a user is connecting a project for the first time, as the project may not
+                // have been synchronized yet.
+                continue;
+            }
+            Models.TextInfo text = projectDoc.Data.Texts[textIndex];
+            List<Chapter> chapters = text.Chapters;
+            Dictionary<string, string> bookPermissions = null;
+            IEnumerable<(
+                int bookIndex,
+                int chapterIndex,
+                Dictionary<string, string> chapterPermissions
+            )> chapterPermissionsInBook = null;
+
+            if (isResource)
+            {
+                bookPermissions = resourcePermissions;
+                // Prepare to write the same resource permission for each chapter in the book/text.
+                chapterPermissionsInBook = chapters.Select(
+                    (Chapter chapter, int chapterIndex) => (textIndex, chapterIndex, bookPermissions)
+                );
             }
             else
             {
-                sourceProjectRef = await this.CreateResourceProjectAsync(curUserId, paratextId);
-            }
+                bookPermissions = await _paratextService.GetPermissionsAsync(
+                    userSecret,
+                    projectDoc.Data,
+                    ptUsernameMapping,
+                    bookNum,
+                    0,
+                    token
+                );
 
-            // Add each user in the target project to the source project so they can access it
-            foreach (string userId in userIds)
-            {
-                try
-                {
-                    // Add the user to the project, if the user does not have a role in it
-                    if (sourceProject == null || !sourceProject.UserRoles.ContainsKey(userId))
-                    {
-                        await this.AddUserAsync(userId, sourceProjectRef, null);
-                    }
-                }
-                catch (ForbiddenException)
-                {
-                    // The user does not have Paratext access
-                }
+                // Get the project permissions for the chapters
+                chapterPermissionsInBook = await Task.WhenAll(
+                    chapters.Select(
+                        async (Chapter chapter, int chapterIndex) =>
+                        {
+                            Dictionary<string, string> chapterPermissions = await _paratextService.GetPermissionsAsync(
+                                userSecret,
+                                projectDoc.Data,
+                                ptUsernameMapping,
+                                bookNum,
+                                chapter.Number,
+                                token
+                            );
+                            return (textIndex, chapterIndex, chapterPermissions);
+                        }
+                    )
+                );
             }
-
-            return new TranslateSource
-            {
-                ParatextId = paratextId,
-                ProjectRef = sourceProjectRef,
-                Name = sourcePTProject.Name,
-                ShortName = sourcePTProject.ShortName,
-                WritingSystem = new WritingSystem { Tag = sourcePTProject.LanguageTag }
-            };
+            projectChapterPermissions.AddRange(chapterPermissionsInBook);
+            projectBookPermissions.Add((textIndex, bookPermissions));
         }
 
-        private string[] GetProjectWithReferenceToSource(string projectId)
+        // Update project metadata
+        await projectDoc.SubmitJson0OpAsync(op =>
         {
-            if (string.IsNullOrEmpty(projectId))
-                return new string[0];
-            IQueryable<SFProject> projectQuery = RealtimeService.QuerySnapshots<SFProject>();
-            return projectQuery
-                .Where(p => p.TranslateConfig.Source != null && p.TranslateConfig.Source.ProjectRef == projectId)
-                .Select(p => p.Id)
-                .ToArray();
-        }
-
-        /// <summary> Determines if a user on a project has the right to share a specific role. </summary>
-        private bool CanUserShareRole(string userId, SFProject project, string role)
-        {
-            if (!IsOnProject(project, userId))
-                return false;
-            if (role == SFProjectRole.CommunityChecker)
-                return true;
-
-            if (role == SFProjectRole.Reviewer)
+            foreach ((int bookIndex, Dictionary<string, string> bookPermissions) in projectBookPermissions)
             {
-                // This may change if we decide that other users should be able to invite reviewers
-                if (IsProjectAdmin(project, userId))
-                    return true;
+                op.Set(pd => pd.Texts[bookIndex].Permissions, bookPermissions, _permissionDictionaryEqualityComparer);
             }
-            else if (role == SFProjectRole.SFObserver)
-            {
-                if (HasParatextRole(project, userId))
-                    return true;
-                if (project.UserRoles.TryGetValue(userId, out string projectRole))
-                {
-                    if (projectRole == SFProjectRole.Reviewer || projectRole == SFProjectRole.SFObserver)
-                        return true;
-                }
-            }
-            return false;
-        }
-
-        /// <summary>
-        /// Ensures that the <see cref="WritingSystem"/> Tag is not null.
-        /// </summary>
-        /// <param name="curUserId">The current user identifier.</param>
-        /// <param name="projectDoc">The project document to check</param>
-        /// <param name="ptProjects">
-        /// The available Paratext projects. If null, the projects will be retrieved from the server.
-        /// </param>
-        /// <returns>The asynchronous task.</returns>
-        /// <exception cref="DataNotFoundException">
-        /// A user secret could not be returned for the user identifier.
-        /// </exception>
-        /// <remarks>
-        /// A issue was introduced in an early version of ScriptureForge where the writing system tag was not set when
-        /// the project was created. This issue has since been fixed. The Machine API requires the writing system tag
-        /// to be specified, and so this method should be called before a project is created in the Machine API to
-        /// ensure that it can be created without error. If the writing system tag is already set, it is not modified.
-        /// If this is a back translation, the writing system tag will not be set here, but will be set on the first
-        /// project build in <see cref="MachineProjectService"/>, as if this method does not update the writing system
-        /// tags, the Machine API Translation Engine creation will be delayed until first build.
-        /// </remarks>
-        private async Task EnsureWritingSystemTagIsSetAsync(
-            string curUserId,
-            IDocument<SFProject> projectDoc,
-            IReadOnlyList<ParatextProject>? ptProjects
-        )
-        {
-            // If we do not have a writing system tag
-            if (
-                string.IsNullOrWhiteSpace(projectDoc.Data.WritingSystem.Tag)
-                || string.IsNullOrWhiteSpace(projectDoc.Data.TranslateConfig.Source?.WritingSystem.Tag)
+            foreach (
+                (
+                    int bookIndex,
+                    int chapterIndex,
+                    Dictionary<string, string> chapterPermissions
+                ) in projectChapterPermissions
             )
             {
-                // Get the projects, if they are missing
-                if (ptProjects == null)
-                {
-                    Attempt<UserSecret> userSecretAttempt = await _userSecrets.TryGetAsync(curUserId);
-                    if (!userSecretAttempt.TryResult(out UserSecret userSecret))
-                        throw new DataNotFoundException("The user does not exist.");
+                op.Set(
+                    pd => pd.Texts[bookIndex].Chapters[chapterIndex].Permissions,
+                    chapterPermissions,
+                    _permissionDictionaryEqualityComparer
+                );
+            }
+        });
+    }
 
-                    ptProjects = await _paratextService.GetProjectsAsync(userSecret);
+    protected override async Task RemoveUserFromProjectAsync(
+        IConnection conn,
+        IDocument<SFProject> projectDoc,
+        IDocument<User> userDoc
+    )
+    {
+        await base.RemoveUserFromProjectAsync(conn, projectDoc, userDoc);
+        IDocument<SFProjectUserConfig> projectUserConfigDoc = await conn.FetchAsync<SFProjectUserConfig>(
+            SFProjectUserConfig.GetDocId(projectDoc.Id, userDoc.Id)
+        );
+        await projectUserConfigDoc.DeleteAsync();
+    }
+
+    /// <summary>
+    /// Returns `userId`'s role on project or resource `project`.
+    /// The role may be the PT role from PT Registry, or a SF role.
+    /// The returned Attempt will be Success if they have a non-None role, or otherwise Failure.
+    /// </summary>
+    protected async override Task<Attempt<string>> TryGetProjectRoleAsync(SFProject project, string userId)
+    {
+        Attempt<UserSecret> userSecretAttempt = await _userSecrets.TryGetAsync(userId);
+        if (userSecretAttempt.TryResult(out UserSecret userSecret))
+        {
+            if (_paratextService.IsResource(project.ParatextId))
+            {
+                // If the project is a resource, get the permission from the DBL
+                string permission = await _paratextService.GetResourcePermissionAsync(
+                    project.ParatextId,
+                    userId,
+                    CancellationToken.None
+                );
+                return permission switch
+                {
+                    TextInfoPermission.None => Attempt.Failure(ProjectRole.None),
+                    TextInfoPermission.Read => Attempt.Success(SFProjectRole.PTObserver),
+                    _
+                        => throw new ArgumentException(
+                            $"Unknown resource permission: '{permission}'",
+                            nameof(permission)
+                        ),
+                };
+            }
+            else
+            {
+                Attempt<string> roleAttempt = await _paratextService.TryGetProjectRoleAsync(
+                    userSecret,
+                    project.ParatextId,
+                    CancellationToken.None
+                );
+                if (roleAttempt.TryResult(out string role))
+                {
+                    return Attempt.Success(role);
                 }
+            }
+        }
 
-                // Update the writing system tag, if it is in the Paratext project
-                if (string.IsNullOrWhiteSpace(projectDoc.Data.WritingSystem.Tag))
+        return Attempt.Failure(ProjectRole.None);
+    }
+
+    private async Task<IDocument<SFProject>> TryGetProjectDocAsync(string projectId, IConnection conn)
+    {
+        try
+        {
+            IDocument<SFProject> projectDoc = await base.GetProjectDocAsync(projectId, conn);
+            return projectDoc;
+        }
+        catch (DataNotFoundException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Determines whether the user is a project translator for the specified project.
+    /// </summary>
+    /// <param name="project">The project.</param>
+    /// <param name="userId">The user identifier.</param>
+    /// <returns>
+    ///   <c>true</c> if a project translator; otherwise, <c>false</c>.
+    /// </returns>
+    /// <remarks>
+    /// This only checks the local project, and is based on <see cref="ProjectService.IsProjectAdmin" />.
+    /// </remarks>
+    private static bool IsProjectTranslator(SFProject project, string userId) =>
+        project.UserRoles.TryGetValue(userId, out string role) && role == SFProjectRole.Translator;
+
+    private static bool HasParatextRole(SFProject project, string userId) =>
+        project.UserRoles.TryGetValue(userId, out string role) && SFProjectRole.IsParatextRole(role);
+
+    private static void UpdateSetting<T>(
+        Json0OpBuilder<SFProject> builder,
+        Expression<Func<SFProject, T>> field,
+        T setting,
+        bool forceUpdate = false
+    )
+    {
+        if (setting != null || forceUpdate)
+            builder.Set(field, setting);
+    }
+
+    /// <summary>
+    /// Asynchronously creates a Scripture Forge project from Paratext resource/project.
+    /// </summary>
+    /// <param name="curUserId">The current user identifier.</param>
+    /// <param name="ptProject">The paratext project.</param>
+    /// <returns>SF project id of created project</returns>
+    /// <remarks>
+    /// This method will also work for a source project that has been deleted for some reason.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException"></exception>
+    private async Task<string> CreateResourceProjectInternalAsync(string curUserId, ParatextProject ptProject)
+    {
+        var project = new SFProject
+        {
+            ParatextId = ptProject.ParatextId,
+            Name = ptProject.Name,
+            ShortName = ptProject.ShortName,
+            WritingSystem = new WritingSystem { Tag = ptProject.LanguageTag },
+            TranslateConfig = new TranslateConfig { TranslationSuggestionsEnabled = false, Source = null },
+            CheckingConfig = new CheckingConfig { CheckingEnabled = false }
+        };
+
+        // Create the new project using the realtime service
+        string projectId = ObjectId.GenerateNewId().ToString();
+        await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
+        {
+            if (
+                this.RealtimeService
+                    .QuerySnapshots<SFProject>()
+                    .Any((SFProject sfProject) => sfProject.ParatextId == project.ParatextId)
+            )
+            {
+                throw new InvalidOperationException(ErrorAlreadyConnectedKey);
+            }
+            IDocument<SFProject> projectDoc = await conn.CreateAsync(projectId, project);
+            await ProjectSecrets.InsertAsync(new SFProjectSecret { Id = projectDoc.Id });
+
+            // Resource projects do not have administrators, so users are added as needed
+        }
+
+        return projectId;
+    }
+
+    /// <summary>
+    /// Gets the translate source asynchronously.
+    /// </summary>
+    /// <param name="curUserId">The current user identifier.</param>
+    /// <param name="userSecret">The user secret.</param>
+    /// <param name="paratextId">The paratext identifier.</param>
+    /// <param name="ptProjects">The paratext projects.</param>
+    /// <param name="userIds">The ids and roles of the users who will need to access the source.</param>
+    /// <returns>The <see cref="TranslateSource"/> object for the specified resource.</returns>
+    /// <exception cref="DataNotFoundException">The source paratext project does not exist.</exception>
+    private async Task<TranslateSource> GetTranslateSourceAsync(
+        string curUserId,
+        UserSecret userSecret,
+        string paratextId,
+        IReadOnlyList<ParatextProject> ptProjects,
+        IReadOnlyDictionary<string, string> userRoles = null
+    )
+    {
+        ParatextProject sourcePTProject = ptProjects.SingleOrDefault(p => p.ParatextId == paratextId);
+        string sourceProjectRef = null;
+        if (sourcePTProject == null)
+        {
+            // If it is not a project, see if there is a matching resource
+            IReadOnlyList<ParatextResource> resources = await this._paratextService.GetResourcesAsync(curUserId);
+            sourcePTProject = resources.SingleOrDefault(r => r.ParatextId == paratextId);
+            if (sourcePTProject == null)
+            {
+                throw new DataNotFoundException("The source paratext project does not exist.");
+            }
+        }
+
+        // Get the users who will access this source resource or project
+        IEnumerable<string> userIds = userRoles != null ? userRoles.Keys : new string[] { curUserId };
+
+        // Get the project reference
+        SFProject sourceProject = RealtimeService
+            .QuerySnapshots<SFProject>()
+            .FirstOrDefault(p => p.ParatextId == paratextId);
+        if (sourceProject != null)
+        {
+            sourceProjectRef = sourceProject.Id;
+        }
+        else
+        {
+            sourceProjectRef = await this.CreateResourceProjectAsync(curUserId, paratextId);
+        }
+
+        // Add each user in the target project to the source project so they can access it
+        foreach (string userId in userIds)
+        {
+            try
+            {
+                // Add the user to the project, if the user does not have a role in it
+                if (sourceProject == null || !sourceProject.UserRoles.ContainsKey(userId))
                 {
-                    ParatextProject ptProject = ptProjects.FirstOrDefault(p => p.ProjectId == projectDoc.Id);
-                    if (!string.IsNullOrEmpty(ptProject?.LanguageTag))
-                    {
-                        await projectDoc.SubmitJson0OpAsync(op =>
-                        {
-                            UpdateSetting(op, p => p.WritingSystem.Tag, ptProject.LanguageTag);
-                        });
-                    }
+                    await this.AddUserAsync(userId, sourceProjectRef, null);
                 }
+            }
+            catch (ForbiddenException)
+            {
+                // The user does not have Paratext access
+            }
+        }
 
-                // Update the source writing system tag, if it is in the Paratext project
-                if (string.IsNullOrWhiteSpace(projectDoc.Data.TranslateConfig.Source?.WritingSystem.Tag))
+        return new TranslateSource
+        {
+            ParatextId = paratextId,
+            ProjectRef = sourceProjectRef,
+            Name = sourcePTProject.Name,
+            ShortName = sourcePTProject.ShortName,
+            WritingSystem = new WritingSystem { Tag = sourcePTProject.LanguageTag }
+        };
+    }
+
+    private string[] GetProjectWithReferenceToSource(string projectId)
+    {
+        if (string.IsNullOrEmpty(projectId))
+            return Array.Empty<string>();
+        IQueryable<SFProject> projectQuery = RealtimeService.QuerySnapshots<SFProject>();
+        return projectQuery
+            .Where(p => p.TranslateConfig.Source != null && p.TranslateConfig.Source.ProjectRef == projectId)
+            .Select(p => p.Id)
+            .ToArray();
+    }
+
+    /// <summary> Determines if a user on a project has the right to share a specific role. </summary>
+    private bool CanUserShareRole(string userId, SFProject project, string role)
+    {
+        if (!IsOnProject(project, userId))
+            return false;
+        if (role == SFProjectRole.CommunityChecker)
+            return true;
+
+        if (role == SFProjectRole.Reviewer)
+        {
+            // This may change if we decide that other users should be able to invite reviewers
+            if (IsProjectAdmin(project, userId))
+                return true;
+        }
+        else if (role == SFProjectRole.SFObserver)
+        {
+            if (HasParatextRole(project, userId))
+                return true;
+            if (project.UserRoles.TryGetValue(userId, out string projectRole))
+            {
+                if (projectRole == SFProjectRole.Reviewer || projectRole == SFProjectRole.SFObserver)
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Ensures that the <see cref="WritingSystem"/> Tag is not null.
+    /// </summary>
+    /// <param name="curUserId">The current user identifier.</param>
+    /// <param name="projectDoc">The project document to check</param>
+    /// <param name="ptProjects">
+    /// The available Paratext projects. If null, the projects will be retrieved from the server.
+    /// </param>
+    /// <returns>The asynchronous task.</returns>
+    /// <exception cref="DataNotFoundException">
+    /// A user secret could not be returned for the user identifier.
+    /// </exception>
+    /// <remarks>
+    /// A issue was introduced in an early version of ScriptureForge where the writing system tag was not set when
+    /// the project was created. This issue has since been fixed. The Machine API requires the writing system tag
+    /// to be specified, and so this method should be called before a project is created in the Machine API to
+    /// ensure that it can be created without error. If the writing system tag is already set, it is not modified.
+    /// If this is a back translation, the writing system tag will not be set here, but will be set on the first
+    /// project build in <see cref="MachineProjectService"/>, as if this method does not update the writing system
+    /// tags, the Machine API Translation Engine creation will be delayed until first build.
+    /// </remarks>
+    private async Task EnsureWritingSystemTagIsSetAsync(
+        string curUserId,
+        IDocument<SFProject> projectDoc,
+        IReadOnlyList<ParatextProject>? ptProjects
+    )
+    {
+        // If we do not have a writing system tag
+        if (
+            string.IsNullOrWhiteSpace(projectDoc.Data.WritingSystem.Tag)
+            || string.IsNullOrWhiteSpace(projectDoc.Data.TranslateConfig.Source?.WritingSystem.Tag)
+        )
+        {
+            // Get the projects, if they are missing
+            if (ptProjects == null)
+            {
+                Attempt<UserSecret> userSecretAttempt = await _userSecrets.TryGetAsync(curUserId);
+                if (!userSecretAttempt.TryResult(out UserSecret userSecret))
+                    throw new DataNotFoundException("The user does not exist.");
+
+                ptProjects = await _paratextService.GetProjectsAsync(userSecret);
+            }
+
+            // Update the writing system tag, if it is in the Paratext project
+            if (string.IsNullOrWhiteSpace(projectDoc.Data.WritingSystem.Tag))
+            {
+                ParatextProject ptProject = ptProjects.FirstOrDefault(p => p.ProjectId == projectDoc.Id);
+                if (!string.IsNullOrEmpty(ptProject?.LanguageTag))
                 {
-                    ParatextProject ptProject = ptProjects.FirstOrDefault(
-                        p => p.ParatextId == projectDoc.Data.TranslateConfig.Source.ParatextId
+                    await projectDoc.SubmitJson0OpAsync(
+                        op => UpdateSetting(op, p => p.WritingSystem.Tag, ptProject.LanguageTag)
                     );
-                    if (!string.IsNullOrEmpty(ptProject?.LanguageTag))
-                    {
-                        await projectDoc.SubmitJson0OpAsync(op =>
-                        {
-                            UpdateSetting(op, p => p.TranslateConfig.Source.WritingSystem.Tag, ptProject.LanguageTag);
-                        });
-                    }
+                }
+            }
+
+            // Update the source writing system tag, if it is in the Paratext project
+            if (string.IsNullOrWhiteSpace(projectDoc.Data.TranslateConfig.Source?.WritingSystem.Tag))
+            {
+                ParatextProject ptProject = ptProjects.FirstOrDefault(
+                    p => p.ParatextId == projectDoc.Data.TranslateConfig.Source.ParatextId
+                );
+                if (!string.IsNullOrEmpty(ptProject?.LanguageTag))
+                {
+                    await projectDoc.SubmitJson0OpAsync(
+                        op => UpdateSetting(op, p => p.TranslateConfig.Source.WritingSystem.Tag, ptProject.LanguageTag)
+                    );
                 }
             }
         }

--- a/src/SIL.XForge.Scripture/Services/SFScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/SFScrTextCollection.cs
@@ -3,80 +3,67 @@ using System.Collections.Generic;
 using Paratext.Data;
 using SIL.WritingSystems;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// Subclass of ParatextData ScrTextCollection that allows us to specify things like SettingsDirectory, but without
+/// additional side effects of using the full ScrTextCollection that we may not be ready for yet or not want when
+/// using ParatextData from Scripture Forge.
+/// </summary>
+public class SFScrTextCollection : ScrTextCollection
 {
-    /// <summary>
-    /// Subclass of ParatextData ScrTextCollection that allows us to specify things like SettingsDirectory, but without
-    /// additional side effects of using the full ScrTextCollection that we may not be ready for yet or not want when
-    /// using ParatextData from Scripture Forge.
-    /// </summary>
-    public class SFScrTextCollection : ScrTextCollection
+    // Keep track of languages that weren't found in SLDR so we don't call over and over for the same bad code.
+    private static readonly List<string> _sldrLookupFailed = new List<string>();
+
+    protected override string DictionariesDirectoryInternal => null;
+
+    protected override void InitializeInternal(string settingsDir, bool allowMigration)
     {
-        // Keep track of languages that weren't found in SLDR so we don't call over and over for the same bad code.
-        private static readonly List<string> _sldrLookupFailed = new List<string>();
+        if (SettingsDirectoryInternal != null && (SettingsDirectoryInternal == settingsDir || settingsDir == null))
+            return;
 
-        protected override string DictionariesDirectoryInternal => null;
-
-        protected override void InitializeInternal(string settingsDir, bool allowMigration)
-        {
-            if (SettingsDirectoryInternal != null && (SettingsDirectoryInternal == settingsDir || settingsDir == null))
-                return;
-
-            // Get settings directory
-            if (settingsDir != null)
-                SettingsDirectoryInternal = settingsDir;
-        }
-
-        protected override void RefreshScrTextsInternal(bool allowMigration)
-        {
-            throw new NotImplementedException("This method should not be used in SF context.");
-        }
-
-        protected override string SelectSettingsFolder()
-        {
-            throw new NotImplementedException("This method should not be used in SF context.");
-        }
-
-        protected override void DeleteDirToRecycleBin(string dir)
-        {
-            throw new NotImplementedException("This method should not be used in SF context.");
-        }
-
-        /// <remarks>This method's implementation was mostly copied from ParatextBase.</remarks>
-        protected override WritingSystemDefinition CreateWsDef(string languageId, bool allowSldr)
-        {
-            // Only check SLDR if allowed for this call and all internet access is enabled - SLDR isn't set up to use proxy.
-            WritingSystemDefinition wsDef = null;
-            if (allowSldr && InternetAccess.Status == InternetUse.Enabled && !_sldrLookupFailed.Contains(languageId))
-            {
-                try
-                {
-                    var sldrFactory = new SldrWritingSystemFactory();
-                    sldrFactory.Create(languageId, out wsDef);
-                }
-                catch (Exception)
-                {
-                    // Ignore any SLDR errors - there have been problems with entries on the server failing to parse.
-                    // Also the id being provided may not be valid.
-                    _sldrLookupFailed.Add(languageId);
-                }
-            }
-            return wsDef;
-        }
-
-        protected override UnsupportedReason MigrateProjectIfNeeded(ScrText scrText)
-        {
-            throw new NotImplementedException("This method should not be used in SF context.");
-        }
-
-        protected override ScrText CreateResourceProject(ProjectName name)
-        {
-            throw new NotImplementedException("This method should not be used in SF context.");
-        }
-
-        protected override ScrText MarbleResourceLookup(string name)
-        {
-            throw new NotImplementedException("This method should not be used in SF context.");
-        }
+        // Get settings directory
+        if (settingsDir != null)
+            SettingsDirectoryInternal = settingsDir;
     }
+
+    protected override void RefreshScrTextsInternal(bool allowMigration) =>
+        throw new NotImplementedException("This method should not be used in SF context.");
+
+    protected override string SelectSettingsFolder() =>
+        throw new NotImplementedException("This method should not be used in SF context.");
+
+    protected override void DeleteDirToRecycleBin(string dir) =>
+        throw new NotImplementedException("This method should not be used in SF context.");
+
+    /// <remarks>This method's implementation was mostly copied from ParatextBase.</remarks>
+    protected override WritingSystemDefinition CreateWsDef(string languageId, bool allowSldr)
+    {
+        // Only check SLDR if allowed for this call and all internet access is enabled - SLDR isn't set up to use proxy.
+        WritingSystemDefinition wsDef = null;
+        if (allowSldr && InternetAccess.Status == InternetUse.Enabled && !_sldrLookupFailed.Contains(languageId))
+        {
+            try
+            {
+                var sldrFactory = new SldrWritingSystemFactory();
+                sldrFactory.Create(languageId, out wsDef);
+            }
+            catch (Exception)
+            {
+                // Ignore any SLDR errors - there have been problems with entries on the server failing to parse.
+                // Also the id being provided may not be valid.
+                _sldrLookupFailed.Add(languageId);
+            }
+        }
+        return wsDef;
+    }
+
+    protected override UnsupportedReason MigrateProjectIfNeeded(ScrText scrText) =>
+        throw new NotImplementedException("This method should not be used in SF context.");
+
+    protected override ScrText CreateResourceProject(ProjectName name) =>
+        throw new NotImplementedException("This method should not be used in SF context.");
+
+    protected override ScrText MarbleResourceLookup(string name) =>
+        throw new NotImplementedException("This method should not be used in SF context.");
 }

--- a/src/SIL.XForge.Scripture/Services/SFScriptureText.cs
+++ b/src/SIL.XForge.Scripture/Services/SFScriptureText.cs
@@ -7,131 +7,127 @@ using SIL.Machine.Corpora;
 using SIL.Machine.Tokenization;
 using SIL.Machine.Utils;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>Set of Scripture text segments.</summary>
+public class SFScriptureText : IText
 {
-    /// <summary>Set of Scripture text segments.</summary>
-    public class SFScriptureText : IText
+    private readonly IEnumerable<TextSegment> _segments;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SFScriptureText"/> class.
+    /// </summary>
+    /// <remarks>Builds segments from texts and references.
+    /// Will use ops in doc that have an insert and a segment attribute providing reference information.
+    /// For example,
+    /// { "insert": "In the beginning ...",
+    ///   "attributes": { "segment": "verse_1_1" } }
+    /// </remarks>
+    public SFScriptureText(
+        ITokenizer<string, int, string> wordTokenizer,
+        string projectId,
+        int book,
+        int chapter,
+        BsonDocument doc
+    )
     {
-        private readonly IEnumerable<TextSegment> _segments;
+        if (doc == null)
+            throw new ArgumentNullException(nameof(doc));
+        doc.TryGetValue("ops", out BsonValue ops);
+        if (ops as BsonArray == null)
+            throw new ArgumentException(@"Doc is missing ops, perhaps the doc was deleted.", nameof(doc));
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SFScriptureText"/> class.
-        /// </summary>
-        /// <remarks>Builds segments from texts and references.
-        /// Will use ops in doc that have an insert and a segment attribute providing reference information.
-        /// For example,
-        /// { "insert": "In the beginning ...",
-        ///   "attributes": { "segment": "verse_1_1" } }
-        /// </remarks>
-        public SFScriptureText(
-            ITokenizer<string, int, string> wordTokenizer,
-            string projectId,
-            int book,
-            int chapter,
-            BsonDocument doc
-        )
+        Id = $"{projectId}_{book}_{chapter}";
+        _segments = GetSegments(wordTokenizer, doc).OrderBy(s => s.SegmentRef).ToArray();
+    }
+
+    public string Id { get; }
+
+    public string SortKey => Id;
+
+    public IEnumerable<TextSegment> GetSegments(bool includeText = true, IText? basedOn = null) => _segments;
+
+    private IEnumerable<TextSegment> GetSegments(ITokenizer<string, int, string> wordTokenizer, BsonDocument doc)
+    {
+        string prevRef = null;
+        bool isSentenceStart = true;
+        bool isInRange = false;
+        var sb = new StringBuilder();
+        var ops = (BsonArray)doc["ops"];
+        foreach (BsonDocument op in ops.Cast<BsonDocument>())
         {
-            if (doc == null)
-                throw new ArgumentNullException(nameof(doc));
-            doc.TryGetValue("ops", out BsonValue ops);
-            if (ops as BsonArray == null)
-                throw new ArgumentException(@"Doc is missing ops, perhaps the doc was deleted.", nameof(doc));
+            // skip embeds
+            if (!op.TryGetValue("insert", out BsonValue value) || value.BsonType != BsonType.String)
+                continue;
 
-            Id = $"{projectId}_{book}_{chapter}";
-            _segments = GetSegments(wordTokenizer, doc).OrderBy(s => s.SegmentRef).ToArray();
-        }
+            if (!op.TryGetValue("attributes", out BsonValue attrsValue))
+                continue;
 
-        public string Id { get; }
+            BsonDocument attrs = attrsValue.AsBsonDocument;
+            if (!attrs.TryGetValue("segment", out BsonValue segmentValue))
+                continue;
 
-        public string SortKey => Id;
-
-        public IEnumerable<TextSegment> GetSegments(bool includeText = true, IText? basedOn = null)
-        {
-            return _segments;
-        }
-
-        private IEnumerable<TextSegment> GetSegments(ITokenizer<string, int, string> wordTokenizer, BsonDocument doc)
-        {
-            string prevRef = null;
-            bool isSentenceStart = true;
-            bool isInRange = false;
-            var sb = new StringBuilder();
-            var ops = (BsonArray)doc["ops"];
-            foreach (BsonDocument op in ops.Cast<BsonDocument>())
+            string curRef = segmentValue.AsString;
+            if (prevRef != null && prevRef != curRef)
             {
-                // skip embeds
-                if (!op.TryGetValue("insert", out BsonValue value) || value.BsonType != BsonType.String)
-                    continue;
+                // The prev range is a range start if the current reference has a '/' (is in a range)
+                // i.e. verse_1_1/li_1
+                bool curRefIsInRange = curRef.Contains('/');
+                bool isRangeStart = curRef.StartsWith(prevRef) && curRefIsInRange;
 
-                if (!op.TryGetValue("attributes", out BsonValue attrsValue))
-                    continue;
+                // We are in range if the previous or current reference contains a '/' (is in a range)
+                bool prevRefIsInRange = prevRef.Contains('/');
+                isInRange = curRefIsInRange || prevRefIsInRange;
 
-                BsonDocument attrs = attrsValue.AsBsonDocument;
-                if (!attrs.TryGetValue("segment", out BsonValue segmentValue))
-                    continue;
-
-                string curRef = segmentValue.AsString;
-                if (prevRef != null && prevRef != curRef)
-                {
-                    // The prev range is a range start if the current reference has a '/' (is in a range)
-                    // i.e. verse_1_1/li_1
-                    bool curRefIsInRange = curRef.Contains('/');
-                    bool isRangeStart = curRef.StartsWith(prevRef) && curRefIsInRange;
-
-                    // We are in range if the previous or current reference contains a '/' (is in a range)
-                    bool prevRefIsInRange = prevRef.Contains('/');
-                    isInRange = curRefIsInRange || prevRefIsInRange;
-
-                    // Return the previous segment, using the current segment to calculate ss,ir,rs values
-                    yield return CreateSegment(
-                        wordTokenizer,
-                        prevRef,
-                        sb.ToString(),
-                        isSentenceStart,
-                        isInRange,
-                        isRangeStart
-                    );
-                    isSentenceStart = sb.ToString().HasSentenceEnding();
-                    sb.Clear();
-                }
-
-                string text = value.AsString;
-                sb.Append(text);
-                prevRef = curRef;
+                // Return the previous segment, using the current segment to calculate ss,ir,rs values
+                yield return CreateSegment(
+                    wordTokenizer,
+                    prevRef,
+                    sb.ToString(),
+                    isSentenceStart,
+                    isInRange,
+                    isRangeStart
+                );
+                isSentenceStart = sb.ToString().HasSentenceEnding();
+                sb.Clear();
             }
 
-            if (prevRef != null)
-            {
-                yield return CreateSegment(wordTokenizer, prevRef, sb.ToString(), isSentenceStart, isInRange, false);
-            }
+            string text = value.AsString;
+            sb.Append(text);
+            prevRef = curRef;
         }
 
-        private TextSegment CreateSegment(
-            ITokenizer<string, int, string> wordTokenizer,
-            string segRef,
-            string segmentStr,
-            bool isSentenceStart,
-            bool isInRange,
-            bool isRangeStart
-        )
+        if (prevRef != null)
         {
-            var keys = new List<string>();
-            foreach (string refPart in segRef.Split('/'))
-            {
-                string[] partKeys = refPart.Split('_');
-                // do not include the paragraph style for sub-segments, so that the segments sort correctly
-                keys.AddRange(keys.Count > 0 ? partKeys.Skip(1) : partKeys);
-            }
-            string[] segment = wordTokenizer.Tokenize(segmentStr).ToArray();
-            return new TextSegment(
-                Id,
-                new TextSegmentRef(keys),
-                segment,
-                isSentenceStart,
-                isInRange,
-                isRangeStart,
-                !segment.Any()
-            );
+            yield return CreateSegment(wordTokenizer, prevRef, sb.ToString(), isSentenceStart, isInRange, false);
         }
+    }
+
+    private TextSegment CreateSegment(
+        ITokenizer<string, int, string> wordTokenizer,
+        string segRef,
+        string segmentStr,
+        bool isSentenceStart,
+        bool isInRange,
+        bool isRangeStart
+    )
+    {
+        var keys = new List<string>();
+        foreach (string refPart in segRef.Split('/'))
+        {
+            string[] partKeys = refPart.Split('_');
+            // do not include the paragraph style for sub-segments, so that the segments sort correctly
+            keys.AddRange(keys.Count > 0 ? partKeys.Skip(1) : partKeys);
+        }
+        string[] segment = wordTokenizer.Tokenize(segmentStr).ToArray();
+        return new TextSegment(
+            Id,
+            new TextSegmentRef(keys),
+            segment,
+            isSentenceStart,
+            isInRange,
+            isRangeStart,
+            !segment.Any()
+        );
     }
 }

--- a/src/SIL.XForge.Scripture/Services/SFServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/SFServiceCollectionExtensions.cs
@@ -1,30 +1,29 @@
 using SIL.XForge.Scripture.Services;
 using SIL.XForge.Services;
 
-namespace Microsoft.Extensions.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class SFServiceCollectionExtensions
 {
-    public static class SFServiceCollectionExtensions
+    /// <summary>
+    /// Adds miscellaneous services that are common to all xForge applications to the DI container.
+    /// </summary>
+    public static IServiceCollection AddSFServices(this IServiceCollection services)
     {
-        /// <summary>
-        /// Adds miscellaneous services that are common to all xForge applications to the DI container.
-        /// </summary>
-        public static IServiceCollection AddSFServices(this IServiceCollection services)
-        {
-            services.AddCommonServices();
-            services.AddSingleton<ISyncService, SyncService>();
-            services.AddSingleton<IParatextService, ParatextService>();
-            services.AddTransient<IDeltaUsxMapper, DeltaUsxMapper>();
-            services.AddTransient<IParatextNotesMapper, ParatextNotesMapper>();
-            services.AddSingleton<IGuidService, GuidService>();
-            services.AddSingleton<ISFProjectService, SFProjectService>();
-            services.AddSingleton<IProjectService, SFProjectService>();
-            services.AddSingleton<IJwtTokenHelper, JwtTokenHelper>();
-            services.AddSingleton<IParatextDataHelper, ParatextDataHelper>();
-            services.AddSingleton<IInternetSharedRepositorySourceProvider, InternetSharedRepositorySourceProvider>();
-            services.AddSingleton<ITransceleratorService, TransceleratorService>();
-            services.AddSingleton<ISFRestClientFactory, SFDblRestClientFactory>();
-            services.AddSingleton<IHgWrapper, HgWrapper>();
-            return services;
-        }
+        services.AddCommonServices();
+        services.AddSingleton<ISyncService, SyncService>();
+        services.AddSingleton<IParatextService, ParatextService>();
+        services.AddTransient<IDeltaUsxMapper, DeltaUsxMapper>();
+        services.AddTransient<IParatextNotesMapper, ParatextNotesMapper>();
+        services.AddSingleton<IGuidService, GuidService>();
+        services.AddSingleton<ISFProjectService, SFProjectService>();
+        services.AddSingleton<IProjectService, SFProjectService>();
+        services.AddSingleton<IJwtTokenHelper, JwtTokenHelper>();
+        services.AddSingleton<IParatextDataHelper, ParatextDataHelper>();
+        services.AddSingleton<IInternetSharedRepositorySourceProvider, InternetSharedRepositorySourceProvider>();
+        services.AddSingleton<ITransceleratorService, TransceleratorService>();
+        services.AddSingleton<ISFRestClientFactory, SFDblRestClientFactory>();
+        services.AddSingleton<IHgWrapper, HgWrapper>();
+        return services;
     }
 }

--- a/src/SIL.XForge.Scripture/Services/SFTextCorpusFactory.cs
+++ b/src/SIL.XForge.Scripture/Services/SFTextCorpusFactory.cs
@@ -16,105 +16,102 @@ using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// This class represents a Machine text corpus for a SF project. It is used during batch training of the Machine
+/// translation engine.
+/// </summary>
+public class SFTextCorpusFactory : ITextCorpusFactory
 {
-    /// <summary>
-    /// This class represents a Machine text corpus for a SF project. It is used during batch training of the Machine
-    /// translation engine.
-    /// </summary>
-    public class SFTextCorpusFactory : ITextCorpusFactory
+    private readonly IMongoClient _mongoClient;
+    private readonly IOptions<DataAccessOptions> _dataAccessOptions;
+    private readonly IRealtimeService _realtimeService;
+    private readonly IOptions<SiteOptions> _siteOptions;
+    private readonly IFileSystemService _fileSystemService;
+
+    public SFTextCorpusFactory(
+        IOptions<DataAccessOptions> dataAccessOptions,
+        IRealtimeService realtimeService,
+        IOptions<SiteOptions> siteOptions,
+        IFileSystemService fileSystemService
+    )
     {
-        private readonly IMongoClient _mongoClient;
-        private readonly IOptions<DataAccessOptions> _dataAccessOptions;
-        private readonly IRealtimeService _realtimeService;
-        private readonly IOptions<SiteOptions> _siteOptions;
-        private readonly IFileSystemService _fileSystemService;
+        _dataAccessOptions = dataAccessOptions;
+        _mongoClient = new MongoClient(dataAccessOptions.Value.ConnectionString);
+        _realtimeService = realtimeService;
+        _siteOptions = siteOptions;
+        _fileSystemService = fileSystemService;
+    }
 
-        public SFTextCorpusFactory(
-            IOptions<DataAccessOptions> dataAccessOptions,
-            IRealtimeService realtimeService,
-            IOptions<SiteOptions> siteOptions,
-            IFileSystemService fileSystemService
-        )
-        {
-            _dataAccessOptions = dataAccessOptions;
-            _mongoClient = new MongoClient(dataAccessOptions.Value.ConnectionString);
-            _realtimeService = realtimeService;
-            _siteOptions = siteOptions;
-            _fileSystemService = fileSystemService;
-        }
+    public async Task<ITextCorpus> CreateAsync(IEnumerable<string> projects, TextCorpusType type) =>
+        new DictionaryTextCorpus(await CreateTextsAsync(projects, type));
 
-        public async Task<ITextCorpus> CreateAsync(IEnumerable<string> projects, TextCorpusType type)
+    private async Task<IReadOnlyList<IText>> CreateTextsAsync(IEnumerable<string> projects, TextCorpusType type)
+    {
+        StringTokenizer wordTokenizer = new LatinWordTokenizer();
+        IMongoDatabase database = _mongoClient.GetDatabase(_dataAccessOptions.Value.MongoDatabaseName);
+        IMongoCollection<BsonDocument> textDataColl = database.GetCollection<BsonDocument>(
+            _realtimeService.GetCollectionName<TextData>()
+        );
+        var texts = new List<IText>();
+        foreach (string projectId in projects)
         {
-            return new DictionaryTextCorpus(await CreateTextsAsync(projects, type));
-        }
-
-        private async Task<IReadOnlyList<IText>> CreateTextsAsync(IEnumerable<string> projects, TextCorpusType type)
-        {
-            StringTokenizer wordTokenizer = new LatinWordTokenizer();
-            IMongoDatabase database = _mongoClient.GetDatabase(_dataAccessOptions.Value.MongoDatabaseName);
-            IMongoCollection<BsonDocument> textDataColl = database.GetCollection<BsonDocument>(
-                _realtimeService.GetCollectionName<TextData>()
-            );
-            var texts = new List<IText>();
-            foreach (string projectId in projects)
+            var project = await _realtimeService.GetSnapshotAsync<SFProject>(projectId);
+            if (string.IsNullOrWhiteSpace(project.TranslateConfig.Source?.ProjectRef))
             {
-                var project = await _realtimeService.GetSnapshotAsync<SFProject>(projectId);
-                if (string.IsNullOrWhiteSpace(project.TranslateConfig.Source?.ProjectRef))
+                throw new DataNotFoundException("The source project reference is missing");
+            }
+
+            string textCorpusProjectId;
+            string paratextId;
+            switch (type)
+            {
+                case TextCorpusType.Source:
+                    textCorpusProjectId = project.TranslateConfig.Source.ProjectRef;
+                    paratextId = project.TranslateConfig.Source.ParatextId;
+                    break;
+
+                case TextCorpusType.Target:
+                    textCorpusProjectId = projectId;
+                    paratextId = project.ParatextId;
+                    break;
+
+                default:
+                    throw new InvalidEnumArgumentException(nameof(type), (int)type, typeof(TextCorpusType));
+            }
+
+            foreach (TextInfo text in project.Texts.Where(t => t.HasSource))
+            {
+                foreach (Chapter chapter in text.Chapters)
                 {
-                    throw new DataNotFoundException("The source project reference is missing");
-                }
-
-                string textCorpusProjectId;
-                string paratextId;
-                switch (type)
-                {
-                    case TextCorpusType.Source:
-                        textCorpusProjectId = project.TranslateConfig.Source.ProjectRef;
-                        paratextId = project.TranslateConfig.Source.ParatextId;
-                        break;
-
-                    case TextCorpusType.Target:
-                        textCorpusProjectId = projectId;
-                        paratextId = project.ParatextId;
-                        break;
-
-                    default:
-                        throw new InvalidEnumArgumentException(nameof(type), (int)type, typeof(TextCorpusType));
-                }
-
-                foreach (TextInfo text in project.Texts.Where(t => t.HasSource))
-                {
-                    foreach (Chapter chapter in text.Chapters)
-                    {
-                        string id = TextData.GetTextDocId(textCorpusProjectId, text.BookNum, chapter.Number);
-                        FilterDefinition<BsonDocument> filter = Builders<BsonDocument>.Filter.Eq("_id", id);
-                        BsonDocument doc = await textDataColl.Find(filter).FirstOrDefaultAsync();
-                        if (doc != null && doc.TryGetValue("ops", out BsonValue ops) && ops as BsonArray != null)
-                            texts.Add(new SFScriptureText(wordTokenizer, projectId, text.BookNum, chapter.Number, doc));
-                    }
-                }
-
-                string termRenderingsFileName = Path.Combine(
-                    _siteOptions.Value.SiteDir,
-                    "sync",
-                    paratextId,
-                    "target",
-                    "TermRenderings.xml"
-                );
-                if (_fileSystemService.FileExists(termRenderingsFileName))
-                {
-                    await using Stream stream = _fileSystemService.OpenFile(termRenderingsFileName, FileMode.Open);
-                    XDocument termRenderingsDoc = await XDocument.LoadAsync(
-                        stream,
-                        LoadOptions.None,
-                        CancellationToken.None
-                    );
-                    texts.Add(new SFBiblicalTermsText(wordTokenizer, projectId, termRenderingsDoc));
+                    string id = TextData.GetTextDocId(textCorpusProjectId, text.BookNum, chapter.Number);
+                    FilterDefinition<BsonDocument> filter = Builders<BsonDocument>.Filter.Eq("_id", id);
+                    BsonDocument doc = await textDataColl.Find(filter).FirstOrDefaultAsync();
+                    if (doc != null && doc.TryGetValue("ops", out BsonValue ops) && ops as BsonArray != null)
+                        texts.Add(new SFScriptureText(wordTokenizer, projectId, text.BookNum, chapter.Number, doc));
                 }
             }
 
-            return texts;
+            string termRenderingsFileName = Path.Combine(
+                _siteOptions.Value.SiteDir,
+                "sync",
+                paratextId,
+                "target",
+                "TermRenderings.xml"
+            );
+            if (_fileSystemService.FileExists(termRenderingsFileName))
+            {
+                await using Stream stream = _fileSystemService.OpenFile(termRenderingsFileName, FileMode.Open);
+                XDocument termRenderingsDoc = await XDocument.LoadAsync(
+                    stream,
+                    LoadOptions.None,
+                    CancellationToken.None
+                );
+                texts.Add(new SFBiblicalTermsText(wordTokenizer, projectId, termRenderingsDoc));
+            }
         }
+
+        return texts;
     }
 }

--- a/src/SIL.XForge.Scripture/Services/SharingLogicWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/SharingLogicWrapper.cs
@@ -1,29 +1,21 @@
 using System;
-using System.Linq;
 using System.Collections.Generic;
-using Paratext.Data;
 using Paratext.Data.Repository;
 
-namespace SIL.XForge.Scripture.Services
-{
-    /// <summary>
-    /// Wraps access to static methods on SharingLogic with a class implementing a mockable interface.
-    /// </summary>
-    public class SharingLogicWrapper : ISharingLogicWrapper
-    {
-        public bool ShareChanges(
-            List<SharedProject> sharedProjects,
-            SharedRepositorySource source,
-            out List<SendReceiveResult> results,
-            IList<SharedProject> reviewProjects
-        )
-        {
-            return SharingLogic.ShareChanges(sharedProjects, source, out results, reviewProjects);
-        }
+namespace SIL.XForge.Scripture.Services;
 
-        public bool HandleErrors(Action action, bool throwExceptions = false)
-        {
-            return SharingLogic.HandleErrors(action, throwExceptions);
-        }
-    }
+/// <summary>
+/// Wraps access to static methods on SharingLogic with a class implementing a mockable interface.
+/// </summary>
+public class SharingLogicWrapper : ISharingLogicWrapper
+{
+    public bool ShareChanges(
+        List<SharedProject> sharedProjects,
+        SharedRepositorySource source,
+        out List<SendReceiveResult> results,
+        IList<SharedProject> reviewProjects
+    ) => SharingLogic.ShareChanges(sharedProjects, source, out results, reviewProjects);
+
+    public bool HandleErrors(Action action, bool throwExceptions = false) =>
+        SharingLogic.HandleErrors(action, throwExceptions);
 }

--- a/src/SIL.XForge.Scripture/Services/SyncProgress.cs
+++ b/src/SIL.XForge.Scripture/Services/SyncProgress.cs
@@ -1,31 +1,24 @@
 using System;
 using SIL.XForge.Scripture.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public class SyncProgress : IProgress<ProgressState>
 {
-    public class SyncProgress : IProgress<ProgressState>
+    public event EventHandler? ProgressUpdated;
+    private string _progressString = "";
+    private double _progressValue = 0;
+
+    public double ProgressValue => _progressValue;
+
+    public void Report(ProgressState progressState)
     {
-        public event EventHandler? ProgressUpdated;
-        private string _progressString = "";
-        private double _progressValue = 0;
-
-        public double ProgressValue
-        {
-            get { return _progressValue; }
-        }
-
-        public void Report(ProgressState progressState)
-        {
-            if (progressState.ProgressString != null)
-                _progressString = progressState.ProgressString;
-            if (progressState.ProgressValue > _progressValue)
-                _progressValue = progressState.ProgressValue;
-            OnProgressUpdated(EventArgs.Empty);
-        }
-
-        protected void OnProgressUpdated(EventArgs e)
-        {
-            ProgressUpdated?.Invoke(this, e);
-        }
+        if (progressState.ProgressString != null)
+            _progressString = progressState.ProgressString;
+        if (progressState.ProgressValue > _progressValue)
+            _progressValue = progressState.ProgressValue;
+        OnProgressUpdated(EventArgs.Empty);
     }
+
+    protected void OnProgressUpdated(EventArgs e) => ProgressUpdated?.Invoke(this, e);
 }

--- a/src/SIL.XForge.Scripture/Services/SyncProgressDisplay.cs
+++ b/src/SIL.XForge.Scripture/Services/SyncProgressDisplay.cs
@@ -1,26 +1,16 @@
 using System;
-using SIL.XForge.Scripture.Models;
 using PtxUtils.Progress;
+using SIL.XForge.Scripture.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public class SyncProgressDisplay : ProgressDisplay
 {
-    public class SyncProgressDisplay : ProgressDisplay
-    {
-        private IProgress<ProgressState> _syncProgress;
+    private IProgress<ProgressState> _syncProgress;
 
-        public SyncProgressDisplay(IProgress<ProgressState> progress)
-        {
-            _syncProgress = progress;
-        }
+    public SyncProgressDisplay(IProgress<ProgressState> progress) => _syncProgress = progress;
 
-        public void SetProgressText(string text)
-        {
-            _syncProgress.Report(new ProgressState { ProgressString = text });
-        }
+    public void SetProgressText(string text) => _syncProgress.Report(new ProgressState { ProgressString = text });
 
-        public void SetProgressValue(double value)
-        {
-            _syncProgress.Report(new ProgressState { ProgressValue = value });
-        }
-    }
+    public void SetProgressValue(double value) => _syncProgress.Report(new ProgressState { ProgressValue = value });
 }

--- a/src/SIL.XForge.Scripture/Services/SyncService.cs
+++ b/src/SIL.XForge.Scripture/Services/SyncService.cs
@@ -2,337 +2,303 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Hangfire;
 using Hangfire.States;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Realtime;
 using SIL.XForge.Realtime.Json0;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Services;
-using Microsoft.AspNetCore.SignalR;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// This class manages syncing SF with the Paratext web service APIs.
+/// </summary>
+public class SyncService : ISyncService
 {
-    /// <summary>
-    /// This class manages syncing SF with the Paratext web service APIs.
-    /// </summary>
-    public class SyncService : ISyncService
-    {
-        private readonly IBackgroundJobClient _backgroundJobClient;
-        private readonly IHubContext<NotificationHub, INotifier> _hubContext;
-        private readonly IRepository<SFProjectSecret> _projectSecrets;
-        private readonly IRepository<SyncMetrics> _syncMetrics;
-        private readonly IRealtimeService _realtimeService;
-        private readonly ILogger<SyncService> _logger;
+    private readonly IBackgroundJobClient _backgroundJobClient;
+    private readonly IHubContext<NotificationHub, INotifier> _hubContext;
+    private readonly IRepository<SFProjectSecret> _projectSecrets;
+    private readonly IRepository<SyncMetrics> _syncMetrics;
+    private readonly IRealtimeService _realtimeService;
+    private readonly ILogger<SyncService> _logger;
 
-        public SyncService(
-            IBackgroundJobClient backgroundJobClient,
-            IHubContext<NotificationHub, INotifier> hubContext,
-            IRepository<SFProjectSecret> projectSecrets,
-            IRepository<SyncMetrics> syncMetrics,
-            IRealtimeService realtimeService,
-            ILogger<SyncService> logger
-        )
+    public SyncService(
+        IBackgroundJobClient backgroundJobClient,
+        IHubContext<NotificationHub, INotifier> hubContext,
+        IRepository<SFProjectSecret> projectSecrets,
+        IRepository<SyncMetrics> syncMetrics,
+        IRealtimeService realtimeService,
+        ILogger<SyncService> logger
+    )
+    {
+        _backgroundJobClient = backgroundJobClient;
+        _hubContext = hubContext;
+        _projectSecrets = projectSecrets;
+        _syncMetrics = syncMetrics;
+        _realtimeService = realtimeService;
+        _logger = logger;
+    }
+
+    public async Task SyncAsync(string curUserId, string projectId, bool trainEngine)
+    {
+        await using IConnection conn = await _realtimeService.ConnectAsync(curUserId);
+        // Load the project document
+        IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
+        if (projectDoc.Data.SyncDisabled)
         {
-            _backgroundJobClient = backgroundJobClient;
-            _hubContext = hubContext;
-            _projectSecrets = projectSecrets;
-            _syncMetrics = syncMetrics;
-            _realtimeService = realtimeService;
-            _logger = logger;
+            throw new ForbiddenException();
         }
 
-        public async Task SyncAsync(string curUserId, string projectId, bool trainEngine)
+        // Load the target project secrets, so we can store the job id
+        if (!(await _projectSecrets.TryGetAsync(projectId)).TryResult(out SFProjectSecret projectSecret))
         {
-            await using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
+            throw new ArgumentException("The target project secret cannot be found.");
+        }
+
+        // See if we can sync the source project
+        string sourceProjectId = projectDoc.Data.TranslateConfig.Source?.ProjectRef;
+        if (!string.IsNullOrWhiteSpace(sourceProjectId))
+        {
+            IDocument<SFProject> sourceProjectDoc = await conn.FetchAsync<SFProject>(sourceProjectId);
+            if (!sourceProjectDoc.IsLoaded || sourceProjectDoc.Data.SyncDisabled)
             {
-                // Load the project document
-                IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
-                if (projectDoc.Data.SyncDisabled)
+                sourceProjectId = null;
+            }
+            else
+            {
+                // Load the source project secrets, so we can store the job id
+                if (
+                    !(await _projectSecrets.TryGetAsync(sourceProjectId)).TryResult(
+                        out SFProjectSecret sourceProjectSecret
+                    )
+                )
                 {
-                    throw new ForbiddenException();
+                    throw new ArgumentException("The source project secret cannot be found.");
                 }
 
-                // Load the target project secrets, so we can store the job id
-                if (!(await _projectSecrets.TryGetAsync(projectId)).TryResult(out SFProjectSecret projectSecret))
+                // Create the sync metrics for the source and target projects
+                var sourceSyncMetrics = new SyncMetrics
                 {
-                    throw new ArgumentException("The target project secret cannot be found.");
-                }
-
-                // See if we can sync the source project
-                string sourceProjectId = projectDoc.Data.TranslateConfig.Source?.ProjectRef;
-                if (!string.IsNullOrWhiteSpace(sourceProjectId))
-                {
-                    IDocument<SFProject> sourceProjectDoc = await conn.FetchAsync<SFProject>(sourceProjectId);
-                    if (!sourceProjectDoc.IsLoaded || sourceProjectDoc.Data.SyncDisabled)
-                    {
-                        sourceProjectId = null;
-                    }
-                    else
-                    {
-                        // Load the source project secrets, so we can store the job id
-                        if (
-                            !(await _projectSecrets.TryGetAsync(sourceProjectId)).TryResult(
-                                out SFProjectSecret sourceProjectSecret
-                            )
-                        )
-                        {
-                            throw new ArgumentException("The source project secret cannot be found.");
-                        }
-
-                        // Create the sync metrics for the source and target projects
-                        var sourceSyncMetrics = new SyncMetrics
-                        {
-                            DateQueued = DateTime.UtcNow,
-                            Id = ObjectId.GenerateNewId().ToString(),
-                            ProjectRef = sourceProjectId,
-                            Status = SyncStatus.Queued,
-                            UserRef = curUserId,
-                        };
-                        await _syncMetrics.InsertAsync(sourceSyncMetrics);
-                        var targetSyncMetrics = new SyncMetrics
-                        {
-                            DateQueued = DateTime.UtcNow,
-                            Id = ObjectId.GenerateNewId().ToString(),
-                            ProjectRef = projectId,
-                            RequiresId = sourceSyncMetrics.Id,
-                            Status = SyncStatus.Queued,
-                            UserRef = curUserId,
-                        };
-                        await _syncMetrics.InsertAsync(targetSyncMetrics);
-
-                        // Schedule the sync for 5 minutes to give us enough time to update the project's sync object
-                        // We do this because there is no "draft" status in hangfire - this is close enough
-                        // After we do that, we will enqueue the job. We do it this way because we don't want to start
-                        // the job unless the queued count and job ids have been incremented appropriately.
-                        // We need to sync the source first so that we can link the source texts and train the engine.
-                        string sourceJobId = _backgroundJobClient.Schedule<ParatextSyncRunner>(
-                            r =>
-                                r.RunAsync(
-                                    sourceProjectId,
-                                    curUserId,
-                                    sourceSyncMetrics.Id,
-                                    false,
-                                    CancellationToken.None
-                                ),
-                            TimeSpan.FromMinutes(5)
-                        );
-                        string targetJobId = _backgroundJobClient.ContinueJobWith<ParatextSyncRunner>(
-                            sourceJobId,
-                            r =>
-                                r.RunAsync(
-                                    projectId,
-                                    curUserId,
-                                    targetSyncMetrics.Id,
-                                    trainEngine,
-                                    CancellationToken.None
-                                ),
-                            null,
-                            JobContinuationOptions.OnAnyFinishedState
-                        );
-                        _logger.LogInformation(
-                            $"Queueing sync for source project {sourceProjectId} with sync metrics id {sourceSyncMetrics.Id}"
-                        );
-                        _logger.LogInformation(
-                            $"Queueing sync for target project {projectId} with sync metrics id {targetSyncMetrics.Id}"
-                        );
-                        try
-                        {
-                            await sourceProjectDoc.SubmitJson0OpAsync(op =>
-                            {
-                                op.Inc(pd => pd.Sync.QueuedCount);
-                            });
-                            WarnIfAnomalousQueuedCount(
-                                sourceProjectDoc.Data.Sync.QueuedCount,
-                                $"For parent SF project id {sourceProjectDoc.Id} after inc."
-                            );
-                            await projectDoc.SubmitJson0OpAsync(op =>
-                            {
-                                op.Inc(pd => pd.Sync.QueuedCount);
-                            });
-                            WarnIfAnomalousQueuedCount(
-                                projectDoc.Data.Sync.QueuedCount,
-                                $"For daughter SF project id {projectDoc.Id} after inc."
-                            );
-
-                            // Store the source job id so we can cancel the job later if needed
-                            await _projectSecrets.UpdateAsync(
-                                sourceProjectSecret.Id,
-                                u =>
-                                {
-                                    u.Add(p => p.JobIds, sourceJobId);
-                                    u.Add(p => p.SyncMetricsIds, sourceSyncMetrics.Id);
-                                }
-                            );
-
-                            // Store the target job id so we can cancel the job later if needed
-                            await _projectSecrets.UpdateAsync(
-                                projectSecret.Id,
-                                u =>
-                                {
-                                    u.Add(p => p.JobIds, targetJobId);
-                                    u.Add(p => p.SyncMetricsIds, targetSyncMetrics.Id);
-                                }
-                            );
-
-                            _backgroundJobClient.ChangeState(sourceJobId, new EnqueuedState());
-                        }
-                        catch (Exception)
-                        {
-                            // Delete the jobs on error, and notify the user
-                            _backgroundJobClient.Delete(targetJobId);
-                            _backgroundJobClient.Delete(sourceJobId);
-                            throw;
-                        }
-
-                        // Exit so we don't queue the target again, in the following block
-                        return;
-                    }
-                }
-
-                // Create the sync metrics for this project
-                var syncMetrics = new SyncMetrics
+                    DateQueued = DateTime.UtcNow,
+                    Id = ObjectId.GenerateNewId().ToString(),
+                    ProjectRef = sourceProjectId,
+                    Status = SyncStatus.Queued,
+                    UserRef = curUserId,
+                };
+                await _syncMetrics.InsertAsync(sourceSyncMetrics);
+                var targetSyncMetrics = new SyncMetrics
                 {
                     DateQueued = DateTime.UtcNow,
                     Id = ObjectId.GenerateNewId().ToString(),
                     ProjectRef = projectId,
+                    RequiresId = sourceSyncMetrics.Id,
                     Status = SyncStatus.Queued,
                     UserRef = curUserId,
                 };
-                await _syncMetrics.InsertAsync(syncMetrics);
+                await _syncMetrics.InsertAsync(targetSyncMetrics);
 
-                // Sync the target project only, as it does not have a source, or the source cannot be synced
-                // See the comments in the block above regarding scheduling for rationale on the process
-                string jobId = _backgroundJobClient.Schedule<ParatextSyncRunner>(
-                    r => r.RunAsync(projectId, curUserId, syncMetrics.Id, trainEngine, CancellationToken.None),
+                // Schedule the sync for 5 minutes to give us enough time to update the project's sync object
+                // We do this because there is no "draft" status in hangfire - this is close enough
+                // After we do that, we will enqueue the job. We do it this way because we don't want to start
+                // the job unless the queued count and job ids have been incremented appropriately.
+                // We need to sync the source first so that we can link the source texts and train the engine.
+                string sourceJobId = _backgroundJobClient.Schedule<ParatextSyncRunner>(
+                    r => r.RunAsync(sourceProjectId, curUserId, sourceSyncMetrics.Id, false, CancellationToken.None),
                     TimeSpan.FromMinutes(5)
                 );
-                _logger.LogInformation($"Queueing sync for project {projectId} with sync metrics id {syncMetrics.Id}");
+                string targetJobId = _backgroundJobClient.ContinueJobWith<ParatextSyncRunner>(
+                    sourceJobId,
+                    r => r.RunAsync(projectId, curUserId, targetSyncMetrics.Id, trainEngine, CancellationToken.None),
+                    null,
+                    JobContinuationOptions.OnAnyFinishedState
+                );
+                _logger.LogInformation(
+                    $"Queueing sync for source project {sourceProjectId} with sync metrics id {sourceSyncMetrics.Id}"
+                );
+                _logger.LogInformation(
+                    $"Queueing sync for target project {projectId} with sync metrics id {targetSyncMetrics.Id}"
+                );
                 try
                 {
-                    await projectDoc.SubmitJson0OpAsync(op =>
-                    {
-                        op.Inc(pd => pd.Sync.QueuedCount);
-                    });
+                    await sourceProjectDoc.SubmitJson0OpAsync(op => op.Inc(pd => pd.Sync.QueuedCount));
+                    WarnIfAnomalousQueuedCount(
+                        sourceProjectDoc.Data.Sync.QueuedCount,
+                        $"For parent SF project id {sourceProjectDoc.Id} after inc."
+                    );
+                    await projectDoc.SubmitJson0OpAsync(op => op.Inc(pd => pd.Sync.QueuedCount));
                     WarnIfAnomalousQueuedCount(
                         projectDoc.Data.Sync.QueuedCount,
-                        $"For SF project id {projectDoc.Id} after inc."
+                        $"For daughter SF project id {projectDoc.Id} after inc."
                     );
 
-                    // Store the job id so we can cancel the job later if needed
+                    // Store the source job id so we can cancel the job later if needed
+                    await _projectSecrets.UpdateAsync(
+                        sourceProjectSecret.Id,
+                        u =>
+                        {
+                            u.Add(p => p.JobIds, sourceJobId);
+                            u.Add(p => p.SyncMetricsIds, sourceSyncMetrics.Id);
+                        }
+                    );
+
+                    // Store the target job id so we can cancel the job later if needed
                     await _projectSecrets.UpdateAsync(
                         projectSecret.Id,
                         u =>
                         {
-                            u.Add(p => p.JobIds, jobId);
-                            u.Add(p => p.SyncMetricsIds, syncMetrics.Id);
+                            u.Add(p => p.JobIds, targetJobId);
+                            u.Add(p => p.SyncMetricsIds, targetSyncMetrics.Id);
                         }
                     );
 
-                    _backgroundJobClient.ChangeState(jobId, new EnqueuedState());
+                    _backgroundJobClient.ChangeState(sourceJobId, new EnqueuedState());
                 }
                 catch (Exception)
                 {
-                    // Delete the job on error, and notify the user
-                    _backgroundJobClient.Delete(jobId);
+                    // Delete the jobs on error, and notify the user
+                    _backgroundJobClient.Delete(targetJobId);
+                    _backgroundJobClient.Delete(sourceJobId);
                     throw;
                 }
-            }
-        }
 
-        public async Task CancelSyncAsync(string curUserId, string projectId)
-        {
-            await using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
-            {
-                IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
-                if (projectDoc.Data.Sync.QueuedCount > 0)
-                {
-                    await CancelProjectDocumentSyncAsync(projectDoc);
-
-                    // Cancel all jobs for the source (if present)
-                    string sourceProjectId = projectDoc.Data.TranslateConfig.Source?.ProjectRef;
-                    if (!string.IsNullOrWhiteSpace(sourceProjectId))
-                    {
-                        IDocument<SFProject> sourceProjectDoc = await conn.FetchAsync<SFProject>(sourceProjectId);
-                        if (sourceProjectDoc.IsLoaded && !sourceProjectDoc.Data.SyncDisabled)
-                        {
-                            if (sourceProjectDoc.Data.Sync.QueuedCount > 0)
-                            {
-                                await CancelProjectDocumentSyncAsync(sourceProjectDoc);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Helper method to warn when QueuedCount is an unexpected value, to assist in investigating problems.
-        /// </summary>
-        internal void WarnIfAnomalousQueuedCount(int queuedCount, string details)
-        {
-            if (queuedCount == 0 || queuedCount == 1)
-            {
+                // Exit so we don't queue the target again, in the following block
                 return;
             }
-            string message = $"SyncService: Project has unexpected QueuedCount of {queuedCount}.";
-            if (!string.IsNullOrEmpty(details))
-            {
-                message += $" {details}";
-            }
-            _logger.LogWarning(message);
         }
 
-        private async Task CancelProjectDocumentSyncAsync(IDocument<SFProject> projectDoc)
+        // Create the sync metrics for this project
+        var syncMetrics = new SyncMetrics
         {
-            // Load the project secrets, so we can get any job ids
-            if ((await _projectSecrets.TryGetAsync(projectDoc.Data.Id)).TryResult(out SFProjectSecret projectSecret))
+            DateQueued = DateTime.UtcNow,
+            Id = ObjectId.GenerateNewId().ToString(),
+            ProjectRef = projectId,
+            Status = SyncStatus.Queued,
+            UserRef = curUserId,
+        };
+        await _syncMetrics.InsertAsync(syncMetrics);
+
+        // Sync the target project only, as it does not have a source, or the source cannot be synced
+        // See the comments in the block above regarding scheduling for rationale on the process
+        string jobId = _backgroundJobClient.Schedule<ParatextSyncRunner>(
+            r => r.RunAsync(projectId, curUserId, syncMetrics.Id, trainEngine, CancellationToken.None),
+            TimeSpan.FromMinutes(5)
+        );
+        _logger.LogInformation($"Queueing sync for project {projectId} with sync metrics id {syncMetrics.Id}");
+        try
+        {
+            await projectDoc.SubmitJson0OpAsync(op => op.Inc(pd => pd.Sync.QueuedCount));
+            WarnIfAnomalousQueuedCount(
+                projectDoc.Data.Sync.QueuedCount,
+                $"For SF project id {projectDoc.Id} after inc."
+            );
+
+            // Store the job id so we can cancel the job later if needed
+            await _projectSecrets.UpdateAsync(
+                projectSecret.Id,
+                u =>
+                {
+                    u.Add(p => p.JobIds, jobId);
+                    u.Add(p => p.SyncMetricsIds, syncMetrics.Id);
+                }
+            );
+
+            _backgroundJobClient.ChangeState(jobId, new EnqueuedState());
+        }
+        catch (Exception)
+        {
+            // Delete the job on error, and notify the user
+            _backgroundJobClient.Delete(jobId);
+            throw;
+        }
+    }
+
+    public async Task CancelSyncAsync(string curUserId, string projectId)
+    {
+        await using IConnection conn = await _realtimeService.ConnectAsync(curUserId);
+        IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
+        if (projectDoc.Data.Sync.QueuedCount > 0)
+        {
+            await CancelProjectDocumentSyncAsync(projectDoc);
+
+            // Cancel all jobs for the source (if present)
+            string sourceProjectId = projectDoc.Data.TranslateConfig.Source?.ProjectRef;
+            if (!string.IsNullOrWhiteSpace(sourceProjectId))
             {
-                // Cancel all jobs for the project
-                foreach (string jobId in projectSecret.JobIds)
+                IDocument<SFProject> sourceProjectDoc = await conn.FetchAsync<SFProject>(sourceProjectId);
+                if (sourceProjectDoc.IsLoaded && !sourceProjectDoc.Data.SyncDisabled)
                 {
-                    _backgroundJobClient.Delete(jobId);
-                }
-
-                // Mark all sync metrics as cancelled
-                foreach (string syncMetricsId in projectSecret.SyncMetricsIds)
-                {
-                    _logger.LogInformation(
-                        $"Cancelling sync for project {projectSecret.Id} with sync metrics id {syncMetricsId}"
-                    );
-                    await _syncMetrics.UpdateAsync(
-                        syncMetricsId,
-                        u =>
-                        {
-                            u.Set(s => s.Status, SyncStatus.Cancelled);
-                        }
-                    );
-                }
-
-                // Remove all job ids and sync metrics ids from the project secrets
-                await _projectSecrets.UpdateAsync(
-                    projectSecret.Id,
-                    u =>
+                    if (sourceProjectDoc.Data.Sync.QueuedCount > 0)
                     {
-                        u.Set(p => p.JobIds, new List<string>());
-                        u.Set(p => p.SyncMetricsIds, new List<string>());
+                        await CancelProjectDocumentSyncAsync(sourceProjectDoc);
                     }
-                );
-
-                WarnIfAnomalousQueuedCount(
-                    projectDoc.Data.Sync.QueuedCount,
-                    $"For SF project id {projectDoc.Id} before setting QueuedCount to 0 as part of cancelling."
-                );
-                // Mark sync as cancelled
-                await _hubContext.NotifySyncProgress(projectDoc.Id, ProgressState.Completed);
-                await projectDoc.SubmitJson0OpAsync(op =>
-                {
-                    op.Set(pd => pd.Sync.QueuedCount, 0);
-                    op.Set(pd => pd.Sync.LastSyncSuccessful, false);
-                });
+                }
             }
+        }
+    }
+
+    /// <summary>
+    /// Helper method to warn when QueuedCount is an unexpected value, to assist in investigating problems.
+    /// </summary>
+    internal void WarnIfAnomalousQueuedCount(int queuedCount, string details)
+    {
+        if (queuedCount == 0 || queuedCount == 1)
+        {
+            return;
+        }
+        string message = $"SyncService: Project has unexpected QueuedCount of {queuedCount}.";
+        if (!string.IsNullOrEmpty(details))
+        {
+            message += $" {details}";
+        }
+        _logger.LogWarning(message);
+    }
+
+    private async Task CancelProjectDocumentSyncAsync(IDocument<SFProject> projectDoc)
+    {
+        // Load the project secrets, so we can get any job ids
+        if ((await _projectSecrets.TryGetAsync(projectDoc.Data.Id)).TryResult(out SFProjectSecret projectSecret))
+        {
+            // Cancel all jobs for the project
+            foreach (string jobId in projectSecret.JobIds)
+            {
+                _backgroundJobClient.Delete(jobId);
+            }
+
+            // Mark all sync metrics as cancelled
+            foreach (string syncMetricsId in projectSecret.SyncMetricsIds)
+            {
+                _logger.LogInformation(
+                    $"Cancelling sync for project {projectSecret.Id} with sync metrics id {syncMetricsId}"
+                );
+                await _syncMetrics.UpdateAsync(syncMetricsId, u => u.Set(s => s.Status, SyncStatus.Cancelled));
+            }
+
+            // Remove all job ids and sync metrics ids from the project secrets
+            await _projectSecrets.UpdateAsync(
+                projectSecret.Id,
+                u =>
+                {
+                    u.Set(p => p.JobIds, new List<string>());
+                    u.Set(p => p.SyncMetricsIds, new List<string>());
+                }
+            );
+
+            WarnIfAnomalousQueuedCount(
+                projectDoc.Data.Sync.QueuedCount,
+                $"For SF project id {projectDoc.Id} before setting QueuedCount to 0 as part of cancelling."
+            );
+            // Mark sync as cancelled
+            await _hubContext.NotifySyncProgress(projectDoc.Id, ProgressState.Completed);
+            await projectDoc.SubmitJson0OpAsync(op =>
+            {
+                op.Set(pd => pd.Sync.QueuedCount, 0);
+                op.Set(pd => pd.Sync.LastSyncSuccessful, false);
+            });
         }
     }
 }

--- a/src/SIL.XForge.Scripture/Services/TransceleratorService.cs
+++ b/src/SIL.XForge.Scripture/Services/TransceleratorService.cs
@@ -1,123 +1,121 @@
-using System.IO;
-using System.Xml;
-using System.Linq;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
+using System.Xml;
 using Microsoft.Extensions.Options;
 using SIL.XForge.Configuration;
-using SIL.XForge.Services;
 using SIL.XForge.Scripture.Models;
+using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public class TransceleratorService : ITransceleratorService
 {
-    public class TransceleratorService : ITransceleratorService
+    private readonly IFileSystemService _fileService;
+    private readonly IOptions<SiteOptions> _siteOptions;
+
+    public TransceleratorService(IFileSystemService fileService, IOptions<SiteOptions> siteOptions)
     {
-        private readonly IFileSystemService _fileService;
-        private readonly IOptions<SiteOptions> _siteOptions;
+        _fileService = fileService;
+        _siteOptions = siteOptions;
+    }
 
-        public TransceleratorService(IFileSystemService fileService, IOptions<SiteOptions> siteOptions)
-        {
-            _fileService = fileService;
-            _siteOptions = siteOptions;
-        }
-
-        public IEnumerable<TransceleratorQuestion> Questions(string paratextId)
-        {
-            IEnumerable<XmlElement> docs = QuestionFiles(paratextId)
-                .Select(file => ReadFileAsXml(file).DocumentElement);
-            // Check that the schema version declared in the file is at least 1.1 (coresponding to Transcelerator version 1.5.2)
-            if (
-                docs.Any(
-                    doc =>
-                        doc.Attributes["version"] == null
-                        || !VersionSatisfies(doc.Attributes["version"].Value, new int[] { 1, 1 })
-                )
+    public IEnumerable<TransceleratorQuestion> Questions(string paratextId)
+    {
+        IEnumerable<XmlElement> docs = QuestionFiles(paratextId).Select(file => ReadFileAsXml(file).DocumentElement);
+        // Check that the schema version declared in the file is at least 1.1 (coresponding to Transcelerator version 1.5.2)
+        if (
+            docs.Any(
+                doc =>
+                    doc.Attributes["version"] == null
+                    || !VersionSatisfies(doc.Attributes["version"].Value, new int[] { 1, 1 })
             )
+        )
+        {
+            throw new DataNotFoundException("Transcelerator version unsupported");
+        }
+        return docs.SelectMany<XmlElement, TransceleratorQuestion>(doc =>
+        {
+            string book = doc.Attributes["book"].Value;
+            string lang = doc.Attributes["xml:lang"].Value;
+            return doc.SelectNodes("Question")
+                .Cast<XmlNode>()
+                .Select(
+                    q =>
+                        new TransceleratorQuestion()
+                        {
+                            Book = book,
+                            StartChapter = AttributeText(q, "startChapter"),
+                            StartVerse = AttributeText(q, "startVerse"),
+                            EndChapter = AttributeText(q, "endChapter"),
+                            EndVerse = AttributeText(q, "endVerse"),
+                            Text = NodeTextOfLanguage(q.SelectNodes("Q/StringAlt").Cast<XmlNode>(), lang),
+                            Id = AttributeText(q, "id")
+                        }
+                );
+        });
+    }
+
+    private IEnumerable<string> QuestionFiles(string paratextId)
+    {
+        string pathToFiles = Path.Combine(
+            _siteOptions.Value.SiteDir,
+            "sync",
+            paratextId,
+            "target",
+            "pluginData",
+            "Transcelerator",
+            "Transcelerator"
+        );
+        string fileRegex = "Translated Checking Questions for \\w+\\.xml$";
+        return _fileService.DirectoryExists(pathToFiles)
+            ? _fileService.EnumerateFiles(pathToFiles).Where(file => Regex.IsMatch(file, fileRegex))
+            : System.Array.Empty<string>();
+    }
+
+    private XmlDocument ReadFileAsXml(string file)
+    {
+        XmlDocument xml = new XmlDocument();
+        // Load it as a string and THEN parse, rather than using xml.Load(path) because the file is UTF-8 but the
+        // XML declaration incorrectly specifies UTF-16.
+        xml.LoadXml(_fileService.FileReadText(file));
+        return xml;
+    }
+
+    private static string NodeTextOfLanguage(IEnumerable<XmlNode> nodes, string lang)
+    {
+        return nodes
+            .Where(node => lang.Equals(node.Attributes["xml:lang"].Value))
+            .Select(node => node.InnerText)
+            .DefaultIfEmpty("")
+            .SingleOrDefault();
+    }
+
+    private static string AttributeText(XmlNode node, string attributeName)
+    {
+        XmlAttribute attribute = node.Attributes[attributeName];
+        return attribute?.Value;
+    }
+
+    /// <summary>
+    /// Determines whether a version string of integers separated by dots (e.g. major.minor.patch) is greater than
+    /// or equal to an array of integers (e.g. "1.2" would satisfy [1, 1]).
+    /// </summary>
+    private static bool VersionSatisfies(string version, int[] numbersToSatisfy)
+    {
+        string[] versionStrings = version.Split(".");
+        for (int i = 0; i < versionStrings.Length && i < numbersToSatisfy.Length; i++)
+        {
+            if (!int.TryParse(versionStrings[i], out int number) || number < numbersToSatisfy[i])
             {
-                throw new DataNotFoundException("Transcelerator version unsupported");
+                return false;
             }
-            return docs.SelectMany<XmlElement, TransceleratorQuestion>(doc =>
+            if (number > numbersToSatisfy[i])
             {
-                string book = doc.Attributes["book"].Value;
-                string lang = doc.Attributes["xml:lang"].Value;
-                return doc.SelectNodes("Question")
-                    .Cast<XmlNode>()
-                    .Select(
-                        q =>
-                            new TransceleratorQuestion()
-                            {
-                                Book = book,
-                                StartChapter = AttributeText(q, "startChapter"),
-                                StartVerse = AttributeText(q, "startVerse"),
-                                EndChapter = AttributeText(q, "endChapter"),
-                                EndVerse = AttributeText(q, "endVerse"),
-                                Text = NodeTextOfLanguage(q.SelectNodes("Q/StringAlt").Cast<XmlNode>(), lang),
-                                Id = AttributeText(q, "id")
-                            }
-                    );
-            });
-        }
-
-        private IEnumerable<string> QuestionFiles(string paratextId)
-        {
-            string pathToFiles = Path.Combine(
-                _siteOptions.Value.SiteDir,
-                "sync",
-                paratextId,
-                "target",
-                "pluginData",
-                "Transcelerator",
-                "Transcelerator"
-            );
-            string fileRegex = "Translated Checking Questions for \\w+\\.xml$";
-            return _fileService.DirectoryExists(pathToFiles)
-                ? _fileService.EnumerateFiles(pathToFiles).Where(file => Regex.IsMatch(file, fileRegex))
-                : new string[] { };
-        }
-
-        private XmlDocument ReadFileAsXml(string file)
-        {
-            XmlDocument xml = new XmlDocument();
-            // Load it as a string and THEN parse, rather than using xml.Load(path) because the file is UTF-8 but the
-            // XML declaration incorrectly specifies UTF-16.
-            xml.LoadXml(_fileService.FileReadText(file));
-            return xml;
-        }
-
-        private string NodeTextOfLanguage(IEnumerable<XmlNode> nodes, string lang)
-        {
-            return nodes
-                .Where(node => lang.Equals(node.Attributes["xml:lang"].Value))
-                .Select(node => node.InnerText)
-                .DefaultIfEmpty("")
-                .SingleOrDefault();
-        }
-
-        private string AttributeText(XmlNode node, string attributeName)
-        {
-            XmlAttribute attribute = node.Attributes[attributeName];
-            return attribute == null ? null : attribute.Value;
-        }
-
-        /// <summary>
-        /// Determines whether a version string of integers separated by dots (e.g. major.minor.patch) is greater than
-        /// or equal to an array of integers (e.g. "1.2" would satisfy [1, 1]).
-        /// </summary>
-        private bool VersionSatisfies(string version, int[] numbersToSatisfy)
-        {
-            string[] versionStrings = version.Split(".");
-            for (int i = 0; i < versionStrings.Length && i < numbersToSatisfy.Length; i++)
-            {
-                if (!int.TryParse(versionStrings[i], out int number) || number < numbersToSatisfy[i])
-                {
-                    return false;
-                }
-                if (number > numbersToSatisfy[i])
-                {
-                    return true;
-                }
+                return true;
             }
-            return versionStrings.Length >= numbersToSatisfy.Length;
         }
+        return versionStrings.Length >= numbersToSatisfy.Length;
     }
 }

--- a/src/SIL.XForge.Scripture/SharedResource.cs
+++ b/src/SIL.XForge.Scripture/SharedResource.cs
@@ -1,62 +1,61 @@
 using System.Collections.Generic;
-using SIL.XForge.Models;
 using System.IO;
 using Newtonsoft.Json;
+using SIL.XForge.Models;
 
-namespace SIL.XForge.Scripture
+namespace SIL.XForge.Scripture;
+
+/// <summary>
+/// This class holds the Keys for looking up localizable strings in the IStringLocalizer.
+/// It also provides the class which IStringLocalizer uses to find the .resx files with the strings
+/// Every string in the Keys class here should also be present in the Resources\SharedResource.en.resx
+/// with the english translation as the value.
+/// </summary>
+public class SharedResource
 {
-    /// <summary>
-    /// This class holds the Keys for looking up localizable strings in the IStringLocalizer.
-    /// It also provides the class which IStringLocalizer uses to find the .resx files with the strings
-    /// Every string in the Keys class here should also be present in the Resources\SharedResource.en.resx
-    /// with the english translation as the value.
-    /// </summary>
-    public class SharedResource
+    public static class Keys
     {
-        public static class Keys
-        {
-            public const string AudioOnlyQuestion = "AudioOnlyQuestion";
-            public const string AudioOnlyResponse = "AudioOnlyResponse";
-            public const string CommunitySupport = "CommunitySupport";
-            public const string EmailBad = "EmailBad";
-            public const string EmailMissing = "EmailMissing";
-            public const string Help = "Help";
-            public const string InviteEmailOption = "InviteEmailOption";
-            public const string InviteFacebookOption = "InviteFacebookOption";
-            public const string InviteGoogleOption = "InviteGoogleOption";
-            public const string InviteGreeting = "InviteGreeting";
-            public const string InviteInstructions = "InviteInstructions";
-            public const string InviteLinkExpires = "InviteLinkExpires";
-            public const string InvitePTOption = "InvitePTOption";
-            public const string InviteSignature = "InviteSignature";
-            public const string InviteSubject = "InviteSubject";
-            public const string Language = "Language";
-            public const string LearnMore = "LearnMore";
-            public const string LogIn = "LogIn";
-            public const string MessageMissing = "MessageMissing";
-            public const string NameMissing = "NameMissing";
-            public const string Privacy = "Privacy";
-            public const string RoleMissing = "RoleMissing";
-            public const string SignUp = "SignUp";
-            public const string Terms = "Terms";
-            public const string UserMissing = "UserMissing";
-        }
+        public const string AudioOnlyQuestion = "AudioOnlyQuestion";
+        public const string AudioOnlyResponse = "AudioOnlyResponse";
+        public const string CommunitySupport = "CommunitySupport";
+        public const string EmailBad = "EmailBad";
+        public const string EmailMissing = "EmailMissing";
+        public const string Help = "Help";
+        public const string InviteEmailOption = "InviteEmailOption";
+        public const string InviteFacebookOption = "InviteFacebookOption";
+        public const string InviteGoogleOption = "InviteGoogleOption";
+        public const string InviteGreeting = "InviteGreeting";
+        public const string InviteInstructions = "InviteInstructions";
+        public const string InviteLinkExpires = "InviteLinkExpires";
+        public const string InvitePTOption = "InvitePTOption";
+        public const string InviteSignature = "InviteSignature";
+        public const string InviteSubject = "InviteSubject";
+        public const string Language = "Language";
+        public const string LearnMore = "LearnMore";
+        public const string LogIn = "LogIn";
+        public const string MessageMissing = "MessageMissing";
+        public const string NameMissing = "NameMissing";
+        public const string Privacy = "Privacy";
+        public const string RoleMissing = "RoleMissing";
+        public const string SignUp = "SignUp";
+        public const string Terms = "Terms";
+        public const string UserMissing = "UserMissing";
+    }
 
-        /// <summary>
-        /// Map of culture identifier (language tag) to interface language object (local name displayed in the chooser)
-        /// </summary>
-        public static Dictionary<string, InterfaceLanguage> Cultures = SharedResource.getCultures();
+    /// <summary>
+    /// Map of culture identifier (language tag) to interface language object (local name displayed in the chooser)
+    /// </summary>
+    public static Dictionary<string, InterfaceLanguage> Cultures = SharedResource.getCultures();
 
-        static Dictionary<string, InterfaceLanguage> getCultures()
+    static Dictionary<string, InterfaceLanguage> getCultures()
+    {
+        // TODO consider making file path relative to current file rather than CWD
+        var cultureData = JsonConvert.DeserializeObject<List<InterfaceLanguage>>(File.ReadAllText("locales.json"));
+        var cultures = new Dictionary<string, InterfaceLanguage> { };
+        foreach (var culture in cultureData)
         {
-            // TODO consider making file path relative to current file rather than CWD
-            var cultureData = JsonConvert.DeserializeObject<List<InterfaceLanguage>>(File.ReadAllText("locales.json"));
-            var cultures = new Dictionary<string, InterfaceLanguage> { };
-            foreach (var culture in cultureData)
-            {
-                cultures.Add(culture.CanonicalTag, culture);
-            }
-            return cultures;
+            cultures.Add(culture.CanonicalTag, culture);
         }
+        return cultures;
     }
 }

--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -20,307 +20,298 @@ using Microsoft.FeatureManagement;
 using SIL.XForge.Configuration;
 using SIL.XForge.Scripture.Services;
 
-namespace SIL.XForge.Scripture
+namespace SIL.XForge.Scripture;
+
+public enum SpaDevServerStartup
 {
-    public enum SpaDevServerStartup
+    None,
+    Start,
+    Listen
+}
+
+public class Startup
+{
+    private static readonly HashSet<string> DevelopmentSpaGetRoutes = new HashSet<string>
     {
-        None,
-        Start,
-        Listen
+        "runtime.js",
+        "runtime.js.map",
+        "polyfills.js",
+        "polyfills.js.map",
+        "styles.css",
+        "styles.css.map",
+        "styles.js",
+        "styles.js.map",
+        "vendor.js",
+        "vendor.js.map",
+        "main.js",
+        "main.js.map",
+        "manifest.json",
+        "sockjs-node"
+    };
+
+    // examples of filenames are "main-es5.4e5295b95e4b6c37b696.js", "styles.a2f070be0b37085d72ba.css"
+    private static readonly HashSet<string> ProductionSpaGetRoutes = new HashSet<string>
+    {
+        "polyfills-es2015",
+        "polyfills-es5",
+        "runtime-es2015",
+        "runtime-es5",
+        "main-es2015",
+        "main-es5",
+        "styles"
+    };
+    private static readonly HashSet<string> SpaGetRoutes = new HashSet<string>
+    {
+        "callback",
+        "connect-project",
+        "login",
+        "projects",
+        "system-administration",
+        "favicon.ico",
+        "assets"
+    };
+
+    private static readonly HashSet<string> DevelopmentSpaPostRoutes = new HashSet<string> { "sockjs-node" };
+    private static readonly HashSet<string> ProductionSpaPostRoutes = new HashSet<string>();
+    private static readonly HashSet<string> SpaPostRoutes = new HashSet<string>();
+
+    public Startup(IConfiguration configuration, IWebHostEnvironment env, ILoggerFactory loggerFactory)
+    {
+        Configuration = configuration;
+        Environment = env;
+        LoggerFactory = loggerFactory;
+        if (IsDevelopmentEnvironment)
+        {
+            SpaGetRoutes.UnionWith(DevelopmentSpaGetRoutes);
+            SpaPostRoutes.UnionWith(DevelopmentSpaPostRoutes);
+        }
+        else
+        {
+            SpaGetRoutes.UnionWith(ProductionSpaGetRoutes);
+            SpaPostRoutes.UnionWith(ProductionSpaPostRoutes);
+        }
     }
 
-    public class Startup
+    public IConfiguration Configuration { get; }
+    public IWebHostEnvironment Environment { get; }
+    public ILoggerFactory LoggerFactory { get; }
+    public IContainer ApplicationContainer { get; private set; }
+
+    private SpaDevServerStartup SpaDevServerStartup
     {
-        private static readonly HashSet<string> DevelopmentSpaGetRoutes = new HashSet<string>
+        get
         {
-            "runtime.js",
-            "runtime.js.map",
-            "polyfills.js",
-            "polyfills.js.map",
-            "styles.css",
-            "styles.css.map",
-            "styles.js",
-            "styles.js.map",
-            "vendor.js",
-            "vendor.js.map",
-            "main.js",
-            "main.js.map",
-            "manifest.json",
-            "sockjs-node"
-        };
-
-        // examples of filenames are "main-es5.4e5295b95e4b6c37b696.js", "styles.a2f070be0b37085d72ba.css"
-        private static readonly HashSet<string> ProductionSpaGetRoutes = new HashSet<string>
-        {
-            "polyfills-es2015",
-            "polyfills-es5",
-            "runtime-es2015",
-            "runtime-es5",
-            "main-es2015",
-            "main-es5",
-            "styles"
-        };
-        private static readonly HashSet<string> SpaGetRoutes = new HashSet<string>
-        {
-            "callback",
-            "connect-project",
-            "login",
-            "projects",
-            "system-administration",
-            "favicon.ico",
-            "assets"
-        };
-
-        private static readonly HashSet<string> DevelopmentSpaPostRoutes = new HashSet<string> { "sockjs-node" };
-        private static readonly HashSet<string> ProductionSpaPostRoutes = new HashSet<string>();
-        private static readonly HashSet<string> SpaPostRoutes = new HashSet<string>();
-
-        public Startup(IConfiguration configuration, IWebHostEnvironment env, ILoggerFactory loggerFactory)
-        {
-            Configuration = configuration;
-            Environment = env;
-            LoggerFactory = loggerFactory;
             if (IsDevelopmentEnvironment)
             {
-                SpaGetRoutes.UnionWith(DevelopmentSpaGetRoutes);
-                SpaPostRoutes.UnionWith(DevelopmentSpaPostRoutes);
+                string startNgServe = Configuration.GetValue("start-ng-serve", "yes");
+                switch (startNgServe)
+                {
+                    case "yes":
+                        return SpaDevServerStartup.Start;
+                    case "listen":
+                        return SpaDevServerStartup.Listen;
+                }
             }
-            else
+            else if (IsTestingEnvironment)
             {
-                SpaGetRoutes.UnionWith(ProductionSpaGetRoutes);
-                SpaPostRoutes.UnionWith(ProductionSpaPostRoutes);
+                return SpaDevServerStartup.Listen;
             }
+            return SpaDevServerStartup.None;
+        }
+    }
+
+    private bool IsDevelopmentEnvironment => Environment.IsDevelopment();
+    private bool IsTestingEnvironment => Environment.IsEnvironment("Testing");
+
+    // This method gets called by the runtime. Use this method to add services to the container.
+    public IServiceProvider ConfigureServices(IServiceCollection services)
+    {
+        var containerBuilder = new ContainerBuilder();
+
+        services.AddExceptionReporting(Configuration);
+
+        services.AddConfiguration(Configuration);
+
+        services.AddFeatureManagement();
+
+        services.AddSignalR();
+
+        string? nodeOptions = Configuration.GetValue<string>("node-options");
+        services.AddSFRealtimeServer(LoggerFactory, Configuration, nodeOptions);
+
+        services.AddSFServices();
+
+        services.AddXFAuthentication(Configuration);
+
+        services.AddSFDataAccess(Configuration);
+
+        services.Configure<RequestLocalizationOptions>(opts =>
+        {
+            var supportedCultures = new List<CultureInfo>();
+            foreach (var culture in SharedResource.Cultures)
+            {
+                supportedCultures.Add(new CultureInfo(culture.Key));
+            }
+
+            opts.DefaultRequestCulture = new RequestCulture("en");
+            // Formatting numbers, dates, etc.
+            opts.SupportedCultures = supportedCultures;
+            // UI strings that we have localized.
+            opts.SupportedUICultures = supportedCultures;
+        });
+
+        services.AddLocalization(options => options.ResourcesPath = "Resources");
+
+        services
+            .AddMvc()
+            // TODO: check if JSON.NET is required
+            .AddNewtonsoftJson()
+            .AddViewLocalization()
+            .AddDataAnnotationsLocalization(
+                options =>
+                    options.DataAnnotationLocalizerProvider = (type, factory) => factory.Create(typeof(SharedResource))
+            );
+
+        services.AddXFJsonRpc();
+
+        if (SpaDevServerStartup == SpaDevServerStartup.None)
+        {
+            // In production, the Angular files will be served from this directory
+            services.AddSpaStaticFiles(configuration => configuration.RootPath = "ClientApp/dist");
         }
 
-        public IConfiguration Configuration { get; }
-        public IWebHostEnvironment Environment { get; }
-        public ILoggerFactory LoggerFactory { get; }
-        public IContainer ApplicationContainer { get; private set; }
+        services.AddSFMachine(Configuration, Environment);
 
-        private SpaDevServerStartup SpaDevServerStartup
+        containerBuilder.Populate(services);
+
+        ApplicationContainer = containerBuilder.Build();
+        return new AutofacServiceProvider(ApplicationContainer);
+    }
+
+    // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+    public void Configure(
+        IApplicationBuilder app,
+        IHostApplicationLifetime appLifetime,
+        IExceptionHandler exceptionHandler
+    )
+    {
+        if (IsDevelopmentEnvironment || IsTestingEnvironment)
         {
-            get
+            app.UseDeveloperExceptionPage();
+        }
+        else
+        {
+            app.UseExceptionHandler(errorApp => exceptionHandler.ReportExceptions(errorApp));
+        }
+
+        app.UseStatusCodePagesWithReExecute("/Status/Error", "?code={0}");
+
+        app.UseForwardedHeaders(new ForwardedHeadersOptions { ForwardedHeaders = ForwardedHeaders.All });
+
+        app.UseRequestLocalization(app.ApplicationServices.GetService<IOptions<RequestLocalizationOptions>>().Value);
+
+        app.UseStaticFiles(
+            new StaticFileOptions
             {
-                if (IsDevelopmentEnvironment)
+                // this will allow files without extensions to be served, which is necessary for LetsEncrypt
+                ServeUnknownFileTypes = true,
+                OnPrepareResponse = ctx => ctx.Context.Response.Headers.Add("Cache-Control", "must-revalidate")
+            }
+        );
+        IOptions<SiteOptions> siteOptions = app.ApplicationServices.GetService<IOptions<SiteOptions>>();
+        app.UseStaticFiles(
+            new StaticFileOptions
+            {
+                FileProvider = new PhysicalFileProvider(Path.Combine(siteOptions.Value.SiteDir, "audio")),
+                RequestPath = "/assets/audio"
+            }
+        );
+
+        if (SpaDevServerStartup == SpaDevServerStartup.None)
+            app.UseSpaStaticFiles();
+
+        app.UseRouting();
+
+        app.UseAuthentication();
+        app.UseAuthorization();
+
+        app.UseRealtimeServer();
+
+        app.UseMachine();
+
+        app.UseSFServices();
+
+        app.UseSFDataAccess();
+
+        app.UsePing();
+
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.MapControllers();
+            endpoints.MapRazorPages();
+            endpoints.MapHub<NotificationHub>(pattern: $"/{UrlConstants.ProjectNotifications}");
+        });
+
+        // Map JSON-RPC controllers after MVC controllers, so that MVC controllers take precedence.
+        app.UseSFJsonRpc();
+
+        app.MapWhen(
+            IsSpaRoute,
+            spaApp =>
+            {
+                // setup all server-side routes before SPA client-side routes, so that the server-side routes supercede
+                // the client-side routes
+                spaApp.UseSpa(spa =>
                 {
-                    string startNgServe = Configuration.GetValue("start-ng-serve", "yes");
-                    switch (startNgServe)
+                    // To learn more about options for serving an Angular SPA from ASP.NET Core,
+                    // see https://go.microsoft.com/fwlink/?linkid=864501
+                    spa.Options.SourcePath = "ClientApp";
+
+                    switch (SpaDevServerStartup)
                     {
-                        case "yes":
-                            return SpaDevServerStartup.Start;
-                        case "listen":
-                            return SpaDevServerStartup.Listen;
+                        case SpaDevServerStartup.Start:
+                            string npmScript = "start";
+                            Console.WriteLine($"Info: SF is serving angular using script {npmScript}.");
+                            spa.UseAngularCliServer(npmScript);
+                            break;
+
+                        case SpaDevServerStartup.Listen:
+                            int port = 4200;
+                            string ngServeUri = $"http://localhost:{port}";
+                            Console.WriteLine($"Info: SF will use an existing angular server at {ngServeUri}.");
+                            spa.UseProxyToSpaDevelopmentServer(ngServeUri);
+                            break;
                     }
-                }
-                else if (IsTestingEnvironment)
-                {
-                    return SpaDevServerStartup.Listen;
-                }
-                return SpaDevServerStartup.None;
-            }
-        }
-
-        private bool IsDevelopmentEnvironment => Environment.IsDevelopment();
-        private bool IsTestingEnvironment => Environment.IsEnvironment("Testing");
-
-        // This method gets called by the runtime. Use this method to add services to the container.
-        public IServiceProvider ConfigureServices(IServiceCollection services)
-        {
-            var containerBuilder = new ContainerBuilder();
-
-            services.AddExceptionReporting(Configuration);
-
-            services.AddConfiguration(Configuration);
-
-            services.AddFeatureManagement();
-
-            services.AddSignalR();
-
-            string? nodeOptions = Configuration.GetValue<string>("node-options");
-            services.AddSFRealtimeServer(LoggerFactory, Configuration, nodeOptions);
-
-            services.AddSFServices();
-
-            services.AddXFAuthentication(Configuration);
-
-            services.AddSFDataAccess(Configuration);
-
-            services.Configure<RequestLocalizationOptions>(opts =>
-            {
-                var supportedCultures = new List<CultureInfo>();
-                foreach (var culture in SharedResource.Cultures)
-                {
-                    supportedCultures.Add(new CultureInfo(culture.Key));
-                }
-
-                opts.DefaultRequestCulture = new RequestCulture("en");
-                // Formatting numbers, dates, etc.
-                opts.SupportedCultures = supportedCultures;
-                // UI strings that we have localized.
-                opts.SupportedUICultures = supportedCultures;
-            });
-
-            services.AddLocalization(options => options.ResourcesPath = "Resources");
-
-            services
-                .AddMvc()
-                // TODO: check if JSON.NET is required
-                .AddNewtonsoftJson()
-                .AddViewLocalization()
-                .AddDataAnnotationsLocalization(options =>
-                {
-                    options.DataAnnotationLocalizerProvider = (type, factory) => factory.Create(typeof(SharedResource));
-                });
-
-            services.AddXFJsonRpc();
-
-            if (SpaDevServerStartup == SpaDevServerStartup.None)
-            {
-                // In production, the Angular files will be served from this directory
-                services.AddSpaStaticFiles(configuration =>
-                {
-                    configuration.RootPath = "ClientApp/dist";
                 });
             }
+        );
 
-            services.AddSFMachine(Configuration, Environment);
+        appLifetime.ApplicationStopped.Register(() => ApplicationContainer.Dispose());
+    }
 
-            containerBuilder.Populate(services);
-
-            ApplicationContainer = containerBuilder.Build();
-            return new AutofacServiceProvider(ApplicationContainer);
-        }
-
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(
-            IApplicationBuilder app,
-            IHostApplicationLifetime appLifetime,
-            IExceptionHandler exceptionHandler
+    internal bool IsSpaRoute(HttpContext context)
+    {
+        string path = context.Request.Path.Value;
+        if (path.Length <= 1)
+            return false;
+        int index = path.IndexOf("/", 1);
+        if (index == -1)
+            index = path.Length;
+        string prefix = path[1..index];
+        if (
+            !IsDevelopmentEnvironment
+            && (
+                prefix.EndsWith(".js")
+                || prefix.EndsWith(".js.map")
+                || prefix.EndsWith(".css")
+                || prefix.EndsWith(".css.map")
+            )
         )
         {
-            if (IsDevelopmentEnvironment || IsTestingEnvironment)
-            {
-                app.UseDeveloperExceptionPage();
-            }
-            else
-            {
-                app.UseExceptionHandler(errorApp => exceptionHandler.ReportExceptions(errorApp));
-            }
-
-            app.UseStatusCodePagesWithReExecute("/Status/Error", "?code={0}");
-
-            app.UseForwardedHeaders(new ForwardedHeadersOptions { ForwardedHeaders = ForwardedHeaders.All });
-
-            app.UseRequestLocalization(
-                app.ApplicationServices.GetService<IOptions<RequestLocalizationOptions>>().Value
-            );
-
-            app.UseStaticFiles(
-                new StaticFileOptions
-                {
-                    // this will allow files without extensions to be served, which is necessary for LetsEncrypt
-                    ServeUnknownFileTypes = true,
-                    OnPrepareResponse = ctx =>
-                    {
-                        ctx.Context.Response.Headers.Add("Cache-Control", "must-revalidate");
-                    }
-                }
-            );
-            IOptions<SiteOptions> siteOptions = app.ApplicationServices.GetService<IOptions<SiteOptions>>();
-            app.UseStaticFiles(
-                new StaticFileOptions
-                {
-                    FileProvider = new PhysicalFileProvider(Path.Combine(siteOptions.Value.SiteDir, "audio")),
-                    RequestPath = "/assets/audio"
-                }
-            );
-
-            if (SpaDevServerStartup == SpaDevServerStartup.None)
-                app.UseSpaStaticFiles();
-
-            app.UseRouting();
-
-            app.UseAuthentication();
-            app.UseAuthorization();
-
-            app.UseRealtimeServer();
-
-            app.UseMachine();
-
-            app.UseSFServices();
-
-            app.UseSFDataAccess();
-
-            app.UsePing();
-
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapControllers();
-                endpoints.MapRazorPages();
-                endpoints.MapHub<NotificationHub>(pattern: $"/{UrlConstants.ProjectNotifications}");
-            });
-
-            // Map JSON-RPC controllers after MVC controllers, so that MVC controllers take precedence.
-            app.UseSFJsonRpc();
-
-            app.MapWhen(
-                IsSpaRoute,
-                spaApp =>
-                {
-                    // setup all server-side routes before SPA client-side routes, so that the server-side routes supercede
-                    // the client-side routes
-                    spaApp.UseSpa(spa =>
-                    {
-                        // To learn more about options for serving an Angular SPA from ASP.NET Core,
-                        // see https://go.microsoft.com/fwlink/?linkid=864501
-                        spa.Options.SourcePath = "ClientApp";
-
-                        switch (SpaDevServerStartup)
-                        {
-                            case SpaDevServerStartup.Start:
-                                string npmScript = "start";
-                                Console.WriteLine($"Info: SF is serving angular using script {npmScript}.");
-                                spa.UseAngularCliServer(npmScript);
-                                break;
-
-                            case SpaDevServerStartup.Listen:
-                                int port = 4200;
-                                string ngServeUri = $"http://localhost:{port}";
-                                Console.WriteLine($"Info: SF will use an existing angular server at {ngServeUri}.");
-                                spa.UseProxyToSpaDevelopmentServer(ngServeUri);
-                                break;
-                        }
-                    });
-                }
-            );
-
-            appLifetime.ApplicationStopped.Register(() => ApplicationContainer.Dispose());
+            int periodIndex = path.IndexOf(".");
+            prefix = prefix[..(periodIndex - 1)];
         }
-
-        internal bool IsSpaRoute(HttpContext context)
-        {
-            string path = context.Request.Path.Value;
-            if (path.Length <= 1)
-                return false;
-            int index = path.IndexOf("/", 1);
-            if (index == -1)
-                index = path.Length;
-            string prefix = path.Substring(1, index - 1);
-            if (
-                !IsDevelopmentEnvironment
-                && (
-                    prefix.EndsWith(".js")
-                    || prefix.EndsWith(".js.map")
-                    || prefix.EndsWith(".css")
-                    || prefix.EndsWith(".css.map")
-                )
-            )
-            {
-                int periodIndex = path.IndexOf(".");
-                prefix = prefix.Substring(0, periodIndex - 1);
-            }
-            return (context.Request.Method == HttpMethods.Get && SpaGetRoutes.Contains(prefix))
-                || (context.Request.Method == HttpMethods.Post && SpaPostRoutes.Contains(prefix));
-        }
+        return (context.Request.Method == HttpMethods.Get && SpaGetRoutes.Contains(prefix))
+            || (context.Request.Method == HttpMethods.Post && SpaPostRoutes.Contains(prefix));
     }
 }

--- a/src/SIL.XForge.Scripture/ViewComponents/FooterViewComponent.cs
+++ b/src/SIL.XForge.Scripture/ViewComponents/FooterViewComponent.cs
@@ -7,42 +7,41 @@ using Newtonsoft.Json;
 using SIL.XForge.Configuration;
 using SIL.XForge.Scripture.Models;
 
-namespace SIL.XForge.Scripture.ViewComponents
+namespace SIL.XForge.Scripture.ViewComponents;
+
+/// <summary>Provides a global shared footer with common logic for all pages</summary>
+public class FooterViewComponent : ViewComponent
 {
-    /// <summary>Provides a global shared footer with common logic for all pages</summary>
-    public class FooterViewComponent : ViewComponent
+    private readonly IOptions<AuthOptions> authOptions;
+    private readonly IOptions<SiteOptions> siteOptions;
+    private readonly IConfiguration configuration;
+
+    public FooterViewComponent(
+        IOptions<AuthOptions> authOptions,
+        IOptions<SiteOptions> siteOptions,
+        IConfiguration configuration
+    )
     {
-        private readonly IOptions<AuthOptions> authOptions;
-        private readonly IOptions<SiteOptions> siteOptions;
-        private readonly IConfiguration configuration;
+        this.authOptions = authOptions;
+        this.siteOptions = siteOptions;
+        this.configuration = configuration;
+    }
 
-        public FooterViewComponent(
-            IOptions<AuthOptions> authOptions,
-            IOptions<SiteOptions> siteOptions,
-            IConfiguration configuration
-        )
+    public IViewComponentResult Invoke()
+    {
+        var appSettings = new RazorPageSettings();
+        var location = Assembly.GetEntryAssembly().Location;
+        appSettings.ProductVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(location).ProductVersion;
+
+        var bugsnagConfig = new Dictionary<string, object>
         {
-            this.authOptions = authOptions;
-            this.siteOptions = siteOptions;
-            this.configuration = configuration;
-        }
+            { "apiKey", configuration.GetValue<string>("Bugsnag:ApiKey") },
+            { "appVersion", appSettings.ProductVersion },
+            { "notifyReleaseStages", configuration.GetSection("Bugsnag:NotifyReleaseStages").Get<string[]>() },
+            { "releaseStage", configuration.GetValue<string>("Bugsnag:ReleaseStage") }
+        };
+        appSettings.BugsnagConfig = JsonConvert.SerializeObject(bugsnagConfig, Formatting.Indented);
 
-        public IViewComponentResult Invoke()
-        {
-            var appSettings = new RazorPageSettings();
-            var location = Assembly.GetEntryAssembly().Location;
-            appSettings.ProductVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(location).ProductVersion;
-
-            var bugsnagConfig = new Dictionary<string, object>
-            {
-                { "apiKey", configuration.GetValue<string>("Bugsnag:ApiKey") },
-                { "appVersion", appSettings.ProductVersion },
-                { "notifyReleaseStages", configuration.GetSection("Bugsnag:NotifyReleaseStages").Get<string[]>() },
-                { "releaseStage", configuration.GetValue<string>("Bugsnag:ReleaseStage") }
-            };
-            appSettings.BugsnagConfig = JsonConvert.SerializeObject(bugsnagConfig, Formatting.Indented);
-
-            return View(appSettings);
-        }
+        return View(appSettings);
     }
 }

--- a/src/SIL.XForge/Configuration/AudioOptions.cs
+++ b/src/SIL.XForge/Configuration/AudioOptions.cs
@@ -1,10 +1,9 @@
-namespace SIL.XForge.Configuration
+namespace SIL.XForge.Configuration;
+
+/// <summary>
+/// This class defines the audio configuration.
+/// </summary>
+public class AudioOptions
 {
-    /// <summary>
-    /// This class defines the audio configuration.
-    /// </summary>
-    public class AudioOptions
-    {
-        public string FfmpegPath { get; set; }
-    }
+    public string FfmpegPath { get; set; }
 }

--- a/src/SIL.XForge/Configuration/AuthOptions.cs
+++ b/src/SIL.XForge/Configuration/AuthOptions.cs
@@ -1,18 +1,17 @@
-namespace SIL.XForge.Configuration
+namespace SIL.XForge.Configuration;
+
+/// <summary>
+/// This class defines the authentication configuration.
+/// </summary>
+public class AuthOptions
 {
-    /// <summary>
-    /// This class defines the authentication configuration.
-    /// </summary>
-    public class AuthOptions
-    {
-        public string Domain { get; set; }
-        public string Audience { get; set; }
-        public string ManagementAudience { get; set; }
-        public string Scope { get; set; }
-        public string FrontendClientId { get; set; }
-        public string BackendClientId { get; set; }
-        public string BackendClientSecret { get; set; }
-        public string WebhookUsername { get; set; }
-        public string WebhookPassword { get; set; }
-    }
+    public string Domain { get; set; }
+    public string Audience { get; set; }
+    public string ManagementAudience { get; set; }
+    public string Scope { get; set; }
+    public string FrontendClientId { get; set; }
+    public string BackendClientId { get; set; }
+    public string BackendClientSecret { get; set; }
+    public string WebhookUsername { get; set; }
+    public string WebhookPassword { get; set; }
 }

--- a/src/SIL.XForge/Configuration/ConfigurationExtensions.cs
+++ b/src/SIL.XForge/Configuration/ConfigurationExtensions.cs
@@ -1,13 +1,13 @@
 using Microsoft.Extensions.Configuration;
 
-namespace SIL.XForge.Configuration
+namespace SIL.XForge.Configuration;
+
+public static class ConfigurationExtensions
 {
-    public static class ConfigurationExtensions
+    public static T GetOptions<T>(this IConfiguration configuration)
+        where T : class, new()
     {
-        public static T GetOptions<T>(this IConfiguration configuration) where T : class, new()
-        {
-            string sectionName = Options.GetSectionName<T>();
-            return configuration.GetSection(sectionName).Get<T>() ?? new T();
-        }
+        string sectionName = Options.GetSectionName<T>();
+        return configuration.GetSection(sectionName).Get<T>() ?? new T();
     }
 }

--- a/src/SIL.XForge/Configuration/ConfigurationServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Configuration/ConfigurationServiceCollectionExtensions.cs
@@ -1,31 +1,27 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace SIL.XForge.Configuration
-{
-    public static class ConfigurationServiceCollectionExtensions
-    {
-        public static IServiceCollection AddConfiguration(
-            this IServiceCollection services,
-            IConfiguration configuration
-        )
-        {
-            services.AddOptions<DataAccessOptions>(configuration);
-            services.AddOptions<SiteOptions>(configuration);
-            services.AddOptions<ParatextOptions>(configuration);
-            services.AddOptions<RealtimeOptions>(configuration);
-            services.AddOptions<AuthOptions>(configuration);
-            services.AddOptions<AudioOptions>(configuration);
-            services.AddOptions<MachineOptions>(configuration);
-            return services;
-        }
+namespace SIL.XForge.Configuration;
 
-        public static IServiceCollection AddOptions<T>(this IServiceCollection services, IConfiguration configuration)
-            where T : class
-        {
-            string sectionName = Options.GetSectionName<T>();
-            services.Configure<T>(configuration.GetSection(sectionName));
-            return services;
-        }
+public static class ConfigurationServiceCollectionExtensions
+{
+    public static IServiceCollection AddConfiguration(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddOptions<DataAccessOptions>(configuration);
+        services.AddOptions<SiteOptions>(configuration);
+        services.AddOptions<ParatextOptions>(configuration);
+        services.AddOptions<RealtimeOptions>(configuration);
+        services.AddOptions<AuthOptions>(configuration);
+        services.AddOptions<AudioOptions>(configuration);
+        services.AddOptions<MachineOptions>(configuration);
+        return services;
+    }
+
+    public static IServiceCollection AddOptions<T>(this IServiceCollection services, IConfiguration configuration)
+        where T : class
+    {
+        string sectionName = Options.GetSectionName<T>();
+        services.Configure<T>(configuration.GetSection(sectionName));
+        return services;
     }
 }

--- a/src/SIL.XForge/Configuration/DataAccessOptions.cs
+++ b/src/SIL.XForge/Configuration/DataAccessOptions.cs
@@ -1,10 +1,9 @@
-namespace SIL.XForge.Configuration
+namespace SIL.XForge.Configuration;
+
+public class DataAccessOptions
 {
-    public class DataAccessOptions
-    {
-        public string ConnectionString { get; set; } = "mongodb://localhost:27017";
-        public string MongoDatabaseName { get; set; } = "xforge";
-        public string JobDatabaseName { get; set; }
-        public string Prefix { get; set; }
-    }
+    public string ConnectionString { get; set; } = "mongodb://localhost:27017";
+    public string MongoDatabaseName { get; set; } = "xforge";
+    public string JobDatabaseName { get; set; }
+    public string Prefix { get; set; }
 }

--- a/src/SIL.XForge/Configuration/DocConfig.cs
+++ b/src/SIL.XForge/Configuration/DocConfig.cs
@@ -1,26 +1,25 @@
 using System;
 using SIL.XForge.Realtime;
 
-namespace SIL.XForge.Configuration
+namespace SIL.XForge.Configuration;
+
+/// <summary>
+/// This class represents the configuration of a real-time document type.
+/// </summary>
+public class DocConfig
 {
-    /// <summary>
-    /// This class represents the configuration of a real-time document type.
-    /// </summary>
-    public class DocConfig
+    public DocConfig(string collectionName, Type type, string otTypeName = OTType.Json0)
     {
-        public DocConfig(string collectionName, Type type, string otTypeName = OTType.Json0)
-        {
-            CollectionName = collectionName;
-            Type = type;
-            OTTypeName = otTypeName;
-        }
-
-        public string CollectionName { get; }
-        public Type Type { get; }
-
-        /// <summary>
-        /// Or `null` if there is no corresponding "o_..." collection for this document type.
-        /// </summary>
-        public string OTTypeName { get; }
+        CollectionName = collectionName;
+        Type = type;
+        OTTypeName = otTypeName;
     }
+
+    public string CollectionName { get; }
+    public Type Type { get; }
+
+    /// <summary>
+    /// Or `null` if there is no corresponding "o_..." collection for this document type.
+    /// </summary>
+    public string OTTypeName { get; }
 }

--- a/src/SIL.XForge/Configuration/MachineOptions.cs
+++ b/src/SIL.XForge/Configuration/MachineOptions.cs
@@ -1,14 +1,13 @@
-namespace SIL.XForge.Configuration
+namespace SIL.XForge.Configuration;
+
+/// <summary>
+/// Configuration options for the Machine API.
+/// </summary>
+public class MachineOptions
 {
-    /// <summary>
-    /// Configuration options for the Machine API.
-    /// </summary>
-    public class MachineOptions
-    {
-        public string ApiServer { get; set; } = string.Empty;
-        public string Audience { get; set; } = string.Empty;
-        public string ClientId { get; set; } = string.Empty;
-        public string ClientSecret { get; set; } = string.Empty;
-        public string TokenUrl { get; set; } = string.Empty;
-    }
+    public string ApiServer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string ClientId { get; set; } = string.Empty;
+    public string ClientSecret { get; set; } = string.Empty;
+    public string TokenUrl { get; set; } = string.Empty;
 }

--- a/src/SIL.XForge/Configuration/Options.cs
+++ b/src/SIL.XForge/Configuration/Options.cs
@@ -1,13 +1,12 @@
-namespace SIL.XForge.Configuration
+namespace SIL.XForge.Configuration;
+
+public static class Options
 {
-    public static class Options
+    public static string GetSectionName<T>()
     {
-        public static string GetSectionName<T>()
-        {
-            string sectionName = typeof(T).Name;
-            if (sectionName.EndsWith("Options"))
-                sectionName = sectionName.Substring(0, sectionName.Length - "Options".Length);
-            return sectionName;
-        }
+        string sectionName = typeof(T).Name;
+        if (sectionName.EndsWith("Options"))
+            sectionName = sectionName[..^"Options".Length];
+        return sectionName;
     }
 }

--- a/src/SIL.XForge/Configuration/ParatextOptions.cs
+++ b/src/SIL.XForge/Configuration/ParatextOptions.cs
@@ -1,11 +1,10 @@
-namespace SIL.XForge.Configuration
+namespace SIL.XForge.Configuration;
+
+public class ParatextOptions
 {
-    public class ParatextOptions
-    {
-        public string ClientId { get; set; } = "client_id";
-        public string ClientSecret { get; set; } = "client_secret";
-        public string HgExe { get; set; }
-        public string ResourcePasswordBase64 { get; set; }
-        public string ResourcePasswordHash { get; set; }
-    }
+    public string ClientId { get; set; } = "client_id";
+    public string ClientSecret { get; set; } = "client_secret";
+    public string HgExe { get; set; }
+    public string ResourcePasswordBase64 { get; set; }
+    public string ResourcePasswordHash { get; set; }
 }

--- a/src/SIL.XForge/Configuration/RealtimeOptions.cs
+++ b/src/SIL.XForge/Configuration/RealtimeOptions.cs
@@ -1,29 +1,28 @@
 using System.Collections.Generic;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Configuration
+namespace SIL.XForge.Configuration;
+
+/// <summary>
+/// This class represents the configuration of the real-time service.
+/// </summary>
+public class RealtimeOptions
 {
+    public string AppModuleName { get; set; }
+    public int Port { get; set; }
+    public bool MigrationsDisabled = false;
+    public DocConfig UserDoc { get; set; } = new DocConfig("users", typeof(User));
+    public DocConfig ProjectDoc { get; set; }
+
     /// <summary>
-    /// This class represents the configuration of the real-time service.
+    /// Additional document types (importantly, collection names) that have project related data. Defining this
+    /// helps identify and delete project data when removing a project.
     /// </summary>
-    public class RealtimeOptions
-    {
-        public string AppModuleName { get; set; }
-        public int Port { get; set; }
-        public bool MigrationsDisabled = false;
-        public DocConfig UserDoc { get; set; } = new DocConfig("users", typeof(User));
-        public DocConfig ProjectDoc { get; set; }
+    public List<DocConfig> ProjectDataDocs { get; set; } = new List<DocConfig>();
 
-        /// <summary>
-        /// Additional document types (importantly, collection names) that have project related data. Defining this
-        /// helps identify and delete project data when removing a project.
-        /// </summary>
-        public List<DocConfig> ProjectDataDocs { get; set; } = new List<DocConfig>();
-
-        /// <summary>
-        /// Document types (importantly, collection names) that have user information, from which to delete records
-        /// when removing a user from the database.
-        /// </summary>
-        public List<DocConfig> UserDataDocs { get; set; } = new List<DocConfig>();
-    }
+    /// <summary>
+    /// Document types (importantly, collection names) that have user information, from which to delete records
+    /// when removing a user from the database.
+    /// </summary>
+    public List<DocConfig> UserDataDocs { get; set; } = new List<DocConfig>();
 }

--- a/src/SIL.XForge/Configuration/SiteOptions.cs
+++ b/src/SIL.XForge/Configuration/SiteOptions.cs
@@ -1,18 +1,17 @@
 using System;
 
-namespace SIL.XForge.Configuration
+namespace SIL.XForge.Configuration;
+
+public class SiteOptions
 {
-    public class SiteOptions
-    {
-        public string Id { get; set; }
-        public string Name { get; set; }
-        public Uri Origin { get; set; }
-        public string SmtpServer { get; set; }
-        public string PortNumber { get; set; }
-        public string EmailFromAddress { get; set; }
-        public bool SendEmail { get; set; }
-        public string IssuesEmail { get; set; }
-        public string SiteDir { get; set; }
-        public string SharedDir { get; set; }
-    }
+    public string Id { get; set; }
+    public string Name { get; set; }
+    public Uri Origin { get; set; }
+    public string SmtpServer { get; set; }
+    public string PortNumber { get; set; }
+    public string EmailFromAddress { get; set; }
+    public bool SendEmail { get; set; }
+    public string IssuesEmail { get; set; }
+    public string SiteDir { get; set; }
+    public string SharedDir { get; set; }
 }

--- a/src/SIL.XForge/Controllers/RpcControllerBase.cs
+++ b/src/SIL.XForge/Controllers/RpcControllerBase.cs
@@ -4,41 +4,32 @@ using EdjCase.JsonRpc.Router.Abstractions;
 using Microsoft.AspNetCore.Authorization;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Controllers
+namespace SIL.XForge.Controllers;
+
+/// <summary>
+/// This is the base class for all JSON-RPC controllers.
+/// </summary>
+[Authorize]
+public abstract class RpcControllerBase : RpcController
 {
-    /// <summary>
-    /// This is the base class for all JSON-RPC controllers.
-    /// </summary>
-    [Authorize]
-    public abstract class RpcControllerBase : RpcController
+    private readonly IExceptionHandler _exceptionHandler;
+    private readonly IUserAccessor _userAccessor;
+
+    protected RpcControllerBase(IUserAccessor userAccessor, IExceptionHandler exceptionHandler)
     {
-        private readonly IExceptionHandler _exceptionHandler;
-        private readonly IUserAccessor _userAccessor;
-
-        protected RpcControllerBase(IUserAccessor userAccessor, IExceptionHandler exceptionHandler)
-        {
-            _userAccessor = userAccessor;
-            _exceptionHandler = exceptionHandler;
-            exceptionHandler.RecordUserIdForException(_userAccessor.UserId);
-        }
-
-        protected string UserId => _userAccessor.UserId;
-        protected string SystemRole => _userAccessor.SystemRole;
-        protected string AuthId => _userAccessor.AuthId;
-
-        protected IRpcMethodResult InvalidParamsError(string message)
-        {
-            return Error((int)RpcErrorCode.InvalidParams, message);
-        }
-
-        protected IRpcMethodResult ForbiddenError()
-        {
-            return Error(-32000, "The user does not have permission to perform this operation.");
-        }
-
-        protected IRpcMethodResult NotFoundError(string message)
-        {
-            return Error(-32001, message);
-        }
+        _userAccessor = userAccessor;
+        _exceptionHandler = exceptionHandler;
+        exceptionHandler.RecordUserIdForException(_userAccessor.UserId);
     }
+
+    protected string UserId => _userAccessor.UserId;
+    protected string SystemRole => _userAccessor.SystemRole;
+    protected string AuthId => _userAccessor.AuthId;
+
+    protected IRpcMethodResult InvalidParamsError(string message) => Error((int)RpcErrorCode.InvalidParams, message);
+
+    protected IRpcMethodResult ForbiddenError() =>
+        Error(-32000, "The user does not have permission to perform this operation.");
+
+    protected IRpcMethodResult NotFoundError(string message) => Error(-32001, message);
 }

--- a/src/SIL.XForge/Controllers/UrlConstants.cs
+++ b/src/SIL.XForge/Controllers/UrlConstants.cs
@@ -1,10 +1,9 @@
-namespace SIL.XForge
+namespace SIL.XForge;
+
+public static class UrlConstants
 {
-    public static class UrlConstants
-    {
-        public const string CommandApiNamespace = "command-api";
-        public const string Users = "users";
-        public const string Projects = "projects";
-        public const string ProjectNotifications = "project-notifications";
-    }
+    public const string CommandApiNamespace = "command-api";
+    public const string Users = "users";
+    public const string Projects = "projects";
+    public const string ProjectNotifications = "project-notifications";
 }

--- a/src/SIL.XForge/Controllers/UsersRpcController.cs
+++ b/src/SIL.XForge/Controllers/UsersRpcController.cs
@@ -9,152 +9,145 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Controllers
+namespace SIL.XForge.Controllers;
+
+/// <summary>
+/// This is the controller for all JSON-RPC commands for users.
+/// </summary>
+public class UsersRpcController : RpcControllerBase
 {
-    /// <summary>
-    /// This is the controller for all JSON-RPC commands for users.
-    /// </summary>
-    public class UsersRpcController : RpcControllerBase
+    private readonly IAuthService _authService;
+    private readonly IExceptionHandler _exceptionHandler;
+    private readonly IWebHostEnvironment _hostingEnv;
+    private readonly IUserService _userService;
+
+    public UsersRpcController(
+        IUserAccessor userAccessor,
+        IUserService userService,
+        IAuthService authService,
+        IWebHostEnvironment hostingEnv,
+        IExceptionHandler exceptionHandler
+    )
+        : base(userAccessor, exceptionHandler)
     {
-        private readonly IAuthService _authService;
-        private readonly IExceptionHandler _exceptionHandler;
-        private readonly IWebHostEnvironment _hostingEnv;
-        private readonly IUserService _userService;
+        _userService = userService;
+        _authService = authService;
+        _hostingEnv = hostingEnv;
+        _exceptionHandler = exceptionHandler;
+    }
 
-        public UsersRpcController(
-            IUserAccessor userAccessor,
-            IUserService userService,
-            IAuthService authService,
-            IWebHostEnvironment hostingEnv,
-            IExceptionHandler exceptionHandler
-        ) : base(userAccessor, exceptionHandler)
+    /// <summary>
+    /// Updates the user entity from the specified Auth0 user profile. Auth0 calls this command from a rule.
+    /// </summary>
+    [Authorize(AuthenticationSchemes = BasicAuthenticationDefaults.AuthenticationScheme)]
+    public Task PushAuthUserProfile(string userId, JsonElement userProfile)
+    {
+        try
         {
-            _userService = userService;
-            _authService = authService;
-            _hostingEnv = hostingEnv;
-            _exceptionHandler = exceptionHandler;
+            return _userService.UpdateUserFromProfileAsync(userId, userProfile.ToString());
         }
-
-        /// <summary>
-        /// Updates the user entity from the specified Auth0 user profile. Auth0 calls this command from a rule.
-        /// </summary>
-        [Authorize(AuthenticationSchemes = BasicAuthenticationDefaults.AuthenticationScheme)]
-        public Task PushAuthUserProfile(string userId, JsonElement userProfile)
+        catch (Exception)
         {
-            try
-            {
-                return _userService.UpdateUserFromProfileAsync(userId, userProfile.ToString());
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string> { { "method", "PushAuthUserProfile" }, { "userId", userId }, }
-                );
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// Updates the current user's entity from the user's corresponding Auth0 profile. This command is used instead
-        /// of <see cref="PushAuthUserProfile"/> in development environments, because Auth0 rules cannot call a local
-        /// development machine.
-        /// </summary>
-        public async Task<IRpcMethodResult> PullAuthUserProfile()
-        {
-            if (!(_hostingEnv.IsDevelopment()))
-                return ForbiddenError();
-
-            string userProfile = await _authService.GetUserAsync(AuthId);
-            await _userService.UpdateUserFromProfileAsync(UserId, userProfile);
-            return Ok();
-        }
-
-        public async Task<IRpcMethodResult> LinkParatextAccount(string primaryId, string secondaryId)
-        {
-            try
-            {
-                await _userService.LinkParatextAccountAsync(primaryId, secondaryId);
-                return Ok();
-            }
-            catch (ArgumentException e)
-            {
-                return InvalidParamsError(e.Message);
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string>
-                    {
-                        { "method", "LinkParatextAccount" },
-                        { "primaryId", primaryId },
-                        { "secondaryId", secondaryId },
-                    }
-                );
-                throw;
-            }
-        }
-
-        public async Task<IRpcMethodResult> UpdateAvatarFromDisplayName()
-        {
-            try
-            {
-                await _userService.UpdateAvatarFromDisplayNameAsync(UserId, AuthId);
-                return Ok();
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string> { { "method", "UpdateAvatarFromDisplayName" }, }
-                );
-                throw;
-            }
-        }
-
-        public async Task<IRpcMethodResult> UpdateInterfaceLanguage(string language)
-        {
-            try
-            {
-                await _userService.UpdateInterfaceLanguageAsync(UserId, AuthId, language);
-                return Ok();
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string>
-                    {
-                        { "method", "UpdateInterfaceLanguage" },
-                        { "language", language },
-                    }
-                );
-                throw;
-            }
-        }
-
-        public async Task<IRpcMethodResult> Delete(string userId)
-        {
-            try
-            {
-                await _userService.DeleteAsync(UserId, SystemRole, userId);
-                return Ok();
-            }
-            catch (ForbiddenException)
-            {
-                return ForbiddenError();
-            }
-            catch (Exception)
-            {
-                _exceptionHandler.RecordEndpointInfoForException(
-                    new Dictionary<string, string> { { "method", "Delete" }, { "userId", userId }, }
-                );
-
-                throw;
-            }
-        }
-
-        [Obsolete("Only here for clients still running a front end that still calls it")]
-        public IRpcMethodResult CheckUserNeedsMigrating(string userId)
-        {
-            return Ok(false);
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string> { { "method", "PushAuthUserProfile" }, { "userId", userId }, }
+            );
+            throw;
         }
     }
+
+    /// <summary>
+    /// Updates the current user's entity from the user's corresponding Auth0 profile. This command is used instead
+    /// of <see cref="PushAuthUserProfile"/> in development environments, because Auth0 rules cannot call a local
+    /// development machine.
+    /// </summary>
+    public async Task<IRpcMethodResult> PullAuthUserProfile()
+    {
+        if (!(_hostingEnv.IsDevelopment()))
+            return ForbiddenError();
+
+        string userProfile = await _authService.GetUserAsync(AuthId);
+        await _userService.UpdateUserFromProfileAsync(UserId, userProfile);
+        return Ok();
+    }
+
+    public async Task<IRpcMethodResult> LinkParatextAccount(string primaryId, string secondaryId)
+    {
+        try
+        {
+            await _userService.LinkParatextAccountAsync(primaryId, secondaryId);
+            return Ok();
+        }
+        catch (ArgumentException e)
+        {
+            return InvalidParamsError(e.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string>
+                {
+                    { "method", "LinkParatextAccount" },
+                    { "primaryId", primaryId },
+                    { "secondaryId", secondaryId },
+                }
+            );
+            throw;
+        }
+    }
+
+    public async Task<IRpcMethodResult> UpdateAvatarFromDisplayName()
+    {
+        try
+        {
+            await _userService.UpdateAvatarFromDisplayNameAsync(UserId, AuthId);
+            return Ok();
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string> { { "method", "UpdateAvatarFromDisplayName" }, }
+            );
+            throw;
+        }
+    }
+
+    public async Task<IRpcMethodResult> UpdateInterfaceLanguage(string language)
+    {
+        try
+        {
+            await _userService.UpdateInterfaceLanguageAsync(UserId, AuthId, language);
+            return Ok();
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string> { { "method", "UpdateInterfaceLanguage" }, { "language", language }, }
+            );
+            throw;
+        }
+    }
+
+    public async Task<IRpcMethodResult> Delete(string userId)
+    {
+        try
+        {
+            await _userService.DeleteAsync(UserId, SystemRole, userId);
+            return Ok();
+        }
+        catch (ForbiddenException)
+        {
+            return ForbiddenError();
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string> { { "method", "Delete" }, { "userId", userId }, }
+            );
+
+            throw;
+        }
+    }
+
+    [Obsolete("Only here for clients still running a front end that still calls it")]
+    public IRpcMethodResult CheckUserNeedsMigrating(string userId) => Ok(false);
 }

--- a/src/SIL.XForge/DataAccess/DataAccessApplicationBuilderExtensions.cs
+++ b/src/SIL.XForge/DataAccess/DataAccessApplicationBuilderExtensions.cs
@@ -3,20 +3,17 @@ using Microsoft.Extensions.DependencyInjection;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
 
-namespace Microsoft.AspNetCore.Builder
+namespace Microsoft.AspNetCore.Builder;
+
+public static class DataAccessApplicationBuilderExtensions
 {
-    public static class DataAccessApplicationBuilderExtensions
+    public static void UseDataAccess(this IApplicationBuilder app)
     {
-        public static void UseDataAccess(this IApplicationBuilder app)
-        {
-            app.UseHangfireDashboard();
+        app.UseHangfireDashboard();
 
-            app.InitRepository<UserSecret>();
-        }
-
-        public static void InitRepository<T>(this IApplicationBuilder app) where T : IIdentifiable
-        {
-            app.ApplicationServices.GetService<IRepository<T>>().Init();
-        }
+        app.InitRepository<UserSecret>();
     }
+
+    public static void InitRepository<T>(this IApplicationBuilder app)
+        where T : IIdentifiable => app.ApplicationServices.GetService<IRepository<T>>().Init();
 }

--- a/src/SIL.XForge/DataAccess/DataAccessClassMap.cs
+++ b/src/SIL.XForge/DataAccess/DataAccessClassMap.cs
@@ -2,28 +2,23 @@ using System;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
 
-namespace SIL.XForge.DataAccess
-{
-    public static class DataAccessClassMap
-    {
-        public static void RegisterConventions(string nspace, params IConvention[] conventions)
-        {
-            var conventionPack = new ConventionPack();
-            conventionPack.AddRange(conventions);
-            ConventionRegistry.Register(
-                nspace,
-                conventionPack,
-                t => t.Namespace != null && t.Namespace.StartsWith(nspace)
-            );
-        }
+namespace SIL.XForge.DataAccess;
 
-        public static void RegisterClass<T>(Action<BsonClassMap<T>> mapSetup)
+public static class DataAccessClassMap
+{
+    public static void RegisterConventions(string nspace, params IConvention[] conventions)
+    {
+        var conventionPack = new ConventionPack();
+        conventionPack.AddRange(conventions);
+        ConventionRegistry.Register(nspace, conventionPack, t => t.Namespace != null && t.Namespace.StartsWith(nspace));
+    }
+
+    public static void RegisterClass<T>(Action<BsonClassMap<T>> mapSetup)
+    {
+        BsonClassMap.RegisterClassMap<T>(cm =>
         {
-            BsonClassMap.RegisterClassMap<T>(cm =>
-            {
-                cm.AutoMap();
-                mapSetup?.Invoke(cm);
-            });
-        }
+            cm.AutoMap();
+            mapSetup?.Invoke(cm);
+        });
     }
 }

--- a/src/SIL.XForge/DataAccess/DataAccessExtensions.cs
+++ b/src/SIL.XForge/DataAccess/DataAccessExtensions.cs
@@ -8,230 +8,216 @@ using MongoDB.Driver.Linq;
 using SIL.XForge.Models;
 using SIL.XForge.Utils;
 
-namespace SIL.XForge.DataAccess
+namespace SIL.XForge.DataAccess;
+
+public static class DataAccessExtensions
 {
-    public static class DataAccessExtensions
+    public static Task<T> UpdateAsync<T>(
+        this IRepository<T> repo,
+        string id,
+        Action<IUpdateBuilder<T>> update,
+        bool upsert = false
+    )
+        where T : IIdentifiable => repo.UpdateAsync(e => e.Id == id, update, upsert);
+
+    public static Task<T> UpdateAsync<T>(
+        this IRepository<T> repo,
+        T entity,
+        Action<IUpdateBuilder<T>> update,
+        bool upsert = false
+    )
+        where T : IIdentifiable => repo.UpdateAsync(entity.Id, update, upsert);
+
+    public static async Task<T> DeleteAsync<T>(this IRepository<T> repo, string id)
+        where T : IIdentifiable => await repo.DeleteAsync(e => e.Id == id);
+
+    public static async Task<bool> DeleteAsync<T>(this IRepository<T> repo, T entity)
+        where T : IIdentifiable => (await repo.DeleteAsync(e => e.Id == entity.Id)) != null;
+
+    public static async Task<T> GetAsync<T>(this IRepository<T> repo, string id)
+        where T : IIdentifiable
     {
-        public static Task<T> UpdateAsync<T>(
-            this IRepository<T> repo,
-            string id,
-            Action<IUpdateBuilder<T>> update,
-            bool upsert = false
-        ) where T : IIdentifiable
-        {
-            return repo.UpdateAsync(e => e.Id == id, update, upsert);
-        }
+        Attempt<T> attempt = await repo.TryGetAsync(id);
+        if (attempt.Success)
+            return attempt.Result;
+        return default;
+    }
 
-        public static Task<T> UpdateAsync<T>(
-            this IRepository<T> repo,
-            T entity,
-            Action<IUpdateBuilder<T>> update,
-            bool upsert = false
-        ) where T : IIdentifiable
-        {
-            return repo.UpdateAsync(entity.Id, update, upsert);
-        }
+    public static async Task<IReadOnlyList<T>> GetAllAsync<T>(this IRepository<T> repo)
+        where T : IIdentifiable => await repo.Query().ToListAsync();
 
-        public static async Task<T> DeleteAsync<T>(this IRepository<T> repo, string id) where T : IIdentifiable
-        {
-            return await repo.DeleteAsync(e => e.Id == id);
-        }
+    public static async Task<Attempt<T>> TryGetAsync<T>(this IRepository<T> repo, string id)
+        where T : IIdentifiable
+    {
+        T entity = await repo.Query().Where(e => e.Id == id).FirstOrDefaultAsync();
+        return new Attempt<T>(entity != null, entity);
+    }
 
-        public static async Task<bool> DeleteAsync<T>(this IRepository<T> repo, T entity) where T : IIdentifiable
-        {
-            return (await repo.DeleteAsync(e => e.Id == entity.Id)) != null;
-        }
+    public static async Task<T> FirstOrDefaultAsync<T>(this IQueryable<T> queryable)
+    {
+        if (queryable is IMongoQueryable<T> mongoQueryable)
+            return await MongoQueryable.FirstOrDefaultAsync(mongoQueryable);
+        else
+            return queryable.FirstOrDefault();
+    }
 
-        public static async Task<T> GetAsync<T>(this IRepository<T> repo, string id) where T : IIdentifiable
-        {
-            Attempt<T> attempt = await repo.TryGetAsync(id);
-            if (attempt.Success)
-                return attempt.Result;
-            return default(T);
-        }
+    public static async Task<T> FirstOrDefaultAsync<T>(
+        this IQueryable<T> queryable,
+        Expression<Func<T, bool>> predicate
+    )
+    {
+        if (queryable is IMongoQueryable<T> mongoQueryable)
+            return await MongoQueryable.FirstOrDefaultAsync(mongoQueryable, predicate);
+        else
+            return queryable.FirstOrDefault(predicate);
+    }
 
-        public static async Task<IReadOnlyList<T>> GetAllAsync<T>(this IRepository<T> repo) where T : IIdentifiable
-        {
-            return await repo.Query().ToListAsync();
-        }
+    public static async Task<T> SingleOrDefaultAsync<T>(this IQueryable<T> queryable)
+    {
+        if (queryable is IMongoQueryable<T> mongoQueryable)
+            return await MongoQueryable.SingleOrDefaultAsync(mongoQueryable);
+        else
+            return queryable.SingleOrDefault();
+    }
 
-        public static async Task<Attempt<T>> TryGetAsync<T>(this IRepository<T> repo, string id) where T : IIdentifiable
-        {
-            T entity = await repo.Query().Where(e => e.Id == id).FirstOrDefaultAsync();
-            return new Attempt<T>(entity != null, entity);
-        }
+    public static async Task<T> SingleOrDefaultAsync<T>(
+        this IQueryable<T> queryable,
+        Expression<Func<T, bool>> predicate
+    )
+    {
+        if (queryable is IMongoQueryable<T> mongoQueryable)
+            return await MongoQueryable.SingleOrDefaultAsync(mongoQueryable, predicate);
+        else
+            return queryable.SingleOrDefault(predicate);
+    }
 
-        public static async Task<T> FirstOrDefaultAsync<T>(this IQueryable<T> queryable)
-        {
-            if (queryable is IMongoQueryable<T> mongoQueryable)
-                return await MongoQueryable.FirstOrDefaultAsync(mongoQueryable);
-            else
-                return queryable.FirstOrDefault();
-        }
+    public static async Task<int> CountAsync<T>(this IQueryable<T> queryable)
+    {
+        if (queryable is IMongoQueryable<T> mongoQueryable)
+            return await MongoQueryable.CountAsync(mongoQueryable);
+        else
+            return queryable.Count();
+    }
 
-        public static async Task<T> FirstOrDefaultAsync<T>(
-            this IQueryable<T> queryable,
-            Expression<Func<T, bool>> predicate
-        )
-        {
-            if (queryable is IMongoQueryable<T> mongoQueryable)
-                return await MongoQueryable.FirstOrDefaultAsync(mongoQueryable, predicate);
-            else
-                return queryable.FirstOrDefault(predicate);
-        }
+    public static async Task<int> CountAsync<T>(this IQueryable<T> queryable, Expression<Func<T, bool>> predicate)
+    {
+        if (queryable is IMongoQueryable<T> mongoQueryable)
+            return await MongoQueryable.CountAsync(mongoQueryable, predicate);
+        else
+            return queryable.Count(predicate);
+    }
 
-        public static async Task<T> SingleOrDefaultAsync<T>(this IQueryable<T> queryable)
-        {
-            if (queryable is IMongoQueryable<T> mongoQueryable)
-                return await MongoQueryable.SingleOrDefaultAsync(mongoQueryable);
-            else
-                return queryable.SingleOrDefault();
-        }
+    public static async Task<bool> AnyAsync<T>(this IQueryable<T> queryable)
+    {
+        if (queryable is IMongoQueryable<T> mongoQueryable)
+            return await MongoQueryable.AnyAsync(mongoQueryable);
+        else
+            return queryable.Any();
+    }
 
-        public static async Task<T> SingleOrDefaultAsync<T>(
-            this IQueryable<T> queryable,
-            Expression<Func<T, bool>> predicate
-        )
-        {
-            if (queryable is IMongoQueryable<T> mongoQueryable)
-                return await MongoQueryable.SingleOrDefaultAsync(mongoQueryable, predicate);
-            else
-                return queryable.SingleOrDefault(predicate);
-        }
+    public static async Task<bool> AnyAsync<T>(this IQueryable<T> queryable, Expression<Func<T, bool>> predicate)
+    {
+        if (queryable is IMongoQueryable<T> mongoQueryable)
+            return await MongoQueryable.AnyAsync(mongoQueryable, predicate);
+        else
+            return queryable.Any(predicate);
+    }
 
-        public static async Task<int> CountAsync<T>(this IQueryable<T> queryable)
+    public static async Task<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(
+        this IQueryable<TSource> queryable,
+        Func<TSource, Task<TKey>> keySelector,
+        Func<TSource, Task<TElement>> elementSelector,
+        IEqualityComparer<TKey> comparer = null
+    )
+    {
+        var results = new Dictionary<TKey, TElement>(comparer);
+        if (queryable is IMongoQueryable<TSource> mongoQueryable)
         {
-            if (queryable is IMongoQueryable<T> mongoQueryable)
-                return await MongoQueryable.CountAsync(mongoQueryable);
-            else
-                return queryable.Count();
-        }
-
-        public static async Task<int> CountAsync<T>(this IQueryable<T> queryable, Expression<Func<T, bool>> predicate)
-        {
-            if (queryable is IMongoQueryable<T> mongoQueryable)
-                return await MongoQueryable.CountAsync(mongoQueryable, predicate);
-            else
-                return queryable.Count(predicate);
-        }
-
-        public static async Task<bool> AnyAsync<T>(this IQueryable<T> queryable)
-        {
-            if (queryable is IMongoQueryable<T> mongoQueryable)
-                return await MongoQueryable.AnyAsync(mongoQueryable);
-            else
-                return queryable.Any();
-        }
-
-        public static async Task<bool> AnyAsync<T>(this IQueryable<T> queryable, Expression<Func<T, bool>> predicate)
-        {
-            if (queryable is IMongoQueryable<T> mongoQueryable)
-                return await MongoQueryable.AnyAsync(mongoQueryable, predicate);
-            else
-                return queryable.Any(predicate);
-        }
-
-        public static async Task<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(
-            this IQueryable<TSource> queryable,
-            Func<TSource, Task<TKey>> keySelector,
-            Func<TSource, Task<TElement>> elementSelector,
-            IEqualityComparer<TKey> comparer = null
-        )
-        {
-            var results = new Dictionary<TKey, TElement>(comparer);
-            if (queryable is IMongoQueryable<TSource> mongoQueryable)
+            using IAsyncCursor<TSource> cursor = await mongoQueryable.ToCursorAsync();
+            while (await cursor.MoveNextAsync())
             {
-                using IAsyncCursor<TSource> cursor = await mongoQueryable.ToCursorAsync();
-                while (await cursor.MoveNextAsync())
-                {
-                    foreach (TSource entity in cursor.Current)
-                        results.Add(await keySelector(entity), await elementSelector(entity));
-                }
-            }
-            else
-            {
-                foreach (TSource entity in queryable)
-                {
+                foreach (TSource entity in cursor.Current)
                     results.Add(await keySelector(entity), await elementSelector(entity));
-                }
             }
-
-            return results;
         }
-
-        public static Task<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(
-            this IQueryable<TSource> queryable,
-            Func<TSource, TKey> keySelector,
-            Func<TSource, TElement> elementSelector,
-            IEqualityComparer<TKey> comparer = null
-        )
+        else
         {
-            return queryable.ToDictionaryAsync(
-                k => Task.FromResult(keySelector(k)),
-                v => Task.FromResult(elementSelector(v)),
-                comparer
-            );
-        }
-
-        public static async Task<List<T>> ToListAsync<T>(this IQueryable<T> queryable)
-        {
-            if (queryable is IMongoQueryable<T> mongoQueryable)
-                return await IAsyncCursorSourceExtensions.ToListAsync(mongoQueryable);
-            else
-                return queryable.ToList();
-        }
-
-        public static async Task<List<TResult>> ToListAsync<TSource, TResult>(
-            this IQueryable<TSource> queryable,
-            Func<TSource, Task<TResult>> selector
-        )
-        {
-            var results = new List<TResult>();
-            if (queryable is IMongoQueryable<TSource> mongoQueryable)
+            foreach (TSource entity in queryable)
             {
-                using (IAsyncCursor<TSource> cursor = await mongoQueryable.ToCursorAsync())
-                {
-                    while (await cursor.MoveNextAsync())
-                    {
-                        foreach (TSource entity in cursor.Current)
-                            results.Add(await selector(entity));
-                    }
-                }
+                results.Add(await keySelector(entity), await elementSelector(entity));
             }
-            else
+        }
+
+        return results;
+    }
+
+    public static Task<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(
+        this IQueryable<TSource> queryable,
+        Func<TSource, TKey> keySelector,
+        Func<TSource, TElement> elementSelector,
+        IEqualityComparer<TKey> comparer = null
+    )
+    {
+        return queryable.ToDictionaryAsync(
+            k => Task.FromResult(keySelector(k)),
+            v => Task.FromResult(elementSelector(v)),
+            comparer
+        );
+    }
+
+    public static async Task<List<T>> ToListAsync<T>(this IQueryable<T> queryable)
+    {
+        if (queryable is IMongoQueryable<T> mongoQueryable)
+            return await IAsyncCursorSourceExtensions.ToListAsync(mongoQueryable);
+        else
+            return queryable.ToList();
+    }
+
+    public static async Task<List<TResult>> ToListAsync<TSource, TResult>(
+        this IQueryable<TSource> queryable,
+        Func<TSource, Task<TResult>> selector
+    )
+    {
+        var results = new List<TResult>();
+        if (queryable is IMongoQueryable<TSource> mongoQueryable)
+        {
+            using IAsyncCursor<TSource> cursor = await mongoQueryable.ToCursorAsync();
+            while (await cursor.MoveNextAsync())
             {
-                foreach (TSource entity in queryable)
+                foreach (TSource entity in cursor.Current)
                     results.Add(await selector(entity));
             }
-            return results;
         }
-
-        public static Task<List<TResult>> ToListAsync<TSource, TResult>(
-            this IQueryable<TSource> query,
-            Func<TSource, TResult> selector
-        )
+        else
         {
-            return query.ToListAsync(e => Task.FromResult(selector(e)));
+            foreach (TSource entity in queryable)
+                results.Add(await selector(entity));
         }
+        return results;
+    }
 
-        public static void CreateOrUpdate<T>(this IMongoIndexManager<T> indexes, CreateIndexModel<T> indexModel)
+    public static Task<List<TResult>> ToListAsync<TSource, TResult>(
+        this IQueryable<TSource> query,
+        Func<TSource, TResult> selector
+    ) => query.ToListAsync(e => Task.FromResult(selector(e)));
+
+    public static void CreateOrUpdate<T>(this IMongoIndexManager<T> indexes, CreateIndexModel<T> indexModel)
+    {
+        try
         {
-            try
+            indexes.CreateOne(indexModel);
+        }
+        catch (MongoCommandException ex)
+        {
+            if (ex.CodeName == "IndexOptionsConflict")
             {
+                string name = ex.Command["indexes"][0]["name"].AsString;
+                indexes.DropOne(name);
                 indexes.CreateOne(indexModel);
             }
-            catch (MongoCommandException ex)
+            else
             {
-                if (ex.CodeName == "IndexOptionsConflict")
-                {
-                    string name = ex.Command["indexes"][0]["name"].AsString;
-                    indexes.DropOne(name);
-                    indexes.CreateOne(indexModel);
-                }
-                else
-                {
-                    throw;
-                }
+                throw;
             }
         }
     }

--- a/src/SIL.XForge/DataAccess/DataAccessServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/DataAccess/DataAccessServiceCollectionExtensions.cs
@@ -11,70 +11,71 @@ using SIL.XForge.Configuration;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
 
-namespace Microsoft.Extensions.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class DataAccessServiceCollectionExtensions
 {
-    public static class DataAccessServiceCollectionExtensions
+    public static IServiceCollection AddDataAccess(this IServiceCollection services, IConfiguration configuration)
     {
-        public static IServiceCollection AddDataAccess(this IServiceCollection services, IConfiguration configuration)
-        {
-            var options = configuration.GetOptions<DataAccessOptions>();
-            string jobDatabaseName = options.JobDatabaseName ?? options.Prefix + "_jobs";
-            services.AddHangfireServer();
-            services.AddHangfire(
-                x =>
-                    x.UseMongoStorage(
-                        $"{options.ConnectionString}/{jobDatabaseName}",
-                        new MongoStorageOptions
+        var options = configuration.GetOptions<DataAccessOptions>();
+        string jobDatabaseName = options.JobDatabaseName ?? options.Prefix + "_jobs";
+        services.AddHangfireServer();
+        services.AddHangfire(
+            x =>
+                x.UseMongoStorage(
+                    $"{options.ConnectionString}/{jobDatabaseName}",
+                    new MongoStorageOptions
+                    {
+                        CheckQueuedJobsStrategy = CheckQueuedJobsStrategy.TailNotificationsCollection,
+                        InvisibilityTimeout = TimeSpan.FromMinutes(120),
+                        MigrationOptions = new MongoMigrationOptions
                         {
-                            CheckQueuedJobsStrategy = CheckQueuedJobsStrategy.TailNotificationsCollection,
-                            InvisibilityTimeout = TimeSpan.FromMinutes(120),
-                            MigrationOptions = new MongoMigrationOptions
-                            {
-                                MigrationStrategy = new MigrateMongoMigrationStrategy(),
-                            },
-                        }
-                    )
-            );
+                            MigrationStrategy = new MigrateMongoMigrationStrategy(),
+                        },
+                    }
+                )
+        );
 
-            DataAccessClassMap.RegisterConventions(
-                "SIL.XForge",
-                new CamelCaseElementNameConvention(),
-                new EnumRepresentationConvention(BsonType.String),
-                new IgnoreIfNullConvention(true)
-            );
+        DataAccessClassMap.RegisterConventions(
+            "SIL.XForge",
+            new CamelCaseElementNameConvention(),
+            new EnumRepresentationConvention(BsonType.String),
+            new IgnoreIfNullConvention(true)
+        );
 
-            DataAccessClassMap.RegisterClass<Json0Snapshot>(cm => cm.MapIdProperty(e => e.Id));
-            DataAccessClassMap.RegisterClass<ProjectSecret>(cm => cm.MapIdProperty(e => e.Id));
+        DataAccessClassMap.RegisterClass<Json0Snapshot>(cm => cm.MapIdProperty(e => e.Id));
+        DataAccessClassMap.RegisterClass<ProjectSecret>(cm => cm.MapIdProperty(e => e.Id));
 
-            services.AddSingleton<IMongoClient>(sp => new MongoClient(options.ConnectionString));
-            services.AddSingleton(sp => sp.GetService<IMongoClient>().GetDatabase(options.MongoDatabaseName));
+        services.AddSingleton<IMongoClient>(sp => new MongoClient(options.ConnectionString));
+        services.AddSingleton(sp => sp.GetService<IMongoClient>().GetDatabase(options.MongoDatabaseName));
 
-            services.AddMongoRepository<UserSecret>("user_secrets", cm => cm.MapIdProperty(us => us.Id));
+        services.AddMongoRepository<UserSecret>("user_secrets", cm => cm.MapIdProperty(us => us.Id));
 
-            return services;
-        }
+        return services;
+    }
 
-        public static void AddMongoRepository<T>(
-            this IServiceCollection services,
-            string collection,
-            Action<BsonClassMap<T>> mapSetup = null,
-            Action<IMongoIndexManager<T>> indexSetup = null
-        ) where T : IIdentifiable
-        {
-            DataAccessClassMap.RegisterClass(mapSetup);
-            services.AddSingleton<IRepository<T>>(sp => CreateMongoRepository(sp, collection, indexSetup));
-        }
+    public static void AddMongoRepository<T>(
+        this IServiceCollection services,
+        string collection,
+        Action<BsonClassMap<T>> mapSetup = null,
+        Action<IMongoIndexManager<T>> indexSetup = null
+    )
+        where T : IIdentifiable
+    {
+        DataAccessClassMap.RegisterClass(mapSetup);
+        services.AddSingleton<IRepository<T>>(sp => CreateMongoRepository(sp, collection, indexSetup));
+    }
 
-        private static MongoRepository<T> CreateMongoRepository<T>(
-            IServiceProvider sp,
-            string collection,
-            Action<IMongoIndexManager<T>> indexSetup
-        ) where T : IIdentifiable
-        {
-            return new MongoRepository<T>(
-                sp.GetService<IMongoDatabase>().GetCollection<T>(collection),
-                c => indexSetup?.Invoke(c.Indexes)
-            );
-        }
+    private static MongoRepository<T> CreateMongoRepository<T>(
+        IServiceProvider sp,
+        string collection,
+        Action<IMongoIndexManager<T>> indexSetup
+    )
+        where T : IIdentifiable
+    {
+        return new MongoRepository<T>(
+            sp.GetService<IMongoDatabase>().GetCollection<T>(collection),
+            c => indexSetup?.Invoke(c.Indexes)
+        );
     }
 }

--- a/src/SIL.XForge/DataAccess/DuplicateKeyException.cs
+++ b/src/SIL.XForge/DataAccess/DuplicateKeyException.cs
@@ -1,13 +1,14 @@
 using System;
 
-namespace SIL.XForge.DataAccess
+namespace SIL.XForge.DataAccess;
+
+public class DuplicateKeyException : Exception
 {
-    public class DuplicateKeyException : Exception
-    {
-        private const string DefaultMessage = "The inserted/updated entity has the same key as an existing entity.";
+    private const string DefaultMessage = "The inserted/updated entity has the same key as an existing entity.";
 
-        public DuplicateKeyException() : base(DefaultMessage) { }
+    public DuplicateKeyException()
+        : base(DefaultMessage) { }
 
-        public DuplicateKeyException(Exception innerException) : base(DefaultMessage, innerException) { }
-    }
+    public DuplicateKeyException(Exception innerException)
+        : base(DefaultMessage, innerException) { }
 }

--- a/src/SIL.XForge/DataAccess/IRepository.cs
+++ b/src/SIL.XForge/DataAccess/IRepository.cs
@@ -4,17 +4,17 @@ using System.Linq.Expressions;
 using System.Threading.Tasks;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.DataAccess
-{
-    public interface IRepository<T> where T : IIdentifiable
-    {
-        void Init();
-        IQueryable<T> Query();
+namespace SIL.XForge.DataAccess;
 
-        Task InsertAsync(T entity);
-        Task<bool> ReplaceAsync(T entity, bool upsert = false);
-        Task<T> UpdateAsync(Expression<Func<T, bool>> filter, Action<IUpdateBuilder<T>> update, bool upsert = false);
-        Task<T> DeleteAsync(Expression<Func<T, bool>> filter);
-        Task<int> DeleteAllAsync(Expression<Func<T, bool>> filter);
-    }
+public interface IRepository<T>
+    where T : IIdentifiable
+{
+    void Init();
+    IQueryable<T> Query();
+
+    Task InsertAsync(T entity);
+    Task<bool> ReplaceAsync(T entity, bool upsert = false);
+    Task<T> UpdateAsync(Expression<Func<T, bool>> filter, Action<IUpdateBuilder<T>> update, bool upsert = false);
+    Task<T> DeleteAsync(Expression<Func<T, bool>> filter);
+    Task<int> DeleteAllAsync(Expression<Func<T, bool>> filter);
 }

--- a/src/SIL.XForge/DataAccess/IUpdateBuilder.cs
+++ b/src/SIL.XForge/DataAccess/IUpdateBuilder.cs
@@ -3,25 +3,25 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.DataAccess
+namespace SIL.XForge.DataAccess;
+
+public interface IUpdateBuilder<T>
+    where T : IIdentifiable
 {
-    public interface IUpdateBuilder<T> where T : IIdentifiable
-    {
-        IUpdateBuilder<T> Set<TField>(Expression<Func<T, TField>> field, TField value);
+    IUpdateBuilder<T> Set<TField>(Expression<Func<T, TField>> field, TField value);
 
-        IUpdateBuilder<T> SetOnInsert<TField>(Expression<Func<T, TField>> field, TField value);
+    IUpdateBuilder<T> SetOnInsert<TField>(Expression<Func<T, TField>> field, TField value);
 
-        IUpdateBuilder<T> Unset<TField>(Expression<Func<T, TField>> field);
+    IUpdateBuilder<T> Unset<TField>(Expression<Func<T, TField>> field);
 
-        IUpdateBuilder<T> Inc(Expression<Func<T, int>> field, int value);
+    IUpdateBuilder<T> Inc(Expression<Func<T, int>> field, int value);
 
-        IUpdateBuilder<T> RemoveAll<TItem>(
-            Expression<Func<T, IEnumerable<TItem>>> field,
-            Expression<Func<TItem, bool>> predicate
-        );
+    IUpdateBuilder<T> RemoveAll<TItem>(
+        Expression<Func<T, IEnumerable<TItem>>> field,
+        Expression<Func<TItem, bool>> predicate
+    );
 
-        IUpdateBuilder<T> Remove<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value);
+    IUpdateBuilder<T> Remove<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value);
 
-        IUpdateBuilder<T> Add<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value);
-    }
+    IUpdateBuilder<T> Add<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value);
 }

--- a/src/SIL.XForge/DataAccess/MemoryRepository.cs
+++ b/src/SIL.XForge/DataAccess/MemoryRepository.cs
@@ -9,212 +9,198 @@ using Newtonsoft.Json;
 using SIL.XForge.Models;
 using SIL.XForge.Utils;
 
-namespace SIL.XForge.DataAccess
+namespace SIL.XForge.DataAccess;
+
+public class MemoryRepository<T> : IRepository<T>
+    where T : IIdentifiable
 {
-    public class MemoryRepository<T> : IRepository<T> where T : IIdentifiable
+    private static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
     {
-        private static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
+        TypeNameHandling = TypeNameHandling.Auto,
+        ContractResolver = new WritableContractResolver()
+    };
+
+    private readonly ConcurrentDictionary<string, string> _entities;
+    private readonly Func<T, object>[] _uniqueKeySelectors;
+    private readonly HashSet<object>[] _uniqueKeys;
+
+    public MemoryRepository(IEnumerable<T> entities)
+        : this(null, entities) { }
+
+    public MemoryRepository(IEnumerable<Func<T, object>> uniqueKeySelectors = null, IEnumerable<T> entities = null)
+    {
+        _uniqueKeySelectors = uniqueKeySelectors?.ToArray() ?? Array.Empty<Func<T, object>>();
+        _uniqueKeys = new HashSet<object>[_uniqueKeySelectors.Length];
+        for (int i = 0; i < _uniqueKeys.Length; i++)
+            _uniqueKeys[i] = new HashSet<object>();
+
+        _entities = new ConcurrentDictionary<string, string>();
+        if (entities != null)
+            Add(entities);
+    }
+
+    public void Init() { }
+
+    public void Add(T entity)
+    {
+        for (int i = 0; i < _uniqueKeySelectors.Length; i++)
         {
-            TypeNameHandling = TypeNameHandling.Auto,
-            ContractResolver = new WritableContractResolver()
-        };
-
-        private readonly ConcurrentDictionary<string, string> _entities;
-        private readonly Func<T, object>[] _uniqueKeySelectors;
-        private readonly HashSet<object>[] _uniqueKeys;
-
-        public MemoryRepository(IEnumerable<T> entities) : this(null, entities) { }
-
-        public MemoryRepository(IEnumerable<Func<T, object>> uniqueKeySelectors = null, IEnumerable<T> entities = null)
-        {
-            _uniqueKeySelectors = uniqueKeySelectors?.ToArray() ?? new Func<T, object>[0];
-            _uniqueKeys = new HashSet<object>[_uniqueKeySelectors.Length];
-            for (int i = 0; i < _uniqueKeys.Length; i++)
-                _uniqueKeys[i] = new HashSet<object>();
-
-            _entities = new ConcurrentDictionary<string, string>();
-            if (entities != null)
-                Add(entities);
+            object key = _uniqueKeySelectors[i](entity);
+            if (key != null)
+                _uniqueKeys[i].Add(key);
         }
+        _entities[entity.Id] = JsonConvert.SerializeObject(entity, Settings);
+    }
 
-        public void Init() { }
-
-        public void Add(T entity)
-        {
-            for (int i = 0; i < _uniqueKeySelectors.Length; i++)
-            {
-                object key = _uniqueKeySelectors[i](entity);
-                if (key != null)
-                    _uniqueKeys[i].Add(key);
-            }
-            _entities[entity.Id] = JsonConvert.SerializeObject(entity, Settings);
-        }
-
-        public void Add(IEnumerable<T> entities)
-        {
-            foreach (T entity in entities)
-                Add(entity);
-        }
-
-        public void Remove(T entity)
-        {
-            for (int i = 0; i < _uniqueKeySelectors.Length; i++)
-            {
-                object key = _uniqueKeySelectors[i](entity);
-                if (key != null)
-                    _uniqueKeys[i].Remove(key);
-            }
-            _entities.TryRemove(entity.Id, out _);
-        }
-
-        public void Replace(T entity)
-        {
-            if (_entities.TryGetValue(entity.Id, out string existingStr))
-            {
-                T existing = DeserializeEntity(entity.Id, existingStr);
-                Remove(existing);
-            }
+    public void Add(IEnumerable<T> entities)
+    {
+        foreach (T entity in entities)
             Add(entity);
-        }
+    }
 
-        public bool Contains(string id)
+    public void Remove(T entity)
+    {
+        for (int i = 0; i < _uniqueKeySelectors.Length; i++)
         {
-            return _entities.ContainsKey(id);
+            object key = _uniqueKeySelectors[i](entity);
+            if (key != null)
+                _uniqueKeys[i].Remove(key);
         }
+        _entities.TryRemove(entity.Id, out _);
+    }
 
-        public T Get(string id)
+    public void Replace(T entity)
+    {
+        if (_entities.TryGetValue(entity.Id, out string existingStr))
         {
-            return DeserializeEntity(id, _entities[id]);
+            T existing = DeserializeEntity(entity.Id, existingStr);
+            Remove(existing);
         }
+        Add(entity);
+    }
 
-        public IQueryable<T> Query()
+    public bool Contains(string id) => _entities.ContainsKey(id);
+
+    public T Get(string id) => DeserializeEntity(id, _entities[id]);
+
+    public IQueryable<T> Query() => _entities.Select(kvp => DeserializeEntity(kvp.Key, kvp.Value)).AsQueryable();
+
+    public Task InsertAsync(T entity)
+    {
+        if (string.IsNullOrEmpty(entity.Id))
+            entity.Id = ObjectId.GenerateNewId().ToString();
+
+        if (_entities.ContainsKey(entity.Id) || CheckDuplicateKeys(entity))
+            throw new DuplicateKeyException();
+
+        Add(entity);
+        return Task.FromResult(true);
+    }
+
+    public Task<bool> ReplaceAsync(T entity, bool upsert = false)
+    {
+        if (string.IsNullOrEmpty(entity.Id))
+            entity.Id = ObjectId.GenerateNewId().ToString();
+
+        if (_entities.ContainsKey(entity.Id) || upsert)
         {
-            return _entities.Select(kvp => DeserializeEntity(kvp.Key, kvp.Value)).AsQueryable();
-        }
-
-        public Task InsertAsync(T entity)
-        {
-            if (string.IsNullOrEmpty(entity.Id))
-                entity.Id = ObjectId.GenerateNewId().ToString();
-
-            if (_entities.ContainsKey(entity.Id) || CheckDuplicateKeys(entity))
-                throw new DuplicateKeyException();
-
-            Add(entity);
+            Replace(entity);
             return Task.FromResult(true);
         }
+        return Task.FromResult(false);
+    }
 
-        public Task<bool> ReplaceAsync(T entity, bool upsert = false)
-        {
-            if (string.IsNullOrEmpty(entity.Id))
-                entity.Id = ObjectId.GenerateNewId().ToString();
-
-            if (_entities.ContainsKey(entity.Id) || upsert)
+    public Task<T> UpdateAsync(Expression<Func<T, bool>> filter, Action<IUpdateBuilder<T>> update, bool upsert = false)
+    {
+        Func<T, bool> filterFunc = filter.Compile();
+        T entity = Query()
+            .AsEnumerable()
+            .FirstOrDefault(e =>
             {
-                Replace(entity);
-                return Task.FromResult(true);
-            }
-            return Task.FromResult(false);
-        }
-
-        public Task<T> UpdateAsync(
-            Expression<Func<T, bool>> filter,
-            Action<IUpdateBuilder<T>> update,
-            bool upsert = false
-        )
-        {
-            Func<T, bool> filterFunc = filter.Compile();
-            T entity = Query()
-                .AsEnumerable()
-                .FirstOrDefault(e =>
+                try
                 {
-                    try
-                    {
-                        return filterFunc(e);
-                    }
-                    catch (Exception)
-                    {
-                        return false;
-                    }
-                });
-            if (entity != null || upsert)
+                    return filterFunc(e);
+                }
+                catch (Exception)
+                {
+                    return false;
+                }
+            });
+        if (entity != null || upsert)
+        {
+            T original = default;
+            bool isInsert = entity == null;
+            if (isInsert)
             {
-                T original = default(T);
-                bool isInsert = entity == null;
-                if (isInsert)
+                entity = (T)Activator.CreateInstance(typeof(T));
+                string id = ObjectId.GenerateNewId().ToString();
+                if (filter.Body is BinaryExpression binaryExpr)
                 {
-                    entity = (T)Activator.CreateInstance(typeof(T));
-                    string id = ObjectId.GenerateNewId().ToString();
-                    var binaryExpr = filter.Body as BinaryExpression;
-                    if (binaryExpr != null)
-                    {
-                        object value = ExpressionHelper.FindConstantValue(binaryExpr.Right);
-                        if (value is string)
-                            id = (string)value;
-                    }
-                    entity.Id = id;
+                    object value = ExpressionHelper.FindConstantValue(binaryExpr.Right);
+                    if (value is string)
+                        id = (string)value;
                 }
-                else
-                {
-                    original = Query().FirstOrDefault(filter);
-                }
-
-                var builder = new MemoryUpdateBuilder<T>(filter, entity, isInsert);
-                update(builder);
-
-                if (CheckDuplicateKeys(entity, original))
-                    throw new DuplicateKeyException();
-
-                Replace(entity);
-            }
-            return Task.FromResult(entity);
-        }
-
-        public Task<T> DeleteAsync(Expression<Func<T, bool>> filter)
-        {
-            T entity = Query().FirstOrDefault(filter);
-            if (entity != null)
-                Remove(entity);
-            return Task.FromResult(entity);
-        }
-
-        public Task<int> DeleteAllAsync(Expression<Func<T, bool>> filter)
-        {
-            T[] entities = Query().Where(filter).ToArray();
-            foreach (T entity in entities)
-                Remove(entity);
-            return Task.FromResult(entities.Length);
-        }
-
-        /// <param name="entity">the new or updated entity to be upserted</param>
-        /// <param name="original">the original entity, if this is an update (or replacement)</param>
-        /// <returns>
-        /// true if there is any existing entity, other than the original, that shares any keys with the new or updated
-        /// entity
-        /// </returns>
-        private bool CheckDuplicateKeys(T entity, T original = default(T))
-        {
-            for (int i = 0; i < _uniqueKeySelectors.Length; i++)
-            {
-                object key = _uniqueKeySelectors[i](entity);
-                if (key != null)
-                {
-                    if (_uniqueKeys[i].Contains(key))
-                    {
-                        if (original == null || !key.Equals(_uniqueKeySelectors[i](original)))
-                            return true;
-                    }
-                }
-            }
-            return false;
-        }
-
-        private static T DeserializeEntity(string id, string json)
-        {
-            var entity = JsonConvert.DeserializeObject<T>(json, Settings);
-            if (entity.Id == null)
                 entity.Id = id;
-            return entity;
+            }
+            else
+            {
+                original = Query().FirstOrDefault(filter);
+            }
+
+            var builder = new MemoryUpdateBuilder<T>(filter, entity, isInsert);
+            update(builder);
+
+            if (CheckDuplicateKeys(entity, original))
+                throw new DuplicateKeyException();
+
+            Replace(entity);
         }
+        return Task.FromResult(entity);
+    }
+
+    public Task<T> DeleteAsync(Expression<Func<T, bool>> filter)
+    {
+        T entity = Query().FirstOrDefault(filter);
+        if (entity != null)
+            Remove(entity);
+        return Task.FromResult(entity);
+    }
+
+    public Task<int> DeleteAllAsync(Expression<Func<T, bool>> filter)
+    {
+        T[] entities = Query().Where(filter).ToArray();
+        foreach (T entity in entities)
+            Remove(entity);
+        return Task.FromResult(entities.Length);
+    }
+
+    /// <param name="entity">the new or updated entity to be upserted</param>
+    /// <param name="original">the original entity, if this is an update (or replacement)</param>
+    /// <returns>
+    /// true if there is any existing entity, other than the original, that shares any keys with the new or updated
+    /// entity
+    /// </returns>
+    private bool CheckDuplicateKeys(T entity, T original = default)
+    {
+        for (int i = 0; i < _uniqueKeySelectors.Length; i++)
+        {
+            object key = _uniqueKeySelectors[i](entity);
+            if (key != null)
+            {
+                if (_uniqueKeys[i].Contains(key))
+                {
+                    if (original == null || !key.Equals(_uniqueKeySelectors[i](original)))
+                        return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static T DeserializeEntity(string id, string json)
+    {
+        var entity = JsonConvert.DeserializeObject<T>(json, Settings);
+        entity.Id ??= id;
+        return entity;
     }
 }

--- a/src/SIL.XForge/DataAccess/MemoryUpdateBuilder.cs
+++ b/src/SIL.XForge/DataAccess/MemoryUpdateBuilder.cs
@@ -7,223 +7,216 @@ using System.Reflection;
 using SIL.XForge.Models;
 using SIL.XForge.Utils;
 
-namespace SIL.XForge.DataAccess
+namespace SIL.XForge.DataAccess;
+
+public class MemoryUpdateBuilder<T> : IUpdateBuilder<T>
+    where T : IIdentifiable
 {
-    public class MemoryUpdateBuilder<T> : IUpdateBuilder<T> where T : IIdentifiable
+    private readonly Expression<Func<T, bool>> _filter;
+    private readonly T _entity;
+    private readonly bool _isInsert;
+
+    public MemoryUpdateBuilder(Expression<Func<T, bool>> filter, T entity, bool isInsert)
     {
-        private readonly Expression<Func<T, bool>> _filter;
-        private readonly T _entity;
-        private readonly bool _isInsert;
+        _filter = filter;
+        _entity = entity;
+        _isInsert = isInsert;
+    }
 
-        public MemoryUpdateBuilder(Expression<Func<T, bool>> filter, T entity, bool isInsert)
-        {
-            _filter = filter;
-            _entity = entity;
-            _isInsert = isInsert;
-        }
+    public IUpdateBuilder<T> Set<TField>(Expression<Func<T, TField>> field, TField value)
+    {
+        (IEnumerable<object> owners, PropertyInfo propInfo, object index) = GetFieldOwners(field);
+        object[] indices = index == null ? null : new[] { index };
+        foreach (object owner in owners)
+            propInfo.SetValue(owner, value, indices);
+        return this;
+    }
 
-        public IUpdateBuilder<T> Set<TField>(Expression<Func<T, TField>> field, TField value)
+    public IUpdateBuilder<T> SetOnInsert<TField>(Expression<Func<T, TField>> field, TField value)
+    {
+        if (_isInsert)
+            Set(field, value);
+        return this;
+    }
+
+    public IUpdateBuilder<T> Unset<TField>(Expression<Func<T, TField>> field)
+    {
+        (IEnumerable<object> owners, PropertyInfo prop, object index) = GetFieldOwners(field);
+        if (index != null)
         {
-            (IEnumerable<object> owners, PropertyInfo propInfo, object index) = GetFieldOwners(field);
-            object[] indices = index == null ? null : new[] { index };
+            // remove value from a dictionary
+            Type dictionaryType = prop.DeclaringType;
+            Type keyType = dictionaryType.GetGenericArguments()[0];
+            MethodInfo removeMethod = dictionaryType.GetMethod("Remove", new[] { keyType });
             foreach (object owner in owners)
-                propInfo.SetValue(owner, value, indices);
-            return this;
+                removeMethod.Invoke(owner, new[] { index });
         }
-
-        public IUpdateBuilder<T> SetOnInsert<TField>(Expression<Func<T, TField>> field, TField value)
+        else
         {
-            if (_isInsert)
-                Set(field, value);
-            return this;
+            // set property to default value
+            object value = null;
+            if (prop.PropertyType.IsValueType)
+                value = Activator.CreateInstance(prop.PropertyType);
+            foreach (object owner in owners)
+                prop.SetValue(owner, value);
         }
+        return this;
+    }
 
-        public IUpdateBuilder<T> Unset<TField>(Expression<Func<T, TField>> field)
+    public IUpdateBuilder<T> Inc(Expression<Func<T, int>> field, int value)
+    {
+        (IEnumerable<object> owners, PropertyInfo prop, object index) = GetFieldOwners(field);
+        object[] indices = index == null ? null : new[] { index };
+        foreach (object owner in owners)
         {
-            (IEnumerable<object> owners, PropertyInfo prop, object index) = GetFieldOwners(field);
-            if (index != null)
+            var curValue = (int)prop.GetValue(owner, indices);
+            curValue += value;
+            prop.SetValue(owner, curValue, indices);
+        }
+        return this;
+    }
+
+    public IUpdateBuilder<T> RemoveAll<TItem>(
+        Expression<Func<T, IEnumerable<TItem>>> field,
+        Expression<Func<TItem, bool>> predicate
+    )
+    {
+        Func<T, IEnumerable<TItem>> getCollection = field.Compile();
+        IEnumerable<TItem> collection = getCollection(_entity);
+        TItem[] toRemove = collection.Where(predicate.Compile()).ToArray();
+        MethodInfo removeMethod = collection.GetType().GetMethod("Remove");
+        foreach (TItem item in toRemove)
+            removeMethod.Invoke(collection, new object[] { item });
+        return this;
+    }
+
+    public IUpdateBuilder<T> Remove<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value)
+    {
+        Func<T, IEnumerable<TItem>> getCollection = field.Compile();
+        IEnumerable<TItem> collection = getCollection(_entity);
+        MethodInfo addMethod = collection.GetType().GetMethod("Remove");
+        addMethod.Invoke(collection, new object[] { value });
+        return this;
+    }
+
+    public IUpdateBuilder<T> Add<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value)
+    {
+        Func<T, IEnumerable<TItem>> getCollection = field.Compile();
+        IEnumerable<TItem> collection = getCollection(_entity);
+        MethodInfo addMethod = collection.GetType().GetMethod("Add");
+        addMethod.Invoke(collection, new object[] { value });
+        return this;
+    }
+
+    private static bool IsAnyMethod(MethodInfo mi) => mi.DeclaringType == typeof(Enumerable) && mi.Name == "Any";
+
+    private static MethodInfo GetFirstOrDefaultMethod(Type type)
+    {
+        return typeof(Enumerable)
+            .GetMethods()
+            .Where(m => m.Name == "FirstOrDefault")
+            .Single(m => m.GetParameters().Length == 2)
+            .MakeGenericMethod(type);
+    }
+
+    private (IEnumerable<object> Owners, PropertyInfo Property, object Index) GetFieldOwners<TField>(
+        Expression<Func<T, TField>> field
+    )
+    {
+        List<object> owners = null;
+        MemberInfo member = null;
+        object index = null;
+        foreach (Expression node in ExpressionHelper.Flatten(field))
+        {
+            var newOwners = new List<object>();
+            if (owners == null)
             {
-                // remove value from a dictionary
-                Type dictionaryType = prop.DeclaringType;
-                Type keyType = dictionaryType.GetGenericArguments()[0];
-                MethodInfo removeMethod = dictionaryType.GetMethod("Remove", new[] { keyType });
-                foreach (object owner in owners)
-                    removeMethod.Invoke(owner, new[] { index });
+                if (_entity != null)
+                    newOwners.Add(_entity);
             }
             else
             {
-                // set property to default value
-                object value = null;
-                if (prop.PropertyType.IsValueType)
-                    value = Activator.CreateInstance(prop.PropertyType);
                 foreach (object owner in owners)
-                    prop.SetValue(owner, value);
-            }
-            return this;
-        }
-
-        public IUpdateBuilder<T> Inc(Expression<Func<T, int>> field, int value)
-        {
-            (IEnumerable<object> owners, PropertyInfo prop, object index) = GetFieldOwners(field);
-            object[] indices = index == null ? null : new[] { index };
-            foreach (object owner in owners)
-            {
-                var curValue = (int)prop.GetValue(owner, indices);
-                curValue += value;
-                prop.SetValue(owner, curValue, indices);
-            }
-            return this;
-        }
-
-        public IUpdateBuilder<T> RemoveAll<TItem>(
-            Expression<Func<T, IEnumerable<TItem>>> field,
-            Expression<Func<TItem, bool>> predicate
-        )
-        {
-            Func<T, IEnumerable<TItem>> getCollection = field.Compile();
-            IEnumerable<TItem> collection = getCollection(_entity);
-            TItem[] toRemove = collection.Where(predicate.Compile()).ToArray();
-            MethodInfo removeMethod = collection.GetType().GetMethod("Remove");
-            foreach (TItem item in toRemove)
-                removeMethod.Invoke(collection, new object[] { item });
-            return this;
-        }
-
-        public IUpdateBuilder<T> Remove<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value)
-        {
-            Func<T, IEnumerable<TItem>> getCollection = field.Compile();
-            IEnumerable<TItem> collection = getCollection(_entity);
-            MethodInfo addMethod = collection.GetType().GetMethod("Remove");
-            addMethod.Invoke(collection, new object[] { value });
-            return this;
-        }
-
-        public IUpdateBuilder<T> Add<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value)
-        {
-            Func<T, IEnumerable<TItem>> getCollection = field.Compile();
-            IEnumerable<TItem> collection = getCollection(_entity);
-            MethodInfo addMethod = collection.GetType().GetMethod("Add");
-            addMethod.Invoke(collection, new object[] { value });
-            return this;
-        }
-
-        private static bool IsAnyMethod(MethodInfo mi)
-        {
-            return mi.DeclaringType == typeof(Enumerable) && mi.Name == "Any";
-        }
-
-        private static MethodInfo GetFirstOrDefaultMethod(Type type)
-        {
-            return typeof(Enumerable)
-                .GetMethods()
-                .Where(m => m.Name == "FirstOrDefault")
-                .Single(m => m.GetParameters().Length == 2)
-                .MakeGenericMethod(type);
-        }
-
-        private (IEnumerable<object> Owners, PropertyInfo Property, object Index) GetFieldOwners<TField>(
-            Expression<Func<T, TField>> field
-        )
-        {
-            List<object> owners = null;
-            MemberInfo member = null;
-            object index = null;
-            foreach (Expression node in ExpressionHelper.Flatten(field))
-            {
-                var newOwners = new List<object>();
-                if (owners == null)
                 {
-                    if (_entity != null)
-                        newOwners.Add(_entity);
-                }
-                else
-                {
-                    foreach (object owner in owners)
+                    object newOwner;
+                    switch (member)
                     {
-                        object newOwner;
-                        switch (member)
-                        {
-                            case MethodInfo method:
-                                switch (index)
-                                {
-                                    case ArrayPosition.FirstMatching:
-                                        if (
-                                            _filter.Body is MethodCallExpression callExpr
-                                            && IsAnyMethod(callExpr.Method)
-                                        )
+                        case MethodInfo method:
+                            switch (index)
+                            {
+                                case ArrayPosition.FirstMatching:
+                                    if (_filter.Body is MethodCallExpression callExpr && IsAnyMethod(callExpr.Method))
+                                    {
+                                        var predicate = (LambdaExpression)callExpr.Arguments[1];
+                                        Type itemType = predicate.Parameters[0].Type;
+                                        MethodInfo firstOrDefault = GetFirstOrDefaultMethod(itemType);
+                                        newOwner = firstOrDefault.Invoke(
+                                            null,
+                                            new object[] { owner, predicate.Compile() }
+                                        );
+                                        if (newOwner != null)
+                                            newOwners.Add(newOwner);
+                                    }
+                                    break;
+                                case ArrayPosition.All:
+                                    newOwners.AddRange(((IEnumerable)owner).Cast<object>());
+                                    break;
+                                default:
+                                    if (owner is IDictionary dict)
+                                    {
+                                        newOwner = dict[index];
+                                        if (newOwner != null)
                                         {
-                                            var predicate = (LambdaExpression)callExpr.Arguments[1];
-                                            Type itemType = predicate.Parameters[0].Type;
-                                            MethodInfo firstOrDefault = GetFirstOrDefaultMethod(itemType);
-                                            newOwner = firstOrDefault.Invoke(
-                                                null,
-                                                new object[] { owner, predicate.Compile() }
-                                            );
-                                            if (newOwner != null)
-                                                newOwners.Add(newOwner);
-                                        }
-                                        break;
-                                    case ArrayPosition.All:
-                                        newOwners.AddRange(((IEnumerable)owner).Cast<object>());
-                                        break;
-                                    default:
-                                        var dict = owner as IDictionary;
-                                        if (dict != null)
-                                        {
-                                            newOwner = dict[index];
-                                            if (newOwner != null)
-                                            {
-                                                newOwners.Add(newOwner);
-                                            }
-                                            else
-                                            {
-                                                Type valueType = owner.GetType().GenericTypeArguments[1];
-                                                newOwner = Activator.CreateInstance(valueType);
-                                                dict[index] = newOwner;
-                                            }
+                                            newOwners.Add(newOwner);
                                         }
                                         else
                                         {
-                                            newOwner = method.Invoke(owner, new object[] { index });
-                                            if (newOwner != null)
-                                                newOwners.Add(newOwner);
+                                            Type valueType = owner.GetType().GenericTypeArguments[1];
+                                            newOwner = Activator.CreateInstance(valueType);
+                                            dict[index] = newOwner;
                                         }
-                                        break;
-                                }
-                                break;
+                                    }
+                                    else
+                                    {
+                                        newOwner = method.Invoke(owner, new object[] { index });
+                                        if (newOwner != null)
+                                            newOwners.Add(newOwner);
+                                    }
+                                    break;
+                            }
+                            break;
 
-                            case PropertyInfo prop:
-                                newOwner = prop.GetValue(owner);
-                                if (newOwner != null)
-                                    newOwners.Add(newOwner);
-                                break;
-                        }
+                        case PropertyInfo prop:
+                            newOwner = prop.GetValue(owner);
+                            if (newOwner != null)
+                                newOwners.Add(newOwner);
+                            break;
                     }
                 }
-                owners = newOwners;
-
-                switch (node)
-                {
-                    case MemberExpression memberExpr:
-                        member = memberExpr.Member;
-                        index = null;
-                        break;
-
-                    case MethodCallExpression methodExpr:
-                        member = methodExpr.Method;
-                        if (member.Name != "get_Item")
-                            throw new ArgumentException("Invalid method call in field expression.", nameof(field));
-
-                        Expression argExpr = methodExpr.Arguments[0];
-                        index = ExpressionHelper.FindConstantValue(argExpr);
-                        break;
-                }
             }
+            owners = newOwners;
 
-            PropertyInfo property = member as PropertyInfo;
-            if (property == null && member != null && index != null)
-                property = member.DeclaringType.GetProperty("Item");
-            return (owners, property, index);
+            switch (node)
+            {
+                case MemberExpression memberExpr:
+                    member = memberExpr.Member;
+                    index = null;
+                    break;
+
+                case MethodCallExpression methodExpr:
+                    member = methodExpr.Method;
+                    if (member.Name != "get_Item")
+                        throw new ArgumentException("Invalid method call in field expression.", nameof(field));
+
+                    Expression argExpr = methodExpr.Arguments[0];
+                    index = ExpressionHelper.FindConstantValue(argExpr);
+                    break;
+            }
         }
+
+        PropertyInfo property = member as PropertyInfo;
+        if (property == null && member != null && index != null)
+            property = member.DeclaringType.GetProperty("Item");
+        return (owners, property, index);
     }
 }

--- a/src/SIL.XForge/DataAccess/MongoRepository.cs
+++ b/src/SIL.XForge/DataAccess/MongoRepository.cs
@@ -5,98 +5,89 @@ using System.Threading.Tasks;
 using MongoDB.Driver;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.DataAccess
+namespace SIL.XForge.DataAccess;
+
+public class MongoRepository<T> : IRepository<T>
+    where T : IIdentifiable
 {
-    public class MongoRepository<T> : IRepository<T> where T : IIdentifiable
+    private readonly IMongoCollection<T> _collection;
+    private readonly Action<IMongoCollection<T>> _init;
+
+    public MongoRepository(IMongoCollection<T> collection, Action<IMongoCollection<T>> init)
     {
-        private readonly IMongoCollection<T> _collection;
-        private readonly Action<IMongoCollection<T>> _init;
+        _collection = collection;
+        _init = init;
+    }
 
-        public MongoRepository(IMongoCollection<T> collection, Action<IMongoCollection<T>> init)
-        {
-            _collection = collection;
-            _init = init;
-        }
+    public void Init() => _init(_collection);
 
-        public void Init()
-        {
-            _init(_collection);
-        }
+    public IQueryable<T> Query() => _collection.AsQueryable();
 
-        public IQueryable<T> Query()
+    public async Task InsertAsync(T entity)
+    {
+        try
         {
-            return _collection.AsQueryable();
+            await _collection.InsertOneAsync(entity);
         }
+        catch (MongoWriteException e)
+        {
+            if (e.WriteError.Category == ServerErrorCategory.DuplicateKey)
+                throw new DuplicateKeyException(e);
+            throw;
+        }
+    }
 
-        public async Task InsertAsync(T entity)
+    public async Task<bool> ReplaceAsync(T entity, bool upsert = false)
+    {
+        try
         {
-            try
-            {
-                await _collection.InsertOneAsync(entity);
-            }
-            catch (MongoWriteException e)
-            {
-                if (e.WriteError.Category == ServerErrorCategory.DuplicateKey)
-                    throw new DuplicateKeyException(e);
-                throw;
-            }
+            ReplaceOneResult result = await _collection.ReplaceOneAsync(
+                e => e.Id == entity.Id,
+                entity,
+                new ReplaceOptions { IsUpsert = upsert }
+            );
+            if (result.IsAcknowledged)
+                return upsert || result.MatchedCount > 0;
+            return false;
         }
+        catch (MongoWriteException e)
+        {
+            if (e.WriteError.Category == ServerErrorCategory.DuplicateKey)
+                throw new DuplicateKeyException();
+            throw;
+        }
+    }
 
-        public async Task<bool> ReplaceAsync(T entity, bool upsert = false)
+    public async Task<T> UpdateAsync(
+        Expression<Func<T, bool>> filter,
+        Action<IUpdateBuilder<T>> update,
+        bool upsert = false
+    )
+    {
+        try
         {
-            try
-            {
-                ReplaceOneResult result = await _collection.ReplaceOneAsync(
-                    e => e.Id == entity.Id,
-                    entity,
-                    new ReplaceOptions { IsUpsert = upsert }
-                );
-                if (result.IsAcknowledged)
-                    return upsert || result.MatchedCount > 0;
-                return false;
-            }
-            catch (MongoWriteException e)
-            {
-                if (e.WriteError.Category == ServerErrorCategory.DuplicateKey)
-                    throw new DuplicateKeyException();
-                throw;
-            }
+            var updateBuilder = new MongoUpdateBuilder<T>();
+            update(updateBuilder);
+            UpdateDefinition<T> updateDef = updateBuilder.Build();
+            return await _collection.FindOneAndUpdateAsync(
+                filter,
+                updateDef,
+                new FindOneAndUpdateOptions<T> { IsUpsert = upsert, ReturnDocument = ReturnDocument.After }
+            );
         }
+        catch (MongoWriteException e)
+        {
+            if (e.WriteError.Category == ServerErrorCategory.DuplicateKey)
+                throw new DuplicateKeyException();
+            throw;
+        }
+    }
 
-        public async Task<T> UpdateAsync(
-            Expression<Func<T, bool>> filter,
-            Action<IUpdateBuilder<T>> update,
-            bool upsert = false
-        )
-        {
-            try
-            {
-                var updateBuilder = new MongoUpdateBuilder<T>();
-                update(updateBuilder);
-                UpdateDefinition<T> updateDef = updateBuilder.Build();
-                return await _collection.FindOneAndUpdateAsync(
-                    filter,
-                    updateDef,
-                    new FindOneAndUpdateOptions<T> { IsUpsert = upsert, ReturnDocument = ReturnDocument.After }
-                );
-            }
-            catch (MongoWriteException e)
-            {
-                if (e.WriteError.Category == ServerErrorCategory.DuplicateKey)
-                    throw new DuplicateKeyException();
-                throw;
-            }
-        }
+    public Task<T> DeleteAsync(Expression<Func<T, bool>> filter) => _collection.FindOneAndDeleteAsync(filter);
 
-        public Task<T> DeleteAsync(Expression<Func<T, bool>> filter)
-        {
-            return _collection.FindOneAndDeleteAsync(filter);
-        }
-
-        public async Task<int> DeleteAllAsync(Expression<Func<T, bool>> filter)
-        {
-            DeleteResult result = await _collection.DeleteManyAsync(filter);
-            return (int)result.DeletedCount;
-        }
+    public async Task<int> DeleteAllAsync(Expression<Func<T, bool>> filter)
+    {
+        DeleteResult result = await _collection.DeleteManyAsync(filter);
+        return (int)result.DeletedCount;
     }
 }

--- a/src/SIL.XForge/DataAccess/MongoUpdateBuilder.cs
+++ b/src/SIL.XForge/DataAccess/MongoUpdateBuilder.cs
@@ -5,74 +5,72 @@ using System.Linq.Expressions;
 using MongoDB.Driver;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.DataAccess
+namespace SIL.XForge.DataAccess;
+
+public class MongoUpdateBuilder<T> : IUpdateBuilder<T>
+    where T : IIdentifiable
 {
-    public class MongoUpdateBuilder<T> : IUpdateBuilder<T> where T : IIdentifiable
+    private readonly UpdateDefinitionBuilder<T> _builder;
+    private readonly List<UpdateDefinition<T>> _defs;
+
+    public MongoUpdateBuilder()
     {
-        private readonly UpdateDefinitionBuilder<T> _builder;
-        private readonly List<UpdateDefinition<T>> _defs;
-
-        public MongoUpdateBuilder()
-        {
-            _builder = Builders<T>.Update;
-            _defs = new List<UpdateDefinition<T>>();
-        }
-
-        public IUpdateBuilder<T> Set<TField>(Expression<Func<T, TField>> field, TField value)
-        {
-            _defs.Add(_builder.Set(ToFieldDefinition(field), value));
-            return this;
-        }
-
-        public IUpdateBuilder<T> SetOnInsert<TField>(Expression<Func<T, TField>> field, TField value)
-        {
-            _defs.Add(_builder.SetOnInsert(ToFieldDefinition(field), value));
-            return this;
-        }
-
-        public IUpdateBuilder<T> Unset<TField>(Expression<Func<T, TField>> field)
-        {
-            _defs.Add(_builder.Unset(ToFieldDefinition(field)));
-            return this;
-        }
-
-        public IUpdateBuilder<T> Inc(Expression<Func<T, int>> field, int value)
-        {
-            _defs.Add(_builder.Inc(ToFieldDefinition(field), value));
-            return this;
-        }
-
-        public IUpdateBuilder<T> RemoveAll<TItem>(
-            Expression<Func<T, IEnumerable<TItem>>> field,
-            Expression<Func<TItem, bool>> predicate
-        )
-        {
-            _defs.Add(_builder.PullFilter(ToFieldDefinition(field), Builders<TItem>.Filter.Where(predicate)));
-            return this;
-        }
-
-        public IUpdateBuilder<T> Remove<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value)
-        {
-            _defs.Add(_builder.Pull(ToFieldDefinition(field), value));
-            return this;
-        }
-
-        public IUpdateBuilder<T> Add<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value)
-        {
-            _defs.Add(_builder.Push(ToFieldDefinition(field), value));
-            return this;
-        }
-
-        public UpdateDefinition<T> Build()
-        {
-            if (_defs.Count == 1)
-                return _defs.Single();
-            return _builder.Combine(_defs);
-        }
-
-        private static FieldDefinition<T, TField> ToFieldDefinition<TField>(Expression<Func<T, TField>> field)
-        {
-            return new XFFieldDefinition<T, TField>(field);
-        }
+        _builder = Builders<T>.Update;
+        _defs = new List<UpdateDefinition<T>>();
     }
+
+    public IUpdateBuilder<T> Set<TField>(Expression<Func<T, TField>> field, TField value)
+    {
+        _defs.Add(_builder.Set(ToFieldDefinition(field), value));
+        return this;
+    }
+
+    public IUpdateBuilder<T> SetOnInsert<TField>(Expression<Func<T, TField>> field, TField value)
+    {
+        _defs.Add(_builder.SetOnInsert(ToFieldDefinition(field), value));
+        return this;
+    }
+
+    public IUpdateBuilder<T> Unset<TField>(Expression<Func<T, TField>> field)
+    {
+        _defs.Add(_builder.Unset(ToFieldDefinition(field)));
+        return this;
+    }
+
+    public IUpdateBuilder<T> Inc(Expression<Func<T, int>> field, int value)
+    {
+        _defs.Add(_builder.Inc(ToFieldDefinition(field), value));
+        return this;
+    }
+
+    public IUpdateBuilder<T> RemoveAll<TItem>(
+        Expression<Func<T, IEnumerable<TItem>>> field,
+        Expression<Func<TItem, bool>> predicate
+    )
+    {
+        _defs.Add(_builder.PullFilter(ToFieldDefinition(field), Builders<TItem>.Filter.Where(predicate)));
+        return this;
+    }
+
+    public IUpdateBuilder<T> Remove<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value)
+    {
+        _defs.Add(_builder.Pull(ToFieldDefinition(field), value));
+        return this;
+    }
+
+    public IUpdateBuilder<T> Add<TItem>(Expression<Func<T, IEnumerable<TItem>>> field, TItem value)
+    {
+        _defs.Add(_builder.Push(ToFieldDefinition(field), value));
+        return this;
+    }
+
+    public UpdateDefinition<T> Build()
+    {
+        if (_defs.Count == 1)
+            return _defs.Single();
+        return _builder.Combine(_defs);
+    }
+
+    private static FieldDefinition<T, TField> ToFieldDefinition<TField>(Expression<Func<T, TField>> field) =>
+        new XFFieldDefinition<T, TField>(field);
 }

--- a/src/SIL.XForge/DataAccess/WritableContractResolver.cs
+++ b/src/SIL.XForge/DataAccess/WritableContractResolver.cs
@@ -4,14 +4,13 @@ using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-namespace SIL.XForge.DataAccess
+namespace SIL.XForge.DataAccess;
+
+public class WritableContractResolver : DefaultContractResolver
 {
-    public class WritableContractResolver : DefaultContractResolver
+    protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
     {
-        protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
-        {
-            IList<JsonProperty> props = base.CreateProperties(type, memberSerialization);
-            return props.Where(p => p.Writable).ToList();
-        }
+        IList<JsonProperty> props = base.CreateProperties(type, memberSerialization);
+        return props.Where(p => p.Writable).ToList();
     }
 }

--- a/src/SIL.XForge/DataAccess/XFFieldDefinition.cs
+++ b/src/SIL.XForge/DataAccess/XFFieldDefinition.cs
@@ -8,10 +8,8 @@ public class XFFieldDefinition<TDocument, TField> : FieldDefinition<TDocument, T
 {
     private readonly ExpressionFieldDefinition<TDocument, TField> _internalDef;
 
-    public XFFieldDefinition(Expression<Func<TDocument, TField>> expression)
-    {
+    public XFFieldDefinition(Expression<Func<TDocument, TField>> expression) =>
         _internalDef = new ExpressionFieldDefinition<TDocument, TField>(expression);
-    }
 
     public override RenderedFieldDefinition<TField> Render(
         IBsonSerializer<TDocument> documentSerializer,

--- a/src/SIL.XForge/ExceptionLogging/ExceptionHandler.cs
+++ b/src/SIL.XForge/ExceptionLogging/ExceptionHandler.cs
@@ -1,91 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
-using System;
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Threading.Tasks;
-using System.Linq;
 
-namespace SIL.XForge
+namespace SIL.XForge;
+
+public class ExceptionHandler : IExceptionHandler
 {
-    public class ExceptionHandler : IExceptionHandler
+    private readonly Bugsnag.IClient _bugsnag;
+
+    public static async Task<string> CreateHttpRequestErrorMessage(HttpResponseMessage response)
     {
-        private readonly Bugsnag.IClient _bugsnag;
-
-        public static async Task<string> CreateHttpRequestErrorMessage(HttpResponseMessage response)
-        {
-            string responseContent = string.Join(
+        string responseContent = string.Join("\n", (await response.Content.ReadAsStringAsync()).Split('\n').Take(10));
+        return string.Join(
                 "\n",
-                (await response.Content.ReadAsStringAsync()).Split('\n').Take(10)
-            );
-            return string.Join(
-                    "\n",
-                    new string[]
-                    {
-                        "HTTP Request error:",
-                        $"{response.RequestMessage.Method} {response.RequestMessage.RequestUri}",
-                        "Response:",
-                        response.ToString(),
-                        "Response content begins with:",
-                        responseContent
-                    }
-                )
-                .Replace("\n", "\n    ");
-        }
-
-        public ExceptionHandler(Bugsnag.IClient client)
-        {
-            _bugsnag = client;
-        }
-
-        public void ReportException(Exception exception)
-        {
-            _bugsnag.Notify(exception);
-        }
-
-        public async Task EnsureSuccessStatusCode(HttpResponseMessage response)
-        {
-            if (!response.IsSuccessStatusCode)
-            {
-                var exception = new HttpRequestException(
-                    await ExceptionHandler.CreateHttpRequestErrorMessage(response)
-                );
-                ReportException(exception);
-                throw exception;
-            }
-        }
-
-        public void ReportExceptions(IApplicationBuilder app)
-        {
-            app.Run(async context =>
-            {
-                context.Response.StatusCode = 500;
-                context.Response.ContentType = "text/plain";
-                await context.Response.WriteAsync("500 Internal Server Error");
-
-                var exceptionHandlerPathFeature = context.Features.Get<IExceptionHandlerPathFeature>();
-                ReportException(exceptionHandlerPathFeature.Error);
-            });
-        }
-
-        public void RecordEndpointInfoForException(Dictionary<string, string> metadata)
-        {
-            _bugsnag.BeforeNotify(report =>
-            {
-                report.Event.Metadata.Add("endpoint", metadata);
-            });
-        }
-
-        public void RecordUserIdForException(string userId)
-        {
-            if (!string.IsNullOrWhiteSpace(userId))
-            {
-                _bugsnag.BeforeNotify(report =>
+                new string[]
                 {
-                    report.Event.User = new Bugsnag.Payload.User { Id = userId, };
-                });
-            }
+                    "HTTP Request error:",
+                    $"{response.RequestMessage.Method} {response.RequestMessage.RequestUri}",
+                    "Response:",
+                    response.ToString(),
+                    "Response content begins with:",
+                    responseContent
+                }
+            )
+            .Replace("\n", "\n    ");
+    }
+
+    public ExceptionHandler(Bugsnag.IClient client) => _bugsnag = client;
+
+    public void ReportException(Exception exception) => _bugsnag.Notify(exception);
+
+    public async Task EnsureSuccessStatusCode(HttpResponseMessage response)
+    {
+        if (!response.IsSuccessStatusCode)
+        {
+            var exception = new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response));
+            ReportException(exception);
+            throw exception;
+        }
+    }
+
+    public void ReportExceptions(IApplicationBuilder app)
+    {
+        app.Run(async context =>
+        {
+            context.Response.StatusCode = 500;
+            context.Response.ContentType = "text/plain";
+            await context.Response.WriteAsync("500 Internal Server Error");
+
+            var exceptionHandlerPathFeature = context.Features.Get<IExceptionHandlerPathFeature>();
+            ReportException(exceptionHandlerPathFeature.Error);
+        });
+    }
+
+    public void RecordEndpointInfoForException(Dictionary<string, string> metadata) =>
+        _bugsnag.BeforeNotify(report => report.Event.Metadata.Add("endpoint", metadata));
+
+    public void RecordUserIdForException(string userId)
+    {
+        if (!string.IsNullOrWhiteSpace(userId))
+        {
+            _bugsnag.BeforeNotify(report => report.Event.User = new Bugsnag.Payload.User { Id = userId, });
         }
     }
 }

--- a/src/SIL.XForge/ExceptionLogging/ExceptionHandlerServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/ExceptionLogging/ExceptionHandlerServiceCollectionExtensions.cs
@@ -1,25 +1,24 @@
-using SIL.XForge;
 using Bugsnag.AspNet.Core;
 using Microsoft.Extensions.Configuration;
+using SIL.XForge;
 
-namespace Microsoft.Extensions.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class ExceptionHandlerServiceCollectionExtensions
 {
-    public static class ExceptionHandlerServiceCollectionExtensions
+    public static IServiceCollection AddExceptionReporting(
+        this IServiceCollection services,
+        IConfiguration configuration
+    )
     {
-        public static IServiceCollection AddExceptionReporting(
-            this IServiceCollection services,
-            IConfiguration configuration
-        )
-        {
-            services.AddScoped<IExceptionHandler, ExceptionHandler>();
-            return services
-                .AddBugsnag()
-                .Configure<Bugsnag.Configuration>(configuration.GetSection("Bugsnag"))
-                .Configure<Bugsnag.Configuration>(config =>
-                {
-                    string location = System.Reflection.Assembly.GetEntryAssembly().Location;
-                    config.AppVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(location).ProductVersion;
-                });
-        }
+        services.AddScoped<IExceptionHandler, ExceptionHandler>();
+        return services
+            .AddBugsnag()
+            .Configure<Bugsnag.Configuration>(configuration.GetSection("Bugsnag"))
+            .Configure<Bugsnag.Configuration>(config =>
+            {
+                string location = System.Reflection.Assembly.GetEntryAssembly().Location;
+                config.AppVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(location).ProductVersion;
+            });
     }
 }

--- a/src/SIL.XForge/ExceptionLogging/IExceptionHandler.cs
+++ b/src/SIL.XForge/ExceptionLogging/IExceptionHandler.cs
@@ -1,21 +1,20 @@
-using Microsoft.AspNetCore.Builder;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
 
-namespace SIL.XForge
+namespace SIL.XForge;
+
+public interface IExceptionHandler
 {
-    public interface IExceptionHandler
-    {
-        void ReportException(Exception exception);
+    void ReportException(Exception exception);
 
-        Task EnsureSuccessStatusCode(HttpResponseMessage response);
+    Task EnsureSuccessStatusCode(HttpResponseMessage response);
 
-        void ReportExceptions(IApplicationBuilder app);
+    void ReportExceptions(IApplicationBuilder app);
 
-        void RecordEndpointInfoForException(Dictionary<string, string> metadata);
+    void RecordEndpointInfoForException(Dictionary<string, string> metadata);
 
-        void RecordUserIdForException(string userId);
-    }
+    void RecordUserIdForException(string userId);
 }

--- a/src/SIL.XForge/Models/IIdentifiable.cs
+++ b/src/SIL.XForge/Models/IIdentifiable.cs
@@ -1,7 +1,6 @@
-namespace SIL.XForge.Models
+namespace SIL.XForge.Models;
+
+public interface IIdentifiable
 {
-    public interface IIdentifiable
-    {
-        string Id { get; set; }
-    }
+    string Id { get; set; }
 }

--- a/src/SIL.XForge/Models/IOwnedData.cs
+++ b/src/SIL.XForge/Models/IOwnedData.cs
@@ -1,7 +1,6 @@
-namespace SIL.XForge.Models
+namespace SIL.XForge.Models;
+
+public interface IOwnedData
 {
-    public interface IOwnedData
-    {
-        string OwnerRef { get; set; }
-    }
+    string OwnerRef { get; set; }
 }

--- a/src/SIL.XForge/Models/InterfaceLanguage.cs
+++ b/src/SIL.XForge/Models/InterfaceLanguage.cs
@@ -1,16 +1,12 @@
-namespace SIL.XForge.Models
+namespace SIL.XForge.Models;
+
+public class InterfaceLanguage
 {
-    public class InterfaceLanguage
-    {
-        public string LocalName { get; set; }
-        public string EnglishName { get; set; }
-        public string CanonicalTag
-        {
-            get { return this.Tags[0]; }
-        }
-        public string Direction { get; set; } = LanguageDirection.LTR;
-        public string[] Tags { get; set; }
-        public bool Production { get; set; } = false;
-        public string Helps { get; set; }
-    }
+    public string LocalName { get; set; }
+    public string EnglishName { get; set; }
+    public string CanonicalTag => this.Tags[0];
+    public string Direction { get; set; } = LanguageDirection.LTR;
+    public string[] Tags { get; set; }
+    public bool Production { get; set; } = false;
+    public string Helps { get; set; }
 }

--- a/src/SIL.XForge/Models/Json0Snapshot.cs
+++ b/src/SIL.XForge/Models/Json0Snapshot.cs
@@ -1,15 +1,14 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace SIL.XForge.Models
-{
-    [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
-    public class Json0Snapshot : IIdentifiable
-    {
-        [JsonIgnore]
-        public string Id { get; set; }
+namespace SIL.XForge.Models;
 
-        [JsonIgnore]
-        public Dictionary<string, object> ExtraElements { get; set; }
-    }
+[JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
+public class Json0Snapshot : IIdentifiable
+{
+    [JsonIgnore]
+    public string Id { get; set; }
+
+    [JsonIgnore]
+    public Dictionary<string, object> ExtraElements { get; set; }
 }

--- a/src/SIL.XForge/Models/LanguageDirection.cs
+++ b/src/SIL.XForge/Models/LanguageDirection.cs
@@ -1,12 +1,11 @@
-namespace SIL.XForge.Models
-{
-    /// <summary>Direction of a language.</summary>
-    public static class LanguageDirection
-    {
-        /// <summary>Left-to-right</summary>
-        public const string LTR = "ltr";
+namespace SIL.XForge.Models;
 
-        /// <summary>Right-to-left</summary>
-        public const string RTL = "rtl";
-    }
+/// <summary>Direction of a language.</summary>
+public static class LanguageDirection
+{
+    /// <summary>Left-to-right</summary>
+    public const string LTR = "ltr";
+
+    /// <summary>Right-to-left</summary>
+    public const string RTL = "rtl";
 }

--- a/src/SIL.XForge/Models/Project.cs
+++ b/src/SIL.XForge/Models/Project.cs
@@ -1,14 +1,13 @@
 using System.Collections.Generic;
 
-namespace SIL.XForge.Models
-{
-    public abstract class Project : Json0Snapshot
-    {
-        public string Name { get; set; }
+namespace SIL.XForge.Models;
 
-        /// <summary>Dictionary of SF user id to project role</summary>
-        public Dictionary<string, string> UserRoles { get; set; } = new Dictionary<string, string>();
-        public Dictionary<string, string[]> UserPermissions { get; set; } = new Dictionary<string, string[]>();
-        public bool SyncDisabled { get; set; }
-    }
+public abstract class Project : Json0Snapshot
+{
+    public string Name { get; set; }
+
+    /// <summary>Dictionary of SF user id to project role</summary>
+    public Dictionary<string, string> UserRoles { get; set; } = new Dictionary<string, string>();
+    public Dictionary<string, string[]> UserPermissions { get; set; } = new Dictionary<string, string[]>();
+    public bool SyncDisabled { get; set; }
 }

--- a/src/SIL.XForge/Models/ProjectData.cs
+++ b/src/SIL.XForge/Models/ProjectData.cs
@@ -1,8 +1,7 @@
-namespace SIL.XForge.Models
+namespace SIL.XForge.Models;
+
+public abstract class ProjectData : Json0Snapshot, IOwnedData
 {
-    public abstract class ProjectData : Json0Snapshot, IOwnedData
-    {
-        public string OwnerRef { get; set; }
-        public string ProjectRef { get; set; }
-    }
+    public string OwnerRef { get; set; }
+    public string ProjectRef { get; set; }
 }

--- a/src/SIL.XForge/Models/ProjectRole.cs
+++ b/src/SIL.XForge/Models/ProjectRole.cs
@@ -1,7 +1,6 @@
-namespace SIL.XForge.Models
+namespace SIL.XForge.Models;
+
+public static class ProjectRole
 {
-    public static class ProjectRole
-    {
-        public const string None = "none";
-    }
+    public const string None = "none";
 }

--- a/src/SIL.XForge/Models/ProjectSecret.cs
+++ b/src/SIL.XForge/Models/ProjectSecret.cs
@@ -1,14 +1,13 @@
 using System.Collections.Generic;
 
-namespace SIL.XForge.Models
-{
-    public abstract class ProjectSecret : IIdentifiable
-    {
-        public string Id { get; set; }
+namespace SIL.XForge.Models;
 
-        /// <summary>
-        /// Outstanding project access shares to specific people, represented by an email address and code pair.
-        /// </summary>
-        public List<ShareKey> ShareKeys { get; set; } = new List<ShareKey>();
-    }
+public abstract class ProjectSecret : IIdentifiable
+{
+    public string Id { get; set; }
+
+    /// <summary>
+    /// Outstanding project access shares to specific people, represented by an email address and code pair.
+    /// </summary>
+    public List<ShareKey> ShareKeys { get; set; } = new List<ShareKey>();
 }

--- a/src/SIL.XForge/Models/QueuedAction.cs
+++ b/src/SIL.XForge/Models/QueuedAction.cs
@@ -1,20 +1,19 @@
-namespace SIL.XForge.Models
+namespace SIL.XForge.Models;
+
+internal enum QueuedAction
 {
-    internal enum QueuedAction
-    {
-        /// <summary>
-        /// The <c>createDoc</c> action.
-        /// </summary>
-        Create = 0,
+    /// <summary>
+    /// The <c>createDoc</c> action.
+    /// </summary>
+    Create = 0,
 
-        /// <summary>
-        /// The <c>deleteDoc</c> action.
-        /// </summary>
-        Delete = 1,
+    /// <summary>
+    /// The <c>deleteDoc</c> action.
+    /// </summary>
+    Delete = 1,
 
-        /// <summary>
-        /// The <c>submitOp</c> action.
-        /// </summary>
-        Submit = 2,
-    }
+    /// <summary>
+    /// The <c>submitOp</c> action.
+    /// </summary>
+    Submit = 2,
 }

--- a/src/SIL.XForge/Models/QueuedOperation.cs
+++ b/src/SIL.XForge/Models/QueuedOperation.cs
@@ -1,90 +1,89 @@
-namespace SIL.XForge.Models
+namespace SIL.XForge.Models;
+
+/// <summary>
+/// A queued operation.
+/// </summary>
+/// <remarks>
+/// This is for use by <see cref="Realtime.QueuedRealtimeServer"/>.
+/// </remarks>
+internal class QueuedOperation
 {
     /// <summary>
-    /// A queued operation.
+    /// Gets or sets the action.
     /// </summary>
+    /// <value>
+    /// The action.
+    /// </value>
     /// <remarks>
-    /// This is for use by <see cref="Realtime.QueuedRealtimeServer"/>.
+    /// This corresponds to the function called on the realtime server.
     /// </remarks>
-    internal class QueuedOperation
-    {
-        /// <summary>
-        /// Gets or sets the action.
-        /// </summary>
-        /// <value>
-        /// The action.
-        /// </value>
-        /// <remarks>
-        /// This corresponds to the function called on the realtime server.
-        /// </remarks>
-        public QueuedAction Action { get; set; }
+    public QueuedAction Action { get; set; }
 
-        /// <summary>
-        /// Gets or sets the collection.
-        /// </summary>
-        /// <value>
-        /// The collection.
-        /// </value>
-        /// <remarks>
-        /// This is specified for all queued operations.
-        /// </remarks>
-        public string Collection { get; set; }
+    /// <summary>
+    /// Gets or sets the collection.
+    /// </summary>
+    /// <value>
+    /// The collection.
+    /// </value>
+    /// <remarks>
+    /// This is specified for all queued operations.
+    /// </remarks>
+    public string Collection { get; set; }
 
-        /// <summary>
-        /// Gets or sets the data.
-        /// </summary>
-        /// <value>
-        /// The data.
-        /// </value>
-        /// <remarks>
-        /// This is required for <see cref="QueuedAction.Create" />.
-        /// </remarks>
-        public object Data { get; set; }
+    /// <summary>
+    /// Gets or sets the data.
+    /// </summary>
+    /// <value>
+    /// The data.
+    /// </value>
+    /// <remarks>
+    /// This is required for <see cref="QueuedAction.Create" />.
+    /// </remarks>
+    public object Data { get; set; }
 
-        /// <summary>
-        /// Gets or sets the handle.
-        /// </summary>
-        /// <value>
-        /// The handle.
-        /// </value>
-        /// <remarks>
-        /// This is specified for all queued operations.
-        /// </remarks>
-        public int Handle { get; set; }
+    /// <summary>
+    /// Gets or sets the handle.
+    /// </summary>
+    /// <value>
+    /// The handle.
+    /// </value>
+    /// <remarks>
+    /// This is specified for all queued operations.
+    /// </remarks>
+    public int Handle { get; set; }
 
-        /// <summary>
-        /// Gets or sets the identifier.
-        /// </summary>
-        /// <value>
-        /// The identifier.
-        /// </value>
-        /// <remarks>
-        /// This is specified for all queued operations.
-        /// </remarks>
-        public string Id { get; set; }
+    /// <summary>
+    /// Gets or sets the identifier.
+    /// </summary>
+    /// <value>
+    /// The identifier.
+    /// </value>
+    /// <remarks>
+    /// This is specified for all queued operations.
+    /// </remarks>
+    public string Id { get; set; }
 
-        /// <summary>
-        /// Gets or sets the operations.
-        /// </summary>
-        /// <value>
-        /// The operations.
-        /// </value>
-        /// <remarks>
-        /// Required for <see cref="QueuedAction.Submit" />.
-        /// This is usually a collection of JSON0 or RichText operations.
-        /// </remarks>
-        public object Op { get; set; }
+    /// <summary>
+    /// Gets or sets the operations.
+    /// </summary>
+    /// <value>
+    /// The operations.
+    /// </value>
+    /// <remarks>
+    /// Required for <see cref="QueuedAction.Submit" />.
+    /// This is usually a collection of JSON0 or RichText operations.
+    /// </remarks>
+    public object Op { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name of the ot type.
-        /// </summary>
-        /// <value>
-        /// The name of the ot type.
-        /// </value>
-        /// <remarks>
-        /// This is required for <see cref="QueuedAction.Create" />.
-        /// See <see cref="Realtime.OTType" /> for allowed values.
-        /// </remarks>
-        public string OtTypeName { get; set; }
-    }
+    /// <summary>
+    /// Gets or sets the name of the ot type.
+    /// </summary>
+    /// <value>
+    /// The name of the ot type.
+    /// </value>
+    /// <remarks>
+    /// This is required for <see cref="QueuedAction.Create" />.
+    /// See <see cref="Realtime.OTType" /> for allowed values.
+    /// </remarks>
+    public string OtTypeName { get; set; }
 }

--- a/src/SIL.XForge/Models/ShareKey.cs
+++ b/src/SIL.XForge/Models/ShareKey.cs
@@ -1,12 +1,11 @@
 using System;
 
-namespace SIL.XForge.Models
+namespace SIL.XForge.Models;
+
+public class ShareKey
 {
-    public class ShareKey
-    {
-        public string Email { get; set; }
-        public string Key { get; set; }
-        public DateTime? ExpirationTime { get; set; }
-        public string ProjectRole { get; set; }
-    }
+    public string Email { get; set; }
+    public string Key { get; set; }
+    public DateTime? ExpirationTime { get; set; }
+    public string ProjectRole { get; set; }
 }

--- a/src/SIL.XForge/Models/Site.cs
+++ b/src/SIL.XForge/Models/Site.cs
@@ -1,12 +1,11 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace SIL.XForge.Models
+namespace SIL.XForge.Models;
+
+[JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
+public class Site
 {
-    [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
-    public class Site
-    {
-        public string CurrentProjectId { get; set; }
-        public List<string> Projects { get; set; } = new List<string>();
-    }
+    public string CurrentProjectId { get; set; }
+    public List<string> Projects { get; set; } = new List<string>();
 }

--- a/src/SIL.XForge/Models/SystemRole.cs
+++ b/src/SIL.XForge/Models/SystemRole.cs
@@ -1,9 +1,8 @@
-namespace SIL.XForge.Models
+namespace SIL.XForge.Models;
+
+public static class SystemRole
 {
-    public static class SystemRole
-    {
-        public const string SystemAdmin = "system_admin";
-        public const string User = "user";
-        public const string None = "none";
-    }
+    public const string SystemAdmin = "system_admin";
+    public const string User = "user";
+    public const string None = "none";
 }

--- a/src/SIL.XForge/Models/Tokens.cs
+++ b/src/SIL.XForge/Models/Tokens.cs
@@ -2,40 +2,39 @@ using System;
 using System.IdentityModel.Tokens.Jwt;
 using Microsoft.IdentityModel.Tokens;
 
-namespace SIL.XForge.Models
+namespace SIL.XForge.Models;
+
+public class Tokens
 {
-    public class Tokens
+    public string AccessToken { get; set; }
+    public string RefreshToken { get; set; }
+
+    public DateTime IssuedAt
     {
-        public string AccessToken { get; set; }
-        public string RefreshToken { get; set; }
-
-        public DateTime IssuedAt
-        {
-            get
-            {
-                if (AccessToken == null)
-                {
-                    return DateTime.MinValue;
-                }
-                var accessToken = new JwtSecurityToken(AccessToken);
-                if (accessToken.Payload.Iat != null)
-                    return EpochTime.DateTime((long)accessToken.Payload.Iat);
-                return DateTime.MinValue;
-            }
-        }
-
-        /// <summary>
-        /// Checks whether the access token is valid and not about to expire.
-        /// </summary>
-        public bool ValidateLifetime()
+        get
         {
             if (AccessToken == null)
             {
-                return false;
+                return DateTime.MinValue;
             }
             var accessToken = new JwtSecurityToken(AccessToken);
-            var now = DateTime.UtcNow;
-            return now >= accessToken.ValidFrom && now <= accessToken.ValidTo - TimeSpan.FromMinutes(2);
+            if (accessToken.Payload.Iat != null)
+                return EpochTime.DateTime((long)accessToken.Payload.Iat);
+            return DateTime.MinValue;
         }
+    }
+
+    /// <summary>
+    /// Checks whether the access token is valid and not about to expire.
+    /// </summary>
+    public bool ValidateLifetime()
+    {
+        if (AccessToken == null)
+        {
+            return false;
+        }
+        var accessToken = new JwtSecurityToken(AccessToken);
+        var now = DateTime.UtcNow;
+        return now >= accessToken.ValidFrom && now <= accessToken.ValidTo - TimeSpan.FromMinutes(2);
     }
 }

--- a/src/SIL.XForge/Models/User.cs
+++ b/src/SIL.XForge/Models/User.cs
@@ -1,18 +1,17 @@
 using System.Collections.Generic;
 
-namespace SIL.XForge.Models
+namespace SIL.XForge.Models;
+
+public class User : Json0Snapshot
 {
-    public class User : Json0Snapshot
-    {
-        public string Name { get; set; }
-        public string Email { get; set; }
-        public string Role { get; set; }
-        public string AvatarUrl { get; set; }
-        public string ParatextId { get; set; }
-        public string DisplayName { get; set; }
-        public bool IsDisplayNameConfirmed { get; set; }
-        public string InterfaceLanguage { get; set; }
-        public string AuthId { get; set; }
-        public Dictionary<string, Site> Sites { get; set; } = new Dictionary<string, Site>();
-    }
+    public string Name { get; set; }
+    public string Email { get; set; }
+    public string Role { get; set; }
+    public string AvatarUrl { get; set; }
+    public string ParatextId { get; set; }
+    public string DisplayName { get; set; }
+    public bool IsDisplayNameConfirmed { get; set; }
+    public string InterfaceLanguage { get; set; }
+    public string AuthId { get; set; }
+    public Dictionary<string, Site> Sites { get; set; } = new Dictionary<string, Site>();
 }

--- a/src/SIL.XForge/Models/UserSecret.cs
+++ b/src/SIL.XForge/Models/UserSecret.cs
@@ -1,17 +1,16 @@
-namespace SIL.XForge.Models
+namespace SIL.XForge.Models;
+
+/// <summary>
+/// This model is used to store user data that we don't want to leak to the front-end. This is stored in a separate
+/// collection.
+/// </summary>
+public class UserSecret : IIdentifiable
 {
     /// <summary>
-    /// This model is used to store user data that we don't want to leak to the front-end. This is stored in a separate
-    /// collection.
+    /// SF user ID of the user that these secrets pertain to. (This is not a different set of IDs for
+    /// specifically user secrets.)
     /// </summary>
-    public class UserSecret : IIdentifiable
-    {
-        /// <summary>
-        /// SF user ID of the user that these secrets pertain to. (This is not a different set of IDs for
-        /// specifically user secrets.)
-        /// </summary>
-        public string Id { get; set; }
+    public string Id { get; set; }
 
-        public Tokens ParatextTokens { get; set; }
-    }
+    public Tokens ParatextTokens { get; set; }
 }

--- a/src/SIL.XForge/Models/WritingSystem.cs
+++ b/src/SIL.XForge/Models/WritingSystem.cs
@@ -1,7 +1,6 @@
-namespace SIL.XForge.Models
+namespace SIL.XForge.Models;
+
+public class WritingSystem
 {
-    public class WritingSystem
-    {
-        public string Tag { get; set; }
-    }
+    public string Tag { get; set; }
 }

--- a/src/SIL.XForge/Realtime/Connection.cs
+++ b/src/SIL.XForge/Realtime/Connection.cs
@@ -3,404 +3,393 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Threading;
 using System.Threading.Tasks;
-using Jering.Javascript.NodeJS;
 using SIL.ObjectModel;
 using SIL.XForge.Configuration;
 using SIL.XForge.Models;
 using SIL.XForge.Realtime.Json0;
 using SIL.XForge.Utils;
 
-namespace SIL.XForge.Realtime
+namespace SIL.XForge.Realtime;
+
+/// <summary>
+/// This class represents a connection with the real-time server.
+/// </summary>
+public class Connection : DisposableBase, IConnection
 {
     /// <summary>
-    /// This class represents a connection with the real-time server.
+    /// The documents cache.
     /// </summary>
-    public class Connection : DisposableBase, IConnection
+    private readonly ConcurrentDictionary<(string, string), object> _documents;
+
+    /// <summary>
+    /// The properties to excluded from the transaction (i.e. to commit immediately).
+    /// </summary>
+    /// <remarks>
+    /// These are in the form "Type.Property.Property", in lower case.
+    /// </remarks>
+    private List<string> _excludedProperties = new List<string>();
+
+    /// <summary>
+    /// The connection handle.
+    /// </summary>
+    private int _handle;
+
+    /// <summary>
+    /// Whether or not this connection is in a transaction state.
+    /// </summary>
+    private bool _isTransaction;
+
+    /// <summary>
+    /// The queued operations.
+    /// </summary>
+    private ConcurrentQueue<QueuedOperation> _queuedOperations = new ConcurrentQueue<QueuedOperation>();
+
+    /// <summary>
+    /// The realtime server to create/modify documents with.
+    /// </summary>
+    private IRealtimeServer _realtimeServer;
+
+    /// <summary>
+    /// The realtime service to use for this connection.
+    /// </summary>
+    private readonly RealtimeService _realtimeService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Connection"/> class.
+    /// </summary>
+    /// <param name="realtimeService">The realtime service.</param>
+    internal Connection(RealtimeService realtimeService)
     {
-        /// <summary>
-        /// The documents cache.
-        /// </summary>
-        private readonly ConcurrentDictionary<(string, string), object> _documents;
+        _realtimeService = realtimeService;
+        _realtimeServer = realtimeService.Server;
+        _documents = new ConcurrentDictionary<(string, string), object>();
+    }
 
-        /// <summary>
-        /// The properties to excluded from the transaction (i.e. to commit immediately).
-        /// </summary>
-        /// <remarks>
-        /// These are in the form "Type.Property.Property", in lower case.
-        /// </remarks>
-        private List<string> _excludedProperties = new List<string>();
+    /// <summary>
+    /// Gets the excluded properties.
+    /// </summary>
+    /// <value>
+    /// The excluded properties.
+    /// </value>
+    /// <remarks>
+    /// This is for unit test verification or debugging.
+    /// </remarks>
+    internal IReadOnlyCollection<string> ExcludedProperties => _excludedProperties;
 
-        /// <summary>
-        /// The connection handle.
-        /// </summary>
-        private int _handle;
+    /// <summary>
+    /// Gets the number of queued operations.
+    /// </summary>
+    /// <value>
+    /// The number of operations in the queue.
+    /// </value>
+    /// <remarks>
+    /// This is for unit test verification or debugging.
+    /// </remarks>
+    internal IReadOnlyCollection<QueuedOperation> QueuedOperations => _queuedOperations;
 
-        /// <summary>
-        /// Whether or not this connection is in a transaction state.
-        /// </summary>
-        private bool _isTransaction;
-
-        /// <summary>
-        /// The queued operations.
-        /// </summary>
-        private ConcurrentQueue<QueuedOperation> _queuedOperations = new ConcurrentQueue<QueuedOperation>();
-
-        /// <summary>
-        /// The realtime server to create/modify documents with.
-        /// </summary>
-        private IRealtimeServer _realtimeServer;
-
-        /// <summary>
-        /// The realtime service to use for this connection.
-        /// </summary>
-        private readonly RealtimeService _realtimeService;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Connection"/> class.
-        /// </summary>
-        /// <param name="realtimeService">The realtime service.</param>
-        internal Connection(RealtimeService realtimeService)
+    /// <summary>
+    /// Begins the transaction.
+    /// </summary>
+    /// <exception cref="ArgumentException">The connection is already in a transaction state.</exception>
+    public void BeginTransaction()
+    {
+        // Start the transaction state, if we are not in a transaction state
+        if (!_isTransaction)
         {
-            _realtimeService = realtimeService;
-            _realtimeServer = realtimeService.Server;
-            _documents = new ConcurrentDictionary<(string, string), object>();
+            _isTransaction = true;
         }
-
-        /// <summary>
-        /// Gets the excluded properties.
-        /// </summary>
-        /// <value>
-        /// The excluded properties.
-        /// </value>
-        /// <remarks>
-        /// This is for unit test verification or debugging.
-        /// </remarks>
-        internal IReadOnlyCollection<string> ExcludedProperties => _excludedProperties;
-
-        /// <summary>
-        /// Gets the number of queued operations.
-        /// </summary>
-        /// <value>
-        /// The number of operations in the queue.
-        /// </value>
-        /// <remarks>
-        /// This is for unit test verification or debugging.
-        /// </remarks>
-        internal IReadOnlyCollection<QueuedOperation> QueuedOperations => _queuedOperations;
-
-        /// <summary>
-        /// Begins the transaction.
-        /// </summary>
-        /// <exception cref="ArgumentException">The connection is already in a transaction state.</exception>
-        public void BeginTransaction()
+        else
         {
-            // Start the transaction state, if we are not in a transaction state
-            if (!_isTransaction)
-            {
-                _isTransaction = true;
-            }
-            else
-            {
-                // We are already in a transaction state
-                throw new ArgumentException("The connection is already in a transaction state.");
-            }
-        }
-
-        /// <summary>
-        /// Commits the transaction.
-        /// </summary>
-        /// <exception cref="ArgumentException">The connection is not in a transaction state.</exception>
-        public async Task CommitTransactionAsync()
-        {
-            if (_isTransaction)
-            {
-                // Execute the queued operations
-                while (_queuedOperations.TryDequeue(out QueuedOperation queuedOperation))
-                {
-                    switch (queuedOperation.Action)
-                    {
-                        case QueuedAction.Create:
-                            await _realtimeServer.CreateDocAsync(
-                                queuedOperation.Handle,
-                                queuedOperation.Collection,
-                                queuedOperation.Id,
-                                queuedOperation.Data,
-                                queuedOperation.OtTypeName
-                            );
-                            break;
-                        case QueuedAction.Delete:
-                            await _realtimeServer.DeleteDocAsync(
-                                queuedOperation.Handle,
-                                queuedOperation.Collection,
-                                queuedOperation.Id
-                            );
-                            break;
-                        case QueuedAction.Submit:
-                            await _realtimeServer.SubmitOpAsync<object>(
-                                queuedOperation.Handle,
-                                queuedOperation.Collection,
-                                queuedOperation.Id,
-                                queuedOperation.Op
-                            );
-                            break;
-                    }
-                }
-
-                // Clear the excluded operations, and reset the transaction state
-                _excludedProperties.Clear();
-                _isTransaction = false;
-            }
-            else
-            {
-                // We are not in a transaction state
-                throw new ArgumentException("The connection is not in a transaction state.");
-            }
-        }
-
-        /// <summary>
-        /// Creates a document asynchronously.
-        /// </summary>
-        /// <typeparam name="T">The document type.</typeparam>
-        /// <param name="collection">The collection.</param>
-        /// <param name="id">The identifier.</param>
-        /// <param name="data">The data.</param>
-        /// <param name="otTypeName">Name of the OT type.</param>
-        /// <returns>
-        /// A snapshot of the created document from the realtime server.
-        /// </returns>
-        public async Task<Snapshot<T>> CreateDocAsync<T>(string collection, string id, T data, string otTypeName)
-        {
-            if (_isTransaction)
-            {
-                // Queue this operation
-                _queuedOperations.Enqueue(
-                    new QueuedOperation
-                    {
-                        Action = QueuedAction.Create,
-                        Collection = collection,
-                        Data = data,
-                        Handle = _handle,
-                        Id = id,
-                        OtTypeName = otTypeName,
-                    }
-                );
-
-                // Return a snapshot
-                return new Snapshot<T> { Data = data, Version = 1, };
-            }
-            else
-            {
-                return await _realtimeServer.CreateDocAsync(_handle, collection, id, data, otTypeName);
-            }
-        }
-
-        /// <summary>
-        /// Deletes a document asynchronously.
-        /// </summary>
-        /// <param name="collection">The collection.</param>
-        /// <param name="id">The identifier.</param>
-        /// <returns>The task.</returns>
-        public async Task DeleteDocAsync(string collection, string id)
-        {
-            if (_isTransaction)
-            {
-                // Queue this operation
-                _queuedOperations.Enqueue(
-                    new QueuedOperation
-                    {
-                        Action = QueuedAction.Delete,
-                        Collection = collection,
-                        Handle = _handle,
-                        Id = id,
-                    }
-                );
-            }
-            else
-            {
-                await _realtimeServer.DeleteDocAsync(_handle, collection, id);
-            }
-        }
-
-        /// <summary>
-        /// Excludes a property from the transaction.
-        /// </summary>
-        /// <typeparam name="T">The type the field belongs to.</typeparam>
-        /// <param name="field">The property field.</param>
-        /// <exception cref="ArgumentException">The connection is not in a transaction state.</exception>
-        /// <remarks>
-        /// Notes:
-        ///  - When a field is excluded from a transaction, operations to it are committed immediately.
-        ///  - Any operations lists that contain an excluded property will all be committed immediately.
-        ///  - You will need to call this again if you begin a new transaction.
-        ///  - This only applies to JSON0 operations.
-        /// </remarks>
-        public void ExcludePropertyFromTransaction<T>(Expression<Func<T, object>> field)
-        {
-            if (_isTransaction)
-            {
-                // Exclude the property, if we are in a transaction state
-                string excluded = (
-                    typeof(T).Name + "." + string.Join('.', new ObjectPath(field).Items)
-                ).ToLowerInvariant();
-                _excludedProperties.Add(excluded);
-            }
-            else
-            {
-                // We are not in a transaction state
-                throw new ArgumentException("The connection is not in a transaction state.");
-            }
-        }
-
-        /// <summary>
-        /// Fetches a document asynchronously.
-        /// </summary>
-        /// <typeparam name="T">The document type.</typeparam>
-        /// <param name="collection">The collection.</param>
-        /// <param name="id">The identifier.</param>
-        /// <returns>
-        /// A snapshot of the fetched document from the realtime server.
-        /// </returns>
-        public async Task<Snapshot<T>> FetchDocAsync<T>(string collection, string id)
-        {
-            return await _realtimeServer.FetchDocAsync<T>(_handle, collection, id);
-        }
-
-        /// <summary>
-        /// Gets the specified document, bound to the current realtime server.
-        /// </summary>
-        /// <typeparam name="T">The document type.</typeparam>
-        /// <param name="id">The identifier.</param>
-        /// <returns>
-        /// The document.
-        /// </returns>
-        public IDocument<T> Get<T>(string id) where T : IIdentifiable
-        {
-            DocConfig docConfig = _realtimeService.GetDocConfig<T>();
-            object doc = _documents.GetOrAdd(
-                (docConfig.CollectionName, id),
-                key =>
-                {
-                    string otTypeName = docConfig.OTTypeName;
-                    return new Document<T>(this, otTypeName, docConfig.CollectionName, id);
-                }
-            );
-            return (Document<T>)doc;
-        }
-
-        /// <summary>
-        /// Rolls back the transaction.
-        /// </summary>
-        /// <exception cref="ArgumentException">The connection is not in a transaction state.</exception>
-        public void RollbackTransaction()
-        {
-            if (_isTransaction)
-            {
-                // Clear the operations
-                _excludedProperties.Clear();
-                _queuedOperations.Clear();
-
-                // Reset the transaction state
-                _isTransaction = false;
-            }
-            else
-            {
-                // We are not in a transaction state
-                throw new ArgumentException("The connection is not in a transaction state.");
-            }
-        }
-
-        /// <summary>
-        /// Submits an operation asynchronously.
-        /// </summary>
-        /// <typeparam name="T">The document type.</typeparam>
-        /// <param name="collection">The collection.</param>
-        /// <param name="id">The identifier.</param>
-        /// <param name="op">The operation.</param>
-        /// <param name="currentDoc">The current document (only used when in a transaction).</param>
-        /// <param name="currentVersion">The current version (only used when in a transaction).</param>
-        /// <returns>
-        /// A snapshot of the document with the submitted operation from the realtime server.
-        /// </returns>
-        public async Task<Snapshot<T>> SubmitOpAsync<T>(
-            string collection,
-            string id,
-            object op,
-            T currentDoc,
-            int currentVersion
-        )
-        {
-            if (_isTransaction)
-            {
-                // If we have a collection of JSON0 operations, see if any are to be committed immediately
-                bool queueOperation = true;
-                if (_excludedProperties.Any() && op is IEnumerable<Json0Op> jsonOps)
-                {
-                    foreach (Json0Op jsonOp in jsonOps)
-                    {
-                        string path = (typeof(T).Name + "." + string.Join('.', jsonOp.Path)).ToLowerInvariant();
-                        if (_excludedProperties.Contains(path))
-                        {
-                            // Do not return the submitted operation, as it will not include the queued ops,
-                            // as SubmitOpAsync writes to then reads directly from the Realtime Server.
-                            _ = await _realtimeServer.SubmitOpAsync<T>(_handle, collection, id, op);
-                            queueOperation = false;
-                            break;
-                        }
-                    }
-                }
-
-                // Queue this operation
-                if (queueOperation)
-                {
-                    _queuedOperations.Enqueue(
-                        new QueuedOperation
-                        {
-                            Action = QueuedAction.Submit,
-                            Collection = collection,
-                            Handle = _handle,
-                            Id = id,
-                            Op = op,
-                        }
-                    );
-                }
-
-                // Return the operation applied to the object
-                string otTypeName = op is IEnumerable<Json0Op> || op is Json0Op ? OTType.Json0 : OTType.RichText;
-                return new Snapshot<T>
-                {
-                    Data = await _realtimeServer.ApplyOpAsync(otTypeName, currentDoc, op),
-                    Version = ++currentVersion,
-                };
-            }
-            else
-            {
-                return await _realtimeServer.SubmitOpAsync<T>(_handle, collection, id, op);
-            }
-        }
-
-        public async ValueTask DisposeAsync()
-        {
-            await _realtimeService.Server.DisconnectAsync(_handle);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Starts the realtime server asynchronously.
-        /// </summary>
-        /// <param name="userId">The user identifier.</param>
-        internal async Task StartAsync(string userId = null)
-        {
-            _handle = await _realtimeService.Server.ConnectAsync(userId);
-        }
-
-        /// <summary>
-        /// Disposes the managed resources.
-        /// </summary>
-        protected override void DisposeManagedResources()
-        {
-            _realtimeService.Server.Disconnect(_handle);
+            // We are already in a transaction state
+            throw new ArgumentException("The connection is already in a transaction state.");
         }
     }
+
+    /// <summary>
+    /// Commits the transaction.
+    /// </summary>
+    /// <exception cref="ArgumentException">The connection is not in a transaction state.</exception>
+    public async Task CommitTransactionAsync()
+    {
+        if (_isTransaction)
+        {
+            // Execute the queued operations
+            while (_queuedOperations.TryDequeue(out QueuedOperation queuedOperation))
+            {
+                switch (queuedOperation.Action)
+                {
+                    case QueuedAction.Create:
+                        await _realtimeServer.CreateDocAsync(
+                            queuedOperation.Handle,
+                            queuedOperation.Collection,
+                            queuedOperation.Id,
+                            queuedOperation.Data,
+                            queuedOperation.OtTypeName
+                        );
+                        break;
+                    case QueuedAction.Delete:
+                        await _realtimeServer.DeleteDocAsync(
+                            queuedOperation.Handle,
+                            queuedOperation.Collection,
+                            queuedOperation.Id
+                        );
+                        break;
+                    case QueuedAction.Submit:
+                        await _realtimeServer.SubmitOpAsync<object>(
+                            queuedOperation.Handle,
+                            queuedOperation.Collection,
+                            queuedOperation.Id,
+                            queuedOperation.Op
+                        );
+                        break;
+                }
+            }
+
+            // Clear the excluded operations, and reset the transaction state
+            _excludedProperties.Clear();
+            _isTransaction = false;
+        }
+        else
+        {
+            // We are not in a transaction state
+            throw new ArgumentException("The connection is not in a transaction state.");
+        }
+    }
+
+    /// <summary>
+    /// Creates a document asynchronously.
+    /// </summary>
+    /// <typeparam name="T">The document type.</typeparam>
+    /// <param name="collection">The collection.</param>
+    /// <param name="id">The identifier.</param>
+    /// <param name="data">The data.</param>
+    /// <param name="otTypeName">Name of the OT type.</param>
+    /// <returns>
+    /// A snapshot of the created document from the realtime server.
+    /// </returns>
+    public async Task<Snapshot<T>> CreateDocAsync<T>(string collection, string id, T data, string otTypeName)
+    {
+        if (_isTransaction)
+        {
+            // Queue this operation
+            _queuedOperations.Enqueue(
+                new QueuedOperation
+                {
+                    Action = QueuedAction.Create,
+                    Collection = collection,
+                    Data = data,
+                    Handle = _handle,
+                    Id = id,
+                    OtTypeName = otTypeName,
+                }
+            );
+
+            // Return a snapshot
+            return new Snapshot<T> { Data = data, Version = 1, };
+        }
+        else
+        {
+            return await _realtimeServer.CreateDocAsync(_handle, collection, id, data, otTypeName);
+        }
+    }
+
+    /// <summary>
+    /// Deletes a document asynchronously.
+    /// </summary>
+    /// <param name="collection">The collection.</param>
+    /// <param name="id">The identifier.</param>
+    /// <returns>The task.</returns>
+    public async Task DeleteDocAsync(string collection, string id)
+    {
+        if (_isTransaction)
+        {
+            // Queue this operation
+            _queuedOperations.Enqueue(
+                new QueuedOperation
+                {
+                    Action = QueuedAction.Delete,
+                    Collection = collection,
+                    Handle = _handle,
+                    Id = id,
+                }
+            );
+        }
+        else
+        {
+            await _realtimeServer.DeleteDocAsync(_handle, collection, id);
+        }
+    }
+
+    /// <summary>
+    /// Excludes a property from the transaction.
+    /// </summary>
+    /// <typeparam name="T">The type the field belongs to.</typeparam>
+    /// <param name="field">The property field.</param>
+    /// <exception cref="ArgumentException">The connection is not in a transaction state.</exception>
+    /// <remarks>
+    /// Notes:
+    ///  - When a field is excluded from a transaction, operations to it are committed immediately.
+    ///  - Any operations lists that contain an excluded property will all be committed immediately.
+    ///  - You will need to call this again if you begin a new transaction.
+    ///  - This only applies to JSON0 operations.
+    /// </remarks>
+    public void ExcludePropertyFromTransaction<T>(Expression<Func<T, object>> field)
+    {
+        if (_isTransaction)
+        {
+            // Exclude the property, if we are in a transaction state
+            string excluded = (typeof(T).Name + "." + string.Join('.', new ObjectPath(field).Items)).ToLowerInvariant();
+            _excludedProperties.Add(excluded);
+        }
+        else
+        {
+            // We are not in a transaction state
+            throw new ArgumentException("The connection is not in a transaction state.");
+        }
+    }
+
+    /// <summary>
+    /// Fetches a document asynchronously.
+    /// </summary>
+    /// <typeparam name="T">The document type.</typeparam>
+    /// <param name="collection">The collection.</param>
+    /// <param name="id">The identifier.</param>
+    /// <returns>
+    /// A snapshot of the fetched document from the realtime server.
+    /// </returns>
+    public async Task<Snapshot<T>> FetchDocAsync<T>(string collection, string id) =>
+        await _realtimeServer.FetchDocAsync<T>(_handle, collection, id);
+
+    /// <summary>
+    /// Gets the specified document, bound to the current realtime server.
+    /// </summary>
+    /// <typeparam name="T">The document type.</typeparam>
+    /// <param name="id">The identifier.</param>
+    /// <returns>
+    /// The document.
+    /// </returns>
+    public IDocument<T> Get<T>(string id)
+        where T : IIdentifiable
+    {
+        DocConfig docConfig = _realtimeService.GetDocConfig<T>();
+        object doc = _documents.GetOrAdd(
+            (docConfig.CollectionName, id),
+            key =>
+            {
+                string otTypeName = docConfig.OTTypeName;
+                return new Document<T>(this, otTypeName, docConfig.CollectionName, id);
+            }
+        );
+        return (Document<T>)doc;
+    }
+
+    /// <summary>
+    /// Rolls back the transaction.
+    /// </summary>
+    /// <exception cref="ArgumentException">The connection is not in a transaction state.</exception>
+    public void RollbackTransaction()
+    {
+        if (_isTransaction)
+        {
+            // Clear the operations
+            _excludedProperties.Clear();
+            _queuedOperations.Clear();
+
+            // Reset the transaction state
+            _isTransaction = false;
+        }
+        else
+        {
+            // We are not in a transaction state
+            throw new ArgumentException("The connection is not in a transaction state.");
+        }
+    }
+
+    /// <summary>
+    /// Submits an operation asynchronously.
+    /// </summary>
+    /// <typeparam name="T">The document type.</typeparam>
+    /// <param name="collection">The collection.</param>
+    /// <param name="id">The identifier.</param>
+    /// <param name="op">The operation.</param>
+    /// <param name="currentDoc">The current document (only used when in a transaction).</param>
+    /// <param name="currentVersion">The current version (only used when in a transaction).</param>
+    /// <returns>
+    /// A snapshot of the document with the submitted operation from the realtime server.
+    /// </returns>
+    public async Task<Snapshot<T>> SubmitOpAsync<T>(
+        string collection,
+        string id,
+        object op,
+        T currentDoc,
+        int currentVersion
+    )
+    {
+        if (_isTransaction)
+        {
+            // If we have a collection of JSON0 operations, see if any are to be committed immediately
+            bool queueOperation = true;
+            if (_excludedProperties.Any() && op is IEnumerable<Json0Op> jsonOps)
+            {
+                foreach (Json0Op jsonOp in jsonOps)
+                {
+                    string path = (typeof(T).Name + "." + string.Join('.', jsonOp.Path)).ToLowerInvariant();
+                    if (_excludedProperties.Contains(path))
+                    {
+                        // Do not return the submitted operation, as it will not include the queued ops,
+                        // as SubmitOpAsync writes to then reads directly from the Realtime Server.
+                        _ = await _realtimeServer.SubmitOpAsync<T>(_handle, collection, id, op);
+                        queueOperation = false;
+                        break;
+                    }
+                }
+            }
+
+            // Queue this operation
+            if (queueOperation)
+            {
+                _queuedOperations.Enqueue(
+                    new QueuedOperation
+                    {
+                        Action = QueuedAction.Submit,
+                        Collection = collection,
+                        Handle = _handle,
+                        Id = id,
+                        Op = op,
+                    }
+                );
+            }
+
+            // Return the operation applied to the object
+            string otTypeName = op is IEnumerable<Json0Op> || op is Json0Op ? OTType.Json0 : OTType.RichText;
+            return new Snapshot<T>
+            {
+                Data = await _realtimeServer.ApplyOpAsync(otTypeName, currentDoc, op),
+                Version = ++currentVersion,
+            };
+        }
+        else
+        {
+            return await _realtimeServer.SubmitOpAsync<T>(_handle, collection, id, op);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _realtimeService.Server.DisconnectAsync(_handle);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Starts the realtime server asynchronously.
+    /// </summary>
+    /// <param name="userId">The user identifier.</param>
+    internal async Task StartAsync(string userId = null) =>
+        _handle = await _realtimeService.Server.ConnectAsync(userId);
+
+    /// <summary>
+    /// Disposes the managed resources.
+    /// </summary>
+    protected override void DisposeManagedResources() => _realtimeService.Server.Disconnect(_handle);
 }

--- a/src/SIL.XForge/Realtime/Document.cs
+++ b/src/SIL.XForge/Realtime/Document.cs
@@ -3,115 +3,115 @@ using System.Threading;
 using System.Threading.Tasks;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Realtime
+namespace SIL.XForge.Realtime;
+
+/// <summary>
+/// This class represents a real-time document.
+/// </summary>
+public class Document<T> : IDocument<T>
+    where T : IIdentifiable
 {
-    /// <summary>
-    /// This class represents a real-time document.
-    /// </summary>
-    public class Document<T> : IDocument<T> where T : IIdentifiable
+    private readonly IConnection _connection;
+    private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
+
+    internal Document(IConnection connection, string otTypeName, string collection, string id)
     {
-        private readonly IConnection _connection;
-        private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
+        _connection = connection;
+        OTTypeName = otTypeName;
+        Collection = collection;
+        Id = id;
+    }
 
-        internal Document(IConnection connection, string otTypeName, string collection, string id)
+    public string Collection { get; }
+
+    public string Id { get; }
+
+    public int Version { get; private set; } = -1;
+
+    public string OTTypeName { get; }
+
+    public T Data { get; private set; }
+
+    public bool IsLoaded => Data != null;
+
+    public async Task CreateAsync(T data)
+    {
+        await _lock.WaitAsync();
+        try
         {
-            _connection = connection;
-            OTTypeName = otTypeName;
-            Collection = collection;
-            Id = id;
+            Snapshot<T> snapshot = await _connection.CreateDocAsync(Collection, Id, data, OTTypeName);
+            UpdateFromSnapshot(snapshot);
         }
-
-        public string Collection { get; }
-
-        public string Id { get; }
-
-        public int Version { get; private set; } = -1;
-
-        public string OTTypeName { get; }
-
-        public T Data { get; private set; }
-
-        public bool IsLoaded => Data != null;
-
-        public async Task CreateAsync(T data)
+        finally
         {
-            await _lock.WaitAsync();
-            try
-            {
-                Snapshot<T> snapshot = await _connection.CreateDocAsync(Collection, Id, data, OTTypeName);
-                UpdateFromSnapshot(snapshot);
-            }
-            finally
-            {
-                _lock.Release();
-            }
+            _lock.Release();
         }
+    }
 
-        public async Task FetchAsync()
+    public async Task FetchAsync()
+    {
+        await _lock.WaitAsync();
+        try
         {
-            await _lock.WaitAsync();
-            try
-            {
-                Snapshot<T> snapshot = await _connection.FetchDocAsync<T>(Collection, Id);
-                UpdateFromSnapshot(snapshot);
-            }
-            finally
-            {
-                _lock.Release();
-            }
+            Snapshot<T> snapshot = await _connection.FetchDocAsync<T>(Collection, Id);
+            UpdateFromSnapshot(snapshot);
         }
+        finally
+        {
+            _lock.Release();
+        }
+    }
 
-        public async Task FetchOrCreateAsync(Func<T> createData)
+    public async Task FetchOrCreateAsync(Func<T> createData)
+    {
+        await _lock.WaitAsync();
+        try
         {
-            await _lock.WaitAsync();
-            try
-            {
-                Snapshot<T> snapshot = await _connection.FetchDocAsync<T>(Collection, Id);
-                if (snapshot.Data == null)
-                    snapshot = await _connection.CreateDocAsync(Collection, Id, createData(), OTTypeName);
-                UpdateFromSnapshot(snapshot);
-            }
-            finally
-            {
-                _lock.Release();
-            }
+            Snapshot<T> snapshot = await _connection.FetchDocAsync<T>(Collection, Id);
+            if (snapshot.Data == null)
+                snapshot = await _connection.CreateDocAsync(Collection, Id, createData(), OTTypeName);
+            UpdateFromSnapshot(snapshot);
         }
+        finally
+        {
+            _lock.Release();
+        }
+    }
 
-        public async Task SubmitOpAsync(object op)
+    public async Task SubmitOpAsync(object op)
+    {
+        await _lock.WaitAsync();
+        try
         {
-            await _lock.WaitAsync();
-            try
-            {
-                Snapshot<T> snapshot = await _connection.SubmitOpAsync<T>(Collection, Id, op, Data, Version);
-                UpdateFromSnapshot(snapshot);
-            }
-            finally
-            {
-                _lock.Release();
-            }
+            Snapshot<T> snapshot = await _connection.SubmitOpAsync<T>(Collection, Id, op, Data, Version);
+            UpdateFromSnapshot(snapshot);
         }
+        finally
+        {
+            _lock.Release();
+        }
+    }
 
-        public async Task DeleteAsync()
+    public async Task DeleteAsync()
+    {
+        await _lock.WaitAsync();
+        try
         {
-            await _lock.WaitAsync();
-            try
-            {
-                await _connection.DeleteDocAsync(Collection, Id);
-                Version = -1;
-                Data = default(T);
-            }
-            finally
-            {
-                _lock.Release();
-            }
+            await _connection.DeleteDocAsync(Collection, Id);
+            Version = -1;
+            Data = default;
         }
+        finally
+        {
+            _lock.Release();
+        }
+    }
 
-        private void UpdateFromSnapshot(Snapshot<T> snapshot)
-        {
-            Version = snapshot.Version;
-            Data = snapshot.Data;
-            if (Data != null)
-                Data.Id = Id;
-        }
+    private void UpdateFromSnapshot(Snapshot<T> snapshot)
+    {
+        Version = snapshot.Version;
+        Data = snapshot.Data;
+        if (Data != null)
+            Data.Id = Id;
     }
 }

--- a/src/SIL.XForge/Realtime/IConnection.cs
+++ b/src/SIL.XForge/Realtime/IConnection.cs
@@ -3,18 +3,18 @@ using System.Linq.Expressions;
 using System.Threading.Tasks;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Realtime
+namespace SIL.XForge.Realtime;
+
+public interface IConnection : IDisposable, IAsyncDisposable
 {
-    public interface IConnection : IDisposable, IAsyncDisposable
-    {
-        void BeginTransaction();
-        Task CommitTransactionAsync();
-        Task<Snapshot<T>> CreateDocAsync<T>(string collection, string id, T data, string otTypeName);
-        Task DeleteDocAsync(string collection, string id);
-        void ExcludePropertyFromTransaction<T>(Expression<Func<T, object>> field);
-        Task<Snapshot<T>> FetchDocAsync<T>(string collection, string id);
-        IDocument<T> Get<T>(string id) where T : IIdentifiable;
-        void RollbackTransaction();
-        Task<Snapshot<T>> SubmitOpAsync<T>(string collection, string id, object op, T currentDoc, int currentVersion);
-    }
+    void BeginTransaction();
+    Task CommitTransactionAsync();
+    Task<Snapshot<T>> CreateDocAsync<T>(string collection, string id, T data, string otTypeName);
+    Task DeleteDocAsync(string collection, string id);
+    void ExcludePropertyFromTransaction<T>(Expression<Func<T, object>> field);
+    Task<Snapshot<T>> FetchDocAsync<T>(string collection, string id);
+    IDocument<T> Get<T>(string id)
+        where T : IIdentifiable;
+    void RollbackTransaction();
+    Task<Snapshot<T>> SubmitOpAsync<T>(string collection, string id, object op, T currentDoc, int currentVersion);
 }

--- a/src/SIL.XForge/Realtime/IDocument.cs
+++ b/src/SIL.XForge/Realtime/IDocument.cs
@@ -2,25 +2,25 @@ using System;
 using System.Threading.Tasks;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Realtime
+namespace SIL.XForge.Realtime;
+
+public interface IDocument<T>
+    where T : IIdentifiable
 {
-    public interface IDocument<T> where T : IIdentifiable
-    {
-        string Collection { get; }
-        string Id { get; }
-        int Version { get; }
-        string OTTypeName { get; }
-        T Data { get; }
-        bool IsLoaded { get; }
+    string Collection { get; }
+    string Id { get; }
+    int Version { get; }
+    string OTTypeName { get; }
+    T Data { get; }
+    bool IsLoaded { get; }
 
-        Task CreateAsync(T data);
+    Task CreateAsync(T data);
 
-        Task FetchAsync();
+    Task FetchAsync();
 
-        Task FetchOrCreateAsync(Func<T> createData);
+    Task FetchOrCreateAsync(Func<T> createData);
 
-        Task SubmitOpAsync(object op);
+    Task SubmitOpAsync(object op);
 
-        Task DeleteAsync();
-    }
+    Task DeleteAsync();
 }

--- a/src/SIL.XForge/Realtime/IRealtimeServer.cs
+++ b/src/SIL.XForge/Realtime/IRealtimeServer.cs
@@ -1,18 +1,17 @@
 using System.Threading.Tasks;
 
-namespace SIL.XForge.Realtime
+namespace SIL.XForge.Realtime;
+
+public interface IRealtimeServer
 {
-    public interface IRealtimeServer
-    {
-        Task<T> ApplyOpAsync<T>(string otTypeName, T data, object op);
-        Task<int> ConnectAsync(string userId = null);
-        Task<Snapshot<T>> CreateDocAsync<T>(int handle, string collection, string id, T data, string otTypeName);
-        Task DeleteDocAsync(int handle, string collection, string id);
-        void Disconnect(int handle);
-        Task DisconnectAsync(int handle);
-        Task<Snapshot<T>> FetchDocAsync<T>(int handle, string collection, string id);
-        void Start(object options);
-        void Stop();
-        Task<Snapshot<T>> SubmitOpAsync<T>(int handle, string collection, string id, object op);
-    }
+    Task<T> ApplyOpAsync<T>(string otTypeName, T data, object op);
+    Task<int> ConnectAsync(string userId = null);
+    Task<Snapshot<T>> CreateDocAsync<T>(int handle, string collection, string id, T data, string otTypeName);
+    Task DeleteDocAsync(int handle, string collection, string id);
+    void Disconnect(int handle);
+    Task DisconnectAsync(int handle);
+    Task<Snapshot<T>> FetchDocAsync<T>(int handle, string collection, string id);
+    void Start(object options);
+    void Stop();
+    Task<Snapshot<T>> SubmitOpAsync<T>(int handle, string collection, string id, object op);
 }

--- a/src/SIL.XForge/Realtime/IRealtimeService.cs
+++ b/src/SIL.XForge/Realtime/IRealtimeService.cs
@@ -2,22 +2,24 @@ using System.Linq;
 using System.Threading.Tasks;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Realtime
+namespace SIL.XForge.Realtime;
+
+public interface IRealtimeService
 {
-    public interface IRealtimeService
-    {
-        void StartServer();
-        void StopServer();
+    void StartServer();
+    void StopServer();
 
-        Task<IConnection> ConnectAsync(string userId = null);
+    Task<IConnection> ConnectAsync(string userId = null);
 
-        string GetCollectionName<T>() where T : IIdentifiable;
+    string GetCollectionName<T>()
+        where T : IIdentifiable;
 
-        IQueryable<T> QuerySnapshots<T>() where T : IIdentifiable;
+    IQueryable<T> QuerySnapshots<T>()
+        where T : IIdentifiable;
 
-        Task DeleteProjectAsync(string projectId);
-        Task DeleteUserAsync(string userId);
+    Task DeleteProjectAsync(string projectId);
+    Task DeleteUserAsync(string userId);
 
-        Task<string> GetLastModifiedUserIdAsync<T>(string id, int version) where T : IIdentifiable;
-    }
+    Task<string> GetLastModifiedUserIdAsync<T>(string id, int version)
+        where T : IIdentifiable;
 }

--- a/src/SIL.XForge/Realtime/Json0/Json0Extensions.cs
+++ b/src/SIL.XForge/Realtime/Json0/Json0Extensions.cs
@@ -2,20 +2,19 @@ using System;
 using System.Threading.Tasks;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Realtime.Json0
-{
-    public static class Json0Extensions
-    {
-        public static async Task SubmitJson0OpAsync<T>(this IDocument<T> doc, Action<Json0OpBuilder<T>> build)
-            where T : Json0Snapshot
-        {
-            if (!doc.IsLoaded)
-                throw new InvalidOperationException("The document has not been loaded.");
+namespace SIL.XForge.Realtime.Json0;
 
-            var builder = new Json0OpBuilder<T>(doc.Data);
-            build(builder);
-            if (builder.Op.Count > 0)
-                await doc.SubmitOpAsync(builder.Op);
-        }
+public static class Json0Extensions
+{
+    public static async Task SubmitJson0OpAsync<T>(this IDocument<T> doc, Action<Json0OpBuilder<T>> build)
+        where T : Json0Snapshot
+    {
+        if (!doc.IsLoaded)
+            throw new InvalidOperationException("The document has not been loaded.");
+
+        var builder = new Json0OpBuilder<T>(doc.Data);
+        build(builder);
+        if (builder.Op.Count > 0)
+            await doc.SubmitOpAsync(builder.Op);
     }
 }

--- a/src/SIL.XForge/Realtime/Json0/Json0Op.cs
+++ b/src/SIL.XForge/Realtime/Json0/Json0Op.cs
@@ -1,33 +1,32 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace SIL.XForge.Realtime.Json0
+namespace SIL.XForge.Realtime.Json0;
+
+/// <summary>
+/// This class represents an OT operation on arbitrary JSON data.
+/// </summary>
+[JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
+public class Json0Op
 {
-    /// <summary>
-    /// This class represents an OT operation on arbitrary JSON data.
-    /// </summary>
-    [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
-    public class Json0Op
-    {
-        [JsonProperty("p")]
-        public List<object> Path { get; set; } = new List<object>();
+    [JsonProperty("p")]
+    public List<object> Path { get; set; } = new List<object>();
 
-        [JsonProperty("li")]
-        public object InsertItem { get; set; }
+    [JsonProperty("li")]
+    public object InsertItem { get; set; }
 
-        [JsonProperty("ld")]
-        public object DeleteItem { get; set; }
+    [JsonProperty("ld")]
+    public object DeleteItem { get; set; }
 
-        [JsonProperty("lm")]
-        public int? MoveIndex { get; set; }
+    [JsonProperty("lm")]
+    public int? MoveIndex { get; set; }
 
-        [JsonProperty("oi")]
-        public object InsertProp { get; set; }
+    [JsonProperty("oi")]
+    public object InsertProp { get; set; }
 
-        [JsonProperty("od")]
-        public object DeleteProp { get; set; }
+    [JsonProperty("od")]
+    public object DeleteProp { get; set; }
 
-        [JsonProperty("na")]
-        public int? Add { get; set; }
-    }
+    [JsonProperty("na")]
+    public int? Add { get; set; }
 }

--- a/src/SIL.XForge/Realtime/Json0/Json0OpBuilder.cs
+++ b/src/SIL.XForge/Realtime/Json0/Json0OpBuilder.cs
@@ -4,209 +4,194 @@ using System.Linq;
 using System.Linq.Expressions;
 using SIL.XForge.Utils;
 
-namespace SIL.XForge.Realtime.Json0
+namespace SIL.XForge.Realtime.Json0;
+
+/// <summary>
+/// Helps build up operations to manipulate RealtimeServer data.
+/// Note: When setting or replacing data, if the request is already true in the `_data` object, then an op may not be created.
+/// </summary>
+public class Json0OpBuilder<T>
 {
-    /// <summary>
-    /// Helps build up operations to manipulate RealtimeServer data.
-    /// Note: When setting or replacing data, if the request is already true in the `_data` object, then an op may not be created.
-    /// </summary>
-    public class Json0OpBuilder<T>
+    private readonly T _data;
+
+    public Json0OpBuilder(T data) => _data = data;
+
+    public List<Json0Op> Op { get; } = new List<Json0Op>();
+
+    public Json0OpBuilder<T> Insert<TItem>(Expression<Func<T, List<TItem>>> field, int index, TItem item)
     {
-        private readonly T _data;
-
-        public Json0OpBuilder(T data)
-        {
-            _data = data;
-        }
-
-        public List<Json0Op> Op { get; } = new List<Json0Op>();
-
-        public Json0OpBuilder<T> Insert<TItem>(Expression<Func<T, List<TItem>>> field, int index, TItem item)
-        {
-            var objectPath = new ObjectPath(field);
-            List<object> path = objectPath.Items.ToList();
-            path.Add(index);
-            Op.Add(new Json0Op { Path = CreateJson0Path(path), InsertItem = item });
-            return this;
-        }
-
-        public Json0OpBuilder<T> Add<TItem>(Expression<Func<T, List<TItem>>> field, TItem item)
-        {
-            var objectPath = new ObjectPath(field);
-            if (!objectPath.TryGetValue(_data, out List<TItem> list) || list == null)
-                throw new InvalidOperationException("The specified list does not exist.");
-            List<object> path = objectPath.Items.ToList();
-            path.Add(list.Count);
-            Op.Add(new Json0Op { Path = CreateJson0Path(path), InsertItem = item });
-            return this;
-        }
-
-        public Json0OpBuilder<T> Remove<TItem>(Expression<Func<T, List<TItem>>> field, int index)
-        {
-            var objectPath = new ObjectPath(field);
-            if (!objectPath.TryGetValue(_data, out List<TItem> list) || list == null)
-                throw new InvalidOperationException("The specified list does not exist.");
-            List<object> path = objectPath.Items.ToList();
-            path.Add(index);
-            Op.Add(new Json0Op { Path = CreateJson0Path(path), DeleteItem = list[index] });
-            return this;
-        }
-
-        public Json0OpBuilder<T> Remove<TItem>(Expression<Func<T, List<TItem>>> field, int index, TItem item)
-        {
-            var objectPath = new ObjectPath(field);
-            List<object> path = objectPath.Items.ToList();
-            path.Add(index);
-            Op.Add(new Json0Op { Path = CreateJson0Path(path), DeleteItem = item });
-            return this;
-        }
-
-        public Json0OpBuilder<T> Replace<TItem>(Expression<Func<T, List<TItem>>> field, int index, TItem newItem)
-        {
-            return Replace(field, index, newItem, EqualityComparer<TItem>.Default);
-        }
-
-        public Json0OpBuilder<T> Replace<TItem>(
-            Expression<Func<T, List<TItem>>> field,
-            int index,
-            TItem newItem,
-            IEqualityComparer<TItem> equalityComparer
-        )
-        {
-            var objectPath = new ObjectPath(field);
-            if (!objectPath.TryGetValue(_data, out List<TItem> list) || list == null)
-                throw new InvalidOperationException("The specified list does not exist.");
-            TItem oldItem = list[index];
-            if (!equalityComparer.Equals(oldItem, newItem))
-            {
-                List<object> path = objectPath.Items.ToList();
-                path.Add(index);
-                Op.Add(
-                    new Json0Op
-                    {
-                        Path = CreateJson0Path(path),
-                        DeleteItem = oldItem,
-                        InsertItem = newItem
-                    }
-                );
-            }
-            return this;
-        }
-
-        public Json0OpBuilder<T> Replace<TItem>(
-            Expression<Func<T, List<TItem>>> field,
-            int index,
-            TItem newItem,
-            TItem oldItem
-        )
-        {
-            return Replace(field, index, newItem, oldItem, EqualityComparer<TItem>.Default);
-        }
-
-        public Json0OpBuilder<T> Replace<TItem>(
-            Expression<Func<T, List<TItem>>> field,
-            int index,
-            TItem newItem,
-            TItem oldItem,
-            IEqualityComparer<TItem> equalityComparer
-        )
-        {
-            if (!equalityComparer.Equals(oldItem, newItem))
-            {
-                var objectPath = new ObjectPath(field);
-                List<object> path = objectPath.Items.ToList();
-                path.Add(index);
-                Op.Add(
-                    new Json0Op
-                    {
-                        Path = CreateJson0Path(path),
-                        DeleteItem = oldItem,
-                        InsertItem = newItem
-                    }
-                );
-            }
-            return this;
-        }
-
-        public Json0OpBuilder<T> Set<TField>(Expression<Func<T, TField>> field, TField value)
-        {
-            return Set(field, value, EqualityComparer<TField>.Default);
-        }
-
-        public Json0OpBuilder<T> Set<TField>(
-            Expression<Func<T, TField>> field,
-            TField value,
-            IEqualityComparer<TField> equalityComparer
-        )
-        {
-            var objectPath = new ObjectPath(field);
-            bool hasOldValue = objectPath.TryGetValue(_data, out TField oldValue);
-            if (!hasOldValue || !equalityComparer.Equals(value, oldValue))
-            {
-                Op.Add(
-                    new Json0Op
-                    {
-                        Path = CreateJson0Path(objectPath.Items),
-                        DeleteProp = hasOldValue ? (object)oldValue : null,
-                        InsertProp = value
-                    }
-                );
-            }
-            return this;
-        }
-
-        public Json0OpBuilder<T> Set<TField>(Expression<Func<T, TField>> field, TField newValue, TField oldValue)
-        {
-            return Set(field, newValue, oldValue, EqualityComparer<TField>.Default);
-        }
-
-        public Json0OpBuilder<T> Set<TField>(
-            Expression<Func<T, TField>> field,
-            TField newValue,
-            TField oldValue,
-            IEqualityComparer<TField> equalityComparer
-        )
-        {
-            if (!equalityComparer.Equals(newValue, oldValue))
-            {
-                var objectPath = new ObjectPath(field);
-                Op.Add(
-                    new Json0Op
-                    {
-                        Path = CreateJson0Path(objectPath.Items),
-                        DeleteProp = oldValue,
-                        InsertProp = newValue
-                    }
-                );
-            }
-            return this;
-        }
-
-        public Json0OpBuilder<T> Unset<TField>(Expression<Func<T, TField>> field)
-        {
-            var objectPath = new ObjectPath(field);
-            if (objectPath.TryGetValue<T, TField>(_data, out TField value) && value != null)
-                Op.Add(new Json0Op { Path = CreateJson0Path(objectPath.Items), DeleteProp = value });
-            return this;
-        }
-
-        public Json0OpBuilder<T> Unset<TField>(Expression<Func<T, TField>> field, TField value)
-        {
-            var objectPath = new ObjectPath(field);
-            Op.Add(new Json0Op { Path = CreateJson0Path(objectPath.Items), DeleteProp = value });
-            return this;
-        }
-
-        public Json0OpBuilder<T> Inc(Expression<Func<T, int>> field, int n = 1)
-        {
-            var objectPath = new ObjectPath(field);
-            Op.Add(new Json0Op { Path = CreateJson0Path(objectPath.Items), Add = n });
-            return this;
-        }
-
-        private static List<object> CreateJson0Path(IEnumerable<object> path)
-        {
-            return path.Select(i => (i is string str) ? str.ToCamelCase() : i).ToList();
-        }
+        var objectPath = new ObjectPath(field);
+        List<object> path = objectPath.Items.ToList();
+        path.Add(index);
+        Op.Add(new Json0Op { Path = CreateJson0Path(path), InsertItem = item });
+        return this;
     }
+
+    public Json0OpBuilder<T> Add<TItem>(Expression<Func<T, List<TItem>>> field, TItem item)
+    {
+        var objectPath = new ObjectPath(field);
+        if (!objectPath.TryGetValue(_data, out List<TItem> list) || list == null)
+            throw new InvalidOperationException("The specified list does not exist.");
+        List<object> path = objectPath.Items.ToList();
+        path.Add(list.Count);
+        Op.Add(new Json0Op { Path = CreateJson0Path(path), InsertItem = item });
+        return this;
+    }
+
+    public Json0OpBuilder<T> Remove<TItem>(Expression<Func<T, List<TItem>>> field, int index)
+    {
+        var objectPath = new ObjectPath(field);
+        if (!objectPath.TryGetValue(_data, out List<TItem> list) || list == null)
+            throw new InvalidOperationException("The specified list does not exist.");
+        List<object> path = objectPath.Items.ToList();
+        path.Add(index);
+        Op.Add(new Json0Op { Path = CreateJson0Path(path), DeleteItem = list[index] });
+        return this;
+    }
+
+    public Json0OpBuilder<T> Remove<TItem>(Expression<Func<T, List<TItem>>> field, int index, TItem item)
+    {
+        var objectPath = new ObjectPath(field);
+        List<object> path = objectPath.Items.ToList();
+        path.Add(index);
+        Op.Add(new Json0Op { Path = CreateJson0Path(path), DeleteItem = item });
+        return this;
+    }
+
+    public Json0OpBuilder<T> Replace<TItem>(Expression<Func<T, List<TItem>>> field, int index, TItem newItem) =>
+        Replace(field, index, newItem, EqualityComparer<TItem>.Default);
+
+    public Json0OpBuilder<T> Replace<TItem>(
+        Expression<Func<T, List<TItem>>> field,
+        int index,
+        TItem newItem,
+        IEqualityComparer<TItem> equalityComparer
+    )
+    {
+        var objectPath = new ObjectPath(field);
+        if (!objectPath.TryGetValue(_data, out List<TItem> list) || list == null)
+            throw new InvalidOperationException("The specified list does not exist.");
+        TItem oldItem = list[index];
+        if (!equalityComparer.Equals(oldItem, newItem))
+        {
+            List<object> path = objectPath.Items.ToList();
+            path.Add(index);
+            Op.Add(
+                new Json0Op
+                {
+                    Path = CreateJson0Path(path),
+                    DeleteItem = oldItem,
+                    InsertItem = newItem
+                }
+            );
+        }
+        return this;
+    }
+
+    public Json0OpBuilder<T> Replace<TItem>(
+        Expression<Func<T, List<TItem>>> field,
+        int index,
+        TItem newItem,
+        TItem oldItem
+    ) => Replace(field, index, newItem, oldItem, EqualityComparer<TItem>.Default);
+
+    public Json0OpBuilder<T> Replace<TItem>(
+        Expression<Func<T, List<TItem>>> field,
+        int index,
+        TItem newItem,
+        TItem oldItem,
+        IEqualityComparer<TItem> equalityComparer
+    )
+    {
+        if (!equalityComparer.Equals(oldItem, newItem))
+        {
+            var objectPath = new ObjectPath(field);
+            List<object> path = objectPath.Items.ToList();
+            path.Add(index);
+            Op.Add(
+                new Json0Op
+                {
+                    Path = CreateJson0Path(path),
+                    DeleteItem = oldItem,
+                    InsertItem = newItem
+                }
+            );
+        }
+        return this;
+    }
+
+    public Json0OpBuilder<T> Set<TField>(Expression<Func<T, TField>> field, TField value) =>
+        Set(field, value, EqualityComparer<TField>.Default);
+
+    public Json0OpBuilder<T> Set<TField>(
+        Expression<Func<T, TField>> field,
+        TField value,
+        IEqualityComparer<TField> equalityComparer
+    )
+    {
+        var objectPath = new ObjectPath(field);
+        bool hasOldValue = objectPath.TryGetValue(_data, out TField oldValue);
+        if (!hasOldValue || !equalityComparer.Equals(value, oldValue))
+        {
+            Op.Add(
+                new Json0Op
+                {
+                    Path = CreateJson0Path(objectPath.Items),
+                    DeleteProp = hasOldValue ? (object)oldValue : null,
+                    InsertProp = value
+                }
+            );
+        }
+        return this;
+    }
+
+    public Json0OpBuilder<T> Set<TField>(Expression<Func<T, TField>> field, TField newValue, TField oldValue) =>
+        Set(field, newValue, oldValue, EqualityComparer<TField>.Default);
+
+    public Json0OpBuilder<T> Set<TField>(
+        Expression<Func<T, TField>> field,
+        TField newValue,
+        TField oldValue,
+        IEqualityComparer<TField> equalityComparer
+    )
+    {
+        if (!equalityComparer.Equals(newValue, oldValue))
+        {
+            var objectPath = new ObjectPath(field);
+            Op.Add(
+                new Json0Op
+                {
+                    Path = CreateJson0Path(objectPath.Items),
+                    DeleteProp = oldValue,
+                    InsertProp = newValue
+                }
+            );
+        }
+        return this;
+    }
+
+    public Json0OpBuilder<T> Unset<TField>(Expression<Func<T, TField>> field)
+    {
+        var objectPath = new ObjectPath(field);
+        if (objectPath.TryGetValue<T, TField>(_data, out TField value) && value != null)
+            Op.Add(new Json0Op { Path = CreateJson0Path(objectPath.Items), DeleteProp = value });
+        return this;
+    }
+
+    public Json0OpBuilder<T> Unset<TField>(Expression<Func<T, TField>> field, TField value)
+    {
+        var objectPath = new ObjectPath(field);
+        Op.Add(new Json0Op { Path = CreateJson0Path(objectPath.Items), DeleteProp = value });
+        return this;
+    }
+
+    public Json0OpBuilder<T> Inc(Expression<Func<T, int>> field, int n = 1)
+    {
+        var objectPath = new ObjectPath(field);
+        Op.Add(new Json0Op { Path = CreateJson0Path(objectPath.Items), Add = n });
+        return this;
+    }
+
+    private static List<object> CreateJson0Path(IEnumerable<object> path) =>
+        path.Select(i => (i is string str) ? str.ToCamelCase() : i).ToList();
 }

--- a/src/SIL.XForge/Realtime/MemoryConnection.cs
+++ b/src/SIL.XForge/Realtime/MemoryConnection.cs
@@ -6,132 +6,115 @@ using SIL.XForge.Configuration;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Realtime
+namespace SIL.XForge.Realtime;
+
+public class MemoryConnection : IConnection
 {
-    public class MemoryConnection : IConnection
+    private readonly MemoryRealtimeService _realtimeService;
+    private readonly Dictionary<(string, string), object> _documents;
+
+    internal MemoryConnection(MemoryRealtimeService realtimeService)
     {
-        private readonly MemoryRealtimeService _realtimeService;
-        private readonly Dictionary<(string, string), object> _documents;
-
-        internal MemoryConnection(MemoryRealtimeService realtimeService)
-        {
-            _realtimeService = realtimeService;
-            _documents = new Dictionary<(string, string), object>();
-        }
-
-        /// <summary>
-        /// Begins the transaction.
-        /// </summary>
-        /// <returns>
-        /// A null value.
-        /// </returns>
-        /// <remarks>
-        /// The <see cref="MemoryConnection" /> does not support transactions.
-        /// No exception is thrown for compatibility reasons.
-        /// </remarks>
-        public void BeginTransaction() { }
-
-        /// <summary>
-        /// Commits the transaction.
-        /// </summary>
-        /// <remarks>
-        /// The <see cref="MemoryConnection" /> does not support transactions.
-        /// No exception is thrown for compatibility reasons.
-        /// </remarks>
-        public Task CommitTransactionAsync()
-        {
-            return Task.CompletedTask;
-        }
-
-        /// <summary>
-        /// Creates a document asynchronously.
-        /// </summary>
-        /// <exception cref="NotImplementedException">
-        /// This is not supported by a <see cref="MemoryConnection" />.
-        /// </exception>
-        public Task<Snapshot<T>> CreateDocAsync<T>(string collection, string id, T data, string otTypeName)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
-        /// Deletes a document asynchronously.
-        /// </summary>
-        /// <exception cref="NotImplementedException">
-        /// This is not supported by a <see cref="MemoryConnection" />.
-        /// </exception>
-        public Task DeleteDocAsync(string collection, string id)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void Dispose()
-        {
-            GC.SuppressFinalize(this);
-        }
-
-        public ValueTask DisposeAsync()
-        {
-            GC.SuppressFinalize(this);
-            return ValueTask.CompletedTask;
-        }
-
-        /// <summary>
-        /// Excludes the field from the transaction.
-        /// </summary>
-        /// <typeparam name="T">The type.</typeparam>
-        /// <param name="op">The field.</param>
-        /// <remarks>
-        /// The <see cref="MemoryConnection" /> does not support transactions.
-        /// </remarks>
-        public void ExcludePropertyFromTransaction<T>(Expression<Func<T, object>> field) { }
-
-        /// <summary>
-        /// Fetches a document asynchronously.
-        /// </summary>
-        /// <exception cref="NotImplementedException">
-        /// This is not supported by a <see cref="MemoryConnection" />.
-        /// </exception>
-        public Task<Snapshot<T>> FetchDocAsync<T>(string collection, string id)
-        {
-            throw new NotImplementedException();
-        }
-
-        public IDocument<T> Get<T>(string id) where T : IIdentifiable
-        {
-            DocConfig docConfig = _realtimeService.GetDocConfig<T>();
-            if (_documents.TryGetValue((docConfig.CollectionName, id), out object docObj))
-                return (IDocument<T>)docObj;
-
-            MemoryRepository<T> repo = _realtimeService.GetRepository<T>();
-            IDocument<T> doc = new MemoryDocument<T>(repo, docConfig.OTTypeName, docConfig.CollectionName, id);
-            _documents[(docConfig.CollectionName, id)] = doc;
-            return doc;
-        }
-
-        /// <summary>
-        /// Rolls back the transaction.
-        /// </summary>
-        /// <remarks>
-        /// The <see cref="MemoryConnection" /> does not support transactions.
-        /// </remarks>
-        public void RollbackTransaction() { }
-
-        /// <summary>
-        /// Submits an operation asynchronously.
-        /// </summary>
-        /// <exception cref="NotImplementedException">
-        /// This is not supported by a <see cref="MemoryConnection" />.
-        /// </exception>
-        public Task<Snapshot<T>> SubmitOpAsync<T>(
-            string collection,
-            string id,
-            object op,
-            T currentDoc,
-            int currentVersion
-        )
-        {
-            throw new NotImplementedException();
-        }
+        _realtimeService = realtimeService;
+        _documents = new Dictionary<(string, string), object>();
     }
+
+    /// <summary>
+    /// Begins the transaction.
+    /// </summary>
+    /// <returns>
+    /// A null value.
+    /// </returns>
+    /// <remarks>
+    /// The <see cref="MemoryConnection" /> does not support transactions.
+    /// No exception is thrown for compatibility reasons.
+    /// </remarks>
+    public void BeginTransaction() { }
+
+    /// <summary>
+    /// Commits the transaction.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="MemoryConnection" /> does not support transactions.
+    /// No exception is thrown for compatibility reasons.
+    /// </remarks>
+    public Task CommitTransactionAsync() => Task.CompletedTask;
+
+    /// <summary>
+    /// Creates a document asynchronously.
+    /// </summary>
+    /// <exception cref="NotImplementedException">
+    /// This is not supported by a <see cref="MemoryConnection" />.
+    /// </exception>
+    public Task<Snapshot<T>> CreateDocAsync<T>(string collection, string id, T data, string otTypeName) =>
+        throw new NotImplementedException();
+
+    /// <summary>
+    /// Deletes a document asynchronously.
+    /// </summary>
+    /// <exception cref="NotImplementedException">
+    /// This is not supported by a <see cref="MemoryConnection" />.
+    /// </exception>
+    public Task DeleteDocAsync(string collection, string id) => throw new NotImplementedException();
+
+    public void Dispose() => GC.SuppressFinalize(this);
+
+    public ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+        return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Excludes the field from the transaction.
+    /// </summary>
+    /// <typeparam name="T">The type.</typeparam>
+    /// <param name="op">The field.</param>
+    /// <remarks>
+    /// The <see cref="MemoryConnection" /> does not support transactions.
+    /// </remarks>
+    public void ExcludePropertyFromTransaction<T>(Expression<Func<T, object>> field) { }
+
+    /// <summary>
+    /// Fetches a document asynchronously.
+    /// </summary>
+    /// <exception cref="NotImplementedException">
+    /// This is not supported by a <see cref="MemoryConnection" />.
+    /// </exception>
+    public Task<Snapshot<T>> FetchDocAsync<T>(string collection, string id) => throw new NotImplementedException();
+
+    public IDocument<T> Get<T>(string id)
+        where T : IIdentifiable
+    {
+        DocConfig docConfig = _realtimeService.GetDocConfig<T>();
+        if (_documents.TryGetValue((docConfig.CollectionName, id), out object docObj))
+            return (IDocument<T>)docObj;
+
+        MemoryRepository<T> repo = _realtimeService.GetRepository<T>();
+        IDocument<T> doc = new MemoryDocument<T>(repo, docConfig.OTTypeName, docConfig.CollectionName, id);
+        _documents[(docConfig.CollectionName, id)] = doc;
+        return doc;
+    }
+
+    /// <summary>
+    /// Rolls back the transaction.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="MemoryConnection" /> does not support transactions.
+    /// </remarks>
+    public void RollbackTransaction() { }
+
+    /// <summary>
+    /// Submits an operation asynchronously.
+    /// </summary>
+    /// <exception cref="NotImplementedException">
+    /// This is not supported by a <see cref="MemoryConnection" />.
+    /// </exception>
+    public Task<Snapshot<T>> SubmitOpAsync<T>(
+        string collection,
+        string id,
+        object op,
+        T currentDoc,
+        int currentVersion
+    ) => throw new NotImplementedException();
 }

--- a/src/SIL.XForge/Realtime/MemoryDocument.cs
+++ b/src/SIL.XForge/Realtime/MemoryDocument.cs
@@ -4,79 +4,79 @@ using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
 using SIL.XForge.Utils;
 
-namespace SIL.XForge.Realtime
+namespace SIL.XForge.Realtime;
+
+public class MemoryDocument<T> : IDocument<T>
+    where T : IIdentifiable
 {
-    public class MemoryDocument<T> : IDocument<T> where T : IIdentifiable
+    private readonly MemoryRepository<T> _repo;
+
+    internal MemoryDocument(MemoryRepository<T> repo, string otTypeName, string collection, string id)
     {
-        private readonly MemoryRepository<T> _repo;
+        _repo = repo;
+        OTTypeName = otTypeName;
+        Collection = collection;
+        Id = id;
+    }
 
-        internal MemoryDocument(MemoryRepository<T> repo, string otTypeName, string collection, string id)
+    public string Collection { get; }
+
+    public string Id { get; }
+
+    public int Version { get; private set; }
+
+    public string OTTypeName { get; }
+
+    public T Data { get; private set; }
+
+    public bool IsLoaded => Data != null;
+
+    public async Task CreateAsync(T data)
+    {
+        if (IsLoaded)
+            throw new InvalidOperationException("The doc already exists.");
+        data.Id = Id;
+        await _repo.InsertAsync(data);
+        Data = data;
+        Version = 0;
+    }
+
+    public async Task DeleteAsync()
+    {
+        if (!_repo.Contains(Id))
         {
-            _repo = repo;
-            OTTypeName = otTypeName;
-            Collection = collection;
-            Id = id;
+            throw new Jering.Javascript.NodeJS.InvocationException(
+                "Document does not exist",
+                "Would be received in production."
+            );
         }
+        await _repo.DeleteAsync(Id);
+        Data = default;
+        Version = -1;
+    }
 
-        public string Collection { get; }
-
-        public string Id { get; }
-
-        public int Version { get; private set; }
-
-        public string OTTypeName { get; }
-
-        public T Data { get; private set; }
-
-        public bool IsLoaded => Data != null;
-
-        public async Task CreateAsync(T data)
+    public async Task FetchAsync()
+    {
+        Attempt<T> attempt = await _repo.TryGetAsync(Id);
+        if (attempt.TryResult(out T data))
         {
-            if (IsLoaded)
-                throw new InvalidOperationException("The doc already exists.");
-            data.Id = Id;
-            await _repo.InsertAsync(data);
             Data = data;
             Version = 0;
         }
+    }
 
-        public async Task DeleteAsync()
-        {
-            if (!_repo.Contains(Id))
-            {
-                throw new Jering.Javascript.NodeJS.InvocationException(
-                    "Document does not exist",
-                    "Would be received in production."
-                );
-            }
-            await _repo.DeleteAsync(Id);
-            Data = default(T);
-            Version = -1;
-        }
+    public async Task FetchOrCreateAsync(Func<T> createData)
+    {
+        await FetchAsync();
+        if (!IsLoaded)
+            await CreateAsync(createData());
+    }
 
-        public async Task FetchAsync()
-        {
-            Attempt<T> attempt = await _repo.TryGetAsync(Id);
-            if (attempt.TryResult(out T data))
-            {
-                Data = data;
-                Version = 0;
-            }
-        }
-
-        public async Task FetchOrCreateAsync(Func<T> createData)
-        {
-            await FetchAsync();
-            if (!IsLoaded)
-                await CreateAsync(createData());
-        }
-
-        public async Task SubmitOpAsync(object op)
-        {
-            Data = await MemoryRealtimeService.Server.ApplyOpAsync(OTTypeName, Data, op);
-            Data.Id = Id;
-            Version++;
-            await _repo.ReplaceAsync(Data);
-        }
+    public async Task SubmitOpAsync(object op)
+    {
+        Data = await MemoryRealtimeService.Server.ApplyOpAsync(OTTypeName, Data, op);
+        Data.Id = Id;
+        Version++;
+        await _repo.ReplaceAsync(Data);
     }
 }

--- a/src/SIL.XForge/Realtime/MemoryRealtimeService.cs
+++ b/src/SIL.XForge/Realtime/MemoryRealtimeService.cs
@@ -10,113 +10,97 @@ using SIL.XForge.Configuration;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Realtime
+namespace SIL.XForge.Realtime;
+
+public class MemoryRealtimeService : IRealtimeService
 {
-    public class MemoryRealtimeService : IRealtimeService
+    internal static readonly RealtimeServer Server = new RealtimeServer(CreateNodeJSService());
+
+    private static INodeJSService CreateNodeJSService()
     {
-        internal static readonly RealtimeServer Server = new RealtimeServer(CreateNodeJSService());
-
-        private static INodeJSService CreateNodeJSService()
-        {
-            var services = new ServiceCollection();
-            services.AddNodeJS();
-            services.Configure<NodeJSProcessOptions>(options =>
-            {
-                options.ProjectPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-                // only uncomment the two lines below when debugging on the Node side otherwise C# build is paused
-                // options.NodeAndV8Options = "--inspect-brk=9230";
-            });
-            // services.Configure<OutOfProcessNodeJSServiceOptions>(options => options.TimeoutMS = -1);
-            services.AddSingleton<IJsonService, RealtimeJsonService>();
-            IServiceProvider sp = services.BuildServiceProvider();
-            return sp.GetRequiredService<INodeJSService>();
-        }
-
-        private readonly Dictionary<Type, object> _repos;
-        private readonly Dictionary<Type, DocConfig> _docConfigs;
-
-        public MemoryRealtimeService()
-        {
-            _repos = new Dictionary<Type, object>();
-            _docConfigs = new Dictionary<Type, DocConfig>();
-        }
-
-        /// <summary>
-        /// Gets or sets the last modified user identifier.
-        /// </summary>
-        /// <value>
-        /// The last modified user identifier.
-        /// </value>
-        /// <remarks>
-        /// This is only for unit test use.
-        /// </remarks>
-        public string LastModifiedUserId { get; set; }
-
-        /// <summary>
-        /// Count of calls to DeleteUserAsync(), for tests.
-        /// </summary>
-        internal int CallCountDeleteUserAsync { get; set; } = 0;
-
-        public void StartServer() { }
-
-        public void StopServer() { }
-
-        public Task<IConnection> ConnectAsync(string userId = null)
-        {
-            return Task.FromResult<IConnection>(new MemoryConnection(this));
-        }
-
-        public virtual Task DeleteProjectAsync(string projectId)
-        {
-            return Task.CompletedTask;
-        }
-
-        public Task DeleteUserAsync(string userId)
-        {
-            CallCountDeleteUserAsync++;
-            return Task.CompletedTask;
-        }
-
-        public string GetCollectionName<T>() where T : IIdentifiable
-        {
-            DocConfig docConfig = GetDocConfig<T>();
-            return docConfig.CollectionName;
-        }
-
-        /// <summary>
-        /// Gets the last modified user's identifier asynchronously.
-        /// </summary>
-        /// <returns>
-        /// Null.
-        /// </returns>
-        /// <remarks>
-        /// This is overridable for unit tests.
-        /// </remarks>
-        public Task<string> GetLastModifiedUserIdAsync<T>(string id, int version) where T : IIdentifiable
-        {
-            return Task.FromResult(LastModifiedUserId);
-        }
-
-        public IQueryable<T> QuerySnapshots<T>() where T : IIdentifiable
-        {
-            return GetRepository<T>().Query();
-        }
-
-        public void AddRepository<T>(string collectionName, string otTypeName, MemoryRepository<T> repo)
-            where T : IIdentifiable
-        {
-            _repos[typeof(T)] = repo;
-            _docConfigs[typeof(T)] = new DocConfig(collectionName, typeof(T), otTypeName);
-        }
-
-        public MemoryRepository<T> GetRepository<T>() where T : IIdentifiable
-        {
-            return (MemoryRepository<T>)_repos[typeof(T)];
-        }
-
-        internal DocConfig GetDocConfig<T>() where T : IIdentifiable
-        {
-            return _docConfigs[typeof(T)];
-        }
+        var services = new ServiceCollection();
+        services.AddNodeJS();
+        services.Configure<NodeJSProcessOptions>(
+            options => options.ProjectPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
+        );
+        // services.Configure<OutOfProcessNodeJSServiceOptions>(options => options.TimeoutMS = -1);
+        services.AddSingleton<IJsonService, RealtimeJsonService>();
+        IServiceProvider sp = services.BuildServiceProvider();
+        return sp.GetRequiredService<INodeJSService>();
     }
+
+    private readonly Dictionary<Type, object> _repos;
+    private readonly Dictionary<Type, DocConfig> _docConfigs;
+
+    public MemoryRealtimeService()
+    {
+        _repos = new Dictionary<Type, object>();
+        _docConfigs = new Dictionary<Type, DocConfig>();
+    }
+
+    /// <summary>
+    /// Gets or sets the last modified user identifier.
+    /// </summary>
+    /// <value>
+    /// The last modified user identifier.
+    /// </value>
+    /// <remarks>
+    /// This is only for unit test use.
+    /// </remarks>
+    public string LastModifiedUserId { get; set; }
+
+    /// <summary>
+    /// Count of calls to DeleteUserAsync(), for tests.
+    /// </summary>
+    internal int CallCountDeleteUserAsync { get; set; } = 0;
+
+    public void StartServer() { }
+
+    public void StopServer() { }
+
+    public Task<IConnection> ConnectAsync(string userId = null) =>
+        Task.FromResult<IConnection>(new MemoryConnection(this));
+
+    public virtual Task DeleteProjectAsync(string projectId) => Task.CompletedTask;
+
+    public Task DeleteUserAsync(string userId)
+    {
+        CallCountDeleteUserAsync++;
+        return Task.CompletedTask;
+    }
+
+    public string GetCollectionName<T>()
+        where T : IIdentifiable
+    {
+        DocConfig docConfig = GetDocConfig<T>();
+        return docConfig.CollectionName;
+    }
+
+    /// <summary>
+    /// Gets the last modified user's identifier asynchronously.
+    /// </summary>
+    /// <returns>
+    /// Null.
+    /// </returns>
+    /// <remarks>
+    /// This is overridable for unit tests.
+    /// </remarks>
+    public Task<string> GetLastModifiedUserIdAsync<T>(string id, int version)
+        where T : IIdentifiable => Task.FromResult(LastModifiedUserId);
+
+    public IQueryable<T> QuerySnapshots<T>()
+        where T : IIdentifiable => GetRepository<T>().Query();
+
+    public void AddRepository<T>(string collectionName, string otTypeName, MemoryRepository<T> repo)
+        where T : IIdentifiable
+    {
+        _repos[typeof(T)] = repo;
+        _docConfigs[typeof(T)] = new DocConfig(collectionName, typeof(T), otTypeName);
+    }
+
+    public MemoryRepository<T> GetRepository<T>()
+        where T : IIdentifiable => (MemoryRepository<T>)_repos[typeof(T)];
+
+    internal DocConfig GetDocConfig<T>()
+        where T : IIdentifiable => _docConfigs[typeof(T)];
 }

--- a/src/SIL.XForge/Realtime/OTType.cs
+++ b/src/SIL.XForge/Realtime/OTType.cs
@@ -1,8 +1,7 @@
-namespace SIL.XForge.Realtime
+namespace SIL.XForge.Realtime;
+
+public class OTType
 {
-    public class OTType
-    {
-        public const string RichText = "rich-text";
-        public const string Json0 = "json0";
-    }
+    public const string RichText = "rich-text";
+    public const string Json0 = "json0";
 }

--- a/src/SIL.XForge/Realtime/RealtimeApplicationBuilderExtensions.cs
+++ b/src/SIL.XForge/Realtime/RealtimeApplicationBuilderExtensions.cs
@@ -1,13 +1,10 @@
 using Microsoft.Extensions.DependencyInjection;
 using SIL.XForge.Realtime;
 
-namespace Microsoft.AspNetCore.Builder
+namespace Microsoft.AspNetCore.Builder;
+
+public static class RealtimeApplicationBuilderExtensions
 {
-    public static class RealtimeApplicationBuilderExtensions
-    {
-        public static void UseRealtimeServer(this IApplicationBuilder app)
-        {
-            app.ApplicationServices.GetService<IRealtimeService>().StartServer();
-        }
-    }
+    public static void UseRealtimeServer(this IApplicationBuilder app) =>
+        app.ApplicationServices.GetService<IRealtimeService>().StartServer();
 }

--- a/src/SIL.XForge/Realtime/RealtimeExtensions.cs
+++ b/src/SIL.XForge/Realtime/RealtimeExtensions.cs
@@ -4,50 +4,47 @@ using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
 using SIL.XForge.Utils;
 
-namespace SIL.XForge.Realtime
+namespace SIL.XForge.Realtime;
+
+public static class RealtimeExtensions
 {
-    public static class RealtimeExtensions
+    public static async Task<Attempt<T>> TryGetSnapshotAsync<T>(this IRealtimeService realtimeService, string id)
+        where T : IIdentifiable
     {
-        public static async Task<Attempt<T>> TryGetSnapshotAsync<T>(this IRealtimeService realtimeService, string id)
-            where T : IIdentifiable
-        {
-            T entity = await realtimeService.QuerySnapshots<T>().FirstOrDefaultAsync(e => e.Id == id);
-            return new Attempt<T>(entity != null, entity);
-        }
+        T entity = await realtimeService.QuerySnapshots<T>().FirstOrDefaultAsync(e => e.Id == id);
+        return new Attempt<T>(entity != null, entity);
+    }
 
-        public static async Task<T> GetSnapshotAsync<T>(this IRealtimeService realtimeService, string id)
-            where T : IIdentifiable
-        {
-            Attempt<T> attempt = await realtimeService.TryGetSnapshotAsync<T>(id);
-            if (attempt.Success)
-                return attempt.Result;
-            return default(T);
-        }
+    public static async Task<T> GetSnapshotAsync<T>(this IRealtimeService realtimeService, string id)
+        where T : IIdentifiable
+    {
+        Attempt<T> attempt = await realtimeService.TryGetSnapshotAsync<T>(id);
+        if (attempt.Success)
+            return attempt.Result;
+        return default;
+    }
 
-        public static async Task<IDocument<T>> FetchAsync<T>(this IConnection conn, string id) where T : IIdentifiable
-        {
-            IDocument<T> doc = conn.Get<T>(id);
-            await doc.FetchAsync();
-            return doc;
-        }
+    public static async Task<IDocument<T>> FetchAsync<T>(this IConnection conn, string id)
+        where T : IIdentifiable
+    {
+        IDocument<T> doc = conn.Get<T>(id);
+        await doc.FetchAsync();
+        return doc;
+    }
 
-        public static async Task<IDocument<T>> CreateAsync<T>(this IConnection conn, string id, T data)
-            where T : IIdentifiable
-        {
-            IDocument<T> doc = conn.Get<T>(id);
-            await doc.CreateAsync(data);
-            return doc;
-        }
+    public static async Task<IDocument<T>> CreateAsync<T>(this IConnection conn, string id, T data)
+        where T : IIdentifiable
+    {
+        IDocument<T> doc = conn.Get<T>(id);
+        await doc.CreateAsync(data);
+        return doc;
+    }
 
-        public static async Task<IDocument<T>> FetchOrCreateAsync<T>(
-            this IConnection conn,
-            string id,
-            Func<T> createData
-        ) where T : IIdentifiable
-        {
-            IDocument<T> doc = conn.Get<T>(id);
-            await doc.FetchOrCreateAsync(createData);
-            return doc;
-        }
+    public static async Task<IDocument<T>> FetchOrCreateAsync<T>(this IConnection conn, string id, Func<T> createData)
+        where T : IIdentifiable
+    {
+        IDocument<T> doc = conn.Get<T>(id);
+        await doc.FetchOrCreateAsync(createData);
+        return doc;
     }
 }

--- a/src/SIL.XForge/Realtime/RealtimeJsonService.cs
+++ b/src/SIL.XForge/Realtime/RealtimeJsonService.cs
@@ -5,46 +5,45 @@ using Jering.Javascript.NodeJS;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-namespace SIL.XForge.Realtime
+namespace SIL.XForge.Realtime;
+
+/// <summary>
+/// A Newtonsoft JSON implementation of <see cref="IJsonService"/>.
+/// This is used for compatibility since Newtonsoft is used elsewhere such as serializing for RPC commands.
+/// A key use is the property mappings in src\SIL.XForge\Realtime\Json0\Json0Op.cs
+/// </summary>
+public class RealtimeJsonService : IJsonService
 {
-    /// <summary>
-    /// A Newtonsoft JSON implementation of <see cref="IJsonService"/>.
-    /// This is used for compatibility since Newtonsoft is used elsewhere such as serializing for RPC commands.
-    /// A key use is the property mappings in src\SIL.XForge\Realtime\Json0\Json0Op.cs
-    /// </summary>
-    public class RealtimeJsonService : IJsonService
+    private readonly IContractResolver _contractResolver = new DefaultContractResolver
     {
-        private readonly IContractResolver _contractResolver = new DefaultContractResolver
+        NamingStrategy = new CamelCaseNamingStrategy(),
+    };
+
+    /// <inheritdoc />
+    public ValueTask<T> DeserializeAsync<T>(Stream stream, CancellationToken cancellationToken = default)
+    {
+        using var sr = new StreamReader(stream, System.Text.Encoding.Default, true, 1024, false);
+        using var reader = new JsonTextReader(sr) { CloseInput = true };
+        var serializer = new JsonSerializer
         {
-            NamingStrategy = new CamelCaseNamingStrategy(),
+            ContractResolver = _contractResolver,
+            NullValueHandling = NullValueHandling.Ignore,
+            MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
         };
+        return ValueTask.FromResult(serializer.Deserialize<T>(reader));
+    }
 
-        /// <inheritdoc />
-        public ValueTask<T> DeserializeAsync<T>(Stream stream, CancellationToken cancellationToken = default)
+    /// <inheritdoc />
+    public async Task SerializeAsync<T>(Stream stream, T value, CancellationToken cancellationToken = default)
+    {
+        await using var sw = new StreamWriter(stream, System.Text.Encoding.Default, 1024, true);
+        using var writer = new JsonTextWriter(sw);
+        var serializer = new JsonSerializer
         {
-            using var sr = new StreamReader(stream, System.Text.Encoding.Default, true, 1024, false);
-            using var reader = new JsonTextReader(sr) { CloseInput = true };
-            var serializer = new JsonSerializer
-            {
-                ContractResolver = _contractResolver,
-                NullValueHandling = NullValueHandling.Ignore,
-                MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
-            };
-            return ValueTask.FromResult(serializer.Deserialize<T>(reader));
-        }
-
-        /// <inheritdoc />
-        public async Task SerializeAsync<T>(Stream stream, T value, CancellationToken cancellationToken = default)
-        {
-            await using var sw = new StreamWriter(stream, System.Text.Encoding.Default, 1024, true);
-            using var writer = new JsonTextWriter(sw);
-            var serializer = new JsonSerializer
-            {
-                ContractResolver = _contractResolver,
-                NullValueHandling = NullValueHandling.Ignore,
-                MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
-            };
-            serializer.Serialize(writer, value);
-        }
+            ContractResolver = _contractResolver,
+            NullValueHandling = NullValueHandling.Ignore,
+            MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
+        };
+        serializer.Serialize(writer, value);
     }
 }

--- a/src/SIL.XForge/Realtime/RealtimeServer.cs
+++ b/src/SIL.XForge/Realtime/RealtimeServer.cs
@@ -2,86 +2,65 @@ using System.IO;
 using System.Threading.Tasks;
 using Jering.Javascript.NodeJS;
 
-namespace SIL.XForge.Realtime
+namespace SIL.XForge.Realtime;
+
+public class RealtimeServer : IRealtimeServer
 {
-    public class RealtimeServer : IRealtimeServer
+    private readonly INodeJSService _nodeJSService;
+    private readonly string _modulePath;
+    private bool _started;
+
+    public RealtimeServer(INodeJSService nodeJSService)
     {
-        private readonly INodeJSService _nodeJSService;
-        private readonly string _modulePath;
-        private bool _started;
-
-        public RealtimeServer(INodeJSService nodeJSService)
-        {
-            _nodeJSService = nodeJSService;
-            _modulePath = Path.Combine("RealtimeServer", "lib", "cjs", "common", "index");
-        }
-
-        public void Start(object options)
-        {
-            if (_started)
-                return;
-            InvokeExportAsync("start", options).GetAwaiter().GetResult();
-            _started = true;
-        }
-
-        public void Stop()
-        {
-            if (!_started)
-                return;
-            InvokeExportAsync("stop").GetAwaiter().GetResult();
-            _started = false;
-        }
-
-        public Task<int> ConnectAsync(string? userId = null)
-        {
-            if (userId != null)
-                return InvokeExportAsync<int>("connect", userId);
-            return InvokeExportAsync<int>("connect");
-        }
-
-        public Task<Snapshot<T>> CreateDocAsync<T>(int handle, string collection, string id, T data, string otTypeName)
-        {
-            return InvokeExportAsync<Snapshot<T>>("createDoc", handle, collection, id, data, otTypeName);
-        }
-
-        public Task<Snapshot<T>> FetchDocAsync<T>(int handle, string collection, string id)
-        {
-            return InvokeExportAsync<Snapshot<T>>("fetchDoc", handle, collection, id);
-        }
-
-        public Task<Snapshot<T>> SubmitOpAsync<T>(int handle, string collection, string id, object op)
-        {
-            return InvokeExportAsync<Snapshot<T>>("submitOp", handle, collection, id, op);
-        }
-
-        public Task DeleteDocAsync(int handle, string collection, string id)
-        {
-            return InvokeExportAsync("deleteDoc", handle, collection, id);
-        }
-
-        public void Disconnect(int handle)
-        {
-            InvokeExportAsync("disconnect", handle).GetAwaiter().GetResult();
-        }
-
-        public Task DisconnectAsync(int handle)
-        {
-            return InvokeExportAsync("disconnect", handle);
-        }
-
-        public Task<T> ApplyOpAsync<T>(string otTypeName, T data, object op)
-        {
-            return InvokeExportAsync<T>("applyOp", otTypeName, data, op);
-        }
-
-        private Task<T> InvokeExportAsync<T>(string exportedFunctionName, params object?[] args)
-        {
-            return _nodeJSService.InvokeFromFileAsync<T>(_modulePath, exportedFunctionName, args);
-        }
-
-        private Task InvokeExportAsync(string exportedFunctionName, params object[] args)
-        {
-            return _nodeJSService.InvokeFromFileAsync(_modulePath, exportedFunctionName, args);
-        }
+        _nodeJSService = nodeJSService;
+        _modulePath = Path.Combine("RealtimeServer", "lib", "cjs", "common", "index");
     }
+
+    public void Start(object options)
+    {
+        if (_started)
+            return;
+        InvokeExportAsync("start", options).GetAwaiter().GetResult();
+        _started = true;
+    }
+
+    public void Stop()
+    {
+        if (!_started)
+            return;
+        InvokeExportAsync("stop").GetAwaiter().GetResult();
+        _started = false;
+    }
+
+    public Task<int> ConnectAsync(string? userId = null)
+    {
+        if (userId != null)
+            return InvokeExportAsync<int>("connect", userId);
+        return InvokeExportAsync<int>("connect");
+    }
+
+    public Task<Snapshot<T>> CreateDocAsync<T>(int handle, string collection, string id, T data, string otTypeName) =>
+        InvokeExportAsync<Snapshot<T>>("createDoc", handle, collection, id, data, otTypeName);
+
+    public Task<Snapshot<T>> FetchDocAsync<T>(int handle, string collection, string id) =>
+        InvokeExportAsync<Snapshot<T>>("fetchDoc", handle, collection, id);
+
+    public Task<Snapshot<T>> SubmitOpAsync<T>(int handle, string collection, string id, object op) =>
+        InvokeExportAsync<Snapshot<T>>("submitOp", handle, collection, id, op);
+
+    public Task DeleteDocAsync(int handle, string collection, string id) =>
+        InvokeExportAsync("deleteDoc", handle, collection, id);
+
+    public void Disconnect(int handle) => InvokeExportAsync("disconnect", handle).GetAwaiter().GetResult();
+
+    public Task DisconnectAsync(int handle) => InvokeExportAsync("disconnect", handle);
+
+    public Task<T> ApplyOpAsync<T>(string otTypeName, T data, object op) =>
+        InvokeExportAsync<T>("applyOp", otTypeName, data, op);
+
+    private Task<T> InvokeExportAsync<T>(string exportedFunctionName, params object?[] args) =>
+        _nodeJSService.InvokeFromFileAsync<T>(_modulePath, exportedFunctionName, args);
+
+    private Task InvokeExportAsync(string exportedFunctionName, params object[] args) =>
+        _nodeJSService.InvokeFromFileAsync(_modulePath, exportedFunctionName, args);
 }

--- a/src/SIL.XForge/Realtime/RealtimeService.cs
+++ b/src/SIL.XForge/Realtime/RealtimeService.cs
@@ -2,255 +2,246 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using SIL.ObjectModel;
 using SIL.XForge.Configuration;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Realtime
+namespace SIL.XForge.Realtime;
+
+/// <summary>
+/// This service is responsible for managing the real-time/ShareDB server. It provides methods for accessing
+/// real-time data and performing actions on the server.
+/// </summary>
+public class RealtimeService : DisposableBase, IRealtimeService
 {
-    /// <summary>
-    /// This service is responsible for managing the real-time/ShareDB server. It provides methods for accessing
-    /// real-time data and performing actions on the server.
-    /// </summary>
-    public class RealtimeService : DisposableBase, IRealtimeService
+    private readonly IOptions<SiteOptions> _siteOptions;
+    private readonly IOptions<DataAccessOptions> _dataAccessOptions;
+    private readonly IOptions<RealtimeOptions> _realtimeOptions;
+    private readonly IOptions<AuthOptions> _authOptions;
+    private readonly IMongoDatabase _database;
+    private readonly Dictionary<Type, DocConfig> _docConfigs;
+    private readonly IConfiguration _configuration;
+
+    public RealtimeService(
+        IRealtimeServer server,
+        IOptions<SiteOptions> siteOptions,
+        IOptions<DataAccessOptions> dataAccessOptions,
+        IOptions<RealtimeOptions> realtimeOptions,
+        IOptions<AuthOptions> authOptions,
+        IMongoClient mongoClient,
+        IConfiguration configuration
+    )
     {
-        private readonly IOptions<SiteOptions> _siteOptions;
-        private readonly IOptions<DataAccessOptions> _dataAccessOptions;
-        private readonly IOptions<RealtimeOptions> _realtimeOptions;
-        private readonly IOptions<AuthOptions> _authOptions;
-        private readonly IMongoDatabase _database;
-        private readonly Dictionary<Type, DocConfig> _docConfigs;
-        private readonly IConfiguration _configuration;
+        Server = server;
+        _siteOptions = siteOptions;
+        _dataAccessOptions = dataAccessOptions;
+        _realtimeOptions = realtimeOptions;
+        _authOptions = authOptions;
+        _database = mongoClient.GetDatabase(_dataAccessOptions.Value.MongoDatabaseName);
+        _configuration = configuration;
 
-        public RealtimeService(
-            IRealtimeServer server,
-            IOptions<SiteOptions> siteOptions,
-            IOptions<DataAccessOptions> dataAccessOptions,
-            IOptions<RealtimeOptions> realtimeOptions,
-            IOptions<AuthOptions> authOptions,
-            IMongoClient mongoClient,
-            IConfiguration configuration
-        )
+        RealtimeOptions options = _realtimeOptions.Value;
+        _docConfigs = new Dictionary<Type, DocConfig>();
+        AddDocConfig(options.UserDoc);
+        AddDocConfig(options.ProjectDoc);
+        foreach (DocConfig projectDataDoc in options.ProjectDataDocs)
         {
-            Server = server;
-            _siteOptions = siteOptions;
-            _dataAccessOptions = dataAccessOptions;
-            _realtimeOptions = realtimeOptions;
-            _authOptions = authOptions;
-            _database = mongoClient.GetDatabase(_dataAccessOptions.Value.MongoDatabaseName);
-            _configuration = configuration;
+            AddDocConfig(projectDataDoc);
+        }
+        foreach (DocConfig userDataDoc in options.UserDataDocs)
+        {
+            AddDocConfig(userDataDoc);
+        }
+    }
 
-            RealtimeOptions options = _realtimeOptions.Value;
-            _docConfigs = new Dictionary<Type, DocConfig>();
-            AddDocConfig(options.UserDoc);
-            AddDocConfig(options.ProjectDoc);
-            foreach (DocConfig projectDataDoc in options.ProjectDataDocs)
-            {
-                AddDocConfig(projectDataDoc);
-            }
-            foreach (DocConfig userDataDoc in options.UserDataDocs)
-            {
-                AddDocConfig(userDataDoc);
-            }
+    internal IRealtimeServer Server { get; }
+
+    public void StartServer()
+    {
+        object options = CreateOptions();
+        Server.Start(options);
+    }
+
+    public void StopServer() => Server.Stop();
+
+    public async Task<IConnection> ConnectAsync(string userId = null)
+    {
+        var conn = new Connection(this);
+        try
+        {
+            await conn.StartAsync(userId);
+            return conn;
+        }
+        catch (Exception)
+        {
+            conn.Dispose();
+            throw;
+        }
+    }
+
+    public string GetCollectionName<T>()
+        where T : IIdentifiable
+    {
+        DocConfig docConfig = GetDocConfig<T>();
+        return docConfig.CollectionName;
+    }
+
+    /// <summary>
+    /// Delete project-related docs from various collections.
+    /// </summary>
+    public async Task DeleteProjectAsync(string projectId)
+    {
+        if (string.IsNullOrEmpty(projectId))
+        {
+            throw new ArgumentException("", nameof(projectId));
         }
 
-        internal IRealtimeServer Server { get; }
+        RealtimeOptions options = _realtimeOptions.Value;
+        var tasks = new List<Task>();
+        foreach (DocConfig docConfig in options.ProjectDataDocs)
+            tasks.Add(DeleteProjectDocsAsync(docConfig.CollectionName, projectId));
+        await Task.WhenAll(tasks);
 
-        public void StartServer()
+        IMongoCollection<BsonDocument> snapshotCollection = _database.GetCollection<BsonDocument>(
+            options.ProjectDoc.CollectionName
+        );
+        FilterDefinition<BsonDocument> idFilter = Builders<BsonDocument>.Filter.Eq("_id", projectId);
+        await snapshotCollection.DeleteManyAsync(idFilter);
+
+        IMongoCollection<BsonDocument> opsCollection = _database.GetCollection<BsonDocument>(
+            $"o_{options.ProjectDoc.CollectionName}"
+        );
+        FilterDefinition<BsonDocument> dFilter = Builders<BsonDocument>.Filter.Eq("d", projectId);
+        await opsCollection.DeleteManyAsync(dFilter);
+    }
+
+    /// <summary>
+    /// Delete user-related docs from various collections.
+    /// </summary>
+    public async Task DeleteUserAsync(string userId)
+    {
+        if (string.IsNullOrEmpty(userId))
         {
-            object options = CreateOptions();
-            Server.Start(options);
+            throw new ArgumentException("", nameof(userId));
         }
 
-        public void StopServer()
+        RealtimeOptions options = _realtimeOptions.Value;
+        IEnumerable<DocConfig> collectionsToProcess = options.UserDataDocs.Append(options.UserDoc);
+        FilterDefinition<BsonDocument> idFilter = Builders<BsonDocument>.Filter.Regex("_id", $"{userId}$");
+        FilterDefinition<BsonDocument> dFilter = Builders<BsonDocument>.Filter.Regex("d", $"{userId}$");
+        foreach (var collection in collectionsToProcess)
         {
-            Server.Stop();
-        }
-
-        public async Task<IConnection> ConnectAsync(string userId = null)
-        {
-            var conn = new Connection(this);
-            try
-            {
-                await conn.StartAsync(userId);
-                return conn;
-            }
-            catch (Exception)
-            {
-                conn.Dispose();
-                throw;
-            }
-        }
-
-        public string GetCollectionName<T>() where T : IIdentifiable
-        {
-            DocConfig docConfig = GetDocConfig<T>();
-            return docConfig.CollectionName;
-        }
-
-        /// <summary>
-        /// Delete project-related docs from various collections.
-        /// </summary>
-        public async Task DeleteProjectAsync(string projectId)
-        {
-            if (string.IsNullOrEmpty(projectId))
-            {
-                throw new ArgumentException("", nameof(projectId));
-            }
-
-            RealtimeOptions options = _realtimeOptions.Value;
-            var tasks = new List<Task>();
-            foreach (DocConfig docConfig in options.ProjectDataDocs)
-                tasks.Add(DeleteProjectDocsAsync(docConfig.CollectionName, projectId));
-            await Task.WhenAll(tasks);
-
             IMongoCollection<BsonDocument> snapshotCollection = _database.GetCollection<BsonDocument>(
-                options.ProjectDoc.CollectionName
+                collection.CollectionName
             );
-            FilterDefinition<BsonDocument> idFilter = Builders<BsonDocument>.Filter.Eq("_id", projectId);
             await snapshotCollection.DeleteManyAsync(idFilter);
 
             IMongoCollection<BsonDocument> opsCollection = _database.GetCollection<BsonDocument>(
-                $"o_{options.ProjectDoc.CollectionName}"
+                $"o_{collection.CollectionName}"
             );
-            FilterDefinition<BsonDocument> dFilter = Builders<BsonDocument>.Filter.Eq("d", projectId);
             await opsCollection.DeleteManyAsync(dFilter);
         }
+    }
 
-        /// <summary>
-        /// Delete user-related docs from various collections.
-        /// </summary>
-        public async Task DeleteUserAsync(string userId)
+    public IQueryable<T> QuerySnapshots<T>()
+        where T : IIdentifiable
+    {
+        string collectionName = GetCollectionName<T>();
+        IMongoCollection<T> collection = _database.GetCollection<T>(collectionName);
+        return collection.AsQueryable();
+    }
+
+    /// <summary>
+    /// Gets the id of the user who last modified the object asynchronously.
+    /// </summary>
+    /// <typeparam name="T">The type in MongoDB</typeparam>
+    /// <param name="id">The identifier.</param>
+    /// <param name="version">The version. If 0 or lower, the version is ignored.</param>
+    /// <returns>
+    /// The user id, or null if unknown.
+    /// </returns>
+    public async Task<string> GetLastModifiedUserIdAsync<T>(string id, int version)
+        where T : IIdentifiable
+    {
+        // Get the collection and definitions
+        string collectionName = GetCollectionName<T>();
+        IMongoCollection<BsonDocument> opsCollection = _database.GetCollection<BsonDocument>($"o_{collectionName}");
+        FilterDefinitionBuilder<BsonDocument> builder = Builders<BsonDocument>.Filter;
+        FilterDefinition<BsonDocument> filter = builder.Eq("d", id);
+        if (version > 0)
         {
-            if (string.IsNullOrEmpty(userId))
-            {
-                throw new ArgumentException("", nameof(userId));
-            }
-
-            RealtimeOptions options = _realtimeOptions.Value;
-            IEnumerable<DocConfig> collectionsToProcess = options.UserDataDocs.Append(options.UserDoc);
-            FilterDefinition<BsonDocument> idFilter = Builders<BsonDocument>.Filter.Regex("_id", $"{userId}$");
-            FilterDefinition<BsonDocument> dFilter = Builders<BsonDocument>.Filter.Regex("d", $"{userId}$");
-            foreach (var collection in collectionsToProcess)
-            {
-                IMongoCollection<BsonDocument> snapshotCollection = _database.GetCollection<BsonDocument>(
-                    collection.CollectionName
-                );
-                await snapshotCollection.DeleteManyAsync(idFilter);
-
-                IMongoCollection<BsonDocument> opsCollection = _database.GetCollection<BsonDocument>(
-                    $"o_{collection.CollectionName}"
-                );
-                await opsCollection.DeleteManyAsync(dFilter);
-            }
+            // The version in the Document is always one more than the version in the operations table
+            filter &= builder.Lt("v", version);
         }
 
-        public IQueryable<T> QuerySnapshots<T>() where T : IIdentifiable
+        FieldDefinition<BsonDocument> field = "v";
+        SortDefinition<BsonDocument> sort = Builders<BsonDocument>.Sort.Descending(field);
+
+        // Use FindAsync(), as opposed to Find(), so that we can mock it
+        using IAsyncCursor<BsonDocument> cursor = await opsCollection.FindAsync(
+            filter,
+            new FindOptions<BsonDocument, BsonDocument>() { Limit = 1, Sort = sort }
+        );
+        BsonDocument doc = await cursor.FirstOrDefaultAsync();
+
+        // Retrieve uId from the metadata, if present
+        // uId is set by sharedb-access, and will be missing if this op was created by a sync
+        if (
+            doc != null
+            && doc.TryGetValue("m", out BsonValue mValue)
+            && mValue is BsonDocument mDoc
+            && mDoc.TryGetValue("uId", out BsonValue uidValue)
+            && uidValue is BsonString uidString
+        )
         {
-            string collectionName = GetCollectionName<T>();
-            IMongoCollection<T> collection = _database.GetCollection<T>(collectionName);
-            return collection.AsQueryable();
+            return uidString.Value;
         }
 
-        /// <summary>
-        /// Gets the id of the user who last modified the object asynchronously.
-        /// </summary>
-        /// <typeparam name="T">The type in MongoDB</typeparam>
-        /// <param name="id">The identifier.</param>
-        /// <param name="version">The version. If 0 or lower, the version is ignored.</param>
-        /// <returns>
-        /// The user id, or null if unknown.
-        /// </returns>
-        public async Task<string> GetLastModifiedUserIdAsync<T>(string id, int version) where T : IIdentifiable
+        // Default to null
+        return null;
+    }
+
+    internal DocConfig GetDocConfig<T>()
+        where T : IIdentifiable => _docConfigs[typeof(T)];
+
+    protected override void DisposeManagedResources() => StopServer();
+
+    private void AddDocConfig(DocConfig docConfig) => _docConfigs[docConfig.Type] = docConfig;
+
+    private async Task DeleteProjectDocsAsync(string collectionName, string projectId)
+    {
+        IMongoCollection<BsonDocument> snapshotCollection = _database.GetCollection<BsonDocument>(collectionName);
+        FilterDefinition<BsonDocument> idFilter = Builders<BsonDocument>.Filter.Regex("_id", $"^{projectId}");
+        await snapshotCollection.DeleteManyAsync(idFilter);
+
+        IMongoCollection<BsonDocument> opsCollection = _database.GetCollection<BsonDocument>($"o_{collectionName}");
+        FilterDefinition<BsonDocument> dFilter = Builders<BsonDocument>.Filter.Regex("d", $"^{projectId}");
+        await opsCollection.DeleteManyAsync(dFilter);
+    }
+
+    private object CreateOptions()
+    {
+        string mongo = $"{_dataAccessOptions.Value.ConnectionString}/{_dataAccessOptions.Value.MongoDatabaseName}";
+        return new
         {
-            // Get the collection and definitions
-            string collectionName = GetCollectionName<T>();
-            IMongoCollection<BsonDocument> opsCollection = _database.GetCollection<BsonDocument>($"o_{collectionName}");
-            FilterDefinitionBuilder<BsonDocument> builder = Builders<BsonDocument>.Filter;
-            FilterDefinition<BsonDocument> filter = builder.Eq("d", id);
-            if (version > 0)
-            {
-                // The version in the Document is always one more than the version in the operations table
-                filter &= builder.Lt("v", version);
-            }
-
-            FieldDefinition<BsonDocument> field = "v";
-            SortDefinition<BsonDocument> sort = Builders<BsonDocument>.Sort.Descending(field);
-
-            // Use FindAsync(), as opposed to Find(), so that we can mock it
-            using IAsyncCursor<BsonDocument> cursor = await opsCollection.FindAsync(
-                filter,
-                new FindOptions<BsonDocument, BsonDocument>() { Limit = 1, Sort = sort }
-            );
-            BsonDocument doc = await cursor.FirstOrDefaultAsync();
-
-            // Retrieve uId from the metadata, if present
-            // uId is set by sharedb-access, and will be missing if this op was created by a sync
-            if (
-                doc != null
-                && doc.TryGetValue("m", out BsonValue mValue)
-                && mValue is BsonDocument mDoc
-                && mDoc.TryGetValue("uId", out BsonValue uidValue)
-                && uidValue is BsonString uidString
-            )
-            {
-                return uidString.Value;
-            }
-
-            // Default to null
-            return null;
-        }
-
-        internal DocConfig GetDocConfig<T>() where T : IIdentifiable
-        {
-            return _docConfigs[typeof(T)];
-        }
-
-        protected override void DisposeManagedResources()
-        {
-            StopServer();
-        }
-
-        private void AddDocConfig(DocConfig docConfig)
-        {
-            _docConfigs[docConfig.Type] = docConfig;
-        }
-
-        private async Task DeleteProjectDocsAsync(string collectionName, string projectId)
-        {
-            IMongoCollection<BsonDocument> snapshotCollection = _database.GetCollection<BsonDocument>(collectionName);
-            FilterDefinition<BsonDocument> idFilter = Builders<BsonDocument>.Filter.Regex("_id", $"^{projectId}");
-            await snapshotCollection.DeleteManyAsync(idFilter);
-
-            IMongoCollection<BsonDocument> opsCollection = _database.GetCollection<BsonDocument>($"o_{collectionName}");
-            FilterDefinition<BsonDocument> dFilter = Builders<BsonDocument>.Filter.Regex("d", $"^{projectId}");
-            await opsCollection.DeleteManyAsync(dFilter);
-        }
-
-        private object CreateOptions()
-        {
-            string mongo = $"{_dataAccessOptions.Value.ConnectionString}/{_dataAccessOptions.Value.MongoDatabaseName}";
-            return new
-            {
-                AppModuleName = _realtimeOptions.Value.AppModuleName,
-                ConnectionString = mongo,
-                Port = _realtimeOptions.Value.Port,
-                Authority = $"https://{_authOptions.Value.Domain}/",
-                Audience = _authOptions.Value.Audience,
-                Scope = _authOptions.Value.Scope,
-                Origin = this._configuration.GetValue<string>("Site:Origin"),
-                BugsnagApiKey = this._configuration.GetValue<string>("Bugsnag:ApiKey"),
-                ReleaseStage = this._configuration.GetValue<string>("Bugsnag:ReleaseStage"),
-                MigrationsDisabled = this._realtimeOptions.Value.MigrationsDisabled,
-                SiteId = this._siteOptions.Value.Id,
-                Version = System.Diagnostics.FileVersionInfo
-                    .GetVersionInfo(@System.Reflection.Assembly.GetEntryAssembly().Location)
-                    .ProductVersion
-            };
-        }
+            _realtimeOptions.Value.AppModuleName,
+            ConnectionString = mongo,
+            _realtimeOptions.Value.Port,
+            Authority = $"https://{_authOptions.Value.Domain}/",
+            _authOptions.Value.Audience,
+            _authOptions.Value.Scope,
+            Origin = this._configuration.GetValue<string>("Site:Origin"),
+            BugsnagApiKey = this._configuration.GetValue<string>("Bugsnag:ApiKey"),
+            ReleaseStage = this._configuration.GetValue<string>("Bugsnag:ReleaseStage"),
+            this._realtimeOptions.Value.MigrationsDisabled,
+            SiteId = this._siteOptions.Value.Id,
+            Version = System.Diagnostics.FileVersionInfo
+                .GetVersionInfo(@System.Reflection.Assembly.GetEntryAssembly().Location)
+                .ProductVersion
+        };
     }
 }

--- a/src/SIL.XForge/Realtime/RealtimeServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Realtime/RealtimeServiceCollectionExtensions.cs
@@ -7,33 +7,32 @@ using Microsoft.Extensions.Logging;
 using SIL.XForge.Configuration;
 using SIL.XForge.Realtime;
 
-namespace Microsoft.Extensions.DependencyInjection
-{
-    public static class RealtimeServiceCollectionExtensions
-    {
-        public static IServiceCollection AddRealtimeServer(
-            this IServiceCollection services,
-            ILoggerFactory loggerFactory,
-            IConfiguration configuration,
-            Action<RealtimeOptions> configureOptions,
-            string? nodeOptions = null
-        )
-        {
-            services.AddNodeJS();
-            services.Configure<NodeJSProcessOptions>(options =>
-            {
-                options.ProjectPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
-                if (!string.IsNullOrWhiteSpace(nodeOptions))
-                {
-                    options.NodeAndV8Options = nodeOptions;
-                }
-            });
-            services.AddSingleton<IJsonService, RealtimeJsonService>();
+namespace Microsoft.Extensions.DependencyInjection;
 
-            services.Configure(configureOptions);
-            services.AddSingleton<IRealtimeServer, RealtimeServer>();
-            services.AddSingleton<IRealtimeService, RealtimeService>();
-            return services;
-        }
+public static class RealtimeServiceCollectionExtensions
+{
+    public static IServiceCollection AddRealtimeServer(
+        this IServiceCollection services,
+        ILoggerFactory loggerFactory,
+        IConfiguration configuration,
+        Action<RealtimeOptions> configureOptions,
+        string? nodeOptions = null
+    )
+    {
+        services.AddNodeJS();
+        services.Configure<NodeJSProcessOptions>(options =>
+        {
+            options.ProjectPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
+            if (!string.IsNullOrWhiteSpace(nodeOptions))
+            {
+                options.NodeAndV8Options = nodeOptions;
+            }
+        });
+        services.AddSingleton<IJsonService, RealtimeJsonService>();
+
+        services.Configure(configureOptions);
+        services.AddSingleton<IRealtimeServer, RealtimeServer>();
+        services.AddSingleton<IRealtimeService, RealtimeService>();
+        return services;
     }
 }

--- a/src/SIL.XForge/Realtime/RichText/Delta.cs
+++ b/src/SIL.XForge/Realtime/RichText/Delta.cs
@@ -1,600 +1,568 @@
-using AbrarJahin.DiffMatchPatch;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using AbrarJahin.DiffMatchPatch;
+using Newtonsoft.Json.Linq;
 
-namespace SIL.XForge.Realtime.RichText
+namespace SIL.XForge.Realtime.RichText;
+
+/// <summary>
+/// Represents the current state of rich text data, or represents changes to be applied to rich text data.
+/// Rich text data includes the plain text and associated formatting.
+/// </summary>
+public class Delta
 {
-    /// <summary>
-    /// Represents the current state of rich text data, or represents changes to be applied to rich text data.
-    /// Rich text data includes the plain text and associated formatting.
-    /// </summary>
-    public class Delta
+    private static readonly Lazy<DeltaEqualityComparer> _equalityComparer = new Lazy<DeltaEqualityComparer>();
+    public static DeltaEqualityComparer EqualityComparer => _equalityComparer.Value;
+    private static readonly diff_match_patch Differ = new diff_match_patch();
+
+    public const string InsertType = "insert";
+    public const string DeleteType = "delete";
+    public const string RetainType = "retain";
+    public const string Attributes = "attributes";
+
+    public static Delta New() => new Delta();
+
+    public Delta() => Ops = new List<JToken>();
+
+    public Delta(IEnumerable<JToken> ops) => Ops = ops.ToList();
+
+    public Delta(Delta delta) => Ops = delta.Ops.Select(op => op.DeepClone()).ToList();
+
+    public List<JToken> Ops { get; set; }
+
+    public Delta Insert(object text, object attributes = null)
     {
-        private static readonly Lazy<DeltaEqualityComparer> _equalityComparer = new Lazy<DeltaEqualityComparer>();
-        public static DeltaEqualityComparer EqualityComparer => _equalityComparer.Value;
-        private static readonly diff_match_patch Differ = new diff_match_patch();
-
-        public const string InsertType = "insert";
-        public const string DeleteType = "delete";
-        public const string RetainType = "retain";
-        public const string Attributes = "attributes";
-
-        public static Delta New()
+        if (text is not JToken textToken)
+            textToken = JToken.FromObject(text);
+        JToken attrsToken = null;
+        if (attributes != null)
         {
-            return new Delta();
+            attrsToken = attributes as JToken;
+            attrsToken ??= JToken.FromObject(attributes);
         }
 
-        public Delta()
-        {
-            Ops = new List<JToken>();
-        }
-
-        public Delta(IEnumerable<JToken> ops)
-        {
-            Ops = ops.ToList();
-        }
-
-        public Delta(Delta delta)
-        {
-            Ops = delta.Ops.Select(op => op.DeepClone()).ToList();
-        }
-
-        public List<JToken> Ops { get; set; }
-
-        public Delta Insert(object text, object attributes = null)
-        {
-            var textToken = text as JToken;
-            if (textToken == null)
-                textToken = JToken.FromObject(text);
-            JToken attrsToken = null;
-            if (attributes != null)
-            {
-                attrsToken = attributes as JToken;
-                if (attrsToken == null)
-                    attrsToken = JToken.FromObject(attributes);
-            }
-
-            if (textToken.Type == JTokenType.String && ((string)textToken).Length == 0)
-                return this;
-
-            var newOp = new JObject(new JProperty(InsertType, textToken));
-            if (attrsToken != null && attrsToken.HasValues)
-                newOp[Attributes] = attrsToken;
-
-            return Add(newOp);
-        }
-
-        public Delta Delete(int length)
-        {
-            if (length <= 0)
-                return this;
-
-            return Add(new JObject(new JProperty(DeleteType, length)));
-        }
-
-        public Delta Retain(int length, object attributes = null)
-        {
-            if (length <= 0)
-                return this;
-
-            JToken attrsToken = null;
-            if (attributes != null)
-            {
-                attrsToken = attributes as JToken;
-                if (attrsToken == null)
-                    attrsToken = JToken.FromObject(attributes);
-            }
-
-            var newOp = new JObject(new JProperty(RetainType, length));
-            if (attrsToken != null && attrsToken.HasValues)
-                newOp[Attributes] = attrsToken;
-
-            return Add(newOp);
-        }
-
-        public Delta Chop()
-        {
-            JToken lastOp = Ops.Count == 0 ? null : Ops[Ops.Count - 1];
-            if (lastOp != null && lastOp[RetainType] != null && lastOp[Attributes] == null)
-                Ops.RemoveAt(Ops.Count - 1);
+        if (textToken.Type == JTokenType.String && ((string)textToken).Length == 0)
             return this;
+
+        var newOp = new JObject(new JProperty(InsertType, textToken));
+        if (attrsToken != null && attrsToken.HasValues)
+            newOp[Attributes] = attrsToken;
+
+        return Add(newOp);
+    }
+
+    public Delta Delete(int length)
+    {
+        if (length <= 0)
+            return this;
+
+        return Add(new JObject(new JProperty(DeleteType, length)));
+    }
+
+    public Delta Retain(int length, object attributes = null)
+    {
+        if (length <= 0)
+            return this;
+
+        JToken attrsToken = null;
+        if (attributes != null)
+        {
+            attrsToken = attributes as JToken;
+            attrsToken ??= JToken.FromObject(attributes);
         }
 
-        public Delta Compose(Delta other)
-        {
-            var thisIter = new OpIterator(Ops);
-            var otherIter = new OpIterator(other.Ops);
-            var delta = new Delta();
-            while (thisIter.HasNext() || otherIter.HasNext())
-            {
-                if (otherIter.PeekType() == InsertType)
-                {
-                    delta.Add(otherIter.Next());
-                }
-                else if (thisIter.PeekType() == DeleteType)
-                {
-                    delta.Add(thisIter.Next());
-                }
-                else
-                {
-                    int length = Math.Min(thisIter.PeekLength(), otherIter.PeekLength());
-                    JToken thisOp = thisIter.Next(length);
-                    JToken otherOp = otherIter.Next(length);
-                    if (otherOp.OpType() == RetainType)
-                    {
-                        var newOp = new JObject();
-                        if (thisOp.OpType() == RetainType)
-                            newOp[RetainType] = length;
-                        else
-                            newOp[InsertType] = thisOp[InsertType];
+        var newOp = new JObject(new JProperty(RetainType, length));
+        if (attrsToken != null && attrsToken.HasValues)
+            newOp[Attributes] = attrsToken;
 
-                        JToken attributes = ComposeAttributes(
-                            thisOp[Attributes],
-                            otherOp[Attributes],
-                            thisOp.OpType() == RetainType
-                        );
-                        if (attributes != null)
-                            newOp[Attributes] = attributes;
-                        delta.Add(newOp);
-                    }
-                    else if (otherOp.OpType() == DeleteType && thisOp.OpType() == RetainType)
-                    {
-                        delta.Add(otherOp);
-                    }
+        return Add(newOp);
+    }
+
+    public Delta Chop()
+    {
+        JToken lastOp = Ops.Count == 0 ? null : Ops[^1];
+        if (lastOp != null && lastOp[RetainType] != null && lastOp[Attributes] == null)
+            Ops.RemoveAt(Ops.Count - 1);
+        return this;
+    }
+
+    public Delta Compose(Delta other)
+    {
+        var thisIter = new OpIterator(Ops);
+        var otherIter = new OpIterator(other.Ops);
+        var delta = new Delta();
+        while (thisIter.HasNext() || otherIter.HasNext())
+        {
+            if (otherIter.PeekType() == InsertType)
+            {
+                delta.Add(otherIter.Next());
+            }
+            else if (thisIter.PeekType() == DeleteType)
+            {
+                delta.Add(thisIter.Next());
+            }
+            else
+            {
+                int length = Math.Min(thisIter.PeekLength(), otherIter.PeekLength());
+                JToken thisOp = thisIter.Next(length);
+                JToken otherOp = otherIter.Next(length);
+                if (otherOp.OpType() == RetainType)
+                {
+                    var newOp = new JObject();
+                    if (thisOp.OpType() == RetainType)
+                        newOp[RetainType] = length;
+                    else
+                        newOp[InsertType] = thisOp[InsertType];
+
+                    JToken attributes = ComposeAttributes(
+                        thisOp[Attributes],
+                        otherOp[Attributes],
+                        thisOp.OpType() == RetainType
+                    );
+                    if (attributes != null)
+                        newOp[Attributes] = attributes;
+                    delta.Add(newOp);
+                }
+                else if (otherOp.OpType() == DeleteType && thisOp.OpType() == RetainType)
+                {
+                    delta.Add(otherOp);
                 }
             }
-            return delta.Chop();
+        }
+        return delta.Chop();
+    }
+
+    public Delta Diff(Delta other)
+    {
+        if (this == other)
+            return new Delta();
+
+        if (other == null)
+        {
+            throw new ArgumentNullException(nameof(other));
         }
 
-        public Delta Diff(Delta other)
+        if (!TryConcatInserts(this, out string thisStr) || !TryConcatInserts(other, out string otherStr))
+            throw new InvalidOperationException("Both deltas must be documents.");
+
+        var delta = new Delta();
+
+        List<Diff> diffResult = Differ.diff_main(thisStr, otherStr);
+        var thisIter = new OpIterator(this.Ops);
+        var otherIter = new OpIterator(other.Ops);
+
+        // If the two deltas have differences in text content, include character IDs in the diff output (thus causing all cids to be changed when applying the diff later).
+        // If the two deltas have identical text content, don't produce a diff of character IDs, except on ops with formatting changes where we will report cid differences.
+        bool retainCharIds = thisStr == otherStr;
+
+        // Note that when the text content is identical, the list of Diff results to process here will contain just one item.
+        foreach (Diff component in diffResult)
         {
-            if (this == other)
-                return new Delta();
-
-            if (other == null)
+            int length = component.text.Length;
+            DeltaOpsAttributeHelper deltaOpsHelper =
+                component.operation == Operation.EQUAL ? new DeltaOpsAttributeHelper(retainCharIds) : null;
+            while (length > 0)
             {
-                throw new ArgumentNullException(nameof(other));
-            }
-
-            if (!TryConcatInserts(this, out string thisStr) || !TryConcatInserts(other, out string otherStr))
-                throw new InvalidOperationException("Both deltas must be documents.");
-
-            var delta = new Delta();
-
-            List<Diff> diffResult = Differ.diff_main(thisStr, otherStr);
-            var thisIter = new OpIterator(this.Ops);
-            var otherIter = new OpIterator(other.Ops);
-
-            // If the two deltas have differences in text content, include character IDs in the diff output (thus causing all cids to be changed when applying the diff later).
-            // If the two deltas have identical text content, don't produce a diff of character IDs, except on ops with formatting changes where we will report cid differences.
-            bool retainCharIds = thisStr == otherStr;
-
-            // Note that when the text content is identical, the list of Diff results to process here will contain just one item.
-            foreach (Diff component in diffResult)
-            {
-                int length = component.text.Length;
-                DeltaOpsAttributeHelper deltaOpsHelper =
-                    component.operation == Operation.EQUAL ? new DeltaOpsAttributeHelper(retainCharIds) : null;
-                while (length > 0)
+                int opLength = 0;
+                switch (component.operation)
                 {
-                    int opLength = 0;
-                    switch (component.operation)
-                    {
-                        case Operation.INSERT:
-                            opLength = Math.Min(otherIter.PeekLength(), length);
-                            delta.Add(otherIter.Next(opLength));
-                            break;
+                    case Operation.INSERT:
+                        opLength = Math.Min(otherIter.PeekLength(), length);
+                        delta.Add(otherIter.Next(opLength));
+                        break;
 
-                        case Operation.DELETE:
-                            opLength = Math.Min(length, thisIter.PeekLength());
-                            thisIter.Next(opLength);
-                            delta.Delete(opLength);
-                            break;
+                    case Operation.DELETE:
+                        opLength = Math.Min(length, thisIter.PeekLength());
+                        thisIter.Next(opLength);
+                        delta.Delete(opLength);
+                        break;
 
-                        case Operation.EQUAL:
-                            opLength = Math.Min(Math.Min(thisIter.PeekLength(), otherIter.PeekLength()), length);
-                            JToken thisOp = thisIter.Next(opLength);
-                            JToken otherOp = otherIter.Next(opLength);
-                            deltaOpsHelper.Add(opLength, thisOp, otherOp);
-                            break;
-                    }
-                    length -= opLength;
+                    case Operation.EQUAL:
+                        opLength = Math.Min(Math.Min(thisIter.PeekLength(), otherIter.PeekLength()), length);
+                        JToken thisOp = thisIter.Next(opLength);
+                        JToken otherOp = otherIter.Next(opLength);
+                        deltaOpsHelper.Add(opLength, thisOp, otherOp);
+                        break;
                 }
-                if (deltaOpsHelper != null)
-                    deltaOpsHelper.AddOpsToDelta(delta);
+                length -= opLength;
             }
-            return delta.Chop();
+            deltaOpsHelper?.AddOpsToDelta(delta);
         }
+        return delta.Chop();
+    }
 
-        public int GetLength()
-        {
-            return Ops.Sum(op => op.OpLength());
-        }
+    public int GetLength() => Ops.Sum(op => op.OpLength());
 
-        public bool DeepEquals(Delta other)
+    public bool DeepEquals(Delta other)
+    {
+        if (Ops.Count != other.Ops.Count)
+            return false;
+
+        for (int i = 0; i < Ops.Count; i++)
         {
-            if (Ops.Count != other.Ops.Count)
+            if (!JToken.DeepEquals(Ops[i], other.Ops[i]))
                 return false;
-
-            for (int i = 0; i < Ops.Count; i++)
-            {
-                if (!JToken.DeepEquals(Ops[i], other.Ops[i]))
-                    return false;
-            }
-            return true;
         }
+        return true;
+    }
 
-        public override string ToString()
-        {
-            var array = new JArray(Ops);
-            return array.ToString();
-        }
+    public override string ToString()
+    {
+        var array = new JArray(Ops);
+        return array.ToString();
+    }
 
-        /// <summary>
-        /// Concatenate all the text belonging to a given verse, including section headings. If the verse string
-        /// given is 0, this returns all the text previous to the first verse in the text.
-        /// </summary>
-        /// <param name="opStr">The string of text belonging to a verse.</param>
-        /// <param name="verseRef">
-        /// The reference to the verse. For example: "1". If the verses in the text data is combined, "1-2".
-        /// </param>
-        /// <param name="includeParaWithStyle">Function to determine if the paragraph break should be included.</param>
-        public bool TryConcatenateInserts(out string opStr, string verseRef, Func<string, bool> includeParaWithStyle)
+    /// <summary>
+    /// Concatenate all the text belonging to a given verse, including section headings. If the verse string
+    /// given is 0, this returns all the text previous to the first verse in the text.
+    /// </summary>
+    /// <param name="opStr">The string of text belonging to a verse.</param>
+    /// <param name="verseRef">
+    /// The reference to the verse. For example: "1". If the verses in the text data is combined, "1-2".
+    /// </param>
+    /// <param name="includeParaWithStyle">Function to determine if the paragraph break should be included.</param>
+    public bool TryConcatenateInserts(out string opStr, string verseRef, Func<string, bool> includeParaWithStyle)
+    {
+        List<JToken> verseOps = new List<JToken>();
+        bool isTargetVerse = verseRef == "0";
+        foreach (JToken op in this.Ops)
         {
-            List<JToken> verseOps = new List<JToken>();
-            bool isTargetVerse = verseRef == "0";
-            foreach (JToken op in this.Ops)
+            if (op[InsertType]?.Type == JTokenType.Object)
             {
-                if (op[InsertType]?.Type == JTokenType.Object)
+                if (((JObject)op[InsertType]).Property("verse")?.Value.Type == JTokenType.Object)
                 {
-                    if (((JObject)op[InsertType]).Property("verse")?.Value.Type == JTokenType.Object)
-                    {
-                        JProperty numberToken = ((JObject)((JObject)op[InsertType]).Property("verse").Value).Property(
-                            "number"
-                        );
-                        // update target verse so we know what verse we are in
-                        isTargetVerse =
-                            numberToken.Value.Type == JTokenType.String && (string)numberToken.Value == verseRef;
-                        continue;
-                    }
-                    else if (((JObject)op[InsertType]).Property("chapter")?.Value.Type == JTokenType.Object)
+                    JProperty numberToken = ((JObject)((JObject)op[InsertType]).Property("verse").Value).Property(
+                        "number"
+                    );
+                    // update target verse so we know what verse we are in
+                    isTargetVerse =
+                        numberToken.Value.Type == JTokenType.String && (string)numberToken.Value == verseRef;
+                    continue;
+                }
+                else if (((JObject)op[InsertType]).Property("chapter")?.Value.Type == JTokenType.Object)
+                    continue;
+            }
+            else if (op[Attributes]?.Type == JTokenType.Object)
+            {
+                var paragraphObj = ((JObject)op[Attributes]).Property("para")?.Value;
+                if (paragraphObj?.Type == JTokenType.Object)
+                {
+                    string style = (string)((JObject)paragraphObj).Property("style").Value;
+                    if (!includeParaWithStyle(style))
                         continue;
                 }
-                else if (op[Attributes]?.Type == JTokenType.Object)
-                {
-                    var paragraphObj = ((JObject)op[Attributes]).Property("para")?.Value;
-                    if (paragraphObj?.Type == JTokenType.Object)
-                    {
-                        string style = (string)((JObject)paragraphObj).Property("style").Value;
-                        if (!includeParaWithStyle(style))
-                            continue;
-                    }
-                }
-
-                if (isTargetVerse)
-                    verseOps.Add(op);
             }
-            Delta verseDeltaOps = new Delta(verseOps);
-            return TryConcatInserts(verseDeltaOps, out opStr);
-        }
 
-        private Delta Add(JToken newOp)
+            if (isTargetVerse)
+                verseOps.Add(op);
+        }
+        Delta verseDeltaOps = new Delta(verseOps);
+        return TryConcatInserts(verseDeltaOps, out opStr);
+    }
+
+    private Delta Add(JToken newOp)
+    {
+        int index = Ops.Count;
+        JToken lastOp = Ops.Count == 0 ? null : Ops[^1];
+        newOp = (JObject)newOp.DeepClone();
+        if (lastOp != null && lastOp.Type == JTokenType.Object)
         {
-            int index = Ops.Count;
-            JToken lastOp = Ops.Count == 0 ? null : Ops[Ops.Count - 1];
-            newOp = (JObject)newOp.DeepClone();
-            if (lastOp != null && lastOp.Type == JTokenType.Object)
+            if (newOp.OpType() == DeleteType && lastOp.OpType() == DeleteType)
             {
-                if (newOp.OpType() == DeleteType && lastOp.OpType() == DeleteType)
+                int delete = (int)lastOp[DeleteType] + (int)newOp[DeleteType];
+                Ops[index - 1] = new JObject(new JProperty(DeleteType, delete));
+                return this;
+            }
+
+            if (lastOp.OpType() == DeleteType && newOp.OpType() == InsertType)
+            {
+                index -= 1;
+                lastOp = index == 0 ? null : Ops[index - 1];
+                if (lastOp?.Type != JTokenType.Object)
                 {
-                    int delete = (int)lastOp[DeleteType] + (int)newOp[DeleteType];
-                    Ops[index - 1] = new JObject(new JProperty(DeleteType, delete));
+                    Ops.Insert(0, newOp);
                     return this;
                 }
-
-                if (lastOp.OpType() == DeleteType && newOp.OpType() == InsertType)
-                {
-                    index -= 1;
-                    lastOp = index == 0 ? null : Ops[index - 1];
-                    if (lastOp?.Type != JTokenType.Object)
-                    {
-                        Ops.Insert(0, newOp);
-                        return this;
-                    }
-                }
-
-                if (JToken.DeepEquals(newOp[Attributes], lastOp[Attributes]))
-                {
-                    if (newOp[InsertType]?.Type == JTokenType.String && lastOp[InsertType]?.Type == JTokenType.String)
-                    {
-                        string insert = (string)lastOp[InsertType] + (string)newOp[InsertType];
-                        var op = new JObject(new JProperty(InsertType, insert));
-                        if (newOp[Attributes]?.Type == JTokenType.Object)
-                            op[Attributes] = newOp[Attributes];
-                        Ops[index - 1] = op;
-                        return this;
-                    }
-                    else if (newOp.OpType() == RetainType && lastOp.OpType() == RetainType)
-                    {
-                        int retain = (int)lastOp[RetainType] + (int)newOp[RetainType];
-                        var op = new JObject(new JProperty(RetainType, retain));
-                        if (newOp[Attributes]?.Type == JTokenType.Object)
-                            op[Attributes] = newOp[Attributes];
-                        Ops[index - 1] = op;
-                        return this;
-                    }
-                }
             }
 
-            Ops.Insert(index, newOp);
-            return this;
-        }
-
-        private static JToken ComposeAttributes(JToken a, JToken b, bool keepNull)
-        {
-            JObject aObj = a?.Type == JTokenType.Object ? (JObject)a : new JObject();
-            JObject bObj = b?.Type == JTokenType.Object ? (JObject)b : new JObject();
-            JObject attributes = (JObject)bObj.DeepClone();
-            if (!keepNull)
-                attributes = new JObject(attributes.Properties().Where(p => p.Value.Type != JTokenType.Null));
-
-            foreach (JProperty prop in aObj.Properties())
+            if (JToken.DeepEquals(newOp[Attributes], lastOp[Attributes]))
             {
-                if (aObj[prop.Name] != null && bObj[prop.Name] == null)
-                    attributes.Add(prop);
+                if (newOp[InsertType]?.Type == JTokenType.String && lastOp[InsertType]?.Type == JTokenType.String)
+                {
+                    string insert = (string)lastOp[InsertType] + (string)newOp[InsertType];
+                    var op = new JObject(new JProperty(InsertType, insert));
+                    if (newOp[Attributes]?.Type == JTokenType.Object)
+                        op[Attributes] = newOp[Attributes];
+                    Ops[index - 1] = op;
+                    return this;
+                }
+                else if (newOp.OpType() == RetainType && lastOp.OpType() == RetainType)
+                {
+                    int retain = (int)lastOp[RetainType] + (int)newOp[RetainType];
+                    var op = new JObject(new JProperty(RetainType, retain));
+                    if (newOp[Attributes]?.Type == JTokenType.Object)
+                        op[Attributes] = newOp[Attributes];
+                    Ops[index - 1] = op;
+                    return this;
+                }
             }
-
-            return attributes.HasValues ? attributes : null;
         }
 
-        private static bool TryConcatInserts(Delta delta, out string str)
+        Ops.Insert(index, newOp);
+        return this;
+    }
+
+    private static JToken ComposeAttributes(JToken a, JToken b, bool keepNull)
+    {
+        JObject aObj = a?.Type == JTokenType.Object ? (JObject)a : new JObject();
+        JObject bObj = b?.Type == JTokenType.Object ? (JObject)b : new JObject();
+        JObject attributes = (JObject)bObj.DeepClone();
+        if (!keepNull)
+            attributes = new JObject(attributes.Properties().Where(p => p.Value.Type != JTokenType.Null));
+
+        foreach (JProperty prop in aObj.Properties())
         {
-            var sb = new StringBuilder();
-            foreach (JToken op in delta.Ops)
+            if (aObj[prop.Name] != null && bObj[prop.Name] == null)
+                attributes.Add(prop);
+        }
+
+        return attributes.HasValues ? attributes : null;
+    }
+
+    private static bool TryConcatInserts(Delta delta, out string str)
+    {
+        var sb = new StringBuilder();
+        foreach (JToken op in delta.Ops)
+        {
+            if (op[InsertType] != null)
             {
-                if (op[InsertType] != null)
-                {
-                    sb.Append(op[InsertType]?.Type == JTokenType.String ? (string)op[InsertType] : "\0");
-                }
-                else
-                {
-                    str = null;
-                    return false;
-                }
+                sb.Append(op[InsertType]?.Type == JTokenType.String ? (string)op[InsertType] : "\0");
             }
-            str = sb.ToString();
-            return true;
-        }
-
-        /// <summary>
-        /// Test for value equality of two JTokens while ignoring the cid object property in char nodes.
-        /// </summary>
-        static bool JTokenDeepEqualsIgnoreCharId(JToken a, JToken b)
-        {
-            if (b == null)
+            else
+            {
+                str = null;
                 return false;
-            // If the token is not an object, it will not have a char property
-            if (a?.Type != JTokenType.Object || b.Type != JTokenType.Object)
-                return JToken.DeepEquals(a, b);
-            JObject aClone = (JObject)a.DeepClone();
-            JObject bClone = (JObject)b.DeepClone();
+            }
+        }
+        str = sb.ToString();
+        return true;
+    }
+
+    /// <summary>
+    /// Test for value equality of two JTokens while ignoring the cid object property in char nodes.
+    /// </summary>
+    static bool JTokenDeepEqualsIgnoreCharId(JToken a, JToken b)
+    {
+        if (b == null)
+            return false;
+        // If the token is not an object, it will not have a char property
+        if (a?.Type != JTokenType.Object || b.Type != JTokenType.Object)
+            return JToken.DeepEquals(a, b);
+        JObject aClone = (JObject)a.DeepClone();
+        JObject bClone = (JObject)b.DeepClone();
+        StripCharId(aClone);
+        StripCharId(bClone);
+        return JToken.DeepEquals(aClone, bClone);
+    }
+
+    static JToken DiffAttributes(JToken a, JToken b, bool ignoreCharIdDifferences)
+    {
+        JObject aObj = a?.Type == JTokenType.Object ? (JObject)a : new JObject();
+        JObject bObj = b?.Type == JTokenType.Object ? (JObject)b : new JObject();
+        // Clone the objects so that if there is a real difference in the attributes we can update the cid
+        // to be the cid for the new object
+        JObject aClone = (JObject)aObj.DeepClone();
+        JObject bClone = (JObject)bObj.DeepClone();
+        if (ignoreCharIdDifferences)
+        {
             StripCharId(aClone);
             StripCharId(bClone);
-            return JToken.DeepEquals(aClone, bClone);
         }
+        // Make a list of all attributes and their values in b, that are changed, new, or removed in b.
+        JObject attributes = aClone
+            .Properties()
+            .Select(p => p.Name)
+            .Concat(bClone.Properties().Select(p => p.Name))
+            .Aggregate(
+                new JObject(),
+                (attrs, key) =>
+                {
+                    if (!JToken.DeepEquals(aClone[key], bClone[key]))
+                        attrs[key] = bObj[key] ?? JValue.CreateNull();
+                    return attrs;
+                }
+            );
+        return attributes.HasValues ? attributes : null;
+    }
 
-        static JToken DiffAttributes(JToken a, JToken b, bool ignoreCharIdDifferences)
+    /// <summary> Does a deep search and strips the cid object property from all char nodes. </summary>
+    static void StripCharId(JObject obj)
+    {
+        if (obj.ContainsKey("char"))
         {
-            JObject aObj = a?.Type == JTokenType.Object ? (JObject)a : new JObject();
-            JObject bObj = b?.Type == JTokenType.Object ? (JObject)b : new JObject();
-            // Clone the objects so that if there is a real difference in the attributes we can update the cid
-            // to be the cid for the new object
-            JObject aClone = (JObject)aObj.DeepClone();
-            JObject bClone = (JObject)bObj.DeepClone();
-            if (ignoreCharIdDifferences)
+            switch (obj["char"].Type)
             {
-                StripCharId(aClone);
-                StripCharId(bClone);
+                case JTokenType.Object:
+                    ((JObject)obj["char"]).Property("cid")?.Remove();
+                    break;
+                case JTokenType.Array:
+                    foreach (JToken token in (JArray)obj["char"])
+                        if (token.Type == JTokenType.Object)
+                            ((JObject)token).Property("cid")?.Remove();
+                    break;
+                default:
+                    break;
             }
-            // Make a list of all attributes and their values in b, that are changed, new, or removed in b.
-            JObject attributes = aClone
-                .Properties()
-                .Select(p => p.Name)
-                .Concat(bClone.Properties().Select(p => p.Name))
-                .Aggregate(
-                    new JObject(),
-                    (attrs, key) =>
-                    {
-                        if (!JToken.DeepEquals(aClone[key], bClone[key]))
-                            attrs[key] = bObj[key] == null ? JValue.CreateNull() : bObj[key];
-                        return attrs;
-                    }
-                );
-            return attributes.HasValues ? attributes : null;
         }
-
-        /// <summary> Does a deep search and strips the cid object property from all char nodes. </summary>
-        static void StripCharId(JObject obj)
+        IEnumerable<string> properties = obj.Properties().Select(p => p.Name);
+        foreach (string prop in properties)
         {
-            if (obj.ContainsKey("char"))
+            JToken token = obj[prop];
+            if (token.Type == JTokenType.Object)
             {
-                switch (obj["char"].Type)
-                {
-                    case JTokenType.Object:
-                        ((JObject)obj["char"]).Property("cid")?.Remove();
-                        break;
-                    case JTokenType.Array:
-                        foreach (JToken token in (JArray)obj["char"])
-                            if (token.Type == JTokenType.Object)
-                                ((JObject)token).Property("cid")?.Remove();
-                        break;
-                    default:
-                        break;
-                }
+                // Strip the cid property off descendant nodes
+                StripCharId((JObject)token);
             }
-            IEnumerable<string> properties = obj.Properties().Select(p => p.Name);
-            foreach (string prop in properties)
+            else if (token.Type == JTokenType.Array)
             {
-                JToken token = obj[prop];
-                if (token.Type == JTokenType.Object)
+                // This JArray represents something similar to insert.note.contents.ops[]
+                for (int i = 0; i < token.Count(); i++)
                 {
-                    // Strip the cid property off descendant nodes
-                    StripCharId((JObject)token);
-                }
-                else if (token.Type == JTokenType.Array)
-                {
-                    // This JArray represents something similar to insert.note.contents.ops[]
-                    for (int i = 0; i < token.Count(); i++)
+                    if (token[i].Type == JTokenType.Object)
                     {
-                        if (token[i].Type == JTokenType.Object)
-                        {
-                            // Strip the cid property off descendant nodes
-                            StripCharId((JObject)token[i]);
-                        }
+                        // Strip the cid property off descendant nodes
+                        StripCharId((JObject)token[i]);
                     }
                 }
             }
         }
+    }
 
-        private class OpIterator
+    private class OpIterator
+    {
+        private readonly IReadOnlyList<JToken> _ops;
+        private int _index;
+        private int _offset;
+
+        public OpIterator(IReadOnlyList<JToken> ops) => _ops = ops;
+
+        public bool HasNext() => PeekLength() < int.MaxValue;
+
+        public JToken Next(int length = int.MaxValue)
         {
-            private readonly IReadOnlyList<JToken> _ops;
-            private int _index;
-            private int _offset;
+            if (_index >= _ops.Count)
+                return new JObject(new JProperty(RetainType, int.MaxValue));
 
-            public OpIterator(IReadOnlyList<JToken> ops)
+            JToken nextOp = _ops[_index];
+            int offset = _offset;
+            int opLength = nextOp.OpLength();
+            if (length >= opLength - offset)
             {
-                _ops = ops;
+                length = opLength - offset;
+                _index++;
+                _offset = 0;
+            }
+            else
+            {
+                _offset += length;
             }
 
-            public bool HasNext()
-            {
-                return PeekLength() < int.MaxValue;
-            }
+            if (nextOp.OpType() == DeleteType)
+                return new JObject(new JProperty(DeleteType, length));
 
-            public JToken Next(int length = int.MaxValue)
-            {
-                if (_index >= _ops.Count)
-                    return new JObject(new JProperty(RetainType, int.MaxValue));
+            var retOp = new JObject();
+            if (nextOp[Attributes] != null)
+                retOp[Attributes] = nextOp[Attributes];
+            if (nextOp.OpType() == RetainType)
+                retOp[RetainType] = length;
+            else if (nextOp[InsertType]?.Type == JTokenType.String)
+                retOp[InsertType] = ((string)nextOp[InsertType]).Substring(offset, length);
+            else
+                retOp[InsertType] = nextOp[InsertType];
+            return retOp;
+        }
 
-                JToken nextOp = _ops[_index];
-                int offset = _offset;
-                int opLength = nextOp.OpLength();
-                if (length >= opLength - offset)
+        public JToken Peek() => _index >= _ops.Count ? null : _ops[_index];
+
+        public int PeekLength()
+        {
+            if (_index >= _ops.Count)
+                return int.MaxValue;
+            return _ops[_index].OpLength() - _offset;
+        }
+
+        public string PeekType()
+        {
+            if (_index >= _ops.Count)
+                return RetainType;
+
+            JToken nextOp = _ops[_index];
+            return nextOp.OpType();
+        }
+    }
+
+    /// <summary>Provides methods to process ops for text that may have attribute changes</summary>
+    private class DeltaOpsAttributeHelper
+    {
+        private List<int> opLengths = new List<int>();
+        private List<JObject> originalDeltaOps = new List<JObject>();
+        private List<JObject> newDeltaOps = new List<JObject>();
+        private bool retainCharIdsOnAttributes;
+
+        public DeltaOpsAttributeHelper(bool retainCharIds) => retainCharIdsOnAttributes = retainCharIds;
+
+        public void Add(int length, JToken originalOp, JToken newOp)
+        {
+            opLengths.Add(length);
+            JObject originalOpObject = originalOp?.Type == JTokenType.Object ? (JObject)originalOp : new JObject();
+            JObject newOpObject = newOp?.Type == JTokenType.Object ? (JObject)newOp : new JObject();
+            originalDeltaOps.Add(originalOpObject);
+            newDeltaOps.Add(newOpObject);
+        }
+
+        /// <summary>Adds the ops to the given delta based on the ops added to the instance of this class</summary>
+        public void AddOpsToDelta(Delta delta)
+        {
+            // To retain cid properties in this diff, we check whether there is a change in
+            // the ops for all the ops in this diff. If the ops differ for any op
+            // in this diff, we update all of the cid properties that have been regenerated. Otherwise,
+            // we use the old cid properties instead of the regenerated ones.
+            bool retainCharIds = retainCharIdsOnAttributes && !HaveOpsChanged();
+            for (int i = 0; i < originalDeltaOps.Count; i++)
+            {
+                JObject originalOp = originalDeltaOps[i];
+                JObject newOp = newDeltaOps[i];
+                if (JTokenDeepEqualsIgnoreCharId(originalOp[InsertType], newOp[InsertType]))
                 {
-                    length = opLength - offset;
-                    _index++;
-                    _offset = 0;
+                    delta.Retain(
+                        opLengths[i],
+                        DiffAttributes(originalOp[Attributes], newOp[Attributes], retainCharIds)
+                    );
                 }
                 else
                 {
-                    _offset += length;
+                    delta.Add(newOp);
+                    delta.Delete(opLengths[i]);
                 }
-
-                if (nextOp.OpType() == DeleteType)
-                    return new JObject(new JProperty(DeleteType, length));
-
-                var retOp = new JObject();
-                if (nextOp[Attributes] != null)
-                    retOp[Attributes] = nextOp[Attributes];
-                if (nextOp.OpType() == RetainType)
-                    retOp[RetainType] = length;
-                else if (nextOp[InsertType]?.Type == JTokenType.String)
-                    retOp[InsertType] = ((string)nextOp[InsertType]).Substring(offset, length);
-                else
-                    retOp[InsertType] = nextOp[InsertType];
-                return retOp;
-            }
-
-            public JToken Peek()
-            {
-                return _index >= _ops.Count ? null : _ops[_index];
-            }
-
-            public int PeekLength()
-            {
-                if (_index >= _ops.Count)
-                    return int.MaxValue;
-                return _ops[_index].OpLength() - _offset;
-            }
-
-            public string PeekType()
-            {
-                if (_index >= _ops.Count)
-                    return RetainType;
-
-                JToken nextOp = _ops[_index];
-                return nextOp.OpType();
             }
         }
 
-        /// <summary>Provides methods to process ops for text that may have attribute changes</summary>
-        private class DeltaOpsAttributeHelper
+        private bool HaveOpsChanged()
         {
-            private List<int> opLengths = new List<int>();
-            private List<JObject> originalDeltaOps = new List<JObject>();
-            private List<JObject> newDeltaOps = new List<JObject>();
-            private bool retainCharIdsOnAttributes;
-
-            public DeltaOpsAttributeHelper(bool retainCharIds)
+            JObject[] originalOpsArray = originalDeltaOps.ToArray();
+            JObject[] newOpsArray = newDeltaOps.ToArray();
+            for (int i = 0; i < originalOpsArray.Length; i++)
             {
-                retainCharIdsOnAttributes = retainCharIds;
+                JObject originalOp = originalOpsArray[i];
+                JObject newOp = newOpsArray[i];
+                if (!JTokenDeepEqualsIgnoreCharId(originalOp[InsertType], newOp[InsertType]))
+                    return true;
+                if (!JTokenDeepEqualsIgnoreCharId(originalOp[Attributes], newOp[Attributes]))
+                    return true;
             }
-
-            public void Add(int length, JToken originalOp, JToken newOp)
-            {
-                opLengths.Add(length);
-                JObject originalOpObject = originalOp?.Type == JTokenType.Object ? (JObject)originalOp : new JObject();
-                JObject newOpObject = newOp?.Type == JTokenType.Object ? (JObject)newOp : new JObject();
-                originalDeltaOps.Add(originalOpObject);
-                newDeltaOps.Add(newOpObject);
-            }
-
-            /// <summary>Adds the ops to the given delta based on the ops added to the instance of this class</summary>
-            public void AddOpsToDelta(Delta delta)
-            {
-                // To retain cid properties in this diff, we check whether there is a change in
-                // the ops for all the ops in this diff. If the ops differ for any op
-                // in this diff, we update all of the cid properties that have been regenerated. Otherwise,
-                // we use the old cid properties instead of the regenerated ones.
-                bool retainCharIds = retainCharIdsOnAttributes && !HaveOpsChanged();
-                for (int i = 0; i < originalDeltaOps.Count; i++)
-                {
-                    JObject originalOp = originalDeltaOps[i];
-                    JObject newOp = newDeltaOps[i];
-                    if (JTokenDeepEqualsIgnoreCharId(originalOp[InsertType], newOp[InsertType]))
-                    {
-                        delta.Retain(
-                            opLengths[i],
-                            DiffAttributes(originalOp[Attributes], newOp[Attributes], retainCharIds)
-                        );
-                    }
-                    else
-                    {
-                        delta.Add(newOp);
-                        delta.Delete(opLengths[i]);
-                    }
-                }
-            }
-
-            private bool HaveOpsChanged()
-            {
-                JObject[] originalOpsArray = originalDeltaOps.ToArray();
-                JObject[] newOpsArray = newDeltaOps.ToArray();
-                for (int i = 0; i < originalOpsArray.Length; i++)
-                {
-                    JObject originalOp = originalOpsArray[i];
-                    JObject newOp = newOpsArray[i];
-                    if (!JTokenDeepEqualsIgnoreCharId(originalOp[InsertType], newOp[InsertType]))
-                        return true;
-                    if (!JTokenDeepEqualsIgnoreCharId(originalOp[Attributes], newOp[Attributes]))
-                        return true;
-                }
-                return false;
-            }
+            return false;
         }
     }
 }

--- a/src/SIL.XForge/Realtime/RichText/DeltaEqualityComparer.cs
+++ b/src/SIL.XForge/Realtime/RichText/DeltaEqualityComparer.cs
@@ -1,22 +1,18 @@
-using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json.Linq;
 
-namespace SIL.XForge.Realtime.RichText
+namespace SIL.XForge.Realtime.RichText;
+
+public class DeltaEqualityComparer : IEqualityComparer<Delta>
 {
-    public class DeltaEqualityComparer : IEqualityComparer<Delta>
+    public bool Equals(Delta x, Delta y) => x == y || (x != null && y != null && x.DeepEquals(y));
+
+    public int GetHashCode(Delta obj)
     {
-        public bool Equals(Delta x, Delta y)
-        {
-            return x == y || (x != null && y != null && x.DeepEquals(y));
-        }
+        if (obj == null)
+            return 0;
 
-        public int GetHashCode(Delta obj)
-        {
-            if (obj == null)
-                return 0;
-
-            return obj.Ops.Aggregate(23, (code, op) => code * 31 + JToken.EqualityComparer.GetHashCode(op));
-        }
+        return obj.Ops.Aggregate(23, (code, op) => code * 31 + JToken.EqualityComparer.GetHashCode(op));
     }
 }

--- a/src/SIL.XForge/Realtime/RichText/OpExtensions.cs
+++ b/src/SIL.XForge/Realtime/RichText/OpExtensions.cs
@@ -1,27 +1,26 @@
 using Newtonsoft.Json.Linq;
 
-namespace SIL.XForge.Realtime.RichText
-{
-    public static class OpExtensions
-    {
-        public static string OpType(this JToken op)
-        {
-            if (op[Delta.DeleteType]?.Type == JTokenType.Integer)
-                return Delta.DeleteType;
-            if (op[Delta.RetainType]?.Type == JTokenType.Integer)
-                return Delta.RetainType;
-            return Delta.InsertType;
-        }
+namespace SIL.XForge.Realtime.RichText;
 
-        public static int OpLength(this JToken op)
-        {
-            if (op[Delta.DeleteType]?.Type == JTokenType.Integer)
-                return (int)op[Delta.DeleteType];
-            if (op[Delta.RetainType]?.Type == JTokenType.Integer)
-                return (int)op[Delta.RetainType];
-            if (op[Delta.InsertType]?.Type == JTokenType.String)
-                return ((string)op[Delta.InsertType]).Length;
-            return 1;
-        }
+public static class OpExtensions
+{
+    public static string OpType(this JToken op)
+    {
+        if (op[Delta.DeleteType]?.Type == JTokenType.Integer)
+            return Delta.DeleteType;
+        if (op[Delta.RetainType]?.Type == JTokenType.Integer)
+            return Delta.RetainType;
+        return Delta.InsertType;
+    }
+
+    public static int OpLength(this JToken op)
+    {
+        if (op[Delta.DeleteType]?.Type == JTokenType.Integer)
+            return (int)op[Delta.DeleteType];
+        if (op[Delta.RetainType]?.Type == JTokenType.Integer)
+            return (int)op[Delta.RetainType];
+        if (op[Delta.InsertType]?.Type == JTokenType.String)
+            return ((string)op[Delta.InsertType]).Length;
+        return 1;
     }
 }

--- a/src/SIL.XForge/Realtime/Snapshot.cs
+++ b/src/SIL.XForge/Realtime/Snapshot.cs
@@ -1,8 +1,7 @@
-namespace SIL.XForge.Realtime
+namespace SIL.XForge.Realtime;
+
+public class Snapshot<T>
 {
-    public class Snapshot<T>
-    {
-        public int Version { get; set; }
-        public T Data { get; set; }
-    }
+    public int Version { get; set; }
+    public T Data { get; set; }
 }

--- a/src/SIL.XForge/Services/AudioService.cs
+++ b/src/SIL.XForge/Services/AudioService.cs
@@ -4,45 +4,37 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using SIL.XForge.Configuration;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+public class AudioService : IAudioService
 {
-    public class AudioService : IAudioService
+    private readonly IOptions<AudioOptions> _audioOptions;
+
+    public AudioService(IOptions<AudioOptions> audioOptions) => _audioOptions = audioOptions;
+
+    public async Task ConvertToMp3Async(string inputPath, string outputPath)
     {
-        private readonly IOptions<AudioOptions> _audioOptions;
-
-        public AudioService(IOptions<AudioOptions> audioOptions)
+        using var process = new Process()
         {
-            _audioOptions = audioOptions;
-        }
-
-        public async Task ConvertToMp3Async(string inputPath, string outputPath)
-        {
-            using (
-                var process = new Process()
-                {
-                    StartInfo = new ProcessStartInfo
-                    {
-                        FileName = _audioOptions.Value.FfmpegPath,
-                        Arguments = $"-y -i \"{inputPath}\" \"{outputPath}\"",
-                        UseShellExecute = false,
-                        CreateNoWindow = true
-                    }
-                }
-            )
+            StartInfo = new ProcessStartInfo
             {
-                process.Start();
-                await WaitForExitAsync(process);
-                if (process.ExitCode != 0)
-                    throw new InvalidOperationException($"Error: Could not convert {inputPath} to mp3");
+                FileName = _audioOptions.Value.FfmpegPath,
+                Arguments = $"-y -i \"{inputPath}\" \"{outputPath}\"",
+                UseShellExecute = false,
+                CreateNoWindow = true
             }
-        }
+        };
+        process.Start();
+        await WaitForExitAsync(process);
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException($"Error: Could not convert {inputPath} to mp3");
+    }
 
-        private static Task WaitForExitAsync(Process process)
-        {
-            var tcs = new TaskCompletionSource<object>();
-            process.EnableRaisingEvents = true;
-            process.Exited += (sender, args) => tcs.TrySetResult(null);
-            return tcs.Task;
-        }
+    private static Task WaitForExitAsync(Process process)
+    {
+        var tcs = new TaskCompletionSource<object>();
+        process.EnableRaisingEvents = true;
+        process.Exited += (sender, args) => tcs.TrySetResult(null);
+        return tcs.Task;
     }
 }

--- a/src/SIL.XForge/Services/AuthService.cs
+++ b/src/SIL.XForge/Services/AuthService.cs
@@ -12,133 +12,122 @@ using Newtonsoft.Json.Linq;
 using SIL.ObjectModel;
 using SIL.XForge.Configuration;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+/// <summary>
+/// This service provides methods for accessing the Auth0 Management API.
+/// </summary>
+public class AuthService : DisposableBase, IAuthService
 {
-    /// <summary>
-    /// This service provides methods for accessing the Auth0 Management API.
-    /// </summary>
-    public class AuthService : DisposableBase, IAuthService
+    private readonly HttpClient _httpClient;
+    private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
+    private string _accessToken;
+    private readonly IOptions<AuthOptions> _authOptions;
+    private readonly IExceptionHandler _exceptionHandler;
+
+    public AuthService(IOptions<AuthOptions> authOptions, IExceptionHandler exceptionHandler)
     {
-        private readonly HttpClient _httpClient;
-        private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
-        private string _accessToken;
-        private readonly IOptions<AuthOptions> _authOptions;
-        private readonly IExceptionHandler _exceptionHandler;
+        _authOptions = authOptions;
+        _exceptionHandler = exceptionHandler;
+        _httpClient = new HttpClient { BaseAddress = new Uri($"https://{_authOptions.Value.Domain}") };
+    }
 
-        public AuthService(IOptions<AuthOptions> authOptions, IExceptionHandler exceptionHandler)
+    public bool ValidateWebhookCredentials(string username, string password)
+    {
+        AuthOptions authOptions = _authOptions.Value;
+        return authOptions.WebhookUsername == username && authOptions.WebhookPassword == password;
+    }
+
+    public Task<string> GetUserAsync(string authId) => CallApiAsync(HttpMethod.Get, $"users/{authId}");
+
+    public Task LinkAccounts(string primaryAuthId, string secondaryAuthId)
+    {
+        var content = new JObject(new JProperty("provider", "oauth2"), new JProperty("user_id", secondaryAuthId));
+        return CallApiAsync(HttpMethod.Post, $"users/{primaryAuthId}/identities", content);
+    }
+
+    public Task UpdateAvatar(string authId, string url)
+    {
+        var content = new JObject(new JProperty("picture", url));
+        return CallApiAsync(new HttpMethod("PATCH"), $"users/{authId}", content);
+    }
+
+    public Task UpdateInterfaceLanguage(string authId, string language)
+    {
+        var content = new JObject(
+            new JProperty("user_metadata", new JObject(new JProperty("interface_language", language)))
+        );
+        // Since .NET Std 2.0 see https://stackoverflow.com/a/23600004/5501739
+        return CallApiAsync(new HttpMethod("PATCH"), $"users/{authId}", content);
+    }
+
+    private async Task<string> CallApiAsync(HttpMethod method, string url, JToken content = null)
+    {
+        bool refreshed = false;
+        while (!refreshed)
         {
-            _authOptions = authOptions;
-            _exceptionHandler = exceptionHandler;
-            _httpClient = new HttpClient { BaseAddress = new Uri($"https://{_authOptions.Value.Domain}") };
+            var (AccessToken, Refreshed) = await GetAccessTokenAsync();
+            string accessToken = AccessToken;
+            refreshed = Refreshed;
+
+            using var request = new HttpRequestMessage(method, $"api/v2/{url}");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+            if (content != null)
+                request.Content = new StringContent(content.ToString(), Encoding.UTF8, "application/json");
+            HttpResponseMessage response = await _httpClient.SendAsync(request);
+            if (response.StatusCode != HttpStatusCode.Unauthorized)
+            {
+                await _exceptionHandler.EnsureSuccessStatusCode(response);
+                return await response.Content.ReadAsStringAsync();
+            }
         }
 
-        public bool ValidateWebhookCredentials(string username, string password)
-        {
-            AuthOptions authOptions = _authOptions.Value;
-            return authOptions.WebhookUsername == username && authOptions.WebhookPassword == password;
-        }
+        throw new SecurityException("The Auth0 access token is invalid.");
+    }
 
-        public Task<string> GetUserAsync(string authId)
+    private async Task<(string AccessToken, bool Refreshed)> GetAccessTokenAsync()
+    {
+        await _lock.WaitAsync();
+        try
         {
-            return CallApiAsync(HttpMethod.Get, $"users/{authId}");
-        }
+            if (!IsAccessTokenExpired())
+                return (_accessToken, false);
 
-        public Task LinkAccounts(string primaryAuthId, string secondaryAuthId)
-        {
-            var content = new JObject(new JProperty("provider", "oauth2"), new JProperty("user_id", secondaryAuthId));
-            return CallApiAsync(HttpMethod.Post, $"users/{primaryAuthId}/identities", content);
-        }
-
-        public Task UpdateAvatar(string authId, string url)
-        {
-            var content = new JObject(new JProperty("picture", url));
-            return CallApiAsync(new HttpMethod("PATCH"), $"users/{authId}", content);
-        }
-
-        public Task UpdateInterfaceLanguage(string authId, string language)
-        {
-            var content = new JObject(
-                new JProperty("user_metadata", new JObject(new JProperty("interface_language", language)))
+            using var request = new HttpRequestMessage(HttpMethod.Post, "oauth/token");
+            AuthOptions options = _authOptions.Value;
+            var requestObj = new JObject(
+                new JProperty("grant_type", "client_credentials"),
+                new JProperty("client_id", options.BackendClientId),
+                new JProperty("client_secret", options.BackendClientSecret),
+                new JProperty("audience", _authOptions.Value.ManagementAudience)
             );
-            // Since .NET Std 2.0 see https://stackoverflow.com/a/23600004/5501739
-            return CallApiAsync(new HttpMethod("PATCH"), $"users/{authId}", content);
-        }
-
-        private async Task<string> CallApiAsync(HttpMethod method, string url, JToken content = null)
-        {
-            bool refreshed = false;
-            while (!refreshed)
+            request.Content = new StringContent(requestObj.ToString(), Encoding.UTF8, "application/json");
+            if (string.IsNullOrEmpty(options.BackendClientSecret))
             {
-                var results = await GetAccessTokenAsync();
-                string accessToken = results.AccessToken;
-                refreshed = results.Refreshed;
-
-                using (var request = new HttpRequestMessage(method, $"api/v2/{url}"))
-                {
-                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-                    if (content != null)
-                        request.Content = new StringContent(content.ToString(), Encoding.UTF8, "application/json");
-                    HttpResponseMessage response = await _httpClient.SendAsync(request);
-                    if (response.StatusCode != HttpStatusCode.Unauthorized)
-                    {
-                        await _exceptionHandler.EnsureSuccessStatusCode(response);
-                        return await response.Content.ReadAsStringAsync();
-                    }
-                }
+                Console.WriteLine("Note: AuthService is using an empty BackendClientSecret.");
             }
+            HttpResponseMessage response = await _httpClient.SendAsync(request);
+            await _exceptionHandler.EnsureSuccessStatusCode(response);
 
-            throw new SecurityException("The Auth0 access token is invalid.");
+            string responseJson = await response.Content.ReadAsStringAsync();
+            var responseObj = JObject.Parse(responseJson);
+            _accessToken = (string)responseObj["access_token"];
+            return (_accessToken, true);
         }
-
-        private async Task<(string AccessToken, bool Refreshed)> GetAccessTokenAsync()
+        finally
         {
-            await _lock.WaitAsync();
-            try
-            {
-                if (!IsAccessTokenExpired())
-                    return (_accessToken, false);
-
-                using (var request = new HttpRequestMessage(HttpMethod.Post, "oauth/token"))
-                {
-                    AuthOptions options = _authOptions.Value;
-                    var requestObj = new JObject(
-                        new JProperty("grant_type", "client_credentials"),
-                        new JProperty("client_id", options.BackendClientId),
-                        new JProperty("client_secret", options.BackendClientSecret),
-                        new JProperty("audience", _authOptions.Value.ManagementAudience)
-                    );
-                    request.Content = new StringContent(requestObj.ToString(), Encoding.UTF8, "application/json");
-                    if (string.IsNullOrEmpty(options.BackendClientSecret))
-                    {
-                        Console.WriteLine("Note: AuthService is using an empty BackendClientSecret.");
-                    }
-                    HttpResponseMessage response = await _httpClient.SendAsync(request);
-                    await _exceptionHandler.EnsureSuccessStatusCode(response);
-
-                    string responseJson = await response.Content.ReadAsStringAsync();
-                    var responseObj = JObject.Parse(responseJson);
-                    _accessToken = (string)responseObj["access_token"];
-                    return (_accessToken, true);
-                }
-            }
-            finally
-            {
-                _lock.Release();
-            }
-        }
-
-        private bool IsAccessTokenExpired()
-        {
-            if (_accessToken == null)
-                return true;
-            var accessToken = new JwtSecurityToken(_accessToken);
-            var now = DateTime.UtcNow;
-            return now < accessToken.ValidFrom || now > accessToken.ValidTo;
-        }
-
-        protected override void DisposeManagedResources()
-        {
-            _httpClient.Dispose();
+            _lock.Release();
         }
     }
+
+    private bool IsAccessTokenExpired()
+    {
+        if (_accessToken == null)
+            return true;
+        var accessToken = new JwtSecurityToken(_accessToken);
+        var now = DateTime.UtcNow;
+        return now < accessToken.ValidFrom || now > accessToken.ValidTo;
+    }
+
+    protected override void DisposeManagedResources() => _httpClient.Dispose();
 }

--- a/src/SIL.XForge/Services/AuthServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Services/AuthServiceCollectionExtensions.cs
@@ -11,86 +11,80 @@ using SIL.XForge;
 using SIL.XForge.Configuration;
 using SIL.XForge.Services;
 
-namespace Microsoft.Extensions.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class AuthServiceCollectionExtensions
 {
-    public static class AuthServiceCollectionExtensions
+    public static IServiceCollection AddXFAuthentication(this IServiceCollection services, IConfiguration configuration)
     {
-        public static IServiceCollection AddXFAuthentication(
-            this IServiceCollection services,
-            IConfiguration configuration
-        )
-        {
-            var authOptions = configuration.GetOptions<AuthOptions>();
-            services
-                .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-                .AddJwtBearer(options =>
+        var authOptions = configuration.GetOptions<AuthOptions>();
+        services
+            .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options =>
+            {
+                options.Authority = $"https://{authOptions.Domain}/";
+                options.Audience = authOptions.Audience;
+                options.Events = new JwtBearerEvents
                 {
-                    options.Authority = $"https://{authOptions.Domain}/";
-                    options.Audience = authOptions.Audience;
-                    options.Events = new JwtBearerEvents
+                    OnMessageReceived = context =>
                     {
-                        OnMessageReceived = context =>
-                        {
-                            // If the request is for our SignalR hub
-                            string? accessToken = context.Request.Query["access_token"];
-                            if (
-                                !string.IsNullOrEmpty(accessToken)
-                                && context.HttpContext.Request.Path.StartsWithSegments(
-                                    $"/{UrlConstants.ProjectNotifications}"
-                                )
+                        // If the request is for our SignalR hub
+                        string? accessToken = context.Request.Query["access_token"];
+                        if (
+                            !string.IsNullOrEmpty(accessToken)
+                            && context.HttpContext.Request.Path.StartsWithSegments(
+                                $"/{UrlConstants.ProjectNotifications}"
                             )
-                            {
-                                // Get the token from the query string
-                                context.Token = accessToken;
-                            }
-
-                            return Task.CompletedTask;
-                        },
-                        OnTokenValidated = context =>
+                        )
                         {
-                            string scopeClaim = context.Principal.FindFirst(c => c.Type == JwtClaimTypes.Scope)?.Value;
-                            var scopes = new HashSet<string>(scopeClaim?.Split(' ') ?? Enumerable.Empty<string>());
-                            if (!scopes.Contains(authOptions.Scope))
-                                context.Fail("A required scope has not been granted.");
-                            return Task.CompletedTask;
+                            // Get the token from the query string
+                            context.Token = accessToken;
                         }
-                    };
-                })
-                .AddBasic(options =>
-                {
-                    options.Events = new BasicAuthenticationEvents
+
+                        return Task.CompletedTask;
+                    },
+                    OnTokenValidated = context =>
                     {
-                        OnValidateCredentials = context =>
+                        string scopeClaim = context.Principal.FindFirst(c => c.Type == JwtClaimTypes.Scope)?.Value;
+                        var scopes = new HashSet<string>(scopeClaim?.Split(' ') ?? Enumerable.Empty<string>());
+                        if (!scopes.Contains(authOptions.Scope))
+                            context.Fail("A required scope has not been granted.");
+                        return Task.CompletedTask;
+                    }
+                };
+            })
+            .AddBasic(options =>
+            {
+                options.Events = new BasicAuthenticationEvents
+                {
+                    OnValidateCredentials = context =>
+                    {
+                        var authService = context.HttpContext.RequestServices.GetService<IAuthService>();
+                        if (authService.ValidateWebhookCredentials(context.Username, context.Password))
                         {
-                            var authService = context.HttpContext.RequestServices.GetService<IAuthService>();
-                            if (authService.ValidateWebhookCredentials(context.Username, context.Password))
+                            Claim[] claims = new[]
                             {
-                                Claim[] claims = new[]
-                                {
-                                    new Claim(
-                                        ClaimTypes.NameIdentifier,
-                                        context.Username,
-                                        ClaimValueTypes.String,
-                                        context.Options.ClaimsIssuer
-                                    ),
-                                    new Claim(
-                                        ClaimTypes.Name,
-                                        context.Username,
-                                        ClaimValueTypes.String,
-                                        context.Options.ClaimsIssuer
-                                    )
-                                };
+                                new Claim(
+                                    ClaimTypes.NameIdentifier,
+                                    context.Username,
+                                    ClaimValueTypes.String,
+                                    context.Options.ClaimsIssuer
+                                ),
+                                new Claim(
+                                    ClaimTypes.Name,
+                                    context.Username,
+                                    ClaimValueTypes.String,
+                                    context.Options.ClaimsIssuer
+                                )
+                            };
 
-                                context.Principal = new ClaimsPrincipal(
-                                    new ClaimsIdentity(claims, context.Scheme.Name)
-                                );
-                                context.Success();
-                            }
-                            return Task.CompletedTask;
+                            context.Principal = new ClaimsPrincipal(new ClaimsIdentity(claims, context.Scheme.Name));
+                            context.Success();
                         }
-                    };
-                });
-            return services;
-        }
+                        return Task.CompletedTask;
+                    }
+                };
+            });
+        return services;
     }
 }

--- a/src/SIL.XForge/Services/CommonServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Services/CommonServiceCollectionExtensions.cs
@@ -1,23 +1,22 @@
 using SIL.XForge.Services;
 
-namespace Microsoft.Extensions.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class CommonServiceCollectionExtensions
 {
-    public static class CommonServiceCollectionExtensions
+    /// <summary>
+    /// Adds miscellaneous services that are common to all xForge applications to the DI container.
+    /// </summary>
+    public static IServiceCollection AddCommonServices(this IServiceCollection services)
     {
-        /// <summary>
-        /// Adds miscellaneous services that are common to all xForge applications to the DI container.
-        /// </summary>
-        public static IServiceCollection AddCommonServices(this IServiceCollection services)
-        {
-            services.AddScoped<IUserAccessor, UserAccessor>();
-            services.AddScoped<IHttpRequestAccessor, HttpRequestAccessor>();
-            services.AddTransient<IEmailService, EmailService>();
-            services.AddTransient<IFileSystemService, FileSystemService>();
-            services.AddSingleton<IAuthService, AuthService>();
-            services.AddSingleton<IUserService, UserService>();
-            services.AddSingleton<ISecurityService, SecurityService>();
-            services.AddSingleton<IAudioService, AudioService>();
-            return services;
-        }
+        services.AddScoped<IUserAccessor, UserAccessor>();
+        services.AddScoped<IHttpRequestAccessor, HttpRequestAccessor>();
+        services.AddTransient<IEmailService, EmailService>();
+        services.AddTransient<IFileSystemService, FileSystemService>();
+        services.AddSingleton<IAuthService, AuthService>();
+        services.AddSingleton<IUserService, UserService>();
+        services.AddSingleton<ISecurityService, SecurityService>();
+        services.AddSingleton<IAudioService, AudioService>();
+        return services;
     }
 }

--- a/src/SIL.XForge/Services/DataNotFoundException.cs
+++ b/src/SIL.XForge/Services/DataNotFoundException.cs
@@ -1,9 +1,9 @@
 using System;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+public class DataNotFoundException : Exception
 {
-    public class DataNotFoundException : Exception
-    {
-        public DataNotFoundException(string message) : base(message) { }
-    }
+    public DataNotFoundException(string message)
+        : base(message) { }
 }

--- a/src/SIL.XForge/Services/EmailService.cs
+++ b/src/SIL.XForge/Services/EmailService.cs
@@ -7,44 +7,43 @@ using Microsoft.Extensions.Options;
 using MimeKit;
 using SIL.XForge.Configuration;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+public class EmailService : IEmailService
 {
-    public class EmailService : IEmailService
+    private readonly IOptions<SiteOptions> _options;
+    private readonly ILogger<EmailService> _logger;
+
+    public EmailService(IOptions<SiteOptions> options, ILogger<EmailService> logger)
     {
-        private readonly IOptions<SiteOptions> _options;
-        private readonly ILogger<EmailService> _logger;
+        _options = options;
+        _logger = logger;
+    }
 
-        public EmailService(IOptions<SiteOptions> options, ILogger<EmailService> logger)
+    public async Task SendEmailAsync(string email, string subject, string body)
+    {
+        SiteOptions siteOptions = _options.Value;
+        string fromAddress = siteOptions.EmailFromAddress;
+        string title = siteOptions.Name;
+        using var mimeMessage = new MimeMessage();
+        mimeMessage.From.Add(new MailboxAddress(title, fromAddress));
+        mimeMessage.To.Add(new MailboxAddress("", email));
+        mimeMessage.Subject = subject;
+
+        var bodyBuilder = new BodyBuilder { HtmlBody = body };
+        mimeMessage.Body = bodyBuilder.ToMessageBody();
+
+        if (siteOptions.SendEmail)
         {
-            _options = options;
-            _logger = logger;
+            using var client = new SmtpClient();
+            await client.ConnectAsync(
+                siteOptions.SmtpServer,
+                Convert.ToInt32(siteOptions.PortNumber),
+                SecureSocketOptions.None
+            );
+            await client.SendAsync(mimeMessage);
+            await client.DisconnectAsync(true);
         }
-
-        public async Task SendEmailAsync(string email, string subject, string body)
-        {
-            SiteOptions siteOptions = _options.Value;
-            string fromAddress = siteOptions.EmailFromAddress;
-            string title = siteOptions.Name;
-            using var mimeMessage = new MimeMessage();
-            mimeMessage.From.Add(new MailboxAddress(title, fromAddress));
-            mimeMessage.To.Add(new MailboxAddress("", email));
-            mimeMessage.Subject = subject;
-
-            var bodyBuilder = new BodyBuilder { HtmlBody = body };
-            mimeMessage.Body = bodyBuilder.ToMessageBody();
-
-            if (siteOptions.SendEmail)
-            {
-                using var client = new SmtpClient();
-                await client.ConnectAsync(
-                    siteOptions.SmtpServer,
-                    Convert.ToInt32(siteOptions.PortNumber),
-                    SecureSocketOptions.None
-                );
-                await client.SendAsync(mimeMessage);
-                await client.DisconnectAsync(true);
-            }
-            _logger.LogInformation("Email Sent\n{0}", mimeMessage.ToString());
-        }
+        _logger.LogInformation("Email Sent\n{0}", mimeMessage.ToString());
     }
 }

--- a/src/SIL.XForge/Services/FileSystemService.cs
+++ b/src/SIL.XForge/Services/FileSystemService.cs
@@ -1,68 +1,33 @@
 using System.Collections.Generic;
 using System.IO;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+public class FileSystemService : IFileSystemService
 {
-    public class FileSystemService : IFileSystemService
-    {
-        public Stream CreateFile(string path)
-        {
-            return File.Create(path);
-        }
+    public Stream CreateFile(string path) => File.Create(path);
 
-        public bool FileExists(string path)
-        {
-            return File.Exists(path);
-        }
+    public bool FileExists(string path) => File.Exists(path);
 
-        public Stream OpenFile(string path, FileMode mode)
-        {
-            return File.Open(path, mode);
-        }
+    public Stream OpenFile(string path, FileMode mode) => File.Open(path, mode);
 
-        public string FileReadText(string path)
-        {
-            return File.ReadAllText(path);
-        }
+    public string FileReadText(string path) => File.ReadAllText(path);
 
-        public void DeleteFile(string path)
-        {
-            File.Delete(path);
-        }
+    public void DeleteFile(string path) => File.Delete(path);
 
-        public void CreateDirectory(string path)
-        {
-            Directory.CreateDirectory(path);
-        }
+    public void CreateDirectory(string path) => Directory.CreateDirectory(path);
 
-        public bool DirectoryExists(string path)
-        {
-            return Directory.Exists(path);
-        }
+    public bool DirectoryExists(string path) => Directory.Exists(path);
 
-        public void MoveDirectory(string sourceDirPath, string targetDirPath)
-        {
-            Directory.Move(sourceDirPath, targetDirPath);
-        }
+    public void MoveDirectory(string sourceDirPath, string targetDirPath) =>
+        Directory.Move(sourceDirPath, targetDirPath);
 
-        public void MoveFile(string sourceFilePath, string targetFilePath)
-        {
-            File.Move(sourceFilePath, targetFilePath);
-        }
+    public void MoveFile(string sourceFilePath, string targetFilePath) => File.Move(sourceFilePath, targetFilePath);
 
-        public void DeleteDirectory(string path)
-        {
-            Directory.Delete(path, true);
-        }
+    public void DeleteDirectory(string path) => Directory.Delete(path, true);
 
-        public IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*")
-        {
-            return Directory.EnumerateFiles(path, searchPattern);
-        }
+    public IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*") =>
+        Directory.EnumerateFiles(path, searchPattern);
 
-        public IEnumerable<string> EnumerateDirectories(string path)
-        {
-            return Directory.EnumerateDirectories(path);
-        }
-    }
+    public IEnumerable<string> EnumerateDirectories(string path) => Directory.EnumerateDirectories(path);
 }

--- a/src/SIL.XForge/Services/ForbiddenException.cs
+++ b/src/SIL.XForge/Services/ForbiddenException.cs
@@ -1,12 +1,12 @@
 using System;
 
-namespace SIL.XForge.Services
-{
-    public class ForbiddenException : Exception
-    {
-        public ForbiddenException() : base("The user does not have permission to perform this operation.") { }
+namespace SIL.XForge.Services;
 
-        public ForbiddenException(string message)
-            : base($"The user does not have permission to perform this operation. {message}") { }
-    }
+public class ForbiddenException : Exception
+{
+    public ForbiddenException()
+        : base("The user does not have permission to perform this operation.") { }
+
+    public ForbiddenException(string message)
+        : base($"The user does not have permission to perform this operation. {message}") { }
 }

--- a/src/SIL.XForge/Services/HttpRequestAccessor.cs
+++ b/src/SIL.XForge/Services/HttpRequestAccessor.cs
@@ -1,18 +1,14 @@
 using Microsoft.AspNetCore.Http;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+public class HttpRequestAccessor : IHttpRequestAccessor
 {
-    public class HttpRequestAccessor : IHttpRequestAccessor
-    {
-        private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public HttpRequestAccessor(IHttpContextAccessor httpContextAccessor)
-        {
-            _httpContextAccessor = httpContextAccessor;
-        }
+    public HttpRequestAccessor(IHttpContextAccessor httpContextAccessor) => _httpContextAccessor = httpContextAccessor;
 
-        public PathString Path => _httpContextAccessor.HttpContext.Request.Path;
+    public PathString Path => _httpContextAccessor.HttpContext.Request.Path;
 
-        public HostString Host => _httpContextAccessor.HttpContext.Request.Host;
-    }
+    public HostString Host => _httpContextAccessor.HttpContext.Request.Host;
 }

--- a/src/SIL.XForge/Services/IAudioService.cs
+++ b/src/SIL.XForge/Services/IAudioService.cs
@@ -1,9 +1,8 @@
 using System.Threading.Tasks;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+public interface IAudioService
 {
-    public interface IAudioService
-    {
-        Task ConvertToMp3Async(string inputPath, string outputPath);
-    }
+    Task ConvertToMp3Async(string inputPath, string outputPath);
 }

--- a/src/SIL.XForge/Services/IAuthService.cs
+++ b/src/SIL.XForge/Services/IAuthService.cs
@@ -1,13 +1,12 @@
 using System.Threading.Tasks;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+public interface IAuthService
 {
-    public interface IAuthService
-    {
-        bool ValidateWebhookCredentials(string username, string password);
-        Task<string> GetUserAsync(string authId);
-        Task LinkAccounts(string primaryAuthId, string secondaryAuthId);
-        Task UpdateAvatar(string authId, string url);
-        Task UpdateInterfaceLanguage(string authId, string language);
-    }
+    bool ValidateWebhookCredentials(string username, string password);
+    Task<string> GetUserAsync(string authId);
+    Task LinkAccounts(string primaryAuthId, string secondaryAuthId);
+    Task UpdateAvatar(string authId, string url);
+    Task UpdateInterfaceLanguage(string authId, string language);
 }

--- a/src/SIL.XForge/Services/IEmailService.cs
+++ b/src/SIL.XForge/Services/IEmailService.cs
@@ -1,9 +1,8 @@
 using System.Threading.Tasks;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+public interface IEmailService
 {
-    public interface IEmailService
-    {
-        Task SendEmailAsync(string email, string subject, string body);
-    }
+    Task SendEmailAsync(string email, string subject, string body);
 }

--- a/src/SIL.XForge/Services/IFileSystemService.cs
+++ b/src/SIL.XForge/Services/IFileSystemService.cs
@@ -1,21 +1,20 @@
 using System.Collections.Generic;
 using System.IO;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+public interface IFileSystemService
 {
-    public interface IFileSystemService
-    {
-        Stream CreateFile(string path);
-        bool FileExists(string path);
-        Stream OpenFile(string path, FileMode mode);
-        string FileReadText(string path);
-        void DeleteFile(string path);
-        void CreateDirectory(string path);
-        bool DirectoryExists(string path);
-        void DeleteDirectory(string path);
-        void MoveDirectory(string sourceDirPath, string targetDirPath);
-        void MoveFile(string sourceFilePath, string targetFilePath);
-        IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*");
-        IEnumerable<string> EnumerateDirectories(string path);
-    }
+    Stream CreateFile(string path);
+    bool FileExists(string path);
+    Stream OpenFile(string path, FileMode mode);
+    string FileReadText(string path);
+    void DeleteFile(string path);
+    void CreateDirectory(string path);
+    bool DirectoryExists(string path);
+    void DeleteDirectory(string path);
+    void MoveDirectory(string sourceDirPath, string targetDirPath);
+    void MoveFile(string sourceFilePath, string targetFilePath);
+    IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*");
+    IEnumerable<string> EnumerateDirectories(string path);
 }

--- a/src/SIL.XForge/Services/IHttpRequestAccessor.cs
+++ b/src/SIL.XForge/Services/IHttpRequestAccessor.cs
@@ -1,10 +1,9 @@
 using Microsoft.AspNetCore.Http;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+public interface IHttpRequestAccessor
 {
-    public interface IHttpRequestAccessor
-    {
-        PathString Path { get; }
-        HostString Host { get; }
-    }
+    PathString Path { get; }
+    HostString Host { get; }
 }

--- a/src/SIL.XForge/Services/IProjectService.cs
+++ b/src/SIL.XForge/Services/IProjectService.cs
@@ -2,25 +2,18 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+public interface IProjectService
 {
-    public interface IProjectService
-    {
-        Task AddUserAsync(string curUserId, string projectId, string projectRole = null);
-        Task RemoveUserAsync(string curUserId, string projectId, string projectUserId);
-        Task RemoveUserWithoutPermissionsCheckAsync(string curUserId, string projectId, string projectUserId);
-        Task<string> GetProjectRoleAsync(string curUserId, string projectId);
-        Task UpdateRoleAsync(string curUserId, string systemRole, string projectId, string projectRole);
-        Task<Uri> SaveAudioAsync(
-            string curUserId,
-            string projectId,
-            string dataId,
-            string extension,
-            Stream inputStream
-        );
-        Task DeleteAudioAsync(string curUserId, string projectId, string ownerId, string dataId);
-        Task SetSyncDisabledAsync(string curUserId, string systemRole, string projectId, bool isDisabled);
-        Task RemoveUserFromAllProjectsAsync(string curUserId, string projectUserId);
-        Task SetUserProjectPermissions(string curUserId, string projectId, string userId, string[] permissions);
-    }
+    Task AddUserAsync(string curUserId, string projectId, string projectRole = null);
+    Task RemoveUserAsync(string curUserId, string projectId, string projectUserId);
+    Task RemoveUserWithoutPermissionsCheckAsync(string curUserId, string projectId, string projectUserId);
+    Task<string> GetProjectRoleAsync(string curUserId, string projectId);
+    Task UpdateRoleAsync(string curUserId, string systemRole, string projectId, string projectRole);
+    Task<Uri> SaveAudioAsync(string curUserId, string projectId, string dataId, string extension, Stream inputStream);
+    Task DeleteAudioAsync(string curUserId, string projectId, string ownerId, string dataId);
+    Task SetSyncDisabledAsync(string curUserId, string systemRole, string projectId, bool isDisabled);
+    Task RemoveUserFromAllProjectsAsync(string curUserId, string projectUserId);
+    Task SetUserProjectPermissions(string curUserId, string projectId, string userId, string[] permissions);
 }

--- a/src/SIL.XForge/Services/ISecurityService.cs
+++ b/src/SIL.XForge/Services/ISecurityService.cs
@@ -1,7 +1,6 @@
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+public interface ISecurityService
 {
-    public interface ISecurityService
-    {
-        string GenerateKey();
-    }
+    string GenerateKey();
 }

--- a/src/SIL.XForge/Services/IUserAccessor.cs
+++ b/src/SIL.XForge/Services/IUserAccessor.cs
@@ -1,11 +1,10 @@
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+public interface IUserAccessor
 {
-    public interface IUserAccessor
-    {
-        bool IsAuthenticated { get; }
-        string UserId { get; }
-        string SystemRole { get; }
-        string Name { get; }
-        string AuthId { get; }
-    }
+    bool IsAuthenticated { get; }
+    string UserId { get; }
+    string SystemRole { get; }
+    string Name { get; }
+    string AuthId { get; }
 }

--- a/src/SIL.XForge/Services/IUserService.cs
+++ b/src/SIL.XForge/Services/IUserService.cs
@@ -1,14 +1,13 @@
 using System.Threading.Tasks;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+public interface IUserService
 {
-    public interface IUserService
-    {
-        Task UpdateUserFromProfileAsync(string curUserId, string userProfileJson);
-        Task LinkParatextAccountAsync(string primaryAuthId, string secondaryAuthId);
-        Task<string> GetUsernameFromUserId(string curUserId, string userId);
-        Task UpdateAvatarFromDisplayNameAsync(string curUserId, string authId);
-        Task UpdateInterfaceLanguageAsync(string curUserId, string authId, string language);
-        Task DeleteAsync(string curUserId, string systemRole, string userId);
-    }
+    Task UpdateUserFromProfileAsync(string curUserId, string userProfileJson);
+    Task LinkParatextAccountAsync(string primaryAuthId, string secondaryAuthId);
+    Task<string> GetUsernameFromUserId(string curUserId, string userId);
+    Task UpdateAvatarFromDisplayNameAsync(string curUserId, string authId);
+    Task UpdateInterfaceLanguageAsync(string curUserId, string authId, string language);
+    Task DeleteAsync(string curUserId, string systemRole, string userId);
 }

--- a/src/SIL.XForge/Services/JsonRpcApplicationBuilderExtensions.cs
+++ b/src/SIL.XForge/Services/JsonRpcApplicationBuilderExtensions.cs
@@ -6,48 +6,46 @@ using Microsoft.Extensions.DependencyInjection;
 using SIL.XForge;
 using SIL.XForge.Controllers;
 
-namespace Microsoft.AspNetCore.Builder
-{
-    public static class JsonRpcApplicationBuilderExtensions
-    {
-        public static void UseXFJsonRpc(this IApplicationBuilder app, Action<RpcEndpointBuilder> configureOptions)
-        {
-            app.Map(
-                $"/{UrlConstants.CommandApiNamespace}",
-                b =>
-                {
-                    // add a custom middleware that authenticates all schemes.
-                    // Workaround for the lack of support of multiple authentication schemes in EdjCase.JsonRpc.
-                    b.Use(
-                        async (context, next) =>
-                        {
-                            var authSchemeProvider =
-                                context.RequestServices.GetService<IAuthenticationSchemeProvider>();
-                            ClaimsPrincipal principal = null;
-                            foreach (AuthenticationScheme scheme in await authSchemeProvider.GetAllSchemesAsync())
-                            {
-                                AuthenticateResult result = await context.AuthenticateAsync(scheme.Name);
-                                if (result.Succeeded)
-                                {
-                                    if (principal == null)
-                                        principal = result.Principal;
-                                    else
-                                        principal.AddIdentities(result.Principal.Identities);
-                                }
-                            }
-                            if (principal != null)
-                                context.User = principal;
-                            await next();
-                        }
-                    );
+namespace Microsoft.AspNetCore.Builder;
 
-                    b.UseJsonRpc(options =>
+public static class JsonRpcApplicationBuilderExtensions
+{
+    public static void UseXFJsonRpc(this IApplicationBuilder app, Action<RpcEndpointBuilder> configureOptions)
+    {
+        app.Map(
+            $"/{UrlConstants.CommandApiNamespace}",
+            b =>
+            {
+                // add a custom middleware that authenticates all schemes.
+                // Workaround for the lack of support of multiple authentication schemes in EdjCase.JsonRpc.
+                b.Use(
+                    async (context, next) =>
                     {
-                        options.AddControllerWithCustomPath<UsersRpcController>(UrlConstants.Users);
-                        configureOptions(options);
-                    });
-                }
-            );
-        }
+                        var authSchemeProvider = context.RequestServices.GetService<IAuthenticationSchemeProvider>();
+                        ClaimsPrincipal principal = null;
+                        foreach (AuthenticationScheme scheme in await authSchemeProvider.GetAllSchemesAsync())
+                        {
+                            AuthenticateResult result = await context.AuthenticateAsync(scheme.Name);
+                            if (result.Succeeded)
+                            {
+                                if (principal == null)
+                                    principal = result.Principal;
+                                else
+                                    principal.AddIdentities(result.Principal.Identities);
+                            }
+                        }
+                        if (principal != null)
+                            context.User = principal;
+                        await next();
+                    }
+                );
+
+                b.UseJsonRpc(options =>
+                {
+                    options.AddControllerWithCustomPath<UsersRpcController>(UrlConstants.Users);
+                    configureOptions(options);
+                });
+            }
+        );
     }
 }

--- a/src/SIL.XForge/Services/JsonRpcServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Services/JsonRpcServiceCollectionExtensions.cs
@@ -5,33 +5,32 @@ using EdjCase.JsonRpc.Router;
 using Microsoft.AspNetCore.Builder;
 using SIL.XForge;
 
-namespace Microsoft.Extensions.DependencyInjection
-{
-    public static class JsonRpcServiceCollectionExtensions
-    {
-        public static IServiceCollection AddXFJsonRpc(this IServiceCollection services)
-        {
-            services.AddJsonRpc(config =>
-            {
-                config.JsonSerializerSettings = new JsonSerializerOptions
-                {
-                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-                };
+namespace Microsoft.Extensions.DependencyInjection;
 
-                config.OnInvokeException = context =>
-                {
-                    var exceptionHandler = context.ServiceProvider.GetService<IExceptionHandler>();
-                    exceptionHandler.ReportException(context.Exception);
-                    var rpcException = new RpcException(
-                        (int)RpcErrorCode.InternalError,
-                        "Exception occurred from target method execution.",
-                        context.Exception
-                    );
-                    return OnExceptionResult.UseExceptionResponse(rpcException);
-                };
-            });
-            return services;
-        }
+public static class JsonRpcServiceCollectionExtensions
+{
+    public static IServiceCollection AddXFJsonRpc(this IServiceCollection services)
+    {
+        services.AddJsonRpc(config =>
+        {
+            config.JsonSerializerSettings = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            };
+
+            config.OnInvokeException = context =>
+            {
+                var exceptionHandler = context.ServiceProvider.GetService<IExceptionHandler>();
+                exceptionHandler.ReportException(context.Exception);
+                var rpcException = new RpcException(
+                    (int)RpcErrorCode.InternalError,
+                    "Exception occurred from target method execution.",
+                    context.Exception
+                );
+                return OnExceptionResult.UseExceptionResponse(rpcException);
+            };
+        });
+        return services;
     }
 }

--- a/src/SIL.XForge/Services/PingApplicationBuilderExtensions.cs
+++ b/src/SIL.XForge/Services/PingApplicationBuilderExtensions.cs
@@ -2,29 +2,28 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Headers;
 using Microsoft.Net.Http.Headers;
 
-namespace Microsoft.AspNetCore.Builder
+namespace Microsoft.AspNetCore.Builder;
+
+public static class PingApplicationBuilderExtensions
 {
-    public static class PingApplicationBuilderExtensions
+    public static void UsePing(this IApplicationBuilder app)
     {
-        public static void UsePing(this IApplicationBuilder app)
-        {
-            app.Map(
-                "/ping",
-                ping =>
-                    ping.Run(async context =>
+        app.Map(
+            "/ping",
+            ping =>
+                ping.Run(async context =>
+                {
+                    ResponseHeaders headers = context.Response.GetTypedHeaders();
+                    headers.CacheControl = new CacheControlHeaderValue
                     {
-                        ResponseHeaders headers = context.Response.GetTypedHeaders();
-                        headers.CacheControl = new CacheControlHeaderValue
-                        {
-                            NoCache = true,
-                            NoStore = true,
-                            MustRevalidate = true
-                        };
-                        headers.Set(HeaderNames.Pragma, "no-cache");
-                        headers.Set(HeaderNames.Expires, "0");
-                        await context.Response.WriteAsync("ok");
-                    })
-            );
-        }
+                        NoCache = true,
+                        NoStore = true,
+                        MustRevalidate = true
+                    };
+                    headers.Set(HeaderNames.Pragma, "no-cache");
+                    headers.Set(HeaderNames.Expires, "0");
+                    await context.Response.WriteAsync("ok");
+                })
+        );
     }
 }

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -11,355 +11,318 @@ using SIL.XForge.Realtime;
 using SIL.XForge.Realtime.Json0;
 using SIL.XForge.Utils;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+/// <summary>
+/// This class contains the common functionality for managing xForge projects.
+/// </summary>
+public abstract class ProjectService<TModel, TSecret> : IProjectService
+    where TModel : Project, new()
+    where TSecret : ProjectSecret
 {
-    /// <summary>
-    /// This class contains the common functionality for managing xForge projects.
-    /// </summary>
-    public abstract class ProjectService<TModel, TSecret> : IProjectService
-        where TModel : Project, new()
-        where TSecret : ProjectSecret
+    private readonly IAudioService _audioService;
+
+    public ProjectService(
+        IRealtimeService realtimeService,
+        IOptions<SiteOptions> siteOptions,
+        IAudioService audioService,
+        IRepository<TSecret> projectSecrets,
+        IFileSystemService fileSystemService
+    )
     {
-        private readonly IAudioService _audioService;
+        RealtimeService = realtimeService;
+        SiteOptions = siteOptions;
+        _audioService = audioService;
+        ProjectSecrets = projectSecrets;
+        FileSystemService = fileSystemService;
+    }
 
-        public ProjectService(
-            IRealtimeService realtimeService,
-            IOptions<SiteOptions> siteOptions,
-            IAudioService audioService,
-            IRepository<TSecret> projectSecrets,
-            IFileSystemService fileSystemService
-        )
+    protected IRealtimeService RealtimeService { get; }
+    protected IOptions<SiteOptions> SiteOptions { get; }
+    protected IRepository<TSecret> ProjectSecrets { get; }
+    protected IFileSystemService FileSystemService { get; }
+    protected abstract string ProjectAdminRole { get; }
+
+    public async Task AddUserAsync(string curUserId, string projectId, string projectRole)
+    {
+        await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
+        IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
+
+        IDocument<User> userDoc = await GetUserDocAsync(curUserId, conn);
+
+        if (userDoc.Data.Role != SystemRole.SystemAdmin || projectRole == null)
         {
-            RealtimeService = realtimeService;
-            SiteOptions = siteOptions;
-            _audioService = audioService;
-            ProjectSecrets = projectSecrets;
-            FileSystemService = fileSystemService;
+            Attempt<string> attempt = await TryGetProjectRoleAsync(projectDoc.Data, curUserId);
+            if (!attempt.TryResult(out projectRole))
+                throw new ForbiddenException();
         }
 
-        protected IRealtimeService RealtimeService { get; }
-        protected IOptions<SiteOptions> SiteOptions { get; }
-        protected IRepository<TSecret> ProjectSecrets { get; }
-        protected IFileSystemService FileSystemService { get; }
-        protected abstract string ProjectAdminRole { get; }
+        await AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole);
+    }
 
-        public async Task AddUserAsync(string curUserId, string projectId, string projectRole)
+    /// <summary>
+    /// Disassociate user projectUserId from project projectId, if curUserId is allowed to cause that.
+    /// </summary>
+    public async Task RemoveUserAsync(string curUserId, string projectId, string projectUserId)
+    {
+        if (curUserId == null || projectId == null || projectUserId == null)
         {
-            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
-            {
-                IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
-
-                IDocument<User> userDoc = await GetUserDocAsync(curUserId, conn);
-
-                if (userDoc.Data.Role != SystemRole.SystemAdmin || projectRole == null)
-                {
-                    Attempt<string> attempt = await TryGetProjectRoleAsync(projectDoc.Data, curUserId);
-                    if (!attempt.TryResult(out projectRole))
-                        throw new ForbiddenException();
-                }
-
-                await AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole);
-            }
+            throw new ArgumentNullException();
         }
+        await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
+        IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
 
-        /// <summary>
-        /// Disassociate user projectUserId from project projectId, if curUserId is allowed to cause that.
-        /// </summary>
-        public async Task RemoveUserAsync(string curUserId, string projectId, string projectUserId)
+        if (curUserId != projectUserId && !IsProjectAdmin(projectDoc.Data, curUserId))
+            throw new ForbiddenException();
+        await RemoveUserCoreAsync(conn, curUserId, projectId, projectUserId);
+    }
+
+    /// <summary>
+    /// Disassociate user projectUserId from project projectId. No permissions check is performed.
+    /// </summary>
+    public async Task RemoveUserWithoutPermissionsCheckAsync(string curUserId, string projectId, string projectUserId)
+    {
+        if (curUserId == null || projectId == null || projectUserId == null)
         {
-            if (curUserId == null || projectId == null || projectUserId == null)
-            {
-                throw new ArgumentNullException();
-            }
-            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
-            {
-                IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
-
-                if (curUserId != projectUserId && !IsProjectAdmin(projectDoc.Data, curUserId))
-                    throw new ForbiddenException();
-                await RemoveUserCoreAsync(conn, curUserId, projectId, projectUserId);
-            }
+            throw new ArgumentNullException();
         }
+        await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
+        await RemoveUserCoreAsync(conn, curUserId, projectId, projectUserId);
+    }
 
-        /// <summary>
-        /// Disassociate user projectUserId from project projectId. No permissions check is performed.
-        /// </summary>
-        public async Task RemoveUserWithoutPermissionsCheckAsync(
-            string curUserId,
-            string projectId,
-            string projectUserId
-        )
+    /// <summary>
+    /// Disassociate user projectUserId from project projectId, without checking permissions.
+    /// </summary>
+    private async Task RemoveUserCoreAsync(IConnection conn, string curUserId, string projectId, string projectUserId)
+    {
+        if (curUserId == null || projectId == null || projectUserId == null)
         {
-            if (curUserId == null || projectId == null || projectUserId == null)
-            {
-                throw new ArgumentNullException();
-            }
-            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
-            {
-                await RemoveUserCoreAsync(conn, curUserId, projectId, projectUserId);
-            }
+            throw new ArgumentNullException();
         }
+        IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
+        IDocument<User> userDoc = await GetUserDocAsync(projectUserId, conn);
+        await RemoveUserFromProjectAsync(conn, projectDoc, userDoc);
+    }
 
-        /// <summary>
-        /// Disassociate user projectUserId from project projectId, without checking permissions.
-        /// </summary>
-        private async Task RemoveUserCoreAsync(
-            IConnection conn,
-            string curUserId,
-            string projectId,
-            string projectUserId
-        )
+    /// <summary>
+    /// Disassociate user projectUserId from all projects on the site that this ProjectService is operating on.
+    /// As requested by curUserId. Permissions to do so are not checked.
+    /// </summary>
+    public async Task RemoveUserFromAllProjectsAsync(string curUserId, string projectUserId)
+    {
+        if (curUserId == null || projectUserId == null)
         {
-            if (curUserId == null || projectId == null || projectUserId == null)
-            {
-                throw new ArgumentNullException();
-            }
-            IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
-            IDocument<User> userDoc = await GetUserDocAsync(projectUserId, conn);
-            await RemoveUserFromProjectAsync(conn, projectDoc, userDoc);
+            throw new ArgumentNullException();
         }
-
-        /// <summary>
-        /// Disassociate user projectUserId from all projects on the site that this ProjectService is operating on.
-        /// As requested by curUserId. Permissions to do so are not checked.
-        /// </summary>
-        public async Task RemoveUserFromAllProjectsAsync(string curUserId, string projectUserId)
+        await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
+        IDocument<User> userDoc = await GetUserDocAsync(projectUserId, conn);
+        IEnumerable<Task> removalTasks = userDoc.Data.Sites[SiteOptions.Value.Id].Projects.Select(
+            (string projectId) => RemoveUserCoreAsync(conn, curUserId, projectId, projectUserId)
+        );
+        // The removals can be processed in parallel in production, but for unit tests, MemoryRealtimeService
+        // does not fully implement concurrent editing of docs, so run them in a sequence.
+        foreach (Task task in removalTasks)
         {
-            if (curUserId == null || projectUserId == null)
-            {
-                throw new ArgumentNullException();
-            }
-            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
-            {
-                IDocument<User> userDoc = await GetUserDocAsync(projectUserId, conn);
-                IEnumerable<Task> removalTasks = userDoc.Data.Sites[SiteOptions.Value.Id].Projects.Select(
-                    (string projectId) => RemoveUserCoreAsync(conn, curUserId, projectId, projectUserId)
-                );
-                // The removals can be processed in parallel in production, but for unit tests, MemoryRealtimeService
-                // does not fully implement concurrent editing of docs, so run them in a sequence.
-                foreach (Task task in removalTasks)
-                {
-                    await task;
-                }
-            }
+            await task;
         }
+    }
 
-        public async Task<string> GetProjectRoleAsync(string curUserId, string projectId)
+    public async Task<string> GetProjectRoleAsync(string curUserId, string projectId)
+    {
+        TModel project;
+        try
         {
-            TModel project;
+            project = await GetProjectAsync(projectId);
+        }
+        catch (DataNotFoundException)
+        {
+            return null;
+        }
+        Attempt<string> attempt = await TryGetProjectRoleAsync(project, curUserId);
+        return attempt.Result;
+    }
+
+    public async Task UpdateRoleAsync(string curUserId, string systemRole, string projectId, string projectRole)
+    {
+        if (systemRole != SystemRole.SystemAdmin)
+            throw new ForbiddenException();
+
+        await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
+        IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
+
+        await projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.UserRoles[curUserId], projectRole));
+    }
+
+    public async Task<Uri> SaveAudioAsync(
+        string curUserId,
+        string projectId,
+        string dataId,
+        string extension,
+        Stream inputStream
+    )
+    {
+        if (!StringUtils.ValidateId(dataId))
+            throw new FormatException($"{nameof(dataId)} is not a valid id.");
+
+        TModel project = await GetProjectAsync(projectId);
+
+        if (!project.UserRoles.ContainsKey(curUserId))
+            throw new ForbiddenException();
+
+        string audioDir = GetAudioDir(projectId);
+        if (!FileSystemService.DirectoryExists(audioDir))
+            FileSystemService.CreateDirectory(audioDir);
+        string outputPath = Path.Combine(audioDir, $"{curUserId}_{dataId}.mp3");
+        if (string.Equals(extension, ".mp3", StringComparison.InvariantCultureIgnoreCase))
+        {
+            await using Stream fileStream = FileSystemService.OpenFile(outputPath, FileMode.Create);
+            await inputStream.CopyToAsync(fileStream);
+        }
+        else
+        {
+            string tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + extension);
             try
             {
-                project = await GetProjectAsync(projectId);
+                await using (Stream fileStream = FileSystemService.OpenFile(tempPath, FileMode.Create))
+                    await inputStream.CopyToAsync(fileStream);
+                await _audioService.ConvertToMp3Async(tempPath, outputPath);
             }
-            catch (DataNotFoundException)
+            finally
             {
-                return null;
-            }
-            Attempt<string> attempt = await TryGetProjectRoleAsync(project, curUserId);
-            return attempt.Result;
-        }
-
-        public async Task UpdateRoleAsync(string curUserId, string systemRole, string projectId, string projectRole)
-        {
-            if (systemRole != SystemRole.SystemAdmin)
-                throw new ForbiddenException();
-
-            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
-            {
-                IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
-
-                await projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.UserRoles[curUserId], projectRole));
+                if (FileSystemService.FileExists(tempPath))
+                    FileSystemService.DeleteFile(tempPath);
             }
         }
+        string outputFileName = Path.GetFileName(outputPath);
+        var uri = new Uri(
+            SiteOptions.Value.Origin,
+            $"assets/audio/{projectId}/{outputFileName}?t={DateTime.UtcNow.ToFileTime()}"
+        );
+        return uri;
+    }
 
-        public async Task<Uri> SaveAudioAsync(
-            string curUserId,
-            string projectId,
-            string dataId,
-            string extension,
-            Stream inputStream
-        )
+    public async Task DeleteAudioAsync(string curUserId, string projectId, string ownerId, string dataId)
+    {
+        if (!StringUtils.ValidateId(dataId))
+            throw new FormatException($"{nameof(dataId)} is not a valid id.");
+
+        TModel project = await GetProjectAsync(projectId);
+
+        if (curUserId != ownerId && !IsProjectAdmin(project, curUserId))
+            throw new ForbiddenException();
+
+        string audioDir = GetAudioDir(projectId);
+        string filePath = Path.Combine(audioDir, $"{ownerId}_{dataId}.mp3");
+        if (FileSystemService.FileExists(filePath))
+            FileSystemService.DeleteFile(filePath);
+    }
+
+    public async Task SetSyncDisabledAsync(string curUserId, string systemRole, string projectId, bool isDisabled)
+    {
+        if (systemRole != SystemRole.SystemAdmin)
+            throw new ForbiddenException();
+
+        await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
+        IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
+        await projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.SyncDisabled, isDisabled));
+    }
+
+    public async Task SetUserProjectPermissions(string curUserId, string projectId, string userId, string[] permissions)
+    {
+        await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
+        IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
+        if (!projectDoc.IsLoaded)
+            throw new DataNotFoundException("The project does not exist.");
+        if (!IsProjectAdmin(projectDoc.Data, curUserId))
+            throw new ForbiddenException();
+
+        if (permissions.Length == 0)
         {
-            if (!StringUtils.ValidateId(dataId))
-                throw new FormatException($"{nameof(dataId)} is not a valid id.");
+            await projectDoc.SubmitJson0OpAsync(op => op.Unset(p => p.UserPermissions[userId]));
+        }
+        else
+        {
+            await projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.UserPermissions[userId], permissions));
+        }
+    }
 
-            TModel project = await GetProjectAsync(projectId);
-
-            if (!project.UserRoles.ContainsKey(curUserId))
-                throw new ForbiddenException();
-
-            string audioDir = GetAudioDir(projectId);
-            if (!FileSystemService.DirectoryExists(audioDir))
-                FileSystemService.CreateDirectory(audioDir);
-            string outputPath = Path.Combine(audioDir, $"{curUserId}_{dataId}.mp3");
-            if (string.Equals(extension, ".mp3", StringComparison.InvariantCultureIgnoreCase))
-            {
-                await using Stream fileStream = FileSystemService.OpenFile(outputPath, FileMode.Create);
-                await inputStream.CopyToAsync(fileStream);
-            }
-            else
-            {
-                string tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + extension);
-                try
-                {
-                    await using (Stream fileStream = FileSystemService.OpenFile(tempPath, FileMode.Create))
-                        await inputStream.CopyToAsync(fileStream);
-                    await _audioService.ConvertToMp3Async(tempPath, outputPath);
-                }
-                finally
-                {
-                    if (FileSystemService.FileExists(tempPath))
-                        FileSystemService.DeleteFile(tempPath);
-                }
-            }
-            string outputFileName = Path.GetFileName(outputPath);
-            var uri = new Uri(
-                SiteOptions.Value.Origin,
-                $"assets/audio/{projectId}/{outputFileName}?t={DateTime.UtcNow.ToFileTime()}"
+    protected virtual async Task AddUserToProjectAsync(
+        IConnection conn,
+        IDocument<TModel> projectDoc,
+        IDocument<User> userDoc,
+        string projectRole,
+        bool removeShareKeys = true
+    )
+    {
+        await projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.UserRoles[userDoc.Id], projectRole));
+        if (removeShareKeys)
+        {
+            await ProjectSecrets.UpdateAsync(
+                p => p.Id == projectDoc.Id,
+                update => update.RemoveAll(p => p.ShareKeys, sk => sk.Email == userDoc.Data.Email)
             );
-            return uri;
         }
+        string siteId = SiteOptions.Value.Id;
+        await userDoc.SubmitJson0OpAsync(op => op.Add(u => u.Sites[siteId].Projects, projectDoc.Id));
+    }
 
-        public async Task DeleteAudioAsync(string curUserId, string projectId, string ownerId, string dataId)
+    internal protected virtual async Task RemoveUserFromProjectAsync(
+        IConnection conn,
+        IDocument<TModel> projectDoc,
+        IDocument<User> userDoc
+    )
+    {
+        if (conn == null || projectDoc == null || userDoc == null)
         {
-            if (!StringUtils.ValidateId(dataId))
-                throw new FormatException($"{nameof(dataId)} is not a valid id.");
-
-            TModel project = await GetProjectAsync(projectId);
-
-            if (curUserId != ownerId && !IsProjectAdmin(project, curUserId))
-                throw new ForbiddenException();
-
-            string audioDir = GetAudioDir(projectId);
-            string filePath = Path.Combine(audioDir, $"{ownerId}_{dataId}.mp3");
-            if (FileSystemService.FileExists(filePath))
-                FileSystemService.DeleteFile(filePath);
+            throw new ArgumentNullException();
         }
-
-        public async Task SetSyncDisabledAsync(string curUserId, string systemRole, string projectId, bool isDisabled)
+        if (projectDoc.IsLoaded)
         {
-            if (systemRole != SystemRole.SystemAdmin)
-                throw new ForbiddenException();
-
-            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
-            {
-                IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
-                await projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.SyncDisabled, isDisabled));
-            }
+            await projectDoc.SubmitJson0OpAsync(op => op.Unset(p => p.UserRoles[userDoc.Id]));
+            await projectDoc.SubmitJson0OpAsync(op => op.Unset(p => p.UserPermissions[userDoc.Id]));
         }
-
-        public async Task SetUserProjectPermissions(
-            string curUserId,
-            string projectId,
-            string userId,
-            string[] permissions
-        )
+        string siteId = SiteOptions.Value.Id;
+        await userDoc.SubmitJson0OpAsync(op =>
         {
-            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
-            {
-                IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
-                if (!projectDoc.IsLoaded)
-                    throw new DataNotFoundException("The project does not exist.");
-                if (!IsProjectAdmin(projectDoc.Data, curUserId))
-                    throw new ForbiddenException();
+            int index = userDoc.Data.Sites[siteId].Projects.IndexOf(projectDoc.Id);
+            op.Remove(u => u.Sites[siteId].Projects, index);
+            if (userDoc.Data.Sites[siteId].CurrentProjectId == projectDoc.Id)
+                op.Unset(u => u.Sites[siteId].CurrentProjectId);
+        });
+    }
 
-                if (permissions.Length == 0)
-                {
-                    await projectDoc.SubmitJson0OpAsync(op => op.Unset(p => p.UserPermissions[userId]));
-                }
-                else
-                {
-                    await projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.UserPermissions[userId], permissions));
-                }
-            }
-        }
+    protected bool IsOnProject(TModel project, string userId) => project.UserRoles.ContainsKey(userId);
 
-        protected virtual async Task AddUserToProjectAsync(
-            IConnection conn,
-            IDocument<TModel> projectDoc,
-            IDocument<User> userDoc,
-            string projectRole,
-            bool removeShareKeys = true
-        )
+    protected bool IsProjectAdmin(TModel project, string userId) =>
+        project.UserRoles.TryGetValue(userId, out string role) && role == ProjectAdminRole;
+
+    protected string GetAudioDir(string projectId) => Path.Combine(SiteOptions.Value.SiteDir, "audio", projectId);
+
+    protected abstract Task<Attempt<string>> TryGetProjectRoleAsync(TModel project, string userId);
+
+    protected async Task<TModel> GetProjectAsync(string projectId)
+    {
+        Attempt<TModel> projectAttempt = await RealtimeService.TryGetSnapshotAsync<TModel>(projectId);
+        if (!projectAttempt.TryResult(out TModel project))
         {
-            await projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.UserRoles[userDoc.Id], projectRole));
-            if (removeShareKeys)
-            {
-                await ProjectSecrets.UpdateAsync(
-                    p => p.Id == projectDoc.Id,
-                    update => update.RemoveAll(p => p.ShareKeys, sk => sk.Email == userDoc.Data.Email)
-                );
-            }
-            string siteId = SiteOptions.Value.Id;
-            await userDoc.SubmitJson0OpAsync(op => op.Add(u => u.Sites[siteId].Projects, projectDoc.Id));
+            throw new DataNotFoundException("The project does not exist.");
         }
+        return project;
+    }
 
-        internal protected virtual async Task RemoveUserFromProjectAsync(
-            IConnection conn,
-            IDocument<TModel> projectDoc,
-            IDocument<User> userDoc
-        )
-        {
-            if (conn == null || projectDoc == null || userDoc == null)
-            {
-                throw new ArgumentNullException();
-            }
-            if (projectDoc.IsLoaded)
-            {
-                await projectDoc.SubmitJson0OpAsync(op => op.Unset(p => p.UserRoles[userDoc.Id]));
-                await projectDoc.SubmitJson0OpAsync(op => op.Unset(p => p.UserPermissions[userDoc.Id]));
-            }
-            string siteId = SiteOptions.Value.Id;
-            await userDoc.SubmitJson0OpAsync(op =>
-            {
-                int index = userDoc.Data.Sites[siteId].Projects.IndexOf(projectDoc.Id);
-                op.Remove(u => u.Sites[siteId].Projects, index);
-                if (userDoc.Data.Sites[siteId].CurrentProjectId == projectDoc.Id)
-                    op.Unset(u => u.Sites[siteId].CurrentProjectId);
-            });
-        }
+    protected async Task<IDocument<TModel>> GetProjectDocAsync(string projectId, IConnection conn)
+    {
+        IDocument<TModel> projectDoc = await conn.FetchAsync<TModel>(projectId);
+        if (!projectDoc.IsLoaded)
+            throw new DataNotFoundException("The project does not exist.");
+        return projectDoc;
+    }
 
-        protected bool IsOnProject(TModel project, string userId)
-        {
-            return project.UserRoles.ContainsKey(userId);
-        }
-
-        protected bool IsProjectAdmin(TModel project, string userId)
-        {
-            return project.UserRoles.TryGetValue(userId, out string role) && role == ProjectAdminRole;
-        }
-
-        protected string GetAudioDir(string projectId)
-        {
-            return Path.Combine(SiteOptions.Value.SiteDir, "audio", projectId);
-        }
-
-        protected abstract Task<Attempt<string>> TryGetProjectRoleAsync(TModel project, string userId);
-
-        protected async Task<TModel> GetProjectAsync(string projectId)
-        {
-            Attempt<TModel> projectAttempt = await RealtimeService.TryGetSnapshotAsync<TModel>(projectId);
-            if (!projectAttempt.TryResult(out TModel project))
-            {
-                throw new DataNotFoundException("The project does not exist.");
-            }
-            return project;
-        }
-
-        protected async Task<IDocument<TModel>> GetProjectDocAsync(string projectId, IConnection conn)
-        {
-            IDocument<TModel> projectDoc = await conn.FetchAsync<TModel>(projectId);
-            if (!projectDoc.IsLoaded)
-                throw new DataNotFoundException("The project does not exist.");
-            return projectDoc;
-        }
-
-        protected async Task<IDocument<User>> GetUserDocAsync(string userId, IConnection conn)
-        {
-            IDocument<User> userDoc = await conn.FetchAsync<User>(userId);
-            if (!userDoc.IsLoaded)
-                throw new DataNotFoundException("The user does not exist.");
-            return userDoc;
-        }
+    protected async Task<IDocument<User>> GetUserDocAsync(string userId, IConnection conn)
+    {
+        IDocument<User> userDoc = await conn.FetchAsync<User>(userId);
+        if (!userDoc.IsLoaded)
+            throw new DataNotFoundException("The user does not exist.");
+        return userDoc;
     }
 }

--- a/src/SIL.XForge/Services/SecurityService.cs
+++ b/src/SIL.XForge/Services/SecurityService.cs
@@ -1,17 +1,16 @@
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.WebUtilities;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+/// <summary>Security related utilities</summary>
+public class SecurityService : ISecurityService
 {
-    /// <summary>Security related utilities</summary>
-    public class SecurityService : ISecurityService
+    /// <summary>Return a random 16-character base-64 string that is safe to use in URLs.</summary>
+    public string GenerateKey()
     {
-        /// <summary>Return a random 16-character base-64 string that is safe to use in URLs.</summary>
-        public string GenerateKey()
-        {
-            System.Span<byte> data = stackalloc byte[12]; // 12 bytes of data become 16 bytes of base-64 text
-            RandomNumberGenerator.Fill(data);
-            return WebEncoders.Base64UrlEncode(data);
-        }
+        System.Span<byte> data = stackalloc byte[12]; // 12 bytes of data become 16 bytes of base-64 text
+        RandomNumberGenerator.Fill(data);
+        return WebEncoders.Base64UrlEncode(data);
     }
 }

--- a/src/SIL.XForge/Services/UserAccessor.cs
+++ b/src/SIL.XForge/Services/UserAccessor.cs
@@ -3,38 +3,34 @@ using IdentityModel;
 using Microsoft.AspNetCore.Http;
 using SIL.XForge.Utils;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+public class UserAccessor : IUserAccessor
 {
-    public class UserAccessor : IUserAccessor
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public UserAccessor(IHttpContextAccessor httpContextAccessor) => _httpContextAccessor = httpContextAccessor;
+
+    private ClaimsPrincipal User => _httpContextAccessor.HttpContext.User;
+
+    public bool IsAuthenticated => User.Identity.IsAuthenticated;
+    public string UserId => User.FindFirst(XFClaimTypes.UserId)?.Value;
+    public string SystemRole => User.FindFirst(XFClaimTypes.Role)?.Value;
+    public string Name
     {
-        private readonly IHttpContextAccessor _httpContextAccessor;
-
-        public UserAccessor(IHttpContextAccessor httpContextAccessor)
+        get
         {
-            _httpContextAccessor = httpContextAccessor;
+            string name = User.Identity.Name;
+            if (!string.IsNullOrWhiteSpace(name))
+                return name;
+
+            Claim sub = User.FindFirst(JwtClaimTypes.Subject);
+            if (sub != null)
+                return sub.Value;
+
+            return string.Empty;
         }
-
-        private ClaimsPrincipal User => _httpContextAccessor.HttpContext.User;
-
-        public bool IsAuthenticated => User.Identity.IsAuthenticated;
-        public string UserId => User.FindFirst(XFClaimTypes.UserId)?.Value;
-        public string SystemRole => User.FindFirst(XFClaimTypes.Role)?.Value;
-        public string Name
-        {
-            get
-            {
-                string name = User.Identity.Name;
-                if (!string.IsNullOrWhiteSpace(name))
-                    return name;
-
-                Claim sub = User.FindFirst(JwtClaimTypes.Subject);
-                if (sub != null)
-                    return sub.Value;
-
-                return string.Empty;
-            }
-        }
-
-        public string AuthId => User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
     }
+
+    public string AuthId => User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
 }

--- a/src/SIL.XForge/Services/UserService.cs
+++ b/src/SIL.XForge/Services/UserService.cs
@@ -12,267 +12,246 @@ using SIL.XForge.Realtime;
 using SIL.XForge.Realtime.Json0;
 using SIL.XForge.Utils;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+/// <summary>
+/// This class manages xForge users.
+/// </summary>
+public class UserService : IUserService
 {
-    /// <summary>
-    /// This class manages xForge users.
-    /// </summary>
-    public class UserService : IUserService
+    public static readonly string PTLinkedToAnotherUserKey = "paratext-linked-to-another-user";
+    private const string EMAIL_PATTERN = "^[a-zA-Z0-9.+_-]+@[a-zA-Z0-9.-]+[.]+[a-zA-Z]{2,}$";
+
+    private readonly IRealtimeService _realtimeService;
+    private readonly IOptions<SiteOptions> _siteOptions;
+    private readonly IRepository<UserSecret> _userSecrets;
+    private readonly IAuthService _authService;
+    private readonly IProjectService _projectService;
+    private readonly ILogger<UserService> _logger;
+
+    public UserService(
+        IRealtimeService realtimeService,
+        IOptions<SiteOptions> siteOptions,
+        IRepository<UserSecret> userSecrets,
+        IAuthService authService,
+        IProjectService projectService,
+        ILogger<UserService> logger
+    )
     {
-        public static readonly string PTLinkedToAnotherUserKey = "paratext-linked-to-another-user";
-        private const string EMAIL_PATTERN = "^[a-zA-Z0-9.+_-]+@[a-zA-Z0-9.-]+[.]+[a-zA-Z]{2,}$";
+        _realtimeService = realtimeService;
+        _siteOptions = siteOptions;
+        _userSecrets = userSecrets;
+        _authService = authService;
+        _projectService = projectService;
+        _logger = logger;
+    }
 
-        private readonly IRealtimeService _realtimeService;
-        private readonly IOptions<SiteOptions> _siteOptions;
-        private readonly IRepository<UserSecret> _userSecrets;
-        private readonly IAuthService _authService;
-        private readonly IProjectService _projectService;
-        private readonly ILogger<UserService> _logger;
-
-        public UserService(
-            IRealtimeService realtimeService,
-            IOptions<SiteOptions> siteOptions,
-            IRepository<UserSecret> userSecrets,
-            IAuthService authService,
-            IProjectService projectService,
-            ILogger<UserService> logger
-        )
+    public async Task UpdateUserFromProfileAsync(string curUserId, string userProfileJson)
+    {
+        var userProfile = JObject.Parse(userProfileJson);
+        var identities = (JArray)userProfile["identities"];
+        JObject ptIdentity = identities.OfType<JObject>().FirstOrDefault(i => (string)i["connection"] == "paratext");
+        Regex emailRegex = new Regex(EMAIL_PATTERN);
+        await using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
         {
-            _realtimeService = realtimeService;
-            _siteOptions = siteOptions;
-            _userSecrets = userSecrets;
-            _authService = authService;
-            _projectService = projectService;
-            _logger = logger;
-        }
-
-        public async Task UpdateUserFromProfileAsync(string curUserId, string userProfileJson)
-        {
-            var userProfile = JObject.Parse(userProfileJson);
-            var identities = (JArray)userProfile["identities"];
-            JObject ptIdentity = identities
-                .OfType<JObject>()
-                .FirstOrDefault(i => (string)i["connection"] == "paratext");
-            Regex emailRegex = new Regex(EMAIL_PATTERN);
-            await using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
-            {
-                string name = (string)userProfile["name"];
-                IDocument<User> userDoc = await conn.FetchOrCreateAsync<User>(
-                    curUserId,
-                    () =>
-                        new User
-                        {
-                            AuthId = (string)userProfile["user_id"],
-                            DisplayName =
-                                string.IsNullOrWhiteSpace(name) || emailRegex.IsMatch(name)
-                                    ? (string)userProfile["nickname"]
-                                    : name
-                        }
-                );
-                await userDoc.SubmitJson0OpAsync(op =>
-                {
-                    op.Set(u => u.Name, name);
-                    op.Set(u => u.Email, (string)userProfile["email"]);
-                    op.Set(u => u.AvatarUrl, (string)userProfile["picture"]);
-                    op.Set(u => u.Role, (string)userProfile["app_metadata"]["xf_role"]);
-                    if (ptIdentity != null)
+            string name = (string)userProfile["name"];
+            IDocument<User> userDoc = await conn.FetchOrCreateAsync<User>(
+                curUserId,
+                () =>
+                    new User
                     {
-                        var ptId = (string)ptIdentity["user_id"];
-                        op.Set(u => u.ParatextId, GetIdpIdFromAuthId(ptId));
+                        AuthId = (string)userProfile["user_id"],
+                        DisplayName =
+                            string.IsNullOrWhiteSpace(name) || emailRegex.IsMatch(name)
+                                ? (string)userProfile["nickname"]
+                                : name
                     }
-                    string language =
-                        userProfile["user_metadata"] == null
-                            ? null
-                            : (string)userProfile["user_metadata"]["interface_language"];
-                    string interfaceLanguage = string.IsNullOrWhiteSpace(language) ? "en" : language;
-                    op.Set(u => u.InterfaceLanguage, interfaceLanguage);
-                    string key = _siteOptions.Value.Id;
-                    if (!userDoc.Data.Sites.ContainsKey(key))
-                        op.Set(u => u.Sites[key], new Site());
-                });
-            }
-
-            if (ptIdentity != null)
+            );
+            await userDoc.SubmitJson0OpAsync(op =>
             {
-                var newPTTokens = new Tokens
+                op.Set(u => u.Name, name);
+                op.Set(u => u.Email, (string)userProfile["email"]);
+                op.Set(u => u.AvatarUrl, (string)userProfile["picture"]);
+                op.Set(u => u.Role, (string)userProfile["app_metadata"]["xf_role"]);
+                if (ptIdentity != null)
                 {
-                    AccessToken = (string)ptIdentity["access_token"],
-                    RefreshToken = (string)ptIdentity["refresh_token"]
-                };
-                UserSecret userSecret = await _userSecrets.UpdateAsync(
-                    curUserId,
-                    update => update.SetOnInsert(put => put.ParatextTokens, newPTTokens),
-                    true
-                );
-
-                // Only update the PT tokens if they are newer
-                if (newPTTokens.IssuedAt > userSecret.ParatextTokens.IssuedAt)
-                {
-                    await _userSecrets.UpdateAsync(
-                        curUserId,
-                        update => update.Set(put => put.ParatextTokens, newPTTokens)
-                    );
+                    var ptId = (string)ptIdentity["user_id"];
+                    op.Set(u => u.ParatextId, GetIdpIdFromAuthId(ptId));
                 }
-                else if (newPTTokens.IssuedAt < userSecret.ParatextTokens.IssuedAt)
-                {
-                    string incomingIAt = newPTTokens.IssuedAt.ToString(
-                        "o",
-                        System.Globalization.CultureInfo.InvariantCulture
-                    );
-                    string currentIAt = userSecret.ParatextTokens.IssuedAt.ToString(
-                        "o",
-                        System.Globalization.CultureInfo.InvariantCulture
-                    );
-                    _logger.LogWarning(
-                        $"When updating user with SF id {curUserId} from auth0 profile, ignoring incoming tokens which were issued at {incomingIAt}, which is earlier than the current tokens {currentIAt}."
-                    );
-                }
-            }
+                string language =
+                    userProfile["user_metadata"] == null
+                        ? null
+                        : (string)userProfile["user_metadata"]["interface_language"];
+                string interfaceLanguage = string.IsNullOrWhiteSpace(language) ? "en" : language;
+                op.Set(u => u.InterfaceLanguage, interfaceLanguage);
+                string key = _siteOptions.Value.Id;
+                if (!userDoc.Data.Sites.ContainsKey(key))
+                    op.Set(u => u.Sites[key], new Site());
+            });
         }
 
-        /// <summary>
-        /// Links the secondary Auth0 account (Paratext account) to the primary Auth0 account for the specified user.
-        /// </summary>
-        public async Task LinkParatextAccountAsync(string primaryAuthId, string paratextAuthId)
+        if (ptIdentity != null)
         {
-            if (!await CheckIsParatextProfileAndFirstLogin(paratextAuthId))
-            {
-                // Another auth0 profile already exists that is linked to the paratext account
-                throw new ArgumentException(PTLinkedToAnotherUserKey);
-            }
-            await _authService.LinkAccounts(primaryAuthId, paratextAuthId);
-            JObject userProfile = JObject.Parse(await _authService.GetUserAsync(primaryAuthId));
-            var primaryUserId = (string)userProfile["app_metadata"]["xf_user_id"];
-            var identities = (JArray)userProfile["identities"];
-            JObject ptIdentity = identities.OfType<JObject>().First(i => (string)i["connection"] == "paratext");
-            var ptId = (string)ptIdentity["user_id"];
-            var ptTokens = new Tokens
+            var newPTTokens = new Tokens
             {
                 AccessToken = (string)ptIdentity["access_token"],
                 RefreshToken = (string)ptIdentity["refresh_token"]
             };
-            await _userSecrets.UpdateAsync(
-                primaryUserId,
-                update => update.Set(us => us.ParatextTokens, ptTokens),
+            UserSecret userSecret = await _userSecrets.UpdateAsync(
+                curUserId,
+                update => update.SetOnInsert(put => put.ParatextTokens, newPTTokens),
                 true
             );
 
-            await using (IConnection conn = await _realtimeService.ConnectAsync(primaryUserId))
+            // Only update the PT tokens if they are newer
+            if (newPTTokens.IssuedAt > userSecret.ParatextTokens.IssuedAt)
             {
-                IDocument<User> userDoc = await conn.FetchAsync<User>(primaryUserId);
-                await userDoc.SubmitJson0OpAsync(op => op.Set(u => u.ParatextId, GetIdpIdFromAuthId(ptId)));
+                await _userSecrets.UpdateAsync(curUserId, update => update.Set(put => put.ParatextTokens, newPTTokens));
             }
-        }
-
-        /// <summary>
-        /// Updates the user avatar on their Auth0 account based off their display name
-        /// </summary>
-        public async Task UpdateAvatarFromDisplayNameAsync(string curUserId, string authId)
-        {
-            await using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
+            else if (newPTTokens.IssuedAt < userSecret.ParatextTokens.IssuedAt)
             {
-                IDocument<User> userDoc = await conn.FetchAsync<User>(curUserId);
-                // Only overwrite the avatar for allowed domains so as not to overwrite an avatar provided by a social connection
-                string[] allowedDomains = { "cdn.auth0.com", "gravatar.com" };
-                if (!allowedDomains.Any(userDoc.Data.AvatarUrl.Contains))
-                {
-                    return;
-                }
-
-                string initials = string.Concat(
-                    userDoc.Data.DisplayName
-                        .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
-                        .Where(x => x.Length > 1 && char.IsLetter(x[0]))
-                        .Select(x => char.ToLower(x[0]))
+                string incomingIAt = newPTTokens.IssuedAt.ToString(
+                    "o",
+                    System.Globalization.CultureInfo.InvariantCulture
                 );
-                if (initials.Length == 0)
-                {
-                    return;
-                }
-                else if (initials.Length > 2)
-                {
-                    // Auth0 avatar images only support 2 characters
-                    initials = $"{initials[0]}{initials[initials.Length - 1]}";
-                }
-                var avatarUrl = $"https://cdn.auth0.com/avatars/{initials}.png";
-                // If user has an email then link to Gravatar with auth0 as a fallback
-                if (userDoc.Data.Email != null && userDoc.Data.Email != "")
-                {
-                    var emailHash = StringUtils.ComputeMd5Hash(userDoc.Data.Email);
-                    var auth0Fallback = System.Web.HttpUtility.UrlEncode(avatarUrl);
-                    avatarUrl = $"https://www.gravatar.com/avatar/{emailHash}?s=480&r=pg&d={auth0Fallback}";
-                }
-                // Update Auth0 profile
-                await _authService.UpdateAvatar(authId, avatarUrl);
-                // Update user doc
-                await userDoc.SubmitJson0OpAsync(op => op.Set(u => u.AvatarUrl, avatarUrl));
+                string currentIAt = userSecret.ParatextTokens.IssuedAt.ToString(
+                    "o",
+                    System.Globalization.CultureInfo.InvariantCulture
+                );
+                _logger.LogWarning(
+                    $"When updating user with SF id {curUserId} from auth0 profile, ignoring incoming tokens which were issued at {incomingIAt}, which is earlier than the current tokens {currentIAt}."
+                );
             }
         }
+    }
 
-        /// <summary>
-        /// Updates the interface language in the specified user's Auth0 account in their userMetadata.
-        /// </summary>
-        public async Task UpdateInterfaceLanguageAsync(string curUserId, string authId, string language)
+    /// <summary>
+    /// Links the secondary Auth0 account (Paratext account) to the primary Auth0 account for the specified user.
+    /// </summary>
+    public async Task LinkParatextAccountAsync(string primaryAuthId, string paratextAuthId)
+    {
+        if (!await CheckIsParatextProfileAndFirstLogin(paratextAuthId))
         {
-            await _authService.UpdateInterfaceLanguage(authId, language);
-
-            await using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
-            {
-                IDocument<User> userDoc = await conn.FetchAsync<User>(curUserId);
-                await userDoc.SubmitJson0OpAsync(op => op.Set(u => u.InterfaceLanguage, language));
-            }
+            // Another auth0 profile already exists that is linked to the paratext account
+            throw new ArgumentException(PTLinkedToAnotherUserKey);
         }
-
-        /// <summary>
-        /// Delete user with SF user id userId, as requested by SF user curUserId who has systemRole.
-        /// </summary>
-        public async Task DeleteAsync(string curUserId, string systemRole, string userId)
+        await _authService.LinkAccounts(primaryAuthId, paratextAuthId);
+        JObject userProfile = JObject.Parse(await _authService.GetUserAsync(primaryAuthId));
+        var primaryUserId = (string)userProfile["app_metadata"]["xf_user_id"];
+        var identities = (JArray)userProfile["identities"];
+        JObject ptIdentity = identities.OfType<JObject>().First(i => (string)i["connection"] == "paratext");
+        var ptId = (string)ptIdentity["user_id"];
+        var ptTokens = new Tokens
         {
-            if (curUserId == null || systemRole == null || userId == null)
-            {
-                throw new ArgumentNullException();
-            }
-            if (systemRole != SystemRole.SystemAdmin && userId != curUserId)
-            {
-                throw new ForbiddenException();
-            }
+            AccessToken = (string)ptIdentity["access_token"],
+            RefreshToken = (string)ptIdentity["refresh_token"]
+        };
+        await _userSecrets.UpdateAsync(primaryUserId, update => update.Set(us => us.ParatextTokens, ptTokens), true);
 
-            await _projectService.RemoveUserFromAllProjectsAsync(curUserId, userId);
-            await _userSecrets.DeleteAsync(userId);
-            await using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
-            {
-                IDocument<User> userDoc = await conn.FetchAsync<User>(userId);
-                await userDoc.DeleteAsync();
-            }
-            // Remove the actual docs.
-            await _realtimeService.DeleteUserAsync(userId);
-        }
+        await using IConnection conn = await _realtimeService.ConnectAsync(primaryUserId);
+        IDocument<User> userDoc = await conn.FetchAsync<User>(primaryUserId);
+        await userDoc.SubmitJson0OpAsync(op => op.Set(u => u.ParatextId, GetIdpIdFromAuthId(ptId)));
+    }
 
-        public async Task<string> GetUsernameFromUserId(string curUserId, string userId)
+    /// <summary>
+    /// Updates the user avatar on their Auth0 account based off their display name
+    /// </summary>
+    public async Task UpdateAvatarFromDisplayNameAsync(string curUserId, string authId)
+    {
+        await using IConnection conn = await _realtimeService.ConnectAsync(curUserId);
+        IDocument<User> userDoc = await conn.FetchAsync<User>(curUserId);
+        // Only overwrite the avatar for allowed domains so as not to overwrite an avatar provided by a social connection
+        string[] allowedDomains = { "cdn.auth0.com", "gravatar.com" };
+        if (!allowedDomains.Any(userDoc.Data.AvatarUrl.Contains))
         {
-            await using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
-            {
-                IDocument<User> userDoc = await conn.FetchAsync<User>(userId);
-                return userDoc.Data.DisplayName;
-            }
+            return;
         }
 
-        /// <summary>
-        /// Gets the identity provider ID from the specified Auth0 ID.
-        /// </summary>
-        private static string GetIdpIdFromAuthId(string authId)
+        string initials = string.Concat(
+            userDoc.Data.DisplayName
+                .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                .Where(x => x.Length > 1 && char.IsLetter(x[0]))
+                .Select(x => char.ToLower(x[0]))
+        );
+        if (initials.Length == 0)
         {
-            return authId.Split('|')[1];
+            return;
+        }
+        else if (initials.Length > 2)
+        {
+            // Auth0 avatar images only support 2 characters
+            initials = $"{initials[0]}{initials[^1]}";
+        }
+        var avatarUrl = $"https://cdn.auth0.com/avatars/{initials}.png";
+        // If user has an email then link to Gravatar with auth0 as a fallback
+        if (userDoc.Data.Email != null && userDoc.Data.Email != "")
+        {
+            var emailHash = StringUtils.ComputeMd5Hash(userDoc.Data.Email);
+            var auth0Fallback = System.Web.HttpUtility.UrlEncode(avatarUrl);
+            avatarUrl = $"https://www.gravatar.com/avatar/{emailHash}?s=480&r=pg&d={auth0Fallback}";
+        }
+        // Update Auth0 profile
+        await _authService.UpdateAvatar(authId, avatarUrl);
+        // Update user doc
+        await userDoc.SubmitJson0OpAsync(op => op.Set(u => u.AvatarUrl, avatarUrl));
+    }
+
+    /// <summary>
+    /// Updates the interface language in the specified user's Auth0 account in their userMetadata.
+    /// </summary>
+    public async Task UpdateInterfaceLanguageAsync(string curUserId, string authId, string language)
+    {
+        await _authService.UpdateInterfaceLanguage(authId, language);
+
+        await using IConnection conn = await _realtimeService.ConnectAsync(curUserId);
+        IDocument<User> userDoc = await conn.FetchAsync<User>(curUserId);
+        await userDoc.SubmitJson0OpAsync(op => op.Set(u => u.InterfaceLanguage, language));
+    }
+
+    /// <summary>
+    /// Delete user with SF user id userId, as requested by SF user curUserId who has systemRole.
+    /// </summary>
+    public async Task DeleteAsync(string curUserId, string systemRole, string userId)
+    {
+        if (curUserId == null || systemRole == null || userId == null)
+        {
+            throw new ArgumentNullException();
+        }
+        if (systemRole != SystemRole.SystemAdmin && userId != curUserId)
+        {
+            throw new ForbiddenException();
         }
 
-        private async Task<bool> CheckIsParatextProfileAndFirstLogin(string authId)
+        await _projectService.RemoveUserFromAllProjectsAsync(curUserId, userId);
+        await _userSecrets.DeleteAsync(userId);
+        await using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
         {
-            JObject userProfile = JObject.Parse(await _authService.GetUserAsync(authId));
-            // Check that the profile for 'authId' is from a paratext connection. If it is not, then
-            // this 'authId' is not from an account with paratext as the primary connection.
-            if (!((string)userProfile["user_id"]).Contains("paratext"))
-                return false;
-            return (int)userProfile["logins_count"] <= 1;
+            IDocument<User> userDoc = await conn.FetchAsync<User>(userId);
+            await userDoc.DeleteAsync();
         }
+        // Remove the actual docs.
+        await _realtimeService.DeleteUserAsync(userId);
+    }
+
+    public async Task<string> GetUsernameFromUserId(string curUserId, string userId)
+    {
+        await using IConnection conn = await _realtimeService.ConnectAsync(curUserId);
+        IDocument<User> userDoc = await conn.FetchAsync<User>(userId);
+        return userDoc.Data.DisplayName;
+    }
+
+    /// <summary>
+    /// Gets the identity provider ID from the specified Auth0 ID.
+    /// </summary>
+    private static string GetIdpIdFromAuthId(string authId) => authId.Split('|')[1];
+
+    private async Task<bool> CheckIsParatextProfileAndFirstLogin(string authId)
+    {
+        JObject userProfile = JObject.Parse(await _authService.GetUserAsync(authId));
+        // Check that the profile for 'authId' is from a paratext connection. If it is not, then
+        // this 'authId' is not from an account with paratext as the primary connection.
+        if (!((string)userProfile["user_id"]).Contains("paratext"))
+            return false;
+        return (int)userProfile["logins_count"] <= 1;
     }
 }

--- a/src/SIL.XForge/Utils/Attempt.cs
+++ b/src/SIL.XForge/Utils/Attempt.cs
@@ -1,37 +1,31 @@
-namespace SIL.XForge.Utils
-{
-    public static class Attempt
-    {
-        public static Attempt<T> Success<T>(T result)
-        {
-            return new Attempt<T>(true, result);
-        }
+namespace SIL.XForge.Utils;
 
-        public static Attempt<T> Failure<T>(T result)
-        {
-            return new Attempt<T>(false, result);
-        }
+public static class Attempt
+{
+    public static Attempt<T> Success<T>(T result) => new Attempt<T>(true, result);
+
+    public static Attempt<T> Failure<T>(T result) => new Attempt<T>(false, result);
+}
+
+public readonly struct Attempt<T>
+{
+    public static Attempt<T> Failure { get; } = new Attempt<T>();
+
+    public Attempt(T result)
+        : this(true, result) { }
+
+    public Attempt(bool success, T result = default)
+    {
+        Success = success;
+        Result = result;
     }
 
-    public struct Attempt<T>
+    public T Result { get; }
+    public bool Success { get; }
+
+    public bool TryResult(out T result)
     {
-        public static Attempt<T> Failure { get; } = new Attempt<T>();
-
-        public Attempt(T result) : this(true, result) { }
-
-        public Attempt(bool success, T result = default(T))
-        {
-            Success = success;
-            Result = result;
-        }
-
-        public T Result { get; }
-        public bool Success { get; }
-
-        public bool TryResult(out T result)
-        {
-            result = Result;
-            return Success;
-        }
+        result = Result;
+        return Success;
     }
 }

--- a/src/SIL.XForge/Utils/ConstantFinder.cs
+++ b/src/SIL.XForge/Utils/ConstantFinder.cs
@@ -2,36 +2,35 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace SIL.XForge.Utils
+namespace SIL.XForge.Utils;
+
+internal class ConstantFinder : ExpressionVisitor
 {
-    internal class ConstantFinder : ExpressionVisitor
+    private readonly Stack<MemberExpression> _nodes = new Stack<MemberExpression>();
+
+    public object Value { get; private set; }
+
+    protected override Expression VisitMember(MemberExpression node)
     {
-        private readonly Stack<MemberExpression> _nodes = new Stack<MemberExpression>();
+        _nodes.Push(node);
+        return base.VisitMember(node);
+    }
 
-        public object Value { get; private set; }
-
-        protected override Expression VisitMember(MemberExpression node)
+    protected override Expression VisitConstant(ConstantExpression node)
+    {
+        object val = node.Value;
+        while (_nodes.Count > 0)
         {
-            _nodes.Push(node);
-            return base.VisitMember(node);
+            MemberExpression prevNode = _nodes.Peek();
+            var fieldInfo = prevNode.Member as FieldInfo;
+            if (fieldInfo != null)
+                val = fieldInfo.GetValue(val);
+            var propertyInfo = prevNode.Member as PropertyInfo;
+            if (propertyInfo != null)
+                val = propertyInfo.GetValue(val);
+            _nodes.Pop();
         }
-
-        protected override Expression VisitConstant(ConstantExpression node)
-        {
-            object val = node.Value;
-            while (_nodes.Count > 0)
-            {
-                MemberExpression prevNode = _nodes.Peek();
-                var fieldInfo = prevNode.Member as FieldInfo;
-                if (fieldInfo != null)
-                    val = fieldInfo.GetValue(val);
-                var propertyInfo = prevNode.Member as PropertyInfo;
-                if (propertyInfo != null)
-                    val = propertyInfo.GetValue(val);
-                _nodes.Pop();
-            }
-            Value = val;
-            return base.VisitConstant(node);
-        }
+        Value = val;
+        return base.VisitConstant(node);
     }
 }

--- a/src/SIL.XForge/Utils/ExpressionHelper.cs
+++ b/src/SIL.XForge/Utils/ExpressionHelper.cs
@@ -2,35 +2,34 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
-namespace SIL.XForge.Utils
+namespace SIL.XForge.Utils;
+
+public static class ExpressionHelper
 {
-    public static class ExpressionHelper
+    public static Expression<Func<T, bool>> ChangePredicateType<T>(LambdaExpression predicate)
     {
-        public static Expression<Func<T, bool>> ChangePredicateType<T>(LambdaExpression predicate)
-        {
-            ParameterExpression param = Expression.Parameter(typeof(T), "x");
-            var body = RebindParameter(param, predicate);
-            return Expression.Lambda<Func<T, bool>>(body, param);
-        }
+        ParameterExpression param = Expression.Parameter(typeof(T), "x");
+        var body = RebindParameter(param, predicate);
+        return Expression.Lambda<Func<T, bool>>(body, param);
+    }
 
-        public static Expression RebindParameter(ParameterExpression param, LambdaExpression lambda)
-        {
-            var e = new ParameterRebinder(param);
-            return e.Visit(lambda.Body);
-        }
+    public static Expression RebindParameter(ParameterExpression param, LambdaExpression lambda)
+    {
+        var e = new ParameterRebinder(param);
+        return e.Visit(lambda.Body);
+    }
 
-        public static IEnumerable<Expression> Flatten(LambdaExpression field)
-        {
-            var flattener = new FieldExpressionFlattener();
-            flattener.Visit(field);
-            return flattener.Nodes;
-        }
+    public static IEnumerable<Expression> Flatten(LambdaExpression field)
+    {
+        var flattener = new FieldExpressionFlattener();
+        flattener.Visit(field);
+        return flattener.Nodes;
+    }
 
-        public static object FindConstantValue(Expression expression)
-        {
-            var finder = new ConstantFinder();
-            finder.Visit(expression);
-            return finder.Value;
-        }
+    public static object FindConstantValue(Expression expression)
+    {
+        var finder = new ConstantFinder();
+        finder.Visit(expression);
+        return finder.Value;
     }
 }

--- a/src/SIL.XForge/Utils/FieldExpressionFlattener.cs
+++ b/src/SIL.XForge/Utils/FieldExpressionFlattener.cs
@@ -2,27 +2,26 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace SIL.XForge.Utils
+namespace SIL.XForge.Utils;
+
+internal class FieldExpressionFlattener : ExpressionVisitor
 {
-    internal class FieldExpressionFlattener : ExpressionVisitor
+    private readonly Stack<Expression> _nodes = new Stack<Expression>();
+    private readonly HashSet<Expression> _argExprs = new HashSet<Expression>();
+
+    public IEnumerable<Expression> Nodes => _nodes;
+
+    protected override Expression VisitMember(MemberExpression node)
     {
-        private readonly Stack<Expression> _nodes = new Stack<Expression>();
-        private readonly HashSet<Expression> _argExprs = new HashSet<Expression>();
-
-        public IEnumerable<Expression> Nodes => _nodes;
-
-        protected override Expression VisitMember(MemberExpression node)
-        {
-            if (node.Member is PropertyInfo && !_argExprs.Contains(node))
-                _nodes.Push(node);
-            return base.VisitMember(node);
-        }
-
-        protected override Expression VisitMethodCall(MethodCallExpression node)
-        {
-            _argExprs.UnionWith(node.Arguments);
+        if (node.Member is PropertyInfo && !_argExprs.Contains(node))
             _nodes.Push(node);
-            return base.VisitMethodCall(node);
-        }
+        return base.VisitMember(node);
+    }
+
+    protected override Expression VisitMethodCall(MethodCallExpression node)
+    {
+        _argExprs.UnionWith(node.Arguments);
+        _nodes.Push(node);
+        return base.VisitMethodCall(node);
     }
 }

--- a/src/SIL.XForge/Utils/ObjectPath.cs
+++ b/src/SIL.XForge/Utils/ObjectPath.cs
@@ -2,68 +2,64 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
-namespace SIL.XForge.Utils
+namespace SIL.XForge.Utils;
+
+public static class ObjectPath<T>
 {
-    public static class ObjectPath<T>
+    public static ObjectPath Create<TField>(Expression<Func<T, TField>> field) => new ObjectPath(field);
+}
+
+/// <summary>
+/// This class is used to represent the path to a particular property inside of an object hierarchy. It parses the
+/// specified lambda expression into a list of property names.
+/// </summary>
+public class ObjectPath
+{
+    public ObjectPath(LambdaExpression expression)
     {
-        public static ObjectPath Create<TField>(Expression<Func<T, TField>> field)
+        Expression = expression;
+        Items = ParsePath(expression);
+    }
+
+    public LambdaExpression Expression { get; }
+
+    public IReadOnlyList<object> Items { get; }
+
+    public bool TryGetValue<TObj, TField>(TObj obj, out TField value)
+    {
+        var getter = (Func<TObj, TField>)Expression.Compile();
+        try
         {
-            return new ObjectPath(field);
+            value = getter(obj);
+            return true;
+        }
+        catch (Exception)
+        {
+            value = default;
+            return false;
         }
     }
 
-    /// <summary>
-    /// This class is used to represent the path to a particular property inside of an object hierarchy. It parses the
-    /// specified lambda expression into a list of property names.
-    /// </summary>
-    public class ObjectPath
+    private static IReadOnlyList<object> ParsePath(LambdaExpression expression)
     {
-        public ObjectPath(LambdaExpression expression)
+        var path = new List<object>();
+        foreach (Expression node in ExpressionHelper.Flatten(expression))
         {
-            Expression = expression;
-            Items = ParsePath(expression);
-        }
-
-        public LambdaExpression Expression { get; }
-
-        public IReadOnlyList<object> Items { get; }
-
-        public bool TryGetValue<TObj, TField>(TObj obj, out TField value)
-        {
-            var getter = (Func<TObj, TField>)Expression.Compile();
-            try
+            switch (node)
             {
-                value = getter(obj);
-                return true;
-            }
-            catch (Exception)
-            {
-                value = default(TField);
-                return false;
+                case MemberExpression memberExpr:
+                    path.Add(memberExpr.Member.Name);
+                    break;
+
+                case MethodCallExpression methodExpr:
+                    if (methodExpr.Method.Name != "get_Item")
+                        throw new ArgumentException("Invalid method call in field expression.", nameof(expression));
+
+                    Expression argExpr = methodExpr.Arguments[0];
+                    path.Add(ExpressionHelper.FindConstantValue(argExpr));
+                    break;
             }
         }
-
-        private static IReadOnlyList<object> ParsePath(LambdaExpression expression)
-        {
-            var path = new List<object>();
-            foreach (Expression node in ExpressionHelper.Flatten(expression))
-            {
-                switch (node)
-                {
-                    case MemberExpression memberExpr:
-                        path.Add(memberExpr.Member.Name);
-                        break;
-
-                    case MethodCallExpression methodExpr:
-                        if (methodExpr.Method.Name != "get_Item")
-                            throw new ArgumentException("Invalid method call in field expression.", nameof(expression));
-
-                        Expression argExpr = methodExpr.Arguments[0];
-                        path.Add(ExpressionHelper.FindConstantValue(argExpr));
-                        break;
-                }
-            }
-            return path;
-        }
+        return path;
     }
 }

--- a/src/SIL.XForge/Utils/ParameterRebinder.cs
+++ b/src/SIL.XForge/Utils/ParameterRebinder.cs
@@ -1,19 +1,12 @@
 using System.Linq.Expressions;
 
-namespace SIL.XForge.Utils
+namespace SIL.XForge.Utils;
+
+internal class ParameterRebinder : ExpressionVisitor
 {
-    internal class ParameterRebinder : ExpressionVisitor
-    {
-        private readonly ParameterExpression _parameter;
+    private readonly ParameterExpression _parameter;
 
-        public ParameterRebinder(ParameterExpression parameter)
-        {
-            _parameter = parameter;
-        }
+    public ParameterRebinder(ParameterExpression parameter) => _parameter = parameter;
 
-        protected override Expression VisitParameter(ParameterExpression p)
-        {
-            return base.VisitParameter(_parameter);
-        }
-    }
+    protected override Expression VisitParameter(ParameterExpression p) => base.VisitParameter(_parameter);
 }

--- a/src/SIL.XForge/Utils/StringUtils.cs
+++ b/src/SIL.XForge/Utils/StringUtils.cs
@@ -1,38 +1,29 @@
-using MongoDB.Bson;
-using Newtonsoft.Json.Serialization;
 using System.Security.Cryptography;
 using System.Text;
+using MongoDB.Bson;
+using Newtonsoft.Json.Serialization;
 
-namespace SIL.XForge.Utils
+namespace SIL.XForge.Utils;
+
+public static class StringUtils
 {
-    public static class StringUtils
+    private static readonly CamelCaseNamingStrategy CamelCaseNamingStrategy = new CamelCaseNamingStrategy();
+
+    public static string ComputeMd5Hash(string message)
     {
-        private static readonly CamelCaseNamingStrategy CamelCaseNamingStrategy = new CamelCaseNamingStrategy();
+        using MD5 md5 = MD5.Create();
+        byte[] input = Encoding.ASCII.GetBytes(message);
+        byte[] hash = md5.ComputeHash(input);
 
-        public static string ComputeMd5Hash(string message)
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < hash.Length; i++)
         {
-            using (MD5 md5 = MD5.Create())
-            {
-                byte[] input = Encoding.ASCII.GetBytes(message);
-                byte[] hash = md5.ComputeHash(input);
-
-                StringBuilder sb = new StringBuilder();
-                for (int i = 0; i < hash.Length; i++)
-                {
-                    sb.Append(hash[i].ToString("X2"));
-                }
-                return sb.ToString().ToLower();
-            }
+            sb.Append(hash[i].ToString("X2"));
         }
-
-        public static string ToCamelCase(this string str)
-        {
-            return CamelCaseNamingStrategy.GetPropertyName(str, false);
-        }
-
-        public static bool ValidateId(string id)
-        {
-            return ObjectId.TryParse(id, out _);
-        }
+        return sb.ToString().ToLower();
     }
+
+    public static string ToCamelCase(this string str) => CamelCaseNamingStrategy.GetPropertyName(str, false);
+
+    public static bool ValidateId(string id) => ObjectId.TryParse(id, out _);
 }

--- a/src/SIL.XForge/Utils/XFClaimTypes.cs
+++ b/src/SIL.XForge/Utils/XFClaimTypes.cs
@@ -1,8 +1,7 @@
-namespace SIL.XForge.Utils
+namespace SIL.XForge.Utils;
+
+public static class XFClaimTypes
 {
-    public static class XFClaimTypes
-    {
-        public const string UserId = "http://xforge.org/userid";
-        public const string Role = "http://xforge.org/role";
-    }
+    public const string UserId = "http://xforge.org/userid";
+    public const string Role = "http://xforge.org/role";
 }

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -11,722 +11,705 @@ using SIL.Machine.WebApi;
 using SIL.XForge.Scripture.Services;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Controllers
+namespace SIL.XForge.Scripture.Controllers;
+
+[TestFixture]
+public class MachineApiControllerTests
 {
-    [TestFixture]
-    public class MachineApiControllerTests
+    private const string Build01 = "build01";
+    private const string Project01 = "project01";
+    private const string User01 = "user01";
+
+    [Test]
+    public async Task GetBuildAsync_BuildEnded()
     {
-        private const string Build01 = "build01";
-        private const string Project01 = "project01";
-        private const string User01 = "user01";
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
+            .Throws(new DataNotFoundException("Entity Deleted"));
 
-        [Test]
-        public async Task GetBuildAsync_BuildEnded()
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
+            Project01,
+            Build01,
+            minRevision: null,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetBuildAsync_MachineApiDown()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
+            Project01,
+            Build01,
+            minRevision: null,
+            CancellationToken.None
+        );
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+        Assert.IsInstanceOf<ObjectResult>(actual.Result);
+        Assert.AreEqual((int)HttpStatusCode.ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
+    }
+
+    [Test]
+    public async Task GetBuildAsync_NoBuildRunning()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
+            .Returns(Task.FromResult<BuildDto>(null));
+
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
+            Project01,
+            Build01,
+            minRevision: null,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<NoContentResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetBuildAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
+            .Throws(new ForbiddenException());
+
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
+            Project01,
+            Build01,
+            minRevision: null,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<ForbidResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetBuildAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
+            .Throws(new DataNotFoundException(string.Empty));
+
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
+            Project01,
+            Build01,
+            minRevision: null,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetBuildAsync_Success()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
+            .Returns(Task.FromResult(new BuildDto()));
+
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
+            Project01,
+            Build01,
+            minRevision: null,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetBuildAsync_NoBuildIdBuildEnded()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
+            .Throws(new DataNotFoundException("Entity Deleted"));
+
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
+            Project01,
+            buildId: null,
+            minRevision: null,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetBuildAsync_NoBuildIdMachineApiDown()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
+            Project01,
+            buildId: null,
+            minRevision: null,
+            CancellationToken.None
+        );
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+        Assert.IsInstanceOf<ObjectResult>(actual.Result);
+        Assert.AreEqual((int)HttpStatusCode.ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
+    }
+
+    [Test]
+    public async Task GetBuildAsync_NoBuildIdNoBuildRunning()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
+            .Returns(Task.FromResult<BuildDto>(null));
+
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
+            Project01,
+            buildId: null,
+            minRevision: null,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<NoContentResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetBuildAsync_NoBuildIdNoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
+            .Throws(new ForbiddenException());
+
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
+            Project01,
+            buildId: null,
+            minRevision: null,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<ForbidResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetBuildAsync_NoBuildIdNoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
+            .Throws(new DataNotFoundException(string.Empty));
+
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
+            Project01,
+            buildId: null,
+            minRevision: null,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetBuildAsync_NoBuildIdSuccess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
+            .Returns(Task.FromResult(new BuildDto()));
+
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
+            Project01,
+            buildId: null,
+            minRevision: null,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetEngineAsync_MachineApiDown()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetEngineAsync(User01, Project01, CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+
+        // SUT
+        ActionResult<EngineDto> actual = await env.Controller.GetEngineAsync(Project01, CancellationToken.None);
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+        Assert.IsInstanceOf<ObjectResult>(actual.Result);
+        Assert.AreEqual((int)HttpStatusCode.ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
+    }
+
+    [Test]
+    public async Task GetEngineAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetEngineAsync(User01, Project01, CancellationToken.None)
+            .Throws(new ForbiddenException());
+
+        // SUT
+        ActionResult<EngineDto> actual = await env.Controller.GetEngineAsync(Project01, CancellationToken.None);
+
+        Assert.IsInstanceOf<ForbidResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetEngineAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetEngineAsync(User01, Project01, CancellationToken.None)
+            .Throws(new DataNotFoundException(string.Empty));
+
+        // SUT
+        ActionResult<EngineDto> actual = await env.Controller.GetEngineAsync(Project01, CancellationToken.None);
+
+        Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetEngineAsync_Success()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetEngineAsync(User01, Project01, CancellationToken.None)
+            .Returns(Task.FromResult(new EngineDto()));
+
+        // SUT
+        ActionResult<EngineDto> actual = await env.Controller.GetEngineAsync(Project01, CancellationToken.None);
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetWordGraphAsync_MachineApiDown()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+
+        // SUT
+        ActionResult<WordGraphDto> actual = await env.Controller.GetWordGraphAsync(
+            Project01,
+            Array.Empty<string>(),
+            CancellationToken.None
+        );
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+        Assert.IsInstanceOf<ObjectResult>(actual.Result);
+        Assert.AreEqual((int)HttpStatusCode.ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
+    }
+
+    [Test]
+    public async Task GetWordGraphAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+            .Throws(new ForbiddenException());
+
+        // SUT
+        ActionResult<WordGraphDto> actual = await env.Controller.GetWordGraphAsync(
+            Project01,
+            Array.Empty<string>(),
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<ForbidResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetWordGraphAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+            .Throws(new DataNotFoundException(string.Empty));
+
+        // SUT
+        ActionResult<WordGraphDto> actual = await env.Controller.GetWordGraphAsync(
+            Project01,
+            Array.Empty<string>(),
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetWordGraphAsync_Success()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+            .Returns(Task.FromResult(new WordGraphDto()));
+
+        // SUT
+        ActionResult<WordGraphDto> actual = await env.Controller.GetWordGraphAsync(
+            Project01,
+            Array.Empty<string>(),
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task StartBuildAsync_MachineApiDown()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .StartBuildAsync(User01, Project01, CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+
+        // SUT
+        ActionResult<BuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+        Assert.IsInstanceOf<ObjectResult>(actual.Result);
+        Assert.AreEqual((int)HttpStatusCode.ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
+    }
+
+    [Test]
+    public async Task StartBuildAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .StartBuildAsync(User01, Project01, CancellationToken.None)
+            .Throws(new ForbiddenException());
+
+        // SUT
+        ActionResult<BuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
+
+        Assert.IsInstanceOf<ForbidResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task StartBuildAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .StartBuildAsync(User01, Project01, CancellationToken.None)
+            .Throws(new DataNotFoundException(string.Empty));
+
+        // SUT
+        ActionResult<BuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
+
+        Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task StartBuildAsync_Success()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .StartBuildAsync(User01, Project01, CancellationToken.None)
+            .Returns(Task.FromResult(new BuildDto()));
+
+        // SUT
+        ActionResult<BuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task TrainSegmentAsync_MachineApiDown()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        var segmentPair = new SegmentPairDto();
+        env.MachineApiService
+            .TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+
+        // SUT
+        ActionResult actual = await env.Controller.TrainSegmentAsync(Project01, segmentPair, CancellationToken.None);
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+        Assert.IsInstanceOf<ObjectResult>(actual);
+        Assert.AreEqual((int)HttpStatusCode.ServiceUnavailable, (actual as ObjectResult)?.StatusCode);
+    }
+
+    [Test]
+    public async Task TrainSegmentAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        var segmentPair = new SegmentPairDto();
+        env.MachineApiService
+            .TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None)
+            .Throws(new ForbiddenException());
+
+        // SUT
+        ActionResult actual = await env.Controller.TrainSegmentAsync(Project01, segmentPair, CancellationToken.None);
+
+        Assert.IsInstanceOf<ForbidResult>(actual);
+    }
+
+    [Test]
+    public async Task TrainSegmentAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        var segmentPair = new SegmentPairDto();
+        env.MachineApiService
+            .TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None)
+            .Throws(new DataNotFoundException(string.Empty));
+
+        // SUT
+        ActionResult actual = await env.Controller.TrainSegmentAsync(Project01, segmentPair, CancellationToken.None);
+
+        Assert.IsInstanceOf<NotFoundResult>(actual);
+    }
+
+    [Test]
+    public async Task TrainSegmentAsync_Success()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        var segmentPair = new SegmentPairDto();
+
+        // SUT
+        ActionResult actual = await env.Controller.TrainSegmentAsync(Project01, segmentPair, CancellationToken.None);
+
+        Assert.IsInstanceOf<OkResult>(actual);
+        await env.MachineApiService
+            .Received(1)
+            .TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task TranslateAsync_MachineApiDown()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+
+        // SUT
+        ActionResult<TranslationResultDto> actual = await env.Controller.TranslateAsync(
+            Project01,
+            Array.Empty<string>(),
+            CancellationToken.None
+        );
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+        Assert.IsInstanceOf<ObjectResult>(actual.Result);
+        Assert.AreEqual((int)HttpStatusCode.ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
+    }
+
+    [Test]
+    public async Task TranslateAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+            .Throws(new ForbiddenException());
+
+        // SUT
+        ActionResult<TranslationResultDto> actual = await env.Controller.TranslateAsync(
+            Project01,
+            Array.Empty<string>(),
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<ForbidResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task TranslateAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+            .Throws(new DataNotFoundException(string.Empty));
+
+        // SUT
+        ActionResult<TranslationResultDto> actual = await env.Controller.TranslateAsync(
+            Project01,
+            Array.Empty<string>(),
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task TranslateAsync_Success()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+            .Returns(Task.FromResult(new TranslationResultDto()));
+
+        // SUT
+        ActionResult<TranslationResultDto> actual = await env.Controller.TranslateAsync(
+            Project01,
+            Array.Empty<string>(),
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task TranslateNAsync_MachineApiDown()
+    {
+        // Set up test environment
+        int n = 1;
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+
+        // SUT
+        ActionResult<TranslationResultDto[]> actual = await env.Controller.TranslateNAsync(
+            Project01,
+            n,
+            Array.Empty<string>(),
+            CancellationToken.None
+        );
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+        Assert.IsInstanceOf<ObjectResult>(actual.Result);
+        Assert.AreEqual((int)HttpStatusCode.ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
+    }
+
+    [Test]
+    public async Task TranslateNAsync_NoPermission()
+    {
+        // Set up test environment
+        int n = 1;
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None)
+            .Throws(new ForbiddenException());
+
+        // SUT
+        ActionResult<TranslationResultDto[]> actual = await env.Controller.TranslateNAsync(
+            Project01,
+            n,
+            Array.Empty<string>(),
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<ForbidResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task TranslateNAsync_NoProject()
+    {
+        // Set up test environment
+        int n = 1;
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None)
+            .Throws(new DataNotFoundException(string.Empty));
+
+        // SUT
+        ActionResult<TranslationResultDto[]> actual = await env.Controller.TranslateNAsync(
+            Project01,
+            n,
+            Array.Empty<string>(),
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task TranslateNAsync_Success()
+    {
+        // Set up test environment
+        int n = 1;
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None)
+            .Returns(Task.FromResult(Array.Empty<TranslationResultDto>()));
+
+        // SUT
+        ActionResult<TranslationResultDto[]> actual = await env.Controller.TranslateNAsync(
+            Project01,
+            n,
+            Array.Empty<string>(),
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+    }
+
+    private class TestEnvironment
+    {
+        public TestEnvironment()
         {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
-                .Throws(new DataNotFoundException("Entity Deleted"));
+            var userAccessor = Substitute.For<IUserAccessor>();
+            userAccessor.UserId.Returns(User01);
+            ExceptionHandler = Substitute.For<IExceptionHandler>();
+            MachineApiService = Substitute.For<IMachineApiService>();
 
-            // SUT
-            ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
-                Project01,
-                Build01,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+            Controller = new MachineApiController(ExceptionHandler, MachineApiService, userAccessor);
         }
 
-        [Test]
-        public async Task GetBuildAsync_MachineApiDown()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-
-            // SUT
-            ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
-                Project01,
-                Build01,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
-            Assert.IsInstanceOf<ObjectResult>(actual.Result);
-            Assert.AreEqual((int)HttpStatusCode.ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
-        }
-
-        [Test]
-        public async Task GetBuildAsync_NoBuildRunning()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
-                .Returns(Task.FromResult<BuildDto>(null));
-
-            // SUT
-            ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
-                Project01,
-                Build01,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<NoContentResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task GetBuildAsync_NoPermission()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
-                .Throws(new ForbiddenException());
-
-            // SUT
-            ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
-                Project01,
-                Build01,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<ForbidResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task GetBuildAsync_NoProject()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
-                .Throws(new DataNotFoundException(string.Empty));
-
-            // SUT
-            ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
-                Project01,
-                Build01,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<NotFoundResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task GetBuildAsync_Success()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
-                .Returns(Task.FromResult(new BuildDto()));
-
-            // SUT
-            ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
-                Project01,
-                Build01,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<OkObjectResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task GetBuildAsync_NoBuildIdBuildEnded()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
-                .Throws(new DataNotFoundException("Entity Deleted"));
-
-            // SUT
-            ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
-                Project01,
-                buildId: null,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<NotFoundResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task GetBuildAsync_NoBuildIdMachineApiDown()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-
-            // SUT
-            ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
-                Project01,
-                buildId: null,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
-            Assert.IsInstanceOf<ObjectResult>(actual.Result);
-            Assert.AreEqual((int)HttpStatusCode.ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
-        }
-
-        [Test]
-        public async Task GetBuildAsync_NoBuildIdNoBuildRunning()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
-                .Returns(Task.FromResult<BuildDto>(null));
-
-            // SUT
-            ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
-                Project01,
-                buildId: null,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<NoContentResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task GetBuildAsync_NoBuildIdNoPermission()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
-                .Throws(new ForbiddenException());
-
-            // SUT
-            ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
-                Project01,
-                buildId: null,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<ForbidResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task GetBuildAsync_NoBuildIdNoProject()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
-                .Throws(new DataNotFoundException(string.Empty));
-
-            // SUT
-            ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
-                Project01,
-                buildId: null,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<NotFoundResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task GetBuildAsync_NoBuildIdSuccess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
-                .Returns(Task.FromResult(new BuildDto()));
-
-            // SUT
-            ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
-                Project01,
-                buildId: null,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<OkObjectResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task GetEngineAsync_MachineApiDown()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetEngineAsync(User01, Project01, CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-
-            // SUT
-            ActionResult<EngineDto> actual = await env.Controller.GetEngineAsync(Project01, CancellationToken.None);
-
-            env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
-            Assert.IsInstanceOf<ObjectResult>(actual.Result);
-            Assert.AreEqual((int)HttpStatusCode.ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
-        }
-
-        [Test]
-        public async Task GetEngineAsync_NoPermission()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetEngineAsync(User01, Project01, CancellationToken.None)
-                .Throws(new ForbiddenException());
-
-            // SUT
-            ActionResult<EngineDto> actual = await env.Controller.GetEngineAsync(Project01, CancellationToken.None);
-
-            Assert.IsInstanceOf<ForbidResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task GetEngineAsync_NoProject()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetEngineAsync(User01, Project01, CancellationToken.None)
-                .Throws(new DataNotFoundException(string.Empty));
-
-            // SUT
-            ActionResult<EngineDto> actual = await env.Controller.GetEngineAsync(Project01, CancellationToken.None);
-
-            Assert.IsInstanceOf<NotFoundResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task GetEngineAsync_Success()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetEngineAsync(User01, Project01, CancellationToken.None)
-                .Returns(Task.FromResult(new EngineDto()));
-
-            // SUT
-            ActionResult<EngineDto> actual = await env.Controller.GetEngineAsync(Project01, CancellationToken.None);
-
-            Assert.IsInstanceOf<OkObjectResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task GetWordGraphAsync_MachineApiDown()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-
-            // SUT
-            ActionResult<WordGraphDto> actual = await env.Controller.GetWordGraphAsync(
-                Project01,
-                Array.Empty<string>(),
-                CancellationToken.None
-            );
-
-            env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
-            Assert.IsInstanceOf<ObjectResult>(actual.Result);
-            Assert.AreEqual((int)HttpStatusCode.ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
-        }
-
-        [Test]
-        public async Task GetWordGraphAsync_NoPermission()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
-                .Throws(new ForbiddenException());
-
-            // SUT
-            ActionResult<WordGraphDto> actual = await env.Controller.GetWordGraphAsync(
-                Project01,
-                Array.Empty<string>(),
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<ForbidResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task GetWordGraphAsync_NoProject()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
-                .Throws(new DataNotFoundException(string.Empty));
-
-            // SUT
-            ActionResult<WordGraphDto> actual = await env.Controller.GetWordGraphAsync(
-                Project01,
-                Array.Empty<string>(),
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<NotFoundResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task GetWordGraphAsync_Success()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
-                .Returns(Task.FromResult(new WordGraphDto()));
-
-            // SUT
-            ActionResult<WordGraphDto> actual = await env.Controller.GetWordGraphAsync(
-                Project01,
-                Array.Empty<string>(),
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<OkObjectResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task StartBuildAsync_MachineApiDown()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .StartBuildAsync(User01, Project01, CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-
-            // SUT
-            ActionResult<BuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
-
-            env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
-            Assert.IsInstanceOf<ObjectResult>(actual.Result);
-            Assert.AreEqual((int)HttpStatusCode.ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
-        }
-
-        [Test]
-        public async Task StartBuildAsync_NoPermission()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .StartBuildAsync(User01, Project01, CancellationToken.None)
-                .Throws(new ForbiddenException());
-
-            // SUT
-            ActionResult<BuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
-
-            Assert.IsInstanceOf<ForbidResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task StartBuildAsync_NoProject()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .StartBuildAsync(User01, Project01, CancellationToken.None)
-                .Throws(new DataNotFoundException(string.Empty));
-
-            // SUT
-            ActionResult<BuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
-
-            Assert.IsInstanceOf<NotFoundResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task StartBuildAsync_Success()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .StartBuildAsync(User01, Project01, CancellationToken.None)
-                .Returns(Task.FromResult(new BuildDto()));
-
-            // SUT
-            ActionResult<BuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
-
-            Assert.IsInstanceOf<OkObjectResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task TrainSegmentAsync_MachineApiDown()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            var segmentPair = new SegmentPairDto();
-            env.MachineApiService
-                .TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-
-            // SUT
-            ActionResult actual = await env.Controller.TrainSegmentAsync(
-                Project01,
-                segmentPair,
-                CancellationToken.None
-            );
-
-            env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
-            Assert.IsInstanceOf<ObjectResult>(actual);
-            Assert.AreEqual((int)HttpStatusCode.ServiceUnavailable, (actual as ObjectResult)?.StatusCode);
-        }
-
-        [Test]
-        public async Task TrainSegmentAsync_NoPermission()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            var segmentPair = new SegmentPairDto();
-            env.MachineApiService
-                .TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None)
-                .Throws(new ForbiddenException());
-
-            // SUT
-            ActionResult actual = await env.Controller.TrainSegmentAsync(
-                Project01,
-                segmentPair,
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<ForbidResult>(actual);
-        }
-
-        [Test]
-        public async Task TrainSegmentAsync_NoProject()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            var segmentPair = new SegmentPairDto();
-            env.MachineApiService
-                .TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None)
-                .Throws(new DataNotFoundException(string.Empty));
-
-            // SUT
-            ActionResult actual = await env.Controller.TrainSegmentAsync(
-                Project01,
-                segmentPair,
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<NotFoundResult>(actual);
-        }
-
-        [Test]
-        public async Task TrainSegmentAsync_Success()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            var segmentPair = new SegmentPairDto();
-
-            // SUT
-            ActionResult actual = await env.Controller.TrainSegmentAsync(
-                Project01,
-                segmentPair,
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<OkResult>(actual);
-            await env.MachineApiService
-                .Received(1)
-                .TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None);
-        }
-
-        [Test]
-        public async Task TranslateAsync_MachineApiDown()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-
-            // SUT
-            ActionResult<TranslationResultDto> actual = await env.Controller.TranslateAsync(
-                Project01,
-                Array.Empty<string>(),
-                CancellationToken.None
-            );
-
-            env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
-            Assert.IsInstanceOf<ObjectResult>(actual.Result);
-            Assert.AreEqual((int)HttpStatusCode.ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
-        }
-
-        [Test]
-        public async Task TranslateAsync_NoPermission()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
-                .Throws(new ForbiddenException());
-
-            // SUT
-            ActionResult<TranslationResultDto> actual = await env.Controller.TranslateAsync(
-                Project01,
-                Array.Empty<string>(),
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<ForbidResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task TranslateAsync_NoProject()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
-                .Throws(new DataNotFoundException(string.Empty));
-
-            // SUT
-            ActionResult<TranslationResultDto> actual = await env.Controller.TranslateAsync(
-                Project01,
-                Array.Empty<string>(),
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<NotFoundResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task TranslateAsync_Success()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
-                .Returns(Task.FromResult(new TranslationResultDto()));
-
-            // SUT
-            ActionResult<TranslationResultDto> actual = await env.Controller.TranslateAsync(
-                Project01,
-                Array.Empty<string>(),
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<OkObjectResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task TranslateNAsync_MachineApiDown()
-        {
-            // Set up test environment
-            int n = 1;
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-
-            // SUT
-            ActionResult<TranslationResultDto[]> actual = await env.Controller.TranslateNAsync(
-                Project01,
-                n,
-                Array.Empty<string>(),
-                CancellationToken.None
-            );
-
-            env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
-            Assert.IsInstanceOf<ObjectResult>(actual.Result);
-            Assert.AreEqual((int)HttpStatusCode.ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
-        }
-
-        [Test]
-        public async Task TranslateNAsync_NoPermission()
-        {
-            // Set up test environment
-            int n = 1;
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None)
-                .Throws(new ForbiddenException());
-
-            // SUT
-            ActionResult<TranslationResultDto[]> actual = await env.Controller.TranslateNAsync(
-                Project01,
-                n,
-                Array.Empty<string>(),
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<ForbidResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task TranslateNAsync_NoProject()
-        {
-            // Set up test environment
-            int n = 1;
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None)
-                .Throws(new DataNotFoundException(string.Empty));
-
-            // SUT
-            ActionResult<TranslationResultDto[]> actual = await env.Controller.TranslateNAsync(
-                Project01,
-                n,
-                Array.Empty<string>(),
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<NotFoundResult>(actual.Result);
-        }
-
-        [Test]
-        public async Task TranslateNAsync_Success()
-        {
-            // Set up test environment
-            int n = 1;
-            var env = new TestEnvironment();
-            env.MachineApiService
-                .TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None)
-                .Returns(Task.FromResult(Array.Empty<TranslationResultDto>()));
-
-            // SUT
-            ActionResult<TranslationResultDto[]> actual = await env.Controller.TranslateNAsync(
-                Project01,
-                n,
-                Array.Empty<string>(),
-                CancellationToken.None
-            );
-
-            Assert.IsInstanceOf<OkObjectResult>(actual.Result);
-        }
-
-        private class TestEnvironment
-        {
-            public TestEnvironment()
-            {
-                var userAccessor = Substitute.For<IUserAccessor>();
-                userAccessor.UserId.Returns(User01);
-                ExceptionHandler = Substitute.For<IExceptionHandler>();
-                MachineApiService = Substitute.For<IMachineApiService>();
-
-                Controller = new MachineApiController(ExceptionHandler, MachineApiService, userAccessor);
-            }
-
-            public MachineApiController Controller { get; }
-            public IExceptionHandler ExceptionHandler { get; }
-            public IMachineApiService MachineApiService { get; }
-        }
+        public MachineApiController Controller { get; }
+        public IExceptionHandler ExceptionHandler { get; }
+        public IMachineApiService MachineApiService { get; }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
@@ -5,42 +5,39 @@ using NUnit.Framework;
 using SIL.XForge.Scripture.Services;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Controllers
+namespace SIL.XForge.Scripture.Controllers;
+
+[TestFixture]
+public class SFProjectsRpcControllerTests
 {
-    [TestFixture]
-    public class SFProjectsRpcControllerTests
+    [Test]
+    public async Task InvitedUsers_Available()
     {
-        [Test]
-        public async Task InvitedUsers_Available()
+        var env = new TestEnvironment();
+        var output = ((await env.Controller.InvitedUsers("some-project-id")) as RpcMethodSuccessResult).ReturnObject;
+        Assert.That(output, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task UninviteUser_Available()
+    {
+        var env = new TestEnvironment();
+        await env.Controller.UninviteUser("some-project-id", "some-email-address");
+    }
+
+    private class TestEnvironment
+    {
+        public TestEnvironment()
         {
-            var env = new TestEnvironment();
-            var output = (
-                (await env.Controller.InvitedUsers("some-project-id")) as RpcMethodSuccessResult
-            ).ReturnObject;
-            Assert.That(output, Is.Not.Null);
+            ExceptionHandler = Substitute.For<IExceptionHandler>();
+            SFProjectService = Substitute.For<ISFProjectService>();
+            UserAccessor = Substitute.For<IUserAccessor>();
+            Controller = new SFProjectsRpcController(UserAccessor, SFProjectService, ExceptionHandler);
         }
 
-        [Test]
-        public async Task UninviteUser_Available()
-        {
-            var env = new TestEnvironment();
-            await env.Controller.UninviteUser("some-project-id", "some-email-address");
-        }
-
-        private class TestEnvironment
-        {
-            public TestEnvironment()
-            {
-                ExceptionHandler = Substitute.For<IExceptionHandler>();
-                SFProjectService = Substitute.For<ISFProjectService>();
-                UserAccessor = Substitute.For<IUserAccessor>();
-                Controller = new SFProjectsRpcController(UserAccessor, SFProjectService, ExceptionHandler);
-            }
-
-            public IExceptionHandler ExceptionHandler { get; }
-            public SFProjectsRpcController Controller { get; }
-            public ISFProjectService SFProjectService { get; }
-            public IUserAccessor UserAccessor { get; }
-        }
+        public IExceptionHandler ExceptionHandler { get; }
+        public SFProjectsRpcController Controller { get; }
+        public ISFProjectService SFProjectService { get; }
+        public IUserAccessor UserAccessor { get; }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/I18N/SharedResourceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/I18N/SharedResourceTests.cs
@@ -5,45 +5,44 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
 
-namespace SIL.XForge.Scripture.I18N
+namespace SIL.XForge.Scripture.I18N;
+
+[TestFixture]
+public class SharedResourceTests
 {
-    [TestFixture]
-    public class SharedResourceTests
+    /// <summary>
+    ///     This test will use reflection to find all the string properties in the SharedResource Keys class.
+    ///     Then it will verify that each of those keys are present in the english .resx file
+    /// </summary>
+    [Test]
+    public void VerifyAllSharedPropsAreInEnglishResx()
     {
-        /// <summary>
-        ///     This test will use reflection to find all the string properties in the SharedResource Keys class.
-        ///     Then it will verify that each of those keys are present in the english .resx file
-        /// </summary>
-        [Test]
-        public void VerifyAllSharedPropsAreInEnglishResx()
+        var options = Options.Create(new LocalizationOptions { ResourcesPath = "Resources" });
+        var factory = new ResourceManagerStringLocalizerFactory(options, NullLoggerFactory.Instance);
+        var localizer = new StringLocalizer<SharedResource>(factory);
+
+        var sharedResourceAsm = Assembly.Load("SIL.XForge.Scripture");
+        Assert.NotNull(sharedResourceAsm, "Um, what did you refactor?");
+        var sharedResourceClass = sharedResourceAsm.GetType("SIL.XForge.Scripture.SharedResource");
+        var sharedKeys = sharedResourceClass?.GetNestedType("Keys");
+        Assert.NotNull(sharedKeys, "Um, what did you refactor?");
+        // grab all the localization keys from SharedResource.Keys static class
+        var publicProps = sharedKeys.GetFields(BindingFlags.Public | BindingFlags.Static);
+        foreach (var propInfo in publicProps.Where(x => x.FieldType == typeof(string)))
         {
-            var options = Options.Create(new LocalizationOptions { ResourcesPath = "Resources" });
-            var factory = new ResourceManagerStringLocalizerFactory(options, NullLoggerFactory.Instance);
-            var localizer = new StringLocalizer<SharedResource>(factory);
-
-            var sharedResourceAsm = Assembly.Load("SIL.XForge.Scripture");
-            Assert.NotNull(sharedResourceAsm, "Um, what did you refactor?");
-            var sharedResourceClass = sharedResourceAsm.GetType("SIL.XForge.Scripture.SharedResource");
-            var sharedKeys = sharedResourceClass?.GetNestedType("Keys");
-            Assert.NotNull(sharedKeys, "Um, what did you refactor?");
-            // grab all the localization keys from SharedResource.Keys static class
-            var publicProps = sharedKeys.GetFields(BindingFlags.Public | BindingFlags.Static);
-            foreach (var propInfo in publicProps.Where(x => x.FieldType == typeof(string)))
-            {
-                var keyValue = (string)propInfo.GetValue(null);
-                var englishStringFromResource = localizer.GetString(keyValue);
-                // verify that each key is found
-                Assert.IsFalse(
-                    englishStringFromResource.ResourceNotFound,
-                    "Missing english string from .resx for " + propInfo.Name
-                );
-            }
-
-            Assert.AreEqual(
-                publicProps.Length,
-                localizer.GetAllStrings().Count(),
-                "There are extra strings in the SharedResources.en.resx which are not in the SharedResource.Keys class"
+            var keyValue = (string)propInfo.GetValue(null);
+            var englishStringFromResource = localizer.GetString(keyValue);
+            // verify that each key is found
+            Assert.IsFalse(
+                englishStringFromResource.ResourceNotFound,
+                "Missing english string from .resx for " + propInfo.Name
             );
         }
+
+        Assert.AreEqual(
+            publicProps.Length,
+            localizer.GetAllStrings().Count(),
+            "There are extra strings in the SharedResources.en.resx which are not in the SharedResource.Keys class"
+        );
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Models/CharAttr.cs
+++ b/test/SIL.XForge.Scripture.Tests/Models/CharAttr.cs
@@ -1,8 +1,7 @@
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+public class CharAttr
 {
-    public class CharAttr
-    {
-        public string Style { get; set; }
-        public string CharID { get; set; }
-    }
+    public string Style { get; set; }
+    public string CharID { get; set; }
 }

--- a/test/SIL.XForge.Scripture.Tests/Models/NoteSyncMetricInfoTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Models/NoteSyncMetricInfoTests.cs
@@ -1,67 +1,66 @@
 using NUnit.Framework;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+[TestFixture]
+public class NoteNoteSyncMetricInfoTests
 {
-    [TestFixture]
-    public class NoteNoteSyncMetricInfoTests
+    [Test]
+    public void NoteSyncMetricInfo_EmptyConstructor()
     {
-        [Test]
-        public void NoteSyncMetricInfo_EmptyConstructor()
-        {
-            // SUT
-            var noteSyncMetricInfo = new NoteSyncMetricInfo();
+        // SUT
+        var noteSyncMetricInfo = new NoteSyncMetricInfo();
 
-            Assert.That(noteSyncMetricInfo.Added, Is.Zero);
-            Assert.That(noteSyncMetricInfo.Deleted, Is.Zero);
-            Assert.That(noteSyncMetricInfo.Updated, Is.Zero);
-            Assert.That(noteSyncMetricInfo.Removed, Is.Zero);
-        }
+        Assert.That(noteSyncMetricInfo.Added, Is.Zero);
+        Assert.That(noteSyncMetricInfo.Deleted, Is.Zero);
+        Assert.That(noteSyncMetricInfo.Updated, Is.Zero);
+        Assert.That(noteSyncMetricInfo.Removed, Is.Zero);
+    }
 
-        [Test]
-        public void NoteSyncMetricInfo_ConstructorParameterOrder()
-        {
-            // SUT
-            var noteSyncMetricInfo = new NoteSyncMetricInfo(1, 2, 3, 4);
+    [Test]
+    public void NoteSyncMetricInfo_ConstructorParameterOrder()
+    {
+        // SUT
+        var noteSyncMetricInfo = new NoteSyncMetricInfo(1, 2, 3, 4);
 
-            Assert.That(noteSyncMetricInfo.Added, Is.EqualTo(1));
-            Assert.That(noteSyncMetricInfo.Deleted, Is.EqualTo(2));
-            Assert.That(noteSyncMetricInfo.Updated, Is.EqualTo(3));
-            Assert.That(noteSyncMetricInfo.Removed, Is.EqualTo(4));
-        }
+        Assert.That(noteSyncMetricInfo.Added, Is.EqualTo(1));
+        Assert.That(noteSyncMetricInfo.Deleted, Is.EqualTo(2));
+        Assert.That(noteSyncMetricInfo.Updated, Is.EqualTo(3));
+        Assert.That(noteSyncMetricInfo.Removed, Is.EqualTo(4));
+    }
 
-        [Test]
-        public void NoteSyncMetricInfo_AddOperatorFirstNull()
-        {
-            var noteSyncMetricInfo = new NoteSyncMetricInfo(1, 2, 3, 4);
+    [Test]
+    public void NoteSyncMetricInfo_AddOperatorFirstNull()
+    {
+        var noteSyncMetricInfo = new NoteSyncMetricInfo(1, 2, 3, 4);
 
-            // SUT
-            var result = null + noteSyncMetricInfo;
+        // SUT
+        var result = null + noteSyncMetricInfo;
 
-            Assert.That(result, Is.EqualTo(noteSyncMetricInfo));
-        }
+        Assert.That(result, Is.EqualTo(noteSyncMetricInfo));
+    }
 
-        [Test]
-        public void NoteSyncMetricInfo_AddOperatorSecondNull()
-        {
-            var noteSyncMetricInfo = new NoteSyncMetricInfo(1, 2, 3, 4);
+    [Test]
+    public void NoteSyncMetricInfo_AddOperatorSecondNull()
+    {
+        var noteSyncMetricInfo = new NoteSyncMetricInfo(1, 2, 3, 4);
 
-            // SUT
-            var result = noteSyncMetricInfo + null;
+        // SUT
+        var result = noteSyncMetricInfo + null;
 
-            Assert.That(result, Is.EqualTo(noteSyncMetricInfo));
-        }
+        Assert.That(result, Is.EqualTo(noteSyncMetricInfo));
+    }
 
-        [Test]
-        public void NoteSyncMetricInfo_AddOperatorBothValues()
-        {
-            var firstNoteSyncMetricInfo = new NoteSyncMetricInfo(1, 2, 3, 5);
-            var secondNoteSyncMetricInfo = new NoteSyncMetricInfo(7, 11, 13, 17);
-            var addedNoteSyncMetricInfo = new NoteSyncMetricInfo(8, 13, 16, 22);
+    [Test]
+    public void NoteSyncMetricInfo_AddOperatorBothValues()
+    {
+        var firstNoteSyncMetricInfo = new NoteSyncMetricInfo(1, 2, 3, 5);
+        var secondNoteSyncMetricInfo = new NoteSyncMetricInfo(7, 11, 13, 17);
+        var addedNoteSyncMetricInfo = new NoteSyncMetricInfo(8, 13, 16, 22);
 
-            // SUT
-            var result = firstNoteSyncMetricInfo + secondNoteSyncMetricInfo;
+        // SUT
+        var result = firstNoteSyncMetricInfo + secondNoteSyncMetricInfo;
 
-            Assert.That(result, Is.EqualTo(addedNoteSyncMetricInfo));
-        }
+        Assert.That(result, Is.EqualTo(addedNoteSyncMetricInfo));
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Models/SyncMetricInfoTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Models/SyncMetricInfoTests.cs
@@ -1,65 +1,64 @@
 using NUnit.Framework;
 
-namespace SIL.XForge.Scripture.Models
+namespace SIL.XForge.Scripture.Models;
+
+[TestFixture]
+public class SyncMetricInfoTests
 {
-    [TestFixture]
-    public class SyncMetricInfoTests
+    [Test]
+    public void SyncMetricInfo_EmptyConstructor()
     {
-        [Test]
-        public void SyncMetricInfo_EmptyConstructor()
-        {
-            // SUT
-            var syncMetricInfo = new SyncMetricInfo();
+        // SUT
+        var syncMetricInfo = new SyncMetricInfo();
 
-            Assert.That(syncMetricInfo.Added, Is.Zero);
-            Assert.That(syncMetricInfo.Deleted, Is.Zero);
-            Assert.That(syncMetricInfo.Updated, Is.Zero);
-        }
+        Assert.That(syncMetricInfo.Added, Is.Zero);
+        Assert.That(syncMetricInfo.Deleted, Is.Zero);
+        Assert.That(syncMetricInfo.Updated, Is.Zero);
+    }
 
-        [Test]
-        public void SyncMetricInfo_ConstructorParameterOrder()
-        {
-            // SUT
-            var syncMetricInfo = new SyncMetricInfo(1, 2, 3);
+    [Test]
+    public void SyncMetricInfo_ConstructorParameterOrder()
+    {
+        // SUT
+        var syncMetricInfo = new SyncMetricInfo(1, 2, 3);
 
-            Assert.That(syncMetricInfo.Added, Is.EqualTo(1));
-            Assert.That(syncMetricInfo.Deleted, Is.EqualTo(2));
-            Assert.That(syncMetricInfo.Updated, Is.EqualTo(3));
-        }
+        Assert.That(syncMetricInfo.Added, Is.EqualTo(1));
+        Assert.That(syncMetricInfo.Deleted, Is.EqualTo(2));
+        Assert.That(syncMetricInfo.Updated, Is.EqualTo(3));
+    }
 
-        [Test]
-        public void SyncMetricInfo_AddOperatorFirstNull()
-        {
-            var syncMetricInfo = new SyncMetricInfo(1, 2, 3);
+    [Test]
+    public void SyncMetricInfo_AddOperatorFirstNull()
+    {
+        var syncMetricInfo = new SyncMetricInfo(1, 2, 3);
 
-            // SUT
-            var result = null + syncMetricInfo;
+        // SUT
+        var result = null + syncMetricInfo;
 
-            Assert.That(result, Is.EqualTo(syncMetricInfo));
-        }
+        Assert.That(result, Is.EqualTo(syncMetricInfo));
+    }
 
-        [Test]
-        public void SyncMetricInfo_AddOperatorSecondNull()
-        {
-            var syncMetricInfo = new SyncMetricInfo(1, 2, 3);
+    [Test]
+    public void SyncMetricInfo_AddOperatorSecondNull()
+    {
+        var syncMetricInfo = new SyncMetricInfo(1, 2, 3);
 
-            // SUT
-            var result = syncMetricInfo + null;
+        // SUT
+        var result = syncMetricInfo + null;
 
-            Assert.That(result, Is.EqualTo(syncMetricInfo));
-        }
+        Assert.That(result, Is.EqualTo(syncMetricInfo));
+    }
 
-        [Test]
-        public void SyncMetricInfo_AddOperatorBothValues()
-        {
-            var firstSyncMetricInfo = new SyncMetricInfo(1, 2, 3);
-            var secondSyncMetricInfo = new SyncMetricInfo(5, 7, 11);
-            var addedSyncMetricInfo = new SyncMetricInfo(6, 9, 14);
+    [Test]
+    public void SyncMetricInfo_AddOperatorBothValues()
+    {
+        var firstSyncMetricInfo = new SyncMetricInfo(1, 2, 3);
+        var secondSyncMetricInfo = new SyncMetricInfo(5, 7, 11);
+        var addedSyncMetricInfo = new SyncMetricInfo(6, 9, 14);
 
-            // SUT
-            var result = firstSyncMetricInfo + secondSyncMetricInfo;
+        // SUT
+        var result = firstSyncMetricInfo + secondSyncMetricInfo;
 
-            Assert.That(result, Is.EqualTo(addedSyncMetricInfo));
-        }
+        Assert.That(result, Is.EqualTo(addedSyncMetricInfo));
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/ComparableProjectPermissionManager.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ComparableProjectPermissionManager.cs
@@ -3,37 +3,31 @@ using Paratext.Data;
 using Paratext.Data.Users;
 using PtxUtils;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// This is an implementation of the ProjectPermissionManager that allows comparison of permission managers.
+/// </summary>
+/// <seealso cref="ProjectPermissionManager" />
+/// <seealso cref="IEquatable{ComparableProjectPermissionManager}" />
+public sealed class ComparableProjectPermissionManager
+    : ProjectPermissionManager,
+        IEquatable<ComparableProjectPermissionManager>
 {
+    public ComparableProjectPermissionManager(ScrText scrText)
+        : base(scrText) { }
+
     /// <summary>
-    /// This is an implementation of the ProjectPermissionManager that allows comparison of permission managers.
+    /// Gets the XML data.
     /// </summary>
-    /// <seealso cref="ProjectPermissionManager" />
-    /// <seealso cref="IEquatable{ComparableProjectPermissionManager}" />
-    public sealed class ComparableProjectPermissionManager
-        : ProjectPermissionManager,
-            IEquatable<ComparableProjectPermissionManager>
-    {
-        public ComparableProjectPermissionManager(ScrText scrText) : base(scrText) { }
+    /// <remarks>
+    /// This is based on the code for <see cref="PermissionManager.Clone" />.
+    /// </remarks>
+    private string XmlData => Memento.ToXmlString(Data, false, true);
 
-        /// <summary>
-        /// Gets the XML data.
-        /// </summary>
-        /// <remarks>
-        /// This is based on the code for <see cref="PermissionManager.Clone" />.
-        /// </remarks>
-        private string XmlData => Memento.ToXmlString(Data, false, true);
+    public bool Equals(ComparableProjectPermissionManager? other) => XmlData == other?.XmlData;
 
-        public bool Equals(ComparableProjectPermissionManager? other) => XmlData == other?.XmlData;
+    public override bool Equals(object? obj) => Equals(obj as ComparableProjectPermissionManager);
 
-        public override bool Equals(object? obj)
-        {
-            return Equals(obj as ComparableProjectPermissionManager);
-        }
-
-        public override int GetHashCode()
-        {
-            return XmlData.GetHashCode();
-        }
-    }
+    public override int GetHashCode() => XmlData.GetHashCode();
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -1,1508 +1,82 @@
-using System.Linq;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Linq;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
 using NUnit.Framework;
 using SIL.XForge.Realtime.RichText;
 using SIL.XForge.Scripture.Models;
-using Newtonsoft.Json.Linq;
-using Microsoft.Extensions.Logging;
-using NSubstitute;
-using System;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class DeltaUsxMapperTests
 {
-    [TestFixture]
-    public class DeltaUsxMapperTests
+    private IGuidService _mapperGuidService;
+    private IGuidService _testGuidService;
+    private ILogger<DeltaUsxMapper> _logger;
+    private IExceptionHandler _exceptionHandler;
+
+    [SetUp]
+    public void Init()
     {
-        private IGuidService _mapperGuidService;
-        private IGuidService _testGuidService;
-        private ILogger<DeltaUsxMapper> _logger;
-        private IExceptionHandler _exceptionHandler;
-
-        [SetUp]
-        public void Init()
-        {
-            _mapperGuidService = new TestGuidService();
-            _testGuidService = new TestGuidService();
-            _logger = Substitute.For<ILogger<DeltaUsxMapper>>();
-            _exceptionHandler = Substitute.For<IExceptionHandler>();
-        }
-
-        [Test]
-        public void ToUsx_HeaderPara()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                0,
-                true,
-                Delta.New().InsertText("Philemon", "h_1").InsertPara("h").Insert("\n")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx("PHM", Para("h", "Philemon"));
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_VerseText()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                1,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertText("Verse text.", "verse_1_1")
-                    .InsertPara("p")
-                    .Insert("\n")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx("PHM", Chapter("1"), Para("p", Verse("1"), "Verse text."));
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_EmptySegments()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                3,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertBlank("verse_1_1")
-                    .InsertVerse("2")
-                    .InsertBlank("verse_1_2")
-                    .InsertPara("p")
-                    .InsertBlank("verse_1_2/li_1")
-                    .InsertPara("li")
-                    .InsertBlank("verse_1_2/li_2")
-                    .InsertPara("li")
-                    .InsertBlank("verse_1_2/p_3")
-                    .InsertVerse("3")
-                    .InsertBlank("verse_1_3")
-                    .InsertPara("p")
-                    .Insert("\n")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), Verse("2")),
-                Para("li"),
-                Para("li"),
-                Para("p", Verse("3"))
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_CharText()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                1,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertText("This is some ", "verse_1_1")
-                    .InsertChar("bold", "bd", _testGuidService.Generate(), "verse_1_1")
-                    .InsertText(" text.", "verse_1_1")
-                    .InsertPara("p")
-                    .Insert("\n")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), "This is some ", Char("bd", "bold"), " text.")
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_EmptyChar()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                1,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertText("This is some ", "verse_1_1")
-                    .InsertEmptyChar("bd", _testGuidService.Generate(), "verse_1_1")
-                    .InsertText(" text.", "verse_1_1")
-                    .InsertPara("p")
-                    .Insert("\n")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), "This is some ", Char("bd", null), " text.")
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_Note()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                1,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertText("This is a verse with a footnote", "verse_1_1")
-                    .InsertNote(
-                        Delta
-                            .New()
-                            .InsertChar("1.1: ", "fr", _testGuidService.Generate())
-                            .InsertChar("Refers to ", "ft", _testGuidService.Generate())
-                            .InsertChar("a footnote", "fq", _testGuidService.Generate())
-                            .Insert(". ")
-                            .InsertChar("John 1:1", "xt", _testGuidService.Generate())
-                            .Insert(" and ")
-                            .InsertChar("Mark 1:1", "xt", _testGuidService.Generate()),
-                        "f",
-                        "+",
-                        "verse_1_1"
-                    )
-                    .InsertText(", so that we can test it.", "verse_1_1")
-                    .InsertPara("p")
-                    .Insert("\n")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                Para(
-                    "p",
-                    Verse("1"),
-                    "This is a verse with a footnote",
-                    Note(
-                        "f",
-                        "+",
-                        Char("fr", "1.1: "),
-                        Char("ft", "Refers to "),
-                        Char("fq", "a footnote"),
-                        ". ",
-                        Char("xt", "John 1:1"),
-                        " and ",
-                        Char("xt", "Mark 1:1")
-                    ),
-                    ", so that we can test it."
-                )
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_Figure()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                1,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertText("This is a verse with a figure", "verse_1_1")
-                    .InsertFigure("file.jpg", "col", "PHM 1:1", "Caption", "verse_1_1")
-                    .InsertText(", so that we can test it.", "verse_1_1")
-                    .InsertPara("p")
-                    .Insert("\n")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                Para(
-                    "p",
-                    Verse("1"),
-                    "This is a verse with a figure",
-                    Figure("file.jpg", "col", "PHM 1:1", "Caption"),
-                    ", so that we can test it."
-                )
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_NestedChars()
-        {
-            string bdCharID = _testGuidService.Generate();
-            string sup1CharID = _testGuidService.Generate();
-            string sup2CharID = _testGuidService.Generate();
-            string sup3CharID = _testGuidService.Generate();
-            var chapterDelta = new ChapterDelta(
-                1,
-                1,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertChar(
-                        "1",
-                        new List<CharAttr>
-                        {
-                            new CharAttr { Style = "bd", CharID = bdCharID },
-                            new CharAttr { Style = "sup", CharID = sup1CharID }
-                        },
-                        "verse_1_1"
-                    )
-                    .InsertChar("This is", "bd", bdCharID, "verse_1_1")
-                    .InsertChar(
-                        "2",
-                        new List<CharAttr>
-                        {
-                            new CharAttr { Style = "bd", CharID = bdCharID },
-                            new CharAttr { Style = "sup", CharID = sup2CharID }
-                        },
-                        "verse_1_1"
-                    )
-                    .InsertChar(" bold text.", "bd", bdCharID, "verse_1_1")
-                    .InsertChar(
-                        "3",
-                        new List<CharAttr>
-                        {
-                            new CharAttr { Style = "bd", CharID = bdCharID },
-                            new CharAttr { Style = "sup", CharID = sup3CharID }
-                        },
-                        "verse_1_1"
-                    )
-                    .InsertText(" This is normal text.", "verse_1_1")
-                    .InsertPara("p")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                Para(
-                    "p",
-                    Verse("1"),
-                    Char("bd", Char("sup", "1"), "This is", Char("sup", "2"), " bold text.", Char("sup", "3")),
-                    " This is normal text."
-                )
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_NestedAdjacentChars()
-        {
-            string bdCharID = _testGuidService.Generate();
-            string sup1CharID = _testGuidService.Generate();
-            string sup2CharID = _testGuidService.Generate();
-            string sup3CharID = _testGuidService.Generate();
-            var chapterDelta = new ChapterDelta(
-                1,
-                1,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertChar(
-                        "1",
-                        new List<CharAttr>
-                        {
-                            new CharAttr { Style = "bd", CharID = bdCharID },
-                            new CharAttr { Style = "sup", CharID = sup1CharID }
-                        },
-                        "verse_1_1"
-                    )
-                    .InsertChar(
-                        "2",
-                        new List<CharAttr>
-                        {
-                            new CharAttr { Style = "bd", CharID = bdCharID },
-                            new CharAttr { Style = "sup", CharID = sup2CharID }
-                        },
-                        "verse_1_1"
-                    )
-                    .InsertChar(
-                        "3",
-                        new List<CharAttr>
-                        {
-                            new CharAttr { Style = "bd", CharID = bdCharID },
-                            new CharAttr { Style = "sup", CharID = sup3CharID }
-                        },
-                        "verse_1_1"
-                    )
-                    .InsertText(" This is normal text.", "verse_1_1")
-                    .InsertPara("p")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                Para(
-                    "p",
-                    Verse("1"),
-                    Char("bd", Char("sup", "1"), Char("sup", "2"), Char("sup", "3")),
-                    " This is normal text."
-                )
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_DoubleNestedAdjacentChars()
-        {
-            string bdCharID = _testGuidService.Generate();
-            string sup1CharID = _testGuidService.Generate();
-            string noCharID = _testGuidService.Generate();
-            string sup2CharID = _testGuidService.Generate();
-            string sup3CharID = _testGuidService.Generate();
-            string sup4CharID = _testGuidService.Generate();
-            var chapterDelta = new ChapterDelta(
-                1,
-                1,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertChar(
-                        "1",
-                        new List<CharAttr>
-                        {
-                            new CharAttr { Style = "bd", CharID = bdCharID },
-                            new CharAttr { Style = "sup", CharID = sup1CharID }
-                        },
-                        "verse_1_1"
-                    )
-                    .InsertChar("This is bold text", "bd", bdCharID, "verse_1_1")
-                    .InsertChar(
-                        " but this is not bold,",
-                        new List<CharAttr>
-                        {
-                            new CharAttr { Style = "bd", CharID = bdCharID },
-                            new CharAttr { Style = "no", CharID = noCharID }
-                        },
-                        "verse_1_1"
-                    )
-                    .InsertChar(
-                        "2",
-                        new List<CharAttr>
-                        {
-                            new CharAttr { Style = "bd", CharID = bdCharID },
-                            new CharAttr { Style = "no", CharID = noCharID },
-                            new CharAttr { Style = "sup", CharID = sup2CharID }
-                        },
-                        "verse_1_1"
-                    )
-                    .InsertChar(
-                        "3",
-                        new List<CharAttr>
-                        {
-                            new CharAttr { Style = "bd", CharID = bdCharID },
-                            new CharAttr { Style = "no", CharID = noCharID },
-                            new CharAttr { Style = "sup", CharID = sup3CharID }
-                        },
-                        "verse_1_1"
-                    )
-                    .InsertChar(" and this is bold.", "bd", bdCharID, "verse_1_1")
-                    .InsertChar(
-                        "4",
-                        new List<CharAttr>
-                        {
-                            new CharAttr { Style = "bd", CharID = bdCharID },
-                            new CharAttr { Style = "sup", CharID = sup4CharID }
-                        },
-                        "verse_1_1"
-                    )
-                    .InsertText(" This is normal text.", "verse_1_1")
-                    .InsertPara("p")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                Para(
-                    "p",
-                    Verse("1"),
-                    Char(
-                        "bd",
-                        Char("sup", "1"),
-                        "This is bold text",
-                        Char("no", " but this is not bold,", Char("sup", "2"), Char("sup", "3")),
-                        " and this is bold.",
-                        Char("sup", "4")
-                    ),
-                    " This is normal text."
-                )
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_AdjacentChars()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                1,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertChar("1", "sup", _testGuidService.Generate(), "verse_1_1")
-                    .InsertChar("2", "sup", _testGuidService.Generate(), "verse_1_1")
-                    .InsertChar("3", "sup", _testGuidService.Generate(), "verse_1_1")
-                    .InsertText(" This is normal text.", "verse_1_1")
-                    .InsertPara("p")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), Char("sup", "1"), Char("sup", "2"), Char("sup", "3"), " This is normal text.")
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_Ref()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                1,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertText("This is a verse with a footnote", "verse_1_1")
-                    .InsertNote(
-                        Delta
-                            .New()
-                            .InsertChar("1.1: ", "fr", _testGuidService.Generate())
-                            .InsertChar("Refers to ", "ft", _testGuidService.Generate())
-                            .InsertChar("a footnote", "fq", _testGuidService.Generate())
-                            .Insert(". ")
-                            .InsertCharRef("John 1:1", "xt", "JHN 1:1", _testGuidService.Generate())
-                            .Insert(" and ")
-                            .InsertCharRef("Mark 1:1", "xt", "MRK 1:1", _testGuidService.Generate())
-                            .Insert("."),
-                        "f",
-                        "+",
-                        "verse_1_1"
-                    )
-                    .InsertText(", so that we can test it.", "verse_1_1")
-                    .InsertPara("p")
-                    .Insert("\n")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                Para(
-                    "p",
-                    Verse("1"),
-                    "This is a verse with a footnote",
-                    Note(
-                        "f",
-                        "+",
-                        Char("fr", "1.1: "),
-                        Char("ft", "Refers to "),
-                        Char("fq", "a footnote"),
-                        ". ",
-                        Char("xt", Ref("JHN 1:1", "John 1:1")),
-                        " and ",
-                        Char("xt", Ref("MRK 1:1", "Mark 1:1")),
-                        "."
-                    ),
-                    ", so that we can test it."
-                )
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_EmptyRef()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                1,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertText("This is a verse with a footnote", "verse_1_1")
-                    .InsertNote(
-                        Delta
-                            .New()
-                            .InsertChar("1:1", "fr", _testGuidService.Generate())
-                            .InsertEmptyChar("ft", _testGuidService.Generate())
-                            .Insert(". ")
-                            .InsertEmptyChar("xo", _testGuidService.Generate())
-                            .InsertCharRef("Mark 1:1", "xt", "MRK 1:1", _testGuidService.Generate()),
-                        "f",
-                        "*",
-                        "verse_1_1"
-                    )
-                    .InsertText(", so that we can test it.", "verse_1_1")
-                    .InsertPara("p")
-                    .Insert("\n")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                Para(
-                    "p",
-                    Verse("1"),
-                    "This is a verse with a footnote",
-                    Note(
-                        "f",
-                        "*",
-                        Char("fr", "1:1"),
-                        Char("ft", null),
-                        ". ",
-                        Char("xo", null),
-                        Char("xt", Ref("MRK 1:1", "Mark 1:1"))
-                    ),
-                    ", so that we can test it."
-                )
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_OptBreak()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                1,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertText("This is a verse with a line break", "verse_1_1")
-                    .InsertOptBreak("verse_1_1")
-                    .InsertText(", so that we can test it.", "verse_1_1")
-                    .InsertPara("p")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), "This is a verse with a line break", OptBreak(), ", so that we can test it.")
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_Milestone()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                1,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertText("This is a verse with a milestone", "verse_1_1")
-                    .InsertMilestone("ts", "verse_1_1")
-                    .InsertText(", so that we can test it.", "verse_1_1")
-                    .InsertPara("p")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), "This is a verse with a milestone", Milestone("ts"), ", so that we can test it.")
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_TableAtEnd()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                3,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertText("Before verse.", "cell_1_1_1")
-                    .InsertVerse("1")
-                    .InsertText("This is verse ", "verse_1_1")
-                    .InsertChar("1", "it", _testGuidService.Generate(), "verse_1_1")
-                    .InsertText(".", "verse_1_1")
-                    .InsertCell(1, 1, "tc1", "start")
-                    .InsertBlank("cell_1_1_2")
-                    .InsertVerse("2")
-                    .InsertText("This is verse 2.", "verse_1_2")
-                    .InsertCell(1, 1, "tc2", "start")
-                    .InsertBlank("cell_1_2_1")
-                    .InsertCell(1, 2, "tc1", "start")
-                    .InsertBlank("cell_1_2_2")
-                    .InsertVerse("3")
-                    .InsertText("This is verse 3.", "verse_1_3")
-                    .InsertCell(1, 2, "tc2", "start")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                Table(
-                    Row(
-                        Cell("tc1", "start", "Before verse.", Verse("1"), "This is verse ", Char("it", "1"), "."),
-                        Cell("tc2", "start", Verse("2"), "This is verse 2.")
-                    ),
-                    Row(Cell("tc1", "start"), Cell("tc2", "start", Verse("3"), "This is verse 3."))
-                )
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_TableInMiddle()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                4,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertText("Before verse.", "cell_1_1_1")
-                    .InsertVerse("1")
-                    .InsertText("This is verse ", "verse_1_1")
-                    .InsertChar("1", "it", _testGuidService.Generate(), "verse_1_1")
-                    .InsertText(".", "verse_1_1")
-                    .InsertCell(1, 1, "tc1", "start")
-                    .InsertBlank("cell_1_1_2")
-                    .InsertVerse("2")
-                    .InsertText("This is verse 2.", "verse_1_2")
-                    .InsertCell(1, 1, "tc2", "start")
-                    .InsertBlank("cell_1_2_1")
-                    .InsertCell(1, 2, "tc1", "start")
-                    .InsertBlank("cell_1_2_2")
-                    .InsertVerse("3")
-                    .InsertText("This is verse 3.", "verse_1_3")
-                    .InsertCell(1, 2, "tc2", "start")
-                    .InsertBlank("p_1")
-                    .InsertVerse("4")
-                    .InsertText("This is verse 4.", "verse_1_4")
-                    .InsertPara("p")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                Table(
-                    Row(
-                        Cell("tc1", "start", "Before verse.", Verse("1"), "This is verse ", Char("it", "1"), "."),
-                        Cell("tc2", "start", Verse("2"), "This is verse 2.")
-                    ),
-                    Row(Cell("tc1", "start"), Cell("tc2", "start", Verse("3"), "This is verse 3."))
-                ),
-                Para("p", Verse("4"), "This is verse 4.")
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_AdjacentTables()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                8,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertBlank("cell_1_1_1")
-                    .InsertVerse("1")
-                    .InsertText("This is verse 1.", "verse_1_1")
-                    .InsertCell(1, 1, "tc1", "start")
-                    .InsertBlank("cell_1_1_2")
-                    .InsertVerse("2")
-                    .InsertText("This is verse 2.", "verse_1_2")
-                    .InsertCell(1, 1, "tc2", "start")
-                    .InsertBlank("cell_1_2_1")
-                    .InsertVerse("3")
-                    .InsertText("This is verse 3.", "verse_1_3")
-                    .InsertCell(1, 2, "tc1", "start")
-                    .InsertBlank("cell_1_2_2")
-                    .InsertVerse("4")
-                    .InsertText("This is verse 4.", "verse_1_4")
-                    .InsertCell(1, 2, "tc2", "start")
-                    .InsertBlank("cell_2_1_1")
-                    .InsertVerse("5")
-                    .InsertText("This is verse 5.", "verse_1_5")
-                    .InsertCell(2, 1, "tc1", "start")
-                    .InsertBlank("cell_2_1_2")
-                    .InsertVerse("6")
-                    .InsertText("This is verse 6.", "verse_1_6")
-                    .InsertCell(2, 1, "tc2", "start")
-                    .InsertBlank("cell_2_2_1")
-                    .InsertVerse("7")
-                    .InsertText("This is verse 7.", "verse_1_7")
-                    .InsertCell(2, 2, "tc1", "start")
-                    .InsertBlank("cell_2_2_2")
-                    .InsertVerse("8")
-                    .InsertText("This is verse 8.", "verse_1_8")
-                    .InsertCell(2, 2, "tc2", "start")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                Table(
-                    Row(
-                        Cell("tc1", "start", Verse("1"), "This is verse 1."),
-                        Cell("tc2", "start", Verse("2"), "This is verse 2.")
-                    ),
-                    Row(
-                        Cell("tc1", "start", Verse("3"), "This is verse 3."),
-                        Cell("tc2", "start", Verse("4"), "This is verse 4.")
-                    )
-                ),
-                Table(
-                    Row(
-                        Cell("tc1", "start", Verse("5"), "This is verse 5."),
-                        Cell("tc2", "start", Verse("6"), "This is verse 6.")
-                    ),
-                    Row(
-                        Cell("tc1", "start", Verse("7"), "This is verse 7."),
-                        Cell("tc2", "start", Verse("8"), "This is verse 8.")
-                    )
-                )
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_ConsecutiveSameStyleEmptyParas()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                0,
-                true,
-                Delta.New().InsertBlank("p_1").InsertPara("p").InsertBlank("p_2").InsertPara("p")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx("PHM", Para("p"), Para("p"));
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_NoParagraphs()
-        {
-            var chapterDeltas = new[]
-            {
-                new ChapterDelta(
-                    1,
-                    3,
-                    true,
-                    Delta
-                        .New()
-                        .InsertChapter("1")
-                        .InsertVerse("1")
-                        .InsertText("This is verse 1.", "verse_1_1")
-                        .InsertVerse("2")
-                        .InsertBlank("verse_1_2")
-                        .InsertVerse("3")
-                        .InsertText("This is verse 3.", "verse_1_3")
-                        .Insert("\n")
-                ),
-                new ChapterDelta(
-                    2,
-                    2,
-                    true,
-                    Delta
-                        .New()
-                        .InsertChapter("2")
-                        .InsertVerse("1")
-                        .InsertBlank("verse_2_1")
-                        .InsertVerse("2")
-                        .InsertBlank("verse_2_2")
-                        .Insert("\n")
-                )
-            };
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM", Chapter("1"), "Text", Chapter("2"), "Text"), chapterDeltas);
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                Verse("1"),
-                "This is verse 1.",
-                Verse("2"),
-                Verse("3"),
-                "This is verse 3.",
-                Chapter("2"),
-                Verse("1"),
-                Verse("2")
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_ImpliedParagraph()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                1,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .Insert("This is an implied paragraph before the first verse.")
-                    .Insert("\n")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertBlank("verse_1_1")
-                    .InsertPara("p")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                "This is an implied paragraph before the first verse.",
-                Para("p", Verse("1"))
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_ImpliedParagraphTwice()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                1,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .Insert("This is an implied paragraph before the first verse.")
-                    .Insert("\n")
-                    .Insert(" This is actually part of the first implied paragraph.")
-                    .Insert("\n")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertBlank("verse_1_1")
-                    .InsertPara("p")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                "This is an implied paragraph before the first verse.",
-                " This is actually part of the first implied paragraph.",
-                Para("p", Verse("1"))
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_ImpliedParagraphInVerse()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                1,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .Insert("This is an implied paragraph before the first verse.")
-                    .Insert("\n")
-                    .InsertText("This is actually an implied paragraph as part of the verse.", "p_1")
-                    .InsertVerse("1")
-                    .InsertBlank("verse_1_1")
-                    .InsertPara("p")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                "This is an implied paragraph before the first verse.",
-                Para("p", "This is actually an implied paragraph as part of the verse.", Verse("1"))
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_NoParagraphsImpliedParagraph()
-        {
-            var chapterDeltas = new[]
-            {
-                new ChapterDelta(
-                    1,
-                    3,
-                    true,
-                    Delta
-                        .New()
-                        .InsertChapter("1")
-                        .Insert("This is an implied paragraph before the first verse.")
-                        .InsertVerse("1")
-                        .InsertText("This is verse 1.", "verse_1_1")
-                        .InsertVerse("2")
-                        .InsertBlank("verse_1_2")
-                        .InsertVerse("3")
-                        .InsertText("This is verse 3.", "verse_1_3")
-                        .Insert("\n")
-                ),
-                new ChapterDelta(
-                    2,
-                    2,
-                    true,
-                    Delta
-                        .New()
-                        .InsertChapter("2")
-                        .InsertVerse("1")
-                        .InsertBlank("verse_2_1")
-                        .InsertVerse("2")
-                        .InsertBlank("verse_2_2")
-                        .Insert("\n")
-                )
-            };
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM", Chapter("1"), "Text", Chapter("2"), "Text"), chapterDeltas);
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                "This is an implied paragraph before the first verse.",
-                Verse("1"),
-                "This is verse 1.",
-                Verse("2"),
-                Verse("3"),
-                "This is verse 3.",
-                Chapter("2"),
-                Verse("1"),
-                Verse("2")
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_EmptyBook()
-        {
-            var chapterDeltas = new[] { new ChapterDelta(1, 0, true, new Delta()) };
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), chapterDeltas);
-
-            XDocument expected = Usx("PHM");
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_MismatchNoChapters_UnchangedUsx()
-        {
-            _exceptionHandler.ClearReceivedCalls();
-            var chapterDeltas = new[] { new ChapterDelta(1, 0, true, new Delta()) };
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-
-            // The USX here has chapters that are not in ChapterDeltas. The chapterDeltas contains
-            // the 1 implicit 'chapter'.
-            XDocument input = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), "Verse text."),
-                Chapter("2"),
-                Para("p", Verse("1"), "Verse text.")
-            );
-
-            // SUT
-            XDocument newUsxDoc = mapper.ToUsx(input, chapterDeltas);
-
-            XDocument expected = input;
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-            _exceptionHandler
-                .Received()
-                .ReportException(Arg.Is<Exception>((Exception e) => e.Message.Contains("no real chapters")));
-        }
-
-        [Test]
-        public void ToUsx_MismatchedChapters_UnchangedUsx()
-        {
-            _exceptionHandler.ClearReceivedCalls();
-            var chapterDeltas = new[]
-            {
-                new ChapterDelta(
-                    1,
-                    0,
-                    true,
-                    new Delta().InsertChapter("1").InsertBlank("p_1").InsertVerse("1").InsertBlank("verse_1_1")
-                )
-            };
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-
-            // The USX here has chapter 2, which is not in chapterDeltas. The chapterDeltas does contain 1 real chapter.
-            XDocument input = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), "Verse text."),
-                Chapter("2"),
-                Para("p", Verse("1"), "Verse text.")
-            );
-
-            // SUT
-            Exception thrown = Assert.Throws<Exception>(() => mapper.ToUsx(input, chapterDeltas));
-            Assert.That(thrown.Message, Contains.Substring("Rethrowing"));
-            Assert.That(thrown.InnerException, Is.TypeOf<IndexOutOfRangeException>());
-        }
-
-        [Test]
-        public void ToUsx_BlankLine()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                3,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertBlank("verse_1_1")
-                    .InsertVerse("2")
-                    .InsertBlank("verse_1_2")
-                    .InsertPara("p")
-                    .InsertPara("b")
-                    .InsertBlank("p_2")
-                    .InsertVerse("3")
-                    .InsertBlank("verse_1_3")
-                    .InsertPara("p")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), Verse("2")),
-                Para("b"),
-                Para("p", Verse("3"))
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_MultipleBookElements()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                1,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertText("Verse text.", "verse_1_1")
-                    .InsertPara("p")
-                    .Insert("\n")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("XXA", Book("PHM"), Chapter("1")), new[] { chapterDelta });
-
-            XDocument expected = Usx("XXA", Book("PHM"), Chapter("1"), Para("p", Verse("1"), "Verse text."));
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_InvalidParaInFirstChapter()
-        {
-            var chapterDeltas = new[]
-            {
-                new ChapterDelta(
-                    1,
-                    1,
-                    false,
-                    Delta
-                        .New()
-                        .InsertText("Book title", "imt_1")
-                        .InsertPara("imt")
-                        .InsertChapter("1")
-                        .InsertBlank("bad_1")
-                        .InsertVerse("1")
-                        .InsertText("New verse text.", "verse_1_1")
-                        .InsertPara("bad", true)
-                ),
-                new ChapterDelta(
-                    2,
-                    1,
-                    true,
-                    Delta
-                        .New()
-                        .InsertChapter("2")
-                        .InsertBlank("p_1")
-                        .InsertVerse("1")
-                        .InsertText("New verse text.", "verse_2_1")
-                        .InsertPara("p")
-                ),
-                new ChapterDelta(
-                    3,
-                    1,
-                    true,
-                    Delta
-                        .New()
-                        .InsertChapter("3")
-                        .InsertBlank("p_1")
-                        .InsertVerse("1")
-                        .InsertText("New verse text.", "verse_3_1")
-                        .InsertPara("p")
-                )
-            };
-
-            var oldUsxDoc = Usx(
-                "PHM",
-                Para("imt", "Book title"),
-                Chapter("1"),
-                Para("bad", Verse("1"), "Old verse text."),
-                Chapter("2"),
-                Para("p", Verse("1"), "Old verse text."),
-                Chapter("3"),
-                Para("p", Verse("1"), "Old verse text.")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(oldUsxDoc, chapterDeltas);
-
-            XDocument expected = Usx(
-                "PHM",
-                Para("imt", "Book title"),
-                Chapter("1"),
-                Para("bad", Verse("1"), "Old verse text."),
-                Chapter("2"),
-                Para("p", Verse("1"), "New verse text."),
-                Chapter("3"),
-                Para("p", Verse("1"), "New verse text.")
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_InvalidParaInMiddleChapter()
-        {
-            var chapterDeltas = new[]
-            {
-                new ChapterDelta(
-                    1,
-                    1,
-                    true,
-                    Delta
-                        .New()
-                        .InsertText("Book title", "imt_1")
-                        .InsertPara("imt")
-                        .InsertChapter("1")
-                        .InsertBlank("p_1")
-                        .InsertVerse("1")
-                        .InsertText("New verse text.", "verse_1_1")
-                        .InsertPara("p")
-                ),
-                new ChapterDelta(
-                    2,
-                    1,
-                    false,
-                    Delta
-                        .New()
-                        .InsertChapter("2")
-                        .InsertBlank("bad_1")
-                        .InsertVerse("1")
-                        .InsertText("New verse text.", "verse_2_1")
-                        .InsertPara("bad", true)
-                ),
-                new ChapterDelta(
-                    3,
-                    1,
-                    true,
-                    Delta
-                        .New()
-                        .InsertChapter("3")
-                        .InsertBlank("p_1")
-                        .InsertVerse("1")
-                        .InsertText("New verse text.", "verse_3_1")
-                        .InsertPara("p")
-                )
-            };
-
-            var oldUsxDoc = Usx(
-                "PHM",
-                Para("imt", "Book title"),
-                Chapter("1"),
-                Para("p", Verse("1"), "Old verse text."),
-                Chapter("2"),
-                Para("bad", Verse("1"), "Old verse text."),
-                Chapter("3"),
-                Para("p", Verse("1"), "Old verse text.")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(oldUsxDoc, chapterDeltas);
-
-            XDocument expected = Usx(
-                "PHM",
-                Para("imt", "Book title"),
-                Chapter("1"),
-                Para("p", Verse("1"), "New verse text."),
-                Chapter("2"),
-                Para("bad", Verse("1"), "Old verse text."),
-                Chapter("3"),
-                Para("p", Verse("1"), "New verse text.")
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_InvalidParaInLastChapter()
-        {
-            var chapterDeltas = new[]
-            {
-                new ChapterDelta(
-                    1,
-                    1,
-                    true,
-                    Delta
-                        .New()
-                        .InsertText("Book title", "imt_1")
-                        .InsertPara("imt")
-                        .InsertChapter("1")
-                        .InsertBlank("p_1")
-                        .InsertVerse("1")
-                        .InsertText("New verse text.", "verse_1_1")
-                        .InsertPara("p")
-                ),
-                new ChapterDelta(
-                    2,
-                    1,
-                    true,
-                    Delta
-                        .New()
-                        .InsertChapter("2")
-                        .InsertBlank("p_1")
-                        .InsertVerse("1")
-                        .InsertText("New verse text.", "verse_2_1")
-                        .InsertPara("p")
-                ),
-                new ChapterDelta(
-                    3,
-                    1,
-                    false,
-                    Delta
-                        .New()
-                        .InsertChapter("3")
-                        .InsertBlank("bad_1")
-                        .InsertVerse("1")
-                        .InsertText("New verse text.", "verse_3_1")
-                        .InsertPara("bad", true)
-                )
-            };
-
-            var oldUsxDoc = Usx(
-                "PHM",
-                Para("imt", "Book title"),
-                Chapter("1"),
-                Para("p", Verse("1"), "Old verse text."),
-                Chapter("2"),
-                Para("p", Verse("1"), "Old verse text."),
-                Chapter("3"),
-                Para("bad", Verse("1"), "Old verse text.")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(oldUsxDoc, chapterDeltas);
-
-            XDocument expected = Usx(
-                "PHM",
-                Para("imt", "Book title"),
-                Chapter("1"),
-                Para("p", Verse("1"), "New verse text."),
-                Chapter("2"),
-                Para("p", Verse("1"), "New verse text."),
-                Chapter("3"),
-                Para("bad", Verse("1"), "Old verse text.")
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_Unmatched()
-        {
-            var chapterDelta = new ChapterDelta(
-                1,
-                1,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("1")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertText("This is a verse with an unmatched marker", "verse_1_1")
-                    .InsertEmbed("unmatched", new JObject(new JProperty("marker", "bad")), "verse_1_1")
-                    .InsertPara("p")
-                    .Insert("\n")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), "This is a verse with an unmatched marker", Unmatched("bad"))
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToUsx_InvalidChapterNumber()
-        {
-            var chapterDelta = new ChapterDelta(
-                2,
-                2,
-                true,
-                Delta
-                    .New()
-                    .InsertChapter("2")
-                    .InsertBlank("p_1")
-                    .InsertVerse("1")
-                    .InsertBlank("verse_2_1")
-                    .InsertVerse("2")
-                    .InsertBlank("verse_2_2")
-                    .InsertPara("p")
-            );
-
-            XDocument oldUsxDoc = Usx("PHM", Chapter("bad"), Para("p", Verse("1"), Verse("2")), Chapter("2"));
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            XDocument newUsxDoc = mapper.ToUsx(oldUsxDoc, new[] { chapterDelta });
-
-            XDocument expected = Usx(
-                "PHM",
-                Chapter("bad"),
-                Para("p", Verse("1"), Verse("2")),
-                Chapter("2"),
-                Para("p", Verse("1"), Verse("2"))
-            );
-            Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        }
-
-        [Test]
-        public void ToDelta_EmptySegments()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), Verse("2")),
-                Para("li"),
-                Para("li"),
-                Para("p", Verse("3"))
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
+        _mapperGuidService = new TestGuidService();
+        _testGuidService = new TestGuidService();
+        _logger = Substitute.For<ILogger<DeltaUsxMapper>>();
+        _exceptionHandler = Substitute.For<IExceptionHandler>();
+    }
+
+    [Test]
+    public void ToUsx_HeaderPara()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            0,
+            true,
+            Delta.New().InsertText("Philemon", "h_1").InsertPara("h").Insert("\n")
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+
+        XDocument expected = Usx("PHM", Para("h", "Philemon"));
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
+
+    [Test]
+    public void ToUsx_VerseText()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            1,
+            true,
+            Delta
+                .New()
+                .InsertChapter("1")
+                .InsertBlank("p_1")
+                .InsertVerse("1")
+                .InsertText("Verse text.", "verse_1_1")
+                .InsertPara("p")
+                .Insert("\n")
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+
+        XDocument expected = Usx("PHM", Chapter("1"), Para("p", Verse("1"), "Verse text."));
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
+
+    [Test]
+    public void ToUsx_EmptySegments()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            3,
+            true,
+            Delta
                 .New()
                 .InsertChapter("1")
                 .InsertBlank("p_1")
@@ -1518,249 +92,92 @@ namespace SIL.XForge.Scripture.Services
                 .InsertBlank("verse_1_2/p_3")
                 .InsertVerse("3")
                 .InsertBlank("verse_1_3")
-                .InsertPara("p");
-
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(3));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
-
-        [Test]
-        public void ToDelta_InvalidChapterNumber()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("bad"),
-                Para("p", Verse("1"), Verse("2")),
-                Chapter("2"),
-                Para("p", Verse("1"), Verse("2"))
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
-                .New()
-                .InsertChapter("2")
-                .InsertBlank("p_1")
-                .InsertVerse("1")
-                .InsertBlank("verse_2_1")
-                .InsertVerse("2")
-                .InsertBlank("verse_2_2")
-                .InsertPara("p");
-
-            Assert.That(chapterDeltas.Count, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(2));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(2));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
-
-        [Test]
-        public void ToDelta_InvalidChapter()
-        {
-            XDocument usxDoc = Usx("PHM", Chapter("1", "bad"), Para("p", Verse("1"), Verse("2")));
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
-                .New()
-                .InsertChapter("1", "bad", true)
-                .InsertBlank("p_1")
-                .InsertVerse("1")
-                .InsertBlank("verse_1_1")
-                .InsertVerse("2")
-                .InsertBlank("verse_1_2")
-                .InsertPara("p");
-
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(2));
-            Assert.That(chapterDeltas[0].IsValid, Is.False);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
-
-        [Test]
-        public void ToDelta_InvalidVerse()
-        {
-            XDocument usxDoc = Usx("PHM", Chapter("1"), Para("p", Verse("1", "bad"), Verse("2")));
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
-                .New()
-                .InsertChapter("1")
-                .InsertBlank("p_1")
-                .InsertVerse("1", "bad", true)
-                .InsertBlank("verse_1_1")
-                .InsertVerse("2")
-                .InsertBlank("verse_1_2")
-                .InsertPara("p");
-
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(2));
-            Assert.That(chapterDeltas[0].IsValid, Is.False);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
-
-        [Test]
-        public void ToDelta_DoublyInvalidInline()
-        {
-            // A node that is invalid for more than one reason is still just invalid, not crashing.
-
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), Char("tei", Char("ver", "blah")), Verse("2"))
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
-                .New()
-                .InsertChapter("1")
-                .InsertBlank("p_1")
-                .InsertVerse("1")
-                .InsertChar(
-                    "blah",
-                    new List<CharAttr>
-                    {
-                        new CharAttr { Style = "tei", CharID = _testGuidService.Generate() },
-                        new CharAttr { Style = "ver", CharID = _testGuidService.Generate() }
-                    },
-                    "verse_1_1",
-                    invalid: true
-                )
-                .InsertVerse("2")
-                .InsertBlank("verse_1_2")
-                .InsertPara("p");
-
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(2));
-            Assert.That(chapterDeltas[0].IsValid, Is.False);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
-
-        [Test]
-        public void ToDelta_InvalidLastVerse()
-        {
-            XDocument usxDoc = Usx("PHM", Chapter("1"), Para("p", Verse("1"), Verse("2bad")));
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
-                .New()
-                .InsertChapter("1")
-                .InsertBlank("p_1")
-                .InsertVerse("1")
-                .InsertBlank("verse_1_1")
-                .InsertVerse("2bad", "v", true)
-                .InsertBlank("verse_1_2bad")
-                .InsertPara("p");
-
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.False);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
-
-        [Test]
-        public void ToDelta_SectionHeader()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Para("mt", "Philemon"),
-                Chapter("1"),
-                Para("p", Verse("1"), Verse("2")),
-                Para("s"),
-                Para("p", Verse("3")),
-                Chapter("2"),
-                Para("p", Verse("1"), Verse("2")),
-                Para("s"),
-                Para("p", Verse("3"))
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expectedChapter1 = Delta
-                .New()
-                .InsertText("Philemon", "mt_1")
-                .InsertPara("mt")
-                .InsertChapter("1")
-                .InsertBlank("p_1")
-                .InsertVerse("1")
-                .InsertBlank("verse_1_1")
-                .InsertVerse("2")
-                .InsertBlank("verse_1_2")
                 .InsertPara("p")
-                .InsertBlank("s_1")
-                .InsertPara("s")
-                .InsertBlank("p_2")
-                .InsertVerse("3")
-                .InsertBlank("verse_1_3")
-                .InsertPara("p");
+                .Insert("\n")
+        );
 
-            var expectedChapter2 = Delta
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), Verse("2")),
+            Para("li"),
+            Para("li"),
+            Para("p", Verse("3"))
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
+
+    [Test]
+    public void ToUsx_CharText()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            1,
+            true,
+            Delta
                 .New()
-                .InsertChapter("2")
+                .InsertChapter("1")
                 .InsertBlank("p_1")
                 .InsertVerse("1")
-                .InsertBlank("verse_2_1")
-                .InsertVerse("2")
-                .InsertBlank("verse_2_2")
+                .InsertText("This is some ", "verse_1_1")
+                .InsertChar("bold", "bd", _testGuidService.Generate(), "verse_1_1")
+                .InsertText(" text.", "verse_1_1")
                 .InsertPara("p")
-                .InsertBlank("s_1")
-                .InsertPara("s")
-                .InsertBlank("p_2")
-                .InsertVerse("3")
-                .InsertBlank("verse_2_3")
-                .InsertPara("p");
+                .Insert("\n")
+        );
 
-            Assert.That(chapterDeltas.Count, Is.EqualTo(2));
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(3));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expectedChapter1));
-            Assert.That(chapterDeltas[1].Number, Is.EqualTo(2));
-            Assert.That(chapterDeltas[1].LastVerse, Is.EqualTo(3));
-            Assert.That(chapterDeltas[1].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[1].Delta.DeepEquals(expectedChapter2));
-        }
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
 
-        [Test]
-        public void ToDelta_Note()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para(
-                    "p",
-                    Verse("1"),
-                    "This is a verse with a footnote",
-                    Note(
-                        "f",
-                        "+",
-                        Char("fr", "1.1: "),
-                        Char("ft", "Refers to "),
-                        Char("fq", "a footnote"),
-                        ". ",
-                        Char("xt", "John 1:1"),
-                        " and ",
-                        Char("xt", "Mark 1:1")
-                    ),
-                    ", so that we can test it."
-                )
-            );
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), "This is some ", Char("bd", "bold"), " text.")
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+    [Test]
+    public void ToUsx_EmptyChar()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            1,
+            true,
+            Delta
+                .New()
+                .InsertChapter("1")
+                .InsertBlank("p_1")
+                .InsertVerse("1")
+                .InsertText("This is some ", "verse_1_1")
+                .InsertEmptyChar("bd", _testGuidService.Generate(), "verse_1_1")
+                .InsertText(" text.", "verse_1_1")
+                .InsertPara("p")
+                .Insert("\n")
+        );
 
-            var expected = Delta
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), "This is some ", Char("bd", null), " text.")
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
+
+    [Test]
+    public void ToUsx_Note()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            1,
+            true,
+            Delta
                 .New()
                 .InsertChapter("1")
                 .InsertBlank("p_1")
@@ -1781,91 +198,45 @@ namespace SIL.XForge.Scripture.Services
                     "verse_1_1"
                 )
                 .InsertText(", so that we can test it.", "verse_1_1")
-                .InsertPara("p");
+                .InsertPara("p")
+                .Insert("\n")
+        );
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
 
-        [Test]
-        public void ToDelta_InvalidNote()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para(
-                    "p",
-                    Verse("1"),
-                    "This is a verse with a footnote",
-                    Note(
-                        "bad",
-                        "+",
-                        Char("fr", "1.1: "),
-                        Char("ft", "Refers to "),
-                        Char("fq", "a footnote"),
-                        ". ",
-                        Char("xt", "John 1:1"),
-                        " and ",
-                        Char("xt", "Mark 1:1")
-                    ),
-                    ", so that we can test it."
-                )
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
-                .New()
-                .InsertChapter("1")
-                .InsertBlank("p_1")
-                .InsertVerse("1")
-                .InsertText("This is a verse with a footnote", "verse_1_1")
-                .InsertNote(
-                    Delta
-                        .New()
-                        .InsertChar("1.1: ", "fr", _testGuidService.Generate())
-                        .InsertChar("Refers to ", "ft", _testGuidService.Generate())
-                        .InsertChar("a footnote", "fq", _testGuidService.Generate())
-                        .Insert(". ")
-                        .InsertChar("John 1:1", "xt", _testGuidService.Generate())
-                        .Insert(" and ")
-                        .InsertChar("Mark 1:1", "xt", _testGuidService.Generate()),
-                    "bad",
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Para(
+                "p",
+                Verse("1"),
+                "This is a verse with a footnote",
+                Note(
+                    "f",
                     "+",
-                    "verse_1_1",
-                    true
-                )
-                .InsertText(", so that we can test it.", "verse_1_1")
-                .InsertPara("p");
+                    Char("fr", "1.1: "),
+                    Char("ft", "Refers to "),
+                    Char("fq", "a footnote"),
+                    ". ",
+                    Char("xt", "John 1:1"),
+                    " and ",
+                    Char("xt", "Mark 1:1")
+                ),
+                ", so that we can test it."
+            )
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.False);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
-
-        [Test]
-        public void ToDelta_Figure()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para(
-                    "p",
-                    Verse("1"),
-                    "This is a verse with a figure",
-                    Figure("file.jpg", "col", "PHM 1:1", "Caption"),
-                    ", so that we can test it."
-                )
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
+    [Test]
+    public void ToUsx_Figure()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            1,
+            true,
+            Delta
                 .New()
                 .InsertChapter("1")
                 .InsertBlank("p_1")
@@ -1873,126 +244,39 @@ namespace SIL.XForge.Scripture.Services
                 .InsertText("This is a verse with a figure", "verse_1_1")
                 .InsertFigure("file.jpg", "col", "PHM 1:1", "Caption", "verse_1_1")
                 .InsertText(", so that we can test it.", "verse_1_1")
-                .InsertPara("p");
+                .InsertPara("p")
+                .Insert("\n")
+        );
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
 
-        [Test]
-        public void ToDelta_InvalidFigure()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para(
-                    "p",
-                    Verse("1"),
-                    "This is a verse with a figure",
-                    Figure("file.jpg", "col", null, "Caption"),
-                    ", so that we can test it."
-                )
-            );
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Para(
+                "p",
+                Verse("1"),
+                "This is a verse with a figure",
+                Figure("file.jpg", "col", "PHM 1:1", "Caption"),
+                ", so that we can test it."
+            )
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
-                .New()
-                .InsertChapter("1")
-                .InsertBlank("p_1")
-                .InsertVerse("1")
-                .InsertText("This is a verse with a figure", "verse_1_1")
-                .InsertFigure("file.jpg", "col", null, "Caption", "verse_1_1", true)
-                .InsertText(", so that we can test it.", "verse_1_1")
-                .InsertPara("p");
-
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.False);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
-
-        [Test]
-        public void ToDelta_CharText()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), "This is some ", Char("bd", "bold"), " text.")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
-                .New()
-                .InsertChapter("1")
-                .InsertBlank("p_1")
-                .InsertVerse("1")
-                .InsertText("This is some ", "verse_1_1")
-                .InsertChar("bold", "bd", _testGuidService.Generate(), "verse_1_1")
-                .InsertText(" text.", "verse_1_1")
-                .InsertPara("p");
-
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
-
-        [Test]
-        public void ToDelta_EmptyChar()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), "This is some ", Char("bd", ""), " text.")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
-                .New()
-                .InsertChapter("1")
-                .InsertBlank("p_1")
-                .InsertVerse("1")
-                .InsertText("This is some ", "verse_1_1")
-                .InsertEmptyChar("bd", _testGuidService.Generate(), "verse_1_1")
-                .InsertText(" text.", "verse_1_1")
-                .InsertPara("p");
-
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
-
-        [Test]
-        public void ToDelta_NestedChars()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para(
-                    "p",
-                    Verse("1"),
-                    Char("bd", Char("sup", "1"), "This is", Char("sup", "2"), " bold text.", Char("sup", "3")),
-                    " This is normal text."
-                )
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            string bdCharID = _testGuidService.Generate();
-            string sup1CharID = _testGuidService.Generate();
-            string sup2CharID = _testGuidService.Generate();
-            string sup3CharID = _testGuidService.Generate();
-            var expected = Delta
+    [Test]
+    public void ToUsx_NestedChars()
+    {
+        string bdCharID = _testGuidService.Generate();
+        string sup1CharID = _testGuidService.Generate();
+        string sup2CharID = _testGuidService.Generate();
+        string sup3CharID = _testGuidService.Generate();
+        var chapterDelta = new ChapterDelta(
+            1,
+            1,
+            true,
+            Delta
                 .New()
                 .InsertChapter("1")
                 .InsertBlank("p_1")
@@ -2027,36 +311,37 @@ namespace SIL.XForge.Scripture.Services
                     "verse_1_1"
                 )
                 .InsertText(" This is normal text.", "verse_1_1")
-                .InsertPara("p");
+                .InsertPara("p")
+        );
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
 
-        [Test]
-        public void ToDelta_NestedAdjacentChars()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para(
-                    "p",
-                    Verse("1"),
-                    Char("bd", Char("sup", "1"), Char("sup", "2"), Char("sup", "3")),
-                    " This is normal text."
-                )
-            );
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Para(
+                "p",
+                Verse("1"),
+                Char("bd", Char("sup", "1"), "This is", Char("sup", "2"), " bold text.", Char("sup", "3")),
+                " This is normal text."
+            )
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            string bdCharID = _testGuidService.Generate();
-            string sup1CharID = _testGuidService.Generate();
-            string sup2CharID = _testGuidService.Generate();
-            string sup3CharID = _testGuidService.Generate();
-            var expected = Delta
+    [Test]
+    public void ToUsx_NestedAdjacentChars()
+    {
+        string bdCharID = _testGuidService.Generate();
+        string sup1CharID = _testGuidService.Generate();
+        string sup2CharID = _testGuidService.Generate();
+        string sup3CharID = _testGuidService.Generate();
+        var chapterDelta = new ChapterDelta(
+            1,
+            1,
+            true,
+            Delta
                 .New()
                 .InsertChapter("1")
                 .InsertBlank("p_1")
@@ -2089,45 +374,39 @@ namespace SIL.XForge.Scripture.Services
                     "verse_1_1"
                 )
                 .InsertText(" This is normal text.", "verse_1_1")
-                .InsertPara("p");
+                .InsertPara("p")
+        );
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
 
-        [Test]
-        public void ToDelta_DoubleNestedAdjacentChars()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para(
-                    "p",
-                    Verse("1"),
-                    Char(
-                        "bd",
-                        Char("sup", "1"),
-                        "This is bold text",
-                        Char("no", " but this is not bold,", Char("sup", "2"), Char("sup", "3")),
-                        " and this is bold.",
-                        Char("sup", "4")
-                    ),
-                    " This is normal text."
-                )
-            );
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Para(
+                "p",
+                Verse("1"),
+                Char("bd", Char("sup", "1"), Char("sup", "2"), Char("sup", "3")),
+                " This is normal text."
+            )
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            string bdCharID = _testGuidService.Generate();
-            string sup1CharID = _testGuidService.Generate();
-            string noCharID = _testGuidService.Generate();
-            string sup2CharID = _testGuidService.Generate();
-            string sup3CharID = _testGuidService.Generate();
-            string sup4CharID = _testGuidService.Generate();
-            var expected = Delta
+    [Test]
+    public void ToUsx_DoubleNestedAdjacentChars()
+    {
+        string bdCharID = _testGuidService.Generate();
+        string sup1CharID = _testGuidService.Generate();
+        string noCharID = _testGuidService.Generate();
+        string sup2CharID = _testGuidService.Generate();
+        string sup3CharID = _testGuidService.Generate();
+        string sup4CharID = _testGuidService.Generate();
+        var chapterDelta = new ChapterDelta(
+            1,
+            1,
+            true,
+            Delta
                 .New()
                 .InsertChapter("1")
                 .InsertBlank("p_1")
@@ -2182,94 +461,40 @@ namespace SIL.XForge.Scripture.Services
                     "verse_1_1"
                 )
                 .InsertText(" This is normal text.", "verse_1_1")
-                .InsertPara("p");
+                .InsertPara("p")
+        );
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
 
-        [Test]
-        public void ToDelta_InvalidChars()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para(
-                    "p",
-                    Verse("1"),
-                    Char("bad", Char("sup", "1"), "This is", Char("sup", "2"), " bold text.", Char("sup", "3")),
-                    " This is normal text."
-                )
-            );
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Para(
+                "p",
+                Verse("1"),
+                Char(
+                    "bd",
+                    Char("sup", "1"),
+                    "This is bold text",
+                    Char("no", " but this is not bold,", Char("sup", "2"), Char("sup", "3")),
+                    " and this is bold.",
+                    Char("sup", "4")
+                ),
+                " This is normal text."
+            )
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            string badCharID = _testGuidService.Generate();
-            string sup1CharID = _testGuidService.Generate();
-            string sup2CharID = _testGuidService.Generate();
-            string sup3CharID = _testGuidService.Generate();
-            var expected = Delta
-                .New()
-                .InsertChapter("1")
-                .InsertBlank("p_1")
-                .InsertVerse("1")
-                .InsertChar(
-                    "1",
-                    new List<CharAttr>
-                    {
-                        new CharAttr { Style = "bad", CharID = badCharID },
-                        new CharAttr { Style = "sup", CharID = sup1CharID }
-                    },
-                    "verse_1_1",
-                    true
-                )
-                .InsertChar("This is", "bad", badCharID, "verse_1_1", true)
-                .InsertChar(
-                    "2",
-                    new List<CharAttr>
-                    {
-                        new CharAttr { Style = "bad", CharID = badCharID },
-                        new CharAttr { Style = "sup", CharID = sup2CharID }
-                    },
-                    "verse_1_1",
-                    true
-                )
-                .InsertChar(" bold text.", "bad", badCharID, "verse_1_1", true)
-                .InsertChar(
-                    "3",
-                    new List<CharAttr>
-                    {
-                        new CharAttr { Style = "bad", CharID = badCharID },
-                        new CharAttr { Style = "sup", CharID = sup3CharID }
-                    },
-                    "verse_1_1",
-                    true
-                )
-                .InsertText(" This is normal text.", "verse_1_1")
-                .InsertPara("p");
-
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.False);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
-
-        [Test]
-        public void ToDelta_AdjacentChars()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), Char("sup", "1"), Char("sup", "2"), Char("sup", "3"), " This is normal text.")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
+    [Test]
+    public void ToUsx_AdjacentChars()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            1,
+            true,
+            Delta
                 .New()
                 .InsertChapter("1")
                 .InsertBlank("p_1")
@@ -2278,44 +503,28 @@ namespace SIL.XForge.Scripture.Services
                 .InsertChar("2", "sup", _testGuidService.Generate(), "verse_1_1")
                 .InsertChar("3", "sup", _testGuidService.Generate(), "verse_1_1")
                 .InsertText(" This is normal text.", "verse_1_1")
-                .InsertPara("p");
+                .InsertPara("p")
+        );
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
 
-        [Test]
-        public void ToDelta_Ref()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para(
-                    "p",
-                    Verse("1"),
-                    "This is a verse with a footnote",
-                    Note(
-                        "f",
-                        "+",
-                        Char("fr", "1.1: "),
-                        Char("ft", "Refers to "),
-                        Char("fq", "a footnote"),
-                        ". ",
-                        Char("xt", Ref("JHN 1:1", "John 1:1")),
-                        " and ",
-                        Char("xt", Ref("MRK 1:1", "Mark 1:1")),
-                        "."
-                    ),
-                    ", so that we can test it."
-                )
-            );
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), Char("sup", "1"), Char("sup", "2"), Char("sup", "3"), " This is normal text.")
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
+    [Test]
+    public void ToUsx_Ref()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            1,
+            true,
+            Delta
                 .New()
                 .InsertChapter("1")
                 .InsertBlank("p_1")
@@ -2337,41 +546,46 @@ namespace SIL.XForge.Scripture.Services
                     "verse_1_1"
                 )
                 .InsertText(", so that we can test it.", "verse_1_1")
-                .InsertPara("p");
+                .InsertPara("p")
+                .Insert("\n")
+        );
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
 
-        [Test]
-        public void ToDelta_EmptyRef()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para(
-                    "p",
-                    Verse("1"),
-                    "This is a verse with a footnote",
-                    Note(
-                        "f",
-                        "*",
-                        Char("fr", "1:1"),
-                        Char("ft", ""),
-                        ". ",
-                        Char("xo", ""),
-                        Char("xt", Ref("MRK 1:1", "Mark 1:1"))
-                    ),
-                    ", so that we can test it."
-                )
-            );
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Para(
+                "p",
+                Verse("1"),
+                "This is a verse with a footnote",
+                Note(
+                    "f",
+                    "+",
+                    Char("fr", "1.1: "),
+                    Char("ft", "Refers to "),
+                    Char("fq", "a footnote"),
+                    ". ",
+                    Char("xt", Ref("JHN 1:1", "John 1:1")),
+                    " and ",
+                    Char("xt", Ref("MRK 1:1", "Mark 1:1")),
+                    "."
+                ),
+                ", so that we can test it."
+            )
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
+    [Test]
+    public void ToUsx_EmptyRef()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            1,
+            true,
+            Delta
                 .New()
                 .InsertChapter("1")
                 .InsertBlank("p_1")
@@ -2390,86 +604,43 @@ namespace SIL.XForge.Scripture.Services
                     "verse_1_1"
                 )
                 .InsertText(", so that we can test it.", "verse_1_1")
-                .InsertPara("p");
+                .InsertPara("p")
+                .Insert("\n")
+        );
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
 
-        [Test]
-        public void ToDelta_InvalidRef()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para(
-                    "p",
-                    Verse("1"),
-                    "This is a verse with a footnote",
-                    Note(
-                        "f",
-                        "+",
-                        Char("fr", "1.1: "),
-                        Char("ft", "Refers to "),
-                        Char("fq", "a footnote"),
-                        ". ",
-                        Char("xt", Ref("bad location", "John 1:1")),
-                        " and ",
-                        Char("xt", Ref("MRK 1:1", "Mark 1:1")),
-                        "."
-                    ),
-                    ", so that we can test it."
-                )
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
-                .New()
-                .InsertChapter("1")
-                .InsertBlank("p_1")
-                .InsertVerse("1")
-                .InsertText("This is a verse with a footnote", "verse_1_1")
-                .InsertNote(
-                    Delta
-                        .New()
-                        .InsertChar("1.1: ", "fr", _testGuidService.Generate())
-                        .InsertChar("Refers to ", "ft", _testGuidService.Generate())
-                        .InsertChar("a footnote", "fq", _testGuidService.Generate())
-                        .Insert(". ")
-                        .InsertCharRef("John 1:1", "xt", "bad location", _testGuidService.Generate(), invalid: true)
-                        .Insert(" and ")
-                        .InsertCharRef("Mark 1:1", "xt", "MRK 1:1", _testGuidService.Generate())
-                        .Insert("."),
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Para(
+                "p",
+                Verse("1"),
+                "This is a verse with a footnote",
+                Note(
                     "f",
-                    "+",
-                    "verse_1_1"
-                )
-                .InsertText(", so that we can test it.", "verse_1_1")
-                .InsertPara("p");
+                    "*",
+                    Char("fr", "1:1"),
+                    Char("ft", null),
+                    ". ",
+                    Char("xo", null),
+                    Char("xt", Ref("MRK 1:1", "Mark 1:1"))
+                ),
+                ", so that we can test it."
+            )
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.False);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
-
-        [Test]
-        public void ToDelta_OptBreak()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), "This is a verse with a line break", OptBreak(), ", so that we can test it.")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
+    [Test]
+    public void ToUsx_OptBreak()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            1,
+            true,
+            Delta
                 .New()
                 .InsertChapter("1")
                 .InsertBlank("p_1")
@@ -2477,95 +648,57 @@ namespace SIL.XForge.Scripture.Services
                 .InsertText("This is a verse with a line break", "verse_1_1")
                 .InsertOptBreak("verse_1_1")
                 .InsertText(", so that we can test it.", "verse_1_1")
-                .InsertPara("p");
+                .InsertPara("p")
+        );
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
 
-        [Test]
-        public void ToDelta_Milestone()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), "This is a verse with a line break", Milestone("ts"), ", so that we can test it.")
-            );
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), "This is a verse with a line break", OptBreak(), ", so that we can test it.")
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
+    [Test]
+    public void ToUsx_Milestone()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            1,
+            true,
+            Delta
                 .New()
                 .InsertChapter("1")
                 .InsertBlank("p_1")
                 .InsertVerse("1")
-                .InsertText("This is a verse with a line break", "verse_1_1")
+                .InsertText("This is a verse with a milestone", "verse_1_1")
                 .InsertMilestone("ts", "verse_1_1")
                 .InsertText(", so that we can test it.", "verse_1_1")
-                .InsertPara("p");
+                .InsertPara("p")
+        );
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
 
-        [Test]
-        public void ToDelta_InvalidMilestone()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para(
-                    "p",
-                    Verse("1"),
-                    "This is a verse with a line break",
-                    Milestone("bad"),
-                    ", so that we can test it."
-                )
-            );
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), "This is a verse with a milestone", Milestone("ts"), ", so that we can test it.")
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
-                .New()
-                .InsertChapter("1")
-                .InsertBlank("p_1")
-                .InsertVerse("1")
-                .InsertText("This is a verse with a line break", "verse_1_1")
-                .InsertMilestone("bad", "verse_1_1", true)
-                .InsertText(", so that we can test it.", "verse_1_1")
-                .InsertPara("p");
-
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.False);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
-
-        [Test]
-        public void ToDelta_TableAtEnd()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Table(
-                    Row(
-                        Cell("tc1", "start", "Before verse.", Verse("1"), "This is verse ", Char("it", "1"), "."),
-                        Cell("tc2", "start", Verse("2"), "This is verse 2.")
-                    ),
-                    Row(Cell("tc1", "start"), Cell("tc2", "start", Verse("3"), "This is verse 3."))
-                )
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
+    [Test]
+    public void ToUsx_TableAtEnd()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            3,
+            true,
+            Delta
                 .New()
                 .InsertChapter("1")
                 .InsertText("Before verse.", "cell_1_1_1")
@@ -2583,34 +716,34 @@ namespace SIL.XForge.Scripture.Services
                 .InsertBlank("cell_1_2_2")
                 .InsertVerse("3")
                 .InsertText("This is verse 3.", "verse_1_3")
-                .InsertCell(1, 2, "tc2", "start");
+                .InsertCell(1, 2, "tc2", "start")
+        );
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(3));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
 
-        [Test]
-        public void ToDelta_TableInMiddle()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Table(
-                    Row(
-                        Cell("tc1", "start", "Before verse.", Verse("1"), "This is verse ", Char("it", "1"), "."),
-                        Cell("tc2", "start", Verse("2"), "This is verse 2.")
-                    ),
-                    Row(Cell("tc1", "start"), Cell("tc2", "start", Verse("3"), "This is verse 3."))
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Table(
+                Row(
+                    Cell("tc1", "start", "Before verse.", Verse("1"), "This is verse ", Char("it", "1"), "."),
+                    Cell("tc2", "start", Verse("2"), "This is verse 2.")
                 ),
-                Para("p", Verse("4"), "This is verse 4.")
-            );
+                Row(Cell("tc1", "start"), Cell("tc2", "start", Verse("3"), "This is verse 3."))
+            )
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
+    [Test]
+    public void ToUsx_TableInMiddle()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            4,
+            true,
+            Delta
                 .New()
                 .InsertChapter("1")
                 .InsertText("Before verse.", "cell_1_1_1")
@@ -2632,46 +765,35 @@ namespace SIL.XForge.Scripture.Services
                 .InsertBlank("p_1")
                 .InsertVerse("4")
                 .InsertText("This is verse 4.", "verse_1_4")
-                .InsertPara("p");
+                .InsertPara("p")
+        );
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(4));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
 
-        [Test]
-        public void ToDelta_AdjacentTables()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Table(
-                    Row(
-                        Cell("tc1", "start", Verse("1"), "This is verse 1."),
-                        Cell("tc2", "start", Verse("2"), "This is verse 2.")
-                    ),
-                    Row(
-                        Cell("tc1", "start", Verse("3"), "This is verse 3."),
-                        Cell("tc2", "start", Verse("4"), "This is verse 4.")
-                    )
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Table(
+                Row(
+                    Cell("tc1", "start", "Before verse.", Verse("1"), "This is verse ", Char("it", "1"), "."),
+                    Cell("tc2", "start", Verse("2"), "This is verse 2.")
                 ),
-                Table(
-                    Row(
-                        Cell("tc1", "start", Verse("5"), "This is verse 5."),
-                        Cell("tc2", "start", Verse("6"), "This is verse 6.")
-                    ),
-                    Row(
-                        Cell("tc1", "start", Verse("7"), "This is verse 7."),
-                        Cell("tc2", "start", Verse("8"), "This is verse 8.")
-                    )
-                )
-            );
+                Row(Cell("tc1", "start"), Cell("tc2", "start", Verse("3"), "This is verse 3."))
+            ),
+            Para("p", Verse("4"), "This is verse 4.")
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
+    [Test]
+    public void ToUsx_AdjacentTables()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            8,
+            true,
+            Delta
                 .New()
                 .InsertChapter("1")
                 .InsertBlank("cell_1_1_1")
@@ -2705,120 +827,117 @@ namespace SIL.XForge.Scripture.Services
                 .InsertBlank("cell_2_2_2")
                 .InsertVerse("8")
                 .InsertText("This is verse 8.", "verse_1_8")
-                .InsertCell(2, 2, "tc2", "start");
+                .InsertCell(2, 2, "tc2", "start")
+        );
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(8));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
 
-        [Test]
-        public void ToDelta_InvalidTable()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Table(
-                    Row(
-                        Cell("bad", "start", "Before verse.", Verse("1"), "This is verse ", Char("it", "1"), "."),
-                        Cell("tc2", "start", Verse("2"), "This is verse 2.")
-                    ),
-                    Row(Cell("tc1", "start"), Cell("tc2", "start", Verse("3"), "This is verse 3."))
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Table(
+                Row(
+                    Cell("tc1", "start", Verse("1"), "This is verse 1."),
+                    Cell("tc2", "start", Verse("2"), "This is verse 2.")
+                ),
+                Row(
+                    Cell("tc1", "start", Verse("3"), "This is verse 3."),
+                    Cell("tc2", "start", Verse("4"), "This is verse 4.")
                 )
-            );
+            ),
+            Table(
+                Row(
+                    Cell("tc1", "start", Verse("5"), "This is verse 5."),
+                    Cell("tc2", "start", Verse("6"), "This is verse 6.")
+                ),
+                Row(
+                    Cell("tc1", "start", Verse("7"), "This is verse 7."),
+                    Cell("tc2", "start", Verse("8"), "This is verse 8.")
+                )
+            )
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+    [Test]
+    public void ToUsx_ConsecutiveSameStyleEmptyParas()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            0,
+            true,
+            Delta.New().InsertBlank("p_1").InsertPara("p").InsertBlank("p_2").InsertPara("p")
+        );
 
-            var expected = Delta
-                .New()
-                .InsertChapter("1")
-                .InsertText("Before verse.", "cell_1_1_1")
-                .InsertVerse("1")
-                .InsertText("This is verse ", "verse_1_1")
-                .InsertChar("1", "it", _testGuidService.Generate(), "verse_1_1")
-                .InsertText(".", "verse_1_1")
-                .InsertCell(1, 1, "bad", "start", true)
-                .InsertBlank("cell_1_1_2")
-                .InsertVerse("2")
-                .InsertText("This is verse 2.", "verse_1_2")
-                .InsertCell(1, 1, "tc2", "start")
-                .InsertBlank("cell_1_2_1")
-                .InsertCell(1, 2, "tc1", "start")
-                .InsertBlank("cell_1_2_2")
-                .InsertVerse("3")
-                .InsertText("This is verse 3.", "verse_1_3")
-                .InsertCell(1, 2, "tc2", "start");
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(3));
-            Assert.That(chapterDeltas[0].IsValid, Is.False);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
+        XDocument expected = Usx("PHM", Para("p"), Para("p"));
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-        [Test]
-        public void ToDelta_NoParagraphs()
+    [Test]
+    public void ToUsx_NoParagraphs()
+    {
+        var chapterDeltas = new[]
         {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Verse("1"),
-                "This is verse 1.",
-                Verse("2"),
-                Verse("3"),
-                "This is verse 3.",
-                Chapter("2"),
-                Verse("1"),
-                Verse("2-3")
-            );
+            new ChapterDelta(
+                1,
+                3,
+                true,
+                Delta
+                    .New()
+                    .InsertChapter("1")
+                    .InsertVerse("1")
+                    .InsertText("This is verse 1.", "verse_1_1")
+                    .InsertVerse("2")
+                    .InsertBlank("verse_1_2")
+                    .InsertVerse("3")
+                    .InsertText("This is verse 3.", "verse_1_3")
+                    .Insert("\n")
+            ),
+            new ChapterDelta(
+                2,
+                2,
+                true,
+                Delta
+                    .New()
+                    .InsertChapter("2")
+                    .InsertVerse("1")
+                    .InsertBlank("verse_2_1")
+                    .InsertVerse("2")
+                    .InsertBlank("verse_2_2")
+                    .Insert("\n")
+            )
+        };
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM", Chapter("1"), "Text", Chapter("2"), "Text"), chapterDeltas);
 
-            var expected1 = Delta
-                .New()
-                .InsertChapter("1")
-                .InsertVerse("1")
-                .InsertText("This is verse 1.", "verse_1_1")
-                .InsertVerse("2")
-                .InsertBlank("verse_1_2")
-                .InsertVerse("3")
-                .InsertText("This is verse 3.", "verse_1_3")
-                .Insert("\n");
-            var expected2 = Delta
-                .New()
-                .InsertChapter("2")
-                .InsertVerse("1")
-                .InsertBlank("verse_2_1")
-                .InsertVerse("2-3")
-                .InsertBlank("verse_2_2-3")
-                .Insert("\n");
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Verse("1"),
+            "This is verse 1.",
+            Verse("2"),
+            Verse("3"),
+            "This is verse 3.",
+            Chapter("2"),
+            Verse("1"),
+            Verse("2")
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(3));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected1));
-            Assert.That(chapterDeltas[1].Number, Is.EqualTo(2));
-            Assert.That(chapterDeltas[1].LastVerse, Is.EqualTo(3));
-            Assert.That(chapterDeltas[1].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[1].Delta.DeepEquals(expected2));
-        }
-
-        [Test]
-        public void ToDelta_ImpliedParagraph()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                "This is an implied paragraph before the first verse.",
-                Para("p", Verse("1"))
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
+    [Test]
+    public void ToUsx_ImpliedParagraph()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            1,
+            true,
+            Delta
                 .New()
                 .InsertChapter("1")
                 .Insert("This is an implied paragraph before the first verse.")
@@ -2826,28 +945,62 @@ namespace SIL.XForge.Scripture.Services
                 .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertBlank("verse_1_1")
-                .InsertPara("p");
+                .InsertPara("p")
+        );
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
 
-        [Test]
-        public void ToDelta_ImpliedParagraphInVerse()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                "This is an implied paragraph before the first verse.",
-                Para("p", "This is actually an implied paragraph as part of the verse.", Verse("1"))
-            );
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            "This is an implied paragraph before the first verse.",
+            Para("p", Verse("1"))
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+    [Test]
+    public void ToUsx_ImpliedParagraphTwice()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            1,
+            true,
+            Delta
+                .New()
+                .InsertChapter("1")
+                .Insert("This is an implied paragraph before the first verse.")
+                .Insert("\n")
+                .Insert(" This is actually part of the first implied paragraph.")
+                .Insert("\n")
+                .InsertBlank("p_1")
+                .InsertVerse("1")
+                .InsertBlank("verse_1_1")
+                .InsertPara("p")
+        );
 
-            var expected = Delta
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            "This is an implied paragraph before the first verse.",
+            " This is actually part of the first implied paragraph.",
+            Para("p", Verse("1"))
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
+
+    [Test]
+    public void ToUsx_ImpliedParagraphInVerse()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            1,
+            true,
+            Delta
                 .New()
                 .InsertChapter("1")
                 .Insert("This is an implied paragraph before the first verse.")
@@ -2855,95 +1008,155 @@ namespace SIL.XForge.Scripture.Services
                 .InsertText("This is actually an implied paragraph as part of the verse.", "p_1")
                 .InsertVerse("1")
                 .InsertBlank("verse_1_1")
-                .InsertPara("p");
+                .InsertPara("p")
+        );
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
 
-        [Test]
-        public void ToDelta_NoParagraphsImpliedParagraph()
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            "This is an implied paragraph before the first verse.",
+            Para("p", "This is actually an implied paragraph as part of the verse.", Verse("1"))
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
+
+    [Test]
+    public void ToUsx_NoParagraphsImpliedParagraph()
+    {
+        var chapterDeltas = new[]
         {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                "This is an implied paragraph before the first verse.",
-                Verse("1"),
-                "This is verse 1.",
-                Verse("2"),
-                Verse("3"),
-                "This is verse 3.",
-                Chapter("2"),
-                Verse("1"),
-                Verse("2-3")
-            );
+            new ChapterDelta(
+                1,
+                3,
+                true,
+                Delta
+                    .New()
+                    .InsertChapter("1")
+                    .Insert("This is an implied paragraph before the first verse.")
+                    .InsertVerse("1")
+                    .InsertText("This is verse 1.", "verse_1_1")
+                    .InsertVerse("2")
+                    .InsertBlank("verse_1_2")
+                    .InsertVerse("3")
+                    .InsertText("This is verse 3.", "verse_1_3")
+                    .Insert("\n")
+            ),
+            new ChapterDelta(
+                2,
+                2,
+                true,
+                Delta
+                    .New()
+                    .InsertChapter("2")
+                    .InsertVerse("1")
+                    .InsertBlank("verse_2_1")
+                    .InsertVerse("2")
+                    .InsertBlank("verse_2_2")
+                    .Insert("\n")
+            )
+        };
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM", Chapter("1"), "Text", Chapter("2"), "Text"), chapterDeltas);
 
-            var expected1 = Delta
-                .New()
-                .InsertChapter("1")
-                .Insert("This is an implied paragraph before the first verse.")
-                .InsertVerse("1")
-                .InsertText("This is verse 1.", "verse_1_1")
-                .InsertVerse("2")
-                .InsertBlank("verse_1_2")
-                .InsertVerse("3")
-                .InsertText("This is verse 3.", "verse_1_3")
-                .Insert("\n");
-            var expected2 = Delta
-                .New()
-                .InsertChapter("2")
-                .InsertVerse("1")
-                .InsertBlank("verse_2_1")
-                .InsertVerse("2-3")
-                .InsertBlank("verse_2_2-3")
-                .Insert("\n");
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            "This is an implied paragraph before the first verse.",
+            Verse("1"),
+            "This is verse 1.",
+            Verse("2"),
+            Verse("3"),
+            "This is verse 3.",
+            Chapter("2"),
+            Verse("1"),
+            Verse("2")
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(3));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected1));
-            Assert.That(chapterDeltas[1].Number, Is.EqualTo(2));
-            Assert.That(chapterDeltas[1].LastVerse, Is.EqualTo(3));
-            Assert.That(chapterDeltas[1].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[1].Delta.DeepEquals(expected2));
-        }
+    [Test]
+    public void ToUsx_EmptyBook()
+    {
+        var chapterDeltas = new[] { new ChapterDelta(1, 0, true, new Delta()) };
 
-        [Test]
-        public void ToDelta_EmptyBook()
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), chapterDeltas);
+
+        XDocument expected = Usx("PHM");
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
+
+    [Test]
+    public void ToUsx_MismatchNoChapters_UnchangedUsx()
+    {
+        _exceptionHandler.ClearReceivedCalls();
+        var chapterDeltas = new[] { new ChapterDelta(1, 0, true, new Delta()) };
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+
+        // The USX here has chapters that are not in ChapterDeltas. The chapterDeltas contains
+        // the 1 implicit 'chapter'.
+        XDocument input = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), "Verse text."),
+            Chapter("2"),
+            Para("p", Verse("1"), "Verse text.")
+        );
+
+        // SUT
+        XDocument newUsxDoc = mapper.ToUsx(input, chapterDeltas);
+
+        XDocument expected = input;
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+        _exceptionHandler
+            .Received()
+            .ReportException(Arg.Is<Exception>((Exception e) => e.Message.Contains("no real chapters")));
+    }
+
+    [Test]
+    public void ToUsx_MismatchedChapters_UnchangedUsx()
+    {
+        _exceptionHandler.ClearReceivedCalls();
+        var chapterDeltas = new[]
         {
-            XDocument usxDoc = Usx("PHM");
+            new ChapterDelta(
+                1,
+                0,
+                true,
+                new Delta().InsertChapter("1").InsertBlank("p_1").InsertVerse("1").InsertBlank("verse_1_1")
+            )
+        };
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
 
-            Assert.That(chapterDeltas.Count, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(0));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(new Delta()));
-        }
+        // The USX here has chapter 2, which is not in chapterDeltas. The chapterDeltas does contain 1 real chapter.
+        XDocument input = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), "Verse text."),
+            Chapter("2"),
+            Para("p", Verse("1"), "Verse text.")
+        );
 
-        [Test]
-        public void ToDelta_EmptyStyle()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), Verse("2")),
-                Para(""),
-                Para("li"),
-                Para("", Verse("3"))
-            );
+        // SUT
+        Exception thrown = Assert.Throws<Exception>(() => mapper.ToUsx(input, chapterDeltas));
+        Assert.That(thrown.Message, Contains.Substring("Rethrowing"));
+        Assert.That(thrown.InnerException, Is.TypeOf<IndexOutOfRangeException>());
+    }
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
+    [Test]
+    public void ToUsx_BlankLine()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            3,
+            true,
+            Delta
                 .New()
                 .InsertChapter("1")
                 .InsertBlank("p_1")
@@ -2952,423 +1165,2168 @@ namespace SIL.XForge.Scripture.Services
                 .InsertVerse("2")
                 .InsertBlank("verse_1_2")
                 .InsertPara("p")
-                .InsertBlank("verse_1_2/_1")
-                .InsertPara("")
-                .InsertBlank("verse_1_2/li_2")
-                .InsertPara("li")
-                .InsertBlank("verse_1_2/_3")
-                .InsertVerse("3")
-                .InsertBlank("verse_1_3")
-                .InsertPara("");
-
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(3));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
-
-        [Test]
-        public void ToDelta_BlankLine()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), Verse("2")),
-                Para("b"),
-                Para("p", Verse("3"))
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
-                .New()
-                .InsertChapter("1")
-                .InsertBlank("p_1")
-                .InsertVerse("1")
-                .InsertBlank("verse_1_1")
-                .InsertVerse("2")
-                .InsertBlank("verse_1_2")
-                .InsertPara("p")
                 .InsertPara("b")
-                .InsertBlank("verse_1_2/p_1")
+                .InsertBlank("p_2")
                 .InsertVerse("3")
                 .InsertBlank("verse_1_3")
-                .InsertPara("p");
+                .InsertPara("p")
+        );
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(3));
-        }
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
 
-        [Test]
-        public void ToDelta_BlankLineContainsText()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), "Verse text."),
-                // support this even though we do not encourage users to type text in line breaks
-                Para("b", "Text in line break"),
-                Para("p", "second segment in verse.")
-            );
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), Verse("2")),
+            Para("b"),
+            Para("p", Verse("3"))
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = new Delta()
+    [Test]
+    public void ToUsx_MultipleBookElements()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            1,
+            true,
+            Delta
+                .New()
                 .InsertChapter("1")
                 .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertText("Verse text.", "verse_1_1")
                 .InsertPara("p")
-                .InsertText("Text in line break")
-                .InsertPara("b")
-                .InsertText("second segment in verse.", "verse_1_1/p_1")
-                .InsertPara("p");
+                .Insert("\n")
+        );
 
-            Assert.That(chapterDeltas.Count(), Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("XXA", Book("PHM"), Chapter("1")), new[] { chapterDelta });
 
-        [Test]
-        public void ToDelta_InvalidParaInFirstChapter()
+        XDocument expected = Usx("XXA", Book("PHM"), Chapter("1"), Para("p", Verse("1"), "Verse text."));
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
+
+    [Test]
+    public void ToUsx_InvalidParaInFirstChapter()
+    {
+        var chapterDeltas = new[]
         {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Para("imt", "Book title"),
-                Chapter("1"),
-                Para("bad", Verse("1"), "Verse text."),
-                Chapter("2"),
-                Para("p", Verse("1"), "Verse text."),
-                Chapter("3"),
-                Para("p", Verse("1"), "Verse text.")
-            );
+            new ChapterDelta(
+                1,
+                1,
+                false,
+                Delta
+                    .New()
+                    .InsertText("Book title", "imt_1")
+                    .InsertPara("imt")
+                    .InsertChapter("1")
+                    .InsertBlank("bad_1")
+                    .InsertVerse("1")
+                    .InsertText("New verse text.", "verse_1_1")
+                    .InsertPara("bad", true)
+            ),
+            new ChapterDelta(
+                2,
+                1,
+                true,
+                Delta
+                    .New()
+                    .InsertChapter("2")
+                    .InsertBlank("p_1")
+                    .InsertVerse("1")
+                    .InsertText("New verse text.", "verse_2_1")
+                    .InsertPara("p")
+            ),
+            new ChapterDelta(
+                3,
+                1,
+                true,
+                Delta
+                    .New()
+                    .InsertChapter("3")
+                    .InsertBlank("p_1")
+                    .InsertVerse("1")
+                    .InsertText("New verse text.", "verse_3_1")
+                    .InsertPara("p")
+            )
+        };
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        var oldUsxDoc = Usx(
+            "PHM",
+            Para("imt", "Book title"),
+            Chapter("1"),
+            Para("bad", Verse("1"), "Old verse text."),
+            Chapter("2"),
+            Para("p", Verse("1"), "Old verse text."),
+            Chapter("3"),
+            Para("p", Verse("1"), "Old verse text.")
+        );
 
-            var expectedChapter1 = Delta
-                .New()
-                .InsertText("Book title", "imt_1")
-                .InsertPara("imt")
-                .InsertChapter("1")
-                .InsertBlank("bad_1")
-                .InsertVerse("1")
-                .InsertText("Verse text.", "verse_1_1")
-                .InsertPara("bad", true);
-            var expectedChapter2 = Delta
-                .New()
-                .InsertChapter("2")
-                .InsertBlank("p_1")
-                .InsertVerse("1")
-                .InsertText("Verse text.", "verse_2_1")
-                .InsertPara("p");
-            var expectedChapter3 = Delta
-                .New()
-                .InsertChapter("3")
-                .InsertBlank("p_1")
-                .InsertVerse("1")
-                .InsertText("Verse text.", "verse_3_1")
-                .InsertPara("p");
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(oldUsxDoc, chapterDeltas);
 
-            Assert.That(chapterDeltas.Count, Is.EqualTo(3));
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.False);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expectedChapter1));
-            Assert.That(chapterDeltas[1].Number, Is.EqualTo(2));
-            Assert.That(chapterDeltas[1].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[1].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[1].Delta.DeepEquals(expectedChapter2));
-            Assert.That(chapterDeltas[2].Number, Is.EqualTo(3));
-            Assert.That(chapterDeltas[2].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[2].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[2].Delta.DeepEquals(expectedChapter3));
-        }
+        XDocument expected = Usx(
+            "PHM",
+            Para("imt", "Book title"),
+            Chapter("1"),
+            Para("bad", Verse("1"), "Old verse text."),
+            Chapter("2"),
+            Para("p", Verse("1"), "New verse text."),
+            Chapter("3"),
+            Para("p", Verse("1"), "New verse text.")
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-        [Test]
-        public void ToDelta_InvalidParaInMiddleChapter()
+    [Test]
+    public void ToUsx_InvalidParaInMiddleChapter()
+    {
+        var chapterDeltas = new[]
         {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Para("imt", "Book title"),
-                Chapter("1"),
-                Para("p", Verse("1"), "Verse text."),
-                Chapter("2"),
-                Para("bad", Verse("1"), "Verse text."),
-                Chapter("3"),
-                Para("p", Verse("1"), "Verse text.")
-            );
+            new ChapterDelta(
+                1,
+                1,
+                true,
+                Delta
+                    .New()
+                    .InsertText("Book title", "imt_1")
+                    .InsertPara("imt")
+                    .InsertChapter("1")
+                    .InsertBlank("p_1")
+                    .InsertVerse("1")
+                    .InsertText("New verse text.", "verse_1_1")
+                    .InsertPara("p")
+            ),
+            new ChapterDelta(
+                2,
+                1,
+                false,
+                Delta
+                    .New()
+                    .InsertChapter("2")
+                    .InsertBlank("bad_1")
+                    .InsertVerse("1")
+                    .InsertText("New verse text.", "verse_2_1")
+                    .InsertPara("bad", true)
+            ),
+            new ChapterDelta(
+                3,
+                1,
+                true,
+                Delta
+                    .New()
+                    .InsertChapter("3")
+                    .InsertBlank("p_1")
+                    .InsertVerse("1")
+                    .InsertText("New verse text.", "verse_3_1")
+                    .InsertPara("p")
+            )
+        };
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        var oldUsxDoc = Usx(
+            "PHM",
+            Para("imt", "Book title"),
+            Chapter("1"),
+            Para("p", Verse("1"), "Old verse text."),
+            Chapter("2"),
+            Para("bad", Verse("1"), "Old verse text."),
+            Chapter("3"),
+            Para("p", Verse("1"), "Old verse text.")
+        );
 
-            var expectedChapter1 = Delta
-                .New()
-                .InsertText("Book title", "imt_1")
-                .InsertPara("imt")
-                .InsertChapter("1")
-                .InsertBlank("p_1")
-                .InsertVerse("1")
-                .InsertText("Verse text.", "verse_1_1")
-                .InsertPara("p");
-            var expectedChapter2 = Delta
-                .New()
-                .InsertChapter("2")
-                .InsertBlank("bad_1")
-                .InsertVerse("1")
-                .InsertText("Verse text.", "verse_2_1")
-                .InsertPara("bad", true);
-            var expectedChapter3 = Delta
-                .New()
-                .InsertChapter("3")
-                .InsertBlank("p_1")
-                .InsertVerse("1")
-                .InsertText("Verse text.", "verse_3_1")
-                .InsertPara("p");
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(oldUsxDoc, chapterDeltas);
 
-            Assert.That(chapterDeltas.Count, Is.EqualTo(3));
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expectedChapter1));
-            Assert.That(chapterDeltas[1].Number, Is.EqualTo(2));
-            Assert.That(chapterDeltas[1].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[1].IsValid, Is.False);
-            Assert.IsTrue(chapterDeltas[1].Delta.DeepEquals(expectedChapter2));
-            Assert.That(chapterDeltas[2].Number, Is.EqualTo(3));
-            Assert.That(chapterDeltas[2].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[2].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[2].Delta.DeepEquals(expectedChapter3));
-        }
+        XDocument expected = Usx(
+            "PHM",
+            Para("imt", "Book title"),
+            Chapter("1"),
+            Para("p", Verse("1"), "New verse text."),
+            Chapter("2"),
+            Para("bad", Verse("1"), "Old verse text."),
+            Chapter("3"),
+            Para("p", Verse("1"), "New verse text.")
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-        [Test]
-        public void ToDelta_InvalidParaInLastChapter()
+    [Test]
+    public void ToUsx_InvalidParaInLastChapter()
+    {
+        var chapterDeltas = new[]
         {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Para("imt", "Book title"),
-                Chapter("1"),
-                Para("p", Verse("1"), "Verse text."),
-                Chapter("2"),
-                Para("p", Verse("1"), "Verse text."),
-                Chapter("3"),
-                Para("bad", Verse("1"), "Verse text.")
-            );
+            new ChapterDelta(
+                1,
+                1,
+                true,
+                Delta
+                    .New()
+                    .InsertText("Book title", "imt_1")
+                    .InsertPara("imt")
+                    .InsertChapter("1")
+                    .InsertBlank("p_1")
+                    .InsertVerse("1")
+                    .InsertText("New verse text.", "verse_1_1")
+                    .InsertPara("p")
+            ),
+            new ChapterDelta(
+                2,
+                1,
+                true,
+                Delta
+                    .New()
+                    .InsertChapter("2")
+                    .InsertBlank("p_1")
+                    .InsertVerse("1")
+                    .InsertText("New verse text.", "verse_2_1")
+                    .InsertPara("p")
+            ),
+            new ChapterDelta(
+                3,
+                1,
+                false,
+                Delta
+                    .New()
+                    .InsertChapter("3")
+                    .InsertBlank("bad_1")
+                    .InsertVerse("1")
+                    .InsertText("New verse text.", "verse_3_1")
+                    .InsertPara("bad", true)
+            )
+        };
 
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        var oldUsxDoc = Usx(
+            "PHM",
+            Para("imt", "Book title"),
+            Chapter("1"),
+            Para("p", Verse("1"), "Old verse text."),
+            Chapter("2"),
+            Para("p", Verse("1"), "Old verse text."),
+            Chapter("3"),
+            Para("bad", Verse("1"), "Old verse text.")
+        );
 
-            var expectedChapter1 = Delta
-                .New()
-                .InsertText("Book title", "imt_1")
-                .InsertPara("imt")
-                .InsertChapter("1")
-                .InsertBlank("p_1")
-                .InsertVerse("1")
-                .InsertText("Verse text.", "verse_1_1")
-                .InsertPara("p");
-            var expectedChapter2 = Delta
-                .New()
-                .InsertChapter("2")
-                .InsertBlank("p_1")
-                .InsertVerse("1")
-                .InsertText("Verse text.", "verse_2_1")
-                .InsertPara("p");
-            var expectedChapter3 = Delta
-                .New()
-                .InsertChapter("3")
-                .InsertBlank("bad_1")
-                .InsertVerse("1")
-                .InsertText("Verse text.", "verse_3_1")
-                .InsertPara("bad", true);
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(oldUsxDoc, chapterDeltas);
 
-            Assert.That(chapterDeltas.Count, Is.EqualTo(3));
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expectedChapter1));
-            Assert.That(chapterDeltas[1].Number, Is.EqualTo(2));
-            Assert.That(chapterDeltas[1].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[1].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[1].Delta.DeepEquals(expectedChapter2));
-            Assert.That(chapterDeltas[2].Number, Is.EqualTo(3));
-            Assert.That(chapterDeltas[2].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[2].IsValid, Is.False);
-            Assert.IsTrue(chapterDeltas[2].Delta.DeepEquals(expectedChapter3));
-        }
+        XDocument expected = Usx(
+            "PHM",
+            Para("imt", "Book title"),
+            Chapter("1"),
+            Para("p", Verse("1"), "New verse text."),
+            Chapter("2"),
+            Para("p", Verse("1"), "New verse text."),
+            Chapter("3"),
+            Para("bad", Verse("1"), "Old verse text.")
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
 
-        [Test]
-        public void ToDelta_InvalidParaContainingVerse()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("s", Verse("1"), "This verse should not exist within this paragraph style")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
-                .New()
-                .InsertChapter("1")
-                .InsertBlank("s_1")
-                .InsertVerse("1")
-                .InsertText("This verse should not exist within this paragraph style", "verse_1_1")
-                .InsertPara("s", true);
-
-            Assert.That(chapterDeltas.Count, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.False);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
-
-        public void ToDelta_LineBreakWithinVerse()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("q", Verse("1"), "Poetry first line"),
-                Para("q", "Poetry second line"),
-                Para("b"),
-                Para("q", "Poetry third line"),
-                Para("q", "Poetry fourth line.")
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = new Delta()
-                .InsertChapter("1")
-                .InsertBlank("q_1")
-                .InsertVerse("1")
-                .InsertText("Poetry first line", "verse_1_1")
-                .InsertPara("q")
-                .InsertText("Poetry second line", "verse_1_1/q_1")
-                .InsertPara("q")
-                .InsertPara("b")
-                .InsertText("Poetry third line", "verse_1_1/q_2")
-                .InsertPara("q")
-                .InsertText("Poetry fourth line.", "verse_1_1/q_3")
-                .InsertPara("q");
-
-            Assert.That(chapterDeltas.Count, Is.EqualTo(1));
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
-
-        [Test]
-        public void ToDelta_Unmatched()
-        {
-            XDocument usxDoc = Usx(
-                "PHM",
-                Chapter("1"),
-                Para("p", Verse("1"), "This is a verse with an unmatched marker", Unmatched("bad"))
-            );
-
-            var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-            List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
-
-            var expected = Delta
+    [Test]
+    public void ToUsx_Unmatched()
+    {
+        var chapterDelta = new ChapterDelta(
+            1,
+            1,
+            true,
+            Delta
                 .New()
                 .InsertChapter("1")
                 .InsertBlank("p_1")
                 .InsertVerse("1")
                 .InsertText("This is a verse with an unmatched marker", "verse_1_1")
                 .InsertEmbed("unmatched", new JObject(new JProperty("marker", "bad")), "verse_1_1")
-                .InsertPara("p");
+                .InsertPara("p")
+                .Insert("\n")
+        );
 
-            Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
-            Assert.That(chapterDeltas[0].IsValid, Is.True);
-            Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
-        }
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
 
-        private static XDocument Usx(string code, params object[] elems)
-        {
-            return new XDocument(new XElement("usx", new XAttribute("version", "2.5"), Book(code), elems));
-        }
-
-        private static XElement Book(string code)
-        {
-            return new XElement("book", new XAttribute("code", code), new XAttribute("style", "id"));
-        }
-
-        private static XElement Para(string style, params object[] contents)
-        {
-            var elem = new XElement("para", new XAttribute("style", style), contents);
-            if (style == "")
-                elem.Add(new XAttribute("status", "unknown"));
-            return elem;
-        }
-
-        private static XElement Chapter(string number, string style = "c")
-        {
-            return new XElement("chapter", new XAttribute("number", number), new XAttribute("style", style));
-        }
-
-        private static XElement Verse(string number, string style = "v")
-        {
-            return new XElement("verse", new XAttribute("number", number), new XAttribute("style", style));
-        }
-
-        private static XElement Char(string style, params object[] contents)
-        {
-            return new XElement("char", new XAttribute("style", style), contents);
-        }
-
-        private static XElement Ref(string loc, string text)
-        {
-            return new XElement("ref", new XAttribute("loc", loc), text);
-        }
-
-        private static XElement Note(string style, string caller, params object[] contents)
-        {
-            return new XElement("note", new XAttribute("style", style), new XAttribute("caller", caller), contents);
-        }
-
-        private static XElement Figure(string file, string size, string reference, string text)
-        {
-            var elem = new XElement("figure", new XAttribute("style", "fig"));
-            if (file != null)
-                elem.Add(new XAttribute("file", file));
-            if (size != null)
-                elem.Add(new XAttribute("size", size));
-            if (reference != null)
-                elem.Add(new XAttribute("ref", reference));
-            if (text != null)
-                elem.Add(text);
-            return elem;
-        }
-
-        private static XElement OptBreak()
-        {
-            return new XElement("optbreak");
-        }
-
-        private static XElement Milestone(string style)
-        {
-            return new XElement("ms", new XAttribute("style", style));
-        }
-
-        private static XElement Table(params object[] contents)
-        {
-            return new XElement("table", contents);
-        }
-
-        private static XElement Row(params object[] contents)
-        {
-            return new XElement("row", new XAttribute("style", "tr"), contents);
-        }
-
-        private static XElement Cell(string style, string align, params object[] contents)
-        {
-            return new XElement("cell", new XAttribute("style", style), new XAttribute("align", align), contents);
-        }
-
-        private static XElement Unmatched(string marker)
-        {
-            return new XElement("unmatched", new XAttribute("marker", marker));
-        }
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), "This is a verse with an unmatched marker", Unmatched("bad"))
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
     }
+
+    [Test]
+    public void ToUsx_InvalidChapterNumber()
+    {
+        var chapterDelta = new ChapterDelta(
+            2,
+            2,
+            true,
+            Delta
+                .New()
+                .InsertChapter("2")
+                .InsertBlank("p_1")
+                .InsertVerse("1")
+                .InsertBlank("verse_2_1")
+                .InsertVerse("2")
+                .InsertBlank("verse_2_2")
+                .InsertPara("p")
+        );
+
+        XDocument oldUsxDoc = Usx("PHM", Chapter("bad"), Para("p", Verse("1"), Verse("2")), Chapter("2"));
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        XDocument newUsxDoc = mapper.ToUsx(oldUsxDoc, new[] { chapterDelta });
+
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("bad"),
+            Para("p", Verse("1"), Verse("2")),
+            Chapter("2"),
+            Para("p", Verse("1"), Verse("2"))
+        );
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
+
+    [Test]
+    public void ToDelta_EmptySegments()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), Verse("2")),
+            Para("li"),
+            Para("li"),
+            Para("p", Verse("3"))
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertBlank("verse_1_1")
+            .InsertVerse("2")
+            .InsertBlank("verse_1_2")
+            .InsertPara("p")
+            .InsertBlank("verse_1_2/li_1")
+            .InsertPara("li")
+            .InsertBlank("verse_1_2/li_2")
+            .InsertPara("li")
+            .InsertBlank("verse_1_2/p_3")
+            .InsertVerse("3")
+            .InsertBlank("verse_1_3")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(3));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_InvalidChapterNumber()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("bad"),
+            Para("p", Verse("1"), Verse("2")),
+            Chapter("2"),
+            Para("p", Verse("1"), Verse("2"))
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("2")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertBlank("verse_2_1")
+            .InsertVerse("2")
+            .InsertBlank("verse_2_2")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas.Count, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(2));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(2));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_InvalidChapter()
+    {
+        XDocument usxDoc = Usx("PHM", Chapter("1", "bad"), Para("p", Verse("1"), Verse("2")));
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1", "bad", true)
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertBlank("verse_1_1")
+            .InsertVerse("2")
+            .InsertBlank("verse_1_2")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(2));
+        Assert.That(chapterDeltas[0].IsValid, Is.False);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_InvalidVerse()
+    {
+        XDocument usxDoc = Usx("PHM", Chapter("1"), Para("p", Verse("1", "bad"), Verse("2")));
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1", "bad", true)
+            .InsertBlank("verse_1_1")
+            .InsertVerse("2")
+            .InsertBlank("verse_1_2")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(2));
+        Assert.That(chapterDeltas[0].IsValid, Is.False);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_DoublyInvalidInline()
+    {
+        // A node that is invalid for more than one reason is still just invalid, not crashing.
+
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), Char("tei", Char("ver", "blah")), Verse("2"))
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertChar(
+                "blah",
+                new List<CharAttr>
+                {
+                    new CharAttr { Style = "tei", CharID = _testGuidService.Generate() },
+                    new CharAttr { Style = "ver", CharID = _testGuidService.Generate() }
+                },
+                "verse_1_1",
+                invalid: true
+            )
+            .InsertVerse("2")
+            .InsertBlank("verse_1_2")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(2));
+        Assert.That(chapterDeltas[0].IsValid, Is.False);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_InvalidLastVerse()
+    {
+        XDocument usxDoc = Usx("PHM", Chapter("1"), Para("p", Verse("1"), Verse("2bad")));
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertBlank("verse_1_1")
+            .InsertVerse("2bad", "v", true)
+            .InsertBlank("verse_1_2bad")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.False);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_SectionHeader()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Para("mt", "Philemon"),
+            Chapter("1"),
+            Para("p", Verse("1"), Verse("2")),
+            Para("s"),
+            Para("p", Verse("3")),
+            Chapter("2"),
+            Para("p", Verse("1"), Verse("2")),
+            Para("s"),
+            Para("p", Verse("3"))
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expectedChapter1 = Delta
+            .New()
+            .InsertText("Philemon", "mt_1")
+            .InsertPara("mt")
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertBlank("verse_1_1")
+            .InsertVerse("2")
+            .InsertBlank("verse_1_2")
+            .InsertPara("p")
+            .InsertBlank("s_1")
+            .InsertPara("s")
+            .InsertBlank("p_2")
+            .InsertVerse("3")
+            .InsertBlank("verse_1_3")
+            .InsertPara("p");
+
+        var expectedChapter2 = Delta
+            .New()
+            .InsertChapter("2")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertBlank("verse_2_1")
+            .InsertVerse("2")
+            .InsertBlank("verse_2_2")
+            .InsertPara("p")
+            .InsertBlank("s_1")
+            .InsertPara("s")
+            .InsertBlank("p_2")
+            .InsertVerse("3")
+            .InsertBlank("verse_2_3")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas.Count, Is.EqualTo(2));
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(3));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expectedChapter1));
+        Assert.That(chapterDeltas[1].Number, Is.EqualTo(2));
+        Assert.That(chapterDeltas[1].LastVerse, Is.EqualTo(3));
+        Assert.That(chapterDeltas[1].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[1].Delta.DeepEquals(expectedChapter2));
+    }
+
+    [Test]
+    public void ToDelta_Note()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para(
+                "p",
+                Verse("1"),
+                "This is a verse with a footnote",
+                Note(
+                    "f",
+                    "+",
+                    Char("fr", "1.1: "),
+                    Char("ft", "Refers to "),
+                    Char("fq", "a footnote"),
+                    ". ",
+                    Char("xt", "John 1:1"),
+                    " and ",
+                    Char("xt", "Mark 1:1")
+                ),
+                ", so that we can test it."
+            )
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("This is a verse with a footnote", "verse_1_1")
+            .InsertNote(
+                Delta
+                    .New()
+                    .InsertChar("1.1: ", "fr", _testGuidService.Generate())
+                    .InsertChar("Refers to ", "ft", _testGuidService.Generate())
+                    .InsertChar("a footnote", "fq", _testGuidService.Generate())
+                    .Insert(". ")
+                    .InsertChar("John 1:1", "xt", _testGuidService.Generate())
+                    .Insert(" and ")
+                    .InsertChar("Mark 1:1", "xt", _testGuidService.Generate()),
+                "f",
+                "+",
+                "verse_1_1"
+            )
+            .InsertText(", so that we can test it.", "verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_InvalidNote()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para(
+                "p",
+                Verse("1"),
+                "This is a verse with a footnote",
+                Note(
+                    "bad",
+                    "+",
+                    Char("fr", "1.1: "),
+                    Char("ft", "Refers to "),
+                    Char("fq", "a footnote"),
+                    ". ",
+                    Char("xt", "John 1:1"),
+                    " and ",
+                    Char("xt", "Mark 1:1")
+                ),
+                ", so that we can test it."
+            )
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("This is a verse with a footnote", "verse_1_1")
+            .InsertNote(
+                Delta
+                    .New()
+                    .InsertChar("1.1: ", "fr", _testGuidService.Generate())
+                    .InsertChar("Refers to ", "ft", _testGuidService.Generate())
+                    .InsertChar("a footnote", "fq", _testGuidService.Generate())
+                    .Insert(". ")
+                    .InsertChar("John 1:1", "xt", _testGuidService.Generate())
+                    .Insert(" and ")
+                    .InsertChar("Mark 1:1", "xt", _testGuidService.Generate()),
+                "bad",
+                "+",
+                "verse_1_1",
+                true
+            )
+            .InsertText(", so that we can test it.", "verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.False);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_Figure()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para(
+                "p",
+                Verse("1"),
+                "This is a verse with a figure",
+                Figure("file.jpg", "col", "PHM 1:1", "Caption"),
+                ", so that we can test it."
+            )
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("This is a verse with a figure", "verse_1_1")
+            .InsertFigure("file.jpg", "col", "PHM 1:1", "Caption", "verse_1_1")
+            .InsertText(", so that we can test it.", "verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_InvalidFigure()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para(
+                "p",
+                Verse("1"),
+                "This is a verse with a figure",
+                Figure("file.jpg", "col", null, "Caption"),
+                ", so that we can test it."
+            )
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("This is a verse with a figure", "verse_1_1")
+            .InsertFigure("file.jpg", "col", null, "Caption", "verse_1_1", true)
+            .InsertText(", so that we can test it.", "verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.False);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_CharText()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), "This is some ", Char("bd", "bold"), " text.")
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("This is some ", "verse_1_1")
+            .InsertChar("bold", "bd", _testGuidService.Generate(), "verse_1_1")
+            .InsertText(" text.", "verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_EmptyChar()
+    {
+        XDocument usxDoc = Usx("PHM", Chapter("1"), Para("p", Verse("1"), "This is some ", Char("bd", ""), " text."));
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("This is some ", "verse_1_1")
+            .InsertEmptyChar("bd", _testGuidService.Generate(), "verse_1_1")
+            .InsertText(" text.", "verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_NestedChars()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para(
+                "p",
+                Verse("1"),
+                Char("bd", Char("sup", "1"), "This is", Char("sup", "2"), " bold text.", Char("sup", "3")),
+                " This is normal text."
+            )
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        string bdCharID = _testGuidService.Generate();
+        string sup1CharID = _testGuidService.Generate();
+        string sup2CharID = _testGuidService.Generate();
+        string sup3CharID = _testGuidService.Generate();
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertChar(
+                "1",
+                new List<CharAttr>
+                {
+                    new CharAttr { Style = "bd", CharID = bdCharID },
+                    new CharAttr { Style = "sup", CharID = sup1CharID }
+                },
+                "verse_1_1"
+            )
+            .InsertChar("This is", "bd", bdCharID, "verse_1_1")
+            .InsertChar(
+                "2",
+                new List<CharAttr>
+                {
+                    new CharAttr { Style = "bd", CharID = bdCharID },
+                    new CharAttr { Style = "sup", CharID = sup2CharID }
+                },
+                "verse_1_1"
+            )
+            .InsertChar(" bold text.", "bd", bdCharID, "verse_1_1")
+            .InsertChar(
+                "3",
+                new List<CharAttr>
+                {
+                    new CharAttr { Style = "bd", CharID = bdCharID },
+                    new CharAttr { Style = "sup", CharID = sup3CharID }
+                },
+                "verse_1_1"
+            )
+            .InsertText(" This is normal text.", "verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_NestedAdjacentChars()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para(
+                "p",
+                Verse("1"),
+                Char("bd", Char("sup", "1"), Char("sup", "2"), Char("sup", "3")),
+                " This is normal text."
+            )
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        string bdCharID = _testGuidService.Generate();
+        string sup1CharID = _testGuidService.Generate();
+        string sup2CharID = _testGuidService.Generate();
+        string sup3CharID = _testGuidService.Generate();
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertChar(
+                "1",
+                new List<CharAttr>
+                {
+                    new CharAttr { Style = "bd", CharID = bdCharID },
+                    new CharAttr { Style = "sup", CharID = sup1CharID }
+                },
+                "verse_1_1"
+            )
+            .InsertChar(
+                "2",
+                new List<CharAttr>
+                {
+                    new CharAttr { Style = "bd", CharID = bdCharID },
+                    new CharAttr { Style = "sup", CharID = sup2CharID }
+                },
+                "verse_1_1"
+            )
+            .InsertChar(
+                "3",
+                new List<CharAttr>
+                {
+                    new CharAttr { Style = "bd", CharID = bdCharID },
+                    new CharAttr { Style = "sup", CharID = sup3CharID }
+                },
+                "verse_1_1"
+            )
+            .InsertText(" This is normal text.", "verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_DoubleNestedAdjacentChars()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para(
+                "p",
+                Verse("1"),
+                Char(
+                    "bd",
+                    Char("sup", "1"),
+                    "This is bold text",
+                    Char("no", " but this is not bold,", Char("sup", "2"), Char("sup", "3")),
+                    " and this is bold.",
+                    Char("sup", "4")
+                ),
+                " This is normal text."
+            )
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        string bdCharID = _testGuidService.Generate();
+        string sup1CharID = _testGuidService.Generate();
+        string noCharID = _testGuidService.Generate();
+        string sup2CharID = _testGuidService.Generate();
+        string sup3CharID = _testGuidService.Generate();
+        string sup4CharID = _testGuidService.Generate();
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertChar(
+                "1",
+                new List<CharAttr>
+                {
+                    new CharAttr { Style = "bd", CharID = bdCharID },
+                    new CharAttr { Style = "sup", CharID = sup1CharID }
+                },
+                "verse_1_1"
+            )
+            .InsertChar("This is bold text", "bd", bdCharID, "verse_1_1")
+            .InsertChar(
+                " but this is not bold,",
+                new List<CharAttr>
+                {
+                    new CharAttr { Style = "bd", CharID = bdCharID },
+                    new CharAttr { Style = "no", CharID = noCharID }
+                },
+                "verse_1_1"
+            )
+            .InsertChar(
+                "2",
+                new List<CharAttr>
+                {
+                    new CharAttr { Style = "bd", CharID = bdCharID },
+                    new CharAttr { Style = "no", CharID = noCharID },
+                    new CharAttr { Style = "sup", CharID = sup2CharID }
+                },
+                "verse_1_1"
+            )
+            .InsertChar(
+                "3",
+                new List<CharAttr>
+                {
+                    new CharAttr { Style = "bd", CharID = bdCharID },
+                    new CharAttr { Style = "no", CharID = noCharID },
+                    new CharAttr { Style = "sup", CharID = sup3CharID }
+                },
+                "verse_1_1"
+            )
+            .InsertChar(" and this is bold.", "bd", bdCharID, "verse_1_1")
+            .InsertChar(
+                "4",
+                new List<CharAttr>
+                {
+                    new CharAttr { Style = "bd", CharID = bdCharID },
+                    new CharAttr { Style = "sup", CharID = sup4CharID }
+                },
+                "verse_1_1"
+            )
+            .InsertText(" This is normal text.", "verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_InvalidChars()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para(
+                "p",
+                Verse("1"),
+                Char("bad", Char("sup", "1"), "This is", Char("sup", "2"), " bold text.", Char("sup", "3")),
+                " This is normal text."
+            )
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        string badCharID = _testGuidService.Generate();
+        string sup1CharID = _testGuidService.Generate();
+        string sup2CharID = _testGuidService.Generate();
+        string sup3CharID = _testGuidService.Generate();
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertChar(
+                "1",
+                new List<CharAttr>
+                {
+                    new CharAttr { Style = "bad", CharID = badCharID },
+                    new CharAttr { Style = "sup", CharID = sup1CharID }
+                },
+                "verse_1_1",
+                true
+            )
+            .InsertChar("This is", "bad", badCharID, "verse_1_1", true)
+            .InsertChar(
+                "2",
+                new List<CharAttr>
+                {
+                    new CharAttr { Style = "bad", CharID = badCharID },
+                    new CharAttr { Style = "sup", CharID = sup2CharID }
+                },
+                "verse_1_1",
+                true
+            )
+            .InsertChar(" bold text.", "bad", badCharID, "verse_1_1", true)
+            .InsertChar(
+                "3",
+                new List<CharAttr>
+                {
+                    new CharAttr { Style = "bad", CharID = badCharID },
+                    new CharAttr { Style = "sup", CharID = sup3CharID }
+                },
+                "verse_1_1",
+                true
+            )
+            .InsertText(" This is normal text.", "verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.False);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_AdjacentChars()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), Char("sup", "1"), Char("sup", "2"), Char("sup", "3"), " This is normal text.")
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertChar("1", "sup", _testGuidService.Generate(), "verse_1_1")
+            .InsertChar("2", "sup", _testGuidService.Generate(), "verse_1_1")
+            .InsertChar("3", "sup", _testGuidService.Generate(), "verse_1_1")
+            .InsertText(" This is normal text.", "verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_Ref()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para(
+                "p",
+                Verse("1"),
+                "This is a verse with a footnote",
+                Note(
+                    "f",
+                    "+",
+                    Char("fr", "1.1: "),
+                    Char("ft", "Refers to "),
+                    Char("fq", "a footnote"),
+                    ". ",
+                    Char("xt", Ref("JHN 1:1", "John 1:1")),
+                    " and ",
+                    Char("xt", Ref("MRK 1:1", "Mark 1:1")),
+                    "."
+                ),
+                ", so that we can test it."
+            )
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("This is a verse with a footnote", "verse_1_1")
+            .InsertNote(
+                Delta
+                    .New()
+                    .InsertChar("1.1: ", "fr", _testGuidService.Generate())
+                    .InsertChar("Refers to ", "ft", _testGuidService.Generate())
+                    .InsertChar("a footnote", "fq", _testGuidService.Generate())
+                    .Insert(". ")
+                    .InsertCharRef("John 1:1", "xt", "JHN 1:1", _testGuidService.Generate())
+                    .Insert(" and ")
+                    .InsertCharRef("Mark 1:1", "xt", "MRK 1:1", _testGuidService.Generate())
+                    .Insert("."),
+                "f",
+                "+",
+                "verse_1_1"
+            )
+            .InsertText(", so that we can test it.", "verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_EmptyRef()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para(
+                "p",
+                Verse("1"),
+                "This is a verse with a footnote",
+                Note(
+                    "f",
+                    "*",
+                    Char("fr", "1:1"),
+                    Char("ft", ""),
+                    ". ",
+                    Char("xo", ""),
+                    Char("xt", Ref("MRK 1:1", "Mark 1:1"))
+                ),
+                ", so that we can test it."
+            )
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("This is a verse with a footnote", "verse_1_1")
+            .InsertNote(
+                Delta
+                    .New()
+                    .InsertChar("1:1", "fr", _testGuidService.Generate())
+                    .InsertEmptyChar("ft", _testGuidService.Generate())
+                    .Insert(". ")
+                    .InsertEmptyChar("xo", _testGuidService.Generate())
+                    .InsertCharRef("Mark 1:1", "xt", "MRK 1:1", _testGuidService.Generate()),
+                "f",
+                "*",
+                "verse_1_1"
+            )
+            .InsertText(", so that we can test it.", "verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_InvalidRef()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para(
+                "p",
+                Verse("1"),
+                "This is a verse with a footnote",
+                Note(
+                    "f",
+                    "+",
+                    Char("fr", "1.1: "),
+                    Char("ft", "Refers to "),
+                    Char("fq", "a footnote"),
+                    ". ",
+                    Char("xt", Ref("bad location", "John 1:1")),
+                    " and ",
+                    Char("xt", Ref("MRK 1:1", "Mark 1:1")),
+                    "."
+                ),
+                ", so that we can test it."
+            )
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("This is a verse with a footnote", "verse_1_1")
+            .InsertNote(
+                Delta
+                    .New()
+                    .InsertChar("1.1: ", "fr", _testGuidService.Generate())
+                    .InsertChar("Refers to ", "ft", _testGuidService.Generate())
+                    .InsertChar("a footnote", "fq", _testGuidService.Generate())
+                    .Insert(". ")
+                    .InsertCharRef("John 1:1", "xt", "bad location", _testGuidService.Generate(), invalid: true)
+                    .Insert(" and ")
+                    .InsertCharRef("Mark 1:1", "xt", "MRK 1:1", _testGuidService.Generate())
+                    .Insert("."),
+                "f",
+                "+",
+                "verse_1_1"
+            )
+            .InsertText(", so that we can test it.", "verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.False);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_OptBreak()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), "This is a verse with a line break", OptBreak(), ", so that we can test it.")
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("This is a verse with a line break", "verse_1_1")
+            .InsertOptBreak("verse_1_1")
+            .InsertText(", so that we can test it.", "verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_Milestone()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), "This is a verse with a line break", Milestone("ts"), ", so that we can test it.")
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("This is a verse with a line break", "verse_1_1")
+            .InsertMilestone("ts", "verse_1_1")
+            .InsertText(", so that we can test it.", "verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_InvalidMilestone()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), "This is a verse with a line break", Milestone("bad"), ", so that we can test it.")
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("This is a verse with a line break", "verse_1_1")
+            .InsertMilestone("bad", "verse_1_1", true)
+            .InsertText(", so that we can test it.", "verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.False);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_TableAtEnd()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Table(
+                Row(
+                    Cell("tc1", "start", "Before verse.", Verse("1"), "This is verse ", Char("it", "1"), "."),
+                    Cell("tc2", "start", Verse("2"), "This is verse 2.")
+                ),
+                Row(Cell("tc1", "start"), Cell("tc2", "start", Verse("3"), "This is verse 3."))
+            )
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertText("Before verse.", "cell_1_1_1")
+            .InsertVerse("1")
+            .InsertText("This is verse ", "verse_1_1")
+            .InsertChar("1", "it", _testGuidService.Generate(), "verse_1_1")
+            .InsertText(".", "verse_1_1")
+            .InsertCell(1, 1, "tc1", "start")
+            .InsertBlank("cell_1_1_2")
+            .InsertVerse("2")
+            .InsertText("This is verse 2.", "verse_1_2")
+            .InsertCell(1, 1, "tc2", "start")
+            .InsertBlank("cell_1_2_1")
+            .InsertCell(1, 2, "tc1", "start")
+            .InsertBlank("cell_1_2_2")
+            .InsertVerse("3")
+            .InsertText("This is verse 3.", "verse_1_3")
+            .InsertCell(1, 2, "tc2", "start");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(3));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_TableInMiddle()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Table(
+                Row(
+                    Cell("tc1", "start", "Before verse.", Verse("1"), "This is verse ", Char("it", "1"), "."),
+                    Cell("tc2", "start", Verse("2"), "This is verse 2.")
+                ),
+                Row(Cell("tc1", "start"), Cell("tc2", "start", Verse("3"), "This is verse 3."))
+            ),
+            Para("p", Verse("4"), "This is verse 4.")
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertText("Before verse.", "cell_1_1_1")
+            .InsertVerse("1")
+            .InsertText("This is verse ", "verse_1_1")
+            .InsertChar("1", "it", _testGuidService.Generate(), "verse_1_1")
+            .InsertText(".", "verse_1_1")
+            .InsertCell(1, 1, "tc1", "start")
+            .InsertBlank("cell_1_1_2")
+            .InsertVerse("2")
+            .InsertText("This is verse 2.", "verse_1_2")
+            .InsertCell(1, 1, "tc2", "start")
+            .InsertBlank("cell_1_2_1")
+            .InsertCell(1, 2, "tc1", "start")
+            .InsertBlank("cell_1_2_2")
+            .InsertVerse("3")
+            .InsertText("This is verse 3.", "verse_1_3")
+            .InsertCell(1, 2, "tc2", "start")
+            .InsertBlank("p_1")
+            .InsertVerse("4")
+            .InsertText("This is verse 4.", "verse_1_4")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(4));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_AdjacentTables()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Table(
+                Row(
+                    Cell("tc1", "start", Verse("1"), "This is verse 1."),
+                    Cell("tc2", "start", Verse("2"), "This is verse 2.")
+                ),
+                Row(
+                    Cell("tc1", "start", Verse("3"), "This is verse 3."),
+                    Cell("tc2", "start", Verse("4"), "This is verse 4.")
+                )
+            ),
+            Table(
+                Row(
+                    Cell("tc1", "start", Verse("5"), "This is verse 5."),
+                    Cell("tc2", "start", Verse("6"), "This is verse 6.")
+                ),
+                Row(
+                    Cell("tc1", "start", Verse("7"), "This is verse 7."),
+                    Cell("tc2", "start", Verse("8"), "This is verse 8.")
+                )
+            )
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("cell_1_1_1")
+            .InsertVerse("1")
+            .InsertText("This is verse 1.", "verse_1_1")
+            .InsertCell(1, 1, "tc1", "start")
+            .InsertBlank("cell_1_1_2")
+            .InsertVerse("2")
+            .InsertText("This is verse 2.", "verse_1_2")
+            .InsertCell(1, 1, "tc2", "start")
+            .InsertBlank("cell_1_2_1")
+            .InsertVerse("3")
+            .InsertText("This is verse 3.", "verse_1_3")
+            .InsertCell(1, 2, "tc1", "start")
+            .InsertBlank("cell_1_2_2")
+            .InsertVerse("4")
+            .InsertText("This is verse 4.", "verse_1_4")
+            .InsertCell(1, 2, "tc2", "start")
+            .InsertBlank("cell_2_1_1")
+            .InsertVerse("5")
+            .InsertText("This is verse 5.", "verse_1_5")
+            .InsertCell(2, 1, "tc1", "start")
+            .InsertBlank("cell_2_1_2")
+            .InsertVerse("6")
+            .InsertText("This is verse 6.", "verse_1_6")
+            .InsertCell(2, 1, "tc2", "start")
+            .InsertBlank("cell_2_2_1")
+            .InsertVerse("7")
+            .InsertText("This is verse 7.", "verse_1_7")
+            .InsertCell(2, 2, "tc1", "start")
+            .InsertBlank("cell_2_2_2")
+            .InsertVerse("8")
+            .InsertText("This is verse 8.", "verse_1_8")
+            .InsertCell(2, 2, "tc2", "start");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(8));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_InvalidTable()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Table(
+                Row(
+                    Cell("bad", "start", "Before verse.", Verse("1"), "This is verse ", Char("it", "1"), "."),
+                    Cell("tc2", "start", Verse("2"), "This is verse 2.")
+                ),
+                Row(Cell("tc1", "start"), Cell("tc2", "start", Verse("3"), "This is verse 3."))
+            )
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertText("Before verse.", "cell_1_1_1")
+            .InsertVerse("1")
+            .InsertText("This is verse ", "verse_1_1")
+            .InsertChar("1", "it", _testGuidService.Generate(), "verse_1_1")
+            .InsertText(".", "verse_1_1")
+            .InsertCell(1, 1, "bad", "start", true)
+            .InsertBlank("cell_1_1_2")
+            .InsertVerse("2")
+            .InsertText("This is verse 2.", "verse_1_2")
+            .InsertCell(1, 1, "tc2", "start")
+            .InsertBlank("cell_1_2_1")
+            .InsertCell(1, 2, "tc1", "start")
+            .InsertBlank("cell_1_2_2")
+            .InsertVerse("3")
+            .InsertText("This is verse 3.", "verse_1_3")
+            .InsertCell(1, 2, "tc2", "start");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(3));
+        Assert.That(chapterDeltas[0].IsValid, Is.False);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_NoParagraphs()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Verse("1"),
+            "This is verse 1.",
+            Verse("2"),
+            Verse("3"),
+            "This is verse 3.",
+            Chapter("2"),
+            Verse("1"),
+            Verse("2-3")
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected1 = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertVerse("1")
+            .InsertText("This is verse 1.", "verse_1_1")
+            .InsertVerse("2")
+            .InsertBlank("verse_1_2")
+            .InsertVerse("3")
+            .InsertText("This is verse 3.", "verse_1_3")
+            .Insert("\n");
+        var expected2 = Delta
+            .New()
+            .InsertChapter("2")
+            .InsertVerse("1")
+            .InsertBlank("verse_2_1")
+            .InsertVerse("2-3")
+            .InsertBlank("verse_2_2-3")
+            .Insert("\n");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(3));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected1));
+        Assert.That(chapterDeltas[1].Number, Is.EqualTo(2));
+        Assert.That(chapterDeltas[1].LastVerse, Is.EqualTo(3));
+        Assert.That(chapterDeltas[1].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[1].Delta.DeepEquals(expected2));
+    }
+
+    [Test]
+    public void ToDelta_ImpliedParagraph()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            "This is an implied paragraph before the first verse.",
+            Para("p", Verse("1"))
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .Insert("This is an implied paragraph before the first verse.")
+            .Insert("\n")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertBlank("verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_ImpliedParagraphInVerse()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            "This is an implied paragraph before the first verse.",
+            Para("p", "This is actually an implied paragraph as part of the verse.", Verse("1"))
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .Insert("This is an implied paragraph before the first verse.")
+            .Insert("\n")
+            .InsertText("This is actually an implied paragraph as part of the verse.", "p_1")
+            .InsertVerse("1")
+            .InsertBlank("verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_NoParagraphsImpliedParagraph()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            "This is an implied paragraph before the first verse.",
+            Verse("1"),
+            "This is verse 1.",
+            Verse("2"),
+            Verse("3"),
+            "This is verse 3.",
+            Chapter("2"),
+            Verse("1"),
+            Verse("2-3")
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected1 = Delta
+            .New()
+            .InsertChapter("1")
+            .Insert("This is an implied paragraph before the first verse.")
+            .InsertVerse("1")
+            .InsertText("This is verse 1.", "verse_1_1")
+            .InsertVerse("2")
+            .InsertBlank("verse_1_2")
+            .InsertVerse("3")
+            .InsertText("This is verse 3.", "verse_1_3")
+            .Insert("\n");
+        var expected2 = Delta
+            .New()
+            .InsertChapter("2")
+            .InsertVerse("1")
+            .InsertBlank("verse_2_1")
+            .InsertVerse("2-3")
+            .InsertBlank("verse_2_2-3")
+            .Insert("\n");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(3));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected1));
+        Assert.That(chapterDeltas[1].Number, Is.EqualTo(2));
+        Assert.That(chapterDeltas[1].LastVerse, Is.EqualTo(3));
+        Assert.That(chapterDeltas[1].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[1].Delta.DeepEquals(expected2));
+    }
+
+    [Test]
+    public void ToDelta_EmptyBook()
+    {
+        XDocument usxDoc = Usx("PHM");
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        Assert.That(chapterDeltas.Count, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(0));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(new Delta()));
+    }
+
+    [Test]
+    public void ToDelta_EmptyStyle()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), Verse("2")),
+            Para(""),
+            Para("li"),
+            Para("", Verse("3"))
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertBlank("verse_1_1")
+            .InsertVerse("2")
+            .InsertBlank("verse_1_2")
+            .InsertPara("p")
+            .InsertBlank("verse_1_2/_1")
+            .InsertPara("")
+            .InsertBlank("verse_1_2/li_2")
+            .InsertPara("li")
+            .InsertBlank("verse_1_2/_3")
+            .InsertVerse("3")
+            .InsertBlank("verse_1_3")
+            .InsertPara("");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(3));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_BlankLine()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), Verse("2")),
+            Para("b"),
+            Para("p", Verse("3"))
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertBlank("verse_1_1")
+            .InsertVerse("2")
+            .InsertBlank("verse_1_2")
+            .InsertPara("p")
+            .InsertPara("b")
+            .InsertBlank("verse_1_2/p_1")
+            .InsertVerse("3")
+            .InsertBlank("verse_1_3")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void ToDelta_BlankLineContainsText()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), "Verse text."),
+            // support this even though we do not encourage users to type text in line breaks
+            Para("b", "Text in line break"),
+            Para("p", "second segment in verse.")
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = new Delta()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("Verse text.", "verse_1_1")
+            .InsertPara("p")
+            .InsertText("Text in line break")
+            .InsertPara("b")
+            .InsertText("second segment in verse.", "verse_1_1/p_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas.Count, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_InvalidParaInFirstChapter()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Para("imt", "Book title"),
+            Chapter("1"),
+            Para("bad", Verse("1"), "Verse text."),
+            Chapter("2"),
+            Para("p", Verse("1"), "Verse text."),
+            Chapter("3"),
+            Para("p", Verse("1"), "Verse text.")
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expectedChapter1 = Delta
+            .New()
+            .InsertText("Book title", "imt_1")
+            .InsertPara("imt")
+            .InsertChapter("1")
+            .InsertBlank("bad_1")
+            .InsertVerse("1")
+            .InsertText("Verse text.", "verse_1_1")
+            .InsertPara("bad", true);
+        var expectedChapter2 = Delta
+            .New()
+            .InsertChapter("2")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("Verse text.", "verse_2_1")
+            .InsertPara("p");
+        var expectedChapter3 = Delta
+            .New()
+            .InsertChapter("3")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("Verse text.", "verse_3_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas.Count, Is.EqualTo(3));
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.False);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expectedChapter1));
+        Assert.That(chapterDeltas[1].Number, Is.EqualTo(2));
+        Assert.That(chapterDeltas[1].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[1].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[1].Delta.DeepEquals(expectedChapter2));
+        Assert.That(chapterDeltas[2].Number, Is.EqualTo(3));
+        Assert.That(chapterDeltas[2].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[2].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[2].Delta.DeepEquals(expectedChapter3));
+    }
+
+    [Test]
+    public void ToDelta_InvalidParaInMiddleChapter()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Para("imt", "Book title"),
+            Chapter("1"),
+            Para("p", Verse("1"), "Verse text."),
+            Chapter("2"),
+            Para("bad", Verse("1"), "Verse text."),
+            Chapter("3"),
+            Para("p", Verse("1"), "Verse text.")
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expectedChapter1 = Delta
+            .New()
+            .InsertText("Book title", "imt_1")
+            .InsertPara("imt")
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("Verse text.", "verse_1_1")
+            .InsertPara("p");
+        var expectedChapter2 = Delta
+            .New()
+            .InsertChapter("2")
+            .InsertBlank("bad_1")
+            .InsertVerse("1")
+            .InsertText("Verse text.", "verse_2_1")
+            .InsertPara("bad", true);
+        var expectedChapter3 = Delta
+            .New()
+            .InsertChapter("3")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("Verse text.", "verse_3_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas.Count, Is.EqualTo(3));
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expectedChapter1));
+        Assert.That(chapterDeltas[1].Number, Is.EqualTo(2));
+        Assert.That(chapterDeltas[1].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[1].IsValid, Is.False);
+        Assert.IsTrue(chapterDeltas[1].Delta.DeepEquals(expectedChapter2));
+        Assert.That(chapterDeltas[2].Number, Is.EqualTo(3));
+        Assert.That(chapterDeltas[2].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[2].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[2].Delta.DeepEquals(expectedChapter3));
+    }
+
+    [Test]
+    public void ToDelta_InvalidParaInLastChapter()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Para("imt", "Book title"),
+            Chapter("1"),
+            Para("p", Verse("1"), "Verse text."),
+            Chapter("2"),
+            Para("p", Verse("1"), "Verse text."),
+            Chapter("3"),
+            Para("bad", Verse("1"), "Verse text.")
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expectedChapter1 = Delta
+            .New()
+            .InsertText("Book title", "imt_1")
+            .InsertPara("imt")
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("Verse text.", "verse_1_1")
+            .InsertPara("p");
+        var expectedChapter2 = Delta
+            .New()
+            .InsertChapter("2")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("Verse text.", "verse_2_1")
+            .InsertPara("p");
+        var expectedChapter3 = Delta
+            .New()
+            .InsertChapter("3")
+            .InsertBlank("bad_1")
+            .InsertVerse("1")
+            .InsertText("Verse text.", "verse_3_1")
+            .InsertPara("bad", true);
+
+        Assert.That(chapterDeltas.Count, Is.EqualTo(3));
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expectedChapter1));
+        Assert.That(chapterDeltas[1].Number, Is.EqualTo(2));
+        Assert.That(chapterDeltas[1].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[1].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[1].Delta.DeepEquals(expectedChapter2));
+        Assert.That(chapterDeltas[2].Number, Is.EqualTo(3));
+        Assert.That(chapterDeltas[2].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[2].IsValid, Is.False);
+        Assert.IsTrue(chapterDeltas[2].Delta.DeepEquals(expectedChapter3));
+    }
+
+    [Test]
+    public void ToDelta_InvalidParaContainingVerse()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("s", Verse("1"), "This verse should not exist within this paragraph style")
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("s_1")
+            .InsertVerse("1")
+            .InsertText("This verse should not exist within this paragraph style", "verse_1_1")
+            .InsertPara("s", true);
+
+        Assert.That(chapterDeltas.Count, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.False);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    public void ToDelta_LineBreakWithinVerse()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("q", Verse("1"), "Poetry first line"),
+            Para("q", "Poetry second line"),
+            Para("b"),
+            Para("q", "Poetry third line"),
+            Para("q", "Poetry fourth line.")
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = new Delta()
+            .InsertChapter("1")
+            .InsertBlank("q_1")
+            .InsertVerse("1")
+            .InsertText("Poetry first line", "verse_1_1")
+            .InsertPara("q")
+            .InsertText("Poetry second line", "verse_1_1/q_1")
+            .InsertPara("q")
+            .InsertPara("b")
+            .InsertText("Poetry third line", "verse_1_1/q_2")
+            .InsertPara("q")
+            .InsertText("Poetry fourth line.", "verse_1_1/q_3")
+            .InsertPara("q");
+
+        Assert.That(chapterDeltas.Count, Is.EqualTo(1));
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void ToDelta_Unmatched()
+    {
+        XDocument usxDoc = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), "This is a verse with an unmatched marker", Unmatched("bad"))
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("This is a verse with an unmatched marker", "verse_1_1")
+            .InsertEmbed("unmatched", new JObject(new JProperty("marker", "bad")), "verse_1_1")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    private static XDocument Usx(string code, params object[] elems) =>
+        new XDocument(new XElement("usx", new XAttribute("version", "2.5"), Book(code), elems));
+
+    private static XElement Book(string code) =>
+        new XElement("book", new XAttribute("code", code), new XAttribute("style", "id"));
+
+    private static XElement Para(string style, params object[] contents)
+    {
+        var elem = new XElement("para", new XAttribute("style", style), contents);
+        if (style == "")
+            elem.Add(new XAttribute("status", "unknown"));
+        return elem;
+    }
+
+    private static XElement Chapter(string number, string style = "c") =>
+        new XElement("chapter", new XAttribute("number", number), new XAttribute("style", style));
+
+    private static XElement Verse(string number, string style = "v") =>
+        new XElement("verse", new XAttribute("number", number), new XAttribute("style", style));
+
+    private static XElement Char(string style, params object[] contents) =>
+        new XElement("char", new XAttribute("style", style), contents);
+
+    private static XElement Ref(string loc, string text) => new XElement("ref", new XAttribute("loc", loc), text);
+
+    private static XElement Note(string style, string caller, params object[] contents) =>
+        new XElement("note", new XAttribute("style", style), new XAttribute("caller", caller), contents);
+
+    private static XElement Figure(string file, string size, string reference, string text)
+    {
+        var elem = new XElement("figure", new XAttribute("style", "fig"));
+        if (file != null)
+            elem.Add(new XAttribute("file", file));
+        if (size != null)
+            elem.Add(new XAttribute("size", size));
+        if (reference != null)
+            elem.Add(new XAttribute("ref", reference));
+        if (text != null)
+            elem.Add(text);
+        return elem;
+    }
+
+    private static XElement OptBreak() => new XElement("optbreak");
+
+    private static XElement Milestone(string style) => new XElement("ms", new XAttribute("style", style));
+
+    private static XElement Table(params object[] contents) => new XElement("table", contents);
+
+    private static XElement Row(params object[] contents) =>
+        new XElement("row", new XAttribute("style", "tr"), contents);
+
+    private static XElement Cell(string style, string align, params object[] contents) =>
+        new XElement("cell", new XAttribute("style", style), new XAttribute("align", align), contents);
+
+    private static XElement Unmatched(string marker) => new XElement("unmatched", new XAttribute("marker", marker));
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxTestExtensions.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxTestExtensions.cs
@@ -4,194 +4,188 @@ using Newtonsoft.Json.Linq;
 using SIL.XForge.Realtime.RichText;
 using SIL.XForge.Scripture.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public static class DeltaUsxTestExtensions
 {
-    public static class DeltaUsxTestExtensions
+    public static Delta InsertPara(this Delta delta, string style, bool invalid = false)
     {
-        public static Delta InsertPara(this Delta delta, string style, bool invalid = false)
-        {
-            var obj = new JObject(new JProperty("style", style));
-            if (style == "")
-                obj.Add(new JProperty("status", "unknown"));
-            JObject attrs = null;
-            if (invalid)
-                attrs = new JObject(new JProperty("invalid-block", true));
-            return delta.InsertPara(obj, attrs);
-        }
-
-        public static Delta InsertNote(
-            this Delta delta,
-            Delta contents,
-            string style,
-            string caller,
-            string segRef,
-            bool invalid = false
-        )
-        {
-            var obj = new JObject(
-                new JProperty("style", style),
-                new JProperty("caller", caller),
-                new JProperty("contents", SerializeDelta(contents))
-            );
-            JObject attrs = null;
-            if (invalid)
-                attrs = new JObject(new JProperty("invalid-inline", true));
-            return delta.InsertEmbed("note", obj, segRef, attrs);
-        }
-
-        public static Delta InsertFigure(
-            this Delta delta,
-            string file,
-            string size,
-            string reference,
-            string text,
-            string segRef,
-            bool invalid = false
-        )
-        {
-            var obj = new JObject(new JProperty("style", "fig"));
-            if (file != null)
-                obj.Add(new JProperty("file", file));
-            if (size != null)
-                obj.Add(new JProperty("size", size));
-            if (reference != null)
-                obj.Add(new JProperty("ref", reference));
-            if (text != null)
-                obj.Add(new JProperty("contents", SerializeDelta(Delta.New().Insert(text))));
-            JObject attrs = null;
-            if (invalid)
-                attrs = new JObject(new JProperty("invalid-inline", true));
-            return delta.InsertEmbed("figure", obj, segRef, attrs);
-        }
-
-        public static Delta InsertChar(
-            this Delta delta,
-            string text,
-            string style,
-            string cid,
-            string segRef = null,
-            bool invalid = false
-        )
-        {
-            var attributes = new JObject(
-                new JProperty("char", new JObject(new JProperty("style", style), new JProperty("cid", cid)))
-            );
-            if (invalid)
-                attributes.Add(new JProperty("invalid-inline", true));
-            return delta.InsertText(text, segRef, attributes);
-        }
-
-        public static Delta InsertChar(
-            this Delta delta,
-            string text,
-            IEnumerable<CharAttr> charAttrs,
-            string segRef = null,
-            bool invalid = false
-        )
-        {
-            var attributes = new JObject(
-                new JProperty(
-                    "char",
-                    charAttrs.Select(
-                        charAttr =>
-                            new JObject(new JProperty("style", charAttr.Style), new JProperty("cid", charAttr.CharID))
-                    )
-                )
-            );
-            if (invalid)
-                attributes.Add(new JProperty("invalid-inline", true));
-            return delta.InsertText(text, segRef, attributes);
-        }
-
-        public static Delta InsertEmptyChar(
-            this Delta delta,
-            string style,
-            string cid,
-            string segRef = null,
-            bool invalid = false
-        )
-        {
-            var attributes = new JObject(
-                new JProperty("char", new JObject(new JProperty("style", style), new JProperty("cid", cid)))
-            );
-            if (invalid)
-                attributes.Add(new JProperty("invalid-inline", true));
-            return delta.InsertEmpty(segRef, attributes);
-        }
-
-        public static Delta InsertCharRef(
-            this Delta delta,
-            string text,
-            string style,
-            string reference,
-            string cid,
-            string segRef = null,
-            bool invalid = false
-        )
-        {
-            var attributes = new JObject(
-                new JProperty("char", new JObject(new JProperty("style", style), new JProperty("cid", cid))),
-                new JProperty("ref", new JObject(new JProperty("loc", reference)))
-            );
-            if (invalid)
-                attributes.Add(new JProperty("invalid-inline", true));
-            return delta.InsertText(text, segRef, attributes);
-        }
-
-        public static Delta InsertChapter(this Delta delta, string number, string style = "c", bool invalid = false)
-        {
-            var obj = new JObject(new JProperty("number", number), new JProperty("style", style));
-            JObject attrs = null;
-            if (invalid)
-                attrs = new JObject(new JProperty("invalid-block", true));
-            return delta.InsertEmbed("chapter", obj, attributes: attrs);
-        }
-
-        public static Delta InsertVerse(this Delta delta, string number, string style = "v", bool invalid = false)
-        {
-            var obj = new JObject(new JProperty("number", number), new JProperty("style", style));
-            JObject attrs = null;
-            if (invalid)
-                attrs = new JObject(new JProperty("invalid-inline", true));
-            return delta.InsertEmbed("verse", obj, attributes: attrs);
-        }
-
-        public static Delta InsertOptBreak(this Delta delta, string segRef = null)
-        {
-            return delta.InsertEmbed("optbreak", new JObject(), segRef);
-        }
-
-        public static Delta InsertMilestone(this Delta delta, string style, string segRef = null, bool invalid = false)
-        {
-            var obj = new JObject(new JProperty("style", style));
-            JObject attrs = null;
-            if (invalid)
-                attrs = new JObject(new JProperty("invalid-inline", true));
-            return delta.InsertEmbed("ms", obj, segRef, attrs);
-        }
-
-        public static Delta InsertCell(
-            this Delta delta,
-            int table,
-            int row,
-            string style,
-            string align,
-            bool invalid = false
-        )
-        {
-            var attrs = new JObject(
-                new JProperty("table", new JObject(new JProperty("id", $"table_{table}"))),
-                new JProperty("row", new JObject(new JProperty("id", $"row_{table}_{row}"))),
-                new JProperty("cell", new JObject(new JProperty("style", style), new JProperty("align", align)))
-            );
-            if (invalid)
-                attrs.Add(new JProperty("invalid-block", true));
-            return delta.Insert("\n", attrs);
-        }
-
-        private static JObject SerializeDelta(Delta delta)
-        {
-            return new JObject(new JProperty("ops", new JArray(delta.Ops)));
-        }
+        var obj = new JObject(new JProperty("style", style));
+        if (style == "")
+            obj.Add(new JProperty("status", "unknown"));
+        JObject attrs = null;
+        if (invalid)
+            attrs = new JObject(new JProperty("invalid-block", true));
+        return delta.InsertPara(obj, attrs);
     }
+
+    public static Delta InsertNote(
+        this Delta delta,
+        Delta contents,
+        string style,
+        string caller,
+        string segRef,
+        bool invalid = false
+    )
+    {
+        var obj = new JObject(
+            new JProperty("style", style),
+            new JProperty("caller", caller),
+            new JProperty("contents", SerializeDelta(contents))
+        );
+        JObject attrs = null;
+        if (invalid)
+            attrs = new JObject(new JProperty("invalid-inline", true));
+        return delta.InsertEmbed("note", obj, segRef, attrs);
+    }
+
+    public static Delta InsertFigure(
+        this Delta delta,
+        string file,
+        string size,
+        string reference,
+        string text,
+        string segRef,
+        bool invalid = false
+    )
+    {
+        var obj = new JObject(new JProperty("style", "fig"));
+        if (file != null)
+            obj.Add(new JProperty("file", file));
+        if (size != null)
+            obj.Add(new JProperty("size", size));
+        if (reference != null)
+            obj.Add(new JProperty("ref", reference));
+        if (text != null)
+            obj.Add(new JProperty("contents", SerializeDelta(Delta.New().Insert(text))));
+        JObject attrs = null;
+        if (invalid)
+            attrs = new JObject(new JProperty("invalid-inline", true));
+        return delta.InsertEmbed("figure", obj, segRef, attrs);
+    }
+
+    public static Delta InsertChar(
+        this Delta delta,
+        string text,
+        string style,
+        string cid,
+        string segRef = null,
+        bool invalid = false
+    )
+    {
+        var attributes = new JObject(
+            new JProperty("char", new JObject(new JProperty("style", style), new JProperty("cid", cid)))
+        );
+        if (invalid)
+            attributes.Add(new JProperty("invalid-inline", true));
+        return delta.InsertText(text, segRef, attributes);
+    }
+
+    public static Delta InsertChar(
+        this Delta delta,
+        string text,
+        IEnumerable<CharAttr> charAttrs,
+        string segRef = null,
+        bool invalid = false
+    )
+    {
+        var attributes = new JObject(
+            new JProperty(
+                "char",
+                charAttrs.Select(
+                    charAttr =>
+                        new JObject(new JProperty("style", charAttr.Style), new JProperty("cid", charAttr.CharID))
+                )
+            )
+        );
+        if (invalid)
+            attributes.Add(new JProperty("invalid-inline", true));
+        return delta.InsertText(text, segRef, attributes);
+    }
+
+    public static Delta InsertEmptyChar(
+        this Delta delta,
+        string style,
+        string cid,
+        string segRef = null,
+        bool invalid = false
+    )
+    {
+        var attributes = new JObject(
+            new JProperty("char", new JObject(new JProperty("style", style), new JProperty("cid", cid)))
+        );
+        if (invalid)
+            attributes.Add(new JProperty("invalid-inline", true));
+        return delta.InsertEmpty(segRef, attributes);
+    }
+
+    public static Delta InsertCharRef(
+        this Delta delta,
+        string text,
+        string style,
+        string reference,
+        string cid,
+        string segRef = null,
+        bool invalid = false
+    )
+    {
+        var attributes = new JObject(
+            new JProperty("char", new JObject(new JProperty("style", style), new JProperty("cid", cid))),
+            new JProperty("ref", new JObject(new JProperty("loc", reference)))
+        );
+        if (invalid)
+            attributes.Add(new JProperty("invalid-inline", true));
+        return delta.InsertText(text, segRef, attributes);
+    }
+
+    public static Delta InsertChapter(this Delta delta, string number, string style = "c", bool invalid = false)
+    {
+        var obj = new JObject(new JProperty("number", number), new JProperty("style", style));
+        JObject attrs = null;
+        if (invalid)
+            attrs = new JObject(new JProperty("invalid-block", true));
+        return delta.InsertEmbed("chapter", obj, attributes: attrs);
+    }
+
+    public static Delta InsertVerse(this Delta delta, string number, string style = "v", bool invalid = false)
+    {
+        var obj = new JObject(new JProperty("number", number), new JProperty("style", style));
+        JObject attrs = null;
+        if (invalid)
+            attrs = new JObject(new JProperty("invalid-inline", true));
+        return delta.InsertEmbed("verse", obj, attributes: attrs);
+    }
+
+    public static Delta InsertOptBreak(this Delta delta, string segRef = null) =>
+        delta.InsertEmbed("optbreak", new JObject(), segRef);
+
+    public static Delta InsertMilestone(this Delta delta, string style, string segRef = null, bool invalid = false)
+    {
+        var obj = new JObject(new JProperty("style", style));
+        JObject attrs = null;
+        if (invalid)
+            attrs = new JObject(new JProperty("invalid-inline", true));
+        return delta.InsertEmbed("ms", obj, segRef, attrs);
+    }
+
+    public static Delta InsertCell(
+        this Delta delta,
+        int table,
+        int row,
+        string style,
+        string align,
+        bool invalid = false
+    )
+    {
+        var attrs = new JObject(
+            new JProperty("table", new JObject(new JProperty("id", $"table_{table}"))),
+            new JProperty("row", new JObject(new JProperty("id", $"row_{table}_{row}"))),
+            new JProperty("cell", new JObject(new JProperty("style", style), new JProperty("align", align)))
+        );
+        if (invalid)
+            attrs.Add(new JProperty("invalid-block", true));
+        return delta.Insert("\n", attrs);
+    }
+
+    private static JObject SerializeDelta(Delta delta) => new JObject(new JProperty("ops", new JArray(delta.Ops)));
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
@@ -8,84 +8,83 @@ using SIL.XForge.Configuration;
 using SIL.XForge.Models;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class InternetSharedRepositorySourceProviderTests
 {
-    [TestFixture]
-    public class InternetSharedRepositorySourceProviderTests
+    [Test]
+    public void GetSource_BadArguments()
     {
-        [Test]
-        public void GetSource_BadArguments()
-        {
-            var env = new TestEnvironment();
-            Assert.Throws<ArgumentException>(() => env.Provider.GetSource(null, null, null));
-            Assert.Throws<ArgumentException>(() => env.Provider.GetSource(null, "abc", "abc"));
-            Assert.Throws<ArgumentException>(() => env.Provider.GetSource(new UserSecret(), null, "abc"));
-            Assert.Throws<ArgumentException>(() => env.Provider.GetSource(new UserSecret(), "abc", null));
-            Assert.Throws<ArgumentException>(() => env.Provider.GetSource(new UserSecret(), string.Empty, "abc"));
-            Assert.Throws<ArgumentException>(() => env.Provider.GetSource(new UserSecret(), "abc", string.Empty));
-        }
+        var env = new TestEnvironment();
+        Assert.Throws<ArgumentException>(() => env.Provider.GetSource(null, null, null));
+        Assert.Throws<ArgumentException>(() => env.Provider.GetSource(null, "abc", "abc"));
+        Assert.Throws<ArgumentException>(() => env.Provider.GetSource(new UserSecret(), null, "abc"));
+        Assert.Throws<ArgumentException>(() => env.Provider.GetSource(new UserSecret(), "abc", null));
+        Assert.Throws<ArgumentException>(() => env.Provider.GetSource(new UserSecret(), string.Empty, "abc"));
+        Assert.Throws<ArgumentException>(() => env.Provider.GetSource(new UserSecret(), "abc", string.Empty));
+    }
 
-        [Test]
-        public void GetSource()
+    [Test]
+    public void GetSource()
+    {
+        var env = new TestEnvironment();
+        var userSecret = new UserSecret
         {
-            var env = new TestEnvironment();
-            var userSecret = new UserSecret
+            Id = "user01",
+            ParatextTokens = new Tokens
             {
-                Id = "user01",
-                ParatextTokens = new Tokens
-                {
-                    AccessToken = TokenHelper.CreateNewAccessToken(),
-                    RefreshToken = "refresh_token01"
-                }
-            };
-            IInternetSharedRepositorySource source = env.Provider.GetSource(userSecret, "srServer", "regServer");
-            Assert.That(source, Is.Not.Null);
-        }
-
-        [Test]
-        public void GetSource_TroubleWithFetchingUsername()
-        {
-            var env = new TestEnvironment();
-            var userSecret = new UserSecret
-            {
-                Id = "user01",
-                ParatextTokens = new Tokens
-                {
-                    AccessToken = TokenHelper.CreateNewAccessToken(),
-                    RefreshToken = "refresh_token01"
-                }
-            };
-            env.MockJwtTokenHelper.GetParatextUsername(Arg.Any<UserSecret>()).Returns(default(string?));
-            Assert.Throws<Exception>(() => env.Provider.GetSource(userSecret, "srServer", "regServer"));
-        }
-
-        private class TestEnvironment
-        {
-            public readonly IJwtTokenHelper MockJwtTokenHelper;
-            public readonly InternetSharedRepositorySourceProvider Provider;
-
-            public TestEnvironment()
-            {
-                MockJwtTokenHelper = Substitute.For<IJwtTokenHelper>();
-                MockJwtTokenHelper.GetJwtTokenFromUserSecret(Arg.Any<UserSecret>()).Returns("token_1234");
-                MockJwtTokenHelper.GetParatextUsername(Arg.Any<UserSecret>()).Returns("ptUsernameHere");
-                RegistryU.Implementation = new DotNetCoreRegistry();
-                InternetAccess.RawStatus = InternetUse.Enabled;
-                var siteOptions = Substitute.For<IOptions<SiteOptions>>();
-                siteOptions.Value.Returns(
-                    new SiteOptions
-                    {
-                        Name = "xForge",
-                        Origin = new Uri("http://localhost"),
-                        SiteDir = "xforge"
-                    }
-                );
-                Provider = new InternetSharedRepositorySourceProvider(
-                    MockJwtTokenHelper,
-                    siteOptions,
-                    Substitute.For<IHgWrapper>()
-                );
+                AccessToken = TokenHelper.CreateNewAccessToken(),
+                RefreshToken = "refresh_token01"
             }
+        };
+        IInternetSharedRepositorySource source = env.Provider.GetSource(userSecret, "srServer", "regServer");
+        Assert.That(source, Is.Not.Null);
+    }
+
+    [Test]
+    public void GetSource_TroubleWithFetchingUsername()
+    {
+        var env = new TestEnvironment();
+        var userSecret = new UserSecret
+        {
+            Id = "user01",
+            ParatextTokens = new Tokens
+            {
+                AccessToken = TokenHelper.CreateNewAccessToken(),
+                RefreshToken = "refresh_token01"
+            }
+        };
+        env.MockJwtTokenHelper.GetParatextUsername(Arg.Any<UserSecret>()).Returns(default(string?));
+        Assert.Throws<Exception>(() => env.Provider.GetSource(userSecret, "srServer", "regServer"));
+    }
+
+    private class TestEnvironment
+    {
+        public readonly IJwtTokenHelper MockJwtTokenHelper;
+        public readonly InternetSharedRepositorySourceProvider Provider;
+
+        public TestEnvironment()
+        {
+            MockJwtTokenHelper = Substitute.For<IJwtTokenHelper>();
+            MockJwtTokenHelper.GetJwtTokenFromUserSecret(Arg.Any<UserSecret>()).Returns("token_1234");
+            MockJwtTokenHelper.GetParatextUsername(Arg.Any<UserSecret>()).Returns("ptUsernameHere");
+            RegistryU.Implementation = new DotNetCoreRegistry();
+            InternetAccess.RawStatus = InternetUse.Enabled;
+            var siteOptions = Substitute.For<IOptions<SiteOptions>>();
+            siteOptions.Value.Returns(
+                new SiteOptions
+                {
+                    Name = "xForge",
+                    Origin = new Uri("http://localhost"),
+                    SiteDir = "xforge"
+                }
+            );
+            Provider = new InternetSharedRepositorySourceProvider(
+                MockJwtTokenHelper,
+                siteOptions,
+                Substitute.For<IHgWrapper>()
+            );
         }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/JwtInternetSharedRepositorySourceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/JwtInternetSharedRepositorySourceTests.cs
@@ -7,80 +7,76 @@ using Paratext.Data;
 using Paratext.Data.Users;
 using SIL.XForge.Scripture.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class JwtInternetSharedRepositorySourceTests
 {
-    [TestFixture]
-    public class JwtInternetSharedRepositorySourceTests
+    [Test]
+    public void CanUserAuthenticateToPTArchives_Works()
     {
-        [Test]
-        public void CanUserAuthenticateToPTArchives_Works()
-        {
-            var env = new TestEnvironment();
-            env.MockPTArchivesClient
-                .Configure()
-                .Get(Arg.Any<string>())
-                .Returns(
-                    _ =>
-                        throw HttpException.Create(
-                            new WebException(),
-                            GenericRequest.Create(new Uri("https://example.com"))
-                        )
-                );
-            // One SUT
-            Assert.That(env.RepoSource.CanUserAuthenticateToPTArchives(), Is.False, "problem when using server");
-
-            env.MockPTArchivesClient
-                .Configure()
-                .Get(Arg.Any<string>())
-                .Returns(
-                    "<repos><repo><proj>ABCD</proj><projid>4011111111111111111111111111111111111111"
-                        + "</projid><projecttype>BackTranslation</projecttype>"
-                        + "<baseprojid>4022222222222222222222222222222222222222</baseprojid>"
-                        + "<tipid>120000000000 tip</tipid><users><user>"
-                        + "<name>Tony Translator</name><role>pt_administrator</role></user></users></repo></repos>"
-                );
-            // One SUT
-            Assert.That(
-                env.RepoSource.CanUserAuthenticateToPTArchives(),
-                Is.True,
-                "successful authentication and received data"
+        var env = new TestEnvironment();
+        env.MockPTArchivesClient
+            .Configure()
+            .Get(Arg.Any<string>())
+            .Returns(
+                _ =>
+                    throw HttpException.Create(
+                        new WebException(),
+                        GenericRequest.Create(new Uri("https://example.com"))
+                    )
             );
+        // One SUT
+        Assert.That(env.RepoSource.CanUserAuthenticateToPTArchives(), Is.False, "problem when using server");
 
-            env.MockPTArchivesClient.Configure().Get(Arg.Any<string>()).Returns(string.Empty);
-            // One SUT
-            Assert.That(
-                env.RepoSource.CanUserAuthenticateToPTArchives(),
-                Is.True,
-                "this would still be a successful authentication"
+        env.MockPTArchivesClient
+            .Configure()
+            .Get(Arg.Any<string>())
+            .Returns(
+                "<repos><repo><proj>ABCD</proj><projid>4011111111111111111111111111111111111111"
+                    + "</projid><projecttype>BackTranslation</projecttype>"
+                    + "<baseprojid>4022222222222222222222222222222222222222</baseprojid>"
+                    + "<tipid>120000000000 tip</tipid><users><user>"
+                    + "<name>Tony Translator</name><role>pt_administrator</role></user></users></repo></repos>"
             );
-        }
+        // One SUT
+        Assert.That(
+            env.RepoSource.CanUserAuthenticateToPTArchives(),
+            Is.True,
+            "successful authentication and received data"
+        );
 
-        private class TestEnvironment
+        env.MockPTArchivesClient.Configure().Get(Arg.Any<string>()).Returns(string.Empty);
+        // One SUT
+        Assert.That(
+            env.RepoSource.CanUserAuthenticateToPTArchives(),
+            Is.True,
+            "this would still be a successful authentication"
+        );
+    }
+
+    private class TestEnvironment
+    {
+        public readonly JwtInternetSharedRepositorySource RepoSource;
+        public readonly IRESTClient MockPTArchivesClient;
+
+        public TestEnvironment()
         {
-            public readonly JwtInternetSharedRepositorySource RepoSource;
-            public readonly IRESTClient MockPTArchivesClient;
-
-            public TestEnvironment()
-            {
-                ParatextUser ptUser = new SFParatextUser("pt-username");
-                JwtRestClient mockPTRegistryClient = Substitute.For<JwtRestClient>(
-                    "https://baseUri.example.com",
-                    "applicationName",
-                    "jwtToken"
-                );
-                RepoSource = Substitute.ForPartsOf<JwtInternetSharedRepositorySource>(
-                    "access-token",
-                    mockPTRegistryClient,
-                    Substitute.For<IHgWrapper>(),
-                    ptUser,
-                    "sr-server-uri"
-                );
-                MockPTArchivesClient = Substitute.For<RESTClient>(
-                    "pt-archives-server.example.com",
-                    "product-version-123"
-                );
-                RepoSource.Configure().GetClient().Returns(MockPTArchivesClient);
-            }
+            ParatextUser ptUser = new SFParatextUser("pt-username");
+            JwtRestClient mockPTRegistryClient = Substitute.For<JwtRestClient>(
+                "https://baseUri.example.com",
+                "applicationName",
+                "jwtToken"
+            );
+            RepoSource = Substitute.ForPartsOf<JwtInternetSharedRepositorySource>(
+                "access-token",
+                mockPTRegistryClient,
+                Substitute.For<IHgWrapper>(),
+                ptUser,
+                "sr-server-uri"
+            );
+            MockPTArchivesClient = Substitute.For<RESTClient>("pt-archives-server.example.com", "product-version-123");
+            RepoSource.Configure().GetClient().Returns(MockPTArchivesClient);
         }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/LazyScrTextCollectionTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/LazyScrTextCollectionTests.cs
@@ -5,50 +5,49 @@ using Paratext.Data;
 using Paratext.Data.ProjectSettingsAccess;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public class LazyScrTextCollectionTests
 {
-    public class LazyScrTextCollectionTests
+    private string _testDirectory;
+    private LazyScrTextCollection _lazyScrTextCollection;
+    private IFileSystemService _fileSystemService;
+
+    [SetUp]
+    public void BeforeEachTest()
     {
-        private string _testDirectory;
-        private LazyScrTextCollection _lazyScrTextCollection;
-        private IFileSystemService _fileSystemService;
+        _testDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        _fileSystemService = Substitute.For<IFileSystemService>();
+        _fileSystemService.DirectoryExists(Arg.Any<string>()).Returns(true);
+        _fileSystemService.FileExists(Arg.Any<string>()).Returns(false);
 
-        [SetUp]
-        public void BeforeEachTest()
-        {
-            _testDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-            _fileSystemService = Substitute.For<IFileSystemService>();
-            _fileSystemService.DirectoryExists(Arg.Any<string>()).Returns(true);
-            _fileSystemService.FileExists(Arg.Any<string>()).Returns(false);
+        _lazyScrTextCollection = new MockLazyScrTextCollection();
+        _lazyScrTextCollection.Initialize(_testDirectory);
+        _lazyScrTextCollection.FileSystemService = _fileSystemService;
+    }
 
-            _lazyScrTextCollection = new MockLazyScrTextCollection();
-            _lazyScrTextCollection.Initialize(_testDirectory);
-            _lazyScrTextCollection.FileSystemService = _fileSystemService;
-        }
+    [Test]
+    public void FindById_DoesNotExist_ReturnsNull()
+    {
+        string username = "User";
+        Assert.IsNull(_lazyScrTextCollection.FindById(username, "projectDoesNotExist"));
+    }
 
-        [Test]
-        public void FindById_DoesNotExist_ReturnsNull()
-        {
-            string username = "User";
-            Assert.IsNull(_lazyScrTextCollection.FindById(username, "projectDoesNotExist"));
-        }
+    [Test]
+    public void FindById_TargetProjectExists_ReturnsProject()
+    {
+        string projectId = "Project01";
+        string username = "User";
+        string projectTextName = "Proj01";
+        string path = Path.Combine(_testDirectory, projectId, "target");
+        string content = $"<ScriptureText><Name>{projectTextName}</Name><guid>{projectId}</guid></ScriptureText>";
+        _fileSystemService.FileReadText(Arg.Any<string>()).Returns(content);
+        _fileSystemService.FileExists(Arg.Any<string>()).Returns(true);
 
-        [Test]
-        public void FindById_TargetProjectExists_ReturnsProject()
-        {
-            string projectId = "Project01";
-            string username = "User";
-            string projectTextName = "Proj01";
-            string path = Path.Combine(_testDirectory, projectId, "target");
-            string content = $"<ScriptureText><Name>{projectTextName}</Name><guid>{projectId}</guid></ScriptureText>";
-            _fileSystemService.FileReadText(Arg.Any<string>()).Returns(content);
-            _fileSystemService.FileExists(Arg.Any<string>()).Returns(true);
-
-            ScrText scrText = _lazyScrTextCollection.FindById(username, projectId);
-            Assert.NotNull(scrText);
-            Assert.AreEqual(projectTextName, scrText.Name);
-            Assert.AreEqual(path, scrText.Directory);
-            _fileSystemService.Received(1).FileExists(Path.Combine(path, ProjectSettings.fileName));
-        }
+        ScrText scrText = _lazyScrTextCollection.FindById(username, projectId);
+        Assert.NotNull(scrText);
+        Assert.AreEqual(projectTextName, scrText.Name);
+        Assert.AreEqual(path, scrText.Directory);
+        _fileSystemService.Received(1).FileExists(Path.Combine(path, ProjectSettings.fileName));
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -22,1452 +22,1649 @@ using SIL.XForge.Scripture.Models;
 using SIL.XForge.Scripture.Realtime;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class MachineApiServiceTests
 {
-    [TestFixture]
-    public class MachineApiServiceTests
+    private const string Project01 = "project01";
+    private const string Project02 = "project02";
+    private const string Project03 = "project03";
+    private const string Build01 = "build01";
+    private const string TranslationEngine01 = "translationEngine01";
+    private const string User01 = "user01";
+
+    [Test]
+    public async Task GetBuildAsync_InProcessNoRevisionNoBuildRunning()
     {
-        private const string Project01 = "project01";
-        private const string Project02 = "project02";
-        private const string Project03 = "project03";
-        private const string Build01 = "build01";
-        private const string TranslationEngine01 = "translationEngine01";
-        private const string User01 = "user01";
-
-        [Test]
-        public async Task GetBuildAsync_InProcessNoRevisionNoBuildRunning()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-            env.Builds
-                .GetByLocatorAsync(BuildLocatorType.Id, Build01, CancellationToken.None)
-                .Returns(Task.FromResult<Build>(null));
-
-            // SUT
-            BuildDto? actual = await env.Service.GetBuildAsync(
-                User01,
-                Project01,
-                Build01,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            Assert.IsNull(actual);
-        }
-
-        [Test]
-        public void GetBuildAsync_InProcessSpecificRevisionBuildEnded()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-
-            // NOTE: It is not possible to test No Build Running, as the Subscription Change cannot be modified
-            env.Builds
-                .SubscribeAsync(Build01, CancellationToken.None)
-                .Returns(Task.FromResult(new Subscription<Build>(Build01, null, _ => { })));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.GetBuildAsync(User01, Project01, Build01, minRevision: 1, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void GetBuildAsync_MachineApiBuildEnded()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            int minRevision = 0;
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-            env.MachineBuildService
-                .GetBuildAsync(TranslationEngine01, Build01, minRevision, CancellationToken.None)
-                .Throws(new DataNotFoundException("Entity Deleted"));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.GetBuildAsync(User01, Project01, Build01, minRevision, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public async Task GetBuildAsync_MachineApiNoBuildRunning()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-            env.MachineBuildService
-                .GetBuildAsync(TranslationEngine01, Build01, null, CancellationToken.None)
-                .Returns(Task.FromResult<BuildDto>(null));
-
-            // SUT
-            BuildDto? actual = await env.Service.GetBuildAsync(
-                User01,
-                Project01,
-                Build01,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            Assert.IsNull(actual);
-        }
-
-        [Test]
-        public void GetBuildAsync_NoFeatureFlagsEnabled()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.GetBuildAsync(User01, Project01, Build01, minRevision: null, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void GetBuildAsync_NoPermission()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.ThrowsAsync<ForbiddenException>(
-                () =>
-                    env.Service.GetBuildAsync(
-                        "invalid_user_id",
-                        Project01,
-                        Build01,
-                        minRevision: null,
-                        CancellationToken.None
-                    )
-            );
-        }
-
-        [Test]
-        public void GetBuildAsync_NoProject()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () =>
-                    env.Service.GetBuildAsync(
-                        User01,
-                        "invalid_project_id",
-                        Build01,
-                        minRevision: null,
-                        CancellationToken.None
-                    )
-            );
-        }
-
-        [Test]
-        public void GetBuildAsync_MachineApiNoTranslationEngine()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.GetBuildAsync(User01, Project03, Build01, minRevision: null, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public async Task GetBuildAsync_InProcessSuccess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            string buildDtoId = $"{Project01}.{Build01}";
-            string message = "Finalizing";
-            double percentCompleted = 0.95;
-            int revision = 553;
-            string state = "ACTIVE";
-            env.Builds
-                .GetByLocatorAsync(BuildLocatorType.Id, Build01, CancellationToken.None)
-                .Returns(
-                    Task.FromResult(
-                        new Build
-                        {
-                            Id = Build01,
-                            Message = message,
-                            PercentCompleted = percentCompleted,
-                            Revision = revision,
-                            State = state,
-                        }
-                    )
-                );
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-
-            // SUT
-            BuildDto? actual = await env.Service.GetBuildAsync(
-                User01,
-                Project01,
-                Build01,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            Assert.IsNotNull(actual);
-            Assert.AreEqual(message, actual.Message);
-            Assert.AreEqual(percentCompleted, actual.PercentCompleted);
-            Assert.AreEqual(revision, actual.Revision);
-            Assert.AreEqual(state, actual.State);
-            Assert.AreEqual(buildDtoId, actual.Id);
-            Assert.AreEqual(MachineApi.GetBuildHref(Project01, Build01), actual.Href);
-            Assert.AreEqual(Project01, actual.Engine.Id);
-            Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Engine.Href);
-        }
-
-        [Test]
-        public async Task GetBuildAsync_MachineApiSuccess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            string buildDtoId = $"{Project01}.{Build01}";
-            string message = "Finalizing";
-            double percentCompleted = 0.95;
-            int revision = 553;
-            string state = "ACTIVE";
-            env.MachineBuildService
-                .GetBuildAsync(TranslationEngine01, Build01, minRevision: null, CancellationToken.None)
-                .Returns(
-                    Task.FromResult(
-                        new BuildDto
-                        {
-                            Href = "https://example.com",
-                            Id = Build01,
-                            Engine = new ResourceDto { Id = "engineId", Href = "https://example.com" },
-                            Message = message,
-                            PercentCompleted = percentCompleted,
-                            Revision = revision,
-                            State = state,
-                        }
-                    )
-                );
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            BuildDto? actual = await env.Service.GetBuildAsync(
-                User01,
-                Project01,
-                Build01,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            Assert.IsNotNull(actual);
-            Assert.AreEqual(message, actual.Message);
-            Assert.AreEqual(percentCompleted, actual.PercentCompleted);
-            Assert.AreEqual(revision, actual.Revision);
-            Assert.AreEqual(state, actual.State);
-            Assert.AreEqual(buildDtoId, actual.Id);
-            Assert.AreEqual(MachineApi.GetBuildHref(Project01, Build01), actual.Href);
-            Assert.AreEqual(Project01, actual.Engine.Id);
-            Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Engine.Href);
-        }
-
-        [Test]
-        public async Task GetBuildAsync_ExecutesOnlyInProcessIfBothEnabled()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-
-            // SUT
-            _ = await env.Service.GetBuildAsync(User01, Project01, Build01, minRevision: null, CancellationToken.None);
-
-            await env.Builds.Received(1).GetByLocatorAsync(BuildLocatorType.Id, Build01, CancellationToken.None);
-            await env.MachineBuildService
-                .DidNotReceiveWithAnyArgs()
-                .GetBuildAsync(TranslationEngine01, Build01, minRevision: null, CancellationToken.None);
-        }
-
-        [Test]
-        public async Task GetCurrentBuildAsync_InProcessNoRevisionNoBuildRunning()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-            env.Builds
-                .GetByLocatorAsync(BuildLocatorType.Engine, TranslationEngine01, CancellationToken.None)
-                .Returns(Task.FromResult<Build>(null));
-
-            // SUT
-            BuildDto? actual = await env.Service.GetCurrentBuildAsync(
-                User01,
-                Project01,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            Assert.IsNull(actual);
-        }
-
-        [Test]
-        public void GetCurrentBuildAsync_InProcessSpecificRevisionBuildEnded()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-
-            // NOTE: It is not possible to test No Build Running, as the Subscription Change cannot be modified
-            env.Builds
-                .SubscribeByEngineIdAsync(TranslationEngine01, CancellationToken.None)
-                .Returns(Task.FromResult(new Subscription<Build>(TranslationEngine01, null, _ => { })));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.GetCurrentBuildAsync(User01, Project01, minRevision: 1, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void GetCurrentBuildAsync_MachineApiBuildEnded()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            int minRevision = 0;
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-            env.MachineBuildService
-                .GetCurrentBuildAsync(TranslationEngine01, minRevision, CancellationToken.None)
-                .Throws(new DataNotFoundException("Entity Deleted"));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.GetCurrentBuildAsync(User01, Project01, minRevision, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public async Task GetCurrentBuildAsync_MachineApiNoBuildRunning()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-            env.MachineBuildService
-                .GetCurrentBuildAsync(TranslationEngine01, null, CancellationToken.None)
-                .Returns(Task.FromResult<BuildDto>(null));
-
-            // SUT
-            BuildDto? actual = await env.Service.GetCurrentBuildAsync(
-                User01,
-                Project01,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            Assert.IsNull(actual);
-        }
-
-        [Test]
-        public void GetCurrentBuildAsync_NoFeatureFlagsEnabled()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.GetCurrentBuildAsync(User01, Project01, minRevision: null, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void GetCurrentBuildAsync_NoPermission()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.ThrowsAsync<ForbiddenException>(
-                () =>
-                    env.Service.GetCurrentBuildAsync(
-                        "invalid_user_id",
-                        Project01,
-                        minRevision: null,
-                        CancellationToken.None
-                    )
-            );
-        }
-
-        [Test]
-        public void GetCurrentBuildAsync_NoProject()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () =>
-                    env.Service.GetCurrentBuildAsync(
-                        User01,
-                        "invalid_project_id",
-                        minRevision: null,
-                        CancellationToken.None
-                    )
-            );
-        }
-
-        [Test]
-        public void GetCurrentBuildAsync_InProcessNoEngine()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-            env.Engines
-                .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
-                .Returns(Task.FromResult<Engine>(null));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.GetCurrentBuildAsync(User01, Project01, minRevision: null, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void GetCurrentBuildAsync_MachineApiNoTranslationEngine()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.GetCurrentBuildAsync(User01, Project03, minRevision: null, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public async Task GetCurrentBuildAsync_InProcessSuccess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            string buildDtoId = $"{Project01}.{Build01}";
-            string message = "Finalizing";
-            double percentCompleted = 0.95;
-            int revision = 553;
-            string state = "ACTIVE";
-            env.Builds
-                .GetByLocatorAsync(BuildLocatorType.Engine, TranslationEngine01, CancellationToken.None)
-                .Returns(
-                    Task.FromResult(
-                        new Build
-                        {
-                            Id = Build01,
-                            Message = message,
-                            PercentCompleted = percentCompleted,
-                            Revision = revision,
-                            State = state,
-                        }
-                    )
-                );
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-
-            // SUT
-            BuildDto? actual = await env.Service.GetCurrentBuildAsync(
-                User01,
-                Project01,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            Assert.IsNotNull(actual);
-            Assert.AreEqual(message, actual.Message);
-            Assert.AreEqual(percentCompleted, actual.PercentCompleted);
-            Assert.AreEqual(revision, actual.Revision);
-            Assert.AreEqual(state, actual.State);
-            Assert.AreEqual(buildDtoId, actual.Id);
-            Assert.AreEqual(MachineApi.GetBuildHref(Project01, Build01), actual.Href);
-            Assert.AreEqual(Project01, actual.Engine.Id);
-            Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Engine.Href);
-        }
-
-        [Test]
-        public async Task GetCurrentBuildAsync_MachineApiSuccess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            string buildDtoId = $"{Project01}.{Build01}";
-            string message = "Finalizing";
-            double percentCompleted = 0.95;
-            int revision = 553;
-            string state = "ACTIVE";
-            env.MachineBuildService
-                .GetCurrentBuildAsync(TranslationEngine01, minRevision: null, CancellationToken.None)
-                .Returns(
-                    Task.FromResult(
-                        new BuildDto
-                        {
-                            Href = "https://example.com",
-                            Id = Build01,
-                            Engine = new ResourceDto { Id = "engineId", Href = "https://example.com" },
-                            Message = message,
-                            PercentCompleted = percentCompleted,
-                            Revision = revision,
-                            State = state,
-                        }
-                    )
-                );
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            BuildDto? actual = await env.Service.GetCurrentBuildAsync(
-                User01,
-                Project01,
-                minRevision: null,
-                CancellationToken.None
-            );
-
-            Assert.IsNotNull(actual);
-            Assert.AreEqual(message, actual.Message);
-            Assert.AreEqual(percentCompleted, actual.PercentCompleted);
-            Assert.AreEqual(revision, actual.Revision);
-            Assert.AreEqual(state, actual.State);
-            Assert.AreEqual(buildDtoId, actual.Id);
-            Assert.AreEqual(MachineApi.GetBuildHref(Project01, Build01), actual.Href);
-            Assert.AreEqual(Project01, actual.Engine.Id);
-            Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Engine.Href);
-        }
-
-        [Test]
-        public async Task GetCurrentBuildAsync_ExecutesOnlyInProcessIfBothEnabled()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-
-            // SUT
-            _ = await env.Service.GetCurrentBuildAsync(User01, Project01, minRevision: null, CancellationToken.None);
-
-            await env.Builds
-                .Received(1)
-                .GetByLocatorAsync(BuildLocatorType.Engine, TranslationEngine01, CancellationToken.None);
-            await env.MachineBuildService
-                .DidNotReceiveWithAnyArgs()
-                .GetCurrentBuildAsync(TranslationEngine01, minRevision: null, CancellationToken.None);
-        }
-
-        [Test]
-        public void GetEngineAsync_NoFeatureFlagsEnabled()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.GetEngineAsync(User01, Project01, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void GetEngineAsync_NoPermission()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.ThrowsAsync<ForbiddenException>(
-                () => env.Service.GetEngineAsync("invalid_user_id", Project01, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void GetEngineAsync_NoProject()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.GetEngineAsync(User01, "invalid_project_id", CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void GetEngineAsync_InProcessNoEngine()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-            env.Engines
-                .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
-                .Returns(Task.FromResult<Engine>(null));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.GetEngineAsync(User01, Project01, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void GetEngineAsync_MachineApiNoTranslationEngine()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.GetEngineAsync(User01, Project03, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void GetEngineAsync_MachineApiOutageNoInProcess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineTranslationService
-                .GetTranslationEngineAsync(TranslationEngine01, CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<BrokenCircuitException>(
-                () => env.Service.GetEngineAsync(User01, Project01, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public async Task GetEngineAsync_MachineApiOutageFailsToInProcess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineTranslationService
-                .GetTranslationEngineAsync(TranslationEngine01, CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-            env.Engines
-                .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
-                .Returns(Task.FromResult(new Engine()));
-
-            // SUT
-            _ = await env.Service.GetEngineAsync(User01, Project01, CancellationToken.None);
-
-            env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
-        }
-
-        [Test]
-        public async Task GetEngineAsync_InProcessSuccess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            string sourceLanguageTag = "en_US";
-            string targetLanguageTag = "en_NZ";
-            int confidence = 100;
-            int corpusSize = 472;
-            env.Engines
-                .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
-                .Returns(
-                    Task.FromResult(
-                        new Engine
-                        {
-                            Confidence = confidence,
-                            Id = Project01,
-                            IsShared = false,
-                            Revision = 1,
-                            SourceLanguageTag = sourceLanguageTag,
-                            TargetLanguageTag = targetLanguageTag,
-                            TrainedSegmentCount = corpusSize,
-                        }
-                    )
-                );
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-
-            // SUT
-            EngineDto actual = await env.Service.GetEngineAsync(User01, Project01, CancellationToken.None);
-
-            Assert.AreEqual(confidence, actual.Confidence);
-            Assert.AreEqual(corpusSize, actual.TrainedSegmentCount);
-            Assert.AreEqual(sourceLanguageTag, actual.SourceLanguageTag);
-            Assert.AreEqual(targetLanguageTag, actual.TargetLanguageTag);
-            Assert.IsFalse(actual.IsShared);
-            Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Href);
-            Assert.AreEqual(1, actual.Projects.Length);
-            Assert.AreEqual(Project01, actual.Projects.First().Id);
-            Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Projects.First().Href);
-        }
-
-        [Test]
-        public async Task GetEngineAsync_MachineApiSuccess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            string sourceLanguageTag = "en_US";
-            string targetLanguageTag = "en_NZ";
-            int confidence = 100;
-            int corpusSize = 472;
-            env.MachineTranslationService
-                .GetTranslationEngineAsync(TranslationEngine01, CancellationToken.None)
-                .Returns(
-                    Task.FromResult(
-                        new MachineApiTranslationEngine
-                        {
-                            Confidence = confidence,
-                            CorpusSize = corpusSize,
-                            Href = "https://example.com",
-                            Id = Project01,
-                            IsBuilding = true,
-                            ModelRevision = 1,
-                            Name = "my_translation_engine",
-                            SourceLanguageTag = sourceLanguageTag,
-                            TargetLanguageTag = targetLanguageTag,
-                            Type = "SmtTransfer",
-                        }
-                    )
-                );
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            EngineDto actual = await env.Service.GetEngineAsync(User01, Project01, CancellationToken.None);
-
-            Assert.AreEqual(confidence, actual.Confidence);
-            Assert.AreEqual(corpusSize, actual.TrainedSegmentCount);
-            Assert.AreEqual(sourceLanguageTag, actual.SourceLanguageTag);
-            Assert.AreEqual(targetLanguageTag, actual.TargetLanguageTag);
-            Assert.IsFalse(actual.IsShared);
-            Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Href);
-            Assert.AreEqual(1, actual.Projects.Length);
-            Assert.AreEqual(Project01, actual.Projects.First().Id);
-            Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Projects.First().Href);
-        }
-
-        [Test]
-        public async Task GetEngineAsync_ExecutesApiAndInProcess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineTranslationService
-                .GetTranslationEngineAsync(TranslationEngine01, CancellationToken.None)
-                .Returns(Task.FromResult(new MachineApiTranslationEngine()));
-            env.Engines
-                .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
-                .Returns(Task.FromResult(new Engine()));
-
-            // SUT
-            _ = await env.Service.GetEngineAsync(User01, Project01, CancellationToken.None);
-
-            await env.Engines
-                .Received(1)
-                .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None);
-            await env.MachineTranslationService
-                .Received(1)
-                .GetTranslationEngineAsync(TranslationEngine01, CancellationToken.None);
-        }
-
-        [Test]
-        public void GetWordGraphAsync_NoFeatureFlagsEnabled()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void GetWordGraphAsync_NoPermission()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.ThrowsAsync<ForbiddenException>(
-                () =>
-                    env.Service.GetWordGraphAsync(
-                        "invalid_user_id",
-                        Project01,
-                        Array.Empty<string>(),
-                        CancellationToken.None
-                    )
-            );
-        }
-
-        [Test]
-        public void GetWordGraphAsync_NoProject()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () =>
-                    env.Service.GetWordGraphAsync(
-                        User01,
-                        "invalid_project_id",
-                        Array.Empty<string>(),
-                        CancellationToken.None
-                    )
-            );
-        }
-
-        [Test]
-        public void GetWordGraphAsync_InProcessNoEngine()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-            env.Engines
-                .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
-                .Returns(Task.FromResult<Engine>(null));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void GetWordGraphAsync_MachineApiNoTranslationEngine()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.GetWordGraphAsync(User01, Project03, Array.Empty<string>(), CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void GetWordGraphAsync_MachineApiOutageNoInProcess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineTranslationService
-                .GetWordGraphAsync(TranslationEngine01, Array.Empty<string>(), CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<BrokenCircuitException>(
-                () => env.Service.GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public async Task GetWordGraphAsync_MachineApiOutageFailsToInProcess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineTranslationService
-                .GetWordGraphAsync(TranslationEngine01, Array.Empty<string>(), CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-            env.EngineService
-                .GetWordGraphAsync(TranslationEngine01, Array.Empty<string>())
-                .Returns(Task.FromResult(new WordGraph(Array.Empty<WordGraphArc>(), Array.Empty<int>())));
-
-            // SUT
-            _ = await env.Service.GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None);
-
-            env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
-        }
-
-        [Test]
-        public async Task GetWordGraphAsync_InProcessSuccess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            float initialStateScore = -91.43696f;
-            env.EngineService
-                .GetWordGraphAsync(TranslationEngine01, Array.Empty<string>())
-                .Returns(
-                    Task.FromResult(
-                        new WordGraph(
-                            new[]
-                            {
-                                new WordGraphArc(
-                                    0,
-                                    0,
-                                    0.0,
-                                    Array.Empty<string>(),
-                                    new WordAlignmentMatrix(0, 0),
-                                    Range<int>.Null,
-                                    Array.Empty<TranslationSources>()
-                                )
-                            },
-                            new[] { 1 },
-                            initialStateScore
-                        )
-                    )
-                );
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-
-            // SUT
-            WordGraphDto actual = await env.Service.GetWordGraphAsync(
-                User01,
-                Project01,
-                Array.Empty<string>(),
-                CancellationToken.None
-            );
-
-            Assert.IsNotNull(actual);
-            Assert.AreEqual(initialStateScore, actual.InitialStateScore);
-            Assert.AreEqual(1, actual.Arcs.Length);
-            Assert.AreEqual(1, actual.FinalStates.Length);
-        }
-
-        [Test]
-        public async Task GetWordGraphAsync_MachineApiSuccess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            float initialStateScore = -91.43696f;
-            env.MachineTranslationService
-                .GetWordGraphAsync(TranslationEngine01, Array.Empty<string>(), CancellationToken.None)
-                .Returns(
-                    Task.FromResult(
-                        new WordGraphDto
-                        {
-                            Arcs = new[] { new WordGraphArcDto() },
-                            FinalStates = new[] { 1 },
-                            InitialStateScore = initialStateScore,
-                        }
-                    )
-                );
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            WordGraphDto actual = await env.Service.GetWordGraphAsync(
-                User01,
-                Project01,
-                Array.Empty<string>(),
-                CancellationToken.None
-            );
-
-            Assert.IsNotNull(actual);
-            Assert.AreEqual(initialStateScore, actual.InitialStateScore);
-            Assert.AreEqual(1, actual.Arcs.Length);
-            Assert.AreEqual(1, actual.FinalStates.Length);
-        }
-
-        [Test]
-        public async Task GetWordGraphAsync_ExecutesApiAndInProcess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.EngineService
-                .GetWordGraphAsync(TranslationEngine01, Array.Empty<string>())
-                .Returns(Task.FromResult(new WordGraph()));
-
-            // SUT
-            _ = await env.Service.GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None);
-
-            await env.EngineService.Received(1).GetWordGraphAsync(TranslationEngine01, Array.Empty<string>());
-            await env.MachineTranslationService
-                .Received(1)
-                .GetWordGraphAsync(TranslationEngine01, Array.Empty<string>(), CancellationToken.None);
-        }
-
-        [Test]
-        public void StartBuildAsync_NoFeatureFlagsEnabled()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.StartBuildAsync(User01, Project01, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void StartBuildAsync_NoPermission()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.ThrowsAsync<ForbiddenException>(
-                () => env.Service.StartBuildAsync("invalid_user_id", Project01, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void StartBuildAsync_NoProject()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.StartBuildAsync(User01, "invalid_project_id", CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void StartBuildAsync_InProcessNoEngine()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-            env.Engines
-                .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
-                .Returns(Task.FromResult<Engine>(null));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.StartBuildAsync(User01, Project01, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void StartBuildAsync_MachineApiNoTranslationEngine()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.StartBuildAsync(User01, Project03, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void StartBuildAsync_MachineApiOutageNoInProcess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineBuildService
-                .StartBuildAsync(TranslationEngine01, CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<BrokenCircuitException>(
-                () => env.Service.StartBuildAsync(User01, Project01, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public async Task StartBuildAsync_MachineApiOutageFailsToInProcess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineBuildService
-                .StartBuildAsync(TranslationEngine01, CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-            env.EngineService.StartBuildAsync(TranslationEngine01).Returns(Task.FromResult(new Build()));
-
-            // SUT
-            _ = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
-
-            env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
-        }
-
-        [Test]
-        public async Task StartBuildAsync_InProcessSuccess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            string buildDtoId = $"{Project01}.{Build01}";
-            string message = "Training language model";
-            double percentCompleted = 0.01;
-            int revision = 2;
-            string state = "ACTIVE";
-            env.EngineService
-                .StartBuildAsync(TranslationEngine01)
-                .Returns(
-                    Task.FromResult(
-                        new Build
-                        {
-                            Id = Build01,
-                            Message = message,
-                            PercentCompleted = percentCompleted,
-                            Revision = revision,
-                            State = state,
-                        }
-                    )
-                );
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-
-            // SUT
-            BuildDto actual = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
-
-            Assert.AreEqual(message, actual.Message);
-            Assert.AreEqual(percentCompleted, actual.PercentCompleted);
-            Assert.AreEqual(revision, actual.Revision);
-            Assert.AreEqual(state, actual.State);
-            Assert.AreEqual(buildDtoId, actual.Id);
-            Assert.AreEqual(MachineApi.GetBuildHref(Project01, Build01), actual.Href);
-            Assert.AreEqual(Project01, actual.Engine.Id);
-            Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Engine.Href);
-        }
-
-        [Test]
-        public async Task StartBuildAsync_MachineApiSuccess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            string buildDtoId = $"{Project01}.{Build01}";
-            string message = "Training language model";
-            double percentCompleted = 0.01;
-            int revision = 2;
-            string state = "ACTIVE";
-            env.MachineBuildService
-                .StartBuildAsync(TranslationEngine01, CancellationToken.None)
-                .Returns(
-                    Task.FromResult(
-                        new BuildDto
-                        {
-                            Href = "https://example.com",
-                            Id = Build01,
-                            Engine = new ResourceDto { Id = "engineId", Href = "https://example.com" },
-                            Message = message,
-                            PercentCompleted = percentCompleted,
-                            Revision = revision,
-                            State = state,
-                        }
-                    )
-                );
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            BuildDto actual = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
-
-            await env.MachineProjectService
-                .Received(1)
-                .SyncProjectCorporaAsync(User01, Project01, CancellationToken.None);
-            Assert.AreEqual(message, actual.Message);
-            Assert.AreEqual(percentCompleted, actual.PercentCompleted);
-            Assert.AreEqual(revision, actual.Revision);
-            Assert.AreEqual(state, actual.State);
-            Assert.AreEqual(buildDtoId, actual.Id);
-            Assert.AreEqual(MachineApi.GetBuildHref(Project01, Build01), actual.Href);
-            Assert.AreEqual(Project01, actual.Engine.Id);
-            Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Engine.Href);
-        }
-
-        [Test]
-        public async Task StartBuildAsync_ExecutesApiAndInProcess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.EngineService.StartBuildAsync(TranslationEngine01).Returns(Task.FromResult(new Build()));
-
-            // SUT
-            _ = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
-
-            await env.EngineService.Received(1).StartBuildAsync(TranslationEngine01);
-            await env.MachineProjectService
-                .Received(1)
-                .SyncProjectCorporaAsync(User01, Project01, CancellationToken.None);
-            await env.MachineBuildService.Received(1).StartBuildAsync(TranslationEngine01, CancellationToken.None);
-        }
-
-        [Test]
-        public void TrainSegmentAsync_NoPermission()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.ThrowsAsync<ForbiddenException>(
-                () =>
-                    env.Service.TrainSegmentAsync(
-                        "invalid_user_id",
-                        Project01,
-                        new SegmentPairDto(),
-                        CancellationToken.None
-                    )
-            );
-        }
-
-        [Test]
-        public void TrainSegmentAsync_NoProject()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () =>
-                    env.Service.TrainSegmentAsync(
-                        User01,
-                        "invalid_project_id",
-                        new SegmentPairDto(),
-                        CancellationToken.None
-                    )
-            );
-        }
-
-        [Test]
-        public void TrainSegmentAsync_InProcessNoEngine()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-            env.Engines
-                .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
-                .Returns(Task.FromResult<Engine>(null));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.TrainSegmentAsync(User01, Project01, new SegmentPairDto(), CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void TrainSegmentAsync_MachineApiNoTranslationEngine()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.TrainSegmentAsync(User01, Project03, new SegmentPairDto(), CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void TrainSegmentAsync_MachineApiOutageNoInProcess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            var segmentPairDto = new SegmentPairDto();
-            env.MachineTranslationService
-                .TrainSegmentAsync(TranslationEngine01, segmentPairDto, CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<BrokenCircuitException>(
-                () => env.Service.TrainSegmentAsync(User01, Project01, segmentPairDto, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public async Task TrainSegmentAsync_MachineApiOutageFailsToInProcess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            var segmentPairDto = new SegmentPairDto();
-            env.MachineTranslationService
-                .TrainSegmentAsync(TranslationEngine01, segmentPairDto, CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-            env.EngineService
-                .TrainSegmentAsync(
-                    TranslationEngine01,
-                    segmentPairDto.SourceSegment,
-                    segmentPairDto.TargetSegment,
-                    segmentPairDto.SentenceStart
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+        env.Builds
+            .GetByLocatorAsync(BuildLocatorType.Id, Build01, CancellationToken.None)
+            .Returns(Task.FromResult<Build>(null));
+
+        // SUT
+        BuildDto? actual = await env.Service.GetBuildAsync(
+            User01,
+            Project01,
+            Build01,
+            minRevision: null,
+            CancellationToken.None
+        );
+
+        Assert.IsNull(actual);
+    }
+
+    [Test]
+    public void GetBuildAsync_InProcessSpecificRevisionBuildEnded()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+
+        // NOTE: It is not possible to test No Build Running, as the Subscription Change cannot be modified
+        env.Builds
+            .SubscribeAsync(Build01, CancellationToken.None)
+            .Returns(Task.FromResult(new Subscription<Build>(Build01, null, _ => { })));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetBuildAsync(User01, Project01, Build01, minRevision: 1, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void GetBuildAsync_MachineApiBuildEnded()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        int minRevision = 0;
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+        env.MachineBuildService
+            .GetBuildAsync(TranslationEngine01, Build01, minRevision, CancellationToken.None)
+            .Throws(new DataNotFoundException("Entity Deleted"));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetBuildAsync(User01, Project01, Build01, minRevision, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public async Task GetBuildAsync_MachineApiNoBuildRunning()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+        env.MachineBuildService
+            .GetBuildAsync(TranslationEngine01, Build01, null, CancellationToken.None)
+            .Returns(Task.FromResult<BuildDto>(null));
+
+        // SUT
+        BuildDto? actual = await env.Service.GetBuildAsync(
+            User01,
+            Project01,
+            Build01,
+            minRevision: null,
+            CancellationToken.None
+        );
+
+        Assert.IsNull(actual);
+    }
+
+    [Test]
+    public void GetBuildAsync_NoFeatureFlagsEnabled()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetBuildAsync(User01, Project01, Build01, minRevision: null, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void GetBuildAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(
+            () =>
+                env.Service.GetBuildAsync(
+                    "invalid_user_id",
+                    Project01,
+                    Build01,
+                    minRevision: null,
+                    CancellationToken.None
                 )
-                .Returns(Task.FromResult(true));
+        );
+    }
 
-            // SUT
-            await env.Service.TrainSegmentAsync(User01, Project01, segmentPairDto, CancellationToken.None);
+    [Test]
+    public void GetBuildAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
 
-            env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
-        }
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () =>
+                env.Service.GetBuildAsync(
+                    User01,
+                    "invalid_project_id",
+                    Build01,
+                    minRevision: null,
+                    CancellationToken.None
+                )
+        );
+    }
 
-        [Test]
-        public async Task TrainSegmentAsync_InProcessSuccess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-            var segmentPair = new SegmentPairDto();
+    [Test]
+    public void GetBuildAsync_MachineApiNoTranslationEngine()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
-            // SUT
-            await env.Service.TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None);
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetBuildAsync(User01, Project03, Build01, minRevision: null, CancellationToken.None)
+        );
+    }
 
-            await env.EngineService
-                .Received(1)
-                .TrainSegmentAsync(
-                    TranslationEngine01,
-                    segmentPair.SourceSegment,
-                    segmentPair.TargetSegment,
-                    segmentPair.SentenceStart
-                );
-        }
-
-        [Test]
-        public async Task TrainSegmentAsync_MachineApiSuccess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-            var segmentPair = new SegmentPairDto();
-
-            // SUT
-            await env.Service.TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None);
-
-            await env.MachineTranslationService
-                .Received(1)
-                .TrainSegmentAsync(TranslationEngine01, segmentPair, CancellationToken.None);
-        }
-
-        [Test]
-        public async Task TrainSegmentAsync_ExecutesApiAndInProcess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            var segmentPair = new SegmentPairDto();
-
-            // SUT
-            await env.Service.TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None);
-
-            await env.EngineService
-                .Received(1)
-                .TrainSegmentAsync(
-                    TranslationEngine01,
-                    segmentPair.SourceSegment,
-                    segmentPair.TargetSegment,
-                    segmentPair.SentenceStart
-                );
-            await env.MachineTranslationService
-                .Received(1)
-                .TrainSegmentAsync(TranslationEngine01, segmentPair, CancellationToken.None);
-        }
-
-        [Test]
-        public void TranslateAsync_NoFeatureFlagsEnabled()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+    [Test]
+    public async Task GetBuildAsync_InProcessSuccess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        string buildDtoId = $"{Project01}.{Build01}";
+        string message = "Finalizing";
+        double percentCompleted = 0.95;
+        int revision = 553;
+        string state = "ACTIVE";
+        env.Builds
+            .GetByLocatorAsync(BuildLocatorType.Id, Build01, CancellationToken.None)
+            .Returns(
+                Task.FromResult(
+                    new Build
+                    {
+                        Id = Build01,
+                        Message = message,
+                        PercentCompleted = percentCompleted,
+                        Revision = revision,
+                        State = state,
+                    }
+                )
             );
-        }
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
 
-        [Test]
-        public void TranslateAsync_NoPermission()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
+        // SUT
+        BuildDto? actual = await env.Service.GetBuildAsync(
+            User01,
+            Project01,
+            Build01,
+            minRevision: null,
+            CancellationToken.None
+        );
 
-            // SUT
-            Assert.ThrowsAsync<ForbiddenException>(
-                () =>
-                    env.Service.TranslateAsync(
-                        "invalid_user_id",
-                        Project01,
+        Assert.IsNotNull(actual);
+        Assert.AreEqual(message, actual.Message);
+        Assert.AreEqual(percentCompleted, actual.PercentCompleted);
+        Assert.AreEqual(revision, actual.Revision);
+        Assert.AreEqual(state, actual.State);
+        Assert.AreEqual(buildDtoId, actual.Id);
+        Assert.AreEqual(MachineApi.GetBuildHref(Project01, Build01), actual.Href);
+        Assert.AreEqual(Project01, actual.Engine.Id);
+        Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Engine.Href);
+    }
+
+    [Test]
+    public async Task GetBuildAsync_MachineApiSuccess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        string buildDtoId = $"{Project01}.{Build01}";
+        string message = "Finalizing";
+        double percentCompleted = 0.95;
+        int revision = 553;
+        string state = "ACTIVE";
+        env.MachineBuildService
+            .GetBuildAsync(TranslationEngine01, Build01, minRevision: null, CancellationToken.None)
+            .Returns(
+                Task.FromResult(
+                    new BuildDto
+                    {
+                        Href = "https://example.com",
+                        Id = Build01,
+                        Engine = new ResourceDto { Id = "engineId", Href = "https://example.com" },
+                        Message = message,
+                        PercentCompleted = percentCompleted,
+                        Revision = revision,
+                        State = state,
+                    }
+                )
+            );
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        BuildDto? actual = await env.Service.GetBuildAsync(
+            User01,
+            Project01,
+            Build01,
+            minRevision: null,
+            CancellationToken.None
+        );
+
+        Assert.IsNotNull(actual);
+        Assert.AreEqual(message, actual.Message);
+        Assert.AreEqual(percentCompleted, actual.PercentCompleted);
+        Assert.AreEqual(revision, actual.Revision);
+        Assert.AreEqual(state, actual.State);
+        Assert.AreEqual(buildDtoId, actual.Id);
+        Assert.AreEqual(MachineApi.GetBuildHref(Project01, Build01), actual.Href);
+        Assert.AreEqual(Project01, actual.Engine.Id);
+        Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Engine.Href);
+    }
+
+    [Test]
+    public async Task GetBuildAsync_ExecutesOnlyInProcessIfBothEnabled()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        _ = await env.Service.GetBuildAsync(User01, Project01, Build01, minRevision: null, CancellationToken.None);
+
+        await env.Builds.Received(1).GetByLocatorAsync(BuildLocatorType.Id, Build01, CancellationToken.None);
+        await env.MachineBuildService
+            .DidNotReceiveWithAnyArgs()
+            .GetBuildAsync(TranslationEngine01, Build01, minRevision: null, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task GetCurrentBuildAsync_InProcessNoRevisionNoBuildRunning()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+        env.Builds
+            .GetByLocatorAsync(BuildLocatorType.Engine, TranslationEngine01, CancellationToken.None)
+            .Returns(Task.FromResult<Build>(null));
+
+        // SUT
+        BuildDto? actual = await env.Service.GetCurrentBuildAsync(
+            User01,
+            Project01,
+            minRevision: null,
+            CancellationToken.None
+        );
+
+        Assert.IsNull(actual);
+    }
+
+    [Test]
+    public void GetCurrentBuildAsync_InProcessSpecificRevisionBuildEnded()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+
+        // NOTE: It is not possible to test No Build Running, as the Subscription Change cannot be modified
+        env.Builds
+            .SubscribeByEngineIdAsync(TranslationEngine01, CancellationToken.None)
+            .Returns(Task.FromResult(new Subscription<Build>(TranslationEngine01, null, _ => { })));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetCurrentBuildAsync(User01, Project01, minRevision: 1, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void GetCurrentBuildAsync_MachineApiBuildEnded()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        int minRevision = 0;
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+        env.MachineBuildService
+            .GetCurrentBuildAsync(TranslationEngine01, minRevision, CancellationToken.None)
+            .Throws(new DataNotFoundException("Entity Deleted"));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetCurrentBuildAsync(User01, Project01, minRevision, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public async Task GetCurrentBuildAsync_MachineApiNoBuildRunning()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+        env.MachineBuildService
+            .GetCurrentBuildAsync(TranslationEngine01, null, CancellationToken.None)
+            .Returns(Task.FromResult<BuildDto>(null));
+
+        // SUT
+        BuildDto? actual = await env.Service.GetCurrentBuildAsync(
+            User01,
+            Project01,
+            minRevision: null,
+            CancellationToken.None
+        );
+
+        Assert.IsNull(actual);
+    }
+
+    [Test]
+    public void GetCurrentBuildAsync_NoFeatureFlagsEnabled()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetCurrentBuildAsync(User01, Project01, minRevision: null, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void GetCurrentBuildAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(
+            () =>
+                env.Service.GetCurrentBuildAsync(
+                    "invalid_user_id",
+                    Project01,
+                    minRevision: null,
+                    CancellationToken.None
+                )
+        );
+    }
+
+    [Test]
+    public void GetCurrentBuildAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () =>
+                env.Service.GetCurrentBuildAsync(
+                    User01,
+                    "invalid_project_id",
+                    minRevision: null,
+                    CancellationToken.None
+                )
+        );
+    }
+
+    [Test]
+    public void GetCurrentBuildAsync_InProcessNoEngine()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+        env.Engines
+            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+            .Returns(Task.FromResult<Engine>(null));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetCurrentBuildAsync(User01, Project01, minRevision: null, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void GetCurrentBuildAsync_MachineApiNoTranslationEngine()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetCurrentBuildAsync(User01, Project03, minRevision: null, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public async Task GetCurrentBuildAsync_InProcessSuccess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        string buildDtoId = $"{Project01}.{Build01}";
+        string message = "Finalizing";
+        double percentCompleted = 0.95;
+        int revision = 553;
+        string state = "ACTIVE";
+        env.Builds
+            .GetByLocatorAsync(BuildLocatorType.Engine, TranslationEngine01, CancellationToken.None)
+            .Returns(
+                Task.FromResult(
+                    new Build
+                    {
+                        Id = Build01,
+                        Message = message,
+                        PercentCompleted = percentCompleted,
+                        Revision = revision,
+                        State = state,
+                    }
+                )
+            );
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+
+        // SUT
+        BuildDto? actual = await env.Service.GetCurrentBuildAsync(
+            User01,
+            Project01,
+            minRevision: null,
+            CancellationToken.None
+        );
+
+        Assert.IsNotNull(actual);
+        Assert.AreEqual(message, actual.Message);
+        Assert.AreEqual(percentCompleted, actual.PercentCompleted);
+        Assert.AreEqual(revision, actual.Revision);
+        Assert.AreEqual(state, actual.State);
+        Assert.AreEqual(buildDtoId, actual.Id);
+        Assert.AreEqual(MachineApi.GetBuildHref(Project01, Build01), actual.Href);
+        Assert.AreEqual(Project01, actual.Engine.Id);
+        Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Engine.Href);
+    }
+
+    [Test]
+    public async Task GetCurrentBuildAsync_MachineApiSuccess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        string buildDtoId = $"{Project01}.{Build01}";
+        string message = "Finalizing";
+        double percentCompleted = 0.95;
+        int revision = 553;
+        string state = "ACTIVE";
+        env.MachineBuildService
+            .GetCurrentBuildAsync(TranslationEngine01, minRevision: null, CancellationToken.None)
+            .Returns(
+                Task.FromResult(
+                    new BuildDto
+                    {
+                        Href = "https://example.com",
+                        Id = Build01,
+                        Engine = new ResourceDto { Id = "engineId", Href = "https://example.com" },
+                        Message = message,
+                        PercentCompleted = percentCompleted,
+                        Revision = revision,
+                        State = state,
+                    }
+                )
+            );
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        BuildDto? actual = await env.Service.GetCurrentBuildAsync(
+            User01,
+            Project01,
+            minRevision: null,
+            CancellationToken.None
+        );
+
+        Assert.IsNotNull(actual);
+        Assert.AreEqual(message, actual.Message);
+        Assert.AreEqual(percentCompleted, actual.PercentCompleted);
+        Assert.AreEqual(revision, actual.Revision);
+        Assert.AreEqual(state, actual.State);
+        Assert.AreEqual(buildDtoId, actual.Id);
+        Assert.AreEqual(MachineApi.GetBuildHref(Project01, Build01), actual.Href);
+        Assert.AreEqual(Project01, actual.Engine.Id);
+        Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Engine.Href);
+    }
+
+    [Test]
+    public async Task GetCurrentBuildAsync_ExecutesOnlyInProcessIfBothEnabled()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        _ = await env.Service.GetCurrentBuildAsync(User01, Project01, minRevision: null, CancellationToken.None);
+
+        await env.Builds
+            .Received(1)
+            .GetByLocatorAsync(BuildLocatorType.Engine, TranslationEngine01, CancellationToken.None);
+        await env.MachineBuildService
+            .DidNotReceiveWithAnyArgs()
+            .GetCurrentBuildAsync(TranslationEngine01, minRevision: null, CancellationToken.None);
+    }
+
+    [Test]
+    public void GetEngineAsync_NoFeatureFlagsEnabled()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetEngineAsync(User01, Project01, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void GetEngineAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.GetEngineAsync("invalid_user_id", Project01, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void GetEngineAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetEngineAsync(User01, "invalid_project_id", CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void GetEngineAsync_InProcessNoEngine()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+        env.Engines
+            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+            .Returns(Task.FromResult<Engine>(null));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetEngineAsync(User01, Project01, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void GetEngineAsync_MachineApiNoTranslationEngine()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetEngineAsync(User01, Project03, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void GetEngineAsync_MachineApiOutageNoInProcess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineTranslationService
+            .GetTranslationEngineAsync(TranslationEngine01, CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<BrokenCircuitException>(
+            () => env.Service.GetEngineAsync(User01, Project01, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public async Task GetEngineAsync_MachineApiOutageFailsToInProcess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineTranslationService
+            .GetTranslationEngineAsync(TranslationEngine01, CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+        env.Engines
+            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+            .Returns(Task.FromResult(new Engine()));
+
+        // SUT
+        _ = await env.Service.GetEngineAsync(User01, Project01, CancellationToken.None);
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+    }
+
+    [Test]
+    public async Task GetEngineAsync_InProcessSuccess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        string sourceLanguageTag = "en_US";
+        string targetLanguageTag = "en_NZ";
+        int confidence = 100;
+        int corpusSize = 472;
+        env.Engines
+            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+            .Returns(
+                Task.FromResult(
+                    new Engine
+                    {
+                        Confidence = confidence,
+                        Id = Project01,
+                        IsShared = false,
+                        Revision = 1,
+                        SourceLanguageTag = sourceLanguageTag,
+                        TargetLanguageTag = targetLanguageTag,
+                        TrainedSegmentCount = corpusSize,
+                    }
+                )
+            );
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+
+        // SUT
+        EngineDto actual = await env.Service.GetEngineAsync(User01, Project01, CancellationToken.None);
+
+        Assert.AreEqual(confidence, actual.Confidence);
+        Assert.AreEqual(corpusSize, actual.TrainedSegmentCount);
+        Assert.AreEqual(sourceLanguageTag, actual.SourceLanguageTag);
+        Assert.AreEqual(targetLanguageTag, actual.TargetLanguageTag);
+        Assert.IsFalse(actual.IsShared);
+        Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Href);
+        Assert.AreEqual(1, actual.Projects.Length);
+        Assert.AreEqual(Project01, actual.Projects.First().Id);
+        Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Projects.First().Href);
+    }
+
+    [Test]
+    public async Task GetEngineAsync_MachineApiSuccess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        string sourceLanguageTag = "en_US";
+        string targetLanguageTag = "en_NZ";
+        int confidence = 100;
+        int corpusSize = 472;
+        env.MachineTranslationService
+            .GetTranslationEngineAsync(TranslationEngine01, CancellationToken.None)
+            .Returns(
+                Task.FromResult(
+                    new MachineApiTranslationEngine
+                    {
+                        Confidence = confidence,
+                        CorpusSize = corpusSize,
+                        Href = "https://example.com",
+                        Id = Project01,
+                        IsBuilding = true,
+                        ModelRevision = 1,
+                        Name = "my_translation_engine",
+                        SourceLanguageTag = sourceLanguageTag,
+                        TargetLanguageTag = targetLanguageTag,
+                        Type = "SmtTransfer",
+                    }
+                )
+            );
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        EngineDto actual = await env.Service.GetEngineAsync(User01, Project01, CancellationToken.None);
+
+        Assert.AreEqual(confidence, actual.Confidence);
+        Assert.AreEqual(corpusSize, actual.TrainedSegmentCount);
+        Assert.AreEqual(sourceLanguageTag, actual.SourceLanguageTag);
+        Assert.AreEqual(targetLanguageTag, actual.TargetLanguageTag);
+        Assert.IsFalse(actual.IsShared);
+        Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Href);
+        Assert.AreEqual(1, actual.Projects.Length);
+        Assert.AreEqual(Project01, actual.Projects.First().Id);
+        Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Projects.First().Href);
+    }
+
+    [Test]
+    public async Task GetEngineAsync_ExecutesApiAndInProcess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineTranslationService
+            .GetTranslationEngineAsync(TranslationEngine01, CancellationToken.None)
+            .Returns(Task.FromResult(new MachineApiTranslationEngine()));
+        env.Engines
+            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+            .Returns(Task.FromResult(new Engine()));
+
+        // SUT
+        _ = await env.Service.GetEngineAsync(User01, Project01, CancellationToken.None);
+
+        await env.Engines.Received(1).GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None);
+        await env.MachineTranslationService
+            .Received(1)
+            .GetTranslationEngineAsync(TranslationEngine01, CancellationToken.None);
+    }
+
+    [Test]
+    public void GetWordGraphAsync_NoFeatureFlagsEnabled()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void GetWordGraphAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(
+            () =>
+                env.Service.GetWordGraphAsync(
+                    "invalid_user_id",
+                    Project01,
+                    Array.Empty<string>(),
+                    CancellationToken.None
+                )
+        );
+    }
+
+    [Test]
+    public void GetWordGraphAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () =>
+                env.Service.GetWordGraphAsync(
+                    User01,
+                    "invalid_project_id",
+                    Array.Empty<string>(),
+                    CancellationToken.None
+                )
+        );
+    }
+
+    [Test]
+    public void GetWordGraphAsync_InProcessNoEngine()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+        env.Engines
+            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+            .Returns(Task.FromResult<Engine>(null));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void GetWordGraphAsync_MachineApiNoTranslationEngine()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetWordGraphAsync(User01, Project03, Array.Empty<string>(), CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void GetWordGraphAsync_MachineApiOutageNoInProcess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineTranslationService
+            .GetWordGraphAsync(TranslationEngine01, Array.Empty<string>(), CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<BrokenCircuitException>(
+            () => env.Service.GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public async Task GetWordGraphAsync_MachineApiOutageFailsToInProcess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineTranslationService
+            .GetWordGraphAsync(TranslationEngine01, Array.Empty<string>(), CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+        env.EngineService
+            .GetWordGraphAsync(TranslationEngine01, Array.Empty<string>())
+            .Returns(Task.FromResult(new WordGraph(Array.Empty<WordGraphArc>(), Array.Empty<int>())));
+
+        // SUT
+        _ = await env.Service.GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None);
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+    }
+
+    [Test]
+    public async Task GetWordGraphAsync_InProcessSuccess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        float initialStateScore = -91.43696f;
+        env.EngineService
+            .GetWordGraphAsync(TranslationEngine01, Array.Empty<string>())
+            .Returns(
+                Task.FromResult(
+                    new WordGraph(
+                        new[]
+                        {
+                            new WordGraphArc(
+                                0,
+                                0,
+                                0.0,
+                                Array.Empty<string>(),
+                                new WordAlignmentMatrix(0, 0),
+                                Range<int>.Null,
+                                Array.Empty<TranslationSources>()
+                            )
+                        },
+                        new[] { 1 },
+                        initialStateScore
+                    )
+                )
+            );
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+
+        // SUT
+        WordGraphDto actual = await env.Service.GetWordGraphAsync(
+            User01,
+            Project01,
+            Array.Empty<string>(),
+            CancellationToken.None
+        );
+
+        Assert.IsNotNull(actual);
+        Assert.AreEqual(initialStateScore, actual.InitialStateScore);
+        Assert.AreEqual(1, actual.Arcs.Length);
+        Assert.AreEqual(1, actual.FinalStates.Length);
+    }
+
+    [Test]
+    public async Task GetWordGraphAsync_MachineApiSuccess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        float initialStateScore = -91.43696f;
+        env.MachineTranslationService
+            .GetWordGraphAsync(TranslationEngine01, Array.Empty<string>(), CancellationToken.None)
+            .Returns(
+                Task.FromResult(
+                    new WordGraphDto
+                    {
+                        Arcs = new[] { new WordGraphArcDto() },
+                        FinalStates = new[] { 1 },
+                        InitialStateScore = initialStateScore,
+                    }
+                )
+            );
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        WordGraphDto actual = await env.Service.GetWordGraphAsync(
+            User01,
+            Project01,
+            Array.Empty<string>(),
+            CancellationToken.None
+        );
+
+        Assert.IsNotNull(actual);
+        Assert.AreEqual(initialStateScore, actual.InitialStateScore);
+        Assert.AreEqual(1, actual.Arcs.Length);
+        Assert.AreEqual(1, actual.FinalStates.Length);
+    }
+
+    [Test]
+    public async Task GetWordGraphAsync_ExecutesApiAndInProcess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.EngineService
+            .GetWordGraphAsync(TranslationEngine01, Array.Empty<string>())
+            .Returns(Task.FromResult(new WordGraph()));
+
+        // SUT
+        _ = await env.Service.GetWordGraphAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None);
+
+        await env.EngineService.Received(1).GetWordGraphAsync(TranslationEngine01, Array.Empty<string>());
+        await env.MachineTranslationService
+            .Received(1)
+            .GetWordGraphAsync(TranslationEngine01, Array.Empty<string>(), CancellationToken.None);
+    }
+
+    [Test]
+    public void StartBuildAsync_NoFeatureFlagsEnabled()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.StartBuildAsync(User01, Project01, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void StartBuildAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.StartBuildAsync("invalid_user_id", Project01, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void StartBuildAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.StartBuildAsync(User01, "invalid_project_id", CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void StartBuildAsync_InProcessNoEngine()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+        env.Engines
+            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+            .Returns(Task.FromResult<Engine>(null));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.StartBuildAsync(User01, Project01, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void StartBuildAsync_MachineApiNoTranslationEngine()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.StartBuildAsync(User01, Project03, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void StartBuildAsync_MachineApiOutageNoInProcess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineBuildService
+            .StartBuildAsync(TranslationEngine01, CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<BrokenCircuitException>(
+            () => env.Service.StartBuildAsync(User01, Project01, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public async Task StartBuildAsync_MachineApiOutageFailsToInProcess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineBuildService
+            .StartBuildAsync(TranslationEngine01, CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+        env.EngineService.StartBuildAsync(TranslationEngine01).Returns(Task.FromResult(new Build()));
+
+        // SUT
+        _ = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+    }
+
+    [Test]
+    public async Task StartBuildAsync_InProcessSuccess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        string buildDtoId = $"{Project01}.{Build01}";
+        string message = "Training language model";
+        double percentCompleted = 0.01;
+        int revision = 2;
+        string state = "ACTIVE";
+        env.EngineService
+            .StartBuildAsync(TranslationEngine01)
+            .Returns(
+                Task.FromResult(
+                    new Build
+                    {
+                        Id = Build01,
+                        Message = message,
+                        PercentCompleted = percentCompleted,
+                        Revision = revision,
+                        State = state,
+                    }
+                )
+            );
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+
+        // SUT
+        BuildDto actual = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
+
+        Assert.AreEqual(message, actual.Message);
+        Assert.AreEqual(percentCompleted, actual.PercentCompleted);
+        Assert.AreEqual(revision, actual.Revision);
+        Assert.AreEqual(state, actual.State);
+        Assert.AreEqual(buildDtoId, actual.Id);
+        Assert.AreEqual(MachineApi.GetBuildHref(Project01, Build01), actual.Href);
+        Assert.AreEqual(Project01, actual.Engine.Id);
+        Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Engine.Href);
+    }
+
+    [Test]
+    public async Task StartBuildAsync_MachineApiSuccess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        string buildDtoId = $"{Project01}.{Build01}";
+        string message = "Training language model";
+        double percentCompleted = 0.01;
+        int revision = 2;
+        string state = "ACTIVE";
+        env.MachineBuildService
+            .StartBuildAsync(TranslationEngine01, CancellationToken.None)
+            .Returns(
+                Task.FromResult(
+                    new BuildDto
+                    {
+                        Href = "https://example.com",
+                        Id = Build01,
+                        Engine = new ResourceDto { Id = "engineId", Href = "https://example.com" },
+                        Message = message,
+                        PercentCompleted = percentCompleted,
+                        Revision = revision,
+                        State = state,
+                    }
+                )
+            );
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        BuildDto actual = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
+
+        await env.MachineProjectService.Received(1).SyncProjectCorporaAsync(User01, Project01, CancellationToken.None);
+        Assert.AreEqual(message, actual.Message);
+        Assert.AreEqual(percentCompleted, actual.PercentCompleted);
+        Assert.AreEqual(revision, actual.Revision);
+        Assert.AreEqual(state, actual.State);
+        Assert.AreEqual(buildDtoId, actual.Id);
+        Assert.AreEqual(MachineApi.GetBuildHref(Project01, Build01), actual.Href);
+        Assert.AreEqual(Project01, actual.Engine.Id);
+        Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Engine.Href);
+    }
+
+    [Test]
+    public async Task StartBuildAsync_ExecutesApiAndInProcess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.EngineService.StartBuildAsync(TranslationEngine01).Returns(Task.FromResult(new Build()));
+
+        // SUT
+        _ = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
+
+        await env.EngineService.Received(1).StartBuildAsync(TranslationEngine01);
+        await env.MachineProjectService.Received(1).SyncProjectCorporaAsync(User01, Project01, CancellationToken.None);
+        await env.MachineBuildService.Received(1).StartBuildAsync(TranslationEngine01, CancellationToken.None);
+    }
+
+    [Test]
+    public void TrainSegmentAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(
+            () =>
+                env.Service.TrainSegmentAsync(
+                    "invalid_user_id",
+                    Project01,
+                    new SegmentPairDto(),
+                    CancellationToken.None
+                )
+        );
+    }
+
+    [Test]
+    public void TrainSegmentAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () =>
+                env.Service.TrainSegmentAsync(
+                    User01,
+                    "invalid_project_id",
+                    new SegmentPairDto(),
+                    CancellationToken.None
+                )
+        );
+    }
+
+    [Test]
+    public void TrainSegmentAsync_InProcessNoEngine()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+        env.Engines
+            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+            .Returns(Task.FromResult<Engine>(null));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.TrainSegmentAsync(User01, Project01, new SegmentPairDto(), CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void TrainSegmentAsync_MachineApiNoTranslationEngine()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.TrainSegmentAsync(User01, Project03, new SegmentPairDto(), CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void TrainSegmentAsync_MachineApiOutageNoInProcess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        var segmentPairDto = new SegmentPairDto();
+        env.MachineTranslationService
+            .TrainSegmentAsync(TranslationEngine01, segmentPairDto, CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<BrokenCircuitException>(
+            () => env.Service.TrainSegmentAsync(User01, Project01, segmentPairDto, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public async Task TrainSegmentAsync_MachineApiOutageFailsToInProcess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        var segmentPairDto = new SegmentPairDto();
+        env.MachineTranslationService
+            .TrainSegmentAsync(TranslationEngine01, segmentPairDto, CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+        env.EngineService
+            .TrainSegmentAsync(
+                TranslationEngine01,
+                segmentPairDto.SourceSegment,
+                segmentPairDto.TargetSegment,
+                segmentPairDto.SentenceStart
+            )
+            .Returns(Task.FromResult(true));
+
+        // SUT
+        await env.Service.TrainSegmentAsync(User01, Project01, segmentPairDto, CancellationToken.None);
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+    }
+
+    [Test]
+    public async Task TrainSegmentAsync_InProcessSuccess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+        var segmentPair = new SegmentPairDto();
+
+        // SUT
+        await env.Service.TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None);
+
+        await env.EngineService
+            .Received(1)
+            .TrainSegmentAsync(
+                TranslationEngine01,
+                segmentPair.SourceSegment,
+                segmentPair.TargetSegment,
+                segmentPair.SentenceStart
+            );
+    }
+
+    [Test]
+    public async Task TrainSegmentAsync_MachineApiSuccess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+        var segmentPair = new SegmentPairDto();
+
+        // SUT
+        await env.Service.TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None);
+
+        await env.MachineTranslationService
+            .Received(1)
+            .TrainSegmentAsync(TranslationEngine01, segmentPair, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task TrainSegmentAsync_ExecutesApiAndInProcess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        var segmentPair = new SegmentPairDto();
+
+        // SUT
+        await env.Service.TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None);
+
+        await env.EngineService
+            .Received(1)
+            .TrainSegmentAsync(
+                TranslationEngine01,
+                segmentPair.SourceSegment,
+                segmentPair.TargetSegment,
+                segmentPair.SentenceStart
+            );
+        await env.MachineTranslationService
+            .Received(1)
+            .TrainSegmentAsync(TranslationEngine01, segmentPair, CancellationToken.None);
+    }
+
+    [Test]
+    public void TranslateAsync_NoFeatureFlagsEnabled()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void TranslateAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(
+            () =>
+                env.Service.TranslateAsync("invalid_user_id", Project01, Array.Empty<string>(), CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void TranslateAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () =>
+                env.Service.TranslateAsync(User01, "invalid_project_id", Array.Empty<string>(), CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void TranslateAsync_InProcessNoEngine()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+        env.Engines
+            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+            .Returns(Task.FromResult<Engine>(null));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void TranslateAsync_MachineApiNoTranslationEngine()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.TranslateAsync(User01, Project03, Array.Empty<string>(), CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void TranslateAsync_MachineApiOutageNoInProcess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineTranslationService
+            .TranslateAsync(TranslationEngine01, Array.Empty<string>(), CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<BrokenCircuitException>(
+            () => env.Service.TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public async Task TranslateAsync_MachineApiOutageFailsToInProcess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineTranslationService
+            .TranslateAsync(TranslationEngine01, Array.Empty<string>(), CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+        env.EngineService
+            .TranslateAsync(TranslationEngine01, Array.Empty<string>())
+            .Returns(
+                Task.FromResult(
+                    new TranslationResult(
                         Array.Empty<string>(),
-                        CancellationToken.None
-                    )
-            );
-        }
-
-        [Test]
-        public void TranslateAsync_NoProject()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () =>
-                    env.Service.TranslateAsync(
-                        User01,
-                        "invalid_project_id",
                         Array.Empty<string>(),
-                        CancellationToken.None
+                        Array.Empty<double>(),
+                        Array.Empty<TranslationSources>(),
+                        new WordAlignmentMatrix(0, 0),
+                        Array.Empty<Phrase>()
                     )
+                )
             );
-        }
 
-        [Test]
-        public void TranslateAsync_InProcessNoEngine()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-            env.Engines
-                .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
-                .Returns(Task.FromResult<Engine>(null));
+        // SUT
+        _ = await env.Service.TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None);
 
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
-            );
-        }
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+    }
 
-        [Test]
-        public void TranslateAsync_MachineApiNoTranslationEngine()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.TranslateAsync(User01, Project03, Array.Empty<string>(), CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void TranslateAsync_MachineApiOutageNoInProcess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineTranslationService
-                .TranslateAsync(TranslationEngine01, Array.Empty<string>(), CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<BrokenCircuitException>(
-                () => env.Service.TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public async Task TranslateAsync_MachineApiOutageFailsToInProcess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineTranslationService
-                .TranslateAsync(TranslationEngine01, Array.Empty<string>(), CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-            env.EngineService
-                .TranslateAsync(TranslationEngine01, Array.Empty<string>())
-                .Returns(
-                    Task.FromResult(
-                        new TranslationResult(
-                            Array.Empty<string>(),
-                            Array.Empty<string>(),
-                            Array.Empty<double>(),
-                            Array.Empty<TranslationSources>(),
-                            new WordAlignmentMatrix(0, 0),
-                            Array.Empty<Phrase>()
-                        )
+    [Test]
+    public async Task TranslateAsync_InProcessSuccess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.EngineService
+            .TranslateAsync(TranslationEngine01, Array.Empty<string>())
+            .Returns(
+                Task.FromResult(
+                    new TranslationResult(
+                        new[] { string.Empty },
+                        new[] { string.Empty },
+                        new[] { 0.0 },
+                        new[] { TranslationSources.Smt },
+                        new WordAlignmentMatrix(1, 1, new[] { (0, 0) }),
+                        new[] { new Phrase(new Range<int>(), 0, 0.0) }
                     )
-                );
+                )
+            );
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
 
-            // SUT
-            _ = await env.Service.TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None);
+        // SUT
+        TranslationResultDto actual = await env.Service.TranslateAsync(
+            User01,
+            Project01,
+            Array.Empty<string>(),
+            CancellationToken.None
+        );
 
-            env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
-        }
+        Assert.IsNotNull(actual);
+        Assert.AreEqual(1, actual.Target.Length);
+        Assert.AreEqual(1, actual.Confidences.Length);
+        Assert.AreEqual(1, actual.Sources.Length);
+        Assert.AreEqual(1, actual.Alignment.Length);
+        Assert.AreEqual(1, actual.Phrases.Length);
+    }
 
-        [Test]
-        public async Task TranslateAsync_InProcessSuccess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.EngineService
-                .TranslateAsync(TranslationEngine01, Array.Empty<string>())
-                .Returns(
-                    Task.FromResult(
+    [Test]
+    public async Task TranslateAsync_MachineApiSuccess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineTranslationService
+            .TranslateAsync(TranslationEngine01, Array.Empty<string>(), CancellationToken.None)
+            .Returns(
+                Task.FromResult(
+                    new TranslationResultDto
+                    {
+                        Alignment = new[] { new AlignedWordPairDto() },
+                        Confidences = new[] { 0.0f },
+                        Phrases = new[] { new PhraseDto() },
+                        Sources = new[] { TranslationSources.Smt },
+                        Target = new[] { string.Empty },
+                    }
+                )
+            );
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        TranslationResultDto actual = await env.Service.TranslateAsync(
+            User01,
+            Project01,
+            Array.Empty<string>(),
+            CancellationToken.None
+        );
+
+        Assert.IsNotNull(actual);
+        Assert.AreEqual(1, actual.Target.Length);
+        Assert.AreEqual(1, actual.Confidences.Length);
+        Assert.AreEqual(1, actual.Sources.Length);
+        Assert.AreEqual(1, actual.Alignment.Length);
+        Assert.AreEqual(1, actual.Phrases.Length);
+    }
+
+    [Test]
+    public async Task TranslateAsync_ExecutesApiAndInProcess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.EngineService
+            .TranslateAsync(TranslationEngine01, Array.Empty<string>())
+            .Returns(
+                Task.FromResult(
+                    new TranslationResult(
+                        Array.Empty<string>(),
+                        Array.Empty<string>(),
+                        Array.Empty<double>(),
+                        Array.Empty<TranslationSources>(),
+                        new WordAlignmentMatrix(0, 0),
+                        Array.Empty<Phrase>()
+                    )
+                )
+            );
+
+        // SUT
+        _ = await env.Service.TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None);
+
+        await env.EngineService.Received(1).TranslateAsync(TranslationEngine01, Array.Empty<string>());
+        await env.MachineTranslationService
+            .Received(1)
+            .TranslateAsync(TranslationEngine01, Array.Empty<string>(), CancellationToken.None);
+    }
+
+    [Test]
+    public void TranslateNAsync_NoPermission()
+    {
+        // Set up test environment
+        int n = 1;
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(
+            () =>
+                env.Service.TranslateNAsync(
+                    "invalid_user_id",
+                    Project01,
+                    n,
+                    Array.Empty<string>(),
+                    CancellationToken.None
+                )
+        );
+    }
+
+    [Test]
+    public void TranslateNAsync_NoProject()
+    {
+        // Set up test environment
+        int n = 1;
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () =>
+                env.Service.TranslateNAsync(
+                    User01,
+                    "invalid_project_id",
+                    n,
+                    Array.Empty<string>(),
+                    CancellationToken.None
+                )
+        );
+    }
+
+    [Test]
+    public void TranslateNAsync_InProcessNoEngine()
+    {
+        // Set up test environment
+        int n = 1;
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
+        env.Engines
+            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+            .Returns(Task.FromResult<Engine>(null));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void TranslateNAsync_MachineApiNoTranslationEngine()
+    {
+        // Set up test environment
+        int n = 1;
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.TranslateNAsync(User01, Project03, n, Array.Empty<string>(), CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void TranslateNAsync_MachineApiOutageNoInProcess()
+    {
+        // Set up test environment
+        int n = 1;
+        var env = new TestEnvironment();
+        env.MachineTranslationService
+            .TranslateNAsync(TranslationEngine01, n, Array.Empty<string>(), CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<BrokenCircuitException>(
+            () => env.Service.TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public async Task TranslateNAsync_MachineApiOutageFailsToInProcess()
+    {
+        // Set up test environment
+        int n = 1;
+        var env = new TestEnvironment();
+        env.MachineTranslationService
+            .TranslateNAsync(TranslationEngine01, n, Array.Empty<string>(), CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+        env.EngineService
+            .TranslateAsync(TranslationEngine01, n, Array.Empty<string>())
+            .Returns(Task.FromResult(Array.Empty<TranslationResult>().AsEnumerable()));
+
+        // SUT
+        _ = await env.Service.TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None);
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+    }
+
+    [Test]
+    public async Task TranslateNAsync_InProcessSuccess()
+    {
+        // Set up test environment
+        int n = 1;
+        var env = new TestEnvironment();
+        env.EngineService
+            .TranslateAsync(TranslationEngine01, n, Array.Empty<string>())
+            .Returns(
+                Task.FromResult(
+                    new[]
+                    {
                         new TranslationResult(
                             new[] { string.Empty },
                             new[] { string.Empty },
@@ -1475,36 +1672,42 @@ namespace SIL.XForge.Scripture.Services
                             new[] { TranslationSources.Smt },
                             new WordAlignmentMatrix(1, 1, new[] { (0, 0) }),
                             new[] { new Phrase(new Range<int>(), 0, 0.0) }
-                        )
-                    )
-                );
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-
-            // SUT
-            TranslationResultDto actual = await env.Service.TranslateAsync(
-                User01,
-                Project01,
-                Array.Empty<string>(),
-                CancellationToken.None
+                        ),
+                    }.AsEnumerable()
+                )
             );
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
 
-            Assert.IsNotNull(actual);
-            Assert.AreEqual(1, actual.Target.Length);
-            Assert.AreEqual(1, actual.Confidences.Length);
-            Assert.AreEqual(1, actual.Sources.Length);
-            Assert.AreEqual(1, actual.Alignment.Length);
-            Assert.AreEqual(1, actual.Phrases.Length);
-        }
+        // SUT
+        TranslationResultDto[] actual = await env.Service.TranslateNAsync(
+            User01,
+            Project01,
+            n,
+            Array.Empty<string>(),
+            CancellationToken.None
+        );
 
-        [Test]
-        public async Task TranslateAsync_MachineApiSuccess()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.MachineTranslationService
-                .TranslateAsync(TranslationEngine01, Array.Empty<string>(), CancellationToken.None)
-                .Returns(
-                    Task.FromResult(
+        Assert.IsNotNull(actual);
+        Assert.AreEqual(1, actual.Length);
+        Assert.AreEqual(1, actual.First().Target.Length);
+        Assert.AreEqual(1, actual.First().Confidences.Length);
+        Assert.AreEqual(1, actual.First().Sources.Length);
+        Assert.AreEqual(1, actual.First().Alignment.Length);
+        Assert.AreEqual(1, actual.First().Phrases.Length);
+    }
+
+    [Test]
+    public async Task TranslateNAsync_MachineApiSuccess()
+    {
+        // Set up test environment
+        int n = 1;
+        var env = new TestEnvironment();
+        env.MachineTranslationService
+            .TranslateNAsync(TranslationEngine01, n, Array.Empty<string>(), CancellationToken.None)
+            .Returns(
+                Task.FromResult(
+                    new[]
+                    {
                         new TranslationResultDto
                         {
                             Alignment = new[] { new AlignedWordPairDto() },
@@ -1512,356 +1715,136 @@ namespace SIL.XForge.Scripture.Services
                             Phrases = new[] { new PhraseDto() },
                             Sources = new[] { TranslationSources.Smt },
                             Target = new[] { string.Empty },
-                        }
-                    )
-                );
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            TranslationResultDto actual = await env.Service.TranslateAsync(
-                User01,
-                Project01,
-                Array.Empty<string>(),
-                CancellationToken.None
+                        },
+                    }
+                )
             );
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
-            Assert.IsNotNull(actual);
-            Assert.AreEqual(1, actual.Target.Length);
-            Assert.AreEqual(1, actual.Confidences.Length);
-            Assert.AreEqual(1, actual.Sources.Length);
-            Assert.AreEqual(1, actual.Alignment.Length);
-            Assert.AreEqual(1, actual.Phrases.Length);
-        }
+        // SUT
+        TranslationResultDto[] actual = await env.Service.TranslateNAsync(
+            User01,
+            Project01,
+            n,
+            Array.Empty<string>(),
+            CancellationToken.None
+        );
 
-        [Test]
-        public async Task TranslateAsync_ExecutesApiAndInProcess()
+        Assert.IsNotNull(actual);
+        Assert.AreEqual(1, actual.Length);
+        Assert.AreEqual(1, actual.First().Target.Length);
+        Assert.AreEqual(1, actual.First().Confidences.Length);
+        Assert.AreEqual(1, actual.First().Sources.Length);
+        Assert.AreEqual(1, actual.First().Alignment.Length);
+        Assert.AreEqual(1, actual.First().Phrases.Length);
+    }
+
+    [Test]
+    public async Task TranslateNAsync_ExecutesApiAndInProcess()
+    {
+        // Set up test environment
+        int n = 1;
+        var env = new TestEnvironment();
+        env.EngineService
+            .TranslateAsync(TranslationEngine01, n, Array.Empty<string>())
+            .Returns(Task.FromResult(Array.Empty<TranslationResult>().AsEnumerable()));
+
+        // SUT
+        _ = await env.Service.TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None);
+
+        await env.EngineService.Received(1).TranslateAsync(TranslationEngine01, n, Array.Empty<string>());
+        await env.MachineTranslationService
+            .Received(1)
+            .TranslateNAsync(TranslationEngine01, n, Array.Empty<string>(), CancellationToken.None);
+    }
+
+    private class TestEnvironment
+    {
+        public TestEnvironment()
         {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.EngineService
-                .TranslateAsync(TranslationEngine01, Array.Empty<string>())
-                .Returns(
-                    Task.FromResult(
-                        new TranslationResult(
-                            Array.Empty<string>(),
-                            Array.Empty<string>(),
-                            Array.Empty<double>(),
-                            Array.Empty<TranslationSources>(),
-                            new WordAlignmentMatrix(0, 0),
-                            Array.Empty<Phrase>()
-                        )
-                    )
-                );
-
-            // SUT
-            _ = await env.Service.TranslateAsync(User01, Project01, Array.Empty<string>(), CancellationToken.None);
-
-            await env.EngineService.Received(1).TranslateAsync(TranslationEngine01, Array.Empty<string>());
-            await env.MachineTranslationService
-                .Received(1)
-                .TranslateAsync(TranslationEngine01, Array.Empty<string>(), CancellationToken.None);
-        }
-
-        [Test]
-        public void TranslateNAsync_NoPermission()
-        {
-            // Set up test environment
-            int n = 1;
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.ThrowsAsync<ForbiddenException>(
-                () =>
-                    env.Service.TranslateNAsync(
-                        "invalid_user_id",
-                        Project01,
-                        n,
-                        Array.Empty<string>(),
-                        CancellationToken.None
-                    )
-            );
-        }
-
-        [Test]
-        public void TranslateNAsync_NoProject()
-        {
-            // Set up test environment
-            int n = 1;
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () =>
-                    env.Service.TranslateNAsync(
-                        User01,
-                        "invalid_project_id",
-                        n,
-                        Array.Empty<string>(),
-                        CancellationToken.None
-                    )
-            );
-        }
-
-        [Test]
-        public void TranslateNAsync_InProcessNoEngine()
-        {
-            // Set up test environment
-            int n = 1;
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-            env.Engines
+            Builds = Substitute.For<IBuildRepository>();
+            Engines = Substitute.For<IEngineRepository>();
+            Engines
                 .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
-                .Returns(Task.FromResult<Engine>(null));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void TranslateNAsync_MachineApiNoTranslationEngine()
-        {
-            // Set up test environment
-            int n = 1;
-            var env = new TestEnvironment();
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.TranslateNAsync(User01, Project03, n, Array.Empty<string>(), CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public void TranslateNAsync_MachineApiOutageNoInProcess()
-        {
-            // Set up test environment
-            int n = 1;
-            var env = new TestEnvironment();
-            env.MachineTranslationService
-                .TranslateNAsync(TranslationEngine01, n, Array.Empty<string>(), CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-
-            // SUT
-            Assert.ThrowsAsync<BrokenCircuitException>(
-                () => env.Service.TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public async Task TranslateNAsync_MachineApiOutageFailsToInProcess()
-        {
-            // Set up test environment
-            int n = 1;
-            var env = new TestEnvironment();
-            env.MachineTranslationService
-                .TranslateNAsync(TranslationEngine01, n, Array.Empty<string>(), CancellationToken.None)
-                .Throws(new BrokenCircuitException());
-            env.EngineService
-                .TranslateAsync(TranslationEngine01, n, Array.Empty<string>())
-                .Returns(Task.FromResult(Array.Empty<TranslationResult>().AsEnumerable()));
-
-            // SUT
-            _ = await env.Service.TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None);
-
-            env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
-        }
-
-        [Test]
-        public async Task TranslateNAsync_InProcessSuccess()
-        {
-            // Set up test environment
-            int n = 1;
-            var env = new TestEnvironment();
-            env.EngineService
-                .TranslateAsync(TranslationEngine01, n, Array.Empty<string>())
                 .Returns(
                     Task.FromResult(
-                        new[]
+                        new Engine
                         {
-                            new TranslationResult(
-                                new[] { string.Empty },
-                                new[] { string.Empty },
-                                new[] { 0.0 },
-                                new[] { TranslationSources.Smt },
-                                new WordAlignmentMatrix(1, 1, new[] { (0, 0) }),
-                                new[] { new Phrase(new Range<int>(), 0, 0.0) }
-                            ),
-                        }.AsEnumerable()
-                    )
-                );
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(false));
-
-            // SUT
-            TranslationResultDto[] actual = await env.Service.TranslateNAsync(
-                User01,
-                Project01,
-                n,
-                Array.Empty<string>(),
-                CancellationToken.None
-            );
-
-            Assert.IsNotNull(actual);
-            Assert.AreEqual(1, actual.Length);
-            Assert.AreEqual(1, actual.First().Target.Length);
-            Assert.AreEqual(1, actual.First().Confidences.Length);
-            Assert.AreEqual(1, actual.First().Sources.Length);
-            Assert.AreEqual(1, actual.First().Alignment.Length);
-            Assert.AreEqual(1, actual.First().Phrases.Length);
-        }
-
-        [Test]
-        public async Task TranslateNAsync_MachineApiSuccess()
-        {
-            // Set up test environment
-            int n = 1;
-            var env = new TestEnvironment();
-            env.MachineTranslationService
-                .TranslateNAsync(TranslationEngine01, n, Array.Empty<string>(), CancellationToken.None)
-                .Returns(
-                    Task.FromResult(
-                        new[]
-                        {
-                            new TranslationResultDto
-                            {
-                                Alignment = new[] { new AlignedWordPairDto() },
-                                Confidences = new[] { 0.0f },
-                                Phrases = new[] { new PhraseDto() },
-                                Sources = new[] { TranslationSources.Smt },
-                                Target = new[] { string.Empty },
-                            },
+                            Confidence = 100,
+                            Id = TranslationEngine01,
+                            SourceLanguageTag = "en_US",
+                            TrainedSegmentCount = 472,
+                            TargetLanguageTag = "en_NZ",
                         }
                     )
                 );
-            env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+            IOptions<EngineOptions> engineOptions = Options.Create(new EngineOptions());
+            EngineService = Substitute.For<IEngineService>();
+            ExceptionHandler = Substitute.For<IExceptionHandler>();
+            FeatureManager = Substitute.For<IFeatureManager>();
+            FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(true));
+            FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(true));
 
-            // SUT
-            TranslationResultDto[] actual = await env.Service.TranslateNAsync(
-                User01,
-                Project01,
-                n,
-                Array.Empty<string>(),
-                CancellationToken.None
+            MachineBuildService = Substitute.For<IMachineBuildService>();
+            MachineProjectService = Substitute.For<IMachineProjectService>();
+            MachineTranslationService = Substitute.For<IMachineTranslationService>();
+            var projectSecrets = new MemoryRepository<SFProjectSecret>(
+                new[]
+                {
+                    new SFProjectSecret
+                    {
+                        Id = Project01,
+                        MachineData = new MachineData { TranslationEngineId = TranslationEngine01 },
+                    },
+                    new SFProjectSecret { Id = Project02 },
+                }
             );
 
-            Assert.IsNotNull(actual);
-            Assert.AreEqual(1, actual.Length);
-            Assert.AreEqual(1, actual.First().Target.Length);
-            Assert.AreEqual(1, actual.First().Confidences.Length);
-            Assert.AreEqual(1, actual.First().Sources.Length);
-            Assert.AreEqual(1, actual.First().Alignment.Length);
-            Assert.AreEqual(1, actual.First().Phrases.Length);
-        }
-
-        [Test]
-        public async Task TranslateNAsync_ExecutesApiAndInProcess()
-        {
-            // Set up test environment
-            int n = 1;
-            var env = new TestEnvironment();
-            env.EngineService
-                .TranslateAsync(TranslationEngine01, n, Array.Empty<string>())
-                .Returns(Task.FromResult(Array.Empty<TranslationResult>().AsEnumerable()));
-
-            // SUT
-            _ = await env.Service.TranslateNAsync(User01, Project01, n, Array.Empty<string>(), CancellationToken.None);
-
-            await env.EngineService.Received(1).TranslateAsync(TranslationEngine01, n, Array.Empty<string>());
-            await env.MachineTranslationService
-                .Received(1)
-                .TranslateNAsync(TranslationEngine01, n, Array.Empty<string>(), CancellationToken.None);
-        }
-
-        private class TestEnvironment
-        {
-            public TestEnvironment()
-            {
-                Builds = Substitute.For<IBuildRepository>();
-                Engines = Substitute.For<IEngineRepository>();
-                Engines
-                    .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
-                    .Returns(
-                        Task.FromResult(
-                            new Engine
-                            {
-                                Confidence = 100,
-                                Id = TranslationEngine01,
-                                SourceLanguageTag = "en_US",
-                                TrainedSegmentCount = 472,
-                                TargetLanguageTag = "en_NZ",
-                            }
-                        )
-                    );
-                IOptions<EngineOptions> engineOptions = Options.Create(new EngineOptions());
-                EngineService = Substitute.For<IEngineService>();
-                ExceptionHandler = Substitute.For<IExceptionHandler>();
-                FeatureManager = Substitute.For<IFeatureManager>();
-                FeatureManager.IsEnabledAsync(FeatureFlags.MachineApi).Returns(Task.FromResult(true));
-                FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(true));
-
-                MachineBuildService = Substitute.For<IMachineBuildService>();
-                MachineProjectService = Substitute.For<IMachineProjectService>();
-                MachineTranslationService = Substitute.For<IMachineTranslationService>();
-                var projectSecrets = new MemoryRepository<SFProjectSecret>(
+            var realtimeService = new SFMemoryRealtimeService();
+            realtimeService.AddRepository(
+                "sf_projects",
+                OTType.Json0,
+                new MemoryRepository<SFProject>(
                     new[]
                     {
-                        new SFProjectSecret
+                        new SFProject
                         {
                             Id = Project01,
-                            MachineData = new MachineData { TranslationEngineId = TranslationEngine01 },
+                            UserRoles = new Dictionary<string, string> { { User01, SFProjectRole.Administrator } },
                         },
-                        new SFProjectSecret { Id = Project02 },
-                    }
-                );
-
-                var realtimeService = new SFMemoryRealtimeService();
-                realtimeService.AddRepository(
-                    "sf_projects",
-                    OTType.Json0,
-                    new MemoryRepository<SFProject>(
-                        new[]
+                        new SFProject { Id = Project02 },
+                        new SFProject
                         {
-                            new SFProject
-                            {
-                                Id = Project01,
-                                UserRoles = new Dictionary<string, string> { { User01, SFProjectRole.Administrator } },
-                            },
-                            new SFProject { Id = Project02 },
-                            new SFProject
-                            {
-                                Id = Project03,
-                                UserRoles = new Dictionary<string, string> { { User01, SFProjectRole.Translator } },
-                            },
-                        }
-                    )
-                );
+                            Id = Project03,
+                            UserRoles = new Dictionary<string, string> { { User01, SFProjectRole.Translator } },
+                        },
+                    }
+                )
+            );
 
-                Service = new MachineApiService(
-                    Builds,
-                    Engines,
-                    engineOptions,
-                    EngineService,
-                    ExceptionHandler,
-                    FeatureManager,
-                    MachineBuildService,
-                    MachineProjectService,
-                    MachineTranslationService,
-                    projectSecrets,
-                    realtimeService
-                );
-            }
-
-            public IBuildRepository Builds { get; }
-            public IEngineRepository Engines { get; }
-            public IEngineService EngineService { get; }
-            public IExceptionHandler ExceptionHandler { get; }
-            public IFeatureManager FeatureManager { get; }
-            public IMachineBuildService MachineBuildService { get; }
-            public IMachineProjectService MachineProjectService { get; }
-            public IMachineTranslationService MachineTranslationService { get; }
-            public MachineApiService Service { get; }
+            Service = new MachineApiService(
+                Builds,
+                Engines,
+                engineOptions,
+                EngineService,
+                ExceptionHandler,
+                FeatureManager,
+                MachineBuildService,
+                MachineProjectService,
+                MachineTranslationService,
+                projectSecrets,
+                realtimeService
+            );
         }
+
+        public IBuildRepository Builds { get; }
+        public IEngineRepository Engines { get; }
+        public IEngineService EngineService { get; }
+        public IExceptionHandler ExceptionHandler { get; }
+        public IFeatureManager FeatureManager { get; }
+        public IMachineBuildService MachineBuildService { get; }
+        public IMachineProjectService MachineProjectService { get; }
+        public IMachineTranslationService MachineTranslationService { get; }
+        public MachineApiService Service { get; }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineBuildServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineBuildServiceTests.cs
@@ -8,59 +8,59 @@ using NUnit.Framework;
 using SIL.Machine.WebApi;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class MachineBuildServiceTests
 {
-    [TestFixture]
-    public class MachineBuildServiceTests
+    private const string Build01 = "build01";
+    private const string TranslationEngine01 = "translationEngine01";
+
+    [Test]
+    public async Task CancelCurrentBuildAsync_Success()
     {
-        private const string Build01 = "build01";
-        private const string TranslationEngine01 = "translationEngine01";
+        // Set up a mock Machine API
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-        [Test]
-        public async Task CancelCurrentBuildAsync_Success()
-        {
-            // Set up a mock Machine API
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // SUT
+        await env.Service.CancelCurrentBuildAsync(TranslationEngine01, CancellationToken.None);
 
-            // SUT
-            await env.Service.CancelCurrentBuildAsync(TranslationEngine01, CancellationToken.None);
+        Assert.AreEqual(1, handler.NumberOfCalls);
+    }
 
-            Assert.AreEqual(1, handler.NumberOfCalls);
-        }
+    [Test]
+    public void CancelCurrentBuildAsync_NoPermission()
+    {
+        // Set up a mock Machine API
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-        [Test]
-        public void CancelCurrentBuildAsync_NoPermission()
-        {
-            // Set up a mock Machine API
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // SUT
+        Assert.ThrowsAsync<HttpRequestException>(
+            () => env.Service.CancelCurrentBuildAsync(TranslationEngine01, CancellationToken.None)
+        );
+    }
 
-            // SUT
-            Assert.ThrowsAsync<HttpRequestException>(
-                () => env.Service.CancelCurrentBuildAsync(TranslationEngine01, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public async Task GetBuildAsync_Success()
-        {
-            // Set up a mock Machine API
-            string state = "Active";
-            string message = "Finalizing";
-            int revision = 553;
-            double percentCompleted = 0.95;
-            string href = $"/translation-engines/{TranslationEngine01}/builds/{Build01}";
-            string response =
-                @$"{{
+    [Test]
+    public async Task GetBuildAsync_Success()
+    {
+        // Set up a mock Machine API
+        string state = "Active";
+        string message = "Finalizing";
+        int revision = 553;
+        double percentCompleted = 0.95;
+        string href = $"/translation-engines/{TranslationEngine01}/builds/{Build01}";
+        string response =
+            @$"{{
                     ""revision"": {revision},
                     ""parent"": {{
                         ""id"": ""{TranslationEngine01}"",
@@ -73,42 +73,42 @@ namespace SIL.XForge.Scripture.Services
                     ""id"": ""{Build01}"",
                     ""href"": ""{href}""
                     }}";
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            BuildDto? actual = await env.Service.GetBuildAsync(
-                TranslationEngine01,
-                Build01,
-                minRevision: null,
-                CancellationToken.None
-            );
+        // SUT
+        BuildDto? actual = await env.Service.GetBuildAsync(
+            TranslationEngine01,
+            Build01,
+            minRevision: null,
+            CancellationToken.None
+        );
 
-            Assert.NotNull(actual);
-            Assert.AreEqual(Build01, actual.Id);
-            Assert.AreEqual(href, actual.Href);
-            Assert.AreEqual(percentCompleted, actual.PercentCompleted);
-            Assert.AreEqual(message, actual.Message);
-            Assert.AreEqual(revision, actual.Revision);
-            Assert.AreEqual(state.ToUpperInvariant(), actual.State);
-            Assert.AreEqual(1, handler.NumberOfCalls);
-        }
+        Assert.NotNull(actual);
+        Assert.AreEqual(Build01, actual.Id);
+        Assert.AreEqual(href, actual.Href);
+        Assert.AreEqual(percentCompleted, actual.PercentCompleted);
+        Assert.AreEqual(message, actual.Message);
+        Assert.AreEqual(revision, actual.Revision);
+        Assert.AreEqual(state.ToUpperInvariant(), actual.State);
+        Assert.AreEqual(1, handler.NumberOfCalls);
+    }
 
-        [Test]
-        public async Task GetBuildAsync_MinRevision()
-        {
-            // Set up a mock Machine API
-            int minRevision = 553;
-            string state = "Active";
-            string message = "Finalizing";
-            int revision = minRevision + 1;
-            double percentCompleted = 0.95;
-            string href = $"/translation-engines/{TranslationEngine01}/builds/{Build01}";
-            string response =
-                @$"{{
+    [Test]
+    public async Task GetBuildAsync_MinRevision()
+    {
+        // Set up a mock Machine API
+        int minRevision = 553;
+        string state = "Active";
+        string message = "Finalizing";
+        int revision = minRevision + 1;
+        double percentCompleted = 0.95;
+        string href = $"/translation-engines/{TranslationEngine01}/builds/{Build01}";
+        string response =
+            @$"{{
                     ""revision"": {revision},
                     ""parent"": {{
                         ""id"": ""{TranslationEngine01}"",
@@ -121,100 +121,100 @@ namespace SIL.XForge.Scripture.Services
                     ""id"": ""{Build01}"",
                     ""href"": ""{href}""
                     }}";
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            BuildDto? actual = await env.Service.GetBuildAsync(
-                TranslationEngine01,
-                Build01,
-                minRevision,
-                CancellationToken.None
-            );
+        // SUT
+        BuildDto? actual = await env.Service.GetBuildAsync(
+            TranslationEngine01,
+            Build01,
+            minRevision,
+            CancellationToken.None
+        );
 
-            Assert.NotNull(actual);
-            Assert.AreEqual(Build01, actual.Id);
-            Assert.AreEqual(href, actual.Href);
-            Assert.AreEqual(percentCompleted, actual.PercentCompleted);
-            Assert.AreEqual(message, actual.Message);
-            Assert.AreEqual(revision, actual.Revision);
-            Assert.AreEqual(state.ToUpperInvariant(), actual.State);
-            Assert.AreEqual(1, handler.NumberOfCalls);
-        }
+        Assert.NotNull(actual);
+        Assert.AreEqual(Build01, actual.Id);
+        Assert.AreEqual(href, actual.Href);
+        Assert.AreEqual(percentCompleted, actual.PercentCompleted);
+        Assert.AreEqual(message, actual.Message);
+        Assert.AreEqual(revision, actual.Revision);
+        Assert.AreEqual(state.ToUpperInvariant(), actual.State);
+        Assert.AreEqual(1, handler.NumberOfCalls);
+    }
 
-        [Test]
-        public void GetBuildAsync_BuildEnded()
-        {
-            // Set up a mock Machine API
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.NoContent);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+    [Test]
+    public void GetBuildAsync_BuildEnded()
+    {
+        // Set up a mock Machine API
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.NoContent);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.GetBuildAsync(TranslationEngine01, Build01, minRevision: 0, CancellationToken.None)
-            );
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetBuildAsync(TranslationEngine01, Build01, minRevision: 0, CancellationToken.None)
+        );
 
-            Assert.AreEqual(1, handler.NumberOfCalls);
-        }
+        Assert.AreEqual(1, handler.NumberOfCalls);
+    }
 
-        [Test]
-        public async Task GetBuildAsync_NoBuildRunning()
-        {
-            // Set up a mock Machine API
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.RequestTimeout);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+    [Test]
+    public async Task GetBuildAsync_NoBuildRunning()
+    {
+        // Set up a mock Machine API
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.RequestTimeout);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            BuildDto? actual = await env.Service.GetBuildAsync(
-                TranslationEngine01,
-                Build01,
-                minRevision: 0,
-                CancellationToken.None
-            );
+        // SUT
+        BuildDto? actual = await env.Service.GetBuildAsync(
+            TranslationEngine01,
+            Build01,
+            minRevision: 0,
+            CancellationToken.None
+        );
 
-            Assert.Null(actual);
-            Assert.AreEqual(1, handler.NumberOfCalls);
-        }
+        Assert.Null(actual);
+        Assert.AreEqual(1, handler.NumberOfCalls);
+    }
 
-        [Test]
-        public void GetBuildAsync_NoPermission()
-        {
-            // Set up a mock Machine API
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+    [Test]
+    public void GetBuildAsync_NoPermission()
+    {
+        // Set up a mock Machine API
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            Assert.ThrowsAsync<HttpRequestException>(
-                () => env.Service.GetBuildAsync(TranslationEngine01, Build01, null, CancellationToken.None)
-            );
-        }
+        // SUT
+        Assert.ThrowsAsync<HttpRequestException>(
+            () => env.Service.GetBuildAsync(TranslationEngine01, Build01, null, CancellationToken.None)
+        );
+    }
 
-        [Test]
-        public async Task GetCurrentBuildAsync_Success()
-        {
-            // Set up a mock Machine API
-            string state = "Active";
-            string message = "Finalizing";
-            int revision = 553;
-            double percentCompleted = 0.95;
-            string href = $"/translation-engines/{TranslationEngine01}/builds/{Build01}";
-            string response =
-                @$"{{
+    [Test]
+    public async Task GetCurrentBuildAsync_Success()
+    {
+        // Set up a mock Machine API
+        string state = "Active";
+        string message = "Finalizing";
+        int revision = 553;
+        double percentCompleted = 0.95;
+        string href = $"/translation-engines/{TranslationEngine01}/builds/{Build01}";
+        string response =
+            @$"{{
                     ""revision"": {revision},
                     ""parent"": {{
                         ""id"": ""{TranslationEngine01}"",
@@ -227,41 +227,41 @@ namespace SIL.XForge.Scripture.Services
                     ""id"": ""{Build01}"",
                     ""href"": ""{href}""
                     }}";
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            BuildDto? actual = await env.Service.GetCurrentBuildAsync(
-                TranslationEngine01,
-                minRevision: null,
-                CancellationToken.None
-            );
+        // SUT
+        BuildDto? actual = await env.Service.GetCurrentBuildAsync(
+            TranslationEngine01,
+            minRevision: null,
+            CancellationToken.None
+        );
 
-            Assert.NotNull(actual);
-            Assert.AreEqual(Build01, actual.Id);
-            Assert.AreEqual(href, actual.Href);
-            Assert.AreEqual(percentCompleted, actual.PercentCompleted);
-            Assert.AreEqual(message, actual.Message);
-            Assert.AreEqual(revision, actual.Revision);
-            Assert.AreEqual(state.ToUpperInvariant(), actual.State);
-            Assert.AreEqual(1, handler.NumberOfCalls);
-        }
+        Assert.NotNull(actual);
+        Assert.AreEqual(Build01, actual.Id);
+        Assert.AreEqual(href, actual.Href);
+        Assert.AreEqual(percentCompleted, actual.PercentCompleted);
+        Assert.AreEqual(message, actual.Message);
+        Assert.AreEqual(revision, actual.Revision);
+        Assert.AreEqual(state.ToUpperInvariant(), actual.State);
+        Assert.AreEqual(1, handler.NumberOfCalls);
+    }
 
-        [Test]
-        public async Task GetCurrentBuildAsync_MinRevision()
-        {
-            // Set up a mock Machine API
-            int minRevision = 553;
-            string state = "Active";
-            string message = "Finalizing";
-            int revision = minRevision + 1;
-            double percentCompleted = 0.95;
-            string href = $"/translation-engines/{TranslationEngine01}/builds/{Build01}";
-            string response =
-                @$"{{
+    [Test]
+    public async Task GetCurrentBuildAsync_MinRevision()
+    {
+        // Set up a mock Machine API
+        int minRevision = 553;
+        string state = "Active";
+        string message = "Finalizing";
+        int revision = minRevision + 1;
+        double percentCompleted = 0.95;
+        string href = $"/translation-engines/{TranslationEngine01}/builds/{Build01}";
+        string response =
+            @$"{{
                     ""revision"": {revision},
                     ""parent"": {{
                         ""id"": ""{TranslationEngine01}"",
@@ -274,96 +274,96 @@ namespace SIL.XForge.Scripture.Services
                     ""id"": ""{Build01}"",
                     ""href"": ""{href}""
                     }}";
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            BuildDto? actual = await env.Service.GetCurrentBuildAsync(
-                TranslationEngine01,
-                minRevision,
-                CancellationToken.None
-            );
+        // SUT
+        BuildDto? actual = await env.Service.GetCurrentBuildAsync(
+            TranslationEngine01,
+            minRevision,
+            CancellationToken.None
+        );
 
-            Assert.NotNull(actual);
-            Assert.AreEqual(Build01, actual.Id);
-            Assert.AreEqual(href, actual.Href);
-            Assert.AreEqual(percentCompleted, actual.PercentCompleted);
-            Assert.AreEqual(message, actual.Message);
-            Assert.AreEqual(revision, actual.Revision);
-            Assert.AreEqual(state.ToUpperInvariant(), actual.State);
-            Assert.AreEqual(1, handler.NumberOfCalls);
-        }
+        Assert.NotNull(actual);
+        Assert.AreEqual(Build01, actual.Id);
+        Assert.AreEqual(href, actual.Href);
+        Assert.AreEqual(percentCompleted, actual.PercentCompleted);
+        Assert.AreEqual(message, actual.Message);
+        Assert.AreEqual(revision, actual.Revision);
+        Assert.AreEqual(state.ToUpperInvariant(), actual.State);
+        Assert.AreEqual(1, handler.NumberOfCalls);
+    }
 
-        [Test]
-        public void GetCurrentBuildAsync_BuildEnded()
-        {
-            // Set up a mock Machine API
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.NoContent);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+    [Test]
+    public void GetCurrentBuildAsync_BuildEnded()
+    {
+        // Set up a mock Machine API
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.NoContent);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.GetCurrentBuildAsync(TranslationEngine01, minRevision: 0, CancellationToken.None)
-            );
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetCurrentBuildAsync(TranslationEngine01, minRevision: 0, CancellationToken.None)
+        );
 
-            Assert.AreEqual(1, handler.NumberOfCalls);
-        }
+        Assert.AreEqual(1, handler.NumberOfCalls);
+    }
 
-        [Test]
-        public async Task GetCurrentBuildAsync_NoBuildRunning()
-        {
-            // Set up a mock Machine API
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.RequestTimeout);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+    [Test]
+    public async Task GetCurrentBuildAsync_NoBuildRunning()
+    {
+        // Set up a mock Machine API
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.RequestTimeout);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            BuildDto? actual = await env.Service.GetCurrentBuildAsync(
-                TranslationEngine01,
-                minRevision: 0,
-                CancellationToken.None
-            );
+        // SUT
+        BuildDto? actual = await env.Service.GetCurrentBuildAsync(
+            TranslationEngine01,
+            minRevision: 0,
+            CancellationToken.None
+        );
 
-            Assert.Null(actual);
-            Assert.AreEqual(1, handler.NumberOfCalls);
-        }
+        Assert.Null(actual);
+        Assert.AreEqual(1, handler.NumberOfCalls);
+    }
 
-        [Test]
-        public void GetCurrentBuildAsync_NoPermission()
-        {
-            // Set up a mock Machine API
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+    [Test]
+    public void GetCurrentBuildAsync_NoPermission()
+    {
+        // Set up a mock Machine API
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            Assert.ThrowsAsync<HttpRequestException>(
-                () => env.Service.GetCurrentBuildAsync(TranslationEngine01, null, CancellationToken.None)
-            );
-        }
+        // SUT
+        Assert.ThrowsAsync<HttpRequestException>(
+            () => env.Service.GetCurrentBuildAsync(TranslationEngine01, null, CancellationToken.None)
+        );
+    }
 
-        [Test]
-        public async Task StartBuildAsync_Success()
-        {
-            // Set up a mock Machine API
-            string state = "Pending";
-            int revision = 2;
-            string href = $"/translation-engines/{TranslationEngine01}/builds/{Build01}";
-            string response =
-                @$"{{
+    [Test]
+    public async Task StartBuildAsync_Success()
+    {
+        // Set up a mock Machine API
+        string state = "Pending";
+        int revision = 2;
+        string href = $"/translation-engines/{TranslationEngine01}/builds/{Build01}";
+        string response =
+            @$"{{
                     ""revision"": {revision},
                     ""parent"": {{
                         ""id"": ""{TranslationEngine01}"",
@@ -374,56 +374,55 @@ namespace SIL.XForge.Scripture.Services
                     ""id"": ""{Build01}"",
                     ""href"": ""{href}""
                     }}";
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            BuildDto actual = await env.Service.StartBuildAsync(TranslationEngine01, CancellationToken.None);
+        // SUT
+        BuildDto actual = await env.Service.StartBuildAsync(TranslationEngine01, CancellationToken.None);
 
-            Assert.AreEqual(Build01, actual.Id);
-            Assert.AreEqual(href, actual.Href);
-            Assert.Zero(actual.PercentCompleted);
-            Assert.Null(actual.Message);
-            Assert.AreEqual(revision, actual.Revision);
-            Assert.AreEqual(state.ToUpperInvariant(), actual.State);
-            Assert.AreEqual(1, handler.NumberOfCalls);
-        }
+        Assert.AreEqual(Build01, actual.Id);
+        Assert.AreEqual(href, actual.Href);
+        Assert.Zero(actual.PercentCompleted);
+        Assert.Null(actual.Message);
+        Assert.AreEqual(revision, actual.Revision);
+        Assert.AreEqual(state.ToUpperInvariant(), actual.State);
+        Assert.AreEqual(1, handler.NumberOfCalls);
+    }
 
-        [Test]
-        public void StartBuildAsync_NoPermission()
+    [Test]
+    public void StartBuildAsync_NoPermission()
+    {
+        // Set up a mock Machine API
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
+
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
+
+        // SUT
+        Assert.ThrowsAsync<HttpRequestException>(
+            () => env.Service.StartBuildAsync(TranslationEngine01, CancellationToken.None)
+        );
+    }
+
+    private class TestEnvironment
+    {
+        public TestEnvironment(HttpClient? httpClient = default)
         {
-            // Set up a mock Machine API
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+            var exceptionHandler = new MockExceptionHandler();
+            var httpClientFactory = Substitute.For<IHttpClientFactory>();
+            httpClientFactory.CreateClient(Arg.Any<string>()).Returns(httpClient);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
-
-            // SUT
-            Assert.ThrowsAsync<HttpRequestException>(
-                () => env.Service.StartBuildAsync(TranslationEngine01, CancellationToken.None)
-            );
+            Service = new MachineBuildService(exceptionHandler, httpClientFactory);
         }
 
-        private class TestEnvironment
-        {
-            public TestEnvironment(HttpClient? httpClient = default)
-            {
-                var exceptionHandler = new MockExceptionHandler();
-                var httpClientFactory = Substitute.For<IHttpClientFactory>();
-                httpClientFactory.CreateClient(Arg.Any<string>()).Returns(httpClient);
+        public MachineBuildService Service { get; }
 
-                Service = new MachineBuildService(exceptionHandler, httpClientFactory);
-            }
-
-            public MachineBuildService Service { get; }
-
-            public static HttpClient CreateHttpClient(HttpMessageHandler handler) =>
-                new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
-        }
+        public static HttpClient CreateHttpClient(HttpMessageHandler handler) =>
+            new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineCorporaServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineCorporaServiceTests.cs
@@ -12,46 +12,46 @@ using NUnit.Framework;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class MachineCorporaServiceTests
 {
-    [TestFixture]
-    public class MachineCorporaServiceTests
+    private const string Project01 = "project01";
+
+    [Test]
+    public void AddCorpusToTranslationEngineAsync_Invalid()
     {
-        private const string Project01 = "project01";
+        // Set up a mock Machine API
+        string translationEngineId = "63372e670935fe633f927c85";
+        string corpusId = "633fdb281a2e7ac760f7193a";
+        string response = "{}";
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-        [Test]
-        public void AddCorpusToTranslationEngineAsync_Invalid()
-        {
-            // Set up a mock Machine API
-            string translationEngineId = "63372e670935fe633f927c85";
-            string corpusId = "633fdb281a2e7ac760f7193a";
-            string response = "{}";
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // SUT
+        Assert.ThrowsAsync<HttpRequestException>(
+            () =>
+                env.Service.AddCorpusToTranslationEngineAsync(
+                    translationEngineId,
+                    corpusId,
+                    false,
+                    CancellationToken.None
+                )
+        );
+    }
 
-            // SUT
-            Assert.ThrowsAsync<HttpRequestException>(
-                () =>
-                    env.Service.AddCorpusToTranslationEngineAsync(
-                        translationEngineId,
-                        corpusId,
-                        false,
-                        CancellationToken.None
-                    )
-            );
-        }
-
-        [Test]
-        public async Task AddCorpusToTranslationEngineAsync_Success()
-        {
-            // Set up a mock Machine API
-            string translationEngineId = "63372e670935fe633f927c85";
-            string corpusId = "633fdb281a2e7ac760f7193a";
-            string response =
-                @$"{{
+    [Test]
+    public async Task AddCorpusToTranslationEngineAsync_Success()
+    {
+        // Set up a mock Machine API
+        string translationEngineId = "63372e670935fe633f927c85";
+        string corpusId = "633fdb281a2e7ac760f7193a";
+        string response =
+            @$"{{
                   ""href"": ""/translation-engines/{translationEngineId}/corpora/{corpusId}"",
                   ""corpus"": {{
                     ""id"": ""{corpusId}"",
@@ -59,122 +59,120 @@ namespace SIL.XForge.Scripture.Services
                   }},
                   ""pretranslate"": false
                 }}";
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            await env.Service.AddCorpusToTranslationEngineAsync(
-                translationEngineId,
-                corpusId,
-                false,
-                CancellationToken.None
-            );
-            Assert.AreEqual(1, handler.NumberOfCalls);
-        }
+        // SUT
+        await env.Service.AddCorpusToTranslationEngineAsync(
+            translationEngineId,
+            corpusId,
+            false,
+            CancellationToken.None
+        );
+        Assert.AreEqual(1, handler.NumberOfCalls);
+    }
 
-        [Test]
-        public async Task CreateCorpusAsync_Success()
-        {
-            // Set up a mock Machine API
-            string corpusId = "633fdb281a2e7ac760f7193a";
-            string response = $"{{\"id\": \"{corpusId}\",\"href\":\"/corpora/{corpusId}\"}}";
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+    [Test]
+    public async Task CreateCorpusAsync_Success()
+    {
+        // Set up a mock Machine API
+        string corpusId = "633fdb281a2e7ac760f7193a";
+        string response = $"{{\"id\": \"{corpusId}\",\"href\":\"/corpora/{corpusId}\"}}";
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            string actual = await env.Service.CreateCorpusAsync(Project01, false, CancellationToken.None);
-            Assert.AreEqual(corpusId, actual);
-            Assert.AreEqual(1, handler.NumberOfCalls);
-        }
+        // SUT
+        string actual = await env.Service.CreateCorpusAsync(Project01, false, CancellationToken.None);
+        Assert.AreEqual(corpusId, actual);
+        Assert.AreEqual(1, handler.NumberOfCalls);
+    }
 
-        [Test]
-        public void DeleteCorpusAsync_NoPermission()
-        {
-            // Set up a mock Machine API
-            string corpusId = "633fdb281a2e7ac760f7193a";
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+    [Test]
+    public void DeleteCorpusAsync_NoPermission()
+    {
+        // Set up a mock Machine API
+        string corpusId = "633fdb281a2e7ac760f7193a";
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            Assert.ThrowsAsync<HttpRequestException>(
-                () => env.Service.DeleteCorpusAsync(corpusId, CancellationToken.None)
-            );
-        }
+        // SUT
+        Assert.ThrowsAsync<HttpRequestException>(() => env.Service.DeleteCorpusAsync(corpusId, CancellationToken.None));
+    }
 
-        [Test]
-        public async Task DeleteCorpusAsync_Success()
-        {
-            // Set up a mock Machine API
-            string corpusId = "633fdb281a2e7ac760f7193a";
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+    [Test]
+    public async Task DeleteCorpusAsync_Success()
+    {
+        // Set up a mock Machine API
+        string corpusId = "633fdb281a2e7ac760f7193a";
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            await env.Service.DeleteCorpusAsync(corpusId, CancellationToken.None);
-        }
+        // SUT
+        await env.Service.DeleteCorpusAsync(corpusId, CancellationToken.None);
+    }
 
-        [Test]
-        public void DeleteCorpusFileAsync_NoPermission()
-        {
-            // Set up a mock Machine API
-            string corpusId = "633fdb281a2e7ac760f7193a";
-            string fileId = "634089bd1706669dc1acf6a4";
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+    [Test]
+    public void DeleteCorpusFileAsync_NoPermission()
+    {
+        // Set up a mock Machine API
+        string corpusId = "633fdb281a2e7ac760f7193a";
+        string fileId = "634089bd1706669dc1acf6a4";
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            Assert.ThrowsAsync<HttpRequestException>(
-                () => env.Service.DeleteCorpusFileAsync(corpusId, fileId, CancellationToken.None)
-            );
-        }
+        // SUT
+        Assert.ThrowsAsync<HttpRequestException>(
+            () => env.Service.DeleteCorpusFileAsync(corpusId, fileId, CancellationToken.None)
+        );
+    }
 
-        [Test]
-        public async Task DeleteCorpusFileAsync_Success()
-        {
-            // Set up a mock Machine API
-            string corpusId = "633fdb281a2e7ac760f7193a";
-            string fileId = "634089bd1706669dc1acf6a4";
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+    [Test]
+    public async Task DeleteCorpusFileAsync_Success()
+    {
+        // Set up a mock Machine API
+        string corpusId = "633fdb281a2e7ac760f7193a";
+        string fileId = "634089bd1706669dc1acf6a4";
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            await env.Service.DeleteCorpusFileAsync(corpusId, fileId, CancellationToken.None);
-        }
+        // SUT
+        await env.Service.DeleteCorpusFileAsync(corpusId, fileId, CancellationToken.None);
+    }
 
-        [Test]
-        public async Task GetCorpusFilesAsync_Success()
-        {
-            // Set up a mock Machine API
-            string fileId = "634089bd1706669dc1acf6a4";
-            string corpusId = "633fdb281a2e7ac760f7193a";
-            string href = $"/corpora/{corpusId}/files/{fileId}";
-            string languageTag = "en";
-            string name = "test.txt";
-            string textId = "test1";
-            string response =
-                @$"[
+    [Test]
+    public async Task GetCorpusFilesAsync_Success()
+    {
+        // Set up a mock Machine API
+        string fileId = "634089bd1706669dc1acf6a4";
+        string corpusId = "633fdb281a2e7ac760f7193a";
+        string href = $"/corpora/{corpusId}/files/{fileId}";
+        string languageTag = "en";
+        string name = "test.txt";
+        string textId = "test1";
+        string response =
+            @$"[
                     {{
                         ""languageTag"": ""{languageTag}"",
                         ""name"": ""{name}"",
@@ -183,102 +181,98 @@ namespace SIL.XForge.Scripture.Services
                         ""href"": ""{href}""
                     }}
                 ]";
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            List<MachineApiCorpusFile> actual = (
-                await env.Service.GetCorpusFilesAsync(corpusId, CancellationToken.None)
-            ).ToList();
-            Assert.AreEqual(1, actual.Count);
-            Assert.AreEqual(fileId, actual.First().Id);
-            Assert.AreEqual(href, actual.First().Href);
-            Assert.AreEqual(languageTag, actual.First().LanguageTag);
-            Assert.AreEqual(name, actual.First().Name);
-            Assert.AreEqual(textId, actual.First().TextId);
-            Assert.IsNull(actual.First().Corpus);
-            Assert.AreEqual(1, handler.NumberOfCalls);
-        }
+        // SUT
+        List<MachineApiCorpusFile> actual = (
+            await env.Service.GetCorpusFilesAsync(corpusId, CancellationToken.None)
+        ).ToList();
+        Assert.AreEqual(1, actual.Count);
+        Assert.AreEqual(fileId, actual.First().Id);
+        Assert.AreEqual(href, actual.First().Href);
+        Assert.AreEqual(languageTag, actual.First().LanguageTag);
+        Assert.AreEqual(name, actual.First().Name);
+        Assert.AreEqual(textId, actual.First().TextId);
+        Assert.IsNull(actual.First().Corpus);
+        Assert.AreEqual(1, handler.NumberOfCalls);
+    }
 
-        [Test]
-        public async Task GetCorpusFilesAsync_NoFiles()
-        {
-            // Set up a mock Machine API
-            string corpusId = "633fdb281a2e7ac760f7193a";
-            string response = "[]";
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+    [Test]
+    public async Task GetCorpusFilesAsync_NoFiles()
+    {
+        // Set up a mock Machine API
+        string corpusId = "633fdb281a2e7ac760f7193a";
+        string response = "[]";
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            IEnumerable<MachineApiCorpusFile> actual = await env.Service.GetCorpusFilesAsync(
-                corpusId,
-                CancellationToken.None
-            );
-            Assert.Zero(actual.Count());
-        }
+        // SUT
+        IEnumerable<MachineApiCorpusFile> actual = await env.Service.GetCorpusFilesAsync(
+            corpusId,
+            CancellationToken.None
+        );
+        Assert.Zero(actual.Count());
+    }
 
-        [Test]
-        public void RemoveCorpusFromTranslationEngineAsync_NoPermission()
-        {
-            // Set up a mock Machine API
-            string translationEngineId = "63372e670935fe633f927c85";
-            string corpusId = "633fdb281a2e7ac760f7193a";
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+    [Test]
+    public void RemoveCorpusFromTranslationEngineAsync_NoPermission()
+    {
+        // Set up a mock Machine API
+        string translationEngineId = "63372e670935fe633f927c85";
+        string corpusId = "633fdb281a2e7ac760f7193a";
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            Assert.ThrowsAsync<HttpRequestException>(
-                () =>
-                    env.Service.RemoveCorpusFromTranslationEngineAsync(
-                        translationEngineId,
-                        corpusId,
-                        CancellationToken.None
-                    )
-            );
-        }
+        // SUT
+        Assert.ThrowsAsync<HttpRequestException>(
+            () =>
+                env.Service.RemoveCorpusFromTranslationEngineAsync(
+                    translationEngineId,
+                    corpusId,
+                    CancellationToken.None
+                )
+        );
+    }
 
-        [Test]
-        public async Task RemoveCorpusFromTranslationEngineAsync_Success()
-        {
-            // Set up a mock Machine API
-            string translationEngineId = "63372e670935fe633f927c85";
-            string corpusId = "633fdb281a2e7ac760f7193a";
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+    [Test]
+    public async Task RemoveCorpusFromTranslationEngineAsync_Success()
+    {
+        // Set up a mock Machine API
+        string translationEngineId = "63372e670935fe633f927c85";
+        string corpusId = "633fdb281a2e7ac760f7193a";
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            await env.Service.RemoveCorpusFromTranslationEngineAsync(
-                translationEngineId,
-                corpusId,
-                CancellationToken.None
-            );
-        }
+        // SUT
+        await env.Service.RemoveCorpusFromTranslationEngineAsync(translationEngineId, corpusId, CancellationToken.None);
+    }
 
-        [Test]
-        public async Task UploadCorpusTextAsync_Success()
-        {
-            // Set up a mock Machine API
-            string fileId = "634089bd1706669dc1acf6a4";
-            string corpusId = "633fdb281a2e7ac760f7193a";
-            string languageTag = "en";
-            string textId = "test1";
-            string name = "my_project";
-            string response =
-                @$"{{
+    [Test]
+    public async Task UploadCorpusTextAsync_Success()
+    {
+        // Set up a mock Machine API
+        string fileId = "634089bd1706669dc1acf6a4";
+        string corpusId = "633fdb281a2e7ac760f7193a";
+        string languageTag = "en";
+        string textId = "test1";
+        string name = "my_project";
+        string response =
+            @$"{{
                     ""id"": ""{fileId}"",
                     ""href"": ""/corpora/{corpusId}/files/{fileId}"",
                     ""corpus"": {{
@@ -289,49 +283,49 @@ namespace SIL.XForge.Scripture.Services
                     ""name"": ""{name}"",
                     ""textId"": ""{textId}""
                 }}";
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
-            string text = "1-1\tLine 1\r\n1-2\tLine 2\tsr";
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
+        string text = "1-1\tLine 1\r\n1-2\tLine 2\tsr";
 
-            // SUT
-            string actual = await env.Service.UploadCorpusTextAsync(
-                corpusId,
-                languageTag,
-                textId,
-                text,
-                CancellationToken.None
-            );
-            Assert.AreEqual(fileId, actual);
-            Assert.AreEqual(1, handler.NumberOfCalls);
-        }
+        // SUT
+        string actual = await env.Service.UploadCorpusTextAsync(
+            corpusId,
+            languageTag,
+            textId,
+            text,
+            CancellationToken.None
+        );
+        Assert.AreEqual(fileId, actual);
+        Assert.AreEqual(1, handler.NumberOfCalls);
+    }
 
-        [Test]
-        public void UploadParatextCorpusAsync_DirectoryNotFound()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            string corpusId = "633fdb281a2e7ac760f7193a";
-            env.FileSystemService.DirectoryExists(Arg.Any<string>()).Returns(false);
+    [Test]
+    public void UploadParatextCorpusAsync_DirectoryNotFound()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        string corpusId = "633fdb281a2e7ac760f7193a";
+        env.FileSystemService.DirectoryExists(Arg.Any<string>()).Returns(false);
 
-            // SUT
-            Assert.ThrowsAsync<DirectoryNotFoundException>(
-                () => env.Service.UploadParatextCorpusAsync(corpusId, "en", "an_invalid_path", CancellationToken.None)
-            );
-        }
+        // SUT
+        Assert.ThrowsAsync<DirectoryNotFoundException>(
+            () => env.Service.UploadParatextCorpusAsync(corpusId, "en", "an_invalid_path", CancellationToken.None)
+        );
+    }
 
-        [Test]
-        public async Task UploadParatextCorpusAsync_Success()
-        {
-            // Set up a mock Machine API
-            string fileId = "634089bd1706669dc1acf6a4";
-            string corpusId = "633fdb281a2e7ac760f7193a";
-            string languageTag = "en";
-            string name = "my_project";
-            string response =
-                @$"{{
+    [Test]
+    public async Task UploadParatextCorpusAsync_Success()
+    {
+        // Set up a mock Machine API
+        string fileId = "634089bd1706669dc1acf6a4";
+        string corpusId = "633fdb281a2e7ac760f7193a";
+        string languageTag = "en";
+        string name = "my_project";
+        string response =
+            @$"{{
                     ""id"": ""{fileId}"",
                     ""href"": ""/corpora/{corpusId}/files/{fileId}"",
                     ""corpus"": {{
@@ -341,48 +335,47 @@ namespace SIL.XForge.Scripture.Services
                     ""languageTag"": ""{languageTag}"",
                     ""name"": ""{name}""
                 }}";
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
-            string fileName = "sample.txt";
-            string path = Path.Combine("a_valid_path", name);
-            string filePath = Path.Combine(path, fileName);
-            env.FileSystemService.DirectoryExists(path).Returns(true);
-            env.FileSystemService.EnumerateFiles(path).Returns(new[] { filePath });
-            env.FileSystemService
-                .OpenFile(filePath, FileMode.Open)
-                .Returns(new MemoryStream(Encoding.UTF8.GetBytes("file_contents")));
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
+        string fileName = "sample.txt";
+        string path = Path.Combine("a_valid_path", name);
+        string filePath = Path.Combine(path, fileName);
+        env.FileSystemService.DirectoryExists(path).Returns(true);
+        env.FileSystemService.EnumerateFiles(path).Returns(new[] { filePath });
+        env.FileSystemService
+            .OpenFile(filePath, FileMode.Open)
+            .Returns(new MemoryStream(Encoding.UTF8.GetBytes("file_contents")));
 
-            // SUT
-            string actual = await env.Service.UploadParatextCorpusAsync(
-                corpusId,
-                languageTag,
-                path,
-                CancellationToken.None
-            );
-            Assert.AreEqual(fileId, actual);
-            Assert.AreEqual(1, handler.NumberOfCalls);
-        }
+        // SUT
+        string actual = await env.Service.UploadParatextCorpusAsync(
+            corpusId,
+            languageTag,
+            path,
+            CancellationToken.None
+        );
+        Assert.AreEqual(fileId, actual);
+        Assert.AreEqual(1, handler.NumberOfCalls);
+    }
 
-        private class TestEnvironment
+    private class TestEnvironment
+    {
+        public TestEnvironment(HttpClient? httpClient = default)
         {
-            public TestEnvironment(HttpClient? httpClient = default)
-            {
-                var exceptionHandler = new MockExceptionHandler();
-                FileSystemService = Substitute.For<IFileSystemService>();
-                var httpClientFactory = Substitute.For<IHttpClientFactory>();
-                httpClientFactory.CreateClient(Arg.Any<string>()).Returns(httpClient);
+            var exceptionHandler = new MockExceptionHandler();
+            FileSystemService = Substitute.For<IFileSystemService>();
+            var httpClientFactory = Substitute.For<IHttpClientFactory>();
+            httpClientFactory.CreateClient(Arg.Any<string>()).Returns(httpClient);
 
-                Service = new MachineCorporaService(exceptionHandler, FileSystemService, httpClientFactory);
-            }
-
-            public IFileSystemService FileSystemService { get; }
-            public MachineCorporaService Service { get; }
-
-            public static HttpClient CreateHttpClient(HttpMessageHandler handler) =>
-                new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+            Service = new MachineCorporaService(exceptionHandler, FileSystemService, httpClientFactory);
         }
+
+        public IFileSystemService FileSystemService { get; }
+        public MachineCorporaService Service { get; }
+
+        public static HttpClient CreateHttpClient(HttpMessageHandler handler) =>
+            new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineTranslationServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineTranslationServiceTests.cs
@@ -9,101 +9,101 @@ using NUnit.Framework;
 using SIL.Machine.WebApi;
 using SIL.XForge.Scripture.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class MachineTranslationServiceTests
 {
-    [TestFixture]
-    public class MachineTranslationServiceTests
+    private const string TranslationEngine01 = "translationEngine01";
+
+    [Test]
+    public async Task CreateTranslationEngineAsync_Success()
     {
-        private const string TranslationEngine01 = "translationEngine01";
+        // Set up a mock Machine API
+        string response =
+            $"{{\"id\": \"{TranslationEngine01}\",\"href\":\"/translation-engines/{TranslationEngine01}\"}}";
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-        [Test]
-        public async Task CreateTranslationEngineAsync_Success()
-        {
-            // Set up a mock Machine API
-            string response =
-                $"{{\"id\": \"{TranslationEngine01}\",\"href\":\"/translation-engines/{TranslationEngine01}\"}}";
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // SUT
+        string actual = await env.Service.CreateTranslationEngineAsync(
+            "name",
+            "en",
+            "en",
+            true,
+            CancellationToken.None
+        );
 
-            // SUT
-            string actual = await env.Service.CreateTranslationEngineAsync(
-                "name",
-                "en",
-                "en",
-                true,
-                CancellationToken.None
-            );
+        Assert.AreEqual(TranslationEngine01, actual);
+        Assert.AreEqual(1, handler.NumberOfCalls);
+    }
 
-            Assert.AreEqual(TranslationEngine01, actual);
-            Assert.AreEqual(1, handler.NumberOfCalls);
-        }
+    [Test]
+    public void DeleteTranslationEngineAsync_NoPermission()
+    {
+        // Set up a mock Machine API
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-        [Test]
-        public void DeleteTranslationEngineAsync_NoPermission()
-        {
-            // Set up a mock Machine API
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // SUT
+        Assert.ThrowsAsync<HttpRequestException>(
+            () => env.Service.DeleteTranslationEngineAsync(TranslationEngine01, CancellationToken.None)
+        );
+    }
 
-            // SUT
-            Assert.ThrowsAsync<HttpRequestException>(
-                () => env.Service.DeleteTranslationEngineAsync(TranslationEngine01, CancellationToken.None)
-            );
-        }
+    [Test]
+    public async Task DeleteTranslationEngineAsync_Success()
+    {
+        // Set up a mock Machine API
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-        [Test]
-        public async Task DeleteTranslationEngineAsync_Success()
-        {
-            // Set up a mock Machine API
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // SUT
+        await env.Service.DeleteTranslationEngineAsync(TranslationEngine01, CancellationToken.None);
+    }
 
-            // SUT
-            await env.Service.DeleteTranslationEngineAsync(TranslationEngine01, CancellationToken.None);
-        }
+    [Test]
+    public void GetTranslationEngineAsync_NoPermission()
+    {
+        // Set up a mock Machine API
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-        [Test]
-        public void GetTranslationEngineAsync_NoPermission()
-        {
-            // Set up a mock Machine API
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // SUT
+        Assert.ThrowsAsync<HttpRequestException>(
+            () => env.Service.GetTranslationEngineAsync(TranslationEngine01, CancellationToken.None)
+        );
+    }
 
-            // SUT
-            Assert.ThrowsAsync<HttpRequestException>(
-                () => env.Service.GetTranslationEngineAsync(TranslationEngine01, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public async Task GetTranslationEngineAsync_Success()
-        {
-            // Set up a mock Machine API
-            string name = "my_translation_engine";
-            string sourceLanguageTag = "en_US";
-            string targetLanguageTag = "en_NZ";
-            string type = "SmtTransfer";
-            int modelRevision = 1;
-            int confidence = 100;
-            int corpusSize = 472;
-            string href = $"/translation-engines/{TranslationEngine01}";
-            string response =
-                $@"{{
+    [Test]
+    public async Task GetTranslationEngineAsync_Success()
+    {
+        // Set up a mock Machine API
+        string name = "my_translation_engine";
+        string sourceLanguageTag = "en_US";
+        string targetLanguageTag = "en_NZ";
+        string type = "SmtTransfer";
+        int modelRevision = 1;
+        int confidence = 100;
+        int corpusSize = 472;
+        string href = $"/translation-engines/{TranslationEngine01}";
+        string response =
+            $@"{{
                 ""name"": ""{name}"",
                 ""sourceLanguageTag"": ""{sourceLanguageTag}"",
                 ""targetLanguageTag"": ""{targetLanguageTag}"",
@@ -115,38 +115,38 @@ namespace SIL.XForge.Scripture.Services
                 ""id"": ""{TranslationEngine01}"",
                 ""href"": ""{href}""
             }}";
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            MachineApiTranslationEngine actual = await env.Service.GetTranslationEngineAsync(
-                TranslationEngine01,
-                CancellationToken.None
-            );
+        // SUT
+        MachineApiTranslationEngine actual = await env.Service.GetTranslationEngineAsync(
+            TranslationEngine01,
+            CancellationToken.None
+        );
 
-            Assert.AreEqual(1, handler.NumberOfCalls);
-            Assert.AreEqual(TranslationEngine01, actual.Id);
-            Assert.AreEqual(href, actual.Href);
-            Assert.AreEqual(name, actual.Name);
-            Assert.AreEqual(sourceLanguageTag, actual.SourceLanguageTag);
-            Assert.AreEqual(targetLanguageTag, actual.TargetLanguageTag);
-            Assert.AreEqual(type, actual.Type);
-            Assert.IsTrue(actual.IsBuilding);
-            Assert.AreEqual(modelRevision, actual.ModelRevision);
-            Assert.AreEqual(confidence, actual.Confidence);
-            Assert.AreEqual(corpusSize, actual.CorpusSize);
-        }
+        Assert.AreEqual(1, handler.NumberOfCalls);
+        Assert.AreEqual(TranslationEngine01, actual.Id);
+        Assert.AreEqual(href, actual.Href);
+        Assert.AreEqual(name, actual.Name);
+        Assert.AreEqual(sourceLanguageTag, actual.SourceLanguageTag);
+        Assert.AreEqual(targetLanguageTag, actual.TargetLanguageTag);
+        Assert.AreEqual(type, actual.Type);
+        Assert.IsTrue(actual.IsBuilding);
+        Assert.AreEqual(modelRevision, actual.ModelRevision);
+        Assert.AreEqual(confidence, actual.Confidence);
+        Assert.AreEqual(corpusSize, actual.CorpusSize);
+    }
 
-        [Test]
-        public async Task GetWordGraphAsync_Success()
-        {
-            // Set up a mock Machine API
-            var segment = new[] { "Test", "Data" };
-            string response =
-                $@"{{
+    [Test]
+    public async Task GetWordGraphAsync_Success()
+    {
+        // Set up a mock Machine API
+        var segment = new[] { "Test", "Data" };
+        string response =
+            $@"{{
                     ""initialStateScore"": -91.43696,
                     ""finalStates"": [
                     2
@@ -202,110 +202,106 @@ namespace SIL.XForge.Scripture.Services
                     }}
                     ]
                 }}";
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            WordGraphDto actual = await env.Service.GetWordGraphAsync(
-                TranslationEngine01,
-                segment,
-                CancellationToken.None
-            );
+        // SUT
+        WordGraphDto actual = await env.Service.GetWordGraphAsync(TranslationEngine01, segment, CancellationToken.None);
 
-            Assert.AreEqual(1, handler.NumberOfCalls);
-            Assert.AreEqual(segment.Length, actual.Arcs.Length);
-            Assert.AreEqual(segment.First().ToLower(), actual.Arcs.First().Words.First().ToLower());
-            Assert.AreEqual(segment.Last().ToLower(), actual.Arcs.Last().Words.First().ToLower());
-        }
+        Assert.AreEqual(1, handler.NumberOfCalls);
+        Assert.AreEqual(segment.Length, actual.Arcs.Length);
+        Assert.AreEqual(segment.First().ToLower(), actual.Arcs.First().Words.First().ToLower());
+        Assert.AreEqual(segment.Last().ToLower(), actual.Arcs.Last().Words.First().ToLower());
+    }
 
-        [Test]
-        public void GetWordGraphAsync_NoPermission()
+    [Test]
+    public void GetWordGraphAsync_NoPermission()
+    {
+        // Set up a mock Machine API
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
+
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
+        var segment = new[] { "Test", "Data" };
+
+        // SUT
+        Assert.ThrowsAsync<HttpRequestException>(
+            () => env.Service.GetWordGraphAsync(TranslationEngine01, segment, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void GetWordGraphAsync_InvalidId()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        var translationEngineId = "../../An-Injection-Attack?this=is~invalid!!";
+        var segment = new[] { "Test", "Data" };
+
+        // SUT
+        Assert.ThrowsAsync<ArgumentException>(
+            () => env.Service.GetWordGraphAsync(translationEngineId, segment, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public async Task TrainSegmentAsync_Success()
+    {
+        // Set up a mock Machine API
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
+
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
+        var segmentPairDto = new SegmentPairDto
         {
-            // Set up a mock Machine API
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+            SentenceStart = true,
+            SourceSegment = new[] { "Test", "Data" },
+            TargetSegment = new[] { "Test", "Data" },
+        };
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
-            var segment = new[] { "Test", "Data" };
+        // SUT
+        await env.Service.TrainSegmentAsync(TranslationEngine01, segmentPairDto, CancellationToken.None);
 
-            // SUT
-            Assert.ThrowsAsync<HttpRequestException>(
-                () => env.Service.GetWordGraphAsync(TranslationEngine01, segment, CancellationToken.None)
-            );
-        }
+        Assert.AreEqual(1, handler.NumberOfCalls);
+    }
 
-        [Test]
-        public void GetWordGraphAsync_InvalidId()
+    [Test]
+    public void TrainSegmentAsync_NoPermission()
+    {
+        // Set up a mock Machine API
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
+
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
+        var segmentPairDto = new SegmentPairDto
         {
-            // Set up test environment
-            var env = new TestEnvironment();
-            var translationEngineId = "../../An-Injection-Attack?this=is~invalid!!";
-            var segment = new[] { "Test", "Data" };
+            SentenceStart = true,
+            SourceSegment = new[] { "Test", "Data" },
+            TargetSegment = new[] { "Test", "Data" },
+        };
 
-            // SUT
-            Assert.ThrowsAsync<ArgumentException>(
-                () => env.Service.GetWordGraphAsync(translationEngineId, segment, CancellationToken.None)
-            );
-        }
+        // SUT
+        Assert.ThrowsAsync<HttpRequestException>(
+            () => env.Service.TrainSegmentAsync(TranslationEngine01, segmentPairDto, CancellationToken.None)
+        );
+    }
 
-        [Test]
-        public async Task TrainSegmentAsync_Success()
-        {
-            // Set up a mock Machine API
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
-
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
-            var segmentPairDto = new SegmentPairDto
-            {
-                SentenceStart = true,
-                SourceSegment = new[] { "Test", "Data" },
-                TargetSegment = new[] { "Test", "Data" },
-            };
-
-            // SUT
-            await env.Service.TrainSegmentAsync(TranslationEngine01, segmentPairDto, CancellationToken.None);
-
-            Assert.AreEqual(1, handler.NumberOfCalls);
-        }
-
-        [Test]
-        public void TrainSegmentAsync_NoPermission()
-        {
-            // Set up a mock Machine API
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
-
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
-            var segmentPairDto = new SegmentPairDto
-            {
-                SentenceStart = true,
-                SourceSegment = new[] { "Test", "Data" },
-                TargetSegment = new[] { "Test", "Data" },
-            };
-
-            // SUT
-            Assert.ThrowsAsync<HttpRequestException>(
-                () => env.Service.TrainSegmentAsync(TranslationEngine01, segmentPairDto, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public async Task TranslateAsync_Success()
-        {
-            // Set up a mock Machine API
-            var segment = new[] { "Test", "Data" };
-            string response =
-                $@"{{
+    [Test]
+    public async Task TranslateAsync_Success()
+    {
+        // Set up a mock Machine API
+        var segment = new[] { "Test", "Data" };
+        string response =
+            $@"{{
                     ""target"": [
                       ""{segment.First()}"",
                       ""{segment.Last()}""
@@ -339,50 +335,50 @@ namespace SIL.XForge.Scripture.Services
                     }}
                     ]
                 }}";
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            TranslationResultDto actual = await env.Service.TranslateAsync(
-                TranslationEngine01,
-                segment,
-                CancellationToken.None
-            );
+        // SUT
+        TranslationResultDto actual = await env.Service.TranslateAsync(
+            TranslationEngine01,
+            segment,
+            CancellationToken.None
+        );
 
-            Assert.AreEqual(1, handler.NumberOfCalls);
-            Assert.AreEqual(segment.Length, actual.Target.Length);
-            Assert.AreEqual(segment.First(), actual.Target.First());
-            Assert.AreEqual(segment.Last(), actual.Target.Last());
-        }
+        Assert.AreEqual(1, handler.NumberOfCalls);
+        Assert.AreEqual(segment.Length, actual.Target.Length);
+        Assert.AreEqual(segment.First(), actual.Target.First());
+        Assert.AreEqual(segment.Last(), actual.Target.Last());
+    }
 
-        [Test]
-        public void TranslateAsync_NoPermission()
-        {
-            // Set up a mock Machine API
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+    [Test]
+    public void TranslateAsync_NoPermission()
+    {
+        // Set up a mock Machine API
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
-            var segment = new[] { "Test", "Data" };
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
+        var segment = new[] { "Test", "Data" };
 
-            // SUT
-            Assert.ThrowsAsync<HttpRequestException>(
-                () => env.Service.TranslateAsync(TranslationEngine01, segment, CancellationToken.None)
-            );
-        }
+        // SUT
+        Assert.ThrowsAsync<HttpRequestException>(
+            () => env.Service.TranslateAsync(TranslationEngine01, segment, CancellationToken.None)
+        );
+    }
 
-        [Test]
-        public async Task TranslateNAsync_Success()
-        {
-            // Set up a mock Machine API
-            var segment = new[] { "Test", "Data" };
-            string response =
-                $@"[
+    [Test]
+    public async Task TranslateNAsync_Success()
+    {
+        // Set up a mock Machine API
+        var segment = new[] { "Test", "Data" };
+        string response =
+            $@"[
                     {{
                       ""target"": [
                         ""{segment.First()}"",
@@ -418,59 +414,58 @@ namespace SIL.XForge.Scripture.Services
                       ]
                     }}
                 ]";
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
 
-            // SUT
-            TranslationResultDto[] actual = await env.Service.TranslateNAsync(
-                TranslationEngine01,
-                n: 2,
-                segment,
-                CancellationToken.None
-            );
+        // SUT
+        TranslationResultDto[] actual = await env.Service.TranslateNAsync(
+            TranslationEngine01,
+            n: 2,
+            segment,
+            CancellationToken.None
+        );
 
-            Assert.AreEqual(1, handler.NumberOfCalls);
-            Assert.AreEqual(segment.Length, actual.First().Target.Length);
-            Assert.AreEqual(segment.First(), actual.First().Target.First());
-            Assert.AreEqual(segment.Last(), actual.First().Target.Last());
-        }
+        Assert.AreEqual(1, handler.NumberOfCalls);
+        Assert.AreEqual(segment.Length, actual.First().Target.Length);
+        Assert.AreEqual(segment.First(), actual.First().Target.First());
+        Assert.AreEqual(segment.Last(), actual.First().Target.Last());
+    }
 
-        [Test]
-        public void TranslateNAsync_NoPermission()
+    [Test]
+    public void TranslateNAsync_NoPermission()
+    {
+        // Set up a mock Machine API
+        string response = string.Empty;
+        var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
+
+        // Set up test environment
+        var env = new TestEnvironment(httpClient);
+        var segment = new[] { "Test", "Data" };
+
+        // SUT
+        Assert.ThrowsAsync<HttpRequestException>(
+            () => env.Service.TranslateNAsync(TranslationEngine01, n: 2, segment, CancellationToken.None)
+        );
+    }
+
+    private class TestEnvironment
+    {
+        public TestEnvironment(HttpClient? httpClient = default)
         {
-            // Set up a mock Machine API
-            string response = string.Empty;
-            var handler = new MockHttpMessageHandler(response, HttpStatusCode.Forbidden);
-            var httpClient = TestEnvironment.CreateHttpClient(handler);
+            var exceptionHandler = new MockExceptionHandler();
+            var httpClientFactory = Substitute.For<IHttpClientFactory>();
+            httpClientFactory.CreateClient(Arg.Any<string>()).Returns(httpClient);
 
-            // Set up test environment
-            var env = new TestEnvironment(httpClient);
-            var segment = new[] { "Test", "Data" };
-
-            // SUT
-            Assert.ThrowsAsync<HttpRequestException>(
-                () => env.Service.TranslateNAsync(TranslationEngine01, n: 2, segment, CancellationToken.None)
-            );
+            Service = new MachineTranslationService(exceptionHandler, httpClientFactory);
         }
 
-        private class TestEnvironment
-        {
-            public TestEnvironment(HttpClient? httpClient = default)
-            {
-                var exceptionHandler = new MockExceptionHandler();
-                var httpClientFactory = Substitute.For<IHttpClientFactory>();
-                httpClientFactory.CreateClient(Arg.Any<string>()).Returns(httpClient);
+        public MachineTranslationService Service { get; }
 
-                Service = new MachineTranslationService(exceptionHandler, httpClientFactory);
-            }
-
-            public MachineTranslationService Service { get; }
-
-            public static HttpClient CreateHttpClient(HttpMessageHandler handler) =>
-                new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
-        }
+        public static HttpClient CreateHttpClient(HttpMessageHandler handler) =>
+            new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MockCommentTags.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockCommentTags.cs
@@ -3,42 +3,41 @@ using Paratext.Data;
 using Paratext.Data.ProjectComments;
 using SIL.XForge.Scripture.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public class MockCommentTags : CommentTags
 {
-    public class MockCommentTags : CommentTags
+    public MockCommentTags(ScrText scrText)
+        : base(scrText) { }
+
+    public CommentTags.CommentTagList TagsList
     {
-        public MockCommentTags(ScrText scrText) : base(scrText) { }
+        set => list = value;
+    }
 
-        public CommentTags.CommentTagList TagsList
-        {
-            set => list = value;
-        }
+    public static MockCommentTags GetCommentTags(string username, string ptProjectId)
+    {
+        var scrtextDir = Path.Combine(Path.GetTempPath(), ptProjectId, "target");
+        var associatedPtUser = new SFParatextUser(username);
+        ProjectName projectName = new ProjectName() { ProjectPath = scrtextDir, ShortName = "Proj" };
+        MockScrText scrText = new MockScrText(associatedPtUser, projectName);
+        return new MockCommentTags(scrText);
+    }
 
-        public static MockCommentTags GetCommentTags(string username, string ptProjectId)
+    internal void InitializeTagList(int[] tagIds)
+    {
+        var tags = new Paratext.Data.ProjectComments.CommentTag[tagIds.Length];
+        for (int i = 0; i < tagIds.Length; i++)
         {
-            var scrtextDir = Path.Combine(Path.GetTempPath(), ptProjectId, "target");
-            var associatedPtUser = new SFParatextUser(username);
-            ProjectName projectName = new ProjectName() { ProjectPath = scrtextDir, ShortName = "Proj" };
-            MockScrText scrText = new MockScrText(associatedPtUser, projectName);
-            return new MockCommentTags(scrText);
+            int tagId = tagIds[i];
+            tags[i] = new Paratext.Data.ProjectComments.CommentTag($"tag{tagId}", $"icon{tagId}", tagId);
         }
+        var tagsList = new CommentTagList { SerializedData = tags };
+        TagsList = tagsList;
+    }
 
-        internal void InitializeTagList(int[] tagIds)
-        {
-            var tags = new Paratext.Data.ProjectComments.CommentTag[tagIds.Length];
-            for (int i = 0; i < tagIds.Length; i++)
-            {
-                int tagId = tagIds[i];
-                tags[i] = new Paratext.Data.ProjectComments.CommentTag($"tag{tagId}", $"icon{tagId}", tagId);
-            }
-            var tagsList = new CommentTagList();
-            tagsList.SerializedData = tags;
-            TagsList = tagsList;
-        }
-
-        protected override void ReadFromDisk()
-        {
-            // Skip calling ReadFromDisk in base class
-        }
+    protected override void ReadFromDisk()
+    {
+        // Skip calling ReadFromDisk in base class
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MockExceptionHandler.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockExceptionHandler.cs
@@ -4,24 +4,23 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public class MockExceptionHandler : IExceptionHandler
 {
-    public class MockExceptionHandler : IExceptionHandler
+    public void ReportException(Exception exception) { }
+
+    public async Task EnsureSuccessStatusCode(HttpResponseMessage response)
     {
-        public void ReportException(Exception exception) { }
-
-        public async Task EnsureSuccessStatusCode(HttpResponseMessage response)
+        if (!response.IsSuccessStatusCode)
         {
-            if (!response.IsSuccessStatusCode)
-            {
-                throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response));
-            }
+            throw new HttpRequestException(await ExceptionHandler.CreateHttpRequestErrorMessage(response));
         }
-
-        public void ReportExceptions(IApplicationBuilder app) { }
-
-        public void RecordEndpointInfoForException(Dictionary<string, string> metadata) { }
-
-        public void RecordUserIdForException(string userId) { }
     }
+
+    public void ReportExceptions(IApplicationBuilder app) { }
+
+    public void RecordEndpointInfoForException(Dictionary<string, string> metadata) { }
+
+    public void RecordUserIdForException(string userId) { }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MockHttpMessageHandler.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockHttpMessageHandler.cs
@@ -1,40 +1,39 @@
-using System.Net.Http;
 using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public class MockHttpMessageHandler : HttpMessageHandler
 {
-    public class MockHttpMessageHandler : HttpMessageHandler
+    private readonly string _response;
+    private readonly HttpStatusCode _statusCode;
+
+    public string? LastInput { get; private set; }
+    public int NumberOfCalls { get; private set; }
+
+    public MockHttpMessageHandler(string response, HttpStatusCode statusCode)
     {
-        private readonly string _response;
-        private readonly HttpStatusCode _statusCode;
+        _response = response;
+        _statusCode = statusCode;
+    }
 
-        public string? LastInput { get; private set; }
-        public int NumberOfCalls { get; private set; }
-
-        public MockHttpMessageHandler(string response, HttpStatusCode statusCode)
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken
+    )
+    {
+        NumberOfCalls++;
+        if (request.Content is not null)
         {
-            _response = response;
-            _statusCode = statusCode;
+            LastInput = await request.Content.ReadAsStringAsync(cancellationToken);
         }
-
-        protected override async Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request,
-            CancellationToken cancellationToken
-        )
+        return new HttpResponseMessage
         {
-            NumberOfCalls++;
-            if (request.Content is not null)
-            {
-                LastInput = await request.Content.ReadAsStringAsync(cancellationToken);
-            }
-            return new HttpResponseMessage
-            {
-                StatusCode = _statusCode,
-                Content = new StringContent(_response),
-                RequestMessage = request,
-            };
-        }
+            StatusCode = _statusCode,
+            Content = new StringContent(_response),
+            RequestMessage = request,
+        };
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MockLazyScrTextCollection.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockLazyScrTextCollection.cs
@@ -1,14 +1,13 @@
 using Paratext.Data;
 using SIL.XForge.Scripture.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public class MockLazyScrTextCollection : LazyScrTextCollection
 {
-    public class MockLazyScrTextCollection : LazyScrTextCollection
+    protected override ScrText CreateScrText(string ptUsername, ProjectName projectName)
     {
-        protected override ScrText CreateScrText(string ptUsername, ProjectName projectName)
-        {
-            var associatedPtUser = new SFParatextUser(ptUsername);
-            return new MockScrText(associatedPtUser, projectName);
-        }
+        var associatedPtUser = new SFParatextUser(ptUsername);
+        return new MockScrText(associatedPtUser, projectName);
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MockProjectSettings.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockProjectSettings.cs
@@ -1,16 +1,16 @@
-namespace Paratext.Data.ProjectSettingsAccess
+namespace Paratext.Data.ProjectSettingsAccess;
+
+/// <summary>Mock for tests.</summary>
+public class MockProjectSettings : ProjectSettings
 {
-    /// <summary>Mock for tests.</summary>
-    public class MockProjectSettings : ProjectSettings
+    private bool _editable = true;
+
+    public MockProjectSettings(ScrText scrText)
+        : base(scrText) { }
+
+    public override bool Editable
     {
-        private bool _editable = true;
-
-        public MockProjectSettings(ScrText scrText) : base(scrText) { }
-
-        public override bool Editable
-        {
-            get { return _editable; }
-            set { _editable = value; }
-        }
+        get => _editable;
+        set => _editable = value;
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MockScrStylesheet.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockScrStylesheet.cs
@@ -1,8 +1,8 @@
-namespace Paratext.Data
+namespace Paratext.Data;
+
+/// <summary>Mock for tests.</summary>
+public class MockScrStylesheet : ScrStylesheet
 {
-    /// <summary>Mock for tests.</summary>
-    public class MockScrStylesheet : ScrStylesheet
-    {
-        public MockScrStylesheet(string path, string alternatePath = null) : base(path, alternatePath) { }
-    }
+    public MockScrStylesheet(string path, string alternatePath = null)
+        : base(path, alternatePath) { }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MockScrText.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockScrText.cs
@@ -9,78 +9,74 @@ using PtxUtils;
 using SIL.Scripture;
 using SIL.WritingSystems;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// Mock which stored text data in keys such as "GEN" or "GEN 3"
+/// </summary>
+public class MockScrText : ScrText
 {
-    /// <summary>
-    /// Mock which stored text data in keys such as "GEN" or "GEN 3"
-    /// </summary>
-    public class MockScrText : ScrText
+    public MockScrText(ParatextUser associatedPtUser, ProjectName projectName)
+        : base(associatedPtUser)
     {
-        public MockScrText(ParatextUser associatedPtUser, ProjectName projectName) : base(associatedPtUser)
-        {
-            this.projectName = projectName;
-            _settings = new MockProjectSettings(this);
-            // ScrText sets its cachedGuid from the settings Guid. Here we are doing it the other way around.
-            // Some tests may need both MockScrText.Guid and MockScrText.Settings.Guid to be set.
-            _language = new MockScrLanguage(this);
-        }
-
-        public HexId CachedGuid
-        {
-            set
-            {
-                cachedGuid = value;
-                Settings.Guid = value;
-            }
-        }
-
-        public Dictionary<string, string> Data = new Dictionary<string, string>();
-
-        /// <summary>
-        /// Return text of specified chapter or book.
-        /// Returns "" if the chapter or book is not found or chapterization problem
-        /// </summary>
-        /// <param name="vref">Specify book or chapter. Verse number is ignored.</param>
-        /// <param name="singleChapter">True to get a single chapter.</param>
-        /// <param name="doMapIn">true to do mapping (normally true)</param>
-        /// <returns>Text of book or chapter</returns>
-        public override string GetText(VerseRef vref, bool singleChapter, bool doMapIn) =>
-            Data.TryGetValue(singleChapter ? vref.Book + " " + vref.Chapter : vref.Book, out string usfm)
-                ? usfm
-                : string.Empty;
-
-        protected override ProjectFileManager CreateFileManager()
-        {
-            ProjectFileManager fileManager = Substitute.For<ProjectFileManager>(this, null);
-            fileManager.IsWritable.Returns(true);
-            return fileManager;
-        }
-
-        protected override PermissionManager CreatePermissionManager()
-        {
-            return new ComparableProjectPermissionManager(this);
-        }
-
-        public override ProjectSettings Settings => _settings;
-        public override ScrStylesheet DefaultStylesheet => new MockScrStylesheet("./usfm.sty");
-        public override string Directory => projectName.ProjectPath;
-        public override string Name => projectName.ShortName;
-        public override ScrLanguage Language => _language;
-        private readonly ScrLanguage _language;
-        private readonly ProjectSettings _settings;
+        this.projectName = projectName;
+        _settings = new MockProjectSettings(this);
+        // ScrText sets its cachedGuid from the settings Guid. Here we are doing it the other way around.
+        // Some tests may need both MockScrText.Guid and MockScrText.Settings.Guid to be set.
+        _language = new MockScrLanguage(this);
     }
 
-    /// <summary>
-    /// Replaces a ScrLanguage for use in testing. Does not use the file system to save/load data.
-    /// </summary>
-    class MockScrLanguage : ScrLanguage
+    public HexId CachedGuid
     {
-        internal MockScrLanguage(ScrText scrText) : base(null, ProjectNormalization.Undefined, scrText) { }
-
-        protected override WritingSystemDefinition LoadWsDef(ScrText scrText)
+        set
         {
-            // Don't load anything from disk for testing and just return the one we already have
-            return wsDef;
+            cachedGuid = value;
+            Settings.Guid = value;
         }
     }
+
+    public Dictionary<string, string> Data = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Return text of specified chapter or book.
+    /// Returns "" if the chapter or book is not found or chapterization problem
+    /// </summary>
+    /// <param name="vref">Specify book or chapter. Verse number is ignored.</param>
+    /// <param name="singleChapter">True to get a single chapter.</param>
+    /// <param name="doMapIn">true to do mapping (normally true)</param>
+    /// <returns>Text of book or chapter</returns>
+    public override string GetText(VerseRef vref, bool singleChapter, bool doMapIn) =>
+        Data.TryGetValue(singleChapter ? vref.Book + " " + vref.Chapter : vref.Book, out string usfm)
+            ? usfm
+            : string.Empty;
+
+    protected override ProjectFileManager CreateFileManager()
+    {
+        ProjectFileManager fileManager = Substitute.For<ProjectFileManager>(this, null);
+        fileManager.IsWritable.Returns(true);
+        return fileManager;
+    }
+
+    protected override PermissionManager CreatePermissionManager() => new ComparableProjectPermissionManager(this);
+
+    public override ProjectSettings Settings => _settings;
+    public override ScrStylesheet DefaultStylesheet => new MockScrStylesheet("./usfm.sty");
+    public override string Directory => projectName.ProjectPath;
+    public override string Name => projectName.ShortName;
+    public override ScrLanguage Language => _language;
+    private readonly ScrLanguage _language;
+    private readonly ProjectSettings _settings;
+}
+
+/// <summary>
+/// Replaces a ScrLanguage for use in testing. Does not use the file system to save/load data.
+/// </summary>
+class MockScrLanguage : ScrLanguage
+{
+    internal MockScrLanguage(ScrText scrText)
+        : base(null, ProjectNormalization.Undefined, scrText) { }
+
+    protected override WritingSystemDefinition LoadWsDef(ScrText scrText) =>
+        // Don't load anything from disk for testing and just return the one we already have
+        wsDef;
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MockText.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockText.cs
@@ -1,17 +1,13 @@
-namespace SIL.XForge.Scripture.Services
+using System.Collections.Generic;
+using SIL.Machine.Corpora;
+
+namespace SIL.XForge.Scripture.Services;
+
+public class MockText : IText
 {
-    using SIL.Machine.Corpora;
-    using System.Collections.Generic;
+    public IEnumerable<TextSegment> GetSegments(bool includeText = true, IText? basedOn = null) => Segments;
 
-    public class MockText : IText
-    {
-        public IEnumerable<TextSegment> GetSegments(bool includeText = true, IText? basedOn = null)
-        {
-            return Segments;
-        }
-
-        public string Id { get; set; } = string.Empty;
-        public List<TextSegment> Segments { get; set; } = new List<TextSegment>();
-        public string? SortKey { get; set; }
-    }
+    public string Id { get; set; } = string.Empty;
+    public List<TextSegment> Segments { get; set; } = new List<TextSegment>();
+    public string? SortKey { get; set; }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MockTextCorpus.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockTextCorpus.cs
@@ -1,19 +1,15 @@
-namespace SIL.XForge.Scripture.Services
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SIL.Machine.Corpora;
+
+namespace SIL.XForge.Scripture.Services;
+
+public class MockTextCorpus : ITextCorpus
 {
-    using SIL.Machine.Corpora;
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
+    public IText CreateNullText(string id) => throw new NotImplementedException();
 
-    public class MockTextCorpus : ITextCorpus
-    {
-        public IText CreateNullText(string id)
-        {
-            throw new NotImplementedException();
-        }
+    public IEnumerable<IText>? Texts { get; set; }
 
-        public IEnumerable<IText>? Texts { get; set; }
-
-        public IText? this[string id] => Texts?.FirstOrDefault(t => t.Id == id);
-    }
+    public IText? this[string id] => Texts?.FirstOrDefault(t => t.Id == id);
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/NotesFormatterTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/NotesFormatterTests.cs
@@ -14,607 +14,599 @@ using SIL.Scripture;
 using SIL.XForge.Scripture.Models;
 using Comment = Paratext.Data.ProjectComments.Comment;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class NotesFormatterTests
 {
-    [TestFixture]
-    public class NotesFormatterTests
+    [Test]
+    public void FormatNotes_CommentText()
     {
-        [Test]
-        public void FormatNotes_CommentText()
+        // Setup the environment
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+
+        // Setup the test data
+        const string xml = "<content>Comment Contents</content>";
+        XmlDocument doc = new XmlDocument();
+        doc.LoadXml(xml);
+        Comment comment = new Comment(associatedPtUser)
         {
-            // Setup the environment
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            env.SetupProject(env.Project01, associatedPtUser);
-
-            // Setup the test data
-            const string xml = "<content>Comment Contents</content>";
-            XmlDocument doc = new XmlDocument();
-            doc.LoadXml(xml);
-            Comment comment = new Comment(associatedPtUser)
-            {
-                Contents = doc.DocumentElement,
-                DateTime = DateTimeOffset.Now,
-                Thread = "Answer_dataId0123",
-                VerseRefStr = "RUT 1:1",
-            };
-            List<CommentThread> commentThreads = new List<CommentThread>
-            {
-                new CommentThread
-                {
-                    ContextScrTextName = env.ProjectScrText?.Name,
-                    ScrText = env.ProjectScrText,
-                    Comments = new List<Comment> { comment },
-                },
-            };
-
-            // We use StringBuilder so we can have the environment specific new line
-            StringBuilder sb = new StringBuilder();
-            sb.AppendLine("<notes version=\"1.1\">");
-            sb.AppendLine($"  <thread id=\"{comment.Thread}\">");
-            sb.AppendLine($"    <selection verseRef=\"{comment.VerseRefStr}\" startPos=\"0\" selectedText=\"\" />");
-            sb.AppendLine($"    <comment user=\"{env.Username01}\" date=\"{comment.DateTime:o}\">");
-            sb.AppendLine("      <content>Comment Contents</content>");
-            sb.AppendLine("    </comment>");
-            sb.AppendLine("  </thread>");
-            sb.Append("</notes>");
-            string expected = sb.ToString();
-
-            // SUT
-            string actual = NotesFormatter.FormatNotes(commentThreads);
-            Assert.AreEqual(expected, actual);
-        }
-
-        [Test]
-        public void FormatNotes_ComplexComment()
+            Contents = doc.DocumentElement,
+            DateTime = DateTimeOffset.Now,
+            Thread = "Answer_dataId0123",
+            VerseRefStr = "RUT 1:1",
+        };
+        List<CommentThread> commentThreads = new List<CommentThread>
         {
-            // Setup the environment
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            env.SetupProject(env.Project01, associatedPtUser);
-
-            // Setup the test data
-            const string xml = "<content><p>Comment Contents</p></content>";
-            XmlDocument doc = new XmlDocument();
-            doc.LoadXml(xml);
-            Comment comment = new Comment(associatedPtUser)
+            new CommentThread
             {
-                ContextAfter = "here.",
-                ContextBefore = "Verse",
-                Contents = doc.DocumentElement,
-                DateTime = DateTimeOffset.Now,
-                ExternalUser = "John Doe",
-                SelectedText = "one",
-                StartPosition = 1,
-                Thread = "Answer_dataId0123",
-                Type = NoteType.Conflict,
-                VerseRefStr = "RUT 1:1",
-            };
-            List<CommentThread> commentThreads = new List<CommentThread>
-            {
-                new CommentThread
-                {
-                    ContextScrTextName = env.ProjectScrText?.Name,
-                    ScrText = env.ProjectScrText,
-                    Comments = new List<Comment> { comment },
-                },
-            };
+                ContextScrTextName = env.ProjectScrText?.Name,
+                ScrText = env.ProjectScrText,
+                Comments = new List<Comment> { comment },
+            },
+        };
 
-            // We use StringBuilder so we can have the environment specific new line
-            StringBuilder sb = new StringBuilder();
-            sb.AppendLine("<notes version=\"1.1\">");
-            sb.AppendLine($"  <thread id=\"{comment.Thread}\" type=\"conflict\">");
-            sb.Append($"    <selection verseRef=\"{comment.VerseRefStr}\" startPos=\"{comment.StartPosition}\"");
-            sb.Append($" selectedText=\"{comment.SelectedText}\" beforeContext=\"{comment.ContextBefore}\"");
-            sb.AppendLine($" afterContext=\"{comment.ContextAfter}\" />");
-            sb.Append($"    <comment user=\"{env.Username01}\" date=\"{comment.DateTime:o}\"");
-            sb.AppendLine($" extUser=\"{comment.ExternalUser}\">");
-            sb.AppendLine("      <content>");
-            sb.AppendLine("        <p>Comment Contents</p>");
-            sb.AppendLine("      </content>");
-            sb.AppendLine("    </comment>");
-            sb.AppendLine("  </thread>");
-            sb.Append("</notes>");
-            string expected = sb.ToString();
+        // We use StringBuilder so we can have the environment specific new line
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine("<notes version=\"1.1\">");
+        sb.AppendLine($"  <thread id=\"{comment.Thread}\">");
+        sb.AppendLine($"    <selection verseRef=\"{comment.VerseRefStr}\" startPos=\"0\" selectedText=\"\" />");
+        sb.AppendLine($"    <comment user=\"{env.Username01}\" date=\"{comment.DateTime:o}\">");
+        sb.AppendLine("      <content>Comment Contents</content>");
+        sb.AppendLine("    </comment>");
+        sb.AppendLine("  </thread>");
+        sb.Append("</notes>");
+        string expected = sb.ToString();
 
-            // SUT
-            string actual = NotesFormatter.FormatNotes(commentThreads);
-            Assert.AreEqual(expected, actual);
-        }
+        // SUT
+        string actual = NotesFormatter.FormatNotes(commentThreads);
+        Assert.AreEqual(expected, actual);
+    }
 
-        [Test]
-        public void FormatNotes_DeletedComment()
+    [Test]
+    public void FormatNotes_ComplexComment()
+    {
+        // Setup the environment
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+
+        // Setup the test data
+        const string xml = "<content><p>Comment Contents</p></content>";
+        XmlDocument doc = new XmlDocument();
+        doc.LoadXml(xml);
+        Comment comment = new Comment(associatedPtUser)
         {
-            // Setup the environment
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            env.SetupProject(env.Project01, associatedPtUser);
-
-            // Setup the test data
-            const string expected = "<notes version=\"1.1\" />";
-            List<CommentThread> commentThreads = new List<CommentThread>
+            ContextAfter = "here.",
+            ContextBefore = "Verse",
+            Contents = doc.DocumentElement,
+            DateTime = DateTimeOffset.Now,
+            ExternalUser = "John Doe",
+            SelectedText = "one",
+            StartPosition = 1,
+            Thread = "Answer_dataId0123",
+            Type = NoteType.Conflict,
+            VerseRefStr = "RUT 1:1",
+        };
+        List<CommentThread> commentThreads = new List<CommentThread>
+        {
+            new CommentThread
             {
-                new CommentThread
+                ContextScrTextName = env.ProjectScrText?.Name,
+                ScrText = env.ProjectScrText,
+                Comments = new List<Comment> { comment },
+            },
+        };
+
+        // We use StringBuilder so we can have the environment specific new line
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine("<notes version=\"1.1\">");
+        sb.AppendLine($"  <thread id=\"{comment.Thread}\" type=\"conflict\">");
+        sb.Append($"    <selection verseRef=\"{comment.VerseRefStr}\" startPos=\"{comment.StartPosition}\"");
+        sb.Append($" selectedText=\"{comment.SelectedText}\" beforeContext=\"{comment.ContextBefore}\"");
+        sb.AppendLine($" afterContext=\"{comment.ContextAfter}\" />");
+        sb.Append($"    <comment user=\"{env.Username01}\" date=\"{comment.DateTime:o}\"");
+        sb.AppendLine($" extUser=\"{comment.ExternalUser}\">");
+        sb.AppendLine("      <content>");
+        sb.AppendLine("        <p>Comment Contents</p>");
+        sb.AppendLine("      </content>");
+        sb.AppendLine("    </comment>");
+        sb.AppendLine("  </thread>");
+        sb.Append("</notes>");
+        string expected = sb.ToString();
+
+        // SUT
+        string actual = NotesFormatter.FormatNotes(commentThreads);
+        Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public void FormatNotes_DeletedComment()
+    {
+        // Setup the environment
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+
+        // Setup the test data
+        const string expected = "<notes version=\"1.1\" />";
+        List<CommentThread> commentThreads = new List<CommentThread>
+        {
+            new CommentThread
+            {
+                ContextScrTextName = env.ProjectScrText?.Name,
+                ScrText = env.ProjectScrText,
+                Comments = new List<Comment>
                 {
-                    ContextScrTextName = env.ProjectScrText?.Name,
-                    ScrText = env.ProjectScrText,
-                    Comments = new List<Comment>
+                    new Comment(associatedPtUser)
                     {
-                        new Comment(associatedPtUser)
-                        {
-                            DateTime = DateTimeOffset.Now,
-                            Deleted = true,
-                            Thread = "Answer_dataId0123",
-                            VerseRefStr = "RUT 1:1",
-                        },
+                        DateTime = DateTimeOffset.Now,
+                        Deleted = true,
+                        Thread = "Answer_dataId0123",
+                        VerseRefStr = "RUT 1:1",
                     },
                 },
-            };
+            },
+        };
 
-            // SUT
-            string actual = NotesFormatter.FormatNotes(commentThreads);
-            Assert.AreEqual(expected, actual);
-        }
+        // SUT
+        string actual = NotesFormatter.FormatNotes(commentThreads);
+        Assert.AreEqual(expected, actual);
+    }
 
-        [Test]
-        public void FormatNotes_DetailedCommentContents()
+    [Test]
+    public void FormatNotes_DetailedCommentContents()
+    {
+        // Setup the environment
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+
+        // Setup the test data
+        string xml = "<content><p>Comment Text<bold>Bold Text</bold><italic>Italic Text</italic>";
+        xml += "<language name=\"en_NZ\">Test</language></p></content>";
+        XmlDocument doc = new XmlDocument();
+        doc.LoadXml(xml);
+        Comment comment = new Comment(associatedPtUser)
         {
-            // Setup the environment
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            env.SetupProject(env.Project01, associatedPtUser);
-
-            // Setup the test data
-            string xml = "<content><p>Comment Text<bold>Bold Text</bold><italic>Italic Text</italic>";
-            xml += "<language name=\"en_NZ\">Test</language></p></content>";
-            XmlDocument doc = new XmlDocument();
-            doc.LoadXml(xml);
-            Comment comment = new Comment(associatedPtUser)
-            {
-                Contents = doc.DocumentElement,
-                DateTime = DateTimeOffset.Now,
-                Thread = "Answer_dataId0123",
-                VerseRefStr = "RUT 1:1",
-            };
-            List<CommentThread> commentThreads = new List<CommentThread>
-            {
-                new CommentThread
-                {
-                    ContextScrTextName = env.ProjectScrText?.Name,
-                    ScrText = env.ProjectScrText,
-                    Comments = new List<Comment> { comment },
-                },
-            };
-
-            // We use StringBuilder so we can have the environment specific new line
-            StringBuilder sb = new StringBuilder();
-            sb.AppendLine("<notes version=\"1.1\">");
-            sb.AppendLine($"  <thread id=\"{comment.Thread}\">");
-            sb.AppendLine($"    <selection verseRef=\"{comment.VerseRefStr}\" startPos=\"0\" selectedText=\"\" />");
-            sb.AppendLine($"    <comment user=\"{env.Username01}\" date=\"{comment.DateTime:o}\">");
-            sb.AppendLine("      <content>");
-            sb.Append("        <p>Comment Text<span style=\"bold\">Bold Text</span>");
-            sb.AppendLine("<span style=\"italic\">Italic Text</span><lang name=\"en_NZ\">Test</lang></p>");
-            sb.AppendLine("      </content>");
-            sb.AppendLine("    </comment>");
-            sb.AppendLine("  </thread>");
-            sb.Append("</notes>");
-            string expected = sb.ToString();
-
-            // SUT
-            string actual = NotesFormatter.FormatNotes(commentThreads);
-            Assert.AreEqual(expected, actual);
-        }
-
-        [Test]
-        public void FormatNotes_EmptyComment()
+            Contents = doc.DocumentElement,
+            DateTime = DateTimeOffset.Now,
+            Thread = "Answer_dataId0123",
+            VerseRefStr = "RUT 1:1",
+        };
+        List<CommentThread> commentThreads = new List<CommentThread>
         {
-            // Setup the environment
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            env.SetupProject(env.Project01, associatedPtUser);
-
-            // Setup the test data
-            const string thread = "Answer_dataId0123";
-            const string verseRefStr = "RUT 1:1";
-            DateTimeOffset commentDate = DateTimeOffset.Now;
-
-            // We use StringBuilder so we can have the environment specific new line
-            StringBuilder sb = new StringBuilder();
-            sb.AppendLine("<notes version=\"1.1\">");
-            sb.AppendLine($"  <thread id=\"{thread}\">");
-            sb.AppendLine($"    <selection verseRef=\"{verseRefStr}\" startPos=\"0\" selectedText=\"\" />");
-            sb.AppendLine($"    <comment user=\"{env.Username01}\" date=\"{commentDate:o}\">");
-            sb.AppendLine("      <content>");
-            sb.AppendLine("        <p></p>");
-            sb.AppendLine("      </content>");
-            sb.AppendLine("    </comment>");
-            sb.AppendLine("  </thread>");
-            sb.Append("</notes>");
-            string expected = sb.ToString();
-            List<CommentThread> commentThreads = new List<CommentThread>
+            new CommentThread
             {
-                new CommentThread
+                ContextScrTextName = env.ProjectScrText?.Name,
+                ScrText = env.ProjectScrText,
+                Comments = new List<Comment> { comment },
+            },
+        };
+
+        // We use StringBuilder so we can have the environment specific new line
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine("<notes version=\"1.1\">");
+        sb.AppendLine($"  <thread id=\"{comment.Thread}\">");
+        sb.AppendLine($"    <selection verseRef=\"{comment.VerseRefStr}\" startPos=\"0\" selectedText=\"\" />");
+        sb.AppendLine($"    <comment user=\"{env.Username01}\" date=\"{comment.DateTime:o}\">");
+        sb.AppendLine("      <content>");
+        sb.Append("        <p>Comment Text<span style=\"bold\">Bold Text</span>");
+        sb.AppendLine("<span style=\"italic\">Italic Text</span><lang name=\"en_NZ\">Test</lang></p>");
+        sb.AppendLine("      </content>");
+        sb.AppendLine("    </comment>");
+        sb.AppendLine("  </thread>");
+        sb.Append("</notes>");
+        string expected = sb.ToString();
+
+        // SUT
+        string actual = NotesFormatter.FormatNotes(commentThreads);
+        Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public void FormatNotes_EmptyComment()
+    {
+        // Setup the environment
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+
+        // Setup the test data
+        const string thread = "Answer_dataId0123";
+        const string verseRefStr = "RUT 1:1";
+        DateTimeOffset commentDate = DateTimeOffset.Now;
+
+        // We use StringBuilder so we can have the environment specific new line
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine("<notes version=\"1.1\">");
+        sb.AppendLine($"  <thread id=\"{thread}\">");
+        sb.AppendLine($"    <selection verseRef=\"{verseRefStr}\" startPos=\"0\" selectedText=\"\" />");
+        sb.AppendLine($"    <comment user=\"{env.Username01}\" date=\"{commentDate:o}\">");
+        sb.AppendLine("      <content>");
+        sb.AppendLine("        <p></p>");
+        sb.AppendLine("      </content>");
+        sb.AppendLine("    </comment>");
+        sb.AppendLine("  </thread>");
+        sb.Append("</notes>");
+        string expected = sb.ToString();
+        List<CommentThread> commentThreads = new List<CommentThread>
+        {
+            new CommentThread
+            {
+                ContextScrTextName = env.ProjectScrText?.Name,
+                ScrText = env.ProjectScrText,
+                Comments = new List<Comment>
                 {
-                    ContextScrTextName = env.ProjectScrText?.Name,
-                    ScrText = env.ProjectScrText,
-                    Comments = new List<Comment>
+                    new Comment(associatedPtUser)
                     {
-                        new Comment(associatedPtUser)
-                        {
-                            DateTime = commentDate,
-                            Thread = thread,
-                            VerseRefStr = verseRefStr,
-                        },
+                        DateTime = commentDate,
+                        Thread = thread,
+                        VerseRefStr = verseRefStr,
                     },
                 },
-            };
+            },
+        };
 
-            // SUT
-            string actual = NotesFormatter.FormatNotes(commentThreads);
-            Assert.AreEqual(expected, actual);
-        }
+        // SUT
+        string actual = NotesFormatter.FormatNotes(commentThreads);
+        Assert.AreEqual(expected, actual);
+    }
 
-        [Test]
-        public void FormatNotes_MultipleComments()
+    [Test]
+    public void FormatNotes_MultipleComments()
+    {
+        // Setup the environment
+        var env = new TestEnvironment();
+        var firstPtUser = new SFParatextUser(env.Username01);
+        var secondPtUser = new SFParatextUser(env.Username02);
+        env.SetupProject(env.Project01, firstPtUser);
+
+        // Setup the test data
+        const string thread = "Answer_dataId0123";
+        const string verseRefStr = "RUT 1:1";
+        DateTimeOffset firstCommentDate = DateTimeOffset.Now.AddDays(-1);
+        DateTimeOffset secondCommentDate = DateTimeOffset.Now;
+        const string xml = "<content><p>Comment Contents</p></content>";
+        XmlDocument doc = new XmlDocument();
+        doc.LoadXml(xml);
+
+        // We use StringBuilder so we can have the environment specific new line
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine("<notes version=\"1.1\">");
+        sb.AppendLine($"  <thread id=\"{thread}\">");
+        sb.AppendLine($"    <selection verseRef=\"{verseRefStr}\" startPos=\"0\" selectedText=\"\" />");
+        sb.AppendLine($"    <comment user=\"{env.Username01}\" date=\"{firstCommentDate:o}\">");
+        sb.AppendLine("      <content>");
+        sb.AppendLine("        <p></p>");
+        sb.AppendLine("      </content>");
+        sb.AppendLine("    </comment>");
+        sb.AppendLine($"    <comment user=\"{env.Username02}\" date=\"{secondCommentDate:o}\">");
+        sb.AppendLine("      <content>");
+        sb.AppendLine("        <p>Comment Contents</p>");
+        sb.AppendLine("      </content>");
+        sb.AppendLine("    </comment>");
+        sb.AppendLine("  </thread>");
+        sb.Append("</notes>");
+        string expected = sb.ToString();
+        List<CommentThread> commentThreads = new List<CommentThread>
         {
-            // Setup the environment
-            var env = new TestEnvironment();
-            var firstPtUser = new SFParatextUser(env.Username01);
-            var secondPtUser = new SFParatextUser(env.Username02);
-            env.SetupProject(env.Project01, firstPtUser);
-
-            // Setup the test data
-            const string thread = "Answer_dataId0123";
-            const string verseRefStr = "RUT 1:1";
-            DateTimeOffset firstCommentDate = DateTimeOffset.Now.AddDays(-1);
-            DateTimeOffset secondCommentDate = DateTimeOffset.Now;
-            const string xml = "<content><p>Comment Contents</p></content>";
-            XmlDocument doc = new XmlDocument();
-            doc.LoadXml(xml);
-
-            // We use StringBuilder so we can have the environment specific new line
-            StringBuilder sb = new StringBuilder();
-            sb.AppendLine("<notes version=\"1.1\">");
-            sb.AppendLine($"  <thread id=\"{thread}\">");
-            sb.AppendLine($"    <selection verseRef=\"{verseRefStr}\" startPos=\"0\" selectedText=\"\" />");
-            sb.AppendLine($"    <comment user=\"{env.Username01}\" date=\"{firstCommentDate:o}\">");
-            sb.AppendLine("      <content>");
-            sb.AppendLine("        <p></p>");
-            sb.AppendLine("      </content>");
-            sb.AppendLine("    </comment>");
-            sb.AppendLine($"    <comment user=\"{env.Username02}\" date=\"{secondCommentDate:o}\">");
-            sb.AppendLine("      <content>");
-            sb.AppendLine("        <p>Comment Contents</p>");
-            sb.AppendLine("      </content>");
-            sb.AppendLine("    </comment>");
-            sb.AppendLine("  </thread>");
-            sb.Append("</notes>");
-            string expected = sb.ToString();
-            List<CommentThread> commentThreads = new List<CommentThread>
+            new CommentThread
             {
-                new CommentThread
+                ContextScrTextName = env.ProjectScrText?.Name,
+                ScrText = env.ProjectScrText,
+                Comments = new List<Comment>
                 {
-                    ContextScrTextName = env.ProjectScrText?.Name,
-                    ScrText = env.ProjectScrText,
-                    Comments = new List<Comment>
+                    new Comment(firstPtUser)
                     {
-                        new Comment(firstPtUser)
-                        {
-                            DateTime = firstCommentDate,
-                            Thread = thread,
-                            VerseRefStr = verseRefStr,
-                        },
-                        new Comment(secondPtUser)
-                        {
-                            DateTime = secondCommentDate,
-                            Thread = thread,
-                            VerseRefStr = verseRefStr,
-                            Contents = doc.DocumentElement,
-                        },
+                        DateTime = firstCommentDate,
+                        Thread = thread,
+                        VerseRefStr = verseRefStr,
+                    },
+                    new Comment(secondPtUser)
+                    {
+                        DateTime = secondCommentDate,
+                        Thread = thread,
+                        VerseRefStr = verseRefStr,
+                        Contents = doc.DocumentElement,
                     },
                 },
-            };
+            },
+        };
 
-            // SUT
-            string actual = NotesFormatter.FormatNotes(commentThreads);
-            Assert.AreEqual(expected, actual);
+        // SUT
+        string actual = NotesFormatter.FormatNotes(commentThreads);
+        Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public void FormatNotes_NoComments()
+    {
+        // Setup the environment
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+
+        // Setup the test data
+        const string expected = "<notes version=\"1.1\" />";
+        List<CommentThread> commentThreads = new List<CommentThread>
+        {
+            new CommentThread { ContextScrTextName = env.ProjectScrText?.Name, ScrText = env.ProjectScrText },
+        };
+
+        // SUT
+        string actual = NotesFormatter.FormatNotes(commentThreads);
+        Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public void ParseNotes_CommentText()
+    {
+        // Setup the environment
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+
+        // Setup the test data
+        string commentText = "Comment Contents";
+        DateTimeOffset commentDate = DateTimeOffset.Now;
+        string thread = "Answer_dataId0123";
+        string verseRefStr = "RUT 1:2";
+        string xml = $"<notes version=\"1.1\"><thread id=\"{thread}\">";
+        xml += $"<selection verseRef=\"{verseRefStr}\" startPos=\"0\" selectedText=\"\" />";
+        xml += $"<comment user=\"{env.Username01}\" date=\"{commentDate:o}\"><content>{commentText}</content>";
+        xml += "</comment></thread></notes>";
+        XElement noteXml = XElement.Parse(xml);
+
+        // SUT
+        List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
+        Assert.AreEqual(1, actual.Count);
+        Assert.AreEqual(1, actual[0].Count);
+        Assert.AreEqual(commentText, actual[0][0].Contents.InnerXml);
+        Assert.AreEqual(commentDate, actual[0][0].DateTime);
+        Assert.AreEqual(false, actual[0][0].Deleted);
+        Assert.AreEqual(thread, actual[0][0].Thread);
+        Assert.AreEqual(env.Username01, actual[0][0].User);
+        Assert.AreEqual("RUT", actual[0][0].VerseRef.Book);
+        Assert.AreEqual(1, actual[0][0].VerseRef.ChapterNum);
+        Assert.AreEqual(2, actual[0][0].VerseRef.VerseNum);
+    }
+
+    [Test]
+    public void ParseNotes_ComplexComment()
+    {
+        // Setup the environment
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+
+        // Setup the test data
+        DateTimeOffset commentDate = DateTimeOffset.Now;
+        string contents = "<p>Comment Contents</p>";
+        string contextAfter = "here.";
+        string contextBefore = "Verse";
+        string externalUser = "John Doe";
+        string selectedText = "one";
+        int startPosition = 1;
+        string thread = "Answer_dataId0123";
+        string verseRefStr = "RUT 1:2";
+        string xml = $"<notes version=\"1.1\"><thread id=\"{thread}\">";
+        xml += $"<selection verseRef=\"{verseRefStr}\" startPos=\"{startPosition}\"";
+        xml += $" selectedText=\"{selectedText}\" beforeContext=\"{contextBefore}\"";
+        xml += $" afterContext=\"{contextAfter}\" />";
+        xml += $"<comment user=\"{env.Username01}\" date=\"{commentDate:o}\"";
+        xml += $" extUser=\"{externalUser}\">";
+        xml += $"<content>{contents}</content></comment></thread></notes>";
+        XElement noteXml = XElement.Parse(xml);
+
+        // SUT
+        List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
+        Assert.AreEqual(1, actual.Count);
+        Assert.AreEqual(1, actual[0].Count);
+        Assert.AreEqual(contents, actual[0][0].Contents.InnerXml);
+        Assert.AreEqual(false, actual[0][0].Deleted);
+        Assert.AreEqual(contextAfter, actual[0][0].ContextAfter);
+        Assert.AreEqual(contextBefore, actual[0][0].ContextBefore);
+        Assert.AreEqual(externalUser, actual[0][0].ExternalUser);
+        Assert.AreEqual(selectedText, actual[0][0].SelectedText);
+        Assert.AreEqual(startPosition, actual[0][0].StartPosition);
+        Assert.AreEqual(thread, actual[0][0].Thread);
+        Assert.AreEqual(env.Username01, actual[0][0].User);
+        Assert.AreEqual("RUT", actual[0][0].VerseRef.Book);
+        Assert.AreEqual(1, actual[0][0].VerseRef.ChapterNum);
+        Assert.AreEqual(2, actual[0][0].VerseRef.VerseNum);
+    }
+
+    [Test]
+    public void ParseNotes_DeletedComment()
+    {
+        // Setup the environment
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+
+        // Setup the test data
+        string thread = "Answer_dataId0123";
+        string xml = $"<notes version=\"1.1\"><thread id=\"{thread}\">";
+        xml += "<comment deleted=\"true\"></comment></thread></notes>";
+        XElement noteXml = XElement.Parse(xml);
+
+        // SUT
+        List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
+        Assert.AreEqual(1, actual.Count);
+        Assert.AreEqual(1, actual[0].Count);
+        Assert.AreEqual(true, actual[0][0].Deleted);
+        Assert.AreEqual(thread, actual[0][0].Thread);
+    }
+
+    [Test]
+    public void ParseNotes_DetailedCommentContents()
+    {
+        // Setup the environment
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+
+        // Setup the test data
+        DateTimeOffset commentDate = DateTimeOffset.Now;
+        string thread = "Answer_dataId0123";
+        string verseRefStr = "RUT 1:2";
+        string xml = $"<notes version=\"1.1\"><thread id=\"{thread}\">";
+        xml += $"<selection verseRef=\"{verseRefStr}\" startPos=\"0\" selectedText=\"\" />";
+        xml += $"<comment user=\"{env.Username01}\" date=\"{commentDate:o}\"><content>";
+        xml += "<p>Comment Text<span style=\"bold\">Bold Text</span>";
+        xml += "<span style=\"italic\">Italic Text</span><lang name=\"en_NZ\">Test</lang></p>";
+        xml += "</content></comment></thread></notes>";
+        XElement noteXml = XElement.Parse(xml);
+
+        // SUT
+        List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
+        Assert.AreEqual(1, actual.Count);
+        Assert.AreEqual(1, actual[0].Count);
+        string contents = "<p>Comment Text<bold>Bold Text</bold><italic>Italic Text</italic>";
+        contents += "<language name=\"en_NZ\">Test</language></p>";
+        Assert.AreEqual(contents, actual[0][0].Contents.InnerXml);
+        Assert.AreEqual(false, actual[0][0].Deleted);
+        Assert.AreEqual(thread, actual[0][0].Thread);
+        Assert.AreEqual(env.Username01, actual[0][0].User);
+        Assert.AreEqual("RUT", actual[0][0].VerseRef.Book);
+        Assert.AreEqual(1, actual[0][0].VerseRef.ChapterNum);
+        Assert.AreEqual(2, actual[0][0].VerseRef.VerseNum);
+    }
+
+    [Test]
+    public void ParseNotes_EmptyComment()
+    {
+        // Setup the environment
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+
+        // Setup the test data
+        DateTimeOffset commentDate = DateTimeOffset.Now;
+        string thread = "Answer_dataId0123";
+        string verseRefStr = "RUT 1:2";
+        string xml = $"<notes version=\"1.1\"><thread id=\"{thread}\">";
+        xml += $"<selection verseRef=\"{verseRefStr}\" startPos=\"0\" selectedText=\"\" />";
+        xml += $"<comment user=\"{env.Username01}\" date=\"{commentDate:o}\"></comment></thread></notes>";
+        XElement noteXml = XElement.Parse(xml);
+
+        // SUT
+        List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
+        Assert.AreEqual(1, actual.Count);
+        Assert.AreEqual(1, actual[0].Count);
+        Assert.AreEqual(string.Empty, actual[0][0].Contents.InnerXml);
+        Assert.AreEqual(commentDate, actual[0][0].DateTime);
+        Assert.AreEqual(false, actual[0][0].Deleted);
+        Assert.AreEqual(thread, actual[0][0].Thread);
+        Assert.AreEqual(env.Username01, actual[0][0].User);
+        Assert.AreEqual("RUT", actual[0][0].VerseRef.Book);
+        Assert.AreEqual(1, actual[0][0].VerseRef.ChapterNum);
+        Assert.AreEqual(2, actual[0][0].VerseRef.VerseNum);
+    }
+
+    [Test]
+    public void ParseNotes_MultipleComments()
+    {
+        // Setup the environment
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+
+        // Setup the test data
+        DateTimeOffset firstCommentDate = DateTimeOffset.Now.AddDays(-1);
+        DateTimeOffset secondCommentDate = DateTimeOffset.Now;
+        string contents = "<p>Comment Contents</p>";
+        string thread = "Answer_dataId0123";
+        string verseRefStr = "RUT 1:2";
+        string xml = $"<notes version=\"1.1\"><thread id=\"{thread}\">";
+        xml += $"<selection verseRef=\"{verseRefStr}\" startPos=\"0\" selectedText=\"\" />";
+        xml += $"<comment user=\"{env.Username01}\" date=\"{firstCommentDate:o}\"></comment>";
+        xml += $"<comment user=\"{env.Username02}\" date=\"{secondCommentDate:o}\">";
+        xml += $"<content>{contents}</content></comment>";
+        xml += "</thread></notes>";
+        XElement noteXml = XElement.Parse(xml);
+
+        // SUT
+        List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
+        Assert.AreEqual(1, actual.Count);
+        Assert.AreEqual(2, actual[0].Count);
+
+        // First Comment
+        Assert.AreEqual(string.Empty, actual[0][0].Contents.InnerXml);
+        Assert.AreEqual(firstCommentDate, actual[0][0].DateTime);
+        Assert.AreEqual(false, actual[0][0].Deleted);
+        Assert.AreEqual(thread, actual[0][0].Thread);
+        Assert.AreEqual(env.Username01, actual[0][0].User);
+        Assert.AreEqual("RUT", actual[0][0].VerseRef.Book);
+        Assert.AreEqual(1, actual[0][0].VerseRef.ChapterNum);
+        Assert.AreEqual(2, actual[0][0].VerseRef.VerseNum);
+
+        // Second Comment
+        Assert.AreEqual(contents, actual[0][1].Contents.InnerXml);
+        Assert.AreEqual(secondCommentDate, actual[0][1].DateTime);
+        Assert.AreEqual(false, actual[0][1].Deleted);
+        Assert.AreEqual(thread, actual[0][1].Thread);
+        Assert.AreEqual(env.Username02, actual[0][1].User);
+        Assert.AreEqual("RUT", actual[0][1].VerseRef.Book);
+        Assert.AreEqual(1, actual[0][1].VerseRef.ChapterNum);
+        Assert.AreEqual(2, actual[0][1].VerseRef.VerseNum);
+    }
+
+    [Test]
+    public void ParseNotes_NoComments()
+    {
+        // Setup the environment
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+
+        // Setup the test data
+        string xml = "<notes version=\"1.1\"></notes>";
+        XElement noteXml = XElement.Parse(xml);
+
+        // SUT
+        List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
+        Assert.AreEqual(0, actual.Count);
+    }
+
+    private class TestEnvironment
+    {
+        public readonly string Project01 = "project01";
+        public readonly string Username01 = "User 01";
+        public readonly string Username02 = "User 02";
+
+        private readonly Dictionary<string, HexId> _ptProjectIds;
+        private readonly string _syncDir = Path.GetTempPath();
+        private readonly string _ruthBookUsfm =
+            "\\id RUT - ProjectNameHere\n" + "\\c 1\n" + "\\v 1 Verse one here.\n" + "\\v 2 Verse 2 here.";
+
+        public TestEnvironment() => _ptProjectIds = new Dictionary<string, HexId> { { Project01, HexId.CreateNew() } };
+
+        public MockScrText? ProjectScrText { get; private set; }
+
+        public void SetupProject(string baseId, ParatextUser associatedPtUser, bool hasEditPermission = true)
+        {
+            string ptProjectId = _ptProjectIds[baseId].Id;
+            ProjectScrText = GetScrText(associatedPtUser, ptProjectId, hasEditPermission);
+            ProjectFileManager projectFileManager = Substitute.For<ProjectFileManager>(ProjectScrText, null);
+            projectFileManager.IsWritable.Returns(true);
+            ProjectScrText.SetFileManager(projectFileManager);
         }
 
-        [Test]
-        public void FormatNotes_NoComments()
+        private MockScrText GetScrText(ParatextUser associatedPtUser, string projectId, bool hasEditPermission = true)
         {
-            // Setup the environment
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            env.SetupProject(env.Project01, associatedPtUser);
-
-            // Setup the test data
-            const string expected = "<notes version=\"1.1\" />";
-            List<CommentThread> commentThreads = new List<CommentThread>
-            {
-                new CommentThread { ContextScrTextName = env.ProjectScrText?.Name, ScrText = env.ProjectScrText },
-            };
-
-            // SUT
-            string actual = NotesFormatter.FormatNotes(commentThreads);
-            Assert.AreEqual(expected, actual);
-        }
-
-        [Test]
-        public void ParseNotes_CommentText()
-        {
-            // Setup the environment
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            env.SetupProject(env.Project01, associatedPtUser);
-
-            // Setup the test data
-            string commentText = "Comment Contents";
-            DateTimeOffset commentDate = DateTimeOffset.Now;
-            string thread = "Answer_dataId0123";
-            string verseRefStr = "RUT 1:2";
-            string xml = $"<notes version=\"1.1\"><thread id=\"{thread}\">";
-            xml += $"<selection verseRef=\"{verseRefStr}\" startPos=\"0\" selectedText=\"\" />";
-            xml += $"<comment user=\"{env.Username01}\" date=\"{commentDate:o}\"><content>{commentText}</content>";
-            xml += "</comment></thread></notes>";
-            XElement noteXml = XElement.Parse(xml);
-
-            // SUT
-            List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
-            Assert.AreEqual(1, actual.Count);
-            Assert.AreEqual(1, actual[0].Count);
-            Assert.AreEqual(commentText, actual[0][0].Contents.InnerXml);
-            Assert.AreEqual(commentDate, actual[0][0].DateTime);
-            Assert.AreEqual(false, actual[0][0].Deleted);
-            Assert.AreEqual(thread, actual[0][0].Thread);
-            Assert.AreEqual(env.Username01, actual[0][0].User);
-            Assert.AreEqual("RUT", actual[0][0].VerseRef.Book);
-            Assert.AreEqual(1, actual[0][0].VerseRef.ChapterNum);
-            Assert.AreEqual(2, actual[0][0].VerseRef.VerseNum);
-        }
-
-        [Test]
-        public void ParseNotes_ComplexComment()
-        {
-            // Setup the environment
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            env.SetupProject(env.Project01, associatedPtUser);
-
-            // Setup the test data
-            DateTimeOffset commentDate = DateTimeOffset.Now;
-            string contents = "<p>Comment Contents</p>";
-            string contextAfter = "here.";
-            string contextBefore = "Verse";
-            string externalUser = "John Doe";
-            string selectedText = "one";
-            int startPosition = 1;
-            string thread = "Answer_dataId0123";
-            string verseRefStr = "RUT 1:2";
-            string xml = $"<notes version=\"1.1\"><thread id=\"{thread}\">";
-            xml += $"<selection verseRef=\"{verseRefStr}\" startPos=\"{startPosition}\"";
-            xml += $" selectedText=\"{selectedText}\" beforeContext=\"{contextBefore}\"";
-            xml += $" afterContext=\"{contextAfter}\" />";
-            xml += $"<comment user=\"{env.Username01}\" date=\"{commentDate:o}\"";
-            xml += $" extUser=\"{externalUser}\">";
-            xml += $"<content>{contents}</content></comment></thread></notes>";
-            XElement noteXml = XElement.Parse(xml);
-
-            // SUT
-            List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
-            Assert.AreEqual(1, actual.Count);
-            Assert.AreEqual(1, actual[0].Count);
-            Assert.AreEqual(contents, actual[0][0].Contents.InnerXml);
-            Assert.AreEqual(false, actual[0][0].Deleted);
-            Assert.AreEqual(contextAfter, actual[0][0].ContextAfter);
-            Assert.AreEqual(contextBefore, actual[0][0].ContextBefore);
-            Assert.AreEqual(externalUser, actual[0][0].ExternalUser);
-            Assert.AreEqual(selectedText, actual[0][0].SelectedText);
-            Assert.AreEqual(startPosition, actual[0][0].StartPosition);
-            Assert.AreEqual(thread, actual[0][0].Thread);
-            Assert.AreEqual(env.Username01, actual[0][0].User);
-            Assert.AreEqual("RUT", actual[0][0].VerseRef.Book);
-            Assert.AreEqual(1, actual[0][0].VerseRef.ChapterNum);
-            Assert.AreEqual(2, actual[0][0].VerseRef.VerseNum);
-        }
-
-        [Test]
-        public void ParseNotes_DeletedComment()
-        {
-            // Setup the environment
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            env.SetupProject(env.Project01, associatedPtUser);
-
-            // Setup the test data
-            string thread = "Answer_dataId0123";
-            string xml = $"<notes version=\"1.1\"><thread id=\"{thread}\">";
-            xml += "<comment deleted=\"true\"></comment></thread></notes>";
-            XElement noteXml = XElement.Parse(xml);
-
-            // SUT
-            List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
-            Assert.AreEqual(1, actual.Count);
-            Assert.AreEqual(1, actual[0].Count);
-            Assert.AreEqual(true, actual[0][0].Deleted);
-            Assert.AreEqual(thread, actual[0][0].Thread);
-        }
-
-        [Test]
-        public void ParseNotes_DetailedCommentContents()
-        {
-            // Setup the environment
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            env.SetupProject(env.Project01, associatedPtUser);
-
-            // Setup the test data
-            DateTimeOffset commentDate = DateTimeOffset.Now;
-            string thread = "Answer_dataId0123";
-            string verseRefStr = "RUT 1:2";
-            string xml = $"<notes version=\"1.1\"><thread id=\"{thread}\">";
-            xml += $"<selection verseRef=\"{verseRefStr}\" startPos=\"0\" selectedText=\"\" />";
-            xml += $"<comment user=\"{env.Username01}\" date=\"{commentDate:o}\"><content>";
-            xml += "<p>Comment Text<span style=\"bold\">Bold Text</span>";
-            xml += "<span style=\"italic\">Italic Text</span><lang name=\"en_NZ\">Test</lang></p>";
-            xml += "</content></comment></thread></notes>";
-            XElement noteXml = XElement.Parse(xml);
-
-            // SUT
-            List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
-            Assert.AreEqual(1, actual.Count);
-            Assert.AreEqual(1, actual[0].Count);
-            string contents = "<p>Comment Text<bold>Bold Text</bold><italic>Italic Text</italic>";
-            contents += "<language name=\"en_NZ\">Test</language></p>";
-            Assert.AreEqual(contents, actual[0][0].Contents.InnerXml);
-            Assert.AreEqual(false, actual[0][0].Deleted);
-            Assert.AreEqual(thread, actual[0][0].Thread);
-            Assert.AreEqual(env.Username01, actual[0][0].User);
-            Assert.AreEqual("RUT", actual[0][0].VerseRef.Book);
-            Assert.AreEqual(1, actual[0][0].VerseRef.ChapterNum);
-            Assert.AreEqual(2, actual[0][0].VerseRef.VerseNum);
-        }
-
-        [Test]
-        public void ParseNotes_EmptyComment()
-        {
-            // Setup the environment
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            env.SetupProject(env.Project01, associatedPtUser);
-
-            // Setup the test data
-            DateTimeOffset commentDate = DateTimeOffset.Now;
-            string thread = "Answer_dataId0123";
-            string verseRefStr = "RUT 1:2";
-            string xml = $"<notes version=\"1.1\"><thread id=\"{thread}\">";
-            xml += $"<selection verseRef=\"{verseRefStr}\" startPos=\"0\" selectedText=\"\" />";
-            xml += $"<comment user=\"{env.Username01}\" date=\"{commentDate:o}\"></comment></thread></notes>";
-            XElement noteXml = XElement.Parse(xml);
-
-            // SUT
-            List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
-            Assert.AreEqual(1, actual.Count);
-            Assert.AreEqual(1, actual[0].Count);
-            Assert.AreEqual(string.Empty, actual[0][0].Contents.InnerXml);
-            Assert.AreEqual(commentDate, actual[0][0].DateTime);
-            Assert.AreEqual(false, actual[0][0].Deleted);
-            Assert.AreEqual(thread, actual[0][0].Thread);
-            Assert.AreEqual(env.Username01, actual[0][0].User);
-            Assert.AreEqual("RUT", actual[0][0].VerseRef.Book);
-            Assert.AreEqual(1, actual[0][0].VerseRef.ChapterNum);
-            Assert.AreEqual(2, actual[0][0].VerseRef.VerseNum);
-        }
-
-        [Test]
-        public void ParseNotes_MultipleComments()
-        {
-            // Setup the environment
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            env.SetupProject(env.Project01, associatedPtUser);
-
-            // Setup the test data
-            DateTimeOffset firstCommentDate = DateTimeOffset.Now.AddDays(-1);
-            DateTimeOffset secondCommentDate = DateTimeOffset.Now;
-            string contents = "<p>Comment Contents</p>";
-            string thread = "Answer_dataId0123";
-            string verseRefStr = "RUT 1:2";
-            string xml = $"<notes version=\"1.1\"><thread id=\"{thread}\">";
-            xml += $"<selection verseRef=\"{verseRefStr}\" startPos=\"0\" selectedText=\"\" />";
-            xml += $"<comment user=\"{env.Username01}\" date=\"{firstCommentDate:o}\"></comment>";
-            xml += $"<comment user=\"{env.Username02}\" date=\"{secondCommentDate:o}\">";
-            xml += $"<content>{contents}</content></comment>";
-            xml += "</thread></notes>";
-            XElement noteXml = XElement.Parse(xml);
-
-            // SUT
-            List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
-            Assert.AreEqual(1, actual.Count);
-            Assert.AreEqual(2, actual[0].Count);
-
-            // First Comment
-            Assert.AreEqual(string.Empty, actual[0][0].Contents.InnerXml);
-            Assert.AreEqual(firstCommentDate, actual[0][0].DateTime);
-            Assert.AreEqual(false, actual[0][0].Deleted);
-            Assert.AreEqual(thread, actual[0][0].Thread);
-            Assert.AreEqual(env.Username01, actual[0][0].User);
-            Assert.AreEqual("RUT", actual[0][0].VerseRef.Book);
-            Assert.AreEqual(1, actual[0][0].VerseRef.ChapterNum);
-            Assert.AreEqual(2, actual[0][0].VerseRef.VerseNum);
-
-            // Second Comment
-            Assert.AreEqual(contents, actual[0][1].Contents.InnerXml);
-            Assert.AreEqual(secondCommentDate, actual[0][1].DateTime);
-            Assert.AreEqual(false, actual[0][1].Deleted);
-            Assert.AreEqual(thread, actual[0][1].Thread);
-            Assert.AreEqual(env.Username02, actual[0][1].User);
-            Assert.AreEqual("RUT", actual[0][1].VerseRef.Book);
-            Assert.AreEqual(1, actual[0][1].VerseRef.ChapterNum);
-            Assert.AreEqual(2, actual[0][1].VerseRef.VerseNum);
-        }
-
-        [Test]
-        public void ParseNotes_NoComments()
-        {
-            // Setup the environment
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            env.SetupProject(env.Project01, associatedPtUser);
-
-            // Setup the test data
-            string xml = "<notes version=\"1.1\"></notes>";
-            XElement noteXml = XElement.Parse(xml);
-
-            // SUT
-            List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
-            Assert.AreEqual(0, actual.Count);
-        }
-
-        private class TestEnvironment
-        {
-            public readonly string Project01 = "project01";
-            public readonly string Username01 = "User 01";
-            public readonly string Username02 = "User 02";
-
-            private readonly Dictionary<string, HexId> _ptProjectIds;
-            private readonly string _syncDir = Path.GetTempPath();
-            private readonly string _ruthBookUsfm =
-                "\\id RUT - ProjectNameHere\n" + "\\c 1\n" + "\\v 1 Verse one here.\n" + "\\v 2 Verse 2 here.";
-
-            public TestEnvironment()
-            {
-                _ptProjectIds = new Dictionary<string, HexId> { { Project01, HexId.CreateNew() } };
-            }
-
-            public MockScrText? ProjectScrText { get; private set; }
-
-            public void SetupProject(string baseId, ParatextUser associatedPtUser, bool hasEditPermission = true)
-            {
-                string ptProjectId = _ptProjectIds[baseId].Id;
-                ProjectScrText = GetScrText(associatedPtUser, ptProjectId, hasEditPermission);
-                ProjectFileManager projectFileManager = Substitute.For<ProjectFileManager>(ProjectScrText, null);
-                projectFileManager.IsWritable.Returns(true);
-                ProjectScrText.SetFileManager(projectFileManager);
-            }
-
-            private MockScrText GetScrText(
-                ParatextUser associatedPtUser,
-                string projectId,
-                bool hasEditPermission = true
-            )
-            {
-                string scrTextDir = Path.Combine(_syncDir, projectId, "target");
-                ProjectName projectName = new ProjectName { ProjectPath = scrTextDir, ShortName = "Proj" };
-                var scrText = new MockScrText(associatedPtUser, projectName) { CachedGuid = HexId.FromStr(projectId) };
-                scrText.Permissions.CreateFirstAdminUser();
-                scrText.Data.Add("RUT", _ruthBookUsfm);
-                scrText.Settings.BooksPresentSet = new BookSet("RUT");
-                if (!hasEditPermission)
-                    scrText.Permissions.SetPermission(null, 8, PermissionSet.Manual, false);
-                return scrText;
-            }
+            string scrTextDir = Path.Combine(_syncDir, projectId, "target");
+            ProjectName projectName = new ProjectName { ProjectPath = scrTextDir, ShortName = "Proj" };
+            var scrText = new MockScrText(associatedPtUser, projectName) { CachedGuid = HexId.FromStr(projectId) };
+            scrText.Permissions.CreateFirstAdminUser();
+            scrText.Data.Add("RUT", _ruthBookUsfm);
+            scrText.Settings.BooksPresentSet = new BookSet("RUT");
+            if (!hasEditPermission)
+                scrText.Permissions.SetPermission(null, 8, PermissionSet.Manual, false);
+            return scrText;
         }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextNoteExtensions.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextNoteExtensions.cs
@@ -1,55 +1,50 @@
 using SIL.XForge.Scripture.Models;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+public static class ParatextNoteTestExtensions
 {
-    public static class ParatextNoteTestExtensions
+    public static string NoteToString(this Note note)
     {
-        public static string NoteToString(this Note note)
-        {
-            string result = $"{note.ThreadId}-{note.SyncUserRef}-{note.ExtUserId}-{note.Content}";
-            if (note.Deleted)
-                result = result + "-deleted";
-            if (note.TagId != null)
-                result = result + $"-tag:{note.TagId}";
-            return result;
-        }
+        string result = $"{note.ThreadId}-{note.SyncUserRef}-{note.ExtUserId}-{note.Content}";
+        if (note.Deleted)
+            result += "-deleted";
+        if (note.TagId != null)
+            result += $"-tag:{note.TagId}";
+        return result;
+    }
 
-        public static string ThreadChangeToString(this NoteThreadChange thread)
-        {
-            string selection =
-                thread.Position == null
-                    ? string.Empty
-                    : $"-Start:{thread.Position.Start}-Length:{thread.Position.Length}";
-            string result =
-                thread.ContextBefore + thread.SelectedText + thread.ContextAfter + $"{selection}-{thread.VerseRefStr}";
-            return result;
-        }
+    public static string ThreadChangeToString(this NoteThreadChange thread)
+    {
+        string selection =
+            thread.Position == null ? string.Empty : $"-Start:{thread.Position.Start}-Length:{thread.Position.Length}";
+        string result =
+            thread.ContextBefore + thread.SelectedText + thread.ContextAfter + $"{selection}-{thread.VerseRefStr}";
+        return result;
+    }
 
-        public static string NoteThreadToString(this NoteThread thread)
-        {
-            string selection =
-                thread.Position == null
-                    ? string.Empty
-                    : $"-Start:{thread.Position.Start}-Length:{thread.Position.Length}";
-            string result =
-                thread.OriginalContextBefore
-                + thread.OriginalSelectedText
-                + thread.OriginalContextAfter
-                + $"{selection}-{thread.VerseRef}";
-            return result;
-        }
+    public static string NoteThreadToString(this NoteThread thread)
+    {
+        string selection =
+            thread.Position == null ? string.Empty : $"-Start:{thread.Position.Start}-Length:{thread.Position.Length}";
+        string result =
+            thread.OriginalContextBefore
+            + thread.OriginalSelectedText
+            + thread.OriginalContextAfter
+            + $"{selection}-{thread.VerseRef}";
+        return result;
+    }
 
-        public static string CommentToString(this Paratext.Data.ProjectComments.Comment comment)
-        {
-            string result =
-                $"{comment.Id}-{comment.VerseRefStr}-{comment.Contents.InnerXml}" + $"-Start:{comment.StartPosition}";
-            if (comment.ExternalUser != null)
-                result = result + $"-{comment.ExternalUser}";
-            if (comment.Deleted)
-                result = result + "-deleted";
-            if (comment.TagsAdded != null)
-                result = result + $"-Tag:{comment.TagsAdded[0]}";
-            return result;
-        }
+    public static string CommentToString(this Paratext.Data.ProjectComments.Comment comment)
+    {
+        string result =
+            $"{comment.Id}-{comment.VerseRefStr}-{comment.Contents.InnerXml}" + $"-Start:{comment.StartPosition}";
+        if (comment.ExternalUser != null)
+            result += $"-{comment.ExternalUser}";
+        if (comment.Deleted)
+            result += "-deleted";
+        if (comment.TagsAdded != null)
+            result += $"-Tag:{comment.TagsAdded[0]}";
+        return result;
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
@@ -13,27 +13,26 @@ using SIL.XForge.Configuration;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
 using SIL.XForge.Realtime;
-using SIL.XForge.Services;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Scripture.Realtime;
+using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class ParatextNotesMapperTests
 {
-    [TestFixture]
-    public class ParatextNotesMapperTests
+    [Test]
+    public async Task GetNotesChangelistAsync_AddNotes()
     {
-        [Test]
-        public async Task GetNotesChangelistAsync_AddNotes()
-        {
-            var env = new TestEnvironment();
-            env.SetParatextProjectRoles(true);
-            await env.InitMapperAsync(false, true);
-            env.AddData(null, null, null, null);
+        var env = new TestEnvironment();
+        env.SetParatextProjectRoles(true);
+        await env.InitMapperAsync(false, true);
+        env.AddData(null, null, null, null);
 
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-            {
-                const string oldNotesText =
-                    @"
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        const string oldNotesText =
+            @"
                     <notes version=""1.1"">
                         <thread id=""ANSWER_answer03"">
                             <selection verseRef=""MAT 1:2"" startPos=""0"" selectedText="""" />
@@ -46,19 +45,17 @@ namespace SIL.XForge.Scripture.Services
                             </comment>
                         </thread>
                     </notes>";
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(
-                    u => u.Username
-                );
-                XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
-                    XElement.Parse(oldNotesText),
-                    await env.GetQuestionDocsAsync(conn),
-                    ptProjectUsers,
-                    TestEnvironment.userRoles,
-                    CheckingAnswerExport.All
-                );
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(u => u.Username);
+        XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
+            XElement.Parse(oldNotesText),
+            await TestEnvironment.GetQuestionDocsAsync(conn),
+            ptProjectUsers,
+            TestEnvironment.userRoles,
+            CheckingAnswerExport.All
+        );
 
-                const string expectedNotesText =
-                    @"
+        const string expectedNotesText =
+            @"
                     <notes version=""1.1"">
                         <thread id=""ANSWER_answer01"">
                             <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
@@ -121,41 +118,37 @@ namespace SIL.XForge.Scripture.Services
                             </comment>
                         </thread>
                     </notes>";
-                Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
+        Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
 
-                Assert.That(ptProjectUsers.Keys, Is.EquivalentTo(new[] { "PT User 1", "PT User 3" }));
-            }
-        }
+        Assert.That(ptProjectUsers.Keys, Is.EquivalentTo(new[] { "PT User 1", "PT User 3" }));
+    }
 
-        [Test]
-        public async Task GetNotesChangelistAsync_UsesCheckerNameForPTUserNotOnProject()
-        {
-            // pt user is a community checker on the project
-            var env = new TestEnvironment();
-            env.SetParatextProjectRoles(false);
-            await env.InitMapperAsync(false, false);
-            env.AddData(null, null, null, null);
+    [Test]
+    public async Task GetNotesChangelistAsync_UsesCheckerNameForPTUserNotOnProject()
+    {
+        // pt user is a community checker on the project
+        var env = new TestEnvironment();
+        env.SetParatextProjectRoles(false);
+        await env.InitMapperAsync(false, false);
+        env.AddData(null, null, null, null);
 
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-            {
-                const string oldNotesText = @"<notes version=""1.1""></notes>";
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(
-                    u => u.Username
-                );
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        const string oldNotesText = @"<notes version=""1.1""></notes>";
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(u => u.Username);
 
-                Dictionary<string, string> userRoles = TestEnvironment.userRoles;
-                userRoles["user03"] = SFProjectRole.CommunityChecker;
-                XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
-                    XElement.Parse(oldNotesText),
-                    await env.GetQuestionDocsAsync(conn),
-                    ptProjectUsers,
-                    userRoles,
-                    CheckingAnswerExport.All
-                );
+        Dictionary<string, string> userRoles = TestEnvironment.userRoles;
+        userRoles["user03"] = SFProjectRole.CommunityChecker;
+        XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
+            XElement.Parse(oldNotesText),
+            await TestEnvironment.GetQuestionDocsAsync(conn),
+            ptProjectUsers,
+            userRoles,
+            CheckingAnswerExport.All
+        );
 
-                // User 03 is listed as a community checker because they are not a PT user on the particular project
-                const string expectedNotesText =
-                    @"
+        // User 03 is listed as a community checker because they are not a PT user on the particular project
+        const string expectedNotesText =
+            @"
                     <notes version=""1.1"">
                         <thread id=""ANSWER_answer01"">
                             <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
@@ -212,23 +205,21 @@ namespace SIL.XForge.Scripture.Services
                         </thread>
                     </notes>";
 
-                Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
-                Assert.That(ptProjectUsers.Keys, Is.EquivalentTo(new[] { "PT User 1" }));
-            }
-        }
+        Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
+        Assert.That(ptProjectUsers.Keys, Is.EquivalentTo(new[] { "PT User 1" }));
+    }
 
-        [Test]
-        public async Task GetNotesChangelistAsync_AddAudioNotes()
-        {
-            var env = new TestEnvironment();
-            env.SetParatextProjectRoles(true);
-            await env.InitMapperAsync(false, true);
-            env.AddData(null, null, null, null, true);
+    [Test]
+    public async Task GetNotesChangelistAsync_AddAudioNotes()
+    {
+        var env = new TestEnvironment();
+        env.SetParatextProjectRoles(true);
+        await env.InitMapperAsync(false, true);
+        env.AddData(null, null, null, null, true);
 
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-            {
-                const string oldNotesText =
-                    @"
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        const string oldNotesText =
+            @"
                     <notes version=""1.1"">
                         <thread id=""ANSWER_answer03"">
                             <selection verseRef=""MAT 1:2"" startPos=""0"" selectedText="""" />
@@ -241,19 +232,17 @@ namespace SIL.XForge.Scripture.Services
                             </comment>
                         </thread>
                     </notes>";
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(
-                    u => u.Username
-                );
-                XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
-                    XElement.Parse(oldNotesText),
-                    await env.GetQuestionDocsAsync(conn),
-                    ptProjectUsers,
-                    TestEnvironment.userRoles,
-                    CheckingAnswerExport.All
-                );
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(u => u.Username);
+        XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
+            XElement.Parse(oldNotesText),
+            await TestEnvironment.GetQuestionDocsAsync(conn),
+            ptProjectUsers,
+            TestEnvironment.userRoles,
+            CheckingAnswerExport.All
+        );
 
-                const string expectedNotesText =
-                    @"
+        const string expectedNotesText =
+            @"
                     <notes version=""1.1"">
                         <thread id=""ANSWER_answer01"">
                             <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
@@ -316,24 +305,22 @@ namespace SIL.XForge.Scripture.Services
                             </comment>
                         </thread>
                     </notes>";
-                Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
+        Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
 
-                Assert.That(ptProjectUsers.Keys, Is.EquivalentTo(new[] { "PT User 1", "PT User 3" }));
-            }
-        }
+        Assert.That(ptProjectUsers.Keys, Is.EquivalentTo(new[] { "PT User 1", "PT User 3" }));
+    }
 
-        [Test]
-        public async Task GetNotesChangelistAsync_ParatextUserNotOnProject_AddNotes()
-        {
-            var env = new TestEnvironment();
-            env.SetParatextProjectRoles(false);
-            await env.InitMapperAsync(false, true);
-            env.AddData(null, null, null, null);
+    [Test]
+    public async Task GetNotesChangelistAsync_ParatextUserNotOnProject_AddNotes()
+    {
+        var env = new TestEnvironment();
+        env.SetParatextProjectRoles(false);
+        await env.InitMapperAsync(false, true);
+        env.AddData(null, null, null, null);
 
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-            {
-                const string oldNotesText =
-                    @"
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        const string oldNotesText =
+            @"
                     <notes version=""1.1"">
                         <thread id=""ANSWER_answer03"">
                             <selection verseRef=""MAT 1:2"" startPos=""0"" selectedText="""" />
@@ -346,24 +333,22 @@ namespace SIL.XForge.Scripture.Services
                             </comment>
                         </thread>
                     </notes>";
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(
-                    u => u.Username
-                );
-                XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
-                    XElement.Parse(oldNotesText),
-                    await env.GetQuestionDocsAsync(conn),
-                    ptProjectUsers,
-                    TestEnvironment.userRoles,
-                    CheckingAnswerExport.All
-                );
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(u => u.Username);
+        XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
+            XElement.Parse(oldNotesText),
+            await TestEnvironment.GetQuestionDocsAsync(conn),
+            ptProjectUsers,
+            TestEnvironment.userRoles,
+            CheckingAnswerExport.All
+        );
 
-                // User 3 is a PT user but does not have a role on this particular PT project, according to the PT
-                // Registry. So we will attribute their comment to user 1, who does have a role on this project
-                // according to the PT registry. Otherwise we would get errors when uploading a note attributed to user
-                // 3's PT username since they do not have appropriate access to write a note. Also, NewSyncUsers will
-                // not contain user 3.
-                const string expectedNotesText =
-                    @"
+        // User 3 is a PT user but does not have a role on this particular PT project, according to the PT
+        // Registry. So we will attribute their comment to user 1, who does have a role on this project
+        // according to the PT registry. Otherwise we would get errors when uploading a note attributed to user
+        // 3's PT username since they do not have appropriate access to write a note. Also, NewSyncUsers will
+        // not contain user 3.
+        const string expectedNotesText =
+            @"
                     <notes version=""1.1"">
                         <thread id=""ANSWER_answer01"">
                             <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
@@ -426,24 +411,22 @@ namespace SIL.XForge.Scripture.Services
                             </comment>
                         </thread>
                     </notes>";
-                Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
+        Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
 
-                Assert.That(ptProjectUsers.Keys, Is.EquivalentTo(new[] { "PT User 1" }));
-            }
-        }
+        Assert.That(ptProjectUsers.Keys, Is.EquivalentTo(new[] { "PT User 1" }));
+    }
 
-        [Test]
-        public async Task GetNotesChangelistAsync_UpdateNotes()
-        {
-            var env = new TestEnvironment();
-            env.SetParatextProjectRoles(true);
-            await env.InitMapperAsync(true, true);
-            env.AddData("syncuser01", "syncuser03", null, "syncuser03");
+    [Test]
+    public async Task GetNotesChangelistAsync_UpdateNotes()
+    {
+        var env = new TestEnvironment();
+        env.SetParatextProjectRoles(true);
+        await env.InitMapperAsync(true, true);
+        env.AddData("syncuser01", "syncuser03", null, "syncuser03");
 
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-            {
-                const string oldNotesText =
-                    @"
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        const string oldNotesText =
+            @"
                     <notes version=""1.1"">
                         <thread id=""ANSWER_answer01"">
                             <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
@@ -473,19 +456,17 @@ namespace SIL.XForge.Scripture.Services
                             </comment>
                         </thread>
                     </notes>";
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(
-                    u => u.Username
-                );
-                XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
-                    XElement.Parse(oldNotesText),
-                    await env.GetQuestionDocsAsync(conn),
-                    ptProjectUsers,
-                    TestEnvironment.userRoles,
-                    CheckingAnswerExport.All
-                );
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(u => u.Username);
+        XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
+            XElement.Parse(oldNotesText),
+            await TestEnvironment.GetQuestionDocsAsync(conn),
+            ptProjectUsers,
+            TestEnvironment.userRoles,
+            CheckingAnswerExport.All
+        );
 
-                const string expectedNotesText =
-                    @"
+        const string expectedNotesText =
+            @"
                     <notes version=""1.1"">
                         <thread id=""ANSWER_answer01"">
                             <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
@@ -530,22 +511,20 @@ namespace SIL.XForge.Scripture.Services
                             </comment>
                         </thread>
                     </notes>";
-                Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
-            }
-        }
+        Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
+    }
 
-        [Test]
-        public async Task GetNotesChangelistAsync_DeleteNotes()
-        {
-            var env = new TestEnvironment();
-            env.SetParatextProjectRoles(true);
-            await env.InitMapperAsync(true, true);
-            env.AddData("syncuser01", "syncuser03", "syncuser03", "syncuser03");
+    [Test]
+    public async Task GetNotesChangelistAsync_DeleteNotes()
+    {
+        var env = new TestEnvironment();
+        env.SetParatextProjectRoles(true);
+        await env.InitMapperAsync(true, true);
+        env.AddData("syncuser01", "syncuser03", "syncuser03", "syncuser03");
 
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-            {
-                const string oldNotesText =
-                    @"
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        const string oldNotesText =
+            @"
                     <notes version=""1.1"">
                         <thread id=""ANSWER_answer01"">
                             <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
@@ -591,19 +570,17 @@ namespace SIL.XForge.Scripture.Services
                             </comment>
                         </thread>
                     </notes>";
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(
-                    u => u.Username
-                );
-                XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
-                    XElement.Parse(oldNotesText),
-                    await env.GetQuestionDocsAsync(conn),
-                    ptProjectUsers,
-                    TestEnvironment.userRoles,
-                    CheckingAnswerExport.All
-                );
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(u => u.Username);
+        XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
+            XElement.Parse(oldNotesText),
+            await TestEnvironment.GetQuestionDocsAsync(conn),
+            ptProjectUsers,
+            TestEnvironment.userRoles,
+            CheckingAnswerExport.All
+        );
 
-                const string expectedNotesText =
-                    @"
+        const string expectedNotesText =
+            @"
                     <notes version=""1.1"">
                         <thread id=""ANSWER_answer01"">
                             <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
@@ -648,34 +625,30 @@ namespace SIL.XForge.Scripture.Services
                             </comment>
                         </thread>
                     </notes>";
-                Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
-            }
-        }
+        Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
+    }
 
-        [Test]
-        public async Task GetNotesChangelistAsync_ExportAllNotes()
-        {
-            var env = new TestEnvironment();
-            env.SetParatextProjectRoles(true);
-            await env.InitMapperAsync(false, true);
-            env.AddData(null, null, null, null);
+    [Test]
+    public async Task GetNotesChangelistAsync_ExportAllNotes()
+    {
+        var env = new TestEnvironment();
+        env.SetParatextProjectRoles(true);
+        await env.InitMapperAsync(false, true);
+        env.AddData(null, null, null, null);
 
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-            {
-                const string oldNotesText = @"<notes version=""1.1""></notes>";
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(
-                    u => u.Username
-                );
-                XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
-                    XElement.Parse(oldNotesText),
-                    await env.GetQuestionDocsAsync(conn),
-                    ptProjectUsers,
-                    TestEnvironment.userRoles,
-                    CheckingAnswerExport.All
-                );
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        const string oldNotesText = @"<notes version=""1.1""></notes>";
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(u => u.Username);
+        XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
+            XElement.Parse(oldNotesText),
+            await TestEnvironment.GetQuestionDocsAsync(conn),
+            ptProjectUsers,
+            TestEnvironment.userRoles,
+            CheckingAnswerExport.All
+        );
 
-                const string expectedNotesText =
-                    @"
+        const string expectedNotesText =
+            @"
                     <notes version=""1.1"">
                         <thread id=""ANSWER_answer01"">
                             <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
@@ -728,61 +701,53 @@ namespace SIL.XForge.Scripture.Services
                             </comment>
                         </thread>
                     </notes>";
-                Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
-            }
-        }
+        Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
+    }
 
-        [Test]
-        public async Task GetNotesChangelistAsync_ExportNoNotes()
-        {
-            var env = new TestEnvironment();
-            env.SetParatextProjectRoles(true);
-            await env.InitMapperAsync(false, true);
-            env.AddData(null, null, null, null);
+    [Test]
+    public async Task GetNotesChangelistAsync_ExportNoNotes()
+    {
+        var env = new TestEnvironment();
+        env.SetParatextProjectRoles(true);
+        await env.InitMapperAsync(false, true);
+        env.AddData(null, null, null, null);
 
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-            {
-                const string oldNotesText = @"<notes version=""1.1""></notes>";
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(
-                    u => u.Username
-                );
-                XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
-                    XElement.Parse(oldNotesText),
-                    await env.GetQuestionDocsAsync(conn),
-                    ptProjectUsers,
-                    TestEnvironment.userRoles,
-                    CheckingAnswerExport.None
-                );
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        const string oldNotesText = @"<notes version=""1.1""></notes>";
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(u => u.Username);
+        XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
+            XElement.Parse(oldNotesText),
+            await TestEnvironment.GetQuestionDocsAsync(conn),
+            ptProjectUsers,
+            TestEnvironment.userRoles,
+            CheckingAnswerExport.None
+        );
 
-                const string expectedNotesText = @"<notes version=""1.1"" />";
-                Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
-            }
-        }
+        const string expectedNotesText = @"<notes version=""1.1"" />";
+        Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
+    }
 
-        [Test]
-        public async Task GetNotesChangelistAsync_ExportOnlyExportableNotes()
-        {
-            var env = new TestEnvironment();
-            env.SetParatextProjectRoles(true);
-            await env.InitMapperAsync(false, true);
-            env.AddData(null, null, null, null);
+    [Test]
+    public async Task GetNotesChangelistAsync_ExportOnlyExportableNotes()
+    {
+        var env = new TestEnvironment();
+        env.SetParatextProjectRoles(true);
+        await env.InitMapperAsync(false, true);
+        env.AddData(null, null, null, null);
 
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-            {
-                const string oldNotesText = @"<notes version=""1.1""></notes>";
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(
-                    u => u.Username
-                );
-                XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
-                    XElement.Parse(oldNotesText),
-                    await env.GetQuestionDocsAsync(conn),
-                    ptProjectUsers,
-                    TestEnvironment.userRoles,
-                    CheckingAnswerExport.MarkedForExport
-                );
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        const string oldNotesText = @"<notes version=""1.1""></notes>";
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(u => u.Username);
+        XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
+            XElement.Parse(oldNotesText),
+            await TestEnvironment.GetQuestionDocsAsync(conn),
+            ptProjectUsers,
+            TestEnvironment.userRoles,
+            CheckingAnswerExport.MarkedForExport
+        );
 
-                const string expectedNotesText =
-                    @"
+        const string expectedNotesText =
+            @"
                     <notes version=""1.1"">
                         <thread id=""ANSWER_answer04"">
                             <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
@@ -795,243 +760,238 @@ namespace SIL.XForge.Scripture.Services
                             </comment>
                         </thread>
                     </notes>";
-                Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
-            }
+        Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
+    }
+
+    private class TestEnvironment
+    {
+        public static readonly Dictionary<string, string> userRoles = new Dictionary<string, string>
+        {
+            { "user01", SFProjectRole.Administrator },
+            { "user02", SFProjectRole.CommunityChecker },
+            { "user03", SFProjectRole.Translator },
+            { "user04", SFProjectRole.CommunityChecker }
+        };
+
+        public TestEnvironment()
+        {
+            UserSecrets = new MemoryRepository<UserSecret>(
+                new[]
+                {
+                    new UserSecret { Id = "user01" },
+                    new UserSecret { Id = "user03" }
+                }
+            );
+
+            RealtimeService = new SFMemoryRealtimeService();
+
+            ParatextService = Substitute.For<IParatextService>();
+            ParatextService.GetParatextUsername(Arg.Is<UserSecret>(u => u.Id == "user01")).Returns("PT User 1");
+            ParatextService.GetParatextUsername(Arg.Is<UserSecret>(u => u.Id == "user03")).Returns("PT User 3");
+
+            UserService = Substitute.For<IUserService>();
+            var userIdToUsername = new Dictionary<string, string>
+            {
+                { "user01", "User 01" },
+                { "user02", "User 02" },
+                { "user03", "User 03" },
+                { "user04", "User 04" }
+            };
+            UserService
+                .GetUsernameFromUserId(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(x => Task.FromResult(userIdToUsername[(string)x[1]]));
+
+            var options = Microsoft.Extensions.Options.Options.Create(
+                new LocalizationOptions { ResourcesPath = "Resources" }
+            );
+            var factory = new ResourceManagerStringLocalizerFactory(options, NullLoggerFactory.Instance);
+            Localizer = new StringLocalizer<SharedResource>(factory);
+            var siteOptions = Substitute.For<IOptions<SiteOptions>>();
+            siteOptions.Value.Returns(new SiteOptions { Name = "xForge", });
+            Mapper = new ParatextNotesMapper(
+                UserSecrets,
+                ParatextService,
+                UserService,
+                Localizer,
+                siteOptions,
+                new TestGuidService()
+            );
         }
 
-        private class TestEnvironment
-        {
-            public static readonly Dictionary<string, string> userRoles = new Dictionary<string, string>
-            {
-                { "user01", SFProjectRole.Administrator },
-                { "user02", SFProjectRole.CommunityChecker },
-                { "user03", SFProjectRole.Translator },
-                { "user04", SFProjectRole.CommunityChecker }
-            };
+        public ParatextNotesMapper Mapper { get; }
+        public MemoryRepository<UserSecret> UserSecrets { get; }
+        public SFMemoryRealtimeService RealtimeService { get; }
+        public IParatextService ParatextService { get; }
+        public IUserService UserService { get; }
+        public IStringLocalizer<SharedResource> Localizer { get; }
+        public IEnumerable<ParatextUserProfile> PtProjectUsers { get; set; }
 
-            public TestEnvironment()
-            {
-                UserSecrets = new MemoryRepository<UserSecret>(
+        public async Task InitMapperAsync(bool includeSyncUsers, bool twoPtUsersOnProject)
+        {
+            SFProject project = Project(includeSyncUsers);
+            PtProjectUsers = project.ParatextUsers;
+            await Mapper.InitAsync(
+                UserSecrets.Get("user01"),
+                ProjectSecret(),
+                ParatextUsersOnProject(twoPtUsersOnProject),
+                project,
+                CancellationToken.None
+            );
+        }
+
+        public void AddData(
+            string answerSyncUserId1,
+            string answerSyncUserId2,
+            string commentSyncUserId1,
+            string commentSyncUserId2,
+            bool useAudioResponses = false
+        )
+        {
+            RealtimeService.AddRepository(
+                "questions",
+                OTType.Json0,
+                new MemoryRepository<Question>(
                     new[]
                     {
-                        new UserSecret { Id = "user01" },
-                        new UserSecret { Id = "user03" }
-                    }
-                );
-
-                RealtimeService = new SFMemoryRealtimeService();
-
-                ParatextService = Substitute.For<IParatextService>();
-                ParatextService.GetParatextUsername(Arg.Is<UserSecret>(u => u.Id == "user01")).Returns("PT User 1");
-                ParatextService.GetParatextUsername(Arg.Is<UserSecret>(u => u.Id == "user03")).Returns("PT User 3");
-
-                UserService = Substitute.For<IUserService>();
-                var userIdToUsername = new Dictionary<string, string>
-                {
-                    { "user01", "User 01" },
-                    { "user02", "User 02" },
-                    { "user03", "User 03" },
-                    { "user04", "User 04" }
-                };
-                UserService
-                    .GetUsernameFromUserId(Arg.Any<string>(), Arg.Any<string>())
-                    .Returns(x => Task.FromResult(userIdToUsername[(string)x[1]]));
-
-                var options = Microsoft.Extensions.Options.Options.Create(
-                    new LocalizationOptions { ResourcesPath = "Resources" }
-                );
-                var factory = new ResourceManagerStringLocalizerFactory(options, NullLoggerFactory.Instance);
-                Localizer = new StringLocalizer<SharedResource>(factory);
-                var siteOptions = Substitute.For<IOptions<SiteOptions>>();
-                siteOptions.Value.Returns(new SiteOptions { Name = "xForge", });
-                Mapper = new ParatextNotesMapper(
-                    UserSecrets,
-                    ParatextService,
-                    UserService,
-                    Localizer,
-                    siteOptions,
-                    new TestGuidService()
-                );
-            }
-
-            public ParatextNotesMapper Mapper { get; }
-            public MemoryRepository<UserSecret> UserSecrets { get; }
-            public SFMemoryRealtimeService RealtimeService { get; }
-            public IParatextService ParatextService { get; }
-            public IUserService UserService { get; }
-            public IStringLocalizer<SharedResource> Localizer { get; }
-            public IEnumerable<ParatextUserProfile> PtProjectUsers { get; set; }
-
-            public async Task InitMapperAsync(bool includeSyncUsers, bool twoPtUsersOnProject)
-            {
-                SFProject project = Project(includeSyncUsers);
-                PtProjectUsers = project.ParatextUsers;
-                await Mapper.InitAsync(
-                    UserSecrets.Get("user01"),
-                    ProjectSecret(),
-                    ParatextUsersOnProject(twoPtUsersOnProject),
-                    project,
-                    CancellationToken.None
-                );
-            }
-
-            public void AddData(
-                string answerSyncUserId1,
-                string answerSyncUserId2,
-                string commentSyncUserId1,
-                string commentSyncUserId2,
-                bool useAudioResponses = false
-            )
-            {
-                RealtimeService.AddRepository(
-                    "questions",
-                    OTType.Json0,
-                    new MemoryRepository<Question>(
-                        new[]
+                        new Question
                         {
-                            new Question
+                            Id = "project01:question01",
+                            DataId = "question01",
+                            VerseRef = new VerseRefData(40, 1, 1),
+                            Text = useAudioResponses ? "" : "Test question?",
+                            Answers =
                             {
-                                Id = "project01:question01",
-                                DataId = "question01",
-                                VerseRef = new VerseRefData(40, 1, 1),
-                                Text = useAudioResponses ? "" : "Test question?",
-                                Answers =
+                                new Answer
                                 {
-                                    new Answer
+                                    DataId = "answer01",
+                                    OwnerRef = "user02",
+                                    SyncUserRef = answerSyncUserId1,
+                                    DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc),
+                                    Text = useAudioResponses ? "" : "Test answer 1.",
+                                    Comments =
                                     {
-                                        DataId = "answer01",
-                                        OwnerRef = "user02",
-                                        SyncUserRef = answerSyncUserId1,
-                                        DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc),
-                                        Text = useAudioResponses ? "" : "Test answer 1.",
-                                        Comments =
+                                        new Comment
                                         {
-                                            new Comment
-                                            {
-                                                DataId = "comment01",
-                                                OwnerRef = "user03",
-                                                SyncUserRef = commentSyncUserId1,
-                                                DateCreated = new DateTime(2019, 1, 1, 9, 0, 0, DateTimeKind.Utc),
-                                                Text = "Test comment 1."
-                                            }
+                                            DataId = "comment01",
+                                            OwnerRef = "user03",
+                                            SyncUserRef = commentSyncUserId1,
+                                            DateCreated = new DateTime(2019, 1, 1, 9, 0, 0, DateTimeKind.Utc),
+                                            Text = "Test comment 1."
                                         }
-                                    },
-                                    new Answer
-                                    {
-                                        DataId = "answer02",
-                                        OwnerRef = "user04",
-                                        SyncUserRef = answerSyncUserId2,
-                                        DateCreated = new DateTime(2019, 1, 2, 8, 0, 0, DateTimeKind.Utc),
-                                        Text = "Test answer 2.",
-                                        VerseRef = new VerseRefData(40, 1, "2-3"),
-                                        ScriptureText = "This is some scripture.",
-                                        Comments =
-                                        {
-                                            new Comment
-                                            {
-                                                DataId = "comment02",
-                                                OwnerRef = "user02",
-                                                SyncUserRef = commentSyncUserId2,
-                                                DateCreated = new DateTime(2019, 1, 2, 9, 0, 0, DateTimeKind.Utc),
-                                                Text = "Test comment 2."
-                                            }
-                                        }
-                                    },
-                                    new Answer
-                                    {
-                                        DataId = "answer04",
-                                        OwnerRef = "user04",
-                                        SyncUserRef = answerSyncUserId2,
-                                        DateCreated = new DateTime(2019, 1, 4, 8, 0, 0, DateTimeKind.Utc),
-                                        Text = "Test answer 4 is marked for export",
-                                        VerseRef = new VerseRefData(40, 1, "2-3"),
-                                        Status = AnswerStatus.Exportable
-                                    },
-                                    new Answer
-                                    {
-                                        DataId = "answer05",
-                                        OwnerRef = "user04",
-                                        SyncUserRef = answerSyncUserId2,
-                                        DateCreated = new DateTime(2019, 1, 5, 8, 0, 0, DateTimeKind.Utc),
-                                        Text = "Test answer 5 is resolved",
-                                        VerseRef = new VerseRefData(40, 1, "2-3"),
-                                        Status = AnswerStatus.Resolved
                                     }
+                                },
+                                new Answer
+                                {
+                                    DataId = "answer02",
+                                    OwnerRef = "user04",
+                                    SyncUserRef = answerSyncUserId2,
+                                    DateCreated = new DateTime(2019, 1, 2, 8, 0, 0, DateTimeKind.Utc),
+                                    Text = "Test answer 2.",
+                                    VerseRef = new VerseRefData(40, 1, "2-3"),
+                                    ScriptureText = "This is some scripture.",
+                                    Comments =
+                                    {
+                                        new Comment
+                                        {
+                                            DataId = "comment02",
+                                            OwnerRef = "user02",
+                                            SyncUserRef = commentSyncUserId2,
+                                            DateCreated = new DateTime(2019, 1, 2, 9, 0, 0, DateTimeKind.Utc),
+                                            Text = "Test comment 2."
+                                        }
+                                    }
+                                },
+                                new Answer
+                                {
+                                    DataId = "answer04",
+                                    OwnerRef = "user04",
+                                    SyncUserRef = answerSyncUserId2,
+                                    DateCreated = new DateTime(2019, 1, 4, 8, 0, 0, DateTimeKind.Utc),
+                                    Text = "Test answer 4 is marked for export",
+                                    VerseRef = new VerseRefData(40, 1, "2-3"),
+                                    Status = AnswerStatus.Exportable
+                                },
+                                new Answer
+                                {
+                                    DataId = "answer05",
+                                    OwnerRef = "user04",
+                                    SyncUserRef = answerSyncUserId2,
+                                    DateCreated = new DateTime(2019, 1, 5, 8, 0, 0, DateTimeKind.Utc),
+                                    Text = "Test answer 5 is resolved",
+                                    VerseRef = new VerseRefData(40, 1, "2-3"),
+                                    Status = AnswerStatus.Resolved
                                 }
                             }
                         }
-                    )
-                );
-            }
-
-            public async Task<IEnumerable<IDocument<Question>>> GetQuestionDocsAsync(IConnection conn)
-            {
-                IDocument<Question> questionDoc = await conn.FetchAsync<Question>("project01:question01");
-                return new[] { questionDoc };
-            }
-
-            public async Task<IEnumerable<IDocument<NoteThread>>> GetNoteThreadDocsAsync(
-                IConnection conn,
-                string[] threadIds
-            )
-            {
-                IDocument<NoteThread>[] noteThreadDocs = new IDocument<NoteThread>[threadIds.Length];
-                var tasks = new List<Task>();
-                for (int i = 0; i < threadIds.Length; i++)
-                {
-                    async Task fetchNoteThread(int index)
-                    {
-                        noteThreadDocs[index] = await conn.FetchAsync<NoteThread>("project01:" + threadIds[index]);
                     }
-                    tasks.Add(fetchNoteThread(i));
-                }
-                await Task.WhenAll(tasks);
-                return noteThreadDocs;
-            }
+                )
+            );
+        }
 
-            public void SetParatextProjectRoles(bool twoPtUserOnProject)
-            {
-                Dictionary<string, string> ptUserRoles = new Dictionary<string, string>();
-                ptUserRoles["ptuser01"] = SFProjectRole.Administrator;
-                if (twoPtUserOnProject)
-                    ptUserRoles["ptuser03"] = SFProjectRole.Translator;
-                ParatextService
-                    .GetProjectRolesAsync(Arg.Any<UserSecret>(), Arg.Any<SFProject>(), Arg.Any<CancellationToken>())
-                    .Returns(ptUserRoles);
-            }
+        public static async Task<IEnumerable<IDocument<Question>>> GetQuestionDocsAsync(IConnection conn)
+        {
+            IDocument<Question> questionDoc = await conn.FetchAsync<Question>("project01:question01");
+            return new[] { questionDoc };
+        }
 
-            private static SFProject Project(bool includeSyncUsers = true)
+        public static async Task<IEnumerable<IDocument<NoteThread>>> GetNoteThreadDocsAsync(
+            IConnection conn,
+            string[] threadIds
+        )
+        {
+            IDocument<NoteThread>[] noteThreadDocs = new IDocument<NoteThread>[threadIds.Length];
+            var tasks = new List<Task>();
+            for (int i = 0; i < threadIds.Length; i++)
             {
-                var ptProjectUsers = new List<ParatextUserProfile>();
-                if (includeSyncUsers)
-                {
-                    ptProjectUsers.Add(new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = "PT User 1" });
-                    ptProjectUsers.Add(new ParatextUserProfile { OpaqueUserId = "syncuser03", Username = "PT User 3" });
-                }
-                return new SFProject
-                {
-                    Id = "project01",
-                    ParatextId = "paratextId",
-                    ParatextUsers = ptProjectUsers,
-                    UserRoles = userRoles
-                };
+                async Task fetchNoteThread(int index) =>
+                    noteThreadDocs[index] = await conn.FetchAsync<NoteThread>("project01:" + threadIds[index]);
+                tasks.Add(fetchNoteThread(i));
             }
+            await Task.WhenAll(tasks);
+            return noteThreadDocs;
+        }
 
-            private static SFProjectSecret ProjectSecret()
+        public void SetParatextProjectRoles(bool twoPtUserOnProject)
+        {
+            Dictionary<string, string> ptUserRoles = new Dictionary<string, string>
             {
-                return new SFProjectSecret { Id = "project01", };
-            }
+                ["ptuser01"] = SFProjectRole.Administrator
+            };
+            if (twoPtUserOnProject)
+                ptUserRoles["ptuser03"] = SFProjectRole.Translator;
+            ParatextService
+                .GetProjectRolesAsync(Arg.Any<UserSecret>(), Arg.Any<SFProject>(), Arg.Any<CancellationToken>())
+                .Returns(ptUserRoles);
+        }
 
-            private static List<User> ParatextUsersOnProject(bool twoPtUsersOnProject)
+        private static SFProject Project(bool includeSyncUsers = true)
+        {
+            var ptProjectUsers = new List<ParatextUserProfile>();
+            if (includeSyncUsers)
             {
-                var ptUsers = new List<User>
-                {
-                    new User { Id = "user01", ParatextId = "ptuser01" }
-                };
-                if (twoPtUsersOnProject)
-                    ptUsers.Add(new User { Id = "user03", ParatextId = "ptuser03" });
-                return ptUsers;
+                ptProjectUsers.Add(new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = "PT User 1" });
+                ptProjectUsers.Add(new ParatextUserProfile { OpaqueUserId = "syncuser03", Username = "PT User 3" });
             }
+            return new SFProject
+            {
+                Id = "project01",
+                ParatextId = "paratextId",
+                ParatextUsers = ptProjectUsers,
+                UserRoles = userRoles
+            };
+        }
+
+        private static SFProjectSecret ProjectSecret() => new SFProjectSecret { Id = "project01", };
+
+        private static List<User> ParatextUsersOnProject(bool twoPtUsersOnProject)
+        {
+            var ptUsers = new List<User>
+            {
+                new User { Id = "user01", ParatextId = "ptuser01" }
+            };
+            if (twoPtUsersOnProject)
+                ptUsers.Add(new User { Id = "user03", ParatextId = "ptuser03" });
+            return ptUsers;
         }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -35,1415 +35,1628 @@ using SIL.XForge.Scripture.Models;
 using SIL.XForge.Scripture.Realtime;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class ParatextServiceTests
 {
-    [TestFixture]
-    public class ParatextServiceTests
+    [Test]
+    public void AssemblyDirectory_DoesNotCrash()
     {
-        [Test]
-        public void AssemblyDirectory_DoesNotCrash()
+        string dir = null;
+        // SUT
+        Assert.DoesNotThrow(() => dir = ParatextService.AssemblyDirectory, "does not crash");
+        Assert.That(string.IsNullOrWhiteSpace(dir), Is.False, "returns something");
+    }
+
+    [Test]
+    public void GetProjectsAsync_BadArguments()
+    {
+        var env = new TestEnvironment();
+        Assert.ThrowsAsync<NullReferenceException>(() => env.Service.GetProjectsAsync(null));
+    }
+
+    [Test]
+    public async Task GetProjectsAsync_ReturnCorrectRepos()
+    {
+        var env = new TestEnvironment();
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
+
+        // SUT
+        IEnumerable<ParatextProject> repos = await env.Service.GetProjectsAsync(user01Secret);
+
+        // Right number of repos returned.
+        Assert.That(repos.Count(), Is.EqualTo(3));
+
+        // Repos returned are the ones we expect.
+        // TODO Make PT repos in data that should not be returned.
+        foreach (string projectName in new string[] { env.Project01, env.Project03, env.Project02 })
         {
-            string dir = null;
-            // SUT
-            Assert.DoesNotThrow(
-                () =>
-                {
-                    dir = ParatextService.AssemblyDirectory;
-                },
-                "does not crash"
-            );
-            Assert.That(string.IsNullOrWhiteSpace(dir), Is.False, "returns something");
+            Assert.That(repos.Single(project => project.ParatextId == env.PTProjectIds[projectName].Id), Is.Not.Null);
         }
 
-        [Test]
-        public void GetProjectsAsync_BadArguments()
+        // Properties of one of the returned repos have the correct values.
+        ParatextProject expectedProject01 = new ParatextProject
         {
-            var env = new TestEnvironment();
-            Assert.ThrowsAsync<NullReferenceException>(() => env.Service.GetProjectsAsync(null));
+            ParatextId = env.PTProjectIds[env.Project01].Id,
+            Name = "Full Name " + env.Project01,
+            ShortName = "P01",
+            LanguageTag = "writingsystem_tag",
+            ProjectId = "sf_id_" + env.Project01,
+            // Not connectable since sf project exists and sf user is on sf project.
+            IsConnectable = false,
+            // Is connected since is in SF database and user is on project
+            IsConnected = true
+        };
+        Assert.That(
+            repos.Single(project => project.ParatextId == env.PTProjectIds[env.Project01].Id).ToString(),
+            Is.EqualTo(expectedProject01.ToString())
+        );
+
+        // Repos are returned in alphabetical order by paratext project name.
+        List<string> repoList = repos.Select(repo => repo.Name).ToList();
+        Assert.That(StringComparer.InvariantCultureIgnoreCase.Compare(repoList[0], repoList[1]), Is.LessThan(0));
+        Assert.That(StringComparer.InvariantCultureIgnoreCase.Compare(repoList[1], repoList[2]), Is.LessThan(0));
+    }
+
+    [Test]
+    public async Task GetProjectsAsync_IncludesNotRegisteredProjects()
+    {
+        // We should include projects that are not in the registry, like back translation projects
+        var env = new TestEnvironment();
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        bool extraSharedRepository = true;
+        env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator, extraSharedRepository);
+
+        // SUT
+        IEnumerable<ParatextProject> repos = await env.Service.GetProjectsAsync(user01Secret);
+
+        // Right number of repos returned.
+        Assert.That(repos.Count(), Is.EqualTo(4), "Including the 4th which does not have metadata");
+
+        // Repos returned are the ones we expect.
+        foreach (string projectName in new string[] { env.Project01, env.Project02, env.Project03, env.Project04 })
+        {
+            Assert.That(repos.Single(project => project.ParatextId == env.PTProjectIds[projectName].Id), Is.Not.Null);
         }
+    }
 
-        [Test]
-        public async Task GetProjectsAsync_ReturnCorrectRepos()
+    [Test]
+    public async Task GetProjectsAsync_ProjectNotOnSF_RetrievesProjectFullName()
+    {
+        var env = new TestEnvironment();
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
+        IEnumerable<ParatextProject> projects = await env.Service.GetProjectsAsync(user01Secret);
+
+        ParatextProject project02 = projects.Single(p => p.ParatextId == env.PTProjectIds[env.Project02].Id);
+        Assert.That(project02.Name, Is.EqualTo("Full Name " + env.Project02));
+    }
+
+    [Test]
+    public async Task GetProjectsAsync_ConnectedConnectable()
+    {
+        var env = new TestEnvironment();
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
+        UserSecret user03Secret = TestEnvironment.MakeUserSecret(env.User03, env.Username03, env.ParatextUserId03);
+        env.SetSharedRepositorySource(user03Secret, UserRoles.TeamMember);
+
+        // Check resulting IsConnectable and IsConnected values across various scenarios of SF project existing,
+        // SF user being a member of the SF project, and PT user being an admin on PT project.
+        var testCases = new[]
         {
-            var env = new TestEnvironment();
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
-
-            // SUT
-            IEnumerable<ParatextProject> repos = await env.Service.GetProjectsAsync(user01Secret);
-
-            // Right number of repos returned.
-            Assert.That(repos.Count(), Is.EqualTo(3));
-
-            // Repos returned are the ones we expect.
-            // TODO Make PT repos in data that should not be returned.
-            foreach (string projectName in new string[] { env.Project01, env.Project03, env.Project02 })
+            new
             {
-                Assert.That(
-                    repos.Single(project => project.ParatextId == env.PTProjectIds[projectName].Id),
-                    Is.Not.Null
-                );
-            }
-
-            // Properties of one of the returned repos have the correct values.
-            ParatextProject expectedProject01 = new ParatextProject
+                // Data
+                paratextProjectId = env.PTProjectIds[env.Project01].Id,
+                sfUserId = env.User01,
+                ptUsername = "User 01",
+                userSecret = user01Secret,
+                // Environmental assumptions
+                sfProjectExists = true,
+                sfUserIsOnSfProject = true,
+                ptUserIsAdminOnPtProject = true,
+                // Expectation to assert
+                isConnected = true,
+                reason1 = "sf project exists and sf user is member of the sf project",
+                isConnectable = false,
+                reason2 = "can not re-connect to project"
+            },
+            new
             {
-                ParatextId = env.PTProjectIds[env.Project01].Id,
-                Name = "Full Name " + env.Project01,
-                ShortName = "P01",
-                LanguageTag = "writingsystem_tag",
-                ProjectId = "sf_id_" + env.Project01,
-                // Not connectable since sf project exists and sf user is on sf project.
-                IsConnectable = false,
-                // Is connected since is in SF database and user is on project
-                IsConnected = true
-            };
+                paratextProjectId = env.PTProjectIds[env.Project01].Id,
+                sfUserId = env.User03,
+                ptUsername = "User 01",
+                userSecret = user03Secret,
+                sfProjectExists = true,
+                sfUserIsOnSfProject = false,
+                ptUserIsAdminOnPtProject = false,
+                isConnected = false,
+                reason1 = "sf project exists and but sf user is not member of the sf project",
+                isConnectable = true,
+                reason2 = "can connect to existing SF project"
+            },
+            new
+            {
+                paratextProjectId = env.PTProjectIds[env.Project02].Id,
+                sfUserId = env.User01,
+                ptUsername = "User 01",
+                userSecret = user01Secret,
+                sfProjectExists = false,
+                sfUserIsOnSfProject = false,
+                ptUserIsAdminOnPtProject = true,
+                isConnected = false,
+                reason1 = "sf project does not exist",
+                isConnectable = true,
+                reason2 = "pt admin can start connection to not-yet-existing sf project"
+            },
+            new
+            {
+                paratextProjectId = env.PTProjectIds[env.Project02].Id,
+                sfUserId = env.User03,
+                ptUsername = "User 03",
+                userSecret = user03Secret,
+                sfProjectExists = false,
+                sfUserIsOnSfProject = false,
+                ptUserIsAdminOnPtProject = false,
+                isConnected = false,
+                reason1 = "sf project does not exist",
+                isConnectable = false,
+                reason2 = "pt non-admin can not start connection to not-yet-existing sf project"
+            },
+        };
+
+        foreach (var testCase in testCases)
+        {
+            // Check that assumptions are true.
             Assert.That(
-                repos.Single(project => project.ParatextId == env.PTProjectIds[env.Project01].Id).ToString(),
-                Is.EqualTo(expectedProject01.ToString())
+                (await env.RealtimeService.GetRepository<SFProject>().GetAllAsync()).Any(
+                    sfProject => sfProject.ParatextId == testCase.paratextProjectId
+                ),
+                Is.EqualTo(testCase.sfProjectExists),
+                "not set up - whether sf project exists or not"
             );
-
-            // Repos are returned in alphabetical order by paratext project name.
-            List<string> repoList = repos.Select(repo => repo.Name).ToList();
-            Assert.That(StringComparer.InvariantCultureIgnoreCase.Compare(repoList[0], repoList[1]), Is.LessThan(0));
-            Assert.That(StringComparer.InvariantCultureIgnoreCase.Compare(repoList[1], repoList[2]), Is.LessThan(0));
-        }
-
-        [Test]
-        public async Task GetProjectsAsync_IncludesNotRegisteredProjects()
-        {
-            // We should include projects that are not in the registry, like back translation projects
-            var env = new TestEnvironment();
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            bool extraSharedRepository = true;
-            env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator, extraSharedRepository);
-
-            // SUT
-            IEnumerable<ParatextProject> repos = await env.Service.GetProjectsAsync(user01Secret);
-
-            // Right number of repos returned.
-            Assert.That(repos.Count(), Is.EqualTo(4), "Including the 4th which does not have metadata");
-
-            // Repos returned are the ones we expect.
-            foreach (string projectName in new string[] { env.Project01, env.Project02, env.Project03, env.Project04 })
+            if (testCase.sfProjectExists)
             {
                 Assert.That(
-                    repos.Single(project => project.ParatextId == env.PTProjectIds[projectName].Id),
-                    Is.Not.Null
+                    (await env.RealtimeService.GetRepository<SFProject>().GetAllAsync())
+                        .Single(sfProject => sfProject.ParatextId == testCase.paratextProjectId)
+                        .UserRoles.ContainsKey(testCase.sfUserId),
+                    Is.EqualTo(testCase.sfUserIsOnSfProject),
+                    "not set up - whether user is on existing sf project or not"
                 );
             }
+            Assert.That(
+                env.MockInternetSharedRepositorySourceProvider
+                    .GetSource(testCase.userSecret, string.Empty, string.Empty)
+                    .GetRepositories()
+                    .FirstOrDefault(sharedRepository => sharedRepository.SendReceiveId.Id == testCase.paratextProjectId)
+                    .SourceUsers.GetRole(testCase.ptUsername) == UserRoles.Administrator,
+                Is.EqualTo(testCase.ptUserIsAdminOnPtProject),
+                "not set up - whether pt user is an admin on pt project"
+            );
+
+            // SUT
+            ParatextProject resultingProjectToExamine = (
+                await env.Service.GetProjectsAsync(testCase.userSecret)
+            ).Single(project => project.ParatextId == testCase.paratextProjectId);
+
+            // Assert expectations.
+            Assert.That(resultingProjectToExamine.IsConnected, Is.EqualTo(testCase.isConnected), testCase.reason1);
+            Assert.That(resultingProjectToExamine.IsConnectable, Is.EqualTo(testCase.isConnectable), testCase.reason2);
         }
+    }
 
-        [Test]
-        public async Task GetProjectsAsync_ProjectNotOnSF_RetrievesProjectFullName()
+    [Test]
+    public async Task GetResourcesAsync_ReturnResources()
+    {
+        var env = new TestEnvironment();
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.SetRestClientFactory(user01Secret);
+        ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+        IEnumerable<ParatextResource> resources = await env.Service.GetResourcesAsync(env.User01);
+        Assert.AreEqual(3, resources.Count());
+    }
+
+    [Test]
+    public void GetResourcesAsync_Problem_EmptyList()
+    {
+        // Set up environment
+        var env = new TestEnvironment();
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        // Set up mock REST client to return unsuccessfully.
+        ISFRestClientFactory mockRestClientFactory = env.SetRestClientFactory(user01Secret);
+        ISFRestClient failureMockClient = Substitute.For<ISFRestClient>();
+        failureMockClient.Get(Arg.Any<string>()).Throws<WebException>();
+        mockRestClientFactory
+            .Create(Arg.Any<string>(), Arg.Is<UserSecret>(s => s.Id == env.User02))
+            .Returns(failureMockClient);
+
+        ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+
+        IEnumerable<ParatextResource> resources = null;
+        // SUT
+        Assert.DoesNotThrowAsync(async () => resources = await env.Service.GetResourcesAsync(env.User02));
+        // "Don't crash when permission problem");
+        Assert.AreEqual(0, resources.Count(), "An empty set of resources should have been returned");
+        env.MockExceptionHandler
+            .Received()
+            .ReportException(
+                Arg.Is<Exception>((Exception e) => e.Message.Contains("inquire about resources and is ignoring error"))
+            );
+    }
+
+    [Test]
+    public void IsResource_JunkInput_No()
+    {
+        var env = new TestEnvironment();
+        // SUTs
+        Assert.That(env.Service.IsResource(null), Is.False);
+        Assert.That(env.Service.IsResource(""), Is.False);
+        Assert.That(env.Service.IsResource("junk"), Is.False);
+    }
+
+    [Test]
+    public void IsResource_NonResourceProjectId_No()
+    {
+        var env = new TestEnvironment();
+        const int lengthOfParatextProjectIds = 40;
+        string id = "1234567890abcdef1234567890abcdef12345678";
+        Assert.That(id.Length, Is.EqualTo(lengthOfParatextProjectIds), "setup. Use an ID of Paratext-ID-length.");
+        // SUT
+        Assert.That(env.Service.IsResource(id), Is.False);
+    }
+
+    [Test]
+    public void IsResource_ResourceProjectId_Yes()
+    {
+        var env = new TestEnvironment();
+        const int lengthOfDblResourceId = 16;
+        string id = "1234567890abcdef";
+        Assert.That(id.Length, Is.EqualTo(lengthOfDblResourceId), "setup. Use an ID of DBL-Resource-ID-length.");
+        // SUT
+        Assert.That(env.Service.IsResource(id), Is.True);
+    }
+
+    [Test]
+    public async Task GetPermissionsAsync_UserResourcePermission()
+    {
+        // Set up environment
+        var env = new TestEnvironment();
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        // Set up mock REST client to return a successful GET request
+        ISFRestClientFactory mockRestClientFactory = env.SetRestClientFactory(user01Secret);
+
+        // Set up mock REST client to return an unsuccessful GET request
+        ISFRestClient failureMockClient = Substitute.For<ISFRestClient>();
+        failureMockClient.Get(Arg.Any<string>()).Returns(string.Empty);
+        mockRestClientFactory
+            .Create(Arg.Any<string>(), Arg.Is<UserSecret>(s => s.Id == env.User02))
+            .Returns(failureMockClient);
+
+        // Set up mock project
+        var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
+        var project = projects.First();
+        project.ParatextId = env.Resource2Id;
+        var ptUsernameMapping = new Dictionary<string, string>()
         {
-            var env = new TestEnvironment();
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
-            IEnumerable<ParatextProject> projects = await env.Service.GetProjectsAsync(user01Secret);
+            { env.User01, env.Username01 },
+            { env.User02, env.Username02 },
+        };
 
-            ParatextProject project02 = projects.Single(p => p.ParatextId == env.PTProjectIds[env.Project02].Id);
-            Assert.That(project02.Name, Is.EqualTo("Full Name " + env.Project02));
-        }
+        var permissions = await env.Service.GetPermissionsAsync(user01Secret, project, ptUsernameMapping);
+        Assert.That(permissions.Count, Is.EqualTo(2));
+        Assert.That(permissions.First().Value, Is.EqualTo(TextInfoPermission.Read));
+        Assert.That(permissions.Last().Value, Is.EqualTo(TextInfoPermission.None));
+    }
 
-        [Test]
-        public async Task GetProjectsAsync_ConnectedConnectable()
-        {
-            var env = new TestEnvironment();
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
-            UserSecret user03Secret = env.MakeUserSecret(env.User03, env.Username03, env.ParatextUserId03);
-            env.SetSharedRepositorySource(user03Secret, UserRoles.TeamMember);
+    [Test]
+    public async Task GetResourcePermissionAsync_UserNoResourcePermission()
+    {
+        // Set up environment
+        var env = new TestEnvironment();
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
 
-            // Check resulting IsConnectable and IsConnected values across various scenarios of SF project existing,
-            // SF user being a member of the SF project, and PT user being an admin on PT project.
-            var testCases = new[]
+        // Set up mock REST client to return a successful GET request
+        env.SetRestClientFactory(user01Secret);
+
+        var paratextId = "resid_is_16_char";
+        var permission = await env.Service.GetResourcePermissionAsync(paratextId, env.User01, CancellationToken.None);
+        Assert.That(permission, Is.EqualTo(TextInfoPermission.None));
+    }
+
+    [Test]
+    public async Task GetResourcePermissionAsync_UserResourcePermission()
+    {
+        // Set up environment
+        var env = new TestEnvironment();
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.SetRestClientFactory(user01Secret);
+        var paratextId = env.Resource2Id;
+        var permission = await env.Service.GetResourcePermissionAsync(paratextId, env.User01, CancellationToken.None);
+        Assert.That(permission, Is.EqualTo(TextInfoPermission.Read));
+    }
+
+    [Test]
+    public void GetBooks_ReturnCorrectNumberOfBooks()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        // Books 1 thru 3.
+        env.ProjectScrText.Settings.BooksPresentSet = new BookSet(1, 3);
+
+        IReadOnlyList<int> result = env.Service.GetBookList(userSecret, ptProjectId);
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result, Is.EquivalentTo(new[] { 1, 2, 3 }));
+    }
+
+    [Test]
+    public void GetBookText_Works()
+    {
+        string ruthBookUsx =
+            "<usx version=\"3.0\">\r\n  <book code=\"RUT\" style=\"id\">- ProjectNameHere"
+            + "</book>\r\n  <chapter number=\"1\" style=\"c\" />\r\n  <verse number=\"1\" style=\"v\" />"
+            + "Verse 1 here. <verse number=\"2\" style=\"v\" />Verse 2 here.</usx>";
+
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        // SUT
+        string result = env.Service.GetBookText(null, ptProjectId, 8);
+        Assert.That(result, Is.EqualTo(ruthBookUsx));
+    }
+
+    [Test]
+    public void GetBookText_NoSuchPtProjectKnown()
+    {
+        var env = new TestEnvironment();
+        string ptProjectId = env.PTProjectIds[env.Project01].Id;
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
+        env.MockScrTextCollection.FindById(env.Username01, ptProjectId).Returns(i => null);
+
+        // SUT
+        Assert.Throws<DataNotFoundException>(() => env.Service.GetBookText(user01Secret, ptProjectId, 8));
+        env.MockScrTextCollection.Received(1).FindById(env.Username01, ptProjectId);
+    }
+
+    [Test]
+    public async Task PutBookText_TextEdited_BookTextIsUpdated()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        // should be able to edit the book text even if the admin user does not have permission
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser, hasEditPermission: false);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        int ruthBookNum = 8;
+        string ruthBookUsx =
+            "<usx version=\"3.0\">\r\n  <book code=\"RUT\" style=\"id\">- ProjectNameHere"
+            + "</book>\r\n  <chapter number=\"1\" style=\"c\" />\r\n  <verse number=\"1\" style=\"v\" />"
+            + "Verse 1 here. <verse number=\"2\" style=\"v\" />Verse 2 here.</usx>";
+
+        JToken token1 = JToken.Parse("{\"insert\": { \"chapter\": { \"number\": \"1\", \"style\": \"c\" } } }");
+        JToken token2 = JToken.Parse("{\"insert\": { \"verse\": { \"number\": \"1\", \"style\": \"v\" } } }");
+        JToken token3 = JToken.Parse(
+            "{\"insert\": \"Verse 1 here. \", \"attributes\": { \"segment\": \"verse_1_1\" } }"
+        );
+        JToken token4 = JToken.Parse("{\"insert\": { \"verse\": { \"number\": \"2\", \"style\": \"v\" } } }");
+        JToken token5 = JToken.Parse(
+            "{\"insert\": \"Verse 2 here. THIS PART IS EDITED!\"," + "\"attributes\": { \"segment\": \"verse_1_2\" } }"
+        );
+
+        TextData data = new TextData(new Delta(new[] { token1, token2, token3, token4, token5 }));
+        XDocument oldDocUsx = XDocument.Parse(ruthBookUsx);
+        DeltaUsxMapper mapper = new DeltaUsxMapper(
+            new TestGuidService(),
+            Substitute.For<ILogger<DeltaUsxMapper>>(),
+            Substitute.For<IExceptionHandler>()
+        );
+        var newDocUsx = mapper.ToUsx(oldDocUsx, new List<ChapterDelta> { new ChapterDelta(1, 2, true, data) });
+        int booksUpdated = await env.Service.PutBookText(userSecret, ptProjectId, ruthBookNum, newDocUsx);
+        env.ProjectFileManager.Received(1).WriteFileCreatingBackup(Arg.Any<string>(), Arg.Any<Action<string>>());
+        Assert.That(booksUpdated, Is.EqualTo(1));
+
+        // PT username is not written to server logs
+        env.MockLogger.AssertNoEvent((LogEvent logEvent) => logEvent.Message.Contains(env.Username01));
+    }
+
+    [Test]
+    public async Task PutBookText_DoesNotRequireChapterAuthors()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        // should be able to edit the book text even if the admin user does not have permission
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser, hasEditPermission: false);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        int ruthBookNum = 8;
+        string ruthBookUsx =
+            "<usx version=\"3.0\">\r\n  <book code=\"RUT\" style=\"id\">- ProjectNameHere"
+            + "</book>\r\n  <chapter number=\"1\" style=\"c\" />\r\n  <verse number=\"1\" style=\"v\" />"
+            + "Verse 1 here. <verse number=\"2\" style=\"v\" />Verse 2 here.</usx>";
+
+        // SUT
+        int booksUpdated = await env.Service.PutBookText(
+            userSecret,
+            ptProjectId,
+            ruthBookNum,
+            XDocument.Parse(ruthBookUsx)
+        );
+
+        // Make sure only one ScrText was loaded
+        env.MockScrTextCollection.Received(1).FindById(env.Username01, ptProjectId);
+        Assert.That(booksUpdated, Is.EqualTo(1));
+
+        // See if there is a message for the user updating the book
+        string logMessage = string.Format(
+            "{0} updated {1} in {2}.",
+            env.User01,
+            Canon.BookNumberToEnglishName(ruthBookNum),
+            env.ProjectScrText.Name
+        );
+        env.MockLogger.AssertHasEvent((LogEvent logEvent) => logEvent.Message == logMessage);
+    }
+
+    [Test]
+    public async Task PutBookText_UpdatesTheBookIfAllSameAuthor()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        // should be able to edit the book text even if the admin user does not have permission
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser, hasEditPermission: false);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        int ruthBookNum = 8;
+        string ruthBookUsx =
+            "<usx version=\"3.0\">\r\n  <book code=\"RUT\" style=\"id\">- ProjectNameHere"
+            + "</book>\r\n  <chapter number=\"1\" style=\"c\" />\r\n  <verse number=\"1\" style=\"v\" />"
+            + "Verse 1 here. <verse number=\"2\" style=\"v\" />Verse 2 here.</usx>";
+        var chapterAuthors = new Dictionary<int, string> { { 1, env.User01 }, { 2, env.User01 }, };
+
+        // SUT
+        int booksUpdated = await env.Service.PutBookText(
+            userSecret,
+            ptProjectId,
+            ruthBookNum,
+            XDocument.Parse(ruthBookUsx),
+            chapterAuthors
+        );
+
+        // Make sure only one ScrText was loaded
+        env.MockScrTextCollection.Received(1).FindById(env.Username01, ptProjectId);
+        Assert.That(booksUpdated, Is.EqualTo(1));
+
+        // See if there is a message for the user updating the book
+        string logMessage = string.Format(
+            "{0} updated {1} in {2}.",
+            env.User01,
+            Canon.BookNumberToEnglishName(ruthBookNum),
+            env.ProjectScrText.Name
+        );
+        env.MockLogger.AssertHasEvent((LogEvent logEvent) => logEvent.Message == logMessage);
+    }
+
+    [Test]
+    public async Task PutBookText_UpdatesTheChapterIfDifferentAuthors()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        // should be able to edit the book text even if the admin user does not have permission
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser, hasEditPermission: false);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        TestEnvironment.MakeUserSecret(env.User02, env.Username02, env.ParatextUserId02);
+
+        int ruthBookNum = 8;
+        string ruthBookUsx =
+            "<usx version=\"3.0\">\r\n  <book code=\"RUT\" style=\"id\">- ProjectNameHere"
+            + "</book>\r\n  <chapter number=\"1\" style=\"c\" />\r\n  <verse number=\"1\" style=\"v\" />"
+            + "Verse 1 here. <verse number=\"2\" style=\"v\" />Verse 2 here.</usx>";
+        var chapterAuthors = new Dictionary<int, string> { { 1, env.User01 }, { 2, env.User02 }, };
+
+        // SUT
+        int booksUpdated = await env.Service.PutBookText(
+            userSecret,
+            ptProjectId,
+            ruthBookNum,
+            XDocument.Parse(ruthBookUsx),
+            chapterAuthors
+        );
+
+        // Make sure two ScrTexts were loaded
+        env.MockScrTextCollection.Received(1).FindById(env.Username01, ptProjectId);
+        env.MockScrTextCollection.Received(1).FindById(env.Username02, ptProjectId);
+        Assert.That(booksUpdated, Is.EqualTo(1));
+
+        // See if there is a message for the user updating the chapter
+        string logMessage = string.Format(
+            "{0} updated chapter {1} of {2} in {3}.",
+            env.User01,
+            1,
+            Canon.BookNumberToEnglishName(ruthBookNum),
+            env.ProjectScrText.Name
+        );
+        env.MockLogger.AssertHasEvent((LogEvent logEvent) => logEvent.Message == logMessage);
+    }
+
+    [Test]
+    public void GetNotes_RetrievesNotes()
+    {
+        int ruthBookNum = 8;
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.ProjectCommentManager.AddComment(
+            new Paratext.Data.ProjectComments.Comment(associatedPtUser)
             {
-                new
-                {
-                    // Data
-                    paratextProjectId = env.PTProjectIds[env.Project01].Id,
-                    sfUserId = env.User01,
-                    ptUsername = "User 01",
-                    userSecret = user01Secret,
-                    // Environmental assumptions
-                    sfProjectExists = true,
-                    sfUserIsOnSfProject = true,
-                    ptUserIsAdminOnPtProject = true,
-                    // Expectation to assert
-                    isConnected = true,
-                    reason1 = "sf project exists and sf user is member of the sf project",
-                    isConnectable = false,
-                    reason2 = "can not re-connect to project"
-                },
-                new
-                {
-                    paratextProjectId = env.PTProjectIds[env.Project01].Id,
-                    sfUserId = env.User03,
-                    ptUsername = "User 01",
-                    userSecret = user03Secret,
-                    sfProjectExists = true,
-                    sfUserIsOnSfProject = false,
-                    ptUserIsAdminOnPtProject = false,
-                    isConnected = false,
-                    reason1 = "sf project exists and but sf user is not member of the sf project",
-                    isConnectable = true,
-                    reason2 = "can connect to existing SF project"
-                },
-                new
-                {
-                    paratextProjectId = env.PTProjectIds[env.Project02].Id,
-                    sfUserId = env.User01,
-                    ptUsername = "User 01",
-                    userSecret = user01Secret,
-                    sfProjectExists = false,
-                    sfUserIsOnSfProject = false,
-                    ptUserIsAdminOnPtProject = true,
-                    isConnected = false,
-                    reason1 = "sf project does not exist",
-                    isConnectable = true,
-                    reason2 = "pt admin can start connection to not-yet-existing sf project"
-                },
-                new
-                {
-                    paratextProjectId = env.PTProjectIds[env.Project02].Id,
-                    sfUserId = env.User03,
-                    ptUsername = "User 03",
-                    userSecret = user03Secret,
-                    sfProjectExists = false,
-                    sfUserIsOnSfProject = false,
-                    ptUserIsAdminOnPtProject = false,
-                    isConnected = false,
-                    reason1 = "sf project does not exist",
-                    isConnectable = false,
-                    reason2 = "pt non-admin can not start connection to not-yet-existing sf project"
-                },
-            };
+                Thread = "Answer_dataId0123",
+                VerseRefStr = "RUT 1:1"
+            }
+        );
+        string notes = env.Service.GetNotes(userSecret, ptProjectId, ruthBookNum);
+        string expected = $"<notes version=\"1.1\">{Environment.NewLine}  <thread id=\"Answer_dataId0123\">";
+        Assert.True(notes.StartsWith(expected));
+    }
 
-            foreach (var testCase in testCases)
+    [Test]
+    public void PutNotes_AddEditDeleteComment_ThreadCorrectlyUpdated()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        DateTime date = DateTime.Now; // This must be consistent as it is a part of the comment id
+
+        // Add new comment
+        string threadId = "Answer_0123";
+        string content = "Content for comment to update.";
+        string verseRef = "RUT 1:1";
+        XElement updateNotesXml = TestEnvironment.GetUpdateNotesXml(threadId, env.User01, date, content, verseRef);
+        var syncMetricInfo = env.Service.PutNotes(userSecret, ptProjectId, updateNotesXml);
+
+        CommentThread thread = env.ProjectCommentManager.FindThread(threadId);
+        Assert.That(thread.Comments.Count, Is.EqualTo(1));
+        var comment = thread.Comments.First();
+        Assert.That(comment.VerseRefStr, Is.EqualTo(verseRef));
+        Assert.That(comment.User, Is.EqualTo(env.User01));
+        Assert.That(comment.Contents.InnerText, Is.EqualTo(content));
+        Assert.That(syncMetricInfo, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
+
+        // Edit a comment
+        content = "Edited: Content for comment to update.";
+        updateNotesXml = TestEnvironment.GetUpdateNotesXml(threadId, env.User01, date, content, verseRef);
+        syncMetricInfo = env.Service.PutNotes(userSecret, ptProjectId, updateNotesXml);
+
+        Assert.That(thread.Comments.Count, Is.EqualTo(1));
+        comment = thread.Comments.First();
+        Assert.That(comment.Contents.InnerText, Is.EqualTo(content));
+        Assert.That(syncMetricInfo, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 1)));
+
+        // Delete a comment
+        updateNotesXml = TestEnvironment.GetUpdateNotesXml(threadId, env.User01, date, content, verseRef, true);
+        syncMetricInfo = env.Service.PutNotes(userSecret, ptProjectId, updateNotesXml);
+
+        Assert.That(thread.Comments.Count, Is.EqualTo(1));
+        comment = thread.Comments.First();
+        Assert.That(comment.Deleted, Is.True, "Comment should be marked deleted");
+        Assert.That(syncMetricInfo, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
+
+        // PT username is not written to server logs
+        env.MockLogger.AssertNoEvent((LogEvent logEvent) => logEvent.Message.Contains(env.Username01));
+    }
+
+    [Test]
+    public async Task GetNoteThreadChanges_NotePositionUpdated()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.AddTextDocs(40, 1, 6, "Context before ", "Text selected");
+
+        env.AddNoteThreadData(
+            new[]
             {
-                // Check that assumptions are true.
-                Assert.That(
-                    (await env.RealtimeService.GetRepository<SFProject>().GetAllAsync()).Any(
-                        sfProject => sfProject.ParatextId == testCase.paratextProjectId
-                    ),
-                    Is.EqualTo(testCase.sfProjectExists),
-                    "not set up - whether sf project exists or not"
-                );
-                if (testCase.sfProjectExists)
+                new ThreadComponents { threadNum = 1, noteCount = 1 }
+            }
+        );
+        env.AddParatextComments(
+            new[]
+            {
+                new ThreadComponents
                 {
-                    Assert.That(
-                        (await env.RealtimeService.GetRepository<SFProject>().GetAllAsync())
-                            .Single(sfProject => sfProject.ParatextId == testCase.paratextProjectId)
-                            .UserRoles.ContainsKey(testCase.sfUserId),
-                        Is.EqualTo(testCase.sfUserIsOnSfProject),
-                        "not set up - whether user is on existing sf project or not"
-                    );
+                    threadNum = 1,
+                    noteCount = 1,
+                    username = env.Username01
+                },
+                new ThreadComponents
+                {
+                    threadNum = 2,
+                    noteCount = 1,
+                    username = env.Username01,
+                    appliesToVerse = true
                 }
-                Assert.That(
-                    env.MockInternetSharedRepositorySourceProvider
-                        .GetSource(testCase.userSecret, string.Empty, string.Empty)
-                        .GetRepositories()
-                        .FirstOrDefault(
-                            sharedRepository => sharedRepository.SendReceiveId.Id == testCase.paratextProjectId
-                        )
-                        .SourceUsers.GetRole(testCase.ptUsername) == UserRoles.Administrator,
-                    Is.EqualTo(testCase.ptUserIsAdminOnPtProject),
-                    "not set up - whether pt user is an admin on pt project"
-                );
-
-                // SUT
-                ParatextProject resultingProjectToExamine = (
-                    await env.Service.GetProjectsAsync(testCase.userSecret)
-                ).Single(project => project.ParatextId == testCase.paratextProjectId);
-
-                // Assert expectations.
-                Assert.That(resultingProjectToExamine.IsConnected, Is.EqualTo(testCase.isConnected), testCase.reason1);
-                Assert.That(
-                    resultingProjectToExamine.IsConnectable,
-                    Is.EqualTo(testCase.isConnectable),
-                    testCase.reason2
-                );
             }
-        }
+        );
 
-        [Test]
-        public async Task GetResourcesAsync_ReturnResources()
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
+            conn,
+            new[] { "thread1" }
+        );
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = new Dictionary<string, ParatextUserProfile>
         {
-            var env = new TestEnvironment();
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.SetRestClientFactory(user01Secret);
-            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
-            IEnumerable<ParatextResource> resources = await env.Service.GetResourcesAsync(env.User01);
-            Assert.AreEqual(3, resources.Count());
-        }
-
-        [Test]
-        public void GetResourcesAsync_Problem_EmptyList()
-        {
-            // Set up environment
-            var env = new TestEnvironment();
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            // Set up mock REST client to return unsuccessfully.
-            ISFRestClientFactory mockRestClientFactory = env.SetRestClientFactory(user01Secret);
-            ISFRestClient failureMockClient = Substitute.For<ISFRestClient>();
-            failureMockClient.Get(Arg.Any<string>()).Throws<WebException>();
-            mockRestClientFactory
-                .Create(Arg.Any<string>(), Arg.Is<UserSecret>(s => s.Id == env.User02))
-                .Returns(failureMockClient);
-
-            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
-
-            IEnumerable<ParatextResource> resources = null;
-            // SUT
-            Assert.DoesNotThrowAsync(async () => resources = await env.Service.GetResourcesAsync(env.User02));
-            // "Don't crash when permission problem");
-            Assert.AreEqual(0, resources.Count(), "An empty set of resources should have been returned");
-            env.MockExceptionHandler
-                .Received()
-                .ReportException(
-                    Arg.Is<Exception>(
-                        (Exception e) => e.Message.Contains("inquire about resources and is ignoring error")
-                    )
-                );
-        }
-
-        [Test]
-        public void IsResource_JunkInput_No()
-        {
-            var env = new TestEnvironment();
-            // SUTs
-            Assert.That(env.Service.IsResource(null), Is.False);
-            Assert.That(env.Service.IsResource(""), Is.False);
-            Assert.That(env.Service.IsResource("junk"), Is.False);
-        }
-
-        [Test]
-        public void IsResource_NonResourceProjectId_No()
-        {
-            var env = new TestEnvironment();
-            const int lengthOfParatextProjectIds = 40;
-            string id = "1234567890abcdef1234567890abcdef12345678";
-            Assert.That(id.Length, Is.EqualTo(lengthOfParatextProjectIds), "setup. Use an ID of Paratext-ID-length.");
-            // SUT
-            Assert.That(env.Service.IsResource(id), Is.False);
-        }
-
-        [Test]
-        public void IsResource_ResourceProjectId_Yes()
-        {
-            var env = new TestEnvironment();
-            const int lengthOfDblResourceId = 16;
-            string id = "1234567890abcdef";
-            Assert.That(id.Length, Is.EqualTo(lengthOfDblResourceId), "setup. Use an ID of DBL-Resource-ID-length.");
-            // SUT
-            Assert.That(env.Service.IsResource(id), Is.True);
-        }
-
-        [Test]
-        public async Task GetPermissionsAsync_UserResourcePermission()
-        {
-            // Set up environment
-            var env = new TestEnvironment();
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            // Set up mock REST client to return a successful GET request
-            ISFRestClientFactory mockRestClientFactory = env.SetRestClientFactory(user01Secret);
-
-            // Set up mock REST client to return an unsuccessful GET request
-            ISFRestClient failureMockClient = Substitute.For<ISFRestClient>();
-            failureMockClient.Get(Arg.Any<string>()).Returns(string.Empty);
-            mockRestClientFactory
-                .Create(Arg.Any<string>(), Arg.Is<UserSecret>(s => s.Id == env.User02))
-                .Returns(failureMockClient);
-
-            // Set up mock project
-            var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
-            var project = projects.First();
-            project.ParatextId = env.Resource2Id;
-            var ptUsernameMapping = new Dictionary<string, string>()
             {
-                { env.User01, env.Username01 },
-                { env.User02, env.Username02 },
-            };
+                env.Username01,
+                new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+            }
+        };
 
-            var permissions = await env.Service.GetPermissionsAsync(user01Secret, project, ptUsernameMapping);
-            Assert.That(permissions.Count(), Is.EqualTo(2));
-            Assert.That(permissions.First().Value, Is.EqualTo(TextInfoPermission.Read));
-            Assert.That(permissions.Last().Value, Is.EqualTo(TextInfoPermission.None));
-        }
+        string contextBefore = "Context before changed ";
+        string selectionText = "Text selected changed";
+        Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(
+            env.Project01,
+            40,
+            1,
+            contextBefore,
+            selectionText,
+            false
+        );
 
-        [Test]
-        public async Task GetResourcePermissionAsync_UserNoResourcePermission()
+        IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
+            userSecret,
+            ptProjectId,
+            40,
+            noteThreadDocs,
+            chapterDeltas,
+            ptProjectUsers
+        );
+        Assert.That(changes.Count, Is.EqualTo(2));
+
+        // Context, including the selected text have changed
+        int expectedStartIndex = contextBefore.Length;
+        NoteThreadChange change1 = changes.First(c => c.ThreadId == "thread1");
+        TextAnchor expected1 = new TextAnchor { Start = expectedStartIndex, Length = selectionText.Length };
+        Assert.That(change1.Position, Is.EqualTo(expected1));
+
+        // This new SF note thread applies to the verse
+        NoteThreadChange change2 = changes.First(c => c.ThreadId == "thread2");
+        TextAnchor expected2 = new TextAnchor { Start = 0, Length = 0 };
+        Assert.That(change2.Position, Is.EqualTo(expected2));
+    }
+
+    [Test]
+    public async Task GetNoteThreadChanges_NotePositionDefaulted()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.AddTextDocs(40, 1, 6, "Context before ", "Text selection", false);
+
+        env.AddNoteThreadData(
+            new[]
+            {
+                new ThreadComponents { threadNum = 1, noteCount = 1 }
+            }
+        );
+        env.AddParatextComments(
+            new[]
+            {
+                new ThreadComponents
+                {
+                    threadNum = 1,
+                    noteCount = 1,
+                    username = env.Username01
+                }
+            }
+        );
+
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
+            conn,
+            new[] { "thread1" }
+        );
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = new Dictionary<string, ParatextUserProfile>
         {
-            // Set up environment
-            var env = new TestEnvironment();
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+            {
+                env.Username01,
+                new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+            }
+        };
+        Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(
+            env.Project01,
+            40,
+            1,
+            "Unrecognizable context ",
+            "unrecognizable selection",
+            false
+        );
 
-            // Set up mock REST client to return a successful GET request
-            env.SetRestClientFactory(user01Secret);
+        IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
+            userSecret,
+            ptProjectId,
+            40,
+            noteThreadDocs,
+            chapterDeltas,
+            ptProjectUsers
+        );
+        Assert.That(changes.Count, Is.EqualTo(1));
 
-            var paratextId = "resid_is_16_char";
-            var permission = await env.Service.GetResourcePermissionAsync(
-                paratextId,
-                env.User01,
-                CancellationToken.None
-            );
-            Assert.That(permission, Is.EqualTo(TextInfoPermission.None));
-        }
+        // Vigorous text changes, the note defaults to the start
+        NoteThreadChange change = changes.First(c => c.ThreadId == "thread1");
+        TextAnchor expected = new TextAnchor { Start = 0, Length = 0 };
+        Assert.That(change.Position, Is.EqualTo(expected));
+    }
 
-        [Test]
-        public async Task GetResourcePermissionAsync_UserResourcePermission()
+    [Test]
+    public async Task GetNoteThreadChanges_RetrievesChanges()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.AddTextDocs(40, 1, 10, "Context before ", "Text selected");
+
+        env.AddNoteThreadData(
+            new[]
+            {
+                new ThreadComponents { threadNum = 1, noteCount = 1 },
+                new ThreadComponents { threadNum = 2, noteCount = 1 },
+                new ThreadComponents { threadNum = 4, noteCount = 2 },
+                new ThreadComponents { threadNum = 5, noteCount = 1 },
+                new ThreadComponents { threadNum = 7, noteCount = 1 },
+                new ThreadComponents { threadNum = 8, noteCount = 1 },
+                new ThreadComponents { threadNum = 9, noteCount = 3 }
+            }
+        );
+        env.AddParatextComments(
+            new[]
+            {
+                new ThreadComponents
+                {
+                    threadNum = 1,
+                    noteCount = 1,
+                    username = env.Username01,
+                    isEdited = true
+                },
+                new ThreadComponents
+                {
+                    threadNum = 2,
+                    noteCount = 1,
+                    username = env.Username01,
+                    isDeleted = true
+                },
+                new ThreadComponents
+                {
+                    threadNum = 3,
+                    noteCount = 1,
+                    username = env.Username02
+                },
+                new ThreadComponents
+                {
+                    threadNum = 4,
+                    noteCount = 1,
+                    username = env.Username01
+                },
+                new ThreadComponents
+                {
+                    threadNum = 6,
+                    noteCount = 1,
+                    isConflict = true
+                },
+                new ThreadComponents
+                {
+                    threadNum = 7,
+                    noteCount = 2,
+                    username = env.Username01
+                },
+                new ThreadComponents
+                {
+                    threadNum = 8,
+                    noteCount = 1,
+                    username = env.Username01
+                },
+                new ThreadComponents
+                {
+                    threadNum = 9,
+                    noteCount = 3,
+                    username = env.Username01
+                }
+            }
+        );
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
+            conn,
+            new[] { "thread1", "thread2", "thread4", "thread5", "thread7", "thread8", "thread9" }
+        );
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
         {
-            // Set up environment
-            var env = new TestEnvironment();
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.SetRestClientFactory(user01Secret);
-            var paratextId = env.Resource2Id;
-            var permission = await env.Service.GetResourcePermissionAsync(
-                paratextId,
-                env.User01,
-                CancellationToken.None
-            );
-            Assert.That(permission, Is.EqualTo(TextInfoPermission.Read));
-        }
+            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+        }.ToDictionary(u => u.Username);
+        Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(
+            env.Project01,
+            40,
+            1,
+            "Context before ",
+            "Text selected"
+        );
 
-        [Test]
-        public void GetBooks_ReturnCorrectNumberOfBooks()
+        // SUT
+        IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
+            userSecret,
+            ptProjectId,
+            40,
+            noteThreadDocs,
+            chapterDeltas,
+            ptProjectUsers
+        );
+        Assert.That(changes.Count, Is.EqualTo(8));
+        Assert.That(changes.FirstOrDefault(c => c.ThreadId == "thread8"), Is.Null);
+
+        // Edited comment
+        NoteThreadChange change01 = changes.Where(c => c.ThreadId == "thread1").Single();
+        Assert.That(
+            change01.ThreadChangeToString(),
+            Is.EqualTo("Context before Text selected thread1 context after.-MAT 1:1")
+        );
+        Assert.That(change01.NotesUpdated.Count, Is.EqualTo(1));
+        string expected1 = "thread1-syncuser01-user02-<p>thread1 note 1: EDITED.</p>-tag:1";
+        Assert.That(change01.NotesUpdated[0].NoteToString(), Is.EqualTo(expected1));
+
+        // Deleted comment
+        NoteThreadChange change02 = changes.Where(c => c.ThreadId == "thread2").Single();
+        Assert.That(
+            change02.ThreadChangeToString(),
+            Is.EqualTo("Context before Text selected thread2 context after.-MAT 1:2")
+        );
+        Assert.That(change02.NotesDeleted.Count, Is.EqualTo(1));
+        string expected2 = "thread2-syncuser01-user02-<p>thread2 note 1.</p>-deleted-tag:1";
+        Assert.That(change02.NotesDeleted[0].NoteToString(), Is.EqualTo(expected2));
+
+        // Added comment on new thread and User 02 added as new pt user
+        NoteThreadChange change03 = changes.Where(c => c.ThreadId == "thread3").Single();
+        Assert.That(
+            change03.ThreadChangeToString(),
+            Is.EqualTo("Context before Text selected thread3 context after.-Start:15-Length:21-MAT 1:3")
+        );
+        Assert.That(change03.NotesAdded.Count, Is.EqualTo(1));
+        string expected3 = "thread3-syncuser04-user02-<p>thread3 note 1.</p>-tag:1";
+        Assert.That(change03.NotesAdded[0].NoteToString(), Is.EqualTo(expected3));
+
+        // Permanently removed comment
+        NoteThreadChange change04 = changes.Where(c => c.ThreadId == "thread4").Single();
+        Assert.That(
+            change04.ThreadChangeToString(),
+            Is.EqualTo("Context before Text selected thread4 context after.-MAT 1:4")
+        );
+        Assert.That(change04.NoteIdsRemoved, Is.EquivalentTo(new[] { "n2onthread4" }));
+
+        // Permanently removed thread
+        NoteThreadChange change05 = changes.Where(c => c.ThreadId == "thread5").Single();
+        Assert.That(
+            change05.ThreadChangeToString(),
+            Is.EqualTo("Context before Text selected thread5 context after.-MAT 1:5")
+        );
+        Assert.That(change05.ThreadRemoved, Is.True);
+
+        // Added conflict comment
+        NoteThreadChange change06 = changes.Where(c => c.ThreadId == "thread6").Single();
+        Assert.That(
+            change06.ThreadChangeToString(),
+            Is.EqualTo("Context before Text selected thread6 context after.-Start:15-Length:21-MAT 1:6")
+        );
+        string expected6 = "thread6---<p>thread6 note 1.</p>-tag:-1";
+        Assert.That(change06.NotesAdded[0].NoteToString(), Is.EqualTo(expected6));
+
+        // Added comment on existing thread
+        NoteThreadChange change07 = changes.Where(c => c.ThreadId == "thread7").Single();
+        string expected7 = "thread7-syncuser01-user02-<p>thread7 note 2.</p>";
+        Assert.That(change07.NotesAdded[0].NoteToString(), Is.EqualTo(expected7));
+
+        // Removed tag icon on repeated todo notes
+        NoteThreadChange change08 = changes.Where(c => c.ThreadId == "thread9").Single();
+        Assert.That(change08.NotesUpdated[0].DataId, Is.EqualTo("n2onthread9"));
+        Assert.That(change08.NotesUpdated[0].TagId, Is.EqualTo(null));
+        Assert.That(change08.NotesUpdated[1].DataId, Is.EqualTo("n3onthread9"));
+        Assert.That(change08.NotesUpdated[1].TagId, Is.EqualTo(null));
+
+        // User 02 is added to the list of Paratext Users when thread3 is added to note thread docs
+        // No users should be added from the new thread6 change which has no paratext user
+        Assert.That(ptProjectUsers.Keys, Is.EquivalentTo(new[] { env.Username01, env.Username02 }));
+    }
+
+    [Test]
+    public async Task GetNoteThreadChanges_AddsNoteProperties()
+    {
+        var env = new TestEnvironment();
+        string sfProjectId = env.Project01;
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(sfProjectId, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.AddTextDoc(40, 1);
+        string threadId = "thread01";
+
+        env.MockGuidService.NewObjectId().Returns("thread01note01");
+
+        // There is a PT Comment.
+        var comment = new Paratext.Data.ProjectComments.Comment(associatedPtUser)
         {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+            Thread = threadId,
+            VerseRefStr = "MAT 1:1",
+            SelectedText = "",
+            ContextBefore = "",
+            ContextAfter = "",
+            StartPosition = 0,
+            Contents = null,
+            Date = $"2019-12-31T08:00:00.0000000+00:00",
+            Deleted = false,
+            Status = NoteStatus.Todo,
+            Type = NoteType.Normal,
+            ConflictType = NoteConflictType.None,
+            AssignedUser = Paratext.Data.ProjectComments.CommentThread.unassignedUser,
+            AcceptedChangeXmlStr = "some xml",
+        };
+        env.AddParatextComment(comment);
 
-            // Books 1 thru 3.
-            env.ProjectScrText.Settings.BooksPresentSet = new BookSet(1, 3);
-
-            IReadOnlyList<int> result = env.Service.GetBookList(userSecret, ptProjectId);
-            Assert.That(result.Count(), Is.EqualTo(3));
-            Assert.That(result, Is.EquivalentTo(new[] { 1, 2, 3 }));
-        }
-
-        [Test]
-        public void GetBookText_Works()
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        // But we have no SF notes.
+        IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
+            conn,
+            Array.Empty<string>()
+        );
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
         {
-            string ruthBookUsx =
-                "<usx version=\"3.0\">\r\n  <book code=\"RUT\" style=\"id\">- ProjectNameHere"
-                + "</book>\r\n  <chapter number=\"1\" style=\"c\" />\r\n  <verse number=\"1\" style=\"v\" />"
-                + "Verse 1 here. <verse number=\"2\" style=\"v\" />Verse 2 here.</usx>";
+            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+        }.ToDictionary(u => u.Username);
+        Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(
+            env.Project01,
+            40,
+            1,
+            "Context before ",
+            "Text selected"
+        );
 
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        // SUT
+        IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
+            userSecret,
+            ptProjectId,
+            40,
+            noteThreadDocs,
+            chapterDeltas,
+            ptProjectUsers
+        );
+        // We fetched a single change, of one new note to create.
 
-            // SUT
-            string result = env.Service.GetBookText(null, ptProjectId, 8);
-            Assert.That(result, Is.EqualTo(ruthBookUsx));
-        }
+        Assert.That(changes.Count, Is.EqualTo(1));
+        NoteThreadChange change = changes.First();
+        Assert.That(change.ThreadId, Is.EqualTo(threadId));
+        Assert.That(change.NotesAdded.Count, Is.EqualTo(1));
+        Note newNote = change.NotesAdded[0];
+        Assert.That(newNote.ThreadId, Is.EqualTo(threadId));
+        Assert.That(newNote.Type, Is.EqualTo(NoteType.Normal.InternalValue));
+        Assert.That(newNote.ConflictType, Is.EqualTo(NoteConflictType.None.InternalValue));
+        Assert.That(newNote.AcceptedChangeXml, Is.EqualTo("some xml"));
+    }
 
-        [Test]
-        public void GetBookText_NoSuchPtProjectKnown()
+    [Test]
+    public async Task GetNoteThreadChanges_LineBreak_TextAnchorUpdated()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        string threadId = "thread1";
+        string text1 = "Text in first verse ";
+        string text2 = "text after ";
+        string selected = "stanza";
+        string text3 = " break";
+
+        var comment = new Paratext.Data.ProjectComments.Comment(associatedPtUser)
         {
-            var env = new TestEnvironment();
-            string ptProjectId = env.PTProjectIds[env.Project01].Id;
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
-            env.MockScrTextCollection.FindById(env.Username01, ptProjectId).Returns(i => null);
+            Thread = threadId,
+            VerseRefStr = "MAT 1:1",
+            SelectedText = "stanza",
+            ContextBefore = text1 + "\\b \\q" + text2 + selected,
+            ContextAfter = text3,
+            StartPosition = text1.Length + text2.Length,
+            Contents = null,
+            Date = $"2019-12-31T08:00:00.0000000+00:00",
+            Deleted = false,
+            Status = NoteStatus.Todo,
+            Type = NoteType.Normal,
+            ConflictType = NoteConflictType.None,
+            AssignedUser = Paratext.Data.ProjectComments.CommentThread.unassignedUser,
+        };
+        env.AddParatextComment(comment);
 
-            // SUT
-            Assert.Throws<DataNotFoundException>(() => env.Service.GetBookText(user01Secret, ptProjectId, 8));
-            env.MockScrTextCollection.Received(1).FindById(env.Username01, ptProjectId);
-        }
-
-        [Test]
-        public async Task PutBookText_TextEdited_BookTextIsUpdated()
+        await using (await env.RealtimeService.ConnectAsync())
         {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            // should be able to edit the book text even if the admin user does not have permission
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser, hasEditPermission: false);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            int ruthBookNum = 8;
-            string ruthBookUsx =
-                "<usx version=\"3.0\">\r\n  <book code=\"RUT\" style=\"id\">- ProjectNameHere"
-                + "</book>\r\n  <chapter number=\"1\" style=\"c\" />\r\n  <verse number=\"1\" style=\"v\" />"
-                + "Verse 1 here. <verse number=\"2\" style=\"v\" />Verse 2 here.</usx>";
-
-            JToken token1 = JToken.Parse("{\"insert\": { \"chapter\": { \"number\": \"1\", \"style\": \"c\" } } }");
-            JToken token2 = JToken.Parse("{\"insert\": { \"verse\": { \"number\": \"1\", \"style\": \"v\" } } }");
-            JToken token3 = JToken.Parse(
-                "{\"insert\": \"Verse 1 here. \", \"attributes\": { \"segment\": \"verse_1_1\" } }"
-            );
-            JToken token4 = JToken.Parse("{\"insert\": { \"verse\": { \"number\": \"2\", \"style\": \"v\" } } }");
-            JToken token5 = JToken.Parse(
-                "{\"insert\": \"Verse 2 here. THIS PART IS EDITED!\","
-                    + "\"attributes\": { \"segment\": \"verse_1_2\" } }"
-            );
-
-            TextData data = new TextData(new Delta(new[] { token1, token2, token3, token4, token5 }));
-            XDocument oldDocUsx = XDocument.Parse(ruthBookUsx);
-            DeltaUsxMapper mapper = new DeltaUsxMapper(
-                new TestGuidService(),
-                Substitute.For<ILogger<DeltaUsxMapper>>(),
-                Substitute.For<IExceptionHandler>()
-            );
-            var newDocUsx = mapper.ToUsx(oldDocUsx, new List<ChapterDelta> { new ChapterDelta(1, 2, true, data) });
-            int booksUpdated = await env.Service.PutBookText(userSecret, ptProjectId, ruthBookNum, newDocUsx);
-            env.ProjectFileManager.Received(1).WriteFileCreatingBackup(Arg.Any<string>(), Arg.Any<Action<string>>());
-            Assert.That(booksUpdated, Is.EqualTo(1));
-
-            // PT username is not written to server logs
-            env.MockLogger.AssertNoEvent((LogEvent logEvent) => logEvent.Message.Contains(env.Username01));
-        }
-
-        [Test]
-        public async Task PutBookText_DoesNotRequireChapterAuthors()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            // should be able to edit the book text even if the admin user does not have permission
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser, hasEditPermission: false);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            int ruthBookNum = 8;
-            string ruthBookUsx =
-                "<usx version=\"3.0\">\r\n  <book code=\"RUT\" style=\"id\">- ProjectNameHere"
-                + "</book>\r\n  <chapter number=\"1\" style=\"c\" />\r\n  <verse number=\"1\" style=\"v\" />"
-                + "Verse 1 here. <verse number=\"2\" style=\"v\" />Verse 2 here.</usx>";
-
-            // SUT
-            int booksUpdated = await env.Service.PutBookText(
+            IEnumerable<IDocument<NoteThread>> noteThreadDocs = Array.Empty<IDocument<NoteThread>>();
+            Dictionary<int, ChapterDelta> chapterDeltas = new Dictionary<int, ChapterDelta>();
+            string chapterText =
+                "[ { \"insert\": { \"chapter\": { \"style\": \"c\", \"number\": \"1\" } } }, "
+                + "{ \"insert\": { \"blank\": true }, \"attributes\": { \"segment\": \"q_1\" } },"
+                + "{ \"insert\": { \"verse\": { \"style\": \"v\", \"number\": \"1\" } } }, "
+                + "{ \"insert\": \""
+                + text1
+                + "\", \"attributes\": { \"segment\": \"verse_1_1\" } }, "
+                + "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"q\" } } }, "
+                + "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"b\" } } }, "
+                + "{ \"insert\": \""
+                + text2
+                + selected
+                + text3
+                + "\", \"attributes\": { \"segment\": \"verse_1_1/q_1\" } } ]";
+            var delta = new Delta(JToken.Parse(chapterText));
+            ChapterDelta chapterDelta = new ChapterDelta(1, 1, true, delta);
+            chapterDeltas.Add(1, chapterDelta);
+            Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
+            {
+                new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+            }.ToDictionary(u => u.Username);
+            IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
                 userSecret,
                 ptProjectId,
-                ruthBookNum,
-                XDocument.Parse(ruthBookUsx)
+                40,
+                noteThreadDocs,
+                chapterDeltas,
+                ptProjectUsers
             );
-
-            // Make sure only one ScrText was loaded
-            env.MockScrTextCollection.Received(1).FindById(env.Username01, ptProjectId);
-            Assert.That(booksUpdated, Is.EqualTo(1));
-
-            // See if there is a message for the user updating the book
-            string logMessage = string.Format(
-                "{0} updated {1} in {2}.",
-                env.User01,
-                Canon.BookNumberToEnglishName(ruthBookNum),
-                env.ProjectScrText.Name
-            );
-            env.MockLogger.AssertHasEvent((LogEvent logEvent) => logEvent.Message == logMessage);
-        }
-
-        [Test]
-        public async Task PutBookText_UpdatesTheBookIfAllSameAuthor()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            // should be able to edit the book text even if the admin user does not have permission
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser, hasEditPermission: false);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            int ruthBookNum = 8;
-            string ruthBookUsx =
-                "<usx version=\"3.0\">\r\n  <book code=\"RUT\" style=\"id\">- ProjectNameHere"
-                + "</book>\r\n  <chapter number=\"1\" style=\"c\" />\r\n  <verse number=\"1\" style=\"v\" />"
-                + "Verse 1 here. <verse number=\"2\" style=\"v\" />Verse 2 here.</usx>";
-            var chapterAuthors = new Dictionary<int, string> { { 1, env.User01 }, { 2, env.User01 }, };
-
-            // SUT
-            int booksUpdated = await env.Service.PutBookText(
-                userSecret,
-                ptProjectId,
-                ruthBookNum,
-                XDocument.Parse(ruthBookUsx),
-                chapterAuthors
-            );
-
-            // Make sure only one ScrText was loaded
-            env.MockScrTextCollection.Received(1).FindById(env.Username01, ptProjectId);
-            Assert.That(booksUpdated, Is.EqualTo(1));
-
-            // See if there is a message for the user updating the book
-            string logMessage = string.Format(
-                "{0} updated {1} in {2}.",
-                env.User01,
-                Canon.BookNumberToEnglishName(ruthBookNum),
-                env.ProjectScrText.Name
-            );
-            env.MockLogger.AssertHasEvent((LogEvent logEvent) => logEvent.Message == logMessage);
-        }
-
-        [Test]
-        public async Task PutBookText_UpdatesTheChapterIfDifferentAuthors()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            // should be able to edit the book text even if the admin user does not have permission
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser, hasEditPermission: false);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.MakeUserSecret(env.User02, env.Username02, env.ParatextUserId02);
-
-            int ruthBookNum = 8;
-            string ruthBookUsx =
-                "<usx version=\"3.0\">\r\n  <book code=\"RUT\" style=\"id\">- ProjectNameHere"
-                + "</book>\r\n  <chapter number=\"1\" style=\"c\" />\r\n  <verse number=\"1\" style=\"v\" />"
-                + "Verse 1 here. <verse number=\"2\" style=\"v\" />Verse 2 here.</usx>";
-            var chapterAuthors = new Dictionary<int, string> { { 1, env.User01 }, { 2, env.User02 }, };
-
-            // SUT
-            int booksUpdated = await env.Service.PutBookText(
-                userSecret,
-                ptProjectId,
-                ruthBookNum,
-                XDocument.Parse(ruthBookUsx),
-                chapterAuthors
-            );
-
-            // Make sure two ScrTexts were loaded
-            env.MockScrTextCollection.Received(1).FindById(env.Username01, ptProjectId);
-            env.MockScrTextCollection.Received(1).FindById(env.Username02, ptProjectId);
-            Assert.That(booksUpdated, Is.EqualTo(1));
-
-            // See if there is a message for the user updating the chapter
-            string logMessage = string.Format(
-                "{0} updated chapter {1} of {2} in {3}.",
-                env.User01,
-                1,
-                Canon.BookNumberToEnglishName(ruthBookNum),
-                env.ProjectScrText.Name
-            );
-            env.MockLogger.AssertHasEvent((LogEvent logEvent) => logEvent.Message == logMessage);
-        }
-
-        [Test]
-        public void GetNotes_RetrievesNotes()
-        {
-            int ruthBookNum = 8;
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.ProjectCommentManager.AddComment(
-                new Paratext.Data.ProjectComments.Comment(associatedPtUser)
-                {
-                    Thread = "Answer_dataId0123",
-                    VerseRefStr = "RUT 1:1"
-                }
-            );
-            string notes = env.Service.GetNotes(userSecret, ptProjectId, ruthBookNum);
-            string expected = $"<notes version=\"1.1\">{Environment.NewLine}  <thread id=\"Answer_dataId0123\">";
-            Assert.True(notes.StartsWith(expected));
-        }
-
-        [Test]
-        public void PutNotes_AddEditDeleteComment_ThreadCorrectlyUpdated()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            DateTime date = DateTime.Now; // This must be consistent as it is a part of the comment id
-
-            // Add new comment
-            string threadId = "Answer_0123";
-            string content = "Content for comment to update.";
-            string verseRef = "RUT 1:1";
-            XElement updateNotesXml = env.GetUpdateNotesXml(threadId, env.User01, date, content, verseRef);
-            var syncMetricInfo = env.Service.PutNotes(userSecret, ptProjectId, updateNotesXml);
-
-            CommentThread thread = env.ProjectCommentManager.FindThread(threadId);
-            Assert.That(thread.Comments.Count, Is.EqualTo(1));
-            var comment = thread.Comments.First();
-            Assert.That(comment.VerseRefStr, Is.EqualTo(verseRef));
-            Assert.That(comment.User, Is.EqualTo(env.User01));
-            Assert.That(comment.Contents.InnerText, Is.EqualTo(content));
-            Assert.That(syncMetricInfo, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
-
-            // Edit a comment
-            content = "Edited: Content for comment to update.";
-            updateNotesXml = env.GetUpdateNotesXml(threadId, env.User01, date, content, verseRef);
-            syncMetricInfo = env.Service.PutNotes(userSecret, ptProjectId, updateNotesXml);
-
-            Assert.That(thread.Comments.Count, Is.EqualTo(1));
-            comment = thread.Comments.First();
-            Assert.That(comment.Contents.InnerText, Is.EqualTo(content));
-            Assert.That(syncMetricInfo, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 1)));
-
-            // Delete a comment
-            updateNotesXml = env.GetUpdateNotesXml(threadId, env.User01, date, content, verseRef, true);
-            syncMetricInfo = env.Service.PutNotes(userSecret, ptProjectId, updateNotesXml);
-
-            Assert.That(thread.Comments.Count, Is.EqualTo(1));
-            comment = thread.Comments.First();
-            Assert.That(comment.Deleted, Is.True, "Comment should be marked deleted");
-            Assert.That(syncMetricInfo, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
-
-            // PT username is not written to server logs
-            env.MockLogger.AssertNoEvent((LogEvent logEvent) => logEvent.Message.Contains(env.Username01));
-        }
-
-        [Test]
-        public async Task GetNoteThreadChanges_NotePositionUpdated()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.AddTextDocs(40, 1, 6, "Context before ", "Text selected");
-
-            env.AddNoteThreadData(
-                new[]
-                {
-                    new ThreadComponents { threadNum = 1, noteCount = 1 }
-                }
-            );
-            env.AddParatextComments(
-                new[]
-                {
-                    new ThreadComponents
-                    {
-                        threadNum = 1,
-                        noteCount = 1,
-                        username = env.Username01
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 2,
-                        noteCount = 1,
-                        username = env.Username01,
-                        appliesToVerse = true
-                    }
-                }
-            );
-
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-            {
-                IEnumerable<IDocument<NoteThread>> noteThreadDocs = await env.GetNoteThreadDocsAsync(
-                    conn,
-                    new[] { "thread1" }
-                );
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = new Dictionary<string, ParatextUserProfile>
-                {
-                    {
-                        env.Username01,
-                        new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-                    }
-                };
-
-                string contextBefore = "Context before changed ";
-                string selectionText = "Text selected changed";
-                Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(
-                    env.Project01,
-                    40,
-                    1,
-                    contextBefore,
-                    selectionText,
-                    false
-                );
-
-                IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
-                    userSecret,
-                    ptProjectId,
-                    40,
-                    noteThreadDocs,
-                    chapterDeltas,
-                    ptProjectUsers
-                );
-                Assert.That(changes.Count, Is.EqualTo(2));
-
-                // Context, including the selected text have changed
-                int expectedStartIndex = contextBefore.Length;
-                NoteThreadChange change1 = changes.First(c => c.ThreadId == "thread1");
-                TextAnchor expected1 = new TextAnchor { Start = expectedStartIndex, Length = selectionText.Length };
-                Assert.That(change1.Position, Is.EqualTo(expected1));
-
-                // This new SF note thread applies to the verse
-                NoteThreadChange change2 = changes.First(c => c.ThreadId == "thread2");
-                TextAnchor expected2 = new TextAnchor { Start = 0, Length = 0 };
-                Assert.That(change2.Position, Is.EqualTo(expected2));
-            }
-        }
-
-        [Test]
-        public async Task GetNoteThreadChanges_NotePositionDefaulted()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.AddTextDocs(40, 1, 6, "Context before ", "Text selection", false);
-
-            env.AddNoteThreadData(
-                new[]
-                {
-                    new ThreadComponents { threadNum = 1, noteCount = 1 }
-                }
-            );
-            env.AddParatextComments(
-                new[]
-                {
-                    new ThreadComponents
-                    {
-                        threadNum = 1,
-                        noteCount = 1,
-                        username = env.Username01
-                    }
-                }
-            );
-
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-            {
-                IEnumerable<IDocument<NoteThread>> noteThreadDocs = await env.GetNoteThreadDocsAsync(
-                    conn,
-                    new[] { "thread1" }
-                );
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = new Dictionary<string, ParatextUserProfile>
-                {
-                    {
-                        env.Username01,
-                        new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-                    }
-                };
-                Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(
-                    env.Project01,
-                    40,
-                    1,
-                    "Unrecognizable context ",
-                    "unrecognizable selection",
-                    false
-                );
-
-                IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
-                    userSecret,
-                    ptProjectId,
-                    40,
-                    noteThreadDocs,
-                    chapterDeltas,
-                    ptProjectUsers
-                );
-                Assert.That(changes.Count, Is.EqualTo(1));
-
-                // Vigorous text changes, the note defaults to the start
-                NoteThreadChange change = changes.First(c => c.ThreadId == "thread1");
-                TextAnchor expected = new TextAnchor { Start = 0, Length = 0 };
-                Assert.That(change.Position, Is.EqualTo(expected));
-            }
-        }
-
-        [Test]
-        public async Task GetNoteThreadChanges_RetrievesChanges()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.AddTextDocs(40, 1, 10, "Context before ", "Text selected");
-
-            env.AddNoteThreadData(
-                new[]
-                {
-                    new ThreadComponents { threadNum = 1, noteCount = 1 },
-                    new ThreadComponents { threadNum = 2, noteCount = 1 },
-                    new ThreadComponents { threadNum = 4, noteCount = 2 },
-                    new ThreadComponents { threadNum = 5, noteCount = 1 },
-                    new ThreadComponents { threadNum = 7, noteCount = 1 },
-                    new ThreadComponents { threadNum = 8, noteCount = 1 },
-                    new ThreadComponents { threadNum = 9, noteCount = 3 }
-                }
-            );
-            env.AddParatextComments(
-                new[]
-                {
-                    new ThreadComponents
-                    {
-                        threadNum = 1,
-                        noteCount = 1,
-                        username = env.Username01,
-                        isEdited = true
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 2,
-                        noteCount = 1,
-                        username = env.Username01,
-                        isDeleted = true
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 3,
-                        noteCount = 1,
-                        username = env.Username02
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 4,
-                        noteCount = 1,
-                        username = env.Username01
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 6,
-                        noteCount = 1,
-                        isConflict = true
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 7,
-                        noteCount = 2,
-                        username = env.Username01
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 8,
-                        noteCount = 1,
-                        username = env.Username01
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 9,
-                        noteCount = 3,
-                        username = env.Username01
-                    }
-                }
-            );
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-            {
-                IEnumerable<IDocument<NoteThread>> noteThreadDocs = await env.GetNoteThreadDocsAsync(
-                    conn,
-                    new[] { "thread1", "thread2", "thread4", "thread5", "thread7", "thread8", "thread9" }
-                );
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
-                {
-                    new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-                }.ToDictionary(u => u.Username);
-                Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(
-                    env.Project01,
-                    40,
-                    1,
-                    "Context before ",
-                    "Text selected"
-                );
-
-                // SUT
-                IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
-                    userSecret,
-                    ptProjectId,
-                    40,
-                    noteThreadDocs,
-                    chapterDeltas,
-                    ptProjectUsers
-                );
-                Assert.That(changes.Count, Is.EqualTo(8));
-                Assert.That(changes.FirstOrDefault(c => c.ThreadId == "thread8"), Is.Null);
-
-                // Edited comment
-                NoteThreadChange change01 = changes.Where(c => c.ThreadId == "thread1").Single();
-                Assert.That(
-                    change01.ThreadChangeToString(),
-                    Is.EqualTo("Context before Text selected thread1 context after.-MAT 1:1")
-                );
-                Assert.That(change01.NotesUpdated.Count, Is.EqualTo(1));
-                string expected1 = "thread1-syncuser01-user02-<p>thread1 note 1: EDITED.</p>-tag:1";
-                Assert.That(change01.NotesUpdated[0].NoteToString(), Is.EqualTo(expected1));
-
-                // Deleted comment
-                NoteThreadChange change02 = changes.Where(c => c.ThreadId == "thread2").Single();
-                Assert.That(
-                    change02.ThreadChangeToString(),
-                    Is.EqualTo("Context before Text selected thread2 context after.-MAT 1:2")
-                );
-                Assert.That(change02.NotesDeleted.Count, Is.EqualTo(1));
-                string expected2 = "thread2-syncuser01-user02-<p>thread2 note 1.</p>-deleted-tag:1";
-                Assert.That(change02.NotesDeleted[0].NoteToString(), Is.EqualTo(expected2));
-
-                // Added comment on new thread and User 02 added as new pt user
-                NoteThreadChange change03 = changes.Where(c => c.ThreadId == "thread3").Single();
-                Assert.That(
-                    change03.ThreadChangeToString(),
-                    Is.EqualTo("Context before Text selected thread3 context after.-Start:15-Length:21-MAT 1:3")
-                );
-                Assert.That(change03.NotesAdded.Count, Is.EqualTo(1));
-                string expected3 = "thread3-syncuser04-user02-<p>thread3 note 1.</p>-tag:1";
-                Assert.That(change03.NotesAdded[0].NoteToString(), Is.EqualTo(expected3));
-
-                // Permanently removed comment
-                NoteThreadChange change04 = changes.Where(c => c.ThreadId == "thread4").Single();
-                Assert.That(
-                    change04.ThreadChangeToString(),
-                    Is.EqualTo("Context before Text selected thread4 context after.-MAT 1:4")
-                );
-                Assert.That(change04.NoteIdsRemoved, Is.EquivalentTo(new[] { "n2onthread4" }));
-
-                // Permanently removed thread
-                NoteThreadChange change05 = changes.Where(c => c.ThreadId == "thread5").Single();
-                Assert.That(
-                    change05.ThreadChangeToString(),
-                    Is.EqualTo("Context before Text selected thread5 context after.-MAT 1:5")
-                );
-                Assert.That(change05.ThreadRemoved, Is.True);
-
-                // Added conflict comment
-                NoteThreadChange change06 = changes.Where(c => c.ThreadId == "thread6").Single();
-                Assert.That(
-                    change06.ThreadChangeToString(),
-                    Is.EqualTo("Context before Text selected thread6 context after.-Start:15-Length:21-MAT 1:6")
-                );
-                string expected6 = "thread6---<p>thread6 note 1.</p>-tag:-1";
-                Assert.That(change06.NotesAdded[0].NoteToString(), Is.EqualTo(expected6));
-
-                // Added comment on existing thread
-                NoteThreadChange change07 = changes.Where(c => c.ThreadId == "thread7").Single();
-                string expected7 = "thread7-syncuser01-user02-<p>thread7 note 2.</p>";
-                Assert.That(change07.NotesAdded[0].NoteToString(), Is.EqualTo(expected7));
-
-                // Removed tag icon on repeated todo notes
-                NoteThreadChange change08 = changes.Where(c => c.ThreadId == "thread9").Single();
-                Assert.That(change08.NotesUpdated[0].DataId, Is.EqualTo("n2onthread9"));
-                Assert.That(change08.NotesUpdated[0].TagId, Is.EqualTo(null));
-                Assert.That(change08.NotesUpdated[1].DataId, Is.EqualTo("n3onthread9"));
-                Assert.That(change08.NotesUpdated[1].TagId, Is.EqualTo(null));
-
-                // User 02 is added to the list of Paratext Users when thread3 is added to note thread docs
-                // No users should be added from the new thread6 change which has no paratext user
-                Assert.That(ptProjectUsers.Keys, Is.EquivalentTo(new[] { env.Username01, env.Username02 }));
-            }
-        }
-
-        [Test]
-        public async Task GetNoteThreadChanges_AddsNoteProperties()
-        {
-            var env = new TestEnvironment();
-            string sfProjectId = env.Project01;
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(sfProjectId, associatedPtUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.AddTextDoc(40, 1);
-            string threadId = "thread01";
-
-            env.MockGuidService.NewObjectId().Returns("thread01note01");
-
-            // There is a PT Comment.
-            var comment = new Paratext.Data.ProjectComments.Comment(associatedPtUser)
-            {
-                Thread = threadId,
-                VerseRefStr = "MAT 1:1",
-                SelectedText = "",
-                ContextBefore = "",
-                ContextAfter = "",
-                StartPosition = 0,
-                Contents = null,
-                Date = $"2019-12-31T08:00:00.0000000+00:00",
-                Deleted = false,
-                Status = NoteStatus.Todo,
-                Type = NoteType.Normal,
-                ConflictType = NoteConflictType.None,
-                AssignedUser = Paratext.Data.ProjectComments.CommentThread.unassignedUser,
-                AcceptedChangeXmlStr = "some xml",
-            };
-            env.AddParatextComment(comment);
-
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-            {
-                // But we have no SF notes.
-                IEnumerable<IDocument<NoteThread>> noteThreadDocs = await env.GetNoteThreadDocsAsync(
-                    conn,
-                    new string[]
-                    { /* empty */
-                    }
-                );
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
-                {
-                    new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-                }.ToDictionary(u => u.Username);
-                Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(
-                    env.Project01,
-                    40,
-                    1,
-                    "Context before ",
-                    "Text selected"
-                );
-
-                // SUT
-                IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
-                    userSecret,
-                    ptProjectId,
-                    40,
-                    noteThreadDocs,
-                    chapterDeltas,
-                    ptProjectUsers
-                );
-                // We fetched a single change, of one new note to create.
-
-                Assert.That(changes.Count, Is.EqualTo(1));
-                NoteThreadChange change = changes.First();
-                Assert.That(change.ThreadId, Is.EqualTo(threadId));
-                Assert.That(change.NotesAdded.Count, Is.EqualTo(1));
-                Note newNote = change.NotesAdded[0];
-                Assert.That(newNote.ThreadId, Is.EqualTo(threadId));
-                Assert.That(newNote.Type, Is.EqualTo(NoteType.Normal.InternalValue));
-                Assert.That(newNote.ConflictType, Is.EqualTo(NoteConflictType.None.InternalValue));
-                Assert.That(newNote.AcceptedChangeXml, Is.EqualTo("some xml"));
-            }
-        }
-
-        [Test]
-        public async Task GetNoteThreadChanges_LineBreak_TextAnchorUpdated()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            string threadId = "thread1";
-            string text1 = "Text in first verse ";
-            string text2 = "text after ";
-            string selected = "stanza";
-            string text3 = " break";
-
-            var comment = new Paratext.Data.ProjectComments.Comment(associatedPtUser)
-            {
-                Thread = threadId,
-                VerseRefStr = "MAT 1:1",
-                SelectedText = "stanza",
-                ContextBefore = text1 + "\\b \\q" + text2 + selected,
-                ContextAfter = text3,
-                StartPosition = text1.Length + text2.Length,
-                Contents = null,
-                Date = $"2019-12-31T08:00:00.0000000+00:00",
-                Deleted = false,
-                Status = NoteStatus.Todo,
-                Type = NoteType.Normal,
-                ConflictType = NoteConflictType.None,
-                AssignedUser = Paratext.Data.ProjectComments.CommentThread.unassignedUser,
-            };
-            env.AddParatextComment(comment);
-
-            await using (await env.RealtimeService.ConnectAsync())
-            {
-                IEnumerable<IDocument<NoteThread>> noteThreadDocs = new IDocument<NoteThread>[0];
-                Dictionary<int, ChapterDelta> chapterDeltas = new Dictionary<int, ChapterDelta>();
-                string chapterText =
-                    "[ { \"insert\": { \"chapter\": { \"style\": \"c\", \"number\": \"1\" } } }, "
-                    + "{ \"insert\": { \"blank\": true }, \"attributes\": { \"segment\": \"q_1\" } },"
-                    + "{ \"insert\": { \"verse\": { \"style\": \"v\", \"number\": \"1\" } } }, "
-                    + "{ \"insert\": \""
-                    + text1
-                    + "\", \"attributes\": { \"segment\": \"verse_1_1\" } }, "
-                    + "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"q\" } } }, "
-                    + "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"b\" } } }, "
-                    + "{ \"insert\": \""
-                    + text2
-                    + selected
-                    + text3
-                    + "\", \"attributes\": { \"segment\": \"verse_1_1/q_1\" } } ]";
-                var delta = new Delta(JToken.Parse(chapterText));
-                ChapterDelta chapterDelta = new ChapterDelta(1, 1, true, delta);
-                chapterDeltas.Add(1, chapterDelta);
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
-                {
-                    new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-                }.ToDictionary(u => u.Username);
-                IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
-                    userSecret,
-                    ptProjectId,
-                    40,
-                    noteThreadDocs,
-                    chapterDeltas,
-                    ptProjectUsers
-                );
-                Assert.That(changes.Count, Is.EqualTo(1));
-                NoteThreadChange change = changes.First();
-                // include the newline length of the q paragraph break, but not the b
-                int startPos = text1.Length + "\n".Length + text2.Length;
-                TextAnchor expected = new TextAnchor { Start = startPos, Length = selected.Length };
-                Assert.That(change.Position, Is.EqualTo(expected));
-            }
-        }
-
-        [Test]
-        public async Task GetNoteThreadChanges_NoChangeTriggersNoUpdate()
-        {
-            var env = new TestEnvironment();
-            IEnumerable<NoteThreadChange> changes = await env.PrepareChangeOnSingleCommentAsync(
-                (Paratext.Data.ProjectComments.Comment comment) => {
-                    // Not modifying comment.
-                }
-            );
-            // There is one PT Comment and one SF Note. No changes were made. So no changes should be reported.
-            Assert.That(changes.Count, Is.Zero);
-        }
-
-        [Test]
-        public async Task GetNoteThreadChanges_UpdateTriggeredFromTypeChange()
-        {
-            var env = new TestEnvironment();
-            IEnumerable<NoteThreadChange> changes = await env.PrepareChangeOnSingleCommentAsync(
-                (Paratext.Data.ProjectComments.Comment comment) =>
-                {
-                    // The incoming PT Comment Type is updated.
-                    Assert.That(comment.Type, Is.Not.EqualTo(NoteType.Conflict), "setup");
-                    comment.Type = NoteType.Conflict;
-                },
-                (NoteThread noteThread) =>
-                {
-                    // Setting a comment type to conflict also changes the tag icon (such as from "icon1" to "conflict1").
-                    // That would make the test pass, because the SF note would have a TagIcon change. But the test would
-                    // not be passing for the desired reason here, which is noticing a change specifically to the type. So
-                    // set the note icon ahead of time, on the SF Note in the SF DB, to "conflict1" so there is
-                    // no change triggered on a change to their icon. The trigger for change should  be from the update to
-                    // the PT Comment Type.
-                    noteThread.Notes[0].TagId = CommentTag.conflictTagId;
-                }
-            );
-
             Assert.That(changes.Count, Is.EqualTo(1));
-
             NoteThreadChange change = changes.First();
-            Assert.That(change.ThreadId, Is.EqualTo("thread01"));
-            Assert.That(change.NotesAdded.Count, Is.Zero);
-            Assert.That(change.NotesDeleted.Count, Is.Zero);
-            Assert.That(change.NotesUpdated.Count, Is.EqualTo(1));
-            Note note = change.NotesUpdated[0];
-            Assert.That(note.ThreadId, Is.EqualTo("thread01"));
-            Assert.That(note.Type, Is.EqualTo(NoteType.Conflict.InternalValue));
+            // include the newline length of the q paragraph break, but not the b
+            int startPos = text1.Length + "\n".Length + text2.Length;
+            TextAnchor expected = new TextAnchor { Start = startPos, Length = selected.Length };
+            Assert.That(change.Position, Is.EqualTo(expected));
         }
+    }
 
-        [Test]
-        public async Task GetNoteThreadChanges_DuplicateComments()
-        {
-            var env = new TestEnvironment();
-            var associatedPTUser = new SFParatextUser(env.Username01);
-            string projectId = env.SetupProject(env.Project01, associatedPTUser);
-            var userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+    [Test]
+    public async Task GetNoteThreadChanges_NoChangeTriggersNoUpdate()
+    {
+        var env = new TestEnvironment();
+        IEnumerable<NoteThreadChange> changes = await env.PrepareChangeOnSingleCommentAsync(
+            (Paratext.Data.ProjectComments.Comment comment) => {
+                // Not modifying comment.
+            }
+        );
+        // There is one PT Comment and one SF Note. No changes were made. So no changes should be reported.
+        Assert.That(changes.Count, Is.Zero);
+    }
 
-            ThreadNoteComponents[] noteComponents = new[]
+    [Test]
+    public async Task GetNoteThreadChanges_UpdateTriggeredFromTypeChange()
+    {
+        var env = new TestEnvironment();
+        IEnumerable<NoteThreadChange> changes = await env.PrepareChangeOnSingleCommentAsync(
+            (Paratext.Data.ProjectComments.Comment comment) =>
             {
-                new ThreadNoteComponents
+                // The incoming PT Comment Type is updated.
+                Assert.That(comment.Type, Is.Not.EqualTo(NoteType.Conflict), "setup");
+                comment.Type = NoteType.Conflict;
+            },
+            (NoteThread noteThread) =>
+                // Setting a comment type to conflict also changes the tag icon (such as from "icon1" to "conflict1").
+                // That would make the test pass, because the SF note would have a TagIcon change. But the test would
+                // not be passing for the desired reason here, which is noticing a change specifically to the type. So
+                // set the note icon ahead of time, on the SF Note in the SF DB, to "conflict1" so there is
+                // no change triggered on a change to their icon. The trigger for change should  be from the update to
+                // the PT Comment Type.
+                noteThread.Notes[0].TagId = CommentTag.conflictTagId
+        );
+
+        Assert.That(changes.Count, Is.EqualTo(1));
+
+        NoteThreadChange change = changes.First();
+        Assert.That(change.ThreadId, Is.EqualTo("thread01"));
+        Assert.That(change.NotesAdded.Count, Is.Zero);
+        Assert.That(change.NotesDeleted.Count, Is.Zero);
+        Assert.That(change.NotesUpdated.Count, Is.EqualTo(1));
+        Note note = change.NotesUpdated[0];
+        Assert.That(note.ThreadId, Is.EqualTo("thread01"));
+        Assert.That(note.Type, Is.EqualTo(NoteType.Conflict.InternalValue));
+    }
+
+    [Test]
+    public async Task GetNoteThreadChanges_DuplicateComments()
+    {
+        var env = new TestEnvironment();
+        var associatedPTUser = new SFParatextUser(env.Username01);
+        string projectId = env.SetupProject(env.Project01, associatedPTUser);
+        var userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        ThreadNoteComponents[] noteComponents = new[]
+        {
+            new ThreadNoteComponents
+            {
+                status = NoteStatus.Todo,
+                tagsAdded = new[] { "1" },
+                assignedPTUser = Paratext.Data.ProjectComments.CommentThread.unassignedUser,
+                // tests that if duplicate project notes exist, the sync succeeds
+                duplicate = true
+            }
+        };
+        env.AddNoteThreadData(
+            new[]
+            {
+                new ThreadComponents
+                {
+                    threadNum = 1,
+                    noteCount = 1,
+                    notes = noteComponents
+                }
+            }
+        );
+
+        env.AddParatextComments(
+            new[]
+            {
+                new ThreadComponents
+                {
+                    threadNum = 1,
+                    noteCount = 1,
+                    notes = noteComponents,
+                    username = env.Username01
+                }
+            }
+        );
+
+        var commentThread = env.ProjectCommentManager.FindThread("thread1");
+        string commentId = commentThread.Comments[0].Id;
+        Assert.That(commentThread.Comments.Where(c => c.Id == commentId).Count, Is.EqualTo(2));
+
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
+            conn,
+            new[] { "thread1" }
+        );
+        Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(
+            projectId,
+            40,
+            1,
+            env.ContextBefore,
+            "Text selected"
+        );
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
+        {
+            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+        }.ToDictionary(u => u.Username);
+        IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
+            userSecret,
+            projectId,
+            40,
+            noteThreadDocs,
+            chapterDeltas,
+            ptProjectUsers
+        );
+
+        Assert.That(changes.Count(), Is.Zero);
+    }
+
+    [Test]
+    public async Task GetNoteThreadChanges_UpdateTriggeredFromConflictTypeChange()
+    {
+        var env = new TestEnvironment();
+        IEnumerable<NoteThreadChange> changes = await env.PrepareChangeOnSingleCommentAsync(
+            (Paratext.Data.ProjectComments.Comment comment) =>
+            {
+                // Already, the PT Comment and SF Note (below) will have Type 'Conflict'.
+                comment.Type = NoteType.Conflict;
+                // But the incoming PT Comment ConflictType is updated.
+                comment.ConflictType = NoteConflictType.VerseTextConflict;
+            },
+            (NoteThread noteThread) =>
+            {
+                noteThread.Notes[0].Type = NoteType.Conflict.InternalValue;
+                // (And set icon to match the note being a conflict note.)
+                noteThread.Notes[0].TagId = CommentTag.conflictTagId;
+                // SF Note ConflictType is something other than what the PT Comment ConflictType is. This is what gets
+                // changed from.
+                noteThread.Notes[0].ConflictType = NoteConflictType.VerseBridgeDifferences.InternalValue;
+            }
+        );
+
+        Assert.That(changes.Count, Is.EqualTo(1));
+
+        NoteThreadChange change = changes.First();
+        Assert.That(change.ThreadId, Is.EqualTo("thread01"));
+        Assert.That(change.NotesAdded.Count, Is.Zero);
+        Assert.That(change.NotesDeleted.Count, Is.Zero);
+        Assert.That(change.NotesUpdated.Count, Is.EqualTo(1));
+        Note note = change.NotesUpdated[0];
+        Assert.That(note.ThreadId, Is.EqualTo("thread01"));
+        Assert.That(note.ConflictType, Is.EqualTo(NoteConflictType.VerseTextConflict.InternalValue));
+    }
+
+    [Test]
+    public async Task GetNoteThreadChanges_UpdateTriggeredFromAcceptedChangeXmlChange()
+    {
+        var env = new TestEnvironment();
+        IEnumerable<NoteThreadChange> changes = await env.PrepareChangeOnSingleCommentAsync(
+            (Paratext.Data.ProjectComments.Comment comment) =>
+            {
+                // Already, the PT Comment and SF Note (below) will have Type 'Conflict' and
+                // ConflictType 'VerseTextConflict'.
+                comment.Type = NoteType.Conflict;
+                comment.ConflictType = NoteConflictType.VerseTextConflict;
+                // But the incoming PT Comment AcceptedChangeXmlStr is updated.
+                comment.AcceptedChangeXmlStr = "new data";
+            },
+            (NoteThread noteThread) =>
+            {
+                noteThread.Notes[0].Type = NoteType.Conflict.InternalValue;
+                // (And set icon to match the note being a conflict note.)
+                noteThread.Notes[0].TagId = CommentTag.conflictTagId;
+                noteThread.Notes[0].ConflictType = NoteConflictType.VerseTextConflict.InternalValue;
+                // The SF Note AcceptedChangeXml is different. This is what gets changed from.
+                noteThread.Notes[0].AcceptedChangeXml = "old data";
+            }
+        );
+
+        Assert.That(changes.Count, Is.EqualTo(1));
+
+        NoteThreadChange change = changes.First();
+        Assert.That(change.ThreadId, Is.EqualTo("thread01"));
+        Assert.That(change.NotesAdded.Count, Is.Zero);
+        Assert.That(change.NotesDeleted.Count, Is.Zero);
+        Assert.That(change.NotesUpdated.Count, Is.EqualTo(1));
+        Note note = change.NotesUpdated[0];
+        Assert.That(note.ThreadId, Is.EqualTo("thread01"));
+        Assert.That(note.AcceptedChangeXml, Is.EqualTo("new data"));
+    }
+
+    [Test]
+    public async Task GetNoteThreadChanges_UseCorrectTagIcon()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.AddTextDocs(40, 1, 10, "Context before ", "Text selected");
+
+        env.AddNoteThreadData(
+            new[]
+            {
+                new ThreadComponents { threadNum = 1, noteCount = 9 },
+            }
+        );
+        ThreadNoteComponents[] threadNotes = new[]
+        {
+            new ThreadNoteComponents { status = NoteStatus.Todo, tagsAdded = new[] { "2" } },
+            new ThreadNoteComponents { status = NoteStatus.Unspecified },
+            new ThreadNoteComponents { status = NoteStatus.Unspecified },
+            new ThreadNoteComponents { status = NoteStatus.Resolved },
+            new ThreadNoteComponents { status = NoteStatus.Todo, tagsAdded = new[] { "3" } },
+            new ThreadNoteComponents { status = NoteStatus.Unspecified },
+            new ThreadNoteComponents { status = NoteStatus.Done },
+            new ThreadNoteComponents { status = NoteStatus.Todo },
+            new ThreadNoteComponents { status = NoteStatus.Todo, tagsAdded = new[] { "4" } }
+        };
+        env.AddParatextComments(
+            new[]
+            {
+                new ThreadComponents
+                {
+                    threadNum = 1,
+                    noteCount = threadNotes.Length,
+                    notes = threadNotes,
+                    username = env.Username01
+                },
+            }
+        );
+
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
+            conn,
+            new[] { "thread1" }
+        );
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
+        {
+            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+        }.ToDictionary(u => u.Username);
+        Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(
+            env.Project01,
+            40,
+            1,
+            "Context before ",
+            "Text selected"
+        );
+        IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
+            userSecret,
+            ptProjectId,
+            40,
+            noteThreadDocs,
+            chapterDeltas,
+            ptProjectUsers
+        );
+
+        List<int?> expectedIcons = new List<int?>() { 2, null, null, 2, 3, null, 3, 3, 4, };
+        NoteThreadChange changedThread = changes.Where(c => c.ThreadId == "thread1").Single();
+        for (int i = 0; i < expectedIcons.Count; i++)
+        {
+            Note note = changedThread.NotesUpdated[i];
+            Assert.That(note.DataId, Is.EqualTo($"n{i + 1}onthread1"));
+            Assert.That(note.TagId, Is.EqualTo(expectedIcons[i]));
+        }
+    }
+
+    [Test]
+    public async Task GetNoteThreadChanges_SetsAssignedUser()
+    {
+        // assign user id to assigned user
+        var env = new TestEnvironment();
+        var associatedPTUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPTUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = new Dictionary<string, ParatextUserProfile>
+        {
+            {
+                env.Username01,
+                new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+            }
+        };
+
+        ThreadNoteComponents[] getThreadNoteComponents(int noteCount, string[] assignedUsers, bool iconChange = false)
+        {
+            var components = new List<ThreadNoteComponents>();
+            string[] commentTagsAdded = new[] { Paratext.Data.ProjectComments.CommentTag.toDoTagId.ToString() };
+            if (iconChange)
+            {
+                string newIconId = "2";
+                commentTagsAdded = new[] { newIconId };
+            }
+            for (int i = 0; i < noteCount; i++)
+            {
+                string assignedUser = null;
+                if (assignedUsers?.Length > i)
+                {
+                    assignedUser = assignedUsers[i];
+                    if (ptProjectUsers.TryGetValue(assignedUsers[i], out ParatextUserProfile ptUser))
+                        assignedUser = ptUser.OpaqueUserId;
+                }
+                var noteComponents = new ThreadNoteComponents
                 {
                     status = NoteStatus.Todo,
-                    tagsAdded = new[] { "1" },
-                    assignedPTUser = Paratext.Data.ProjectComments.CommentThread.unassignedUser,
-                    // tests that if duplicate project notes exist, the sync succeeds
-                    duplicate = true
-                }
-            };
-            env.AddNoteThreadData(
-                new[]
-                {
-                    new ThreadComponents
-                    {
-                        threadNum = 1,
-                        noteCount = 1,
-                        notes = noteComponents
-                    }
-                }
-            );
-
-            env.AddParatextComments(
-                new[]
-                {
-                    new ThreadComponents
-                    {
-                        threadNum = 1,
-                        noteCount = 1,
-                        notes = noteComponents,
-                        username = env.Username01
-                    }
-                }
-            );
-
-            var commentThread = env.ProjectCommentManager.FindThread("thread1");
-            string commentId = commentThread.Comments[0].Id;
-            Assert.That(commentThread.Comments.Where(c => c.Id == commentId).Count, Is.EqualTo(2));
-
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-            {
-                IEnumerable<IDocument<NoteThread>> noteThreadDocs = await env.GetNoteThreadDocsAsync(
-                    conn,
-                    new[] { "thread1" }
-                );
-                Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(
-                    projectId,
-                    40,
-                    1,
-                    env.ContextBefore,
-                    "Text selected"
-                );
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
-                {
-                    new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-                }.ToDictionary(u => u.Username);
-                IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
-                    userSecret,
-                    projectId,
-                    40,
-                    noteThreadDocs,
-                    chapterDeltas,
-                    ptProjectUsers
-                );
-
-                Assert.That(changes.Count(), Is.Zero);
+                    tagsAdded = i == 0 ? commentTagsAdded : null,
+                    assignedPTUser = assignedUser
+                };
+                components.Add(noteComponents);
             }
+            return components.ToArray();
         }
-
-        [Test]
-        public async Task GetNoteThreadChanges_UpdateTriggeredFromConflictTypeChange()
-        {
-            var env = new TestEnvironment();
-            IEnumerable<NoteThreadChange> changes = await env.PrepareChangeOnSingleCommentAsync(
-                (Paratext.Data.ProjectComments.Comment comment) =>
-                {
-                    // Already, the PT Comment and SF Note (below) will have Type 'Conflict'.
-                    comment.Type = NoteType.Conflict;
-                    // But the incoming PT Comment ConflictType is updated.
-                    comment.ConflictType = NoteConflictType.VerseTextConflict;
-                },
-                (NoteThread noteThread) =>
-                {
-                    noteThread.Notes[0].Type = NoteType.Conflict.InternalValue;
-                    // (And set icon to match the note being a conflict note.)
-                    noteThread.Notes[0].TagId = CommentTag.conflictTagId;
-                    // SF Note ConflictType is something other than what the PT Comment ConflictType is. This is what gets
-                    // changed from.
-                    noteThread.Notes[0].ConflictType = NoteConflictType.VerseBridgeDifferences.InternalValue;
-                }
-            );
-
-            Assert.That(changes.Count, Is.EqualTo(1));
-
-            NoteThreadChange change = changes.First();
-            Assert.That(change.ThreadId, Is.EqualTo("thread01"));
-            Assert.That(change.NotesAdded.Count, Is.Zero);
-            Assert.That(change.NotesDeleted.Count, Is.Zero);
-            Assert.That(change.NotesUpdated.Count, Is.EqualTo(1));
-            Note note = change.NotesUpdated[0];
-            Assert.That(note.ThreadId, Is.EqualTo("thread01"));
-            Assert.That(note.ConflictType, Is.EqualTo(NoteConflictType.VerseTextConflict.InternalValue));
-        }
-
-        [Test]
-        public async Task GetNoteThreadChanges_UpdateTriggeredFromAcceptedChangeXmlChange()
-        {
-            var env = new TestEnvironment();
-            IEnumerable<NoteThreadChange> changes = await env.PrepareChangeOnSingleCommentAsync(
-                (Paratext.Data.ProjectComments.Comment comment) =>
-                {
-                    // Already, the PT Comment and SF Note (below) will have Type 'Conflict' and
-                    // ConflictType 'VerseTextConflict'.
-                    comment.Type = NoteType.Conflict;
-                    comment.ConflictType = NoteConflictType.VerseTextConflict;
-                    // But the incoming PT Comment AcceptedChangeXmlStr is updated.
-                    comment.AcceptedChangeXmlStr = "new data";
-                },
-                (NoteThread noteThread) =>
-                {
-                    noteThread.Notes[0].Type = NoteType.Conflict.InternalValue;
-                    // (And set icon to match the note being a conflict note.)
-                    noteThread.Notes[0].TagId = CommentTag.conflictTagId;
-                    noteThread.Notes[0].ConflictType = NoteConflictType.VerseTextConflict.InternalValue;
-                    // The SF Note AcceptedChangeXml is different. This is what gets changed from.
-                    noteThread.Notes[0].AcceptedChangeXml = "old data";
-                }
-            );
-
-            Assert.That(changes.Count, Is.EqualTo(1));
-
-            NoteThreadChange change = changes.First();
-            Assert.That(change.ThreadId, Is.EqualTo("thread01"));
-            Assert.That(change.NotesAdded.Count, Is.Zero);
-            Assert.That(change.NotesDeleted.Count, Is.Zero);
-            Assert.That(change.NotesUpdated.Count, Is.EqualTo(1));
-            Note note = change.NotesUpdated[0];
-            Assert.That(note.ThreadId, Is.EqualTo("thread01"));
-            Assert.That(note.AcceptedChangeXml, Is.EqualTo("new data"));
-        }
-
-        [Test]
-        public async Task GetNoteThreadChanges_UseCorrectTagIcon()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.AddTextDocs(40, 1, 10, "Context before ", "Text selected");
-
-            env.AddNoteThreadData(
-                new[]
-                {
-                    new ThreadComponents { threadNum = 1, noteCount = 9 },
-                }
-            );
-            ThreadNoteComponents[] threadNotes = new[]
+        ThreadNoteComponents[] threadDocNotes7 = getThreadNoteComponents(1, new[] { env.Username02 });
+        ThreadNoteComponents[] threadDocNotes8 = getThreadNoteComponents(1, new[] { env.Username02 });
+        env.AddNoteThreadData(
+            new[]
             {
-                new ThreadNoteComponents { status = NoteStatus.Todo, tagsAdded = new[] { "2" } },
-                new ThreadNoteComponents { status = NoteStatus.Unspecified },
-                new ThreadNoteComponents { status = NoteStatus.Unspecified },
-                new ThreadNoteComponents { status = NoteStatus.Resolved },
-                new ThreadNoteComponents { status = NoteStatus.Todo, tagsAdded = new[] { "3" } },
-                new ThreadNoteComponents { status = NoteStatus.Unspecified },
-                new ThreadNoteComponents { status = NoteStatus.Done },
-                new ThreadNoteComponents { status = NoteStatus.Todo },
-                new ThreadNoteComponents { status = NoteStatus.Todo, tagsAdded = new[] { "4" } }
-            };
-            env.AddParatextComments(
-                new[]
+                new ThreadComponents { threadNum = 1, noteCount = 1 },
+                new ThreadComponents { threadNum = 3, noteCount = 1 },
+                new ThreadComponents { threadNum = 4, noteCount = 1 },
+                new ThreadComponents { threadNum = 5, noteCount = 1 },
+                new ThreadComponents { threadNum = 6, noteCount = 1 },
+                new ThreadComponents
                 {
-                    new ThreadComponents
-                    {
-                        threadNum = 1,
-                        noteCount = threadNotes.Count(),
-                        notes = threadNotes,
-                        username = env.Username01
-                    },
-                }
-            );
-
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-            {
-                IEnumerable<IDocument<NoteThread>> noteThreadDocs = await env.GetNoteThreadDocsAsync(
-                    conn,
-                    new[] { "thread1" }
-                );
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
+                    threadNum = 7,
+                    noteCount = 1,
+                    notes = threadDocNotes7
+                },
+                new ThreadComponents
                 {
-                    new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-                }.ToDictionary(u => u.Username);
-                Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(
-                    env.Project01,
-                    40,
-                    1,
-                    "Context before ",
-                    "Text selected"
-                );
-                IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
-                    userSecret,
-                    ptProjectId,
-                    40,
-                    noteThreadDocs,
-                    chapterDeltas,
-                    ptProjectUsers
-                );
-
-                List<int?> expectedIcons = new List<int?>() { 2, null, null, 2, 3, null, 3, 3, 4, };
-                NoteThreadChange changedThread = changes.Where(c => c.ThreadId == "thread1").Single();
-                for (int i = 0; i < expectedIcons.Count(); i++)
-                {
-                    Note note = changedThread.NotesUpdated[i];
-                    Assert.That(note.DataId, Is.EqualTo($"n{i + 1}onthread1"));
-                    Assert.That(note.TagId, Is.EqualTo(expectedIcons[i]));
+                    threadNum = 8,
+                    noteCount = 1,
+                    notes = threadDocNotes8
                 }
             }
-        }
+        );
 
-        [Test]
-        public async Task GetNoteThreadChanges_SetsAssignedUser()
+        string unassignedUserString = Paratext.Data.ProjectComments.CommentThread.unassignedUser;
+        string teamUserString = Paratext.Data.ProjectComments.CommentThread.teamUser;
+        ThreadNoteComponents[] threadNotes1 = getThreadNoteComponents(2, new[] { teamUserString, env.Username02 });
+        ThreadNoteComponents[] threadNotes2 = getThreadNoteComponents(1, new[] { env.Username02 });
+        ThreadNoteComponents[] threadNotes3 = getThreadNoteComponents(1, new[] { env.Username02 });
+        ThreadNoteComponents[] threadNotes4 = getThreadNoteComponents(1, new[] { teamUserString });
+        ThreadNoteComponents[] threadNotes5 = getThreadNoteComponents(1, new[] { unassignedUserString }, true);
+        ThreadNoteComponents[] threadNotes7 = getThreadNoteComponents(1, null);
+        env.AddParatextComments(
+            new[]
+            {
+                new ThreadComponents
+                {
+                    threadNum = 1,
+                    noteCount = 2,
+                    username = env.Username01,
+                    notes = threadNotes1
+                },
+                new ThreadComponents
+                {
+                    threadNum = 2,
+                    noteCount = 1,
+                    username = env.Username01,
+                    notes = threadNotes2
+                },
+                new ThreadComponents
+                {
+                    threadNum = 3,
+                    noteCount = 1,
+                    username = env.Username01,
+                    notes = threadNotes3
+                },
+                new ThreadComponents
+                {
+                    threadNum = 4,
+                    noteCount = 1,
+                    username = env.Username01,
+                    notes = threadNotes4
+                },
+                new ThreadComponents
+                {
+                    threadNum = 5,
+                    noteCount = 1,
+                    username = env.Username01,
+                    notes = threadNotes5
+                },
+                new ThreadComponents
+                {
+                    threadNum = 6,
+                    noteCount = 1,
+                    username = env.Username01
+                },
+                new ThreadComponents
+                {
+                    threadNum = 7,
+                    noteCount = 1,
+                    username = env.Username01,
+                    notes = threadNotes7
+                },
+                new ThreadComponents
+                {
+                    threadNum = 8,
+                    noteCount = 1,
+                    username = env.Username01
+                },
+                new ThreadComponents { threadNum = 9, noteCount = 1 }
+            }
+        );
+
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        // SUT
+        IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
+            conn,
+            new[] { "thread1", "thread3", "thread4", "thread5", "thread6", "thread7", "thread8" }
+        );
+        var deltas = env.GetChapterDeltasByBook(env.Project01, 40, 1, "Context before ", "Text selected", true);
+        IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
+            userSecret,
+            ptProjectId,
+            40,
+            noteThreadDocs,
+            deltas,
+            ptProjectUsers
+        );
+
+        Assert.That(changes.Count, Is.EqualTo(8));
+        Assert.That(changes.Any(c => c.ThreadId == "thread6"), Is.False);
+        // Note added and user assigned
+        NoteThreadChange change1 = changes.Single(c => c.ThreadId == "thread1");
+        // User 2 is added to ptProjectUsers
+        Assert.That(ptProjectUsers.TryGetValue(env.Username02, out ParatextUserProfile ptUser02), Is.True);
+        Assert.That(change1.Assignment, Is.EqualTo(ptUser02.OpaqueUserId));
+        Assert.That(change1.NotesAdded.Count, Is.EqualTo(1));
+
+        // Note thread added and user assigned
+        NoteThreadChange change2 = changes.Single(c => c.ThreadId == "thread2");
+        Assert.That(change2.Assignment, Is.EqualTo(ptUser02.OpaqueUserId));
+        Assert.That(change2.NotesAdded.Count, Is.EqualTo(1));
+
+        // Note updated with new user assigned
+        NoteThreadChange change3 = changes.Single(c => c.ThreadId == "thread3");
+        Assert.That(change3.Assignment, Is.EqualTo(ptUser02.OpaqueUserId));
+        Assert.That(change3.NotesUpdated.Count, Is.EqualTo(1));
+        Assert.That(change3.NotesUpdated[0].Assignment, Is.EqualTo(ptUser02.OpaqueUserId));
+
+        // Note updated with team assigned
+        NoteThreadChange change4 = changes.Single(c => c.ThreadId == "thread4");
+        Assert.That(change4.Assignment, Is.EqualTo(Paratext.Data.ProjectComments.CommentThread.teamUser));
+        Assert.That(change4.NotesUpdated.Count, Is.EqualTo(1));
+        Assert.That(
+            change4.NotesUpdated[0].Assignment,
+            Is.EqualTo(Paratext.Data.ProjectComments.CommentThread.teamUser)
+        );
+
+        // Note tagsAdded updated but assigned user unchanged
+        NoteThreadChange change5 = changes.Single(c => c.ThreadId == "thread5");
+        Assert.That(change5.Assignment, Is.EqualTo(""));
+        Assert.That(change5.NotesUpdated.Count, Is.EqualTo(1));
+        Assert.That(change5.NotesUpdated[0].Assignment, Is.EqualTo(unassignedUserString));
+
+        // Note assigned to user 02 updated to null
+        NoteThreadChange change7 = changes.Single(c => c.ThreadId == "thread7");
+        Assert.That(change7.Assignment, Is.EqualTo(unassignedUserString));
+        Assert.That(change7.NotesUpdated.Count, Is.EqualTo(1));
+        Assert.That(change7.NotesUpdated[0].Assignment, Is.Null);
+
+        // Note assigned to user 02 is unassigned
+        NoteThreadChange change8 = changes.Single(c => c.ThreadId == "thread8");
+        Assert.That(change8.Assignment, Is.EqualTo(unassignedUserString));
+        Assert.That(change8.NotesUpdated.Count, Is.EqualTo(1));
+        Assert.That(change8.NotesUpdated[0].Assignment, Is.EqualTo(unassignedUserString));
+
+        // Note created with no Paratext user
+        NoteThreadChange change9 = changes.Single(c => c.ThreadId == "thread9");
+        Assert.That(change9.NotesAdded.Count, Is.EqualTo(1));
+        Assert.That(change9.NotesAdded[0].SyncUserRef, Is.Null);
+        Assert.That(change9.Assignment, Is.EqualTo(unassignedUserString));
+
+        // User 02 is added to the list of Paratext Users on thread1 as an assigned user
+        // No users should be added from the new thread9 change which has no paratext user
+        // or through null assignment on thread7
+        Assert.That(ptProjectUsers.Keys, Is.EquivalentTo(new[] { env.Username01, env.Username02 }));
+    }
+
+    [Test]
+    public async Task GetNoteThreadChanges_MatchNotePositionToVerseText()
+    {
+        var env = new TestEnvironment();
+        var associatedPTUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPTUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        env.AddParatextComments(
+            new[]
+            {
+                new ThreadComponents
+                {
+                    threadNum = 1,
+                    noteCount = 1,
+                    username = env.Username01,
+                    alternateText = SelectionType.RelatedVerse
+                },
+                new ThreadComponents
+                {
+                    threadNum = 8,
+                    noteCount = 1,
+                    username = env.Username01,
+                    alternateText = SelectionType.Section
+                },
+                new ThreadComponents
+                {
+                    threadNum = 9,
+                    noteCount = 1,
+                    username = env.Username01,
+                    alternateText = SelectionType.SectionEnd
+                },
+                new ThreadComponents
+                {
+                    threadNum = 10,
+                    noteCount = 1,
+                    username = env.Username01,
+                    alternateText = SelectionType.RelatedVerse
+                }
+            }
+        );
+
+        await using (await env.RealtimeService.ConnectAsync())
         {
-            // assign user id to assigned user
-            var env = new TestEnvironment();
-            var associatedPTUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPTUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+            var deltas = env.GetChapterDeltasByBook(
+                env.Project01,
+                40,
+                1,
+                "Context before ",
+                "Text selected",
+                true,
+                true
+            );
             Dictionary<string, ParatextUserProfile> ptProjectUsers = new Dictionary<string, ParatextUserProfile>
             {
                 {
@@ -1451,2120 +1664,1803 @@ namespace SIL.XForge.Scripture.Services
                     new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
                 }
             };
+            IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
+                userSecret,
+                ptProjectId,
+                40,
+                Array.Empty<IDocument<NoteThread>>(),
+                deltas,
+                ptProjectUsers
+            );
 
-            ThreadNoteComponents[] getThreadNoteComponents(
-                int noteCount,
-                string[] assignedUsers,
-                bool iconChange = false
+            Assert.That(changes.Count, Is.EqualTo(4));
+            NoteThreadChange thread1Change = changes.Single(c => c.ThreadId == "thread1");
+            // The full matching text of thread1Change.SelectedText is not found. The best match is a substring.
+            // This test also verifies that fetching verse text for verse 1 will fetch text from segment
+            // "verse_1_1" but not segment "verse_1_10/p_1" (even tho the second segment name starts with the first
+            // segment name). Incorrectly also fetching from "verse_1_10/p_1" would result in having a match for
+            // thread1Change.SelectedText.
+            Assert.That(thread1Change.SelectedText, Is.EqualTo("other text in verse"), "setup");
+            Assert.That(thread1Change.Position.Length, Is.LessThan("other text in verse".Length));
+
+            NoteThreadChange thread8Change = changes.Single(c => c.ThreadId == "thread8");
+            string textBefore8 = "Context before Text selected thread8 context after.\n";
+            int thread8AnchoringLength = "Section heading text".Length;
+            TextAnchor expected8 = new TextAnchor { Start = textBefore8.Length, Length = thread8AnchoringLength };
+            Assert.That(thread8Change.Position, Is.EqualTo(expected8));
+
+            NoteThreadChange thread9Change = changes.Single(c => c.ThreadId == "thread9");
+            string textBefore9 = "Context before Text selected thread9 context after.\nSection heading text";
+            int thread9AnchorLength = 0;
+            TextAnchor expected9 = new TextAnchor { Start = textBefore9.Length, Length = thread9AnchorLength };
+            Assert.That(thread9Change.Position, Is.EqualTo(expected9));
+
+            NoteThreadChange thread10Change = changes.Single(c => c.ThreadId == "thread10");
+            string textBefore10 = "Context before Text selected thread10 context after.\n*";
+            int thread10AnchoringLength = "other text in verse".Length;
+            TextAnchor expected10 = new TextAnchor { Start = textBefore10.Length, Length = thread10AnchoringLength };
+            // This test also verifies that fetching verse text for verse 10 will fetch text from both segments
+            // "verse_1_10" and "verse_1_10/p_1".
+            Assert.That(thread10Change.Position, Is.EqualTo(expected10));
+        }
+    }
+
+    [Test]
+    public async Task GetNoteThreadChanges_ReattachedNote_PositionUpdated()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.AddTextDocs(40, 1, 6, "Context before ", "Text selected");
+        // The text doc is set up so that verse 7 has unique text that we reattach to
+        string verseStr = "MAT 1:7";
+        ReattachedThreadInfo rti = env.GetReattachedThreadInfo(verseStr);
+
+        env.AddNoteThreadData(
+            new[]
+            {
+                new ThreadComponents { threadNum = 1, noteCount = 1 },
+                new ThreadComponents
+                {
+                    threadNum = 3,
+                    noteCount = 1,
+                    reattachedVerseStr = verseStr
+                },
+                new ThreadComponents { threadNum = 4, noteCount = 1 },
+                new ThreadComponents
+                {
+                    threadNum = 5,
+                    noteCount = 1,
+                    reattachedVerseStr = verseStr
+                }
+            }
+        );
+        env.AddParatextComments(
+            new[]
+            {
+                new ThreadComponents
+                {
+                    threadNum = 1,
+                    noteCount = 1,
+                    username = env.Username01,
+                    reattachedVerseStr = verseStr
+                },
+                new ThreadComponents
+                {
+                    threadNum = 2,
+                    noteCount = 1,
+                    username = env.Username01,
+                    reattachedVerseStr = verseStr
+                },
+                new ThreadComponents
+                {
+                    threadNum = 3,
+                    noteCount = 1,
+                    username = env.Username01,
+                    reattachedVerseStr = verseStr
+                },
+                new ThreadComponents
+                {
+                    threadNum = 4,
+                    noteCount = 2,
+                    username = env.Username01,
+                    reattachedVerseStr = verseStr
+                },
+                new ThreadComponents
+                {
+                    threadNum = 5,
+                    noteCount = 1,
+                    username = env.Username01
+                }
+            }
+        );
+
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
+            conn,
+            new[] { "thread1", "thread3", "thread4", "thread5" }
+        );
+        Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(
+            env.Project01,
+            40,
+            1,
+            env.ContextBefore,
+            "Text selected"
+        );
+        Dictionary<string, ParatextUserProfile> syncUsers = new Dictionary<string, ParatextUserProfile>
+        {
+            {
+                env.Username01,
+                new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+            }
+        };
+        IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
+            userSecret,
+            ptProjectId,
+            40,
+            noteThreadDocs,
+            chapterDeltas,
+            syncUsers
+        );
+        Assert.That(changes.Count, Is.EqualTo(4));
+
+        // The reattach note in thread3 is existing and is not changed
+        Assert.That(changes.FirstOrDefault(c => c.ThreadId == "thread3"), Is.Null);
+        // Existing thread reattached
+        NoteThreadChange change1 = changes.Single(c => c.ThreadId == "thread1");
+        Assert.That(change1.NotesAdded.Count, Is.EqualTo(1));
+        Assert.That(change1.NotesAdded.Single().Reattached, Is.Not.Null);
+        TextAnchor expectedAnchor = new TextAnchor
+        {
+            Start = rti.contextBefore.Length,
+            Length = rti.selectedText.Length
+        };
+        Assert.That(change1.Position, Is.EqualTo(expectedAnchor));
+
+        // New thread note reattached
+        NoteThreadChange change2 = changes.Single(c => c.ThreadId == "thread2");
+        Assert.That(change2.NotesAdded.Count, Is.EqualTo(2));
+        Assert.That(change2.NotesAdded[1].Reattached, Is.Not.Null);
+        Assert.That(change2.Position, Is.EqualTo(expectedAnchor));
+
+        // Existing thread new comment and reattached
+        NoteThreadChange change4 = changes.Single(c => c.ThreadId == "thread4");
+        Assert.That(change4.NotesAdded.Count, Is.EqualTo(2));
+        Assert.That(change4.NotesAdded[1].Reattached, Is.Not.Null);
+        Assert.That(change4.Position, Is.EqualTo(expectedAnchor));
+
+        // Existing thread and reattach comment removed
+        NoteThreadChange change5 = changes.Single(c => c.ThreadId == "thread5");
+        Assert.That(change5.NoteIdsRemoved.Count, Is.EqualTo(1));
+        Assert.That(change5.NoteIdsRemoved[0], Is.EqualTo("reattachedthread5"));
+        // The context of the original note thread is not what the thread was reattached and un-reattached to
+        Assert.That(change5.ContextBefore, Is.Not.EqualTo(rti.contextBefore));
+        Assert.That(change5.SelectedText, Is.Not.EqualTo(rti.selectedText));
+        TextAnchor originalAnchor = new TextAnchor
+        {
+            Start = change5.ContextBefore.Length,
+            Length = change5.SelectedText.Length
+        };
+        Assert.That(change5.Position, Is.EqualTo(originalAnchor));
+    }
+
+    [Test]
+    public async Task UpdateParatextComments_AddsComment()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        string threadId = "thread1";
+        env.AddNoteThreadData(
+            new[]
+            {
+                new ThreadComponents
+                {
+                    threadNum = 1,
+                    noteCount = 1,
+                    isNew = true
+                }
+            }
+        );
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        CommentThread thread = env.ProjectCommentManager.FindThread(threadId);
+        Assert.That(thread, Is.Null);
+        IDocument<NoteThread> noteThreadDoc = await TestEnvironment.GetNoteThreadDocAsync(conn, threadId);
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = new Dictionary<string, ParatextUserProfile>();
+        var syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
+            userSecret,
+            ptProjectId,
+            40,
+            new[] { noteThreadDoc },
+            ptProjectUsers,
+            env.TagCount
+        );
+        thread = env.ProjectCommentManager.FindThread(threadId);
+        Assert.That(thread.Comments.Count, Is.EqualTo(1));
+        var comment = thread.Comments.First();
+        string expected =
+            "thread1/User 02/2019-01-01T08:00:00.0000000+00:00-"
+            + "MAT 1:1-"
+            + "<p>thread1 note 1.</p>-"
+            + "Start:0-"
+            + "user02-"
+            + "Tag:1";
+        Assert.That(comment.CommentToString(), Is.EqualTo(expected));
+        Assert.That(ptProjectUsers.Keys, Is.EquivalentTo(new[] { env.Username02 }));
+        Assert.That(noteThreadDoc.Data.Notes[0].SyncUserRef, Is.EqualTo("syncuser02"));
+        Assert.That(syncMetricInfo, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
+
+        // PT username is not written to server logs
+        env.MockLogger.AssertNoEvent((LogEvent logEvent) => logEvent.Message.Contains(env.Username02));
+    }
+
+    [Test]
+    public async Task UpdateParatextComments_AddsCommentTagIdNotSet()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string paratextId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        string threadId = "thread1";
+        env.AddNoteThreadData(
+            new[]
+            {
+                new ThreadComponents
+                {
+                    threadNum = 1,
+                    noteCount = 1,
+                    isNew = true,
+                    notes = new[] { new ThreadNoteComponents { } }
+                }
+            }
+        );
+        await using IConnection conn = await env.RealtimeService.ConnectAsync(env.User01);
+        CommentThread commentThread = env.ProjectCommentManager.FindThread(threadId);
+        Assert.That(commentThread, Is.Null);
+        IDocument<NoteThread> noteThreadDoc = await TestEnvironment.GetNoteThreadDocAsync(conn, threadId);
+        var paratextUsers = new Dictionary<string, ParatextUserProfile>();
+        int newSfNoteTagId = env.TagCount + 1;
+        var syncMetricsInfo = await env.Service.UpdateParatextCommentsAsync(
+            userSecret,
+            paratextId,
+            40,
+            new[] { noteThreadDoc },
+            paratextUsers,
+            newSfNoteTagId
+        );
+        commentThread = env.ProjectCommentManager.FindThread(threadId);
+        Assert.That(commentThread.Comments.Count, Is.EqualTo(1));
+        Assert.That(commentThread.Comments[0].TagsAdded, Is.EquivalentTo(new[] { $"{newSfNoteTagId}" }));
+        Assert.That(syncMetricsInfo, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
+    }
+
+    [Test]
+    public async Task UpdateParatextComments_EditsComment()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        string threadId = "thread1";
+        env.AddNoteThreadData(
+            new[]
+            {
+                new ThreadComponents
+                {
+                    threadNum = 1,
+                    noteCount = 1,
+                    username = env.Username01,
+                    isEdited = true
+                }
+            }
+        );
+        env.AddParatextComments(
+            new[]
+            {
+                new ThreadComponents
+                {
+                    threadNum = 1,
+                    noteCount = 1,
+                    username = env.Username01
+                }
+            }
+        );
+
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        IDocument<NoteThread> noteThreadDoc = await TestEnvironment.GetNoteThreadDocAsync(conn, threadId);
+        // Edit a comment
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
+        {
+            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+        }.ToDictionary(u => u.Username);
+        var syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
+            userSecret,
+            ptProjectId,
+            40,
+            new[] { noteThreadDoc },
+            ptProjectUsers,
+            env.TagCount
+        );
+
+        CommentThread thread = env.ProjectCommentManager.FindThread(threadId);
+        Assert.That(thread.Comments.Count, Is.EqualTo(1));
+        var comment = thread.Comments.First();
+        string expected =
+            "thread1/User 01/2019-01-01T08:00:00.0000000+00:00-"
+            + "MAT 1:1-"
+            + "<p>thread1 note 1: EDITED.</p>-"
+            + "Start:15-"
+            + "user02-"
+            + "Tag:1";
+        Assert.That(comment.CommentToString(), Is.EqualTo(expected));
+        Assert.That(ptProjectUsers.Count, Is.EqualTo(1));
+        Assert.That(syncMetricInfo, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 1)));
+
+        // PT username is not written to server logs
+        env.MockLogger.AssertNoEvent((LogEvent logEvent) => logEvent.Message.Contains(env.Username01));
+    }
+
+    [Test]
+    public async Task UpdateParatextComments_DeletesComment()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        string threadId = "thread1";
+        env.AddNoteThreadData(
+            new[]
+            {
+                new ThreadComponents
+                {
+                    threadNum = 1,
+                    noteCount = 1,
+                    username = env.Username01,
+                    isDeleted = true
+                }
+            }
+        );
+        env.AddParatextComments(
+            new[]
+            {
+                new ThreadComponents
+                {
+                    threadNum = 1,
+                    noteCount = 1,
+                    username = env.Username01
+                }
+            }
+        );
+
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        IDocument<NoteThread> noteThreadDoc = await TestEnvironment.GetNoteThreadDocAsync(conn, threadId);
+
+        // Delete a comment
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
+        {
+            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+        }.ToDictionary(u => u.Username);
+        var syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
+            userSecret,
+            ptProjectId,
+            40,
+            new[] { noteThreadDoc },
+            ptProjectUsers,
+            env.TagCount
+        );
+
+        CommentThread thread = env.ProjectCommentManager.FindThread(threadId);
+        Assert.That(thread.Comments.Count, Is.EqualTo(1));
+        var comment = thread.Comments.First();
+        string expected =
+            "thread1/User 01/2019-01-01T08:00:00.0000000+00:00-"
+            + "MAT 1:1-"
+            + "<p>thread1 note 1.</p>-"
+            + "Start:15-"
+            + "user02-"
+            + "deleted-"
+            + "Tag:1";
+        Assert.That(comment.CommentToString(), Is.EqualTo(expected));
+        Assert.That(syncMetricInfo, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
+
+        // PT username is not written to server logs
+        env.MockLogger.AssertNoEvent((LogEvent logEvent) => logEvent.Message.Contains(env.Username01));
+    }
+
+    [Test]
+    public void GetParatextSettings_RetrievesTagIcons()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string paratextId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        var noteTag = new NoteTag
+        {
+            TagId = 5,
+            Icon = "sf05",
+            Name = "SF Note Tag",
+        };
+        env.SetupCommentTags(env.ProjectScrText, noteTag);
+        ParatextSettings? settings = env.Service.GetParatextSettings(userSecret, paratextId);
+        Assert.That(settings?.NoteTags.Any(t => t.Name == noteTag.Name), Is.True);
+    }
+
+    [Test]
+    public void GetParatextSettings_NoteTagSetToNull()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string paratextId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        var noteTag = new NoteTag
+        {
+            TagId = CommentTag.notSetId,
+            Icon = "sf05",
+            Name = "SF Note Tag"
+        };
+        ParatextSettings? settings = env.Service.GetParatextSettings(userSecret, paratextId);
+        Assert.That(settings?.NoteTags.FirstOrDefault(t => t.Icon == noteTag.Icon), Is.Null);
+    }
+
+    [Test]
+    public void UpdateCommentTag_WritesTagIcon()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string paratextId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        string icon = "someIcon";
+        var noteTag = new NoteTag
+        {
+            TagId = CommentTag.notSetId,
+            Icon = icon,
+            Name = "SF Note Tag"
+        };
+        env.Service.UpdateCommentTag(userSecret, paratextId, noteTag);
+        // the new tag is created with a tag id one greater than the last used id
+        int tagId = env.TagCount + 1;
+        ParatextSettings? settings = env.Service.GetParatextSettings(userSecret, paratextId);
+        Assert.That(settings?.NoteTags.First(t => t.Icon == icon).TagId, Is.EqualTo(tagId));
+    }
+
+    [Test]
+    public void UpdateCommentTag_DoesNotWriteIfExistingTag()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string paratextId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        int existingId = 5;
+        var noteTag = new NoteTag
+        {
+            TagId = existingId,
+            Icon = "existingIcon",
+            Name = "SF Note Tag"
+        };
+        env.SetupCommentTags(env.ProjectScrText, noteTag);
+        Assert.Throws<ArgumentException>(() => env.Service.UpdateCommentTag(userSecret, paratextId, noteTag));
+    }
+
+    [Test]
+    public void SendReceiveAsync_BadArguments()
+    {
+        var env = new TestEnvironment();
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.SendReceiveAsync(null, null, null));
+        Assert.ThrowsAsync<ArgumentNullException>(
+            () => env.Service.SendReceiveAsync(null, env.PTProjectIds[env.Project01].Id, null)
+        );
+        Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.SendReceiveAsync(user01Secret, null, null));
+    }
+
+    [Test]
+    public void SendReceiveAsync_ShareChangesErrors_Throws()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string projectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
+        env.SetupSuccessfulSendReceive();
+        // Setup share changes to be unsuccessful
+        env.MockSharingLogicWrapper
+            .ShareChanges(
+                Arg.Any<List<SharedProject>>(),
+                Arg.Any<SharedRepositorySource>(),
+                out Arg.Any<List<SendReceiveResult>>(),
+                Arg.Any<List<SharedProject>>()
             )
+            .Returns(false);
+
+        InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(
+            () => env.Service.SendReceiveAsync(user01Secret, projectId, null)
+        );
+        Assert.That(ex.Message, Does.Contain("Failed: Errors occurred"));
+
+        // Check exception is thrown if errors occurred, even if share changes succeeded
+        env.MockSharingLogicWrapper.HandleErrors(Arg.Any<Action>()).Returns(false);
+        ex = Assert.ThrowsAsync<InvalidOperationException>(
+            () => env.Service.SendReceiveAsync(user01Secret, projectId, null)
+        );
+        Assert.That(ex.Message, Does.Contain("Failed: Errors occurred"));
+    }
+
+    [Test]
+    public void SendReceiveAsync_NoMatchingSourceRepository_Throws()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
+
+        ArgumentException ex = Assert.ThrowsAsync<ArgumentException>(
+            () => env.Service.SendReceiveAsync(user01Secret, "badProjectId", null)
+        );
+        Assert.That(ex.Message, Does.Contain("PT projects with the following PT ids were requested"));
+    }
+
+    [Test]
+    public void SendReceiveAsync_ShareChangesErrors_InResultsOnly()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string projectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
+        env.SetupSuccessfulSendReceive();
+        // Setup share changes to be unsuccessful, but return true
+        // This scenario occurs if a project is locked on the PT server
+        env.MockSharingLogicWrapper
+            .ShareChanges(
+                Arg.Any<List<SharedProject>>(),
+                Arg.Any<SharedRepositorySource>(),
+                out Arg.Any<List<SendReceiveResult>>(),
+                Arg.Any<List<SharedProject>>()
+            )
+            .Returns(x =>
             {
-                var components = new List<ThreadNoteComponents>();
-                string[] commentTagsAdded = new[] { Paratext.Data.ProjectComments.CommentTag.toDoTagId.ToString() };
-                if (iconChange)
+                x[2] = new List<SendReceiveResult>
                 {
-                    string newIconId = "2";
-                    commentTagsAdded = new[] { newIconId };
-                }
-                for (int i = 0; i < noteCount; i++)
-                {
-                    string assignedUser = null;
-                    if (assignedUsers?.Length > i)
-                    {
-                        assignedUser = assignedUsers[i];
-                        if (ptProjectUsers.TryGetValue(assignedUsers[i], out ParatextUserProfile ptUser))
-                            assignedUser = ptUser.OpaqueUserId;
-                    }
-                    var noteComponents = new ThreadNoteComponents { status = NoteStatus.Todo };
-                    noteComponents.tagsAdded = i == 0 ? commentTagsAdded : null;
-                    noteComponents.assignedPTUser = assignedUser;
-                    components.Add(noteComponents);
-                }
-                return components.ToArray();
-            }
-            ThreadNoteComponents[] threadDocNotes7 = getThreadNoteComponents(1, new[] { env.Username02 });
-            ThreadNoteComponents[] threadDocNotes8 = getThreadNoteComponents(1, new[] { env.Username02 });
-            env.AddNoteThreadData(
-                new[]
-                {
-                    new ThreadComponents { threadNum = 1, noteCount = 1 },
-                    new ThreadComponents { threadNum = 3, noteCount = 1 },
-                    new ThreadComponents { threadNum = 4, noteCount = 1 },
-                    new ThreadComponents { threadNum = 5, noteCount = 1 },
-                    new ThreadComponents { threadNum = 6, noteCount = 1 },
-                    new ThreadComponents
-                    {
-                        threadNum = 7,
-                        noteCount = 1,
-                        notes = threadDocNotes7
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 8,
-                        noteCount = 1,
-                        notes = threadDocNotes8
-                    }
-                }
-            );
-
-            string unassignedUserString = Paratext.Data.ProjectComments.CommentThread.unassignedUser;
-            string teamUserString = Paratext.Data.ProjectComments.CommentThread.teamUser;
-            ThreadNoteComponents[] threadNotes1 = getThreadNoteComponents(2, new[] { teamUserString, env.Username02 });
-            ThreadNoteComponents[] threadNotes2 = getThreadNoteComponents(1, new[] { env.Username02 });
-            ThreadNoteComponents[] threadNotes3 = getThreadNoteComponents(1, new[] { env.Username02 });
-            ThreadNoteComponents[] threadNotes4 = getThreadNoteComponents(1, new[] { teamUserString });
-            ThreadNoteComponents[] threadNotes5 = getThreadNoteComponents(1, new[] { unassignedUserString }, true);
-            ThreadNoteComponents[] threadNotes7 = getThreadNoteComponents(1, null);
-            env.AddParatextComments(
-                new[]
-                {
-                    new ThreadComponents
-                    {
-                        threadNum = 1,
-                        noteCount = 2,
-                        username = env.Username01,
-                        notes = threadNotes1
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 2,
-                        noteCount = 1,
-                        username = env.Username01,
-                        notes = threadNotes2
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 3,
-                        noteCount = 1,
-                        username = env.Username01,
-                        notes = threadNotes3
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 4,
-                        noteCount = 1,
-                        username = env.Username01,
-                        notes = threadNotes4
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 5,
-                        noteCount = 1,
-                        username = env.Username01,
-                        notes = threadNotes5
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 6,
-                        noteCount = 1,
-                        username = env.Username01
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 7,
-                        noteCount = 1,
-                        username = env.Username01,
-                        notes = threadNotes7
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 8,
-                        noteCount = 1,
-                        username = env.Username01
-                    },
-                    new ThreadComponents { threadNum = 9, noteCount = 1 }
-                }
-            );
-
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-            {
-                // SUT
-                IEnumerable<IDocument<NoteThread>> noteThreadDocs = await env.GetNoteThreadDocsAsync(
-                    conn,
-                    new[] { "thread1", "thread3", "thread4", "thread5", "thread6", "thread7", "thread8" }
-                );
-                var deltas = env.GetChapterDeltasByBook(env.Project01, 40, 1, "Context before ", "Text selected", true);
-                IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
-                    userSecret,
-                    ptProjectId,
-                    40,
-                    noteThreadDocs,
-                    deltas,
-                    ptProjectUsers
-                );
-
-                Assert.That(changes.Count, Is.EqualTo(8));
-                Assert.That(changes.Any(c => c.ThreadId == "thread6"), Is.False);
-                // Note added and user assigned
-                NoteThreadChange change1 = changes.Single(c => c.ThreadId == "thread1");
-                // User 2 is added to ptProjectUsers
-                Assert.That(ptProjectUsers.TryGetValue(env.Username02, out ParatextUserProfile ptUser02), Is.True);
-                Assert.That(change1.Assignment, Is.EqualTo(ptUser02.OpaqueUserId));
-                Assert.That(change1.NotesAdded.Count, Is.EqualTo(1));
-
-                // Note thread added and user assigned
-                NoteThreadChange change2 = changes.Single(c => c.ThreadId == "thread2");
-                Assert.That(change2.Assignment, Is.EqualTo(ptUser02.OpaqueUserId));
-                Assert.That(change2.NotesAdded.Count, Is.EqualTo(1));
-
-                // Note updated with new user assigned
-                NoteThreadChange change3 = changes.Single(c => c.ThreadId == "thread3");
-                Assert.That(change3.Assignment, Is.EqualTo(ptUser02.OpaqueUserId));
-                Assert.That(change3.NotesUpdated.Count, Is.EqualTo(1));
-                Assert.That(change3.NotesUpdated[0].Assignment, Is.EqualTo(ptUser02.OpaqueUserId));
-
-                // Note updated with team assigned
-                NoteThreadChange change4 = changes.Single(c => c.ThreadId == "thread4");
-                Assert.That(change4.Assignment, Is.EqualTo(Paratext.Data.ProjectComments.CommentThread.teamUser));
-                Assert.That(change4.NotesUpdated.Count, Is.EqualTo(1));
-                Assert.That(
-                    change4.NotesUpdated[0].Assignment,
-                    Is.EqualTo(Paratext.Data.ProjectComments.CommentThread.teamUser)
-                );
-
-                // Note tagsAdded updated but assigned user unchanged
-                NoteThreadChange change5 = changes.Single(c => c.ThreadId == "thread5");
-                Assert.That(change5.Assignment, Is.EqualTo(""));
-                Assert.That(change5.NotesUpdated.Count, Is.EqualTo(1));
-                Assert.That(change5.NotesUpdated[0].Assignment, Is.EqualTo(unassignedUserString));
-
-                // Note assigned to user 02 updated to null
-                NoteThreadChange change7 = changes.Single(c => c.ThreadId == "thread7");
-                Assert.That(change7.Assignment, Is.EqualTo(unassignedUserString));
-                Assert.That(change7.NotesUpdated.Count, Is.EqualTo(1));
-                Assert.That(change7.NotesUpdated[0].Assignment, Is.Null);
-
-                // Note assigned to user 02 is unassigned
-                NoteThreadChange change8 = changes.Single(c => c.ThreadId == "thread8");
-                Assert.That(change8.Assignment, Is.EqualTo(unassignedUserString));
-                Assert.That(change8.NotesUpdated.Count, Is.EqualTo(1));
-                Assert.That(change8.NotesUpdated[0].Assignment, Is.EqualTo(unassignedUserString));
-
-                // Note created with no Paratext user
-                NoteThreadChange change9 = changes.Single(c => c.ThreadId == "thread9");
-                Assert.That(change9.NotesAdded.Count, Is.EqualTo(1));
-                Assert.That(change9.NotesAdded[0].SyncUserRef, Is.Null);
-                Assert.That(change9.Assignment, Is.EqualTo(unassignedUserString));
-
-                // User 02 is added to the list of Paratext Users on thread1 as an assigned user
-                // No users should be added from the new thread9 change which has no paratext user
-                // or through null assignment on thread7
-                Assert.That(ptProjectUsers.Keys, Is.EquivalentTo(new[] { env.Username01, env.Username02 }));
-            }
-        }
-
-        [Test]
-        public async Task GetNoteThreadChanges_MatchNotePositionToVerseText()
-        {
-            var env = new TestEnvironment();
-            var associatedPTUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPTUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            env.AddParatextComments(
-                new[]
-                {
-                    new ThreadComponents
-                    {
-                        threadNum = 1,
-                        noteCount = 1,
-                        username = env.Username01,
-                        alternateText = SelectionType.RelatedVerse
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 8,
-                        noteCount = 1,
-                        username = env.Username01,
-                        alternateText = SelectionType.Section
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 9,
-                        noteCount = 1,
-                        username = env.Username01,
-                        alternateText = SelectionType.SectionEnd
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 10,
-                        noteCount = 1,
-                        username = env.Username01,
-                        alternateText = SelectionType.RelatedVerse
-                    }
-                }
-            );
-
-            await using (await env.RealtimeService.ConnectAsync())
-            {
-                var deltas = env.GetChapterDeltasByBook(
-                    env.Project01,
-                    40,
-                    1,
-                    "Context before ",
-                    "Text selected",
-                    true,
-                    true
-                );
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = new Dictionary<string, ParatextUserProfile>
-                {
-                    {
-                        env.Username01,
-                        new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-                    }
+                    new SendReceiveResult(new SharedProject()) { Result = SendReceiveResultEnum.Failed, },
                 };
-                IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
-                    userSecret,
-                    ptProjectId,
-                    40,
-                    new IDocument<NoteThread>[0],
-                    deltas,
-                    ptProjectUsers
-                );
+                return true;
+            });
 
-                Assert.That(changes.Count, Is.EqualTo(4));
-                NoteThreadChange thread1Change = changes.Single(c => c.ThreadId == "thread1");
-                // The full matching text of thread1Change.SelectedText is not found. The best match is a substring.
-                // This test also verifies that fetching verse text for verse 1 will fetch text from segment
-                // "verse_1_1" but not segment "verse_1_10/p_1" (even tho the second segment name starts with the first
-                // segment name). Incorrectly also fetching from "verse_1_10/p_1" would result in having a match for
-                // thread1Change.SelectedText.
-                Assert.That(thread1Change.SelectedText, Is.EqualTo("other text in verse"), "setup");
-                Assert.That(thread1Change.Position.Length, Is.LessThan("other text in verse".Length));
+        InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(
+            () => env.Service.SendReceiveAsync(user01Secret, projectId, null)
+        );
+        Assert.That(ex.Message, Does.Contain("Failed: Errors occurred"));
 
-                NoteThreadChange thread8Change = changes.Single(c => c.ThreadId == "thread8");
-                string textBefore8 = "Context before Text selected thread8 context after.\n";
-                int thread8AnchoringLength = "Section heading text".Length;
-                TextAnchor expected8 = new TextAnchor { Start = textBefore8.Length, Length = thread8AnchoringLength };
-                Assert.That(thread8Change.Position, Is.EqualTo(expected8));
+        // Check exception is thrown if errors occurred, even if share changes succeeded
+        env.MockSharingLogicWrapper.HandleErrors(Arg.Any<Action>()).Returns(false);
+        ex = Assert.ThrowsAsync<InvalidOperationException>(
+            () => env.Service.SendReceiveAsync(user01Secret, projectId, null)
+        );
+        Assert.That(ex.Message, Does.Contain("Failed: Errors occurred"));
+    }
 
-                NoteThreadChange thread9Change = changes.Single(c => c.ThreadId == "thread9");
-                string textBefore9 = "Context before Text selected thread9 context after.\nSection heading text";
-                int thread9AnchorLength = 0;
-                TextAnchor expected9 = new TextAnchor { Start = textBefore9.Length, Length = thread9AnchorLength };
-                Assert.That(thread9Change.Position, Is.EqualTo(expected9));
+    [Test]
+    public async Task SendReceiveAsync_UserIsAdministrator_Succeeds()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        IInternetSharedRepositorySource mockSource = env.SetSharedRepositorySource(
+            user01Secret,
+            UserRoles.Administrator
+        );
+        env.SetupSuccessfulSendReceive();
 
-                NoteThreadChange thread10Change = changes.Single(c => c.ThreadId == "thread10");
-                string textBefore10 = "Context before Text selected thread10 context after.\n*";
-                int thread10AnchoringLength = "other text in verse".Length;
-                TextAnchor expected10 = new TextAnchor
-                {
-                    Start = textBefore10.Length,
-                    Length = thread10AnchoringLength
-                };
-                // This test also verifies that fetching verse text for verse 10 will fetch text from both segments
-                // "verse_1_10" and "verse_1_10/p_1".
-                Assert.That(thread10Change.Position, Is.EqualTo(expected10));
-            }
-        }
-
-        [Test]
-        public async Task GetNoteThreadChanges_ReattachedNote_PositionUpdated()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.AddTextDocs(40, 1, 6, "Context before ", "Text selected");
-            // The text doc is set up so that verse 7 has unique text that we reattach to
-            string verseStr = "MAT 1:7";
-            ReattachedThreadInfo rti = env.GetReattachedThreadInfo(verseStr);
-
-            env.AddNoteThreadData(
-                new[]
-                {
-                    new ThreadComponents { threadNum = 1, noteCount = 1 },
-                    new ThreadComponents
-                    {
-                        threadNum = 3,
-                        noteCount = 1,
-                        reattachedVerseStr = verseStr
-                    },
-                    new ThreadComponents { threadNum = 4, noteCount = 1 },
-                    new ThreadComponents
-                    {
-                        threadNum = 5,
-                        noteCount = 1,
-                        reattachedVerseStr = verseStr
-                    }
-                }
+        // SUT 1
+        await env.Service.SendReceiveAsync(user01Secret, ptProjectId, null);
+        env.MockSharingLogicWrapper
+            .Received(1)
+            .ShareChanges(
+                Arg.Is<List<SharedProject>>(list => list.Count == 1 && list[0].SendReceiveId.Id == ptProjectId),
+                Arg.Any<SharedRepositorySource>(),
+                out Arg.Any<List<SendReceiveResult>>(),
+                Arg.Is<List<SharedProject>>(list => list.Count == 1 && list[0].SendReceiveId.Id == ptProjectId)
             );
-            env.AddParatextComments(
-                new[]
-                {
-                    new ThreadComponents
-                    {
-                        threadNum = 1,
-                        noteCount = 1,
-                        username = env.Username01,
-                        reattachedVerseStr = verseStr
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 2,
-                        noteCount = 1,
-                        username = env.Username01,
-                        reattachedVerseStr = verseStr
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 3,
-                        noteCount = 1,
-                        username = env.Username01,
-                        reattachedVerseStr = verseStr
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 4,
-                        noteCount = 2,
-                        username = env.Username01,
-                        reattachedVerseStr = verseStr
-                    },
-                    new ThreadComponents
-                    {
-                        threadNum = 5,
-                        noteCount = 1,
-                        username = env.Username01
-                    }
-                }
-            );
+        mockSource.DidNotReceive().Pull(Arg.Any<string>(), Arg.Any<SharedRepository>());
+        env.MockSharingLogicWrapper.ClearReceivedCalls();
 
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
+        // Passing a PT project Id for a project the user does not have access to fails early without doing S/R
+        // SUT 2
+        ArgumentException resultingException = Assert.ThrowsAsync<ArgumentException>(
+            () => env.Service.SendReceiveAsync(user01Secret, "unknownPtProjectId8")
+        );
+        Assert.That(resultingException.Message, Does.Contain("unknownPtProjectId8"));
+        env.MockSharingLogicWrapper
+            .DidNotReceive()
+            .ShareChanges(default, Arg.Any<SharedRepositorySource>(), out Arg.Any<List<SendReceiveResult>>(), default);
+    }
+
+    [Test]
+    public async Task SendReceiveAsync_ProjectNotYetCloned()
+    {
+        var env = new TestEnvironment();
+        string ptProjectId = env.PTProjectIds[env.Project02].Id;
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        IInternetSharedRepositorySource mockSource = env.SetSharedRepositorySource(
+            user01Secret,
+            UserRoles.Administrator
+        );
+        env.SetupSuccessfulSendReceive();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        // FindById fails the first time, and then succeeds the second time after the pt project repo is cloned.
+        MockScrText scrText = env.GetScrText(associatedPtUser, ptProjectId);
+        env.MockScrTextCollection.FindById(env.Username01, ptProjectId).Returns(null, scrText);
+
+        string clonePath = Path.Combine(env.SyncDir, ptProjectId, "target");
+        env.MockFileSystemService.DirectoryExists(clonePath).Returns(false);
+
+        // SUT
+        await env.Service.SendReceiveAsync(user01Secret, ptProjectId, null);
+        // Should have tried to clone the needed repo.
+        env.MockFileSystemService.Received(1).CreateDirectory(clonePath);
+        mockSource.Received(1).Pull(clonePath, Arg.Any<SharedRepository>());
+        env.MockHgWrapper.Received(1).Update(clonePath);
+    }
+
+    [Test]
+    public async Task SendReceiveAsync_SourceProjectPresent_BothSucceeds()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string targetProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        string sourceProjectId = env.PTProjectIds[env.Project02].Id;
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        IInternetSharedRepositorySource mockSource = env.SetSharedRepositorySource(
+            user01Secret,
+            UserRoles.Administrator
+        );
+        env.SetupSuccessfulSendReceive();
+
+        ScrText sourceScrText = env.GetScrText(associatedPtUser, sourceProjectId);
+        env.MockScrTextCollection.FindById(env.Username01, sourceProjectId).Returns(sourceScrText);
+
+        // Get the permissions, as the ScrText will be disposed in ShareChanges()
+        ComparableProjectPermissionManager sourceScrTextPermissions = (ComparableProjectPermissionManager)
+            sourceScrText.Permissions;
+        ComparableProjectPermissionManager targetScrTextPermissions = (ComparableProjectPermissionManager)
+            env.ProjectScrText.Permissions;
+
+        ParatextProject targetProject = await env.Service.SendReceiveAsync(user01Secret, targetProjectId);
+        Assert.IsNotNull(targetProject);
+        ParatextProject sourceProject = await env.Service.SendReceiveAsync(user01Secret, sourceProjectId);
+        Assert.IsNotNull(sourceProject);
+        // Below, we are checking also that the SharedProject has a
+        // Permissions that is set from the SharedProject's ScrText.Permissions.
+        // Better may be to assert that each SharedProject.Permissions.GetUser()
+        // returns a desired PT username, if the test environment wasn't
+        // mired in mock.
+        env.MockSharingLogicWrapper
+            .Received(2)
+            .ShareChanges(
+                Arg.Is<List<SharedProject>>(
+                    list =>
+                        list.Count().Equals(1)
+                        && (list[0].SendReceiveId.Id == targetProjectId || list[0].SendReceiveId.Id == sourceProjectId)
+                        && (
+                            sourceScrTextPermissions.Equals((ComparableProjectPermissionManager)list[0].Permissions)
+                            || targetScrTextPermissions.Equals((ComparableProjectPermissionManager)list[0].Permissions)
+                        )
+                ),
+                Arg.Any<SharedRepositorySource>(),
+                out Arg.Any<List<SendReceiveResult>>(),
+                Arg.Any<List<SharedProject>>()
+            );
+        env.MockFileSystemService.DidNotReceive().DeleteDirectory(Arg.Any<string>());
+
+        // Replaces obsolete source project if the source project has been changed
+        string newSourceProjectId = env.PTProjectIds[env.Project03].Id;
+        string sourcePath = Path.Combine(env.SyncDir, newSourceProjectId, "target");
+
+        // Only set the the new source ScrText when it is "cloned" to the filesystem
+        env.MockFileSystemService
+            .When(fs => fs.CreateDirectory(sourcePath))
+            .Do(_ =>
             {
-                IEnumerable<IDocument<NoteThread>> noteThreadDocs = await env.GetNoteThreadDocsAsync(
-                    conn,
-                    new[] { "thread1", "thread3", "thread4", "thread5" }
-                );
-                Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(
-                    env.Project01,
-                    40,
-                    1,
-                    env.ContextBefore,
-                    "Text selected"
-                );
-                Dictionary<string, ParatextUserProfile> syncUsers = new Dictionary<string, ParatextUserProfile>
-                {
-                    {
-                        env.Username01,
-                        new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-                    }
-                };
-                IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
-                    userSecret,
-                    ptProjectId,
-                    40,
-                    noteThreadDocs,
-                    chapterDeltas,
-                    syncUsers
-                );
-                Assert.That(changes.Count, Is.EqualTo(4));
-
-                // The reattach note in thread3 is existing and is not changed
-                Assert.That(changes.FirstOrDefault(c => c.ThreadId == "thread3"), Is.Null);
-                // Existing thread reattached
-                NoteThreadChange change1 = changes.Single(c => c.ThreadId == "thread1");
-                Assert.That(change1.NotesAdded.Count, Is.EqualTo(1));
-                Assert.That(change1.NotesAdded.Single().Reattached, Is.Not.Null);
-                TextAnchor expectedAnchor = new TextAnchor
-                {
-                    Start = rti.contextBefore.Length,
-                    Length = rti.selectedText.Length
-                };
-                Assert.That(change1.Position, Is.EqualTo(expectedAnchor));
-
-                // New thread note reattached
-                NoteThreadChange change2 = changes.Single(c => c.ThreadId == "thread2");
-                Assert.That(change2.NotesAdded.Count, Is.EqualTo(2));
-                Assert.That(change2.NotesAdded[1].Reattached, Is.Not.Null);
-                Assert.That(change2.Position, Is.EqualTo(expectedAnchor));
-
-                // Existing thread new comment and reattached
-                NoteThreadChange change4 = changes.Single(c => c.ThreadId == "thread4");
-                Assert.That(change4.NotesAdded.Count, Is.EqualTo(2));
-                Assert.That(change4.NotesAdded[1].Reattached, Is.Not.Null);
-                Assert.That(change4.Position, Is.EqualTo(expectedAnchor));
-
-                // Existing thread and reattach comment removed
-                NoteThreadChange change5 = changes.Single(c => c.ThreadId == "thread5");
-                Assert.That(change5.NoteIdsRemoved.Count, Is.EqualTo(1));
-                Assert.That(change5.NoteIdsRemoved[0], Is.EqualTo("reattachedthread5"));
-                // The context of the original note thread is not what the thread was reattached and un-reattached to
-                Assert.That(change5.ContextBefore, Is.Not.EqualTo(rti.contextBefore));
-                Assert.That(change5.SelectedText, Is.Not.EqualTo(rti.selectedText));
-                TextAnchor originalAnchor = new TextAnchor
-                {
-                    Start = change5.ContextBefore.Length,
-                    Length = change5.SelectedText.Length
-                };
-                Assert.That(change5.Position, Is.EqualTo(originalAnchor));
-            }
-        }
-
-        [Test]
-        public async Task UpdateParatextComments_AddsComment()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            string threadId = "thread1";
-            env.AddNoteThreadData(
-                new[]
-                {
-                    new ThreadComponents
-                    {
-                        threadNum = 1,
-                        noteCount = 1,
-                        isNew = true
-                    }
-                }
-            );
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-            {
-                CommentThread thread = env.ProjectCommentManager.FindThread(threadId);
-                Assert.That(thread, Is.Null);
-                IDocument<NoteThread> noteThreadDoc = await env.GetNoteThreadDocAsync(conn, threadId);
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = new Dictionary<string, ParatextUserProfile>();
-                var syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
-                    userSecret,
-                    ptProjectId,
-                    40,
-                    new[] { noteThreadDoc },
-                    ptProjectUsers,
-                    env.TagCount
-                );
-                thread = env.ProjectCommentManager.FindThread(threadId);
-                Assert.That(thread.Comments.Count, Is.EqualTo(1));
-                var comment = thread.Comments.First();
-                string expected =
-                    "thread1/User 02/2019-01-01T08:00:00.0000000+00:00-"
-                    + "MAT 1:1-"
-                    + "<p>thread1 note 1.</p>-"
-                    + "Start:0-"
-                    + "user02-"
-                    + "Tag:1";
-                Assert.That(comment.CommentToString(), Is.EqualTo(expected));
-                Assert.That(ptProjectUsers.Keys, Is.EquivalentTo(new[] { env.Username02 }));
-                Assert.That(noteThreadDoc.Data.Notes[0].SyncUserRef, Is.EqualTo("syncuser02"));
-                Assert.That(syncMetricInfo, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
-
-                // PT username is not written to server logs
-                env.MockLogger.AssertNoEvent((LogEvent logEvent) => logEvent.Message.Contains(env.Username02));
-            }
-        }
-
-        [Test]
-        public async Task UpdateParatextComments_AddsCommentTagIdNotSet()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string paratextId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            string threadId = "thread1";
-            env.AddNoteThreadData(
-                new[]
-                {
-                    new ThreadComponents
-                    {
-                        threadNum = 1,
-                        noteCount = 1,
-                        isNew = true,
-                        notes = new[] { new ThreadNoteComponents { } }
-                    }
-                }
-            );
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync(env.User01))
-            {
-                CommentThread commentThread = env.ProjectCommentManager.FindThread(threadId);
-                Assert.That(commentThread, Is.Null);
-                IDocument<NoteThread> noteThreadDoc = await env.GetNoteThreadDocAsync(conn, threadId);
-                var paratextUsers = new Dictionary<string, ParatextUserProfile>();
-                int newSfNoteTagId = env.TagCount + 1;
-                var syncMetricsInfo = await env.Service.UpdateParatextCommentsAsync(
-                    userSecret,
-                    paratextId,
-                    40,
-                    new[] { noteThreadDoc },
-                    paratextUsers,
-                    newSfNoteTagId
-                );
-                commentThread = env.ProjectCommentManager.FindThread(threadId);
-                Assert.That(commentThread.Comments.Count, Is.EqualTo(1));
-                Assert.That(commentThread.Comments[0].TagsAdded, Is.EquivalentTo(new[] { $"{newSfNoteTagId}" }));
-                Assert.That(syncMetricsInfo, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
-            }
-        }
-
-        [Test]
-        public async Task UpdateParatextComments_EditsComment()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            string threadId = "thread1";
-            env.AddNoteThreadData(
-                new[]
-                {
-                    new ThreadComponents
-                    {
-                        threadNum = 1,
-                        noteCount = 1,
-                        username = env.Username01,
-                        isEdited = true
-                    }
-                }
-            );
-            env.AddParatextComments(
-                new[]
-                {
-                    new ThreadComponents
-                    {
-                        threadNum = 1,
-                        noteCount = 1,
-                        username = env.Username01
-                    }
-                }
-            );
-
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-            {
-                IDocument<NoteThread> noteThreadDoc = await env.GetNoteThreadDocAsync(conn, threadId);
-                // Edit a comment
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
-                {
-                    new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-                }.ToDictionary(u => u.Username);
-                var syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
-                    userSecret,
-                    ptProjectId,
-                    40,
-                    new[] { noteThreadDoc },
-                    ptProjectUsers,
-                    env.TagCount
-                );
-
-                CommentThread thread = env.ProjectCommentManager.FindThread(threadId);
-                Assert.That(thread.Comments.Count, Is.EqualTo(1));
-                var comment = thread.Comments.First();
-                string expected =
-                    "thread1/User 01/2019-01-01T08:00:00.0000000+00:00-"
-                    + "MAT 1:1-"
-                    + "<p>thread1 note 1: EDITED.</p>-"
-                    + "Start:15-"
-                    + "user02-"
-                    + "Tag:1";
-                Assert.That(comment.CommentToString(), Is.EqualTo(expected));
-                Assert.That(ptProjectUsers.Count(), Is.EqualTo(1));
-                Assert.That(syncMetricInfo, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 1)));
-
-                // PT username is not written to server logs
-                env.MockLogger.AssertNoEvent((LogEvent logEvent) => logEvent.Message.Contains(env.Username01));
-            }
-        }
-
-        [Test]
-        public async Task UpdateParatextComments_DeletesComment()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            string threadId = "thread1";
-            env.AddNoteThreadData(
-                new[]
-                {
-                    new ThreadComponents
-                    {
-                        threadNum = 1,
-                        noteCount = 1,
-                        username = env.Username01,
-                        isDeleted = true
-                    }
-                }
-            );
-            env.AddParatextComments(
-                new[]
-                {
-                    new ThreadComponents
-                    {
-                        threadNum = 1,
-                        noteCount = 1,
-                        username = env.Username01
-                    }
-                }
-            );
-
-            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-            {
-                IDocument<NoteThread> noteThreadDoc = await env.GetNoteThreadDocAsync(conn, threadId);
-
-                // Delete a comment
-                Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
-                {
-                    new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-                }.ToDictionary(u => u.Username);
-                var syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
-                    userSecret,
-                    ptProjectId,
-                    40,
-                    new[] { noteThreadDoc },
-                    ptProjectUsers,
-                    env.TagCount
-                );
-
-                CommentThread thread = env.ProjectCommentManager.FindThread(threadId);
-                Assert.That(thread.Comments.Count, Is.EqualTo(1));
-                var comment = thread.Comments.First();
-                string expected =
-                    "thread1/User 01/2019-01-01T08:00:00.0000000+00:00-"
-                    + "MAT 1:1-"
-                    + "<p>thread1 note 1.</p>-"
-                    + "Start:15-"
-                    + "user02-"
-                    + "deleted-"
-                    + "Tag:1";
-                Assert.That(comment.CommentToString(), Is.EqualTo(expected));
-                Assert.That(syncMetricInfo, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
-
-                // PT username is not written to server logs
-                env.MockLogger.AssertNoEvent((LogEvent logEvent) => logEvent.Message.Contains(env.Username01));
-            }
-        }
-
-        [Test]
-        public void GetParatextSettings_RetrievesTagIcons()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string paratextId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            var noteTag = new NoteTag
-            {
-                TagId = 5,
-                Icon = "sf05",
-                Name = "SF Note Tag",
-            };
-            env.SetupCommentTags(env.ProjectScrText, noteTag);
-            ParatextSettings? settings = env.Service.GetParatextSettings(userSecret, paratextId);
-            Assert.That(settings?.NoteTags.Any(t => t.Name == noteTag.Name), Is.True);
-        }
-
-        [Test]
-        public void GetParatextSettings_NoteTagSetToNull()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string paratextId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            var noteTag = new NoteTag
-            {
-                TagId = CommentTag.notSetId,
-                Icon = "sf05",
-                Name = "SF Note Tag"
-            };
-            ParatextSettings? settings = env.Service.GetParatextSettings(userSecret, paratextId);
-            Assert.That(settings?.NoteTags.FirstOrDefault(t => t.Icon == noteTag.Icon), Is.Null);
-        }
-
-        [Test]
-        public void UpdateCommentTag_WritesTagIcon()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string paratextId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            string icon = "someIcon";
-            var noteTag = new NoteTag
-            {
-                TagId = CommentTag.notSetId,
-                Icon = icon,
-                Name = "SF Note Tag"
-            };
-            env.Service.UpdateCommentTag(userSecret, paratextId, noteTag);
-            // the new tag is created with a tag id one greater than the last used id
-            int tagId = env.TagCount + 1;
-            ParatextSettings? settings = env.Service.GetParatextSettings(userSecret, paratextId);
-            Assert.That(settings?.NoteTags.First(t => t.Icon == icon).TagId, Is.EqualTo(tagId));
-        }
-
-        [Test]
-        public void UpdateCommentTag_DoesNotWriteIfExistingTag()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string paratextId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            int existingId = 5;
-            var noteTag = new NoteTag
-            {
-                TagId = existingId,
-                Icon = "existingIcon",
-                Name = "SF Note Tag"
-            };
-            env.SetupCommentTags(env.ProjectScrText, noteTag);
-            Assert.Throws<ArgumentException>(() => env.Service.UpdateCommentTag(userSecret, paratextId, noteTag));
-        }
-
-        [Test]
-        public void SendReceiveAsync_BadArguments()
-        {
-            var env = new TestEnvironment();
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.SendReceiveAsync(null, null, null));
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => env.Service.SendReceiveAsync(null, env.PTProjectIds[env.Project01].Id, null)
-            );
-            Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.SendReceiveAsync(user01Secret, null, null));
-        }
-
-        [Test]
-        public void SendReceiveAsync_ShareChangesErrors_Throws()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string projectId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
-            env.SetupSuccessfulSendReceive();
-            // Setup share changes to be unsuccessful
-            env.MockSharingLogicWrapper
-                .ShareChanges(
-                    Arg.Any<List<SharedProject>>(),
-                    Arg.Any<SharedRepositorySource>(),
-                    out Arg.Any<List<SendReceiveResult>>(),
-                    Arg.Any<List<SharedProject>>()
-                )
-                .Returns(false);
-
-            InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(
-                () => env.Service.SendReceiveAsync(user01Secret, projectId, null)
-            );
-            Assert.That(ex.Message, Does.Contain("Failed: Errors occurred"));
-
-            // Check exception is thrown if errors occurred, even if share changes succeeded
-            env.MockSharingLogicWrapper.HandleErrors(Arg.Any<Action>()).Returns(false);
-            ex = Assert.ThrowsAsync<InvalidOperationException>(
-                () => env.Service.SendReceiveAsync(user01Secret, projectId, null)
-            );
-            Assert.That(ex.Message, Does.Contain("Failed: Errors occurred"));
-        }
-
-        [Test]
-        public void SendReceiveAsync_NoMatchingSourceRepository_Throws()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
-
-            ArgumentException ex = Assert.ThrowsAsync<ArgumentException>(
-                () => env.Service.SendReceiveAsync(user01Secret, "badProjectId", null)
-            );
-            Assert.That(ex.Message, Does.Contain("PT projects with the following PT ids were requested"));
-        }
-
-        [Test]
-        public void SendReceiveAsync_ShareChangesErrors_InResultsOnly()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string projectId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
-            env.SetupSuccessfulSendReceive();
-            // Setup share changes to be unsuccessful, but return true
-            // This scenario occurs if a project is locked on the PT server
-            env.MockSharingLogicWrapper
-                .ShareChanges(
-                    Arg.Any<List<SharedProject>>(),
-                    Arg.Any<SharedRepositorySource>(),
-                    out Arg.Any<List<SendReceiveResult>>(),
-                    Arg.Any<List<SharedProject>>()
-                )
-                .Returns(x =>
-                {
-                    x[2] = new List<SendReceiveResult>
-                    {
-                        new SendReceiveResult(new SharedProject()) { Result = SendReceiveResultEnum.Failed, },
-                    };
-                    return true;
-                });
-
-            InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(
-                () => env.Service.SendReceiveAsync(user01Secret, projectId, null)
-            );
-            Assert.That(ex.Message, Does.Contain("Failed: Errors occurred"));
-
-            // Check exception is thrown if errors occurred, even if share changes succeeded
-            env.MockSharingLogicWrapper.HandleErrors(Arg.Any<Action>()).Returns(false);
-            ex = Assert.ThrowsAsync<InvalidOperationException>(
-                () => env.Service.SendReceiveAsync(user01Secret, projectId, null)
-            );
-            Assert.That(ex.Message, Does.Contain("Failed: Errors occurred"));
-        }
-
-        [Test]
-        public async Task SendReceiveAsync_UserIsAdministrator_Succeeds()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            IInternetSharedRepositorySource mockSource = env.SetSharedRepositorySource(
-                user01Secret,
-                UserRoles.Administrator
-            );
-            env.SetupSuccessfulSendReceive();
-
-            // SUT 1
-            await env.Service.SendReceiveAsync(user01Secret, ptProjectId, null);
-            env.MockSharingLogicWrapper
-                .Received(1)
-                .ShareChanges(
-                    Arg.Is<List<SharedProject>>(list => list.Count == 1 && list[0].SendReceiveId.Id == ptProjectId),
-                    Arg.Any<SharedRepositorySource>(),
-                    out Arg.Any<List<SendReceiveResult>>(),
-                    Arg.Is<List<SharedProject>>(list => list.Count == 1 && list[0].SendReceiveId.Id == ptProjectId)
-                );
-            mockSource.DidNotReceive().Pull(Arg.Any<string>(), Arg.Any<SharedRepository>());
-            env.MockSharingLogicWrapper.ClearReceivedCalls();
-
-            // Passing a PT project Id for a project the user does not have access to fails early without doing S/R
-            // SUT 2
-            ArgumentException resultingException = Assert.ThrowsAsync<ArgumentException>(
-                () => env.Service.SendReceiveAsync(user01Secret, "unknownPtProjectId8")
-            );
-            Assert.That(resultingException.Message, Does.Contain("unknownPtProjectId8"));
-            env.MockSharingLogicWrapper
-                .DidNotReceive()
-                .ShareChanges(
-                    default,
-                    Arg.Any<SharedRepositorySource>(),
-                    out Arg.Any<List<SendReceiveResult>>(),
-                    default
-                );
-        }
-
-        [Test]
-        public async Task SendReceiveAsync_ProjectNotYetCloned()
-        {
-            var env = new TestEnvironment();
-            string ptProjectId = env.PTProjectIds[env.Project02].Id;
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            IInternetSharedRepositorySource mockSource = env.SetSharedRepositorySource(
-                user01Secret,
-                UserRoles.Administrator
-            );
-            env.SetupSuccessfulSendReceive();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            // FindById fails the first time, and then succeeds the second time after the pt project repo is cloned.
-            MockScrText scrText = env.GetScrText(associatedPtUser, ptProjectId);
-            env.MockScrTextCollection.FindById(env.Username01, ptProjectId).Returns(null, scrText);
-
-            string clonePath = Path.Combine(env.SyncDir, ptProjectId, "target");
-            env.MockFileSystemService.DirectoryExists(clonePath).Returns(false);
-
-            // SUT
-            await env.Service.SendReceiveAsync(user01Secret, ptProjectId, null);
-            // Should have tried to clone the needed repo.
-            env.MockFileSystemService.Received(1).CreateDirectory(clonePath);
-            mockSource.Received(1).Pull(clonePath, Arg.Any<SharedRepository>());
-            env.MockHgWrapper.Received(1).Update(clonePath);
-        }
-
-        [Test]
-        public async Task SendReceiveAsync_SourceProjectPresent_BothSucceeds()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string targetProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            string sourceProjectId = env.PTProjectIds[env.Project02].Id;
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            IInternetSharedRepositorySource mockSource = env.SetSharedRepositorySource(
-                user01Secret,
-                UserRoles.Administrator
-            );
-            env.SetupSuccessfulSendReceive();
-
-            ScrText sourceScrText = env.GetScrText(associatedPtUser, sourceProjectId);
-            env.MockScrTextCollection.FindById(env.Username01, sourceProjectId).Returns(sourceScrText);
-
-            // Get the permissions, as the ScrText will be disposed in ShareChanges()
-            ComparableProjectPermissionManager sourceScrTextPermissions = (ComparableProjectPermissionManager)
-                sourceScrText.Permissions;
-            ComparableProjectPermissionManager targetScrTextPermissions = (ComparableProjectPermissionManager)
-                env.ProjectScrText.Permissions;
-
-            ParatextProject targetProject = await env.Service.SendReceiveAsync(user01Secret, targetProjectId);
-            Assert.IsNotNull(targetProject);
-            ParatextProject sourceProject = await env.Service.SendReceiveAsync(user01Secret, sourceProjectId);
-            Assert.IsNotNull(sourceProject);
-            // Below, we are checking also that the SharedProject has a
-            // Permissions that is set from the SharedProject's ScrText.Permissions.
-            // Better may be to assert that each SharedProject.Permissions.GetUser()
-            // returns a desired PT username, if the test environment wasn't
-            // mired in mock.
-            env.MockSharingLogicWrapper
-                .Received(2)
-                .ShareChanges(
-                    Arg.Is<List<SharedProject>>(
-                        list =>
-                            list.Count().Equals(1)
-                            && (
-                                list[0].SendReceiveId.Id == targetProjectId
-                                || list[0].SendReceiveId.Id == sourceProjectId
-                            )
-                            && (
-                                sourceScrTextPermissions.Equals((ComparableProjectPermissionManager)list[0].Permissions)
-                                || targetScrTextPermissions.Equals(
-                                    (ComparableProjectPermissionManager)list[0].Permissions
-                                )
-                            )
-                    ),
-                    Arg.Any<SharedRepositorySource>(),
-                    out Arg.Any<List<SendReceiveResult>>(),
-                    Arg.Any<List<SharedProject>>()
-                );
-            env.MockFileSystemService.DidNotReceive().DeleteDirectory(Arg.Any<string>());
-
-            // Replaces obsolete source project if the source project has been changed
-            string newSourceProjectId = env.PTProjectIds[env.Project03].Id;
-            string sourcePath = Path.Combine(env.SyncDir, newSourceProjectId, "target");
-
-            // Only set the the new source ScrText when it is "cloned" to the filesystem
-            env.MockFileSystemService
-                .When(fs => fs.CreateDirectory(sourcePath))
-                .Do(_ =>
-                {
-                    ScrText newSourceScrText = env.GetScrText(associatedPtUser, newSourceProjectId);
-                    env.MockScrTextCollection.FindById(env.Username01, newSourceProjectId).Returns(newSourceScrText);
-                });
-
-            targetProject = await env.Service.SendReceiveAsync(user01Secret, targetProjectId);
-            Assert.IsNotNull(targetProject);
-            sourceProject = await env.Service.SendReceiveAsync(user01Secret, newSourceProjectId);
-            Assert.IsNotNull(sourceProject);
-            env.MockFileSystemService.DidNotReceive().DeleteDirectory(Arg.Any<string>());
-            env.MockFileSystemService.Received(1).CreateDirectory(sourcePath);
-            mockSource
-                .Received(1)
-                .Pull(sourcePath, Arg.Is<SharedRepository>(repo => repo.SendReceiveId.Id == newSourceProjectId));
-            env.MockHgWrapper.Received(1).Update(sourcePath);
-        }
-
-        [Test]
-        public async Task SendReceiveAsync_SourceResource_Missing()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
-            env.SetupSuccessfulSendReceive();
-            env.SetRestClientFactory(user01Secret);
-            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
-            string resourceId = "test_resource_id"; // A missing or invalid resource or project
-            await env.Service.SendReceiveAsync(user01Secret, ptProjectId);
-            Assert.ThrowsAsync<ArgumentException>(() => env.Service.SendReceiveAsync(user01Secret, resourceId));
-        }
-
-        [Test]
-        public async Task SendReceiveAsync_SourceResource_Valid()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
-            env.SetupSuccessfulSendReceive();
-            env.SetRestClientFactory(user01Secret);
-            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
-            string resourceId = env.Resource3Id; // See the XML in SetRestClientFactory for this
-            ParatextProject targetProject = await env.Service.SendReceiveAsync(user01Secret, ptProjectId);
-            Assert.IsNotNull(targetProject);
-            ParatextProject sourceProject = await env.Service.SendReceiveAsync(user01Secret, resourceId);
-            Assert.IsNotNull(sourceProject);
-            Assert.IsInstanceOf(typeof(ParatextResource), sourceProject);
-        }
-
-        [Test]
-        public async Task TryGetProjectRoleAsync_BadArguments()
-        {
-            var env = new TestEnvironment();
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            var attempt = await env.Service.TryGetProjectRoleAsync(null, "paratextIdHere", CancellationToken.None);
-            Assert.That(attempt.Success, Is.False);
-            Assert.That(attempt.Result, Is.Null);
-
-            attempt = await env.Service.TryGetProjectRoleAsync(userSecret, null, CancellationToken.None);
-            Assert.That(attempt.Success, Is.False);
-            Assert.That(attempt.Result, Is.Null);
-        }
-
-        [Test]
-        public async Task TryGetProjectRoleAsync_UsesTheRepositoryForUnregisteredProjects()
-        {
-            var env = new TestEnvironment();
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.AddProjectRepository();
-            env.SetSharedRepositorySource(userSecret, UserRoles.Administrator);
-            var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
-            var project = projects.First();
-            env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
-            // SUT
-            var attempt = await env.Service.TryGetProjectRoleAsync(
-                userSecret,
-                project.ParatextId,
-                CancellationToken.None
-            );
-            Assert.That(attempt.Success, Is.True);
-            Assert.That(attempt.Result, Is.EqualTo(SFProjectRole.Administrator));
-        }
-
-        [Test]
-        public async Task TryGetProjectRoleAsync_UsesTheRepositoryForUnregisteredProjectsAndFailsIfUserDoesntExist()
-        {
-            var env = new TestEnvironment();
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.AddProjectRepository();
-            // Notice that SetSharedRepositorySource is not called here
-            var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
-            var project = projects.First();
-            env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
-            // SUT
-            var attempt = await env.Service.TryGetProjectRoleAsync(
-                userSecret,
-                project.ParatextId,
-                CancellationToken.None
-            );
-            Assert.That(attempt.Success, Is.False);
-            Assert.That(attempt.Result, Is.Empty);
-        }
-
-        [Test]
-        public async Task GetProjectRolesAsync_UsesTheRepositoryForUnregisteredProjects()
-        {
-            var env = new TestEnvironment();
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.MakeUserSecret(env.User02, env.Username02, env.ParatextUserId02);
-            env.AddProjectRepository();
-            env.SetSharedRepositorySource(userSecret, UserRoles.Administrator);
-            var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
-            SFProject project = projects.First();
-            Assert.That(project.UserRoles.Count, Is.EqualTo(2), "setup");
-            env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
-            // SUT
-            var roles = await env.Service.GetProjectRolesAsync(userSecret, project, CancellationToken.None);
-            Assert.That(roles.Count, Is.EqualTo(2));
-            var firstRole = new KeyValuePair<string, string>(env.ParatextUserId01, SFProjectRole.Administrator);
-            Assert.That(roles.First(), Is.EqualTo(firstRole));
-            var secondRole = new KeyValuePair<string, string>(env.ParatextUserId02, SFProjectRole.Administrator);
-            Assert.That(roles.Last(), Is.EqualTo(secondRole));
-        }
-
-        [Test]
-        public async Task GetProjectRolesAsync_UnregisteredProject_SkipsNonPTUsers()
-        {
-            var env = new TestEnvironment();
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.MakeUserSecret(env.User02, env.Username02, env.ParatextUserId02);
-            SFProject proj = env.NewSFProject();
-            proj.UserRoles.Add(env.User04, SFProjectRole.CommunityChecker);
-            env.AddProjectRepository(proj);
-            env.SetSharedRepositorySource(userSecret, UserRoles.Administrator);
-            var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
-            SFProject project = projects.First();
-            Assert.That(project.UserRoles.Count, Is.EqualTo(3), "setup");
-            env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
-            // SUT
-            var roles = await env.Service.GetProjectRolesAsync(userSecret, project, CancellationToken.None);
-            Assert.That(roles.Count, Is.EqualTo(2), "map of PT roles should only include PT users");
-            var firstRole = new KeyValuePair<string, string>(env.ParatextUserId01, SFProjectRole.Administrator);
-            Assert.That(roles.First(), Is.EqualTo(firstRole));
-            var secondRole = new KeyValuePair<string, string>(env.ParatextUserId02, SFProjectRole.Administrator);
-            Assert.That(roles.Last(), Is.EqualTo(secondRole));
-        }
-
-        [Test]
-        public async Task GetProjectRolesAsync_UnregisteredProject_MoreInfoWhenHttpException()
-        {
-            var env = new TestEnvironment();
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.MakeUserSecret(env.User02, env.Username02, env.ParatextUserId02);
-            env.AddProjectRepository();
-            IInternetSharedRepositorySource source = env.SetSharedRepositorySource(userSecret, UserRoles.Administrator);
-            var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
-            SFProject project = projects.First();
-            // The 404 Not Found response here from the registry client lets us get into the
-            // unregistered area of the SUT.
-            env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
-
-            source
-                .GetRepositories()
-                .Returns(x => throw HttpException.Create(new WebException("401: Unauthorized"), (HttpWebRequest)null));
-
-            // SUT
-            Assert.ThrowsAsync<HttpException>(
-                () => env.Service.GetProjectRolesAsync(userSecret, project, CancellationToken.None)
-            );
-
-            // Various pieces of significant data are reported when a 401 Unauthorized goes thru.
-            string[] notes = { "unregistered", project.ParatextId, project.Id, userSecret.Id, "role" };
-            env.MockLogger.AssertHasEvent(
-                (LogEvent logEvent) => notes.All((string note) => logEvent.Message.Contains(note))
-            );
-        }
-
-        [Test]
-        public async Task IsRegisteredAsync_Works()
-        {
-            var env = new TestEnvironment();
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            using HttpResponseMessage okResponse = env.MakeOkHttpResponseMessage("\"some-project-pt-id\"");
-            env.MakeRegistryClientReturn(okResponse);
-            // One SUT
-            Assert.That(
-                await env.Service.IsRegisteredAsync(userSecret, "some-project-pt-id", CancellationToken.None),
-                Is.True
-            );
-
-            env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
-            // One SUT
-            Assert.That(
-                await env.Service.IsRegisteredAsync(userSecret, "some-project-pt-id", CancellationToken.None),
-                Is.False
-            );
-
-            env.MakeRegistryClientReturn(env.UnauthorizedHttpResponseMessage);
-            // One SUT
-            HttpRequestException exc = Assert.ThrowsAsync<HttpRequestException>(
-                () => env.Service.IsRegisteredAsync(userSecret, "some-project-pt-id", CancellationToken.None)
-            );
-            Assert.That(exc.Message, Contains.Substring("Unauthorized"), "relevant error info should be coming thru");
-        }
-
-        [Test]
-        public async Task GetParatextUsernameMappingAsync_UsesTheRepositoryForUnregisteredProjects()
-        {
-            var env = new TestEnvironment();
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            env.MakeUserSecret(env.User02, env.Username02, env.ParatextUserId02);
-            env.AddProjectRepository();
-            env.SetSharedRepositorySource(userSecret, UserRoles.Administrator);
-            var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
-            var project = projects.First();
-            env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
-            // SUT
-            var mapping = await env.Service.GetParatextUsernameMappingAsync(
-                userSecret,
-                project,
-                CancellationToken.None
-            );
-            Assert.That(mapping.Count, Is.EqualTo(2));
-            Assert.That(mapping.First(), Is.EqualTo(new KeyValuePair<string, string>(env.User01, env.Username01)));
-            Assert.That(mapping.Last(), Is.EqualTo(new KeyValuePair<string, string>(env.User02, env.Username02)));
-        }
-
-        [Test]
-        public async Task GetParatextUsernameMappingAsync_ReturnsEmptyMappingForResourceProject()
-        {
-            var env = new TestEnvironment();
-            const string resourceId = "1234567890abcdef";
-            Assert.That(resourceId.Length, Is.EqualTo(SFInstallableDblResource.ResourceIdentifierLength));
-            var userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            var mapping = await env.Service.GetParatextUsernameMappingAsync(
-                userSecret,
-                new SFProject { ParatextId = resourceId },
-                CancellationToken.None
-            );
-            Assert.That(mapping.Count, Is.EqualTo(0));
-        }
-
-        [Test]
-        public async Task GetParatextUsernameMappingAsync_WarnsWhenDuplicatePTUsernamesInUnregisteredProject()
-        {
-            var env = new TestEnvironment();
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            // Note that the following user secret has same PT username and id as the other user. This presumably
-            // represents a bad DB state.
-            env.MakeUserSecret(env.User02, env.Username01, env.ParatextUserId01);
-            env.MockJwtTokenHelper
-                .GetParatextUsername(Arg.Is<UserSecret>(u => u.Id == env.User02))
-                .Returns(env.Username01);
-
-            env.AddProjectRepository();
-            env.SetSharedRepositorySource(userSecret, UserRoles.Administrator);
-            var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
-            var project = projects.First();
-            env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
-            // SUT
-            var mapping = await env.Service.GetParatextUsernameMappingAsync(
-                userSecret,
-                project,
-                CancellationToken.None
-            );
-            string[] requiredLogWords = { "unregistered", env.Username01, "duplicate" };
-            // Warn about the situation.
-            env.MockLogger.AssertHasEvent(
-                (LogEvent ev) => requiredLogWords.All((string requiredWord) => ev.Message.Contains(requiredWord))
-            );
-            // And still return the data.
-            Assert.That(mapping.Count, Is.EqualTo(2));
-        }
-
-        enum SelectionType
-        {
-            Standard,
-            RelatedVerse,
-            Section,
-            SectionEnd
-        }
-
-        struct ThreadComponents
-        {
-            public int threadNum;
-            public int noteCount;
-            public ThreadNoteComponents[] notes;
-            public string username;
-            public SelectionType alternateText;
-            public bool isNew;
-            public bool isEdited;
-            public bool isDeleted;
-            public bool isConflict;
-            public bool appliesToVerse;
-            public string reattachedVerseStr;
-        }
-
-        struct ReattachedThreadInfo
-        {
-            public string verseStr;
-            public string selectedText;
-            public string startPos;
-            public string contextBefore;
-            public string contextAfter;
-        }
-
-        struct ThreadNoteComponents
-        {
-            public Enum<NoteStatus> status;
-            public string[] tagsAdded;
-            public string assignedPTUser;
-            public bool duplicate;
-        }
-
-        [Test]
-        public void GetLatestSharedVersion_ForPTProject()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            ScrText scrText = env.GetScrText(associatedPtUser, ptProjectId);
-            string lastPublicRevision = "abc123";
-            env.MockHgWrapper.GetLastPublicRevision(scrText.Directory).Returns(lastPublicRevision);
-
-            // SUT
-            string latestSharedVersion = env.Service.GetLatestSharedVersion(user01Secret, ptProjectId);
-
-            Assert.That(latestSharedVersion, Is.EqualTo(lastPublicRevision));
-        }
-
-        [Test]
-        public void GetLatestSharedVersion_ForDBLResource()
-        {
-            var env = new TestEnvironment();
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            string resourcePTId = "1234567890123456";
-            Assert.That(
-                resourcePTId,
-                Has.Length.EqualTo(SFInstallableDblResource.ResourceIdentifierLength),
-                "setup. Should be using a project ID that is a resource ID"
-            );
-
-            // SUT
-            string latestSharedVersion = env.Service.GetLatestSharedVersion(user01Secret, resourcePTId);
-
-            Assert.That(
-                latestSharedVersion,
-                Is.Null,
-                "DBL resources do not have hg repositories to have a last pushed or pulled hg commit id."
-            );
-            // Wouldn't have ended up trying to find a ScrText or querying hg.
-            env.MockScrTextCollection.DidNotReceiveWithAnyArgs().FindById(default, default);
-            env.MockHgWrapper.DidNotReceiveWithAnyArgs().GetLastPublicRevision(default);
-        }
-
-        [Test]
-        public void BackupExists_Failure()
-        {
-            // Setup test environment
-            var env = new TestEnvironment();
-            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            env.MockFileSystemService.FileExists(Arg.Any<string>()).Throws(new UnauthorizedAccessException());
-
-            // SUT
-            bool result = env.Service.BackupExists(user01Secret, ptProjectId);
-            Assert.IsFalse(result);
-        }
-
-        [Test]
-        public void BackupExists_Missing()
-        {
-            // Setup test environment
-            var env = new TestEnvironment();
-            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            env.MockFileSystemService.FileExists(Arg.Any<string>()).Returns(false);
-
-            // SUT
-            bool result = env.Service.BackupExists(user01Secret, ptProjectId);
-            Assert.IsFalse(result);
-        }
-
-        [Test]
-        public void BackupExists_Success()
-        {
-            // Setup test environment
-            var env = new TestEnvironment();
-            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            env.MockFileSystemService.FileExists(Arg.Any<string>()).Returns(true);
-
-            // SUT
-            bool result = env.Service.BackupExists(user01Secret, ptProjectId);
-            Assert.IsTrue(result);
-        }
-
-        [Test]
-        public void BackupRepository_Failure()
-        {
-            // Setup test environment
-            var env = new TestEnvironment();
-            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            env.MockFileSystemService.FileExists(Arg.Any<string>()).Throws(new UnauthorizedAccessException());
-
-            // SUT
-            bool result = env.Service.BackupRepository(user01Secret, ptProjectId);
-            Assert.IsFalse(result);
-        }
-
-        [Test]
-        public void BackupRepository_InvalidProject()
-        {
-            // Setup test environment
-            var env = new TestEnvironment();
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            string ptProjectId = "invalid_project";
-
-            // SUT
-            bool result = env.Service.BackupRepository(user01Secret, ptProjectId);
-            Assert.IsFalse(result);
-        }
-
-        [Test]
-        public void BackupRepository_Success()
-        {
-            // Setup test environment
-            var env = new TestEnvironment();
-            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-
-            // SUT
-            bool result = env.Service.BackupRepository(user01Secret, ptProjectId);
-            Assert.IsTrue(result);
-        }
-
-        [Test]
-        public void RestoreRepository_Failure()
-        {
-            // Setup test environment
-            var env = new TestEnvironment();
-            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            env.MockFileSystemService.FileExists(Arg.Any<string>()).Throws(new UnauthorizedAccessException());
-
-            // SUT
-            bool result = env.Service.RestoreRepository(user01Secret, ptProjectId);
-            Assert.IsFalse(result);
-            env.MockHgWrapper.DidNotReceiveWithAnyArgs().RestoreRepository(default, default);
-            env.MockHgWrapper.DidNotReceiveWithAnyArgs().MarkSharedChangeSetsPublic(default);
-        }
-
-        [Test]
-        public void RestoreRepository_Missing()
-        {
-            // Setup test environment
-            var env = new TestEnvironment();
-            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            env.MockFileSystemService.FileExists(Arg.Any<string>()).Returns(false);
-
-            // SUT
-            bool result = env.Service.RestoreRepository(user01Secret, ptProjectId);
-            Assert.IsFalse(result);
-            env.MockHgWrapper.DidNotReceiveWithAnyArgs().RestoreRepository(default, default);
-            env.MockHgWrapper.DidNotReceiveWithAnyArgs().MarkSharedChangeSetsPublic(default);
-        }
-
-        [Test]
-        public void RestoreRepository_Success()
-        {
-            // Setup test environment
-            var env = new TestEnvironment();
-            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            env.MockFileSystemService.FileExists(Arg.Any<string>()).Returns(true);
-
-            // SUT
-            bool result = env.Service.RestoreRepository(user01Secret, ptProjectId);
-            Assert.IsTrue(result);
-            env.MockHgWrapper.ReceivedWithAnyArgs().RestoreRepository(default, default);
-            env.MockHgWrapper.ReceivedWithAnyArgs().MarkSharedChangeSetsPublic(default);
-        }
-
-        [Test]
-        public void RestoreRepository_ExistingRestoredRepository_Success()
-        {
-            var env = new TestEnvironment();
-            string scrtextDir = "/srv/scriptureforge/projects";
-            ScrTextCollection.Initialize(scrtextDir);
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            env.MockFileSystemService.FileExists(Arg.Any<string>()).Returns(true);
-            env.MockFileSystemService
-                .DirectoryExists(Arg.Any<string>())
-                .Returns(x => ((string)x[0]).Contains(ptProjectId));
-
-            // SUT
-            bool result = env.Service.RestoreRepository(user01Secret, ptProjectId);
-            Assert.IsTrue(result);
-            env.MockHgWrapper.ReceivedWithAnyArgs().RestoreRepository(default, default);
-            env.MockHgWrapper.ReceivedWithAnyArgs().MarkSharedChangeSetsPublic(default);
-            string projectRepository = Path.Combine(scrtextDir, "_Backups", ptProjectId);
-            string restoredRepository = projectRepository + "_Restored";
-            // Removes leftover folders from a failed previous restore
-            env.MockFileSystemService.Received().DeleteDirectory(projectRepository);
-            env.MockFileSystemService.Received().DeleteDirectory(restoredRepository);
-        }
-
-        [Test]
-        public void LocalProjectDirExists_Works()
-        {
-            var env = new TestEnvironment();
-            Assert.That(env.Service.LocalProjectDirExists(env.PTProjectIds[env.Project01].Id), Is.True);
-            Assert.That(env.Service.LocalProjectDirExists("not-existing"), Is.False);
-        }
-
-        [Test]
-        public async Task CanUserAuthenticateToPTRegistryAsync_Works()
-        {
-            var env = new TestEnvironment();
-            UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            // One SUT
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => env.Service.CanUserAuthenticateToPTRegistryAsync(null),
-                "throw on unacceptable input"
-            );
-
-            // One SUT
-            Assert.ThrowsAsync<ArgumentException>(
-                () =>
-                    env.Service.CanUserAuthenticateToPTRegistryAsync(
-                        new UserSecret() { Id = null, ParatextTokens = null }
-                    ),
-                "the user secret does not have usable content"
-            );
-
-            env.MakeRegistryClientReturn(env.UnauthorizedHttpResponseMessage);
-
-            // One SUT
-            Assert.That(
-                await env.Service.CanUserAuthenticateToPTRegistryAsync(user01Secret),
-                Is.False,
-                "authorization token is not accepted by server. unauthorized."
-            );
-
-            using HttpResponseMessage okResponse = env.MakeOkHttpResponseMessage(
-                @"{
+                ScrText newSourceScrText = env.GetScrText(associatedPtUser, newSourceProjectId);
+                env.MockScrTextCollection.FindById(env.Username01, newSourceProjectId).Returns(newSourceScrText);
+            });
+
+        targetProject = await env.Service.SendReceiveAsync(user01Secret, targetProjectId);
+        Assert.IsNotNull(targetProject);
+        sourceProject = await env.Service.SendReceiveAsync(user01Secret, newSourceProjectId);
+        Assert.IsNotNull(sourceProject);
+        env.MockFileSystemService.DidNotReceive().DeleteDirectory(Arg.Any<string>());
+        env.MockFileSystemService.Received(1).CreateDirectory(sourcePath);
+        mockSource
+            .Received(1)
+            .Pull(sourcePath, Arg.Is<SharedRepository>(repo => repo.SendReceiveId.Id == newSourceProjectId));
+        env.MockHgWrapper.Received(1).Update(sourcePath);
+    }
+
+    [Test]
+    public async Task SendReceiveAsync_SourceResource_Missing()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
+        env.SetupSuccessfulSendReceive();
+        env.SetRestClientFactory(user01Secret);
+        ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+        string resourceId = "test_resource_id"; // A missing or invalid resource or project
+        await env.Service.SendReceiveAsync(user01Secret, ptProjectId);
+        Assert.ThrowsAsync<ArgumentException>(() => env.Service.SendReceiveAsync(user01Secret, resourceId));
+    }
+
+    [Test]
+    public async Task SendReceiveAsync_SourceResource_Valid()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
+        env.SetupSuccessfulSendReceive();
+        env.SetRestClientFactory(user01Secret);
+        ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+        string resourceId = env.Resource3Id; // See the XML in SetRestClientFactory for this
+        ParatextProject targetProject = await env.Service.SendReceiveAsync(user01Secret, ptProjectId);
+        Assert.IsNotNull(targetProject);
+        ParatextProject sourceProject = await env.Service.SendReceiveAsync(user01Secret, resourceId);
+        Assert.IsNotNull(sourceProject);
+        Assert.IsInstanceOf(typeof(ParatextResource), sourceProject);
+    }
+
+    [Test]
+    public async Task TryGetProjectRoleAsync_BadArguments()
+    {
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        var attempt = await env.Service.TryGetProjectRoleAsync(null, "paratextIdHere", CancellationToken.None);
+        Assert.That(attempt.Success, Is.False);
+        Assert.That(attempt.Result, Is.Null);
+
+        attempt = await env.Service.TryGetProjectRoleAsync(userSecret, null, CancellationToken.None);
+        Assert.That(attempt.Success, Is.False);
+        Assert.That(attempt.Result, Is.Null);
+    }
+
+    [Test]
+    public async Task TryGetProjectRoleAsync_UsesTheRepositoryForUnregisteredProjects()
+    {
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.AddProjectRepository();
+        env.SetSharedRepositorySource(userSecret, UserRoles.Administrator);
+        var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
+        var project = projects.First();
+        env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
+        // SUT
+        var attempt = await env.Service.TryGetProjectRoleAsync(userSecret, project.ParatextId, CancellationToken.None);
+        Assert.That(attempt.Success, Is.True);
+        Assert.That(attempt.Result, Is.EqualTo(SFProjectRole.Administrator));
+    }
+
+    [Test]
+    public async Task TryGetProjectRoleAsync_UsesTheRepositoryForUnregisteredProjectsAndFailsIfUserDoesntExist()
+    {
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.AddProjectRepository();
+        // Notice that SetSharedRepositorySource is not called here
+        var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
+        var project = projects.First();
+        env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
+        // SUT
+        var attempt = await env.Service.TryGetProjectRoleAsync(userSecret, project.ParatextId, CancellationToken.None);
+        Assert.That(attempt.Success, Is.False);
+        Assert.That(attempt.Result, Is.Empty);
+    }
+
+    [Test]
+    public async Task GetProjectRolesAsync_UsesTheRepositoryForUnregisteredProjects()
+    {
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        TestEnvironment.MakeUserSecret(env.User02, env.Username02, env.ParatextUserId02);
+        env.AddProjectRepository();
+        env.SetSharedRepositorySource(userSecret, UserRoles.Administrator);
+        var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
+        SFProject project = projects.First();
+        Assert.That(project.UserRoles.Count, Is.EqualTo(2), "setup");
+        env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
+        // SUT
+        var roles = await env.Service.GetProjectRolesAsync(userSecret, project, CancellationToken.None);
+        Assert.That(roles.Count, Is.EqualTo(2));
+        var firstRole = new KeyValuePair<string, string>(env.ParatextUserId01, SFProjectRole.Administrator);
+        Assert.That(roles.First(), Is.EqualTo(firstRole));
+        var secondRole = new KeyValuePair<string, string>(env.ParatextUserId02, SFProjectRole.Administrator);
+        Assert.That(roles.Last(), Is.EqualTo(secondRole));
+    }
+
+    [Test]
+    public async Task GetProjectRolesAsync_UnregisteredProject_SkipsNonPTUsers()
+    {
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        TestEnvironment.MakeUserSecret(env.User02, env.Username02, env.ParatextUserId02);
+        SFProject proj = env.NewSFProject();
+        proj.UserRoles.Add(env.User04, SFProjectRole.CommunityChecker);
+        env.AddProjectRepository(proj);
+        env.SetSharedRepositorySource(userSecret, UserRoles.Administrator);
+        var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
+        SFProject project = projects.First();
+        Assert.That(project.UserRoles.Count, Is.EqualTo(3), "setup");
+        env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
+        // SUT
+        var roles = await env.Service.GetProjectRolesAsync(userSecret, project, CancellationToken.None);
+        Assert.That(roles.Count, Is.EqualTo(2), "map of PT roles should only include PT users");
+        var firstRole = new KeyValuePair<string, string>(env.ParatextUserId01, SFProjectRole.Administrator);
+        Assert.That(roles.First(), Is.EqualTo(firstRole));
+        var secondRole = new KeyValuePair<string, string>(env.ParatextUserId02, SFProjectRole.Administrator);
+        Assert.That(roles.Last(), Is.EqualTo(secondRole));
+    }
+
+    [Test]
+    public async Task GetProjectRolesAsync_UnregisteredProject_MoreInfoWhenHttpException()
+    {
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        TestEnvironment.MakeUserSecret(env.User02, env.Username02, env.ParatextUserId02);
+        env.AddProjectRepository();
+        IInternetSharedRepositorySource source = env.SetSharedRepositorySource(userSecret, UserRoles.Administrator);
+        var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
+        SFProject project = projects.First();
+        // The 404 Not Found response here from the registry client lets us get into the
+        // unregistered area of the SUT.
+        env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
+
+        source
+            .GetRepositories()
+            .Returns(x => throw HttpException.Create(new WebException("401: Unauthorized"), (HttpWebRequest)null));
+
+        // SUT
+        Assert.ThrowsAsync<HttpException>(
+            () => env.Service.GetProjectRolesAsync(userSecret, project, CancellationToken.None)
+        );
+
+        // Various pieces of significant data are reported when a 401 Unauthorized goes thru.
+        string[] notes = { "unregistered", project.ParatextId, project.Id, userSecret.Id, "role" };
+        env.MockLogger.AssertHasEvent(
+            (LogEvent logEvent) => notes.All((string note) => logEvent.Message.Contains(note))
+        );
+    }
+
+    [Test]
+    public async Task IsRegisteredAsync_Works()
+    {
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        using HttpResponseMessage okResponse = TestEnvironment.MakeOkHttpResponseMessage("\"some-project-pt-id\"");
+        env.MakeRegistryClientReturn(okResponse);
+        // One SUT
+        Assert.That(
+            await env.Service.IsRegisteredAsync(userSecret, "some-project-pt-id", CancellationToken.None),
+            Is.True
+        );
+
+        env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
+        // One SUT
+        Assert.That(
+            await env.Service.IsRegisteredAsync(userSecret, "some-project-pt-id", CancellationToken.None),
+            Is.False
+        );
+
+        env.MakeRegistryClientReturn(env.UnauthorizedHttpResponseMessage);
+        // One SUT
+        HttpRequestException exc = Assert.ThrowsAsync<HttpRequestException>(
+            () => env.Service.IsRegisteredAsync(userSecret, "some-project-pt-id", CancellationToken.None)
+        );
+        Assert.That(exc.Message, Contains.Substring("Unauthorized"), "relevant error info should be coming thru");
+    }
+
+    [Test]
+    public async Task GetParatextUsernameMappingAsync_UsesTheRepositoryForUnregisteredProjects()
+    {
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        TestEnvironment.MakeUserSecret(env.User02, env.Username02, env.ParatextUserId02);
+        env.AddProjectRepository();
+        env.SetSharedRepositorySource(userSecret, UserRoles.Administrator);
+        var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
+        var project = projects.First();
+        env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
+        // SUT
+        var mapping = await env.Service.GetParatextUsernameMappingAsync(userSecret, project, CancellationToken.None);
+        Assert.That(mapping.Count, Is.EqualTo(2));
+        Assert.That(mapping.First(), Is.EqualTo(new KeyValuePair<string, string>(env.User01, env.Username01)));
+        Assert.That(mapping.Last(), Is.EqualTo(new KeyValuePair<string, string>(env.User02, env.Username02)));
+    }
+
+    [Test]
+    public async Task GetParatextUsernameMappingAsync_ReturnsEmptyMappingForResourceProject()
+    {
+        var env = new TestEnvironment();
+        const string resourceId = "1234567890abcdef";
+        Assert.That(resourceId.Length, Is.EqualTo(SFInstallableDblResource.ResourceIdentifierLength));
+        var userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        var mapping = await env.Service.GetParatextUsernameMappingAsync(
+            userSecret,
+            new SFProject { ParatextId = resourceId },
+            CancellationToken.None
+        );
+        Assert.That(mapping.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task GetParatextUsernameMappingAsync_WarnsWhenDuplicatePTUsernamesInUnregisteredProject()
+    {
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        // Note that the following user secret has same PT username and id as the other user. This presumably
+        // represents a bad DB state.
+        TestEnvironment.MakeUserSecret(env.User02, env.Username01, env.ParatextUserId01);
+        env.MockJwtTokenHelper.GetParatextUsername(Arg.Is<UserSecret>(u => u.Id == env.User02)).Returns(env.Username01);
+
+        env.AddProjectRepository();
+        env.SetSharedRepositorySource(userSecret, UserRoles.Administrator);
+        var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
+        var project = projects.First();
+        env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
+        // SUT
+        var mapping = await env.Service.GetParatextUsernameMappingAsync(userSecret, project, CancellationToken.None);
+        string[] requiredLogWords = { "unregistered", env.Username01, "duplicate" };
+        // Warn about the situation.
+        env.MockLogger.AssertHasEvent(
+            (LogEvent ev) => requiredLogWords.All((string requiredWord) => ev.Message.Contains(requiredWord))
+        );
+        // And still return the data.
+        Assert.That(mapping.Count, Is.EqualTo(2));
+    }
+
+    enum SelectionType
+    {
+        Standard,
+        RelatedVerse,
+        Section,
+        SectionEnd
+    }
+
+    struct ThreadComponents
+    {
+        public int threadNum;
+        public int noteCount;
+        public ThreadNoteComponents[] notes;
+        public string username;
+        public SelectionType alternateText;
+        public bool isNew;
+        public bool isEdited;
+        public bool isDeleted;
+        public bool isConflict;
+        public bool appliesToVerse;
+        public string reattachedVerseStr;
+    }
+
+    struct ReattachedThreadInfo
+    {
+        public string verseStr;
+        public string selectedText;
+        public string startPos;
+        public string contextBefore;
+        public string contextAfter;
+    }
+
+    struct ThreadNoteComponents
+    {
+        public Enum<NoteStatus> status;
+        public string[] tagsAdded;
+        public string assignedPTUser;
+        public bool duplicate;
+    }
+
+    [Test]
+    public void GetLatestSharedVersion_ForPTProject()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        ScrText scrText = env.GetScrText(associatedPtUser, ptProjectId);
+        string lastPublicRevision = "abc123";
+        env.MockHgWrapper.GetLastPublicRevision(scrText.Directory).Returns(lastPublicRevision);
+
+        // SUT
+        string latestSharedVersion = env.Service.GetLatestSharedVersion(user01Secret, ptProjectId);
+
+        Assert.That(latestSharedVersion, Is.EqualTo(lastPublicRevision));
+    }
+
+    [Test]
+    public void GetLatestSharedVersion_ForDBLResource()
+    {
+        var env = new TestEnvironment();
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        string resourcePTId = "1234567890123456";
+        Assert.That(
+            resourcePTId,
+            Has.Length.EqualTo(SFInstallableDblResource.ResourceIdentifierLength),
+            "setup. Should be using a project ID that is a resource ID"
+        );
+
+        // SUT
+        string latestSharedVersion = env.Service.GetLatestSharedVersion(user01Secret, resourcePTId);
+
+        Assert.That(
+            latestSharedVersion,
+            Is.Null,
+            "DBL resources do not have hg repositories to have a last pushed or pulled hg commit id."
+        );
+        // Wouldn't have ended up trying to find a ScrText or querying hg.
+        env.MockScrTextCollection.DidNotReceiveWithAnyArgs().FindById(default, default);
+        env.MockHgWrapper.DidNotReceiveWithAnyArgs().GetLastPublicRevision(default);
+    }
+
+    [Test]
+    public void BackupExists_Failure()
+    {
+        // Setup test environment
+        var env = new TestEnvironment();
+        ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        env.MockFileSystemService.FileExists(Arg.Any<string>()).Throws(new UnauthorizedAccessException());
+
+        // SUT
+        bool result = env.Service.BackupExists(user01Secret, ptProjectId);
+        Assert.IsFalse(result);
+    }
+
+    [Test]
+    public void BackupExists_Missing()
+    {
+        // Setup test environment
+        var env = new TestEnvironment();
+        ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        env.MockFileSystemService.FileExists(Arg.Any<string>()).Returns(false);
+
+        // SUT
+        bool result = env.Service.BackupExists(user01Secret, ptProjectId);
+        Assert.IsFalse(result);
+    }
+
+    [Test]
+    public void BackupExists_Success()
+    {
+        // Setup test environment
+        var env = new TestEnvironment();
+        ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        env.MockFileSystemService.FileExists(Arg.Any<string>()).Returns(true);
+
+        // SUT
+        bool result = env.Service.BackupExists(user01Secret, ptProjectId);
+        Assert.IsTrue(result);
+    }
+
+    [Test]
+    public void BackupRepository_Failure()
+    {
+        // Setup test environment
+        var env = new TestEnvironment();
+        ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        env.MockFileSystemService.FileExists(Arg.Any<string>()).Throws(new UnauthorizedAccessException());
+
+        // SUT
+        bool result = env.Service.BackupRepository(user01Secret, ptProjectId);
+        Assert.IsFalse(result);
+    }
+
+    [Test]
+    public void BackupRepository_InvalidProject()
+    {
+        // Setup test environment
+        var env = new TestEnvironment();
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        string ptProjectId = "invalid_project";
+
+        // SUT
+        bool result = env.Service.BackupRepository(user01Secret, ptProjectId);
+        Assert.IsFalse(result);
+    }
+
+    [Test]
+    public void BackupRepository_Success()
+    {
+        // Setup test environment
+        var env = new TestEnvironment();
+        ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+
+        // SUT
+        bool result = env.Service.BackupRepository(user01Secret, ptProjectId);
+        Assert.IsTrue(result);
+    }
+
+    [Test]
+    public void RestoreRepository_Failure()
+    {
+        // Setup test environment
+        var env = new TestEnvironment();
+        ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        env.MockFileSystemService.FileExists(Arg.Any<string>()).Throws(new UnauthorizedAccessException());
+
+        // SUT
+        bool result = env.Service.RestoreRepository(user01Secret, ptProjectId);
+        Assert.IsFalse(result);
+        env.MockHgWrapper.DidNotReceiveWithAnyArgs().RestoreRepository(default, default);
+        env.MockHgWrapper.DidNotReceiveWithAnyArgs().MarkSharedChangeSetsPublic(default);
+    }
+
+    [Test]
+    public void RestoreRepository_Missing()
+    {
+        // Setup test environment
+        var env = new TestEnvironment();
+        ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        env.MockFileSystemService.FileExists(Arg.Any<string>()).Returns(false);
+
+        // SUT
+        bool result = env.Service.RestoreRepository(user01Secret, ptProjectId);
+        Assert.IsFalse(result);
+        env.MockHgWrapper.DidNotReceiveWithAnyArgs().RestoreRepository(default, default);
+        env.MockHgWrapper.DidNotReceiveWithAnyArgs().MarkSharedChangeSetsPublic(default);
+    }
+
+    [Test]
+    public void RestoreRepository_Success()
+    {
+        // Setup test environment
+        var env = new TestEnvironment();
+        ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        env.MockFileSystemService.FileExists(Arg.Any<string>()).Returns(true);
+
+        // SUT
+        bool result = env.Service.RestoreRepository(user01Secret, ptProjectId);
+        Assert.IsTrue(result);
+        env.MockHgWrapper.ReceivedWithAnyArgs().RestoreRepository(default, default);
+        env.MockHgWrapper.ReceivedWithAnyArgs().MarkSharedChangeSetsPublic(default);
+    }
+
+    [Test]
+    public void RestoreRepository_ExistingRestoredRepository_Success()
+    {
+        var env = new TestEnvironment();
+        string scrtextDir = "/srv/scriptureforge/projects";
+        ScrTextCollection.Initialize(scrtextDir);
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        env.MockFileSystemService.FileExists(Arg.Any<string>()).Returns(true);
+        env.MockFileSystemService.DirectoryExists(Arg.Any<string>()).Returns(x => ((string)x[0]).Contains(ptProjectId));
+
+        // SUT
+        bool result = env.Service.RestoreRepository(user01Secret, ptProjectId);
+        Assert.IsTrue(result);
+        env.MockHgWrapper.ReceivedWithAnyArgs().RestoreRepository(default, default);
+        env.MockHgWrapper.ReceivedWithAnyArgs().MarkSharedChangeSetsPublic(default);
+        string projectRepository = Path.Combine(scrtextDir, "_Backups", ptProjectId);
+        string restoredRepository = projectRepository + "_Restored";
+        // Removes leftover folders from a failed previous restore
+        env.MockFileSystemService.Received().DeleteDirectory(projectRepository);
+        env.MockFileSystemService.Received().DeleteDirectory(restoredRepository);
+    }
+
+    [Test]
+    public void LocalProjectDirExists_Works()
+    {
+        var env = new TestEnvironment();
+        Assert.That(env.Service.LocalProjectDirExists(env.PTProjectIds[env.Project01].Id), Is.True);
+        Assert.That(env.Service.LocalProjectDirExists("not-existing"), Is.False);
+    }
+
+    [Test]
+    public async Task CanUserAuthenticateToPTRegistryAsync_Works()
+    {
+        var env = new TestEnvironment();
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        // One SUT
+        Assert.ThrowsAsync<ArgumentNullException>(
+            () => env.Service.CanUserAuthenticateToPTRegistryAsync(null),
+            "throw on unacceptable input"
+        );
+
+        // One SUT
+        Assert.ThrowsAsync<ArgumentException>(
+            () =>
+                env.Service.CanUserAuthenticateToPTRegistryAsync(new UserSecret() { Id = null, ParatextTokens = null }),
+            "the user secret does not have usable content"
+        );
+
+        env.MakeRegistryClientReturn(env.UnauthorizedHttpResponseMessage);
+
+        // One SUT
+        Assert.That(
+            await env.Service.CanUserAuthenticateToPTRegistryAsync(user01Secret),
+            Is.False,
+            "authorization token is not accepted by server. unauthorized."
+        );
+
+        using HttpResponseMessage okResponse = TestEnvironment.MakeOkHttpResponseMessage(
+            @"{
                     ""sub"": ""ptUserIdCode11111"",
                 }"
-            );
-            env.MakeRegistryClientReturn(okResponse);
+        );
+        env.MakeRegistryClientReturn(okResponse);
 
-            // One SUT
-            Assert.That(
-                await env.Service.CanUserAuthenticateToPTRegistryAsync(user01Secret),
-                Is.True,
-                "authorization token is accepted by server"
-            );
-        }
+        // One SUT
+        Assert.That(
+            await env.Service.CanUserAuthenticateToPTRegistryAsync(user01Secret),
+            Is.True,
+            "authorization token is accepted by server"
+        );
+    }
 
-        [Test]
-        public async Task CanUserAuthenticateToPTArchivesAsync_Works()
+    [Test]
+    public async Task CanUserAuthenticateToPTArchivesAsync_Works()
+    {
+        var env = new TestEnvironment();
+        TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        string userSFId = env.User01;
+
+        // One SUT
+        Assert.ThrowsAsync<ArgumentException>(
+            () => env.Service.CanUserAuthenticateToPTArchivesAsync(null),
+            "unacceptable null input"
+        );
+
+        // One SUT
+        Assert.ThrowsAsync<ArgumentException>(
+            () => env.Service.CanUserAuthenticateToPTArchivesAsync(string.Empty),
+            "unacceptable empty input"
+        );
+
+        IInternetSharedRepositorySource mockSource = Substitute.For<IInternetSharedRepositorySource>();
+
+        env.MockInternetSharedRepositorySourceProvider
+            .GetSource(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns(mockSource);
+        mockSource.CanUserAuthenticateToPTArchives().Returns(false);
+
+        // One SUT
+        Assert.That(await env.Service.CanUserAuthenticateToPTArchivesAsync(userSFId), Is.False, "unauthorized");
+
+        mockSource.CanUserAuthenticateToPTArchives().Returns(true);
+
+        // One SUT
+        Assert.That(await env.Service.CanUserAuthenticateToPTArchivesAsync(userSFId), Is.True, "authorized");
+    }
+
+    [Test]
+    public void ResourceDocsNeedUpdating_NotResource()
+    {
+        // Setup test environment
+        var env = new TestEnvironment();
+        var project = new SFProject { ParatextId = env.PTProjectIds[env.Project01].Id, };
+        var resource = new ParatextResource();
+
+        // SUT
+        var result = env.Service.ResourceDocsNeedUpdating(project, resource);
+        Assert.That(env.Service.IsResource(project.ParatextId), Is.False);
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void ResourceDocsNeedUpdating_NoResourceConfig()
+    {
+        // Setup test environment
+        var env = new TestEnvironment();
+        var project = new SFProject { ParatextId = env.Resource1Id, };
+        var resource = new ParatextResource();
+
+        // SUT
+        var result = env.Service.ResourceDocsNeedUpdating(project, resource);
+        Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void ResourceDocsNeedUpdating_NotChanged_SameTimestamp()
+    {
+        // Setup test environment
+        var env = new TestEnvironment();
+        var timestamp = DateTime.Now;
+        var project = new SFProject
         {
-            var env = new TestEnvironment();
-            env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
-            string userSFId = env.User01;
-
-            // One SUT
-            Assert.ThrowsAsync<ArgumentException>(
-                () => env.Service.CanUserAuthenticateToPTArchivesAsync(null),
-                "unacceptable null input"
-            );
-
-            // One SUT
-            Assert.ThrowsAsync<ArgumentException>(
-                () => env.Service.CanUserAuthenticateToPTArchivesAsync(string.Empty),
-                "unacceptable empty input"
-            );
-
-            IInternetSharedRepositorySource mockSource = Substitute.For<IInternetSharedRepositorySource>();
-
-            env.MockInternetSharedRepositorySourceProvider
-                .GetSource(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<string>())
-                .Returns(mockSource);
-            mockSource.CanUserAuthenticateToPTArchives().Returns(false);
-
-            // One SUT
-            Assert.That(await env.Service.CanUserAuthenticateToPTArchivesAsync(userSFId), Is.False, "unauthorized");
-
-            mockSource.CanUserAuthenticateToPTArchives().Returns(true);
-
-            // One SUT
-            Assert.That(await env.Service.CanUserAuthenticateToPTArchivesAsync(userSFId), Is.True, "authorized");
-        }
-
-        [Test]
-        public void ResourceDocsNeedUpdating_NotResource()
-        {
-            // Setup test environment
-            var env = new TestEnvironment();
-            var project = new SFProject { ParatextId = env.PTProjectIds[env.Project01].Id, };
-            var resource = new ParatextResource();
-
-            // SUT
-            var result = env.Service.ResourceDocsNeedUpdating(project, resource);
-            Assert.That(env.Service.IsResource(project.ParatextId), Is.False);
-            Assert.That(result, Is.True);
-        }
-
-        [Test]
-        public void ResourceDocsNeedUpdating_NoResourceConfig()
-        {
-            // Setup test environment
-            var env = new TestEnvironment();
-            var project = new SFProject { ParatextId = env.Resource1Id, };
-            var resource = new ParatextResource();
-
-            // SUT
-            var result = env.Service.ResourceDocsNeedUpdating(project, resource);
-            Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
-            Assert.That(result, Is.True);
-        }
-
-        [Test]
-        public void ResourceDocsNeedUpdating_NotChanged_SameTimestamp()
-        {
-            // Setup test environment
-            var env = new TestEnvironment();
-            var timestamp = DateTime.Now;
-            var project = new SFProject
+            ParatextId = env.Resource1Id,
+            ResourceConfig = new ResourceConfig
             {
-                ParatextId = env.Resource1Id,
-                ResourceConfig = new ResourceConfig
-                {
-                    CreatedTimestamp = timestamp,
-                    ManifestChecksum = "manifest1",
-                    PermissionsChecksum = "permissions1",
-                    Revision = 1,
-                },
-            };
-            var resource = new ParatextResource
-            {
-                AvailableRevision = 1,
                 CreatedTimestamp = timestamp,
                 ManifestChecksum = "manifest1",
                 PermissionsChecksum = "permissions1",
-            };
-
-            // SUT
-            var result = env.Service.ResourceDocsNeedUpdating(project, resource);
-            Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
-            Assert.That(result, Is.False);
-        }
-
-        [Test]
-        public void ResourceDocsNeedUpdating_NotChanged_DifferentTimestamp()
+                Revision = 1,
+            },
+        };
+        var resource = new ParatextResource
         {
-            // Setup test environment
-            var env = new TestEnvironment();
-            var timestamp = DateTime.Now;
-            var project = new SFProject
-            {
-                ParatextId = env.Resource1Id,
-                ResourceConfig = new ResourceConfig
-                {
-                    CreatedTimestamp = timestamp,
-                    ManifestChecksum = "manifest1",
-                    PermissionsChecksum = "permissions1",
-                    Revision = 1,
-                },
-            };
-            var resource = new ParatextResource
-            {
-                AvailableRevision = 1,
-                CreatedTimestamp = timestamp.AddHours(1),
-                ManifestChecksum = "manifest1",
-                PermissionsChecksum = "permissions1",
-            };
+            AvailableRevision = 1,
+            CreatedTimestamp = timestamp,
+            ManifestChecksum = "manifest1",
+            PermissionsChecksum = "permissions1",
+        };
 
-            // SUT
-            var result = env.Service.ResourceDocsNeedUpdating(project, resource);
-            Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
-            Assert.That(result, Is.False);
-        }
+        // SUT
+        var result = env.Service.ResourceDocsNeedUpdating(project, resource);
+        Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
+        Assert.That(result, Is.False);
+    }
 
-        [Test]
-        public void ResourceDocsNeedUpdating_DifferentManifest_EarlierTimestamp()
+    [Test]
+    public void ResourceDocsNeedUpdating_NotChanged_DifferentTimestamp()
+    {
+        // Setup test environment
+        var env = new TestEnvironment();
+        var timestamp = DateTime.Now;
+        var project = new SFProject
         {
-            // Setup test environment
-            var env = new TestEnvironment();
-            var timestamp = DateTime.Now;
-            var project = new SFProject
+            ParatextId = env.Resource1Id,
+            ResourceConfig = new ResourceConfig
             {
-                ParatextId = env.Resource1Id,
-                ResourceConfig = new ResourceConfig
-                {
-                    CreatedTimestamp = timestamp,
-                    ManifestChecksum = "manifest1",
-                    PermissionsChecksum = "permissions1",
-                    Revision = 1,
-                },
-            };
-            var resource = new ParatextResource
-            {
-                AvailableRevision = 1,
-                CreatedTimestamp = timestamp.AddHours(-1),
-                ManifestChecksum = "manifest2",
-                PermissionsChecksum = "permissions1",
-            };
-
-            // SUT
-            var result = env.Service.ResourceDocsNeedUpdating(project, resource);
-            Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
-            Assert.That(result, Is.False);
-        }
-
-        [Test]
-        public void ResourceDocsNeedUpdating_DifferentManifest_LaterTimestamp()
-        {
-            // Setup test environment
-            var env = new TestEnvironment();
-            var timestamp = DateTime.Now;
-            var project = new SFProject
-            {
-                ParatextId = env.Resource1Id,
-                ResourceConfig = new ResourceConfig
-                {
-                    CreatedTimestamp = timestamp,
-                    ManifestChecksum = "manifest1",
-                    PermissionsChecksum = "permissions1",
-                    Revision = 1,
-                },
-            };
-            var resource = new ParatextResource
-            {
-                AvailableRevision = 1,
-                CreatedTimestamp = timestamp.AddHours(1),
-                ManifestChecksum = "manifest2",
-                PermissionsChecksum = "permissions1",
-            };
-
-            // SUT
-            var result = env.Service.ResourceDocsNeedUpdating(project, resource);
-            Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
-            Assert.That(result, Is.True);
-        }
-
-        [Test]
-        public void ResourceDocsNeedUpdating_LaterRevision()
-        {
-            // Setup test environment
-            var env = new TestEnvironment();
-            var timestamp = DateTime.Now;
-            var project = new SFProject
-            {
-                ParatextId = env.Resource1Id,
-                ResourceConfig = new ResourceConfig
-                {
-                    CreatedTimestamp = timestamp,
-                    ManifestChecksum = "manifest1",
-                    PermissionsChecksum = "permissions1",
-                    Revision = 1,
-                },
-            };
-            var resource = new ParatextResource
-            {
-                AvailableRevision = 2,
                 CreatedTimestamp = timestamp,
                 ManifestChecksum = "manifest1",
                 PermissionsChecksum = "permissions1",
-            };
-
-            // SUT
-            var result = env.Service.ResourceDocsNeedUpdating(project, resource);
-            Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
-            Assert.That(result, Is.True);
-        }
-
-        [Test]
-        public void ResourceDocsNeedUpdating_ChangedPermissions()
+                Revision = 1,
+            },
+        };
+        var resource = new ParatextResource
         {
-            // Setup test environment
-            var env = new TestEnvironment();
-            var timestamp = DateTime.Now;
-            var project = new SFProject
+            AvailableRevision = 1,
+            CreatedTimestamp = timestamp.AddHours(1),
+            ManifestChecksum = "manifest1",
+            PermissionsChecksum = "permissions1",
+        };
+
+        // SUT
+        var result = env.Service.ResourceDocsNeedUpdating(project, resource);
+        Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void ResourceDocsNeedUpdating_DifferentManifest_EarlierTimestamp()
+    {
+        // Setup test environment
+        var env = new TestEnvironment();
+        var timestamp = DateTime.Now;
+        var project = new SFProject
+        {
+            ParatextId = env.Resource1Id,
+            ResourceConfig = new ResourceConfig
             {
-                ParatextId = env.Resource1Id,
-                ResourceConfig = new ResourceConfig
-                {
-                    CreatedTimestamp = timestamp,
-                    ManifestChecksum = "manifest1",
-                    PermissionsChecksum = "permissions1",
-                    Revision = 1,
-                },
-            };
-            var resource = new ParatextResource
-            {
-                AvailableRevision = 1,
                 CreatedTimestamp = timestamp,
                 ManifestChecksum = "manifest1",
-                PermissionsChecksum = "permissions2",
-            };
-
-            // SUT
-            var result = env.Service.ResourceDocsNeedUpdating(project, resource);
-            Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
-            Assert.That(result, Is.True);
-        }
-
-        [Test]
-        public void SetRepoToRevision_SetsAndChecks()
+                PermissionsChecksum = "permissions1",
+                Revision = 1,
+            },
+        };
+        var resource = new ParatextResource
         {
-            TestEnvironment env = new();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string projectPTId = env.SetupProject(env.Project01, associatedPtUser);
-            string rev = "some-desired-revision";
-            env.MockHgWrapper
-                .GetRepoRevision(
-                    Arg.Is<string>((string repoPath) => repoPath.EndsWith(Path.Combine(projectPTId, "target")))
+            AvailableRevision = 1,
+            CreatedTimestamp = timestamp.AddHours(-1),
+            ManifestChecksum = "manifest2",
+            PermissionsChecksum = "permissions1",
+        };
+
+        // SUT
+        var result = env.Service.ResourceDocsNeedUpdating(project, resource);
+        Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void ResourceDocsNeedUpdating_DifferentManifest_LaterTimestamp()
+    {
+        // Setup test environment
+        var env = new TestEnvironment();
+        var timestamp = DateTime.Now;
+        var project = new SFProject
+        {
+            ParatextId = env.Resource1Id,
+            ResourceConfig = new ResourceConfig
+            {
+                CreatedTimestamp = timestamp,
+                ManifestChecksum = "manifest1",
+                PermissionsChecksum = "permissions1",
+                Revision = 1,
+            },
+        };
+        var resource = new ParatextResource
+        {
+            AvailableRevision = 1,
+            CreatedTimestamp = timestamp.AddHours(1),
+            ManifestChecksum = "manifest2",
+            PermissionsChecksum = "permissions1",
+        };
+
+        // SUT
+        var result = env.Service.ResourceDocsNeedUpdating(project, resource);
+        Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void ResourceDocsNeedUpdating_LaterRevision()
+    {
+        // Setup test environment
+        var env = new TestEnvironment();
+        var timestamp = DateTime.Now;
+        var project = new SFProject
+        {
+            ParatextId = env.Resource1Id,
+            ResourceConfig = new ResourceConfig
+            {
+                CreatedTimestamp = timestamp,
+                ManifestChecksum = "manifest1",
+                PermissionsChecksum = "permissions1",
+                Revision = 1,
+            },
+        };
+        var resource = new ParatextResource
+        {
+            AvailableRevision = 2,
+            CreatedTimestamp = timestamp,
+            ManifestChecksum = "manifest1",
+            PermissionsChecksum = "permissions1",
+        };
+
+        // SUT
+        var result = env.Service.ResourceDocsNeedUpdating(project, resource);
+        Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void ResourceDocsNeedUpdating_ChangedPermissions()
+    {
+        // Setup test environment
+        var env = new TestEnvironment();
+        var timestamp = DateTime.Now;
+        var project = new SFProject
+        {
+            ParatextId = env.Resource1Id,
+            ResourceConfig = new ResourceConfig
+            {
+                CreatedTimestamp = timestamp,
+                ManifestChecksum = "manifest1",
+                PermissionsChecksum = "permissions1",
+                Revision = 1,
+            },
+        };
+        var resource = new ParatextResource
+        {
+            AvailableRevision = 1,
+            CreatedTimestamp = timestamp,
+            ManifestChecksum = "manifest1",
+            PermissionsChecksum = "permissions2",
+        };
+
+        // SUT
+        var result = env.Service.ResourceDocsNeedUpdating(project, resource);
+        Assert.That(env.Service.IsResource(project.ParatextId), Is.True);
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void SetRepoToRevision_SetsAndChecks()
+    {
+        TestEnvironment env = new();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string projectPTId = env.SetupProject(env.Project01, associatedPtUser);
+        string rev = "some-desired-revision";
+        env.MockHgWrapper
+            .GetRepoRevision(
+                Arg.Is<string>((string repoPath) => repoPath.EndsWith(Path.Combine(projectPTId, "target")))
+            )
+            .Returns(rev);
+        // SUT
+        env.Service.SetRepoToRevision(
+            TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01),
+            projectPTId,
+            rev
+        );
+        env.MockHgWrapper.Received().Update(Arg.Any<string>(), rev);
+        env.MockHgWrapper.Received().GetRepoRevision(Arg.Any<string>());
+    }
+
+    [Test]
+    public void SetRepoToRevision_DetectsProblem()
+    {
+        TestEnvironment env = new();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string projectPTId = env.SetupProject(env.Project01, associatedPtUser);
+        string rev = "some-desired-new-revision";
+        string wrongRev = "not-the-rev-we-wanted";
+        env.MockHgWrapper.GetRepoRevision(Arg.Any<string>()).Returns(wrongRev);
+        // SUT
+        Assert.Throws<Exception>(
+            () =>
+                env.Service.SetRepoToRevision(
+                    TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01),
+                    projectPTId,
+                    rev
                 )
-                .Returns(rev);
-            // SUT
-            env.Service.SetRepoToRevision(
-                env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01),
-                projectPTId,
-                rev
-            );
-            env.MockHgWrapper.Received().Update(Arg.Any<string>(), rev);
-            env.MockHgWrapper.Received().GetRepoRevision(Arg.Any<string>());
-        }
+        );
+        env.MockHgWrapper.Received().Update(Arg.Any<string>(), rev);
+        env.MockHgWrapper.Received().GetRepoRevision(Arg.Any<string>());
+    }
 
-        [Test]
-        public void SetRepoToRevision_DetectsProblem()
-        {
-            TestEnvironment env = new();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string projectPTId = env.SetupProject(env.Project01, associatedPtUser);
-            string rev = "some-desired-new-revision";
-            string wrongRev = "not-the-rev-we-wanted";
-            env.MockHgWrapper.GetRepoRevision(Arg.Any<string>()).Returns(wrongRev);
-            // SUT
-            Assert.Throws<Exception>(
-                () =>
-                    env.Service.SetRepoToRevision(
-                        env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01),
-                        projectPTId,
-                        rev
-                    )
-            );
-            env.MockHgWrapper.Received().Update(Arg.Any<string>(), rev);
-            env.MockHgWrapper.Received().GetRepoRevision(Arg.Any<string>());
-        }
+    [Test]
+    public void GetLanguageId_GetsTheLanguageIdFromTheScrText()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
 
-        [Test]
-        public void GetLanguageId_GetsTheLanguageIdFromTheScrText()
-        {
-            var env = new TestEnvironment();
-            var associatedPtUser = new SFParatextUser(env.Username01);
-            string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-            UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        // SUT
+        string languageId = env.Service.GetLanguageId(userSecret, ptProjectId);
+        Assert.AreEqual(LanguageId.English.Id, languageId);
+    }
 
-            // SUT
-            string languageId = env.Service.GetLanguageId(userSecret, ptProjectId);
-            Assert.AreEqual(LanguageId.English.Id, languageId);
-        }
+    private class TestEnvironment : IDisposable
+    {
+        public readonly string ParatextUserId01 = "paratext01";
+        public readonly string ParatextUserId02 = "paratext02";
+        public readonly string ParatextUserId03 = "paratext03";
+        public readonly string Project01 = "project01";
+        public readonly string Project02 = "project02";
+        public readonly string Project03 = "project03";
+        public readonly string Project04 = "project04";
+        public readonly string Resource1Id = "e01f11e9b4b8e338";
+        public readonly string Resource2Id = "5e51f89e89947acb";
+        public readonly string Resource3Id = "9bb76cd3e5a7f9b4";
+        public readonly Dictionary<string, HexId> PTProjectIds = new Dictionary<string, HexId>();
+        public readonly string User01 = "user01";
+        public readonly string User02 = "user02";
+        public readonly string User03 = "user03";
 
-        private class TestEnvironment : IDisposable
-        {
-            public readonly string ParatextUserId01 = "paratext01";
-            public readonly string ParatextUserId02 = "paratext02";
-            public readonly string ParatextUserId03 = "paratext03";
-            public readonly string Project01 = "project01";
-            public readonly string Project02 = "project02";
-            public readonly string Project03 = "project03";
-            public readonly string Project04 = "project04";
-            public readonly string Resource1Id = "e01f11e9b4b8e338";
-            public readonly string Resource2Id = "5e51f89e89947acb";
-            public readonly string Resource3Id = "9bb76cd3e5a7f9b4";
-            public readonly Dictionary<string, HexId> PTProjectIds = new Dictionary<string, HexId>();
-            public readonly string User01 = "user01";
-            public readonly string User02 = "user02";
-            public readonly string User03 = "user03";
+        // User04 is a SF user and is not a PT user.
+        public readonly string User04 = "user04";
+        public readonly string Username01 = "User 01";
+        public readonly string Username02 = "User 02";
+        public readonly string Username03 = "User 03";
+        public readonly string SyncDir = Path.GetTempPath();
+        public readonly string ContextBefore = "Context before ";
+        public readonly string ContextAfter = " context after.";
+        public readonly string AlternateBefore = "Alternate before ";
+        public readonly string AlternateAfter = " alternate after.";
+        public readonly string ReattachedSelectedText = "reattached text";
+        public readonly int TagCount = 10;
 
-            // User04 is a SF user and is not a PT user.
-            public readonly string User04 = "user04";
-            public readonly string Username01 = "User 01";
-            public readonly string Username02 = "User 02";
-            public readonly string Username03 = "User 03";
-            public readonly string SyncDir = Path.GetTempPath();
-            public readonly string ContextBefore = "Context before ";
-            public readonly string ContextAfter = " context after.";
-            public readonly string AlternateBefore = "Alternate before ";
-            public readonly string AlternateAfter = " alternate after.";
-            public readonly string ReattachedSelectedText = "reattached text";
-            public readonly int TagCount = 10;
+        private readonly string ruthBookUsfm =
+            "\\id RUT - ProjectNameHere\n" + "\\c 1\n" + "\\v 1 Verse 1 here.\n" + "\\v 2 Verse 2 here.";
 
-            private readonly string ruthBookUsfm =
-                "\\id RUT - ProjectNameHere\n" + "\\c 1\n" + "\\v 1 Verse 1 here.\n" + "\\v 2 Verse 2 here.";
-
-            public readonly HttpResponseMessage UnauthorizedHttpResponseMessage =
-                new(HttpStatusCode.Unauthorized)
-                {
-                    RequestMessage = new HttpRequestMessage(HttpMethod.Get, "some-request-uri"),
-                    Content = new ByteArrayContent(Encoding.UTF8.GetBytes("big problem"))
-                };
-
-            public readonly HttpResponseMessage NotFoundHttpResponseMessage =
-                new(HttpStatusCode.NotFound)
-                {
-                    RequestMessage = new HttpRequestMessage(HttpMethod.Get, "some-request-uri"),
-                    Content = new ByteArrayContent(Encoding.UTF8.GetBytes("we looked everywhere"))
-                };
-
-            public readonly IWebHostEnvironment MockWebHostEnvironment;
-            public readonly IOptions<ParatextOptions> MockParatextOptions;
-            public readonly IRepository<UserSecret> MockRepository;
-            public readonly SFMemoryRealtimeService RealtimeService;
-            public readonly IExceptionHandler MockExceptionHandler;
-            public readonly IOptions<SiteOptions> MockSiteOptions;
-            public readonly IFileSystemService MockFileSystemService;
-            public readonly IScrTextCollection MockScrTextCollection;
-            public readonly ISharingLogicWrapper MockSharingLogicWrapper;
-            public readonly IHgWrapper MockHgWrapper;
-            public readonly MockLogger<ParatextService> MockLogger;
-            public readonly IJwtTokenHelper MockJwtTokenHelper;
-            public readonly IParatextDataHelper MockParatextDataHelper;
-            public readonly IInternetSharedRepositorySourceProvider MockInternetSharedRepositorySourceProvider;
-            public readonly ISFRestClientFactory MockRestClientFactory;
-            public readonly IGuidService MockGuidService;
-            public readonly ParatextService Service;
-            public readonly HttpClient MockRegistryHttpClient;
-            private bool disposed;
-
-            public TestEnvironment()
+        public readonly HttpResponseMessage UnauthorizedHttpResponseMessage =
+            new(HttpStatusCode.Unauthorized)
             {
-                MockWebHostEnvironment = Substitute.For<IWebHostEnvironment>();
-                MockParatextOptions = Substitute.For<IOptions<ParatextOptions>>();
-                MockExceptionHandler = Substitute.For<IExceptionHandler>();
-                MockSiteOptions = Substitute.For<IOptions<SiteOptions>>();
-                MockFileSystemService = Substitute.For<IFileSystemService>();
-                MockLogger = new MockLogger<ParatextService>();
-                MockScrTextCollection = Substitute.For<IScrTextCollection>();
-                MockSharingLogicWrapper = Substitute.For<ISharingLogicWrapper>();
-                MockHgWrapper = Substitute.For<IHgWrapper>();
-                MockJwtTokenHelper = Substitute.For<IJwtTokenHelper>();
-                MockParatextDataHelper = Substitute.For<IParatextDataHelper>();
-                MockInternetSharedRepositorySourceProvider = Substitute.For<IInternetSharedRepositorySourceProvider>();
-                MockRestClientFactory = Substitute.For<ISFRestClientFactory>();
-                MockGuidService = Substitute.For<IGuidService>();
-                MockRegistryHttpClient = Substitute.For<HttpClient>();
+                RequestMessage = new HttpRequestMessage(HttpMethod.Get, "some-request-uri"),
+                Content = new ByteArrayContent(Encoding.UTF8.GetBytes("big problem"))
+            };
 
-                DateTime aSecondAgo = DateTime.Now - TimeSpan.FromSeconds(1);
-                string accessToken1 = TokenHelper.CreateAccessToken(
-                    aSecondAgo - TimeSpan.FromMinutes(20),
-                    aSecondAgo,
-                    ParatextUserId01
-                );
-                string accessToken2 = TokenHelper.CreateAccessToken(
-                    aSecondAgo - TimeSpan.FromMinutes(20),
-                    aSecondAgo,
-                    ParatextUserId02
-                );
-                string accessToken3 = TokenHelper.CreateAccessToken(
-                    aSecondAgo - TimeSpan.FromMinutes(20),
-                    aSecondAgo,
-                    ParatextUserId03
-                );
-                MockRepository = new MemoryRepository<UserSecret>(
-                    new[]
+        public readonly HttpResponseMessage NotFoundHttpResponseMessage =
+            new(HttpStatusCode.NotFound)
+            {
+                RequestMessage = new HttpRequestMessage(HttpMethod.Get, "some-request-uri"),
+                Content = new ByteArrayContent(Encoding.UTF8.GetBytes("we looked everywhere"))
+            };
+
+        public readonly IWebHostEnvironment MockWebHostEnvironment;
+        public readonly IOptions<ParatextOptions> MockParatextOptions;
+        public readonly IRepository<UserSecret> MockRepository;
+        public readonly SFMemoryRealtimeService RealtimeService;
+        public readonly IExceptionHandler MockExceptionHandler;
+        public readonly IOptions<SiteOptions> MockSiteOptions;
+        public readonly IFileSystemService MockFileSystemService;
+        public readonly IScrTextCollection MockScrTextCollection;
+        public readonly ISharingLogicWrapper MockSharingLogicWrapper;
+        public readonly IHgWrapper MockHgWrapper;
+        public readonly MockLogger<ParatextService> MockLogger;
+        public readonly IJwtTokenHelper MockJwtTokenHelper;
+        public readonly IParatextDataHelper MockParatextDataHelper;
+        public readonly IInternetSharedRepositorySourceProvider MockInternetSharedRepositorySourceProvider;
+        public readonly ISFRestClientFactory MockRestClientFactory;
+        public readonly IGuidService MockGuidService;
+        public readonly ParatextService Service;
+        public readonly HttpClient MockRegistryHttpClient;
+        private bool disposed;
+
+        public TestEnvironment()
+        {
+            MockWebHostEnvironment = Substitute.For<IWebHostEnvironment>();
+            MockParatextOptions = Substitute.For<IOptions<ParatextOptions>>();
+            MockExceptionHandler = Substitute.For<IExceptionHandler>();
+            MockSiteOptions = Substitute.For<IOptions<SiteOptions>>();
+            MockFileSystemService = Substitute.For<IFileSystemService>();
+            MockLogger = new MockLogger<ParatextService>();
+            MockScrTextCollection = Substitute.For<IScrTextCollection>();
+            MockSharingLogicWrapper = Substitute.For<ISharingLogicWrapper>();
+            MockHgWrapper = Substitute.For<IHgWrapper>();
+            MockJwtTokenHelper = Substitute.For<IJwtTokenHelper>();
+            MockParatextDataHelper = Substitute.For<IParatextDataHelper>();
+            MockInternetSharedRepositorySourceProvider = Substitute.For<IInternetSharedRepositorySourceProvider>();
+            MockRestClientFactory = Substitute.For<ISFRestClientFactory>();
+            MockGuidService = Substitute.For<IGuidService>();
+            MockRegistryHttpClient = Substitute.For<HttpClient>();
+
+            DateTime aSecondAgo = DateTime.Now - TimeSpan.FromSeconds(1);
+            string accessToken1 = TokenHelper.CreateAccessToken(
+                aSecondAgo - TimeSpan.FromMinutes(20),
+                aSecondAgo,
+                ParatextUserId01
+            );
+            string accessToken2 = TokenHelper.CreateAccessToken(
+                aSecondAgo - TimeSpan.FromMinutes(20),
+                aSecondAgo,
+                ParatextUserId02
+            );
+            string accessToken3 = TokenHelper.CreateAccessToken(
+                aSecondAgo - TimeSpan.FromMinutes(20),
+                aSecondAgo,
+                ParatextUserId03
+            );
+            MockRepository = new MemoryRepository<UserSecret>(
+                new[]
+                {
+                    new UserSecret
                     {
-                        new UserSecret
-                        {
-                            Id = User01,
-                            ParatextTokens = new Tokens
-                            {
-                                AccessToken = accessToken1,
-                                RefreshToken = "refresh_token_1234"
-                            },
-                        },
-                        new UserSecret
-                        {
-                            Id = User02,
-                            ParatextTokens = new Tokens
-                            {
-                                AccessToken = accessToken2,
-                                RefreshToken = "refresh_token_1234"
-                            },
-                        },
-                        new UserSecret
-                        {
-                            Id = User03,
-                            ParatextTokens = new Tokens
-                            {
-                                AccessToken = accessToken3,
-                                RefreshToken = "refresh_token_1234"
-                            },
-                        },
-                    }
-                );
+                        Id = User01,
+                        ParatextTokens = new Tokens { AccessToken = accessToken1, RefreshToken = "refresh_token_1234" },
+                    },
+                    new UserSecret
+                    {
+                        Id = User02,
+                        ParatextTokens = new Tokens { AccessToken = accessToken2, RefreshToken = "refresh_token_1234" },
+                    },
+                    new UserSecret
+                    {
+                        Id = User03,
+                        ParatextTokens = new Tokens { AccessToken = accessToken3, RefreshToken = "refresh_token_1234" },
+                    },
+                }
+            );
 
-                RealtimeService = new SFMemoryRealtimeService();
+            RealtimeService = new SFMemoryRealtimeService();
 
-                int guidServiceCharId = 1;
-                MockGuidService.Generate().Returns(_ => $"{guidServiceCharId++}");
-                string guidServiceGuidPrefix = "syncuser0";
-                int guidServiceObjectId = 2;
-                MockGuidService.NewObjectId().Returns(_ => guidServiceGuidPrefix + guidServiceObjectId++);
+            int guidServiceCharId = 1;
+            MockGuidService.Generate().Returns(_ => $"{guidServiceCharId++}");
+            string guidServiceGuidPrefix = "syncuser0";
+            int guidServiceObjectId = 2;
+            MockGuidService.NewObjectId().Returns(_ => guidServiceGuidPrefix + guidServiceObjectId++);
 
-                Service = new ParatextService(
-                    MockWebHostEnvironment,
-                    MockParatextOptions,
-                    MockRepository,
-                    RealtimeService,
-                    MockExceptionHandler,
-                    MockSiteOptions,
-                    MockFileSystemService,
-                    MockLogger,
-                    MockJwtTokenHelper,
-                    MockParatextDataHelper,
-                    MockInternetSharedRepositorySourceProvider,
-                    MockGuidService,
-                    MockRestClientFactory,
-                    MockHgWrapper
-                );
-                Service.ScrTextCollection = MockScrTextCollection;
-                Service.SharingLogicWrapper = MockSharingLogicWrapper;
-                Service.SyncDir = SyncDir;
-                Service._registryClient = MockRegistryHttpClient;
-
-                PTProjectIds.Add(Project01, HexId.CreateNew());
-                PTProjectIds.Add(Project02, HexId.CreateNew());
-                PTProjectIds.Add(Project03, HexId.CreateNew());
-                PTProjectIds.Add(Project04, HexId.CreateNew());
-
-                MockJwtTokenHelper
-                    .GetParatextUsername(Arg.Is<UserSecret>(u => u != null && u.Id == User01))
-                    .Returns(Username01);
-                MockJwtTokenHelper
-                    .GetParatextUsername(Arg.Is<UserSecret>(u => u != null && u.Id == User02))
-                    .Returns(Username02);
-                MockJwtTokenHelper
-                    .GetParatextUsername(Arg.Is<UserSecret>(u => u != null && u.Id == User03))
-                    .Returns(Username03);
-                MockJwtTokenHelper.GetJwtTokenFromUserSecret(Arg.Any<UserSecret>()).Returns(accessToken1);
-                MockJwtTokenHelper
-                    .RefreshAccessTokenAsync(
-                        Arg.Any<ParatextOptions>(),
-                        Arg.Any<Tokens>(),
-                        Arg.Any<HttpClient>(),
-                        Arg.Any<CancellationToken>()
-                    )
-                    .Returns(
-                        Task.FromResult(new Tokens { AccessToken = accessToken1, RefreshToken = "refresh_token_1234" })
-                    );
-                MockFileSystemService.DirectoryExists(SyncDir).Returns(true);
-                RegistryU.Implementation = new DotNetCoreRegistry();
-                ScrTextCollection.Implementation = new SFScrTextCollection();
-                AddProjectRepository();
-            }
-
-            public MockScrText ProjectScrText { get; set; }
-            public CommentManager ProjectCommentManager { get; set; }
-            public ProjectFileManager ProjectFileManager { get; set; }
-
-            public HttpResponseMessage MakeOkHttpResponseMessage(string content)
+            Service = new ParatextService(
+                MockWebHostEnvironment,
+                MockParatextOptions,
+                MockRepository,
+                RealtimeService,
+                MockExceptionHandler,
+                MockSiteOptions,
+                MockFileSystemService,
+                MockLogger,
+                MockJwtTokenHelper,
+                MockParatextDataHelper,
+                MockInternetSharedRepositorySourceProvider,
+                MockGuidService,
+                MockRestClientFactory,
+                MockHgWrapper
+            )
             {
-                return new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    RequestMessage = new HttpRequestMessage(HttpMethod.Get, "some-request-uri"),
-                    Content = new ByteArrayContent(Encoding.UTF8.GetBytes(content))
-                };
-            }
+                ScrTextCollection = MockScrTextCollection,
+                SharingLogicWrapper = MockSharingLogicWrapper,
+                SyncDir = SyncDir,
+                _registryClient = MockRegistryHttpClient
+            };
 
-            public UserSecret MakeUserSecret(string userSecretId, string username, string paratextUserId)
-            {
-                DateTime aSecondAgo = DateTime.Now - TimeSpan.FromSeconds(1);
-                string accessToken = TokenHelper.CreateAccessToken(
-                    aSecondAgo - TimeSpan.FromMinutes(20),
-                    aSecondAgo,
-                    paratextUserId
+            PTProjectIds.Add(Project01, HexId.CreateNew());
+            PTProjectIds.Add(Project02, HexId.CreateNew());
+            PTProjectIds.Add(Project03, HexId.CreateNew());
+            PTProjectIds.Add(Project04, HexId.CreateNew());
+
+            MockJwtTokenHelper
+                .GetParatextUsername(Arg.Is<UserSecret>(u => u != null && u.Id == User01))
+                .Returns(Username01);
+            MockJwtTokenHelper
+                .GetParatextUsername(Arg.Is<UserSecret>(u => u != null && u.Id == User02))
+                .Returns(Username02);
+            MockJwtTokenHelper
+                .GetParatextUsername(Arg.Is<UserSecret>(u => u != null && u.Id == User03))
+                .Returns(Username03);
+            MockJwtTokenHelper.GetJwtTokenFromUserSecret(Arg.Any<UserSecret>()).Returns(accessToken1);
+            MockJwtTokenHelper
+                .RefreshAccessTokenAsync(
+                    Arg.Any<ParatextOptions>(),
+                    Arg.Any<Tokens>(),
+                    Arg.Any<HttpClient>(),
+                    Arg.Any<CancellationToken>()
+                )
+                .Returns(
+                    Task.FromResult(new Tokens { AccessToken = accessToken1, RefreshToken = "refresh_token_1234" })
                 );
-                UserSecret userSecret = new UserSecret
-                {
-                    Id = userSecretId,
-                    ParatextTokens = new Tokens { AccessToken = accessToken, RefreshToken = "refresh_token_1234" }
-                };
-                return userSecret;
-            }
+            MockFileSystemService.DirectoryExists(SyncDir).Returns(true);
+            RegistryU.Implementation = new DotNetCoreRegistry();
+            ScrTextCollection.Implementation = new SFScrTextCollection();
+            AddProjectRepository();
+        }
 
-            public ISFRestClientFactory SetRestClientFactory(UserSecret userSecret)
+        public MockScrText ProjectScrText { get; set; }
+        public CommentManager ProjectCommentManager { get; set; }
+        public ProjectFileManager ProjectFileManager { get; set; }
+
+        public static HttpResponseMessage MakeOkHttpResponseMessage(string content)
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK)
             {
-                ISFRestClient mockClient = Substitute.For<ISFRestClient>();
-                string json =
-                    @"{
+                RequestMessage = new HttpRequestMessage(HttpMethod.Get, "some-request-uri"),
+                Content = new ByteArrayContent(Encoding.UTF8.GetBytes(content))
+            };
+        }
+
+        public static UserSecret MakeUserSecret(string userSecretId, string username, string paratextUserId)
+        {
+            DateTime aSecondAgo = DateTime.Now - TimeSpan.FromSeconds(1);
+            string accessToken = TokenHelper.CreateAccessToken(
+                aSecondAgo - TimeSpan.FromMinutes(20),
+                aSecondAgo,
+                paratextUserId
+            );
+            UserSecret userSecret = new UserSecret
+            {
+                Id = userSecretId,
+                ParatextTokens = new Tokens { AccessToken = accessToken, RefreshToken = "refresh_token_1234" }
+            };
+            return userSecret;
+        }
+
+        public ISFRestClientFactory SetRestClientFactory(UserSecret userSecret)
+        {
+            ISFRestClient mockClient = Substitute.For<ISFRestClient>();
+            string json =
+                @"{
     ""resources"": [
         {
             ""languageCode"": ""urw"",
@@ -3576,8 +3472,8 @@ namespace SIL.XForge.Scripture.Services
             ""name"": ""SobP15"",
             ""permissions-checksum"": ""1ab119321b305f99"",
             ""id"": """
-                    + this.Resource1Id
-                    + @""",
+                + this.Resource1Id
+                + @""",
             ""relevance"": {
                 ""basic_permissions"": [
                     ""allow_any_user""
@@ -3596,8 +3492,8 @@ namespace SIL.XForge.Scripture.Services
             ""name"": ""AruNT04"",
             ""permissions-checksum"": ""1ab119321b305f99"",
             ""id"": """
-                    + this.Resource2Id
-                    + @""",
+                + this.Resource2Id
+                + @""",
             ""relevance"": {
                 ""basic_permissions"": [
                     ""allow_any_user""
@@ -3616,8 +3512,8 @@ namespace SIL.XForge.Scripture.Services
             ""name"": ""RV1895"",
             ""permissions-checksum"": ""1ab119321b305f99"",
             ""id"": """
-                    + this.Resource3Id
-                    + @""",
+                + this.Resource3Id
+                + @""",
             ""relevance"": {
                 ""basic_permissions"": [
                     ""allow_any_user""
@@ -3628,817 +3524,796 @@ namespace SIL.XForge.Scripture.Services
         }
     ]
 }";
-                mockClient.Get(Arg.Any<string>()).Returns(json);
-                mockClient.GetFile(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
-                MockRestClientFactory
-                    .Create(Arg.Any<string>(), Arg.Is<UserSecret>(s => s.Id == userSecret.Id))
-                    .Returns(mockClient);
-                return MockRestClientFactory;
-            }
+            mockClient.Get(Arg.Any<string>()).Returns(json);
+            mockClient.GetFile(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+            MockRestClientFactory
+                .Create(Arg.Any<string>(), Arg.Is<UserSecret>(s => s.Id == userSecret.Id))
+                .Returns(mockClient);
+            return MockRestClientFactory;
+        }
 
-            /// <summary>
-            /// If extraSharedRepository, a SharedRepository will be made that does not have corresponding
-            /// ProjectMetadata.
-            /// </summary>
-            public IInternetSharedRepositorySource SetSharedRepositorySource(
-                UserSecret userSecret,
-                UserRoles userRoleOnAllThePtProjects,
-                bool extraSharedRepository = false
-            )
+        /// <summary>
+        /// If extraSharedRepository, a SharedRepository will be made that does not have corresponding
+        /// ProjectMetadata.
+        /// </summary>
+        public IInternetSharedRepositorySource SetSharedRepositorySource(
+            UserSecret userSecret,
+            UserRoles userRoleOnAllThePtProjects,
+            bool extraSharedRepository = false
+        )
+        {
+            // Set up the XML for the user roles - we could use an XML Document, but this is simpler
+            // The schema is from ParatextData.InternalProjectUserAccessData
+            // As the logic in PermissionManager is self-contained, this is better than a substitute
+            string xml =
+                "<ProjectUserAccess PeerSharing=\"true\">"
+                + $"<User UserName=\"{Username01}\" FirstUser=\"true\" UnregisteredUser=\"false\">"
+                + $"<Role>{userRoleOnAllThePtProjects}</Role><AllBooks>true</AllBooks>"
+                + "<Books /><Permissions /><AutomaticBooks /><AutomaticPermissions />"
+                + "</User>"
+                + $"<User UserName=\"{Username02}\" FirstUser=\"false\" UnregisteredUser=\"false\">"
+                + $"<Role>{userRoleOnAllThePtProjects}</Role><AllBooks>true</AllBooks>"
+                + "<Books /><Permissions /><AutomaticBooks /><AutomaticPermissions />"
+                + "</User>"
+                + $"<User UserName=\"{Username03}\" FirstUser=\"false\" UnregisteredUser=\"false\">"
+                + $"<Role>{userRoleOnAllThePtProjects}</Role><AllBooks>true</AllBooks>"
+                + "<Books /><Permissions /><AutomaticBooks /><AutomaticPermissions />"
+                + "</User>"
+                + "</ProjectUserAccess>";
+            PermissionManager sourceUsers = new PermissionManager(xml);
+            IInternetSharedRepositorySource mockSource = Substitute.For<IInternetSharedRepositorySource>();
+            SharedRepository repo1 = new SharedRepository
             {
-                // Set up the XML for the user roles - we could use an XML Document, but this is simpler
-                // The schema is from ParatextData.InternalProjectUserAccessData
-                // As the logic in PermissionManager is self-contained, this is better than a substitute
-                string xml =
-                    "<ProjectUserAccess PeerSharing=\"true\">"
-                    + $"<User UserName=\"{Username01}\" FirstUser=\"true\" UnregisteredUser=\"false\">"
-                    + $"<Role>{userRoleOnAllThePtProjects}</Role><AllBooks>true</AllBooks>"
-                    + "<Books /><Permissions /><AutomaticBooks /><AutomaticPermissions />"
-                    + "</User>"
-                    + $"<User UserName=\"{Username02}\" FirstUser=\"false\" UnregisteredUser=\"false\">"
-                    + $"<Role>{userRoleOnAllThePtProjects}</Role><AllBooks>true</AllBooks>"
-                    + "<Books /><Permissions /><AutomaticBooks /><AutomaticPermissions />"
-                    + "</User>"
-                    + $"<User UserName=\"{Username03}\" FirstUser=\"false\" UnregisteredUser=\"false\">"
-                    + $"<Role>{userRoleOnAllThePtProjects}</Role><AllBooks>true</AllBooks>"
-                    + "<Books /><Permissions /><AutomaticBooks /><AutomaticPermissions />"
-                    + "</User>"
-                    + "</ProjectUserAccess>";
-                PermissionManager sourceUsers = new PermissionManager(xml);
-                IInternetSharedRepositorySource mockSource = Substitute.For<IInternetSharedRepositorySource>();
-                SharedRepository repo1 = new SharedRepository
-                {
-                    SendReceiveId = PTProjectIds[Project01],
-                    ScrTextName = "P01",
-                    SourceUsers = sourceUsers
-                };
-                SharedRepository repo2 = new SharedRepository
-                {
-                    SendReceiveId = PTProjectIds[Project02],
-                    ScrTextName = "P02",
-                    SourceUsers = sourceUsers
-                };
-                SharedRepository repo3 = new SharedRepository
-                {
-                    SendReceiveId = PTProjectIds[Project03],
-                    ScrTextName = "P03",
-                    SourceUsers = sourceUsers
-                };
-                SharedRepository repo4 = new SharedRepository
-                {
-                    SendReceiveId = PTProjectIds[Project04],
-                    ScrTextName = "P04",
-                    SourceUsers = sourceUsers
-                };
-
-                ProjectMetadata projMeta1 = GetMetadata(PTProjectIds[Project01].Id, "Full Name " + Project01);
-                ProjectMetadata projMeta2 = GetMetadata(PTProjectIds[Project02].Id, "Full Name " + Project02);
-                ProjectMetadata projMeta3 = GetMetadata(PTProjectIds[Project03].Id, "Full Name " + Project03);
-
-                var sharedRepositories = new List<SharedRepository> { repo1, repo3, repo2 };
-                if (extraSharedRepository)
-                {
-                    sharedRepositories.Add(repo4);
-                }
-                mockSource.GetRepositories().Returns(sharedRepositories);
-                mockSource.GetProjectsMetaData().Returns(new[] { projMeta1, projMeta2, projMeta3 });
-
-                // An HttpException means that the repo is already unlocked, so any code should be OK with this
-                mockSource
-                    .When(s => s.UnlockRemoteRepository(Arg.Any<SharedRepository>()))
-                    .Do(
-                        x =>
-                            throw Paratext.Data.HttpException.Create(
-                                new WebException(),
-                                GenericRequest.Create(new Uri("http://localhost/"))
-                            )
-                    );
-                MockInternetSharedRepositorySourceProvider
-                    .GetSource(Arg.Is<UserSecret>(s => s.Id == userSecret.Id), Arg.Any<string>(), Arg.Any<string>())
-                    .Returns(mockSource);
-                return mockSource;
-            }
-
-            public SFProject NewSFProject()
+                SendReceiveId = PTProjectIds[Project01],
+                ScrTextName = "P01",
+                SourceUsers = sourceUsers
+            };
+            SharedRepository repo2 = new SharedRepository
             {
-                return new SFProject
+                SendReceiveId = PTProjectIds[Project02],
+                ScrTextName = "P02",
+                SourceUsers = sourceUsers
+            };
+            SharedRepository repo3 = new SharedRepository
+            {
+                SendReceiveId = PTProjectIds[Project03],
+                ScrTextName = "P03",
+                SourceUsers = sourceUsers
+            };
+            SharedRepository repo4 = new SharedRepository
+            {
+                SendReceiveId = PTProjectIds[Project04],
+                ScrTextName = "P04",
+                SourceUsers = sourceUsers
+            };
+
+            ProjectMetadata projMeta1 = GetMetadata(PTProjectIds[Project01].Id, "Full Name " + Project01);
+            ProjectMetadata projMeta2 = GetMetadata(PTProjectIds[Project02].Id, "Full Name " + Project02);
+            ProjectMetadata projMeta3 = GetMetadata(PTProjectIds[Project03].Id, "Full Name " + Project03);
+
+            var sharedRepositories = new List<SharedRepository> { repo1, repo3, repo2 };
+            if (extraSharedRepository)
+            {
+                sharedRepositories.Add(repo4);
+            }
+            mockSource.GetRepositories().Returns(sharedRepositories);
+            mockSource.GetProjectsMetaData().Returns(new[] { projMeta1, projMeta2, projMeta3 });
+
+            // An HttpException means that the repo is already unlocked, so any code should be OK with this
+            mockSource
+                .When(s => s.UnlockRemoteRepository(Arg.Any<SharedRepository>()))
+                .Do(
+                    x =>
+                        throw Paratext.Data.HttpException.Create(
+                            new WebException(),
+                            GenericRequest.Create(new Uri("http://localhost/"))
+                        )
+                );
+            MockInternetSharedRepositorySourceProvider
+                .GetSource(Arg.Is<UserSecret>(s => s.Id == userSecret.Id), Arg.Any<string>(), Arg.Any<string>())
+                .Returns(mockSource);
+            return mockSource;
+        }
+
+        public SFProject NewSFProject()
+        {
+            return new SFProject
+            {
+                Id = "sf_id_" + Project01,
+                ParatextId = PTProjectIds[Project01].Id,
+                Name = "Full Name " + Project01,
+                ShortName = "P01",
+                WritingSystem = new WritingSystem { Tag = "writingsystem_tag" },
+                TranslateConfig = new TranslateConfig
                 {
-                    Id = "sf_id_" + Project01,
-                    ParatextId = PTProjectIds[Project01].Id,
-                    Name = "Full Name " + Project01,
-                    ShortName = "P01",
-                    WritingSystem = new WritingSystem { Tag = "writingsystem_tag" },
-                    TranslateConfig = new TranslateConfig
+                    TranslationSuggestionsEnabled = true,
+                    Source = new TranslateSource
                     {
-                        TranslationSuggestionsEnabled = true,
-                        Source = new TranslateSource
+                        ParatextId = "paratextId",
+                        Name = "Source",
+                        ShortName = "SRC",
+                        WritingSystem = new WritingSystem { Tag = "qaa" }
+                    }
+                },
+                CheckingConfig = new CheckingConfig { ShareEnabled = false },
+                UserRoles = new Dictionary<string, string>
+                {
+                    { User01, SFProjectRole.Administrator },
+                    { User02, SFProjectRole.CommunityChecker }
+                },
+                Texts =
+                {
+                    new TextInfo
+                    {
+                        BookNum = 40,
+                        Chapters =
                         {
-                            ParatextId = "paratextId",
-                            Name = "Source",
-                            ShortName = "SRC",
-                            WritingSystem = new WritingSystem { Tag = "qaa" }
+                            new Chapter
+                            {
+                                Number = 1,
+                                LastVerse = 6,
+                                IsValid = true,
+                                Permissions = { }
+                            }
                         }
                     },
-                    CheckingConfig = new CheckingConfig { ShareEnabled = false },
-                    UserRoles = new Dictionary<string, string>
+                    new TextInfo
                     {
-                        { User01, SFProjectRole.Administrator },
-                        { User02, SFProjectRole.CommunityChecker }
-                    },
-                    Texts =
-                    {
-                        new TextInfo
+                        BookNum = 41,
+                        Chapters =
                         {
-                            BookNum = 40,
-                            Chapters =
+                            new Chapter
                             {
-                                new Chapter
-                                {
-                                    Number = 1,
-                                    LastVerse = 6,
-                                    IsValid = true,
-                                    Permissions = { }
-                                }
-                            }
-                        },
-                        new TextInfo
-                        {
-                            BookNum = 41,
-                            Chapters =
+                                Number = 1,
+                                LastVerse = 3,
+                                IsValid = true,
+                                Permissions = { }
+                            },
+                            new Chapter
                             {
-                                new Chapter
-                                {
-                                    Number = 1,
-                                    LastVerse = 3,
-                                    IsValid = true,
-                                    Permissions = { }
-                                },
-                                new Chapter
-                                {
-                                    Number = 2,
-                                    LastVerse = 3,
-                                    IsValid = true,
-                                    Permissions = { }
-                                }
+                                Number = 2,
+                                LastVerse = 3,
+                                IsValid = true,
+                                Permissions = { }
                             }
                         }
                     }
-                };
-            }
+                }
+            };
+        }
 
-            public void AddProjectRepository(SFProject proj = null)
-            {
-                proj ??= NewSFProject();
-                RealtimeService.AddRepository(
-                    "sf_projects",
-                    OTType.Json0,
-                    new MemoryRepository<SFProject>(new[] { proj })
-                );
-                MockFileSystemService
-                    .DirectoryExists(
-                        Arg.Is<string>(
-                            (string path) => path.EndsWith(Path.Combine(PTProjectIds[Project01].Id, "target"))
-                        )
-                    )
-                    .Returns(true);
-            }
+        public void AddProjectRepository(SFProject proj = null)
+        {
+            proj ??= NewSFProject();
+            RealtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(new[] { proj }));
+            MockFileSystemService
+                .DirectoryExists(
+                    Arg.Is<string>((string path) => path.EndsWith(Path.Combine(PTProjectIds[Project01].Id, "target")))
+                )
+                .Returns(true);
+        }
 
-            public void AddTextDocs(
-                int bookNum,
-                int chapterNum,
-                int verses,
-                string contextBefore,
-                string selectedText,
-                bool useThreadSuffix = true
-            )
-            {
-                TextData[] texts = new TextData[1];
-                Delta chapterDelta = GetChapterDelta(
-                    chapterNum,
-                    verses,
-                    contextBefore,
-                    selectedText,
-                    useThreadSuffix,
-                    false
-                );
-                texts[0] = new TextData(chapterDelta) { Id = TextData.GetTextDocId(Project01, bookNum, chapterNum) };
-                RealtimeService.AddRepository("texts", OTType.RichText, new MemoryRepository<TextData>(texts));
-            }
+        public void AddTextDocs(
+            int bookNum,
+            int chapterNum,
+            int verses,
+            string contextBefore,
+            string selectedText,
+            bool useThreadSuffix = true
+        )
+        {
+            TextData[] texts = new TextData[1];
+            Delta chapterDelta = GetChapterDelta(
+                chapterNum,
+                verses,
+                contextBefore,
+                selectedText,
+                useThreadSuffix,
+                false
+            );
+            texts[0] = new TextData(chapterDelta) { Id = TextData.GetTextDocId(Project01, bookNum, chapterNum) };
+            RealtimeService.AddRepository("texts", OTType.RichText, new MemoryRepository<TextData>(texts));
+        }
 
-            public void AddTextDoc(int bookNum, int chapterNum)
-            {
-                TextData[] texts = new TextData[1];
-                Delta chapterDelta = Delta.New().Insert("In the beginning");
-                texts[0] = new TextData(chapterDelta) { Id = TextData.GetTextDocId(Project01, bookNum, chapterNum) };
-                RealtimeService.AddRepository("texts", OTType.RichText, new MemoryRepository<TextData>(texts));
-            }
+        public void AddTextDoc(int bookNum, int chapterNum)
+        {
+            TextData[] texts = new TextData[1];
+            Delta chapterDelta = Delta.New().Insert("In the beginning");
+            texts[0] = new TextData(chapterDelta) { Id = TextData.GetTextDocId(Project01, bookNum, chapterNum) };
+            RealtimeService.AddRepository("texts", OTType.RichText, new MemoryRepository<TextData>(texts));
+        }
 
-            public void AddNoteThreadData(ThreadComponents[] threadComponents)
+        public void AddNoteThreadData(ThreadComponents[] threadComponents)
+        {
+            IEnumerable<NoteThread> threads = Array.Empty<NoteThread>();
+            foreach (var comp in threadComponents)
             {
-                IEnumerable<NoteThread> threads = new NoteThread[0];
-                foreach (var comp in threadComponents)
+                string threadId = "thread" + comp.threadNum;
+                string text = "Text selected " + threadId;
+                string selectedText = comp.appliesToVerse ? ContextBefore + text + ContextAfter : text;
+
+                var noteThread = new NoteThread
                 {
-                    string threadId = "thread" + comp.threadNum;
-                    string text = "Text selected " + threadId;
-                    string selectedText = comp.appliesToVerse ? ContextBefore + text + ContextAfter : text;
-
-                    var noteThread = new NoteThread
+                    Id = "project01:" + threadId,
+                    DataId = threadId,
+                    ProjectRef = "project01",
+                    OwnerRef = "user01",
+                    VerseRef = new VerseRefData(40, 1, comp.threadNum),
+                    OriginalSelectedText = selectedText,
+                    OriginalContextBefore = comp.appliesToVerse ? "" : ContextBefore,
+                    Position = comp.appliesToVerse
+                        ? new TextAnchor()
+                        : new TextAnchor { Start = ContextBefore.Length, Length = text.Length },
+                    OriginalContextAfter = comp.appliesToVerse ? "" : ContextAfter,
+                    Status = NoteStatus.Todo.InternalValue,
+                    Assignment =
+                        comp.notes == null
+                            ? Paratext.Data.ProjectComments.CommentThread.unassignedUser
+                            : comp.notes[^1].assignedPTUser
+                };
+                List<Note> notes = new List<Note>();
+                for (int i = 1; i <= comp.noteCount; i++)
+                {
+                    ThreadNoteComponents noteComponent = new ThreadNoteComponents
                     {
-                        Id = "project01:" + threadId,
-                        DataId = threadId,
-                        ProjectRef = "project01",
-                        OwnerRef = "user01",
-                        VerseRef = new VerseRefData(40, 1, comp.threadNum),
-                        OriginalSelectedText = selectedText,
-                        OriginalContextBefore = comp.appliesToVerse ? "" : ContextBefore,
-                        Position = comp.appliesToVerse
-                            ? new TextAnchor()
-                            : new TextAnchor { Start = ContextBefore.Length, Length = text.Length },
-                        OriginalContextAfter = comp.appliesToVerse ? "" : ContextAfter,
-                        Status = NoteStatus.Todo.InternalValue,
-                        Assignment =
-                            comp.notes == null
-                                ? Paratext.Data.ProjectComments.CommentThread.unassignedUser
-                                : comp.notes[comp.notes.Count() - 1].assignedPTUser
+                        status = NoteStatus.Todo,
+                        tagsAdded = new[] { Paratext.Data.ProjectComments.CommentTag.toDoTagId.ToString() },
+                        assignedPTUser = Paratext.Data.ProjectComments.CommentThread.unassignedUser
                     };
-                    List<Note> notes = new List<Note>();
-                    for (int i = 1; i <= comp.noteCount; i++)
+                    if (comp.notes != null)
+                        noteComponent = comp.notes[i - 1];
+                    Note note = new Note
                     {
-                        ThreadNoteComponents noteComponent = new ThreadNoteComponents
+                        DataId = $"n{i}on{threadId}",
+                        ThreadId = threadId,
+                        Type = NoteType.Normal.InternalValue,
+                        ConflictType = Note.NoConflictType,
+                        OwnerRef = "user02",
+                        ExtUserId = "user02",
+                        Content = comp.isEdited
+                            ? $"<p>{threadId} note {i}: EDITED.</p>"
+                            : $"<p>{threadId} note {i}.</p>",
+                        SyncUserRef = comp.isNew ? null : "syncuser01",
+                        DateCreated = new DateTime(2019, 1, i, 8, 0, 0, DateTimeKind.Utc),
+                        TagId = noteComponent.tagsAdded == null ? null : int.Parse(noteComponent.tagsAdded[0]),
+                        Deleted = comp.isDeleted,
+                        Status = noteComponent.status.InternalValue,
+                        Assignment = noteComponent.assignedPTUser
+                    };
+                    notes.Add(note);
+                    if (noteComponent.duplicate)
+                        notes.Add(note);
+                }
+                if (comp.reattachedVerseStr != null)
+                {
+                    ReattachedThreadInfo rti = GetReattachedThreadInfo(comp.reattachedVerseStr);
+                    notes.Add(
+                        new Note
                         {
-                            status = NoteStatus.Todo,
-                            tagsAdded = new[] { Paratext.Data.ProjectComments.CommentTag.toDoTagId.ToString() },
-                            assignedPTUser = Paratext.Data.ProjectComments.CommentThread.unassignedUser
-                        };
-                        if (comp.notes != null)
-                            noteComponent = comp.notes[i - 1];
-                        Note note = new Note
-                        {
-                            DataId = $"n{i}on{threadId}",
+                            DataId = $"reattached{threadId}",
                             ThreadId = threadId,
                             Type = NoteType.Normal.InternalValue,
                             ConflictType = Note.NoConflictType,
                             OwnerRef = "user02",
                             ExtUserId = "user02",
-                            Content = comp.isEdited
-                                ? $"<p>{threadId} note {i}: EDITED.</p>"
-                                : $"<p>{threadId} note {i}.</p>",
-                            SyncUserRef = comp.isNew ? null : "syncuser01",
-                            DateCreated = new DateTime(2019, 1, i, 8, 0, 0, DateTimeKind.Utc),
-                            TagId = noteComponent.tagsAdded == null ? null : int.Parse(noteComponent.tagsAdded[0]),
-                            Deleted = comp.isDeleted,
-                            Status = noteComponent.status.InternalValue,
-                            Assignment = noteComponent.assignedPTUser
-                        };
-                        notes.Add(note);
-                        if (noteComponent.duplicate)
-                            notes.Add(note);
-                    }
-                    if (comp.reattachedVerseStr != null)
-                    {
-                        ReattachedThreadInfo rti = GetReattachedThreadInfo(comp.reattachedVerseStr);
-                        notes.Add(
-                            new Note
-                            {
-                                DataId = $"reattached{threadId}",
-                                ThreadId = threadId,
-                                Type = NoteType.Normal.InternalValue,
-                                ConflictType = Note.NoConflictType,
-                                OwnerRef = "user02",
-                                ExtUserId = "user02",
-                                SyncUserRef = "syncuser01",
-                                DateCreated = new DateTime(2019, 1, 20, 8, 0, 0, DateTimeKind.Utc),
-                                Status = NoteStatus.Unspecified.InternalValue,
-                                Reattached = ReattachedThreadInfoStr(rti)
-                            }
-                        );
-                        noteThread.Position = new TextAnchor
-                        {
-                            Start = rti.contextBefore.Length,
-                            Length = rti.selectedText.Length
-                        };
-                    }
-                    noteThread.Notes = notes;
-                    if (notes.Count > 0)
-                        threads = threads.Append(noteThread);
-                }
-                RealtimeService.AddRepository("note_threads", OTType.Json0, new MemoryRepository<NoteThread>(threads));
-            }
-
-            public void AddThread(NoteThread thread)
-            {
-                var threads = new NoteThread[1];
-                threads[0] = thread;
-                RealtimeService.AddRepository("note_threads", OTType.Json0, new MemoryRepository<NoteThread>(threads));
-            }
-
-            public Dictionary<int, ChapterDelta> GetChapterDeltasByBook(
-                string projectId,
-                int bookNum,
-                int chapters,
-                string contextBefore,
-                string selectedText,
-                bool useThreadSuffix = true,
-                bool includeRelatedVerse = false
-            )
-            {
-                Dictionary<int, ChapterDelta> chapterDeltas = new Dictionary<int, ChapterDelta>();
-                int numVersesInChapter = 10;
-                for (int i = 1; i <= chapters; i++)
-                {
-                    Delta delta = GetChapterDelta(
-                        i,
-                        numVersesInChapter,
-                        contextBefore,
-                        selectedText,
-                        useThreadSuffix,
-                        includeRelatedVerse
-                    );
-                    chapterDeltas.Add(i, new ChapterDelta(i, numVersesInChapter, true, delta));
-                }
-                return chapterDeltas;
-            }
-
-            public XElement GetUpdateNotesXml(
-                string threadId,
-                string user,
-                DateTime date,
-                string content,
-                string verseRef = "MAT 1:1",
-                bool delete = false
-            )
-            {
-                XElement notesElem = new XElement("notes", new XAttribute("version", "1.1"));
-                XElement threadElem = new XElement(
-                    "thread",
-                    new XAttribute("id", threadId),
-                    new XElement(
-                        "selection",
-                        new XAttribute("verseRef", verseRef),
-                        new XAttribute("startPos", 0),
-                        new XAttribute("selectedText", "")
-                    )
-                );
-                XElement commentElem = new XElement("comment", new XAttribute("user", user));
-                commentElem.Add(new XAttribute("date", date.ToString("o")));
-                XElement contentElem = new XElement("content");
-                contentElem.Add(content);
-                commentElem.Add(contentElem);
-                if (delete)
-                {
-                    commentElem.SetAttributeValue("deleted", true);
-                    commentElem.SetAttributeValue("versionNbr", null);
-                }
-                threadElem.Add(commentElem);
-                notesElem.Add(threadElem);
-                return notesElem;
-            }
-
-            public async Task<IEnumerable<IDocument<NoteThread>>> GetNoteThreadDocsAsync(
-                IConnection connection,
-                string[] threadIds
-            )
-            {
-                List<IDocument<NoteThread>> noteThreadDocs = new List<IDocument<NoteThread>>();
-                foreach (string threadId in threadIds)
-                    noteThreadDocs.Add(await GetNoteThreadDocAsync(connection, threadId));
-                return noteThreadDocs;
-            }
-
-            public async Task<IDocument<NoteThread>> GetNoteThreadDocAsync(IConnection connection, string threadId)
-            {
-                return await connection.FetchAsync<NoteThread>("project01:" + threadId);
-            }
-
-            public string SetupProject(string baseId, ParatextUser associatedPtUser, bool hasEditPermission = true)
-            {
-                string ptProjectId = PTProjectIds[baseId].Id;
-                ProjectScrText = GetScrText(associatedPtUser, ptProjectId, hasEditPermission);
-
-                // We set the file manager here so we can track file manager operations after
-                // the ScrText object has been disposed in ParatextService.
-                ProjectFileManager = Substitute.For<ProjectFileManager>(ProjectScrText, null);
-                ProjectFileManager.IsWritable.Returns(true);
-                ProjectScrText.SetFileManager(ProjectFileManager);
-                ProjectCommentManager = CommentManager.Get(ProjectScrText);
-                MockScrTextCollection.FindById(Arg.Any<string>(), ptProjectId).Returns(ProjectScrText);
-                SetupCommentTags(ProjectScrText, null);
-                return ptProjectId;
-            }
-
-            public void AddParatextComments(ThreadComponents[] components)
-            {
-                XmlDocument doc = new XmlDocument();
-                foreach (ThreadComponents comp in components)
-                {
-                    string threadId = "thread" + comp.threadNum;
-                    var associatedPtUser = new SFParatextUser(comp.username ?? "");
-                    string before = ContextBefore;
-                    string after = ContextAfter;
-                    string text = "Text selected " + threadId;
-                    string selectedText = comp.appliesToVerse ? ContextBefore + text + ContextAfter : text;
-                    string verseStr = $"MAT 1:{comp.threadNum}";
-                    string sectionHeading = "Section heading text";
-
-                    switch (comp.alternateText)
-                    {
-                        case SelectionType.RelatedVerse:
-                            // The alternate text is in a subsequent paragraph with a footnote represented by '*'
-                            before = before + text + after + "\n*";
-                            after = "";
-                            selectedText = "other text in verse";
-                            break;
-                        case SelectionType.Section:
-                            before = before + text + after;
-                            after = "";
-                            selectedText = sectionHeading;
-                            break;
-                        case SelectionType.SectionEnd:
-                            before = before + text + after + sectionHeading;
-                            after = " \\p";
-                            selectedText = "";
-                            break;
-                    }
-
-                    Paratext.Data.ProjectComments.Comment getThreadComment()
-                    {
-                        return new Paratext.Data.ProjectComments.Comment(associatedPtUser)
-                        {
-                            Thread = threadId,
-                            VerseRefStr = verseStr,
-                            SelectedText = selectedText,
-                            ContextBefore = comp.appliesToVerse ? "" : before,
-                            ContextAfter = comp.appliesToVerse ? "" : after,
-                            StartPosition = comp.appliesToVerse ? 0 : before.Length,
-                        };
-                    }
-
-                    for (int i = 1; i <= comp.noteCount; i++)
-                    {
-                        string date = $"2019-01-0{i}T08:00:00.0000000+00:00";
-                        XmlElement content = doc.CreateElement("Contents");
-                        content.InnerXml = comp.isEdited
-                            ? $"<p>{threadId} note {i}: EDITED.</p>"
-                            : $"<p>{threadId} note {i}.</p>";
-                        Paratext.Data.ProjectComments.Comment comment = getThreadComment();
-
-                        ThreadNoteComponents note = new ThreadNoteComponents
-                        {
-                            status = NoteStatus.Todo,
-                            tagsAdded = new[] { Paratext.Data.ProjectComments.CommentTag.toDoTagId.ToString() },
-                            assignedPTUser = Paratext.Data.ProjectComments.CommentThread.unassignedUser
-                        };
-                        if (comp.notes != null)
-                            note = comp.notes[i - 1];
-
-                        comment.Contents = content;
-                        comment.Date = date;
-                        comment.Deleted = comp.isDeleted;
-                        comment.Status = note.status;
-                        comment.ExternalUser = comp.isConflict ? "" : "user02";
-                        comment.TagsAdded = comp.isConflict
-                            ? null
-                            : note.tagsAdded == null
-                                ? null
-                                : note.tagsAdded;
-                        comment.Type = comp.isConflict ? NoteType.Conflict : NoteType.Normal;
-                        comment.ConflictType = NoteConflictType.None;
-                        comment.AssignedUser = note.assignedPTUser;
-                        ProjectCommentManager.AddComment(comment);
-                        if (note.duplicate)
-                            ProjectCommentManager.AddComment(comment);
-                    }
-
-                    if (comp.reattachedVerseStr != null)
-                    {
-                        ReattachedThreadInfo rti = GetReattachedThreadInfo(comp.reattachedVerseStr);
-                        Paratext.Data.ProjectComments.Comment reattachedComment = getThreadComment();
-                        reattachedComment.Status = NoteStatus.Unspecified;
-                        reattachedComment.Date = "2019-01-20T08:00:00.0000000+00:00";
-                        reattachedComment.Reattached = ReattachedThreadInfoStr(rti);
-                        ProjectCommentManager.AddComment(reattachedComment);
-                    }
-                }
-            }
-
-            public void AddParatextComment(Paratext.Data.ProjectComments.Comment comment)
-            {
-                ProjectCommentManager.AddComment(comment);
-            }
-
-            public MockScrText GetScrText(
-                ParatextUser associatedPtUser,
-                string projectId,
-                bool hasEditPermission = true
-            )
-            {
-                string scrtextDir = Path.Combine(SyncDir, projectId, "target");
-                ProjectName projectName = new ProjectName() { ProjectPath = scrtextDir, ShortName = "Proj" };
-                var scrText = new MockScrText(associatedPtUser, projectName);
-                scrText.CachedGuid = HexId.FromStr(projectId);
-                scrText.Permissions.CreateFirstAdminUser();
-                scrText.Data.Add("RUT", ruthBookUsfm);
-                scrText.Settings.BooksPresentSet = new BookSet("RUT");
-                scrText.Settings.LanguageID = LanguageId.English;
-                if (!hasEditPermission)
-                    scrText.Permissions.SetPermission(null, 8, PermissionSet.Manual, false);
-                return scrText;
-            }
-
-            public void SetupCommentTags(MockScrText scrText, NoteTag noteTag)
-            {
-                var tags = new List<CommentTag>();
-                for (int tagId = 1; tagId <= TagCount; tagId++)
-                {
-                    if (tagId < TagCount)
-                    {
-                        if (noteTag != null && tagId == noteTag.TagId)
-                            tags.Add(new CommentTag(noteTag.Name, noteTag.Icon, tagId));
-                        else
-                            tags.Add(new CommentTag($"tag{tagId}", $"icon{tagId}", tagId));
-                    }
-                }
-
-                CommentTags.CommentTagList list = new CommentTags.CommentTagList();
-                list.SerializedData = tags.ToArray();
-                list.SerializedLastUsedId = TagCount;
-                scrText.FileManager.GetXml<CommentTags.CommentTagList>(Arg.Any<string>()).Returns(list);
-            }
-
-            public void SetupSuccessfulSendReceive()
-            {
-                MockSharingLogicWrapper
-                    .ShareChanges(
-                        Arg.Any<List<SharedProject>>(),
-                        Arg.Any<SharedRepositorySource>(),
-                        out Arg.Any<List<SendReceiveResult>>(),
-                        Arg.Any<List<SharedProject>>()
-                    )
-                    .Returns(true);
-                // Have the HandleErrors method run its first argument, which would be the ShareChanges() call.
-                // This helps check that the implementation code is calling ShareChanges().
-                MockSharingLogicWrapper
-                    .HandleErrors(Arg.Any<Action>())
-                    .Returns(callInfo =>
-                    {
-                        callInfo.Arg<Action>()();
-                        return true;
-                    });
-            }
-
-            public ReattachedThreadInfo GetReattachedThreadInfo(string verseStr)
-            {
-                string startPos = AlternateBefore.Length.ToString();
-                return new ReattachedThreadInfo
-                {
-                    verseStr = verseStr,
-                    selectedText = ReattachedSelectedText,
-                    startPos = startPos,
-                    contextBefore = AlternateBefore,
-                    contextAfter = AlternateAfter
-                };
-            }
-
-            public string ReattachedThreadInfoStr(ReattachedThreadInfo rnt)
-            {
-                string[] reattachParts = new[]
-                {
-                    rnt.verseStr,
-                    rnt.selectedText,
-                    rnt.startPos,
-                    rnt.contextBefore,
-                    rnt.contextAfter
-                };
-                return string.Join(StringUtils.orcCharacter, reattachParts);
-            }
-
-            /// <summary>
-            /// Helper method for testing changes detected when comparing incoming Paratext Comments to
-            /// existing SF Notes. `modifyComment` and `modifyNoteThread` allow adjustment to the incoming Paratext
-            /// Comment and the existing SF note thread (and its notes) before they are examined for differences.
-            /// </summary>
-            public async Task<IEnumerable<NoteThreadChange>> PrepareChangeOnSingleCommentAsync(
-                Action<Paratext.Data.ProjectComments.Comment> modifyComment,
-                Action<NoteThread> modifyNoteThread = null
-            )
-            {
-                var env = this;
-                string sfProjectId = env.Project01;
-                var associatedPtUser = new SFParatextUser(env.Username01);
-                string ptProjectId = env.SetupProject(sfProjectId, associatedPtUser);
-                UserSecret userSecret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-                env.AddTextDoc(40, 1);
-                env.MockGuidService.NewObjectId().Returns("thread01note01");
-
-                string threadId = "thread01";
-                string threadOwner = env.User01;
-
-                // Put into the SF DB a NoteThread and a Note, that will need to be updated with new PT Comment data.
-
-                var thread01 = new NoteThread
-                {
-                    Id = "project01:" + threadId,
-                    DataId = threadId,
-                    ProjectRef = sfProjectId,
-                    OwnerRef = threadOwner,
-                    VerseRef = new VerseRefData(40, 1, 1),
-                    OriginalSelectedText = "",
-                    OriginalContextBefore = "",
-                    Position = new TextAnchor(),
-                    OriginalContextAfter = "",
-                    Status = NoteStatus.Todo.InternalValue,
-                    Assignment = Paratext.Data.ProjectComments.CommentThread.unassignedUser,
-                    Notes =
-                    {
-                        new Note
-                        {
-                            DataId = $"{threadId}note01",
-                            ThreadId = threadId,
-                            Type = NoteType.Normal.InternalValue,
-                            ConflictType = Note.NoConflictType,
-                            OwnerRef = threadOwner,
-                            ExtUserId = "user02",
                             SyncUserRef = "syncuser01",
-                            DateCreated = new DateTime(2019, 12, 31, 8, 0, 0, DateTimeKind.Utc),
-                            TagId = CommentTag.toDoTagId,
-                            Deleted = false,
-                            Status = NoteStatus.Todo.InternalValue,
-                            Assignment = Paratext.Data.ProjectComments.CommentThread.unassignedUser,
-                            Content = $"<p>Note content.</p>",
-                            AcceptedChangeXml = null,
+                            DateCreated = new DateTime(2019, 1, 20, 8, 0, 0, DateTimeKind.Utc),
+                            Status = NoteStatus.Unspecified.InternalValue,
+                            Reattached = ReattachedThreadInfoStr(rti)
                         }
-                    }
-                };
-                if (modifyNoteThread != null)
-                {
-                    modifyNoteThread(thread01);
-                }
-
-                env.AddThread(thread01);
-
-                // Create a PT Comment with updated data that SF will consider when composing a change report.
-
-                XmlDocument doc = new XmlDocument();
-                XmlElement commentContents = doc.CreateElement("Contents");
-                commentContents.InnerXml = $"<p>Note content.</p>";
-                var comment = new Paratext.Data.ProjectComments.Comment(associatedPtUser)
-                {
-                    Thread = threadId,
-                    VerseRefStr = "MAT 1:1",
-                    SelectedText = "",
-                    ContextBefore = "",
-                    ContextAfter = "",
-                    StartPosition = 0,
-                    Date = $"2019-12-31T08:00:00.0000000+00:00",
-                    Deleted = false,
-                    Status = NoteStatus.Todo,
-                    Type = NoteType.Normal,
-                    // ConflictType = (unset / default)
-                    AssignedUser = Paratext.Data.ProjectComments.CommentThread.unassignedUser,
-                    Contents = commentContents,
-                    AcceptedChangeXmlStr = null,
-                };
-                modifyComment(comment);
-                env.AddParatextComment(comment);
-
-                await using (IConnection conn = await env.RealtimeService.ConnectAsync())
-                {
-                    IEnumerable<IDocument<NoteThread>> noteThreadDocs = await env.GetNoteThreadDocsAsync(
-                        conn,
-                        new[] { "thread01" }
                     );
-                    Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
+                    noteThread.Position = new TextAnchor
                     {
-                        new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-                    }.ToDictionary(u => u.Username);
-                    Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(
-                        env.Project01,
-                        40,
-                        1,
-                        "Context before ",
-                        "Text selected"
-                    );
-
-                    // SUT
-                    IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
-                        userSecret,
-                        ptProjectId,
-                        40,
-                        noteThreadDocs,
-                        chapterDeltas,
-                        ptProjectUsers
-                    );
-
-                    return changes;
+                        Start = rti.contextBefore.Length,
+                        Length = rti.selectedText.Length
+                    };
                 }
+                noteThread.Notes = notes;
+                if (notes.Count > 0)
+                    threads = threads.Append(noteThread);
             }
+            RealtimeService.AddRepository("note_threads", OTType.Json0, new MemoryRepository<NoteThread>(threads));
+        }
 
-            public void MakeRegistryClientReturn(HttpResponseMessage responseMessage)
+        public void AddThread(NoteThread thread)
+        {
+            var threads = new NoteThread[1];
+            threads[0] = thread;
+            RealtimeService.AddRepository("note_threads", OTType.Json0, new MemoryRepository<NoteThread>(threads));
+        }
+
+        public Dictionary<int, ChapterDelta> GetChapterDeltasByBook(
+            string projectId,
+            int bookNum,
+            int chapters,
+            string contextBefore,
+            string selectedText,
+            bool useThreadSuffix = true,
+            bool includeRelatedVerse = false
+        )
+        {
+            Dictionary<int, ChapterDelta> chapterDeltas = new Dictionary<int, ChapterDelta>();
+            int numVersesInChapter = 10;
+            for (int i = 1; i <= chapters; i++)
             {
-                MockRegistryHttpClient
-                    .SendAsync(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>())
-                    .Returns(responseMessage);
+                Delta delta = GetChapterDelta(
+                    i,
+                    numVersesInChapter,
+                    contextBefore,
+                    selectedText,
+                    useThreadSuffix,
+                    includeRelatedVerse
+                );
+                chapterDeltas.Add(i, new ChapterDelta(i, numVersesInChapter, true, delta));
             }
+            return chapterDeltas;
+        }
 
-            public void Dispose()
+        public static XElement GetUpdateNotesXml(
+            string threadId,
+            string user,
+            DateTime date,
+            string content,
+            string verseRef = "MAT 1:1",
+            bool delete = false
+        )
+        {
+            XElement notesElem = new XElement("notes", new XAttribute("version", "1.1"));
+            XElement threadElem = new XElement(
+                "thread",
+                new XAttribute("id", threadId),
+                new XElement(
+                    "selection",
+                    new XAttribute("verseRef", verseRef),
+                    new XAttribute("startPos", 0),
+                    new XAttribute("selectedText", "")
+                )
+            );
+            XElement commentElem = new XElement("comment", new XAttribute("user", user));
+            commentElem.Add(new XAttribute("date", date.ToString("o")));
+            XElement contentElem = new XElement("content");
+            contentElem.Add(content);
+            commentElem.Add(contentElem);
+            if (delete)
             {
-                Dispose(disposing: true);
-                GC.SuppressFinalize(this);
+                commentElem.SetAttributeValue("deleted", true);
+                commentElem.SetAttributeValue("versionNbr", null);
             }
+            threadElem.Add(commentElem);
+            notesElem.Add(threadElem);
+            return notesElem;
+        }
 
-            protected virtual void Dispose(bool disposing)
+        public static async Task<IEnumerable<IDocument<NoteThread>>> GetNoteThreadDocsAsync(
+            IConnection connection,
+            string[] threadIds
+        )
+        {
+            List<IDocument<NoteThread>> noteThreadDocs = new List<IDocument<NoteThread>>();
+            foreach (string threadId in threadIds)
+                noteThreadDocs.Add(await GetNoteThreadDocAsync(connection, threadId));
+            return noteThreadDocs;
+        }
+
+        public static async Task<IDocument<NoteThread>> GetNoteThreadDocAsync(
+            IConnection connection,
+            string threadId
+        ) => await connection.FetchAsync<NoteThread>("project01:" + threadId);
+
+        public string SetupProject(string baseId, ParatextUser associatedPtUser, bool hasEditPermission = true)
+        {
+            string ptProjectId = PTProjectIds[baseId].Id;
+            ProjectScrText = GetScrText(associatedPtUser, ptProjectId, hasEditPermission);
+
+            // We set the file manager here so we can track file manager operations after
+            // the ScrText object has been disposed in ParatextService.
+            ProjectFileManager = Substitute.For<ProjectFileManager>(ProjectScrText, null);
+            ProjectFileManager.IsWritable.Returns(true);
+            ProjectScrText.SetFileManager(ProjectFileManager);
+            ProjectCommentManager = CommentManager.Get(ProjectScrText);
+            MockScrTextCollection.FindById(Arg.Any<string>(), ptProjectId).Returns(ProjectScrText);
+            SetupCommentTags(ProjectScrText, null);
+            return ptProjectId;
+        }
+
+        public void AddParatextComments(ThreadComponents[] components)
+        {
+            XmlDocument doc = new XmlDocument();
+            foreach (ThreadComponents comp in components)
             {
-                if (disposed)
-                    return;
-                if (disposing)
+                string threadId = "thread" + comp.threadNum;
+                var associatedPtUser = new SFParatextUser(comp.username ?? "");
+                string before = ContextBefore;
+                string after = ContextAfter;
+                string text = "Text selected " + threadId;
+                string selectedText = comp.appliesToVerse ? ContextBefore + text + ContextAfter : text;
+                string verseStr = $"MAT 1:{comp.threadNum}";
+                string sectionHeading = "Section heading text";
+
+                switch (comp.alternateText)
                 {
-                    UnauthorizedHttpResponseMessage?.Dispose();
-                    NotFoundHttpResponseMessage?.Dispose();
+                    case SelectionType.RelatedVerse:
+                        // The alternate text is in a subsequent paragraph with a footnote represented by '*'
+                        before = before + text + after + "\n*";
+                        after = "";
+                        selectedText = "other text in verse";
+                        break;
+                    case SelectionType.Section:
+                        before = before + text + after;
+                        after = "";
+                        selectedText = sectionHeading;
+                        break;
+                    case SelectionType.SectionEnd:
+                        before = before + text + after + sectionHeading;
+                        after = " \\p";
+                        selectedText = "";
+                        break;
                 }
-                disposed = true;
-            }
 
-            private Delta GetChapterDelta(
-                int chapterNum,
-                int verses,
-                string contextBefore,
-                string selectedText,
-                bool useThreadSuffix,
-                bool includeExtraLastVerseSegment
-            )
-            {
-                var chapterText = new StringBuilder();
-                chapterText.Append("[ { \"insert\": { \"chapter\": { \"number\": \"" + chapterNum + "\" } }}");
-                for (int i = 1; i <= verses; i++)
+                Paratext.Data.ProjectComments.Comment getThreadComment()
                 {
-                    string noteSelectedText = useThreadSuffix ? selectedText + $" thread{i}" : selectedText;
-                    string before = contextBefore;
-                    string after = ContextAfter;
-                    // Make verse 7 with alternate text to optionally use to re-attach to
-                    if (i == 7)
+                    return new Paratext.Data.ProjectComments.Comment(associatedPtUser)
                     {
-                        before = AlternateBefore;
-                        after = AlternateAfter;
-                        noteSelectedText = ReattachedSelectedText;
+                        Thread = threadId,
+                        VerseRefStr = verseStr,
+                        SelectedText = selectedText,
+                        ContextBefore = comp.appliesToVerse ? "" : before,
+                        ContextAfter = comp.appliesToVerse ? "" : after,
+                        StartPosition = comp.appliesToVerse ? 0 : before.Length,
+                    };
+                }
+
+                for (int i = 1; i <= comp.noteCount; i++)
+                {
+                    string date = $"2019-01-0{i}T08:00:00.0000000+00:00";
+                    XmlElement content = doc.CreateElement("Contents");
+                    content.InnerXml = comp.isEdited
+                        ? $"<p>{threadId} note {i}: EDITED.</p>"
+                        : $"<p>{threadId} note {i}.</p>";
+                    Paratext.Data.ProjectComments.Comment comment = getThreadComment();
+
+                    ThreadNoteComponents note = new ThreadNoteComponents
+                    {
+                        status = NoteStatus.Todo,
+                        tagsAdded = new[] { Paratext.Data.ProjectComments.CommentTag.toDoTagId.ToString() },
+                        assignedPTUser = Paratext.Data.ProjectComments.CommentThread.unassignedUser
+                    };
+                    if (comp.notes != null)
+                        note = comp.notes[i - 1];
+
+                    comment.Contents = content;
+                    comment.Date = date;
+                    comment.Deleted = comp.isDeleted;
+                    comment.Status = note.status;
+                    comment.ExternalUser = comp.isConflict ? "" : "user02";
+                    comment.TagsAdded = comp.isConflict ? null : note.tagsAdded ?? null;
+                    comment.Type = comp.isConflict ? NoteType.Conflict : NoteType.Normal;
+                    comment.ConflictType = NoteConflictType.None;
+                    comment.AssignedUser = note.assignedPTUser;
+                    ProjectCommentManager.AddComment(comment);
+                    if (note.duplicate)
+                        ProjectCommentManager.AddComment(comment);
+                }
+
+                if (comp.reattachedVerseStr != null)
+                {
+                    ReattachedThreadInfo rti = GetReattachedThreadInfo(comp.reattachedVerseStr);
+                    Paratext.Data.ProjectComments.Comment reattachedComment = getThreadComment();
+                    reattachedComment.Status = NoteStatus.Unspecified;
+                    reattachedComment.Date = "2019-01-20T08:00:00.0000000+00:00";
+                    reattachedComment.Reattached = ReattachedThreadInfoStr(rti);
+                    ProjectCommentManager.AddComment(reattachedComment);
+                }
+            }
+        }
+
+        public void AddParatextComment(Paratext.Data.ProjectComments.Comment comment) =>
+            ProjectCommentManager.AddComment(comment);
+
+        public MockScrText GetScrText(ParatextUser associatedPtUser, string projectId, bool hasEditPermission = true)
+        {
+            string scrtextDir = Path.Combine(SyncDir, projectId, "target");
+            ProjectName projectName = new ProjectName() { ProjectPath = scrtextDir, ShortName = "Proj" };
+            var scrText = new MockScrText(associatedPtUser, projectName) { CachedGuid = HexId.FromStr(projectId) };
+            scrText.Permissions.CreateFirstAdminUser();
+            scrText.Data.Add("RUT", ruthBookUsfm);
+            scrText.Settings.BooksPresentSet = new BookSet("RUT");
+            scrText.Settings.LanguageID = LanguageId.English;
+            if (!hasEditPermission)
+                scrText.Permissions.SetPermission(null, 8, PermissionSet.Manual, false);
+            return scrText;
+        }
+
+        public void SetupCommentTags(MockScrText scrText, NoteTag noteTag)
+        {
+            var tags = new List<CommentTag>();
+            for (int tagId = 1; tagId <= TagCount; tagId++)
+            {
+                if (tagId < TagCount)
+                {
+                    if (noteTag != null && tagId == noteTag.TagId)
+                        tags.Add(new CommentTag(noteTag.Name, noteTag.Icon, tagId));
+                    else
+                        tags.Add(new CommentTag($"tag{tagId}", $"icon{tagId}", tagId));
+                }
+            }
+
+            CommentTags.CommentTagList list = new CommentTags.CommentTagList
+            {
+                SerializedData = tags.ToArray(),
+                SerializedLastUsedId = TagCount
+            };
+            scrText.FileManager.GetXml<CommentTags.CommentTagList>(Arg.Any<string>()).Returns(list);
+        }
+
+        public void SetupSuccessfulSendReceive()
+        {
+            MockSharingLogicWrapper
+                .ShareChanges(
+                    Arg.Any<List<SharedProject>>(),
+                    Arg.Any<SharedRepositorySource>(),
+                    out Arg.Any<List<SendReceiveResult>>(),
+                    Arg.Any<List<SharedProject>>()
+                )
+                .Returns(true);
+            // Have the HandleErrors method run its first argument, which would be the ShareChanges() call.
+            // This helps check that the implementation code is calling ShareChanges().
+            MockSharingLogicWrapper
+                .HandleErrors(Arg.Any<Action>())
+                .Returns(callInfo =>
+                {
+                    callInfo.Arg<Action>()();
+                    return true;
+                });
+        }
+
+        public ReattachedThreadInfo GetReattachedThreadInfo(string verseStr)
+        {
+            string startPos = AlternateBefore.Length.ToString();
+            return new ReattachedThreadInfo
+            {
+                verseStr = verseStr,
+                selectedText = ReattachedSelectedText,
+                startPos = startPos,
+                contextBefore = AlternateBefore,
+                contextAfter = AlternateAfter
+            };
+        }
+
+        public static string ReattachedThreadInfoStr(ReattachedThreadInfo rnt)
+        {
+            string[] reattachParts = new[]
+            {
+                rnt.verseStr,
+                rnt.selectedText,
+                rnt.startPos,
+                rnt.contextBefore,
+                rnt.contextAfter
+            };
+            return string.Join(StringUtils.orcCharacter, reattachParts);
+        }
+
+        /// <summary>
+        /// Helper method for testing changes detected when comparing incoming Paratext Comments to
+        /// existing SF Notes. `modifyComment` and `modifyNoteThread` allow adjustment to the incoming Paratext
+        /// Comment and the existing SF note thread (and its notes) before they are examined for differences.
+        /// </summary>
+        public async Task<IEnumerable<NoteThreadChange>> PrepareChangeOnSingleCommentAsync(
+            Action<Paratext.Data.ProjectComments.Comment> modifyComment,
+            Action<NoteThread> modifyNoteThread = null
+        )
+        {
+            var env = this;
+            string sfProjectId = env.Project01;
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            string ptProjectId = env.SetupProject(sfProjectId, associatedPtUser);
+            UserSecret userSecret = MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+            env.AddTextDoc(40, 1);
+            env.MockGuidService.NewObjectId().Returns("thread01note01");
+
+            string threadId = "thread01";
+            string threadOwner = env.User01;
+
+            // Put into the SF DB a NoteThread and a Note, that will need to be updated with new PT Comment data.
+
+            var thread01 = new NoteThread
+            {
+                Id = "project01:" + threadId,
+                DataId = threadId,
+                ProjectRef = sfProjectId,
+                OwnerRef = threadOwner,
+                VerseRef = new VerseRefData(40, 1, 1),
+                OriginalSelectedText = "",
+                OriginalContextBefore = "",
+                Position = new TextAnchor(),
+                OriginalContextAfter = "",
+                Status = NoteStatus.Todo.InternalValue,
+                Assignment = Paratext.Data.ProjectComments.CommentThread.unassignedUser,
+                Notes =
+                {
+                    new Note
+                    {
+                        DataId = $"{threadId}note01",
+                        ThreadId = threadId,
+                        Type = NoteType.Normal.InternalValue,
+                        ConflictType = Note.NoConflictType,
+                        OwnerRef = threadOwner,
+                        ExtUserId = "user02",
+                        SyncUserRef = "syncuser01",
+                        DateCreated = new DateTime(2019, 12, 31, 8, 0, 0, DateTimeKind.Utc),
+                        TagId = CommentTag.toDoTagId,
+                        Deleted = false,
+                        Status = NoteStatus.Todo.InternalValue,
+                        Assignment = Paratext.Data.ProjectComments.CommentThread.unassignedUser,
+                        Content = $"<p>Note content.</p>",
+                        AcceptedChangeXml = null,
                     }
+                }
+            };
+            modifyNoteThread?.Invoke(thread01);
+
+            env.AddThread(thread01);
+
+            // Create a PT Comment with updated data that SF will consider when composing a change report.
+
+            XmlDocument doc = new XmlDocument();
+            XmlElement commentContents = doc.CreateElement("Contents");
+            commentContents.InnerXml = $"<p>Note content.</p>";
+            var comment = new Paratext.Data.ProjectComments.Comment(associatedPtUser)
+            {
+                Thread = threadId,
+                VerseRefStr = "MAT 1:1",
+                SelectedText = "",
+                ContextBefore = "",
+                ContextAfter = "",
+                StartPosition = 0,
+                Date = $"2019-12-31T08:00:00.0000000+00:00",
+                Deleted = false,
+                Status = NoteStatus.Todo,
+                Type = NoteType.Normal,
+                // ConflictType = (unset / default)
+                AssignedUser = Paratext.Data.ProjectComments.CommentThread.unassignedUser,
+                Contents = commentContents,
+                AcceptedChangeXmlStr = null,
+            };
+            modifyComment(comment);
+            env.AddParatextComment(comment);
+
+            await using IConnection conn = await env.RealtimeService.ConnectAsync();
+            IEnumerable<IDocument<NoteThread>> noteThreadDocs = await GetNoteThreadDocsAsync(
+                conn,
+                new[] { "thread01" }
+            );
+            Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
+            {
+                new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+            }.ToDictionary(u => u.Username);
+            Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(
+                env.Project01,
+                40,
+                1,
+                "Context before ",
+                "Text selected"
+            );
+
+            // SUT
+            IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
+                userSecret,
+                ptProjectId,
+                40,
+                noteThreadDocs,
+                chapterDeltas,
+                ptProjectUsers
+            );
+
+            return changes;
+        }
+
+        public void MakeRegistryClientReturn(HttpResponseMessage responseMessage)
+        {
+            MockRegistryHttpClient
+                .SendAsync(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>())
+                .Returns(responseMessage);
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposed)
+                return;
+            if (disposing)
+            {
+                UnauthorizedHttpResponseMessage?.Dispose();
+                NotFoundHttpResponseMessage?.Dispose();
+            }
+            disposed = true;
+        }
+
+        private Delta GetChapterDelta(
+            int chapterNum,
+            int verses,
+            string contextBefore,
+            string selectedText,
+            bool useThreadSuffix,
+            bool includeExtraLastVerseSegment
+        )
+        {
+            var chapterText = new StringBuilder();
+            chapterText.Append("[ { \"insert\": { \"chapter\": { \"number\": \"" + chapterNum + "\" } }}");
+            for (int i = 1; i <= verses; i++)
+            {
+                string noteSelectedText = useThreadSuffix ? selectedText + $" thread{i}" : selectedText;
+                string before = contextBefore;
+                string after = ContextAfter;
+                // Make verse 7 with alternate text to optionally use to re-attach to
+                if (i == 7)
+                {
+                    before = AlternateBefore;
+                    after = AlternateAfter;
+                    noteSelectedText = ReattachedSelectedText;
+                }
+                chapterText.Append(
+                    ","
+                        + "{ \"insert\": { \"verse\": { \"number\": \""
+                        + i
+                        + "\" } }}, "
+                        + "{ \"insert\": \""
+                        + before
+                        + noteSelectedText
+                        + after
+                        + "\", "
+                        + "\"attributes\": { \"segment\": \"verse_"
+                        + chapterNum
+                        + "_"
+                        + i
+                        + "\" } }"
+                );
+                if (i == 8 || i == 9)
+                {
+                    // create a new section heading after verse 8
                     chapterText.Append(
-                        ","
-                            + "{ \"insert\": { \"verse\": { \"number\": \""
-                            + i
-                            + "\" } }}, "
-                            + "{ \"insert\": \""
-                            + before
-                            + noteSelectedText
-                            + after
-                            + "\", "
-                            + "\"attributes\": { \"segment\": \"verse_"
-                            + chapterNum
-                            + "_"
-                            + i
-                            + "\" } }"
-                    );
-                    if (i == 8 || i == 9)
-                    {
-                        // create a new section heading after verse 8
-                        chapterText.Append(
-                            " ,"
-                                + "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"p\" } }}, "
-                                + "{ \"insert\": \"Section heading text\", \"attributes\": { \"segment\": \"s_1\" } }, "
-                                + "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"s\" } }}, "
-                                + "{ \"insert\": { \"blank\": true }, \"attributes\": { \"segment\": \"p_1\" } }"
-                        );
-                    }
-                }
-                if (includeExtraLastVerseSegment)
-                {
-                    // Add a second segment in the last verse (Note the segment name ends with "/p_1").
-                    string verseRef = $"verse_{chapterNum}_{verses}";
-                    chapterText.Append(
-                        ", { \"insert\": \"\n\" },"
-                            + "{ \"insert\": { \"note\": { \"caller\": \"*\" } }, "
-                            + "\"attributes\": { \"segment\": \""
-                            + verseRef
-                            + "\" } },"
-                            + "{ \"insert\": \"other text in verse\", "
-                            + "\"attributes\": { \"segment\": \""
-                            + verseRef
-                            + "/p_1\" } }"
+                        " ,"
+                            + "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"p\" } }}, "
+                            + "{ \"insert\": \"Section heading text\", \"attributes\": { \"segment\": \"s_1\" } }, "
+                            + "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"s\" } }}, "
+                            + "{ \"insert\": { \"blank\": true }, \"attributes\": { \"segment\": \"p_1\" } }"
                     );
                 }
-                chapterText.Append("]");
-                return new Delta(JToken.Parse(chapterText.ToString()));
             }
-
-            private ProjectMetadata GetMetadata(string projectId, string fullname)
+            if (includeExtraLastVerseSegment)
             {
-                string json =
-                    "{\"identification_name\": \""
-                    + fullname
-                    + "\", \"identification_systemId\": [{\"type\": \"paratext\", \"text\": \""
-                    + projectId
-                    + "\"}]}";
-                return new ProjectMetadata(JObject.Parse(json));
+                // Add a second segment in the last verse (Note the segment name ends with "/p_1").
+                string verseRef = $"verse_{chapterNum}_{verses}";
+                chapterText.Append(
+                    ", { \"insert\": \"\n\" },"
+                        + "{ \"insert\": { \"note\": { \"caller\": \"*\" } }, "
+                        + "\"attributes\": { \"segment\": \""
+                        + verseRef
+                        + "\" } },"
+                        + "{ \"insert\": \"other text in verse\", "
+                        + "\"attributes\": { \"segment\": \""
+                        + verseRef
+                        + "/p_1\" } }"
+                );
             }
+            chapterText.Append(']');
+            return new Delta(JToken.Parse(chapterText.ToString()));
+        }
+
+        private static ProjectMetadata GetMetadata(string projectId, string fullname)
+        {
+            string json =
+                "{\"identification_name\": \""
+                + fullname
+                + "\", \"identification_systemId\": [{\"type\": \"paratext\", \"text\": \""
+                + projectId
+                + "\"}]}";
+            return new ProjectMetadata(JObject.Parse(json));
         }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -23,3040 +23,2851 @@ using SIL.XForge.Scripture.Realtime;
 using SIL.XForge.Services;
 using SIL.XForge.Utils;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class ParatextSyncRunnerTests
 {
-    [TestFixture]
-    public class ParatextSyncRunnerTests
+    [Test]
+    public async Task SyncAsync_ProjectDoesNotExist()
     {
-        [Test]
-        public async Task SyncAsync_ProjectDoesNotExist()
-        {
-            var env = new TestEnvironment();
-
-            // SUT
-            await env.Runner.RunAsync("project03", "user01", "project03", false, CancellationToken.None);
-        }
-
-        [Test]
-        public async Task SyncAsync_UserDoesNotExist()
-        {
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, true, false);
-            env.ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), "target").Returns("beforeSR");
-
-            await env.Runner.RunAsync("project01", "user03", "project01", false, CancellationToken.None);
-
-            SFProject project = env.VerifyProjectSync(false);
-            Assert.That(project.Sync.DataInSync, Is.True);
-
-            // Check that the failure was logged in the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
-        }
-
-        [Test]
-        public async Task SyncAsync_Error()
-        {
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, false, false);
-            env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-            env.DeltaUsxMapper.When(d => d.ToChapterDeltas(Arg.Any<XDocument>())).Do(x => throw new Exception());
-
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            SFProject project = env.VerifyProjectSync(false);
-            Assert.That(project.Sync.DataInSync, Is.False);
-
-            // Check that the failure was logged in the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
-        }
-
-        [Test]
-        public async Task SyncAsync_NewProjectTranslationSuggestionsAndCheckingDisabled()
-        {
-            var env = new TestEnvironment();
-            env.SetupSFData(false, false, false, false);
-            env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
-
-            await env.Runner.RunAsync("project01", "user01", "project01", true, CancellationToken.None);
-
-            Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
-            Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
-            Assert.That(env.ContainsText("project01", "MRK", 1), Is.True);
-            Assert.That(env.ContainsText("project01", "MRK", 2), Is.True);
-
-            Assert.That(env.ContainsText("project02", "MAT", 1), Is.False);
-            Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
-            Assert.That(env.ContainsText("project02", "MRK", 1), Is.False);
-            Assert.That(env.ContainsText("project02", "MRK", 2), Is.False);
-
-            Assert.That(env.ContainsQuestion("MAT", 1), Is.False);
-            Assert.That(env.ContainsQuestion("MAT", 2), Is.False);
-            Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
-            Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
-
-            await env.MachineProjectService
-                .DidNotReceive()
-                .BuildProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-            env.VerifyProjectSync(true);
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 4, deleted: 0, updated: 0)));
-            syncMetrics = env.GetSyncMetrics("project02");
-            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
-        }
-
-        [Test]
-        public async Task SyncAsync_NewProjectTranslationSuggestionsAndCheckingEnabled()
-        {
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, false, false);
-            env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
-
-            await env.Runner.RunAsync("project02", "user01", "project02", true, CancellationToken.None);
-            await env.Runner.RunAsync("project01", "user01", "project01", true, CancellationToken.None);
-
-            Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
-            Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
-            Assert.That(env.ContainsText("project01", "MRK", 1), Is.True);
-            Assert.That(env.ContainsText("project01", "MRK", 2), Is.True);
-
-            Assert.That(env.ContainsText("project02", "MAT", 1), Is.True);
-            Assert.That(env.ContainsText("project02", "MAT", 2), Is.True);
-            Assert.That(env.ContainsText("project02", "MRK", 1), Is.False);
-            Assert.That(env.ContainsText("project02", "MRK", 2), Is.False);
-
-            Assert.That(env.ContainsQuestion("MAT", 1), Is.False);
-            Assert.That(env.ContainsQuestion("MAT", 2), Is.False);
-            Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
-            Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
-
-            await env.MachineProjectService.Received().BuildProjectAsync("user01", "project01", CancellationToken.None);
-            env.VerifyProjectSync(true);
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 4, deleted: 0, updated: 0)));
-            syncMetrics = env.GetSyncMetrics("project02");
-            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
-        }
-
-        [Test]
-        public async Task SyncAsync_NewProjectOnlyTranslationSuggestionsEnabled()
-        {
-            var env = new TestEnvironment();
-            env.SetupSFData(true, false, false, false);
-            env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
-
-            await env.Runner.RunAsync("project02", "user01", "project02", true, CancellationToken.None);
-            await env.Runner.RunAsync("project01", "user01", "project01", true, CancellationToken.None);
-
-            Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
-            Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
-            Assert.That(env.ContainsText("project01", "MRK", 1), Is.True);
-            Assert.That(env.ContainsText("project01", "MRK", 2), Is.True);
-
-            Assert.That(env.ContainsText("project02", "MAT", 1), Is.True);
-            Assert.That(env.ContainsText("project02", "MAT", 2), Is.True);
-            Assert.That(env.ContainsText("project02", "MRK", 1), Is.False);
-            Assert.That(env.ContainsText("project02", "MRK", 2), Is.False);
-
-            Assert.That(env.ContainsQuestion("MAT", 1), Is.False);
-            Assert.That(env.ContainsQuestion("MAT", 2), Is.False);
-            Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
-            Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
-
-            await env.MachineProjectService.Received().BuildProjectAsync("user01", "project01", CancellationToken.None);
-            env.VerifyProjectSync(true);
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 4, deleted: 0, updated: 0)));
-            syncMetrics = env.GetSyncMetrics("project02");
-            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
-        }
-
-        [Test]
-        public async Task SyncAsync_NewProjectOnlyCheckingEnabled()
-        {
-            var env = new TestEnvironment();
-            env.SetupSFData(false, true, false, false);
-            env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
-
-            await env.Runner.RunAsync("project01", "user01", "project01", true, CancellationToken.None);
-
-            Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
-            Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
-            Assert.That(env.ContainsText("project01", "MRK", 1), Is.True);
-            Assert.That(env.ContainsText("project01", "MRK", 2), Is.True);
-
-            Assert.That(env.ContainsText("project02", "MAT", 1), Is.False);
-            Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
-            Assert.That(env.ContainsText("project02", "MRK", 1), Is.False);
-            Assert.That(env.ContainsText("project02", "MRK", 2), Is.False);
-
-            Assert.That(env.ContainsQuestion("MAT", 1), Is.False);
-            Assert.That(env.ContainsQuestion("MAT", 2), Is.False);
-            Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
-            Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
-
-            await env.MachineProjectService
-                .DidNotReceive()
-                .BuildProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-            env.VerifyProjectSync(true);
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 4, deleted: 0, updated: 0)));
-            syncMetrics = env.GetSyncMetrics("project02");
-            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
-        }
-
-        [Test]
-        public async Task SyncAsync_NewProjectOnlyNoMatchingSourceText_TranslationSuggestionEnabled()
-        {
-            var env = new TestEnvironment();
-            env.SetupSFData(true, false, false, false);
-            env.SetupPTData(new Book("MAT", 2, false));
-
-            await env.Runner.RunAsync("project02", "user01", "project02", true, CancellationToken.None);
-            await env.Runner.RunAsync("project01", "user01", "project01", true, CancellationToken.None);
-
-            Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
-            Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
-            Assert.That(env.ContainsText("project02", "MAT", 1), Is.False);
-            Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
-
-            await env.MachineProjectService
-                .DidNotReceive()
-                .BuildProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-            env.VerifyProjectSync(true);
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
-            syncMetrics = env.GetSyncMetrics("project02");
-            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
-        }
-
-        [Test]
-        public async Task SyncAsync_DataNotChanged()
-        {
-            var env = new TestEnvironment();
-            Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
-            env.SetupSFData(true, true, false, false, books);
-            env.SetupPTData(books);
-
-            // SUT
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            env.MockLogger.AssertEventCount(
-                (LogEvent logEvent) =>
-                    logEvent.LogLevel == LogLevel.Information && Regex.IsMatch(logEvent.Message, "Starting"),
-                1
-            );
-
-            await env.ParatextService
-                .DidNotReceive()
-                .PutBookText(Arg.Any<UserSecret>(), "target", 40, Arg.Any<XDocument>());
-            await env.ParatextService
-                .DidNotReceive()
-                .PutBookText(Arg.Any<UserSecret>(), "target", 41, Arg.Any<XDocument>());
-
-            await env.ParatextService
-                .DidNotReceive()
-                .PutBookText(Arg.Any<UserSecret>(), "source", 40, Arg.Any<XDocument>());
-            await env.ParatextService
-                .DidNotReceive()
-                .PutBookText(Arg.Any<UserSecret>(), "source", 41, Arg.Any<XDocument>());
-
-            var delta = Delta.New().InsertText("text");
-            Assert.That(env.GetText("project01", "MAT", 1).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project01", "MAT", 2).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project01", "MRK", 1).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project01", "MRK", 2).DeepEquals(delta), Is.True);
-
-            Assert.That(env.GetText("project02", "MAT", 1).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project02", "MAT", 2).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project02", "MRK", 1).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project02", "MRK", 2).DeepEquals(delta), Is.True);
-
-            env.ParatextService.DidNotReceive().PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<XElement>());
-
-            SFProject project = env.VerifyProjectSync(true);
-            Assert.That(project.ParatextUsers.Count, Is.EqualTo(2));
-            Assert.That(project.UserRoles["user01"], Is.EqualTo(SFProjectRole.Administrator));
-            Assert.That(project.UserRoles["user02"], Is.EqualTo(SFProjectRole.Translator));
-        }
-
-        [Test]
-        public async Task SyncAsync_DataChangedTranslateAndCheckingEnabled()
-        {
-            var env = new TestEnvironment();
-            Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
-            env.SetupSFData(true, true, true, false, books);
-            env.SetupPTData(books);
-
-            await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            await env.ParatextService
-                .Received()
-                .PutBookText(
-                    Arg.Any<UserSecret>(),
-                    "target",
-                    40,
-                    Arg.Any<XDocument>(),
-                    Arg.Any<Dictionary<int, string>>()
-                );
-            await env.ParatextService
-                .Received()
-                .PutBookText(
-                    Arg.Any<UserSecret>(),
-                    "target",
-                    41,
-                    Arg.Any<XDocument>(),
-                    Arg.Any<Dictionary<int, string>>()
-                );
-
-            await env.ParatextService
-                .Received()
-                .PutBookText(
-                    Arg.Any<UserSecret>(),
-                    "source",
-                    40,
-                    Arg.Any<XDocument>(),
-                    Arg.Any<Dictionary<int, string>>()
-                );
-            await env.ParatextService
-                .Received()
-                .PutBookText(
-                    Arg.Any<UserSecret>(),
-                    "source",
-                    41,
-                    Arg.Any<XDocument>(),
-                    Arg.Any<Dictionary<int, string>>()
-                );
-
-            var delta = Delta.New().InsertText("text");
-            Assert.That(env.GetText("project01", "MAT", 1).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project01", "MAT", 2).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project01", "MRK", 1).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project01", "MRK", 2).DeepEquals(delta), Is.True);
-
-            Assert.That(env.GetText("project02", "MAT", 1).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project02", "MAT", 2).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project02", "MRK", 1).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project02", "MRK", 2).DeepEquals(delta), Is.True);
-
-            env.ParatextService.Received(2).PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<XElement>());
-
-            SFProject project = env.GetProject();
-            Assert.That(project.ParatextUsers.Count, Is.EqualTo(2));
-            env.VerifyProjectSync(true);
-        }
-
-        [Test]
-        public async Task SyncAsync_DataChangedTranslateEnabledCheckingDisabled()
-        {
-            var env = new TestEnvironment();
-            Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
-            env.SetupSFData(true, false, true, false, books);
-            env.SetupPTData(books);
-
-            await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            await env.ParatextService
-                .Received()
-                .PutBookText(
-                    Arg.Any<UserSecret>(),
-                    "target",
-                    40,
-                    Arg.Any<XDocument>(),
-                    Arg.Any<Dictionary<int, string>>()
-                );
-            await env.ParatextService
-                .Received()
-                .PutBookText(
-                    Arg.Any<UserSecret>(),
-                    "target",
-                    41,
-                    Arg.Any<XDocument>(),
-                    Arg.Any<Dictionary<int, string>>()
-                );
-
-            await env.ParatextService
-                .Received()
-                .PutBookText(
-                    Arg.Any<UserSecret>(),
-                    "source",
-                    40,
-                    Arg.Any<XDocument>(),
-                    Arg.Any<Dictionary<int, string>>()
-                );
-            await env.ParatextService
-                .Received()
-                .PutBookText(
-                    Arg.Any<UserSecret>(),
-                    "source",
-                    41,
-                    Arg.Any<XDocument>(),
-                    Arg.Any<Dictionary<int, string>>()
-                );
-
-            env.ParatextService.DidNotReceive().PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<XElement>());
-
-            var delta = Delta.New().InsertText("text");
-            Assert.That(env.GetText("project01", "MAT", 1).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project01", "MAT", 2).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project01", "MRK", 1).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project01", "MRK", 2).DeepEquals(delta), Is.True);
-
-            Assert.That(env.GetText("project02", "MAT", 1).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project02", "MAT", 2).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project02", "MRK", 1).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project02", "MRK", 2).DeepEquals(delta), Is.True);
-
-            SFProject project = env.GetProject();
-            Assert.That(project.ParatextUsers.Count, Is.EqualTo(2));
-            env.VerifyProjectSync(true);
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 2)));
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 4)));
-            syncMetrics = env.GetSyncMetrics("project02");
-            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 2)));
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 4)));
-        }
-
-        [Test]
-        public async Task SyncAsync_ChaptersChanged()
-        {
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, false, false, new Book("MAT", 2), new Book("MRK", 2));
-            env.SetupPTData(new Book("MAT", 3), new Book("MRK", 1));
-            env.AddParatextNoteThreadData(new Book("MRK", 2));
-            Assert.That(env.ContainsNote(2), Is.True);
-
-            await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-            env.ParatextService
-                .Received()
-                .GetNoteThreadChanges(
-                    Arg.Any<UserSecret>(),
-                    "target",
-                    41,
-                    Arg.Is<IEnumerable<IDocument<NoteThread>>>(
-                        threads => threads.Any(t => t.Id == "project01:thread02")
-                    ),
-                    Arg.Any<Dictionary<int, ChapterDelta>>(),
-                    Arg.Any<Dictionary<string, ParatextUserProfile>>()
-                );
-
-            Assert.That(env.ContainsText("project01", "MAT", 3), Is.True);
-            Assert.That(env.ContainsText("project01", "MRK", 2), Is.False);
-
-            Assert.That(env.ContainsText("project02", "MAT", 3), Is.True);
-            Assert.That(env.ContainsText("project02", "MRK", 2), Is.False);
-
-            Assert.That(env.ContainsQuestion("MAT", 2), Is.True);
-            Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
-            Assert.That(env.ContainsNote(2), Is.True);
-            env.VerifyProjectSync(true);
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 2)));
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 1, updated: 0)));
-            Assert.That(syncMetrics.Questions, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
-            syncMetrics = env.GetSyncMetrics("project02");
-            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 2)));
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 1, updated: 0)));
-            Assert.That(syncMetrics.Questions, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
-        }
-
-        [Test]
-        public async Task SyncAsync_ChapterValidityChanged()
-        {
-            var env = new TestEnvironment();
-            env.SetupSFData(
-                true,
-                true,
-                false,
-                false,
-                new Book("MAT", 2),
-                new Book("MRK", 2) { InvalidChapters = { 1 } }
-            );
-            env.SetupPTData(new Book("MAT", 2) { InvalidChapters = { 2 } }, new Book("MRK", 2));
-
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            SFProject project = env.GetProject();
-            Assert.That(project.Texts[0].Chapters[0].IsValid, Is.True);
-            Assert.That(project.Texts[0].Chapters[1].IsValid, Is.False);
-            Assert.That(project.Texts[1].Chapters[0].IsValid, Is.True);
-            Assert.That(project.Texts[1].Chapters[1].IsValid, Is.True);
-            env.VerifyProjectSync(true);
-        }
-
-        [Test]
-        public async Task SyncAsync_BooksChanged()
-        {
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, false, false, new Book("MAT", 2), new Book("MRK", 2));
-            env.SetupPTData(new Book("MAT", 2), new Book("LUK", 2));
-            // Need to make sure we have notes BEFORE the sync
-            env.AddParatextNoteThreadData(new Book("MRK", 2));
-
-            // Expectations of setup
-            Assert.That(env.ContainsText("project01", "MRK", 1), Is.True);
-            Assert.That(env.ContainsText("project01", "MRK", 2), Is.True);
-            Assert.That(env.ContainsText("project01", "LUK", 1), Is.False);
-            Assert.That(env.ContainsText("project01", "LUK", 2), Is.False);
-
-            Assert.That(env.ContainsText("project02", "MRK", 1), Is.True);
-            Assert.That(env.ContainsText("project02", "MRK", 2), Is.True);
-            Assert.That(env.ContainsText("project02", "LUK", 1), Is.False);
-            Assert.That(env.ContainsText("project02", "LUK", 2), Is.False);
-
-            Assert.That(env.ContainsQuestion("MRK", 1), Is.True);
-            Assert.That(env.ContainsQuestion("MRK", 2), Is.True);
-            Assert.That(env.ContainsQuestion("MAT", 1), Is.True);
-            Assert.That(env.ContainsQuestion("MAT", 2), Is.True);
-
-            Assert.That(env.ContainsNote(2), Is.True);
-
-            // SUT
-            await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            Assert.That(env.ContainsText("project01", "MRK", 1), Is.False);
-            Assert.That(env.ContainsText("project01", "MRK", 2), Is.False);
-            Assert.That(env.ContainsText("project01", "LUK", 1), Is.True);
-            Assert.That(env.ContainsText("project01", "LUK", 2), Is.True);
-
-            Assert.That(env.ContainsText("project02", "MRK", 1), Is.False);
-            Assert.That(env.ContainsText("project02", "MRK", 2), Is.False);
-            Assert.That(env.ContainsText("project02", "LUK", 1), Is.True);
-            Assert.That(env.ContainsText("project02", "LUK", 2), Is.True);
-
-            Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
-            Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
-            Assert.That(env.ContainsQuestion("MAT", 1), Is.True);
-            Assert.That(env.ContainsQuestion("MAT", 2), Is.True);
-
-            Assert.That(env.ContainsNote(2), Is.False);
-            env.VerifyProjectSync(true);
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 1, updated: 1)));
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 2, updated: 0)));
-            Assert.That(
-                syncMetrics.Notes,
-                Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
-            );
-            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
-            Assert.That(syncMetrics.Questions, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 2, updated: 0)));
-            syncMetrics = env.GetSyncMetrics("project02");
-            Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 1, updated: 1)));
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 2, updated: 0)));
-            Assert.That(
-                syncMetrics.Notes,
-                Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
-            );
-            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
-            Assert.That(syncMetrics.Questions, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 2, updated: 0)));
-        }
-
-        [Test]
-        public async Task SyncAsync_UserRoleChangedAndUserRemoved()
-        {
-            var env = new TestEnvironment();
-            Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
-            env.SetupSFData(true, true, false, false, books);
-            env.SetupPTData(books);
-            var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Translator } };
-            env.ParatextService
-                .GetProjectRolesAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is((SFProject project) => project.ParatextId == "target"),
-                    Arg.Any<CancellationToken>()
-                )
-                .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
-
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            SFProject project = env.VerifyProjectSync(true);
-            Assert.That(project.UserRoles["user01"], Is.EqualTo(SFProjectRole.Translator));
-            await env.SFProjectService
-                .Received()
-                .RemoveUserWithoutPermissionsCheckAsync("user01", "project01", "user02");
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Users, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
-        }
-
-        [Test]
-        public async Task SyncAsync_SetsUserPermissions()
-        {
-            var env = new TestEnvironment();
-            Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
-            env.SetupSFData(true, true, false, false, books);
-            env.SetupPTData(books);
-            var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Translator } };
-            env.ParatextService
-                .GetProjectRolesAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is((SFProject project) => project.ParatextId == "target"),
-                    Arg.Any<CancellationToken>()
-                )
-                .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
-
-            // SUT
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            await env.SFProjectService
-                .Received()
-                .UpdatePermissionsAsync(
-                    "user01",
-                    Arg.Is<IDocument<SFProject>>(
-                        (IDocument<SFProject> sfProjDoc) =>
-                            sfProjDoc.Data.Id == "project01" && sfProjDoc.Data.ParatextId == "target"
-                    ),
-                    Arg.Any<CancellationToken>()
-                );
-        }
-
-        [Test]
-        public async Task SyncAsync_ProjectTextSetToNotEditable()
-        {
-            var env = new TestEnvironment();
-            Book[] books = { new Book("MAT", 1) };
-            env.SetupSFData(true, true, true, false, books);
-            env.SetupPTData(books);
-            SFProject project = env.GetProject("project01");
-            Assert.That(project.Editable, Is.True, "setup");
-            var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Administrator } };
-            env.ParatextService
-                .GetProjectRolesAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is((SFProject project) => project.ParatextId == "target"),
-                    Arg.Any<CancellationToken>()
-                )
-                .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
-
-            env.ParatextService
-                .GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
-                .Returns(new ParatextSettings { Editable = false });
-
-            // SUT
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-            await env.ParatextService
-                .DidNotReceiveWithAnyArgs()
-                .PutBookText(default, default, default, default, default);
-            project = env.VerifyProjectSync(true);
-            Assert.That(project.Editable, Is.False);
-        }
-
-        [Test]
-        public async Task SyncAsync_CreatesNoteTagIcon()
-        {
-            var env = new TestEnvironment();
-            Book[] books = { new Book("MAT", 1) };
-            env.SetupSFData(true, true, false, true, books);
-            await env.SetupUndefinedNoteTag("project01");
-            SFProject project = env.GetProject();
-            Assert.That(project.TranslateConfig.DefaultNoteTagId, Is.Null);
-            // introduce a PT note thread
-            env.AddParatextNoteThreadData(books[0]);
-            env.SetupPTData(books);
-
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-            env.VerifyProjectSync(true, null, "project01");
-            // expect that we do not create a new note tag
-            env.ParatextService
-                .DidNotReceive()
-                .UpdateCommentTag(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<NoteTag>());
-
-            // introduce an SF note thread
-            env.AddParatextNoteThreadData(books[0], true);
-            env.ParatextService
-                .UpdateCommentTag(Arg.Any<UserSecret>(), "target", Arg.Any<NoteTag>())
-                .Returns(env.translateNoteTagId);
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-            project = env.VerifyProjectSync(true, null, "project01");
-            // expect that a new note tag is created
-            env.ParatextService
-                .Received()
-                .UpdateCommentTag(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<NoteTag>());
-            Assert.That(project.TranslateConfig.DefaultNoteTagId, Is.EqualTo(env.translateNoteTagId));
-        }
-
-        [Test]
-        public async Task SyncAsync_UpdatesExistingNoteTags()
-        {
-            var env = new TestEnvironment();
-            Book[] books = { new Book("MAT", 1) };
-            env.SetupSFData(true, true, false, true, books);
-            var noteTags = new List<NoteTag>
-            {
-                new NoteTag
-                {
-                    TagId = 1,
-                    Name = "To do",
-                    Icon = NoteTag.defaultTagIcon
-                },
-                new NoteTag
-                {
-                    TagId = 2,
-                    Name = "Original tag",
-                    Icon = "originalIcon"
-                },
-                new NoteTag
-                {
-                    TagId = 3,
-                    Name = "Tag to delete",
-                    Icon = "delete"
-                }
-            };
-            await env.SetupProjectNoteTags("project01", noteTags);
-            env.SetupPTData(books);
-            var newNoteTags = new List<NoteTag>
-            {
-                new NoteTag
-                {
-                    TagId = 1,
-                    Name = "To do",
-                    Icon = NoteTag.defaultTagIcon
-                },
-                new NoteTag
-                {
-                    TagId = 2,
-                    Name = "Edited tag",
-                    Icon = "editedIcon"
-                }
-            };
-            env.ParatextService
-                .GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
-                .Returns(new ParatextSettings { NoteTags = newNoteTags });
-
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-            SFProject project = env.VerifyProjectSync(true, null, "project01");
-            Assert.That(project.NoteTags.Select(t => t.Name), Is.EquivalentTo(newNoteTags.Select(t => t.Name)));
-        }
-
-        [Test]
-        public async Task SyncAsync_SetsProjectSettings()
-        {
-            var env = new TestEnvironment();
-            Book[] books = { new Book("MAT", 1) };
-            env.SetupSFData(true, true, true, false, books);
-            env.SetupPTData(books);
-
-            var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Administrator } };
-            env.ParatextService
-                .GetProjectRolesAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>(project => project.ParatextId == "target"),
-                    Arg.Any<CancellationToken>()
-                )
-                .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
-            int fontSize = 10;
-            string font = ProjectSettings.defaultFontName;
-            SFProject project = env.GetProject();
-            Assert.That(project.DefaultFontSize, Is.EqualTo(fontSize));
-            Assert.That(project.DefaultFont, Is.EqualTo(font));
-            int newFontSize = 16;
-            string newFont = "Doulos SIL";
-            string customIcon = "customIcon01";
-            List<NoteTag> noteTags = new List<NoteTag>
-            {
-                new NoteTag
-                {
-                    TagId = env.translateNoteTagId,
-                    Icon = customIcon,
-                    Name = "Tag Name"
-                }
-            };
-            env.ParatextService
-                .GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
-                .Returns(
-                    new ParatextSettings
-                    {
-                        DefaultFontSize = newFontSize,
-                        DefaultFont = newFont,
-                        NoteTags = noteTags
-                    }
-                );
-
-            // SUT
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-            project = env.VerifyProjectSync(true);
-            Assert.That(project.DefaultFontSize, Is.EqualTo(newFontSize));
-            Assert.That(project.DefaultFont, Is.EqualTo(newFont));
-            Assert.That(project.NoteTags.Select(t => t.Icon), Is.EquivalentTo(new[] { customIcon }));
-        }
-
-        [Test]
-        public async Task SyncAsync_ProjectSettingsIsNull_SyncFailsAndTextNotUpdated()
-        {
-            var env = new TestEnvironment();
-            Book[] books = { new Book("MAT", 1) };
-            env.SetupSFData(true, true, true, false, books);
-            env.SetupPTData(books);
-
-            var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Administrator } };
-            env.ParatextService
-                .GetProjectRolesAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is((SFProject project) => project.ParatextId == "target"),
-                    Arg.Any<CancellationToken>()
-                )
-                .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
-            env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(x => null);
-
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-            env.VerifyProjectSync(false);
-            await env.ParatextService
-                .DidNotReceiveWithAnyArgs()
-                .PutBookText(default, default, default, default, default);
-
-            // Check that the failure was logged in the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
-        }
-
-        [Test]
-        public async Task SyncAsync_CheckerWithPTAccountNotRemoved()
-        {
-            var env = new TestEnvironment();
-            Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
-            env.SetupSFData(true, true, false, false, books);
-            env.SetupPTData(books);
-            var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Administrator } };
-            env.ParatextService
-                .GetProjectRolesAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is((SFProject project) => project.ParatextId == "target"),
-                    Arg.Any<CancellationToken>()
-                )
-                .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
-
-            await env.SetUserRole("user02", SFProjectRole.CommunityChecker);
-            SFProject project = env.GetProject();
-            Assert.That(project.UserRoles["user02"], Is.EqualTo(SFProjectRole.CommunityChecker));
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            env.VerifyProjectSync(true);
-            await env.SFProjectService.DidNotReceiveWithAnyArgs().RemoveUserAsync("user01", "project01", "user02");
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Users, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
-        }
-
-        [Test]
-        public async Task SyncAsync_LanguageIsRightToLeft_ProjectPropertySet()
-        {
-            var env = new TestEnvironment();
-            Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
-            env.SetupSFData(true, false, false, false, books);
-            env.SetupPTData(books);
-
-            env.ParatextService
-                .GetParatextSettings(Arg.Any<UserSecret>(), "target")
-                .Returns(new ParatextSettings { IsRightToLeft = true });
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            SFProject project = env.GetProject();
-            env.ParatextService.Received().GetParatextSettings(Arg.Any<UserSecret>(), "target");
-            env.ParatextService.Received().GetParatextSettings(Arg.Any<UserSecret>(), "source");
-            Assert.That(project.IsRightToLeft, Is.True);
-            Assert.That(project.TranslateConfig.Source.IsRightToLeft, Is.False);
-        }
-
-        [Test]
-        public async Task SyncAsync_FullName_ProjectPropertyNotSetIfNull()
-        {
-            var env = new TestEnvironment();
-            Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
-            env.SetupSFData(true, false, false, false, books);
-            env.SetupPTData(books);
-
-            env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), "target").Returns(new ParatextSettings());
-
-            // SUT
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            SFProject project = env.GetProject();
-            env.ParatextService.Received().GetParatextSettings(Arg.Any<UserSecret>(), "target");
-            Assert.That(project.Name, Is.EqualTo("project01"));
-        }
-
-        [Test]
-        public async Task SyncAsync_FullName_ProjectPropertySet()
-        {
-            var env = new TestEnvironment();
-            Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
-            env.SetupSFData(true, false, false, false, books);
-            env.SetupPTData(books);
-
-            string newFullName = "New Full Name";
-            env.ParatextService
-                .GetParatextSettings(Arg.Any<UserSecret>(), "target")
-                .Returns(new ParatextSettings { FullName = newFullName });
-
-            // SUT
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            SFProject project = env.GetProject();
-            env.ParatextService.Received().GetParatextSettings(Arg.Any<UserSecret>(), "target");
-            Assert.That(project.Name, Is.EqualTo(newFullName));
-        }
-
-        [Test]
-        public async Task SyncAsync_TextDocAlreadyExists()
-        {
-            var env = new TestEnvironment();
-            env.SetupSFData(false, false, false, false, new Book("MAT", 2), new Book("MRK", 2));
-            env.RealtimeService
-                .GetRepository<TextData>()
-                .Add(
-                    new TextData(Delta.New().InsertText("old text")) { Id = TextData.GetTextDocId("project01", 42, 1) }
-                );
-            env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2), new Book("LUK", 2));
-
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            var delta = Delta.New().InsertText("text");
-            Assert.That(env.GetText("project01", "MAT", 1).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project01", "MAT", 2).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project01", "MRK", 1).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project01", "MRK", 2).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project01", "LUK", 1).DeepEquals(delta), Is.True);
-            Assert.That(env.GetText("project01", "LUK", 2).DeepEquals(delta), Is.True);
-            env.VerifyProjectSync(true);
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
-            syncMetrics = env.GetSyncMetrics("project02");
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
-        }
-
-        [Test]
-        public async Task SyncAsync_DbMissingChapter()
-        {
-            // The project in the DB has a book, but a Source chapter is missing from that book.
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, false, false, new Book("MAT", 3, 3) { MissingSourceChapters = { 2 } });
-            env.SetupPTData(new Book("MAT", 3, true));
-
-            // DB should start with Target chapter 2 but without Source chapter 2.
-            Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
-            Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
-
-            // SUT
-            await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            // No errors or exceptions were logged
-            env.MockLogger.AssertNoEvent(
-                (LogEvent logEvent) => logEvent.LogLevel == LogLevel.Error || logEvent.Exception != null
-            );
-
-            var chapterContent = Delta.New().InsertText("text");
-            // DB should contain Source chapter 2 now from Paratext.
-            Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
-            Assert.That(env.ContainsText("project02", "MAT", 2), Is.True);
-            Assert.That(env.GetText("project01", "MAT", 2).DeepEquals(chapterContent), Is.True);
-            Assert.That(env.GetText("project02", "MAT", 2).DeepEquals(chapterContent), Is.True);
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
-            syncMetrics = env.GetSyncMetrics("project02");
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
-        }
-
-        [Test]
-        public async Task SyncAsync_ParatextMissingChapter()
-        {
-            // The project in Paratext has a book, but a chapter is missing from that book.
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, false, false, new Book("MAT", 3, true));
-            env.SetupPTData(new Book("MAT", 3, 3) { MissingTargetChapters = { 2 }, MissingSourceChapters = { 2 } });
-
-            var chapterContent = Delta.New().InsertText("text");
-            Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
-            Assert.That(env.ContainsText("project02", "MAT", 1), Is.True);
-            // DB should start with a chapter 2.
-            Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
-            Assert.That(env.ContainsText("project02", "MAT", 2), Is.True);
-            Assert.That(env.GetText("project01", "MAT", 2).DeepEquals(chapterContent), Is.True);
-            Assert.That(env.GetText("project02", "MAT", 2).DeepEquals(chapterContent), Is.True);
-            Assert.That(env.ContainsText("project01", "MAT", 3), Is.True);
-            Assert.That(env.ContainsText("project02", "MAT", 3), Is.True);
-
-            // SUT
-            await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            // No errors or exceptions were logged
-            env.MockLogger.AssertNoEvent(
-                (LogEvent logEvent) => logEvent.LogLevel == LogLevel.Error || logEvent.Exception != null
-            );
-
-            // DB should now be missing chapter 2, but retain chapters 1 and 3.
-            Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
-            Assert.That(env.ContainsText("project02", "MAT", 1), Is.True);
-            Assert.That(env.ContainsText("project01", "MAT", 2), Is.False);
-            Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
-            Assert.That(env.ContainsText("project01", "MAT", 3), Is.True);
-            Assert.That(env.ContainsText("project02", "MAT", 3), Is.True);
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
-            syncMetrics = env.GetSyncMetrics("project02");
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
-        }
-
-        [Test]
-        public async Task SyncAsync_DbAndParatextMissingChapter()
-        {
-            // The project has a book, but a Source chapter is missing from that book. Both in the DB and in Paratext.
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, false, false, new Book("MAT", 3, 3) { MissingSourceChapters = { 2 } });
-            env.SetupPTData(new Book("MAT", 3, 3) { MissingSourceChapters = { 2 } });
-
-            // DB should start without Source chapter 2.
-            Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
-            Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
-
-            // SUT
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            // No errors or exceptions were logged
-            env.MockLogger.AssertNoEvent(
-                (LogEvent logEvent) => logEvent.LogLevel == LogLevel.Error || logEvent.Exception != null
-            );
-
-            // DB should still be missing Source chapter 2.
-            Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
-            Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
-            syncMetrics = env.GetSyncMetrics("project02");
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
-        }
-
-        [Test]
-        public async Task SyncAsync_ParatextMissingAllChapters()
-        {
-            // The project in PT has a book, but no chapters.
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, false, false, new Book("MAT", 3, true));
-            env.SetupPTData(new Book("MAT", 0, true));
-
-            var chapterContent = Delta.New().InsertText("text");
-            Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
-            Assert.That(env.ContainsText("project02", "MAT", 1), Is.True);
-            Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
-            Assert.That(env.ContainsText("project02", "MAT", 2), Is.True);
-            Assert.That(env.GetText("project01", "MAT", 2).DeepEquals(chapterContent), Is.True);
-            Assert.That(env.GetText("project02", "MAT", 2).DeepEquals(chapterContent), Is.True);
-            Assert.That(env.ContainsText("project01", "MAT", 3), Is.True);
-            Assert.That(env.ContainsText("project02", "MAT", 3), Is.True);
-
-            // SUT
-            await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            // No errors or exceptions were logged
-            env.MockLogger.AssertNoEvent(
-                (LogEvent logEvent) => logEvent.LogLevel == LogLevel.Error || logEvent.Exception != null
-            );
-
-            // DB should now be missing all chapters except for the first, implicit chapter.
-            Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
-            Assert.That(env.ContainsText("project02", "MAT", 1), Is.True);
-            Assert.That(env.ContainsText("project01", "MAT", 2), Is.False);
-            Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
-            Assert.That(env.ContainsText("project01", "MAT", 3), Is.False);
-            Assert.That(env.ContainsText("project02", "MAT", 3), Is.False);
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 2, updated: 1)));
-            syncMetrics = env.GetSyncMetrics("project02");
-            Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 2, updated: 1)));
-        }
-
-        [Test]
-        public async Task RunAsync_NoRecordOfSyncedToRepositoryVersion_DoesFullSync()
-        {
-            var env = new TestEnvironment();
-            string projectSFId = "project03";
-            string userId = "user01";
-
-            SFProject project = env.SetupProjectWithExpectedImportedRev(projectSFId, null);
-            Assert.That(project.Sync.DataInSync, Is.Null, "setup. Should be testing what happens when this is null.");
-            string projectPTId = project.ParatextId;
-            env.ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), projectPTId).Returns("1", "2");
-            // The expected after-sync repository version can be past the original, before-sync project version,
-            // even if there were no local changes, since there may be incoming changes from the PT Archives server.
-            string expectedRepositoryVersion = "2";
-            // SUT
-            await env.RunAndAssertContinuesAsync(projectSFId, userId, expectedRepositoryVersion);
-            // Shouldn't be setting repo rev.
-            env.ParatextService
-                .DidNotReceive()
-                .SetRepoToRevision(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<string>());
-        }
-
-        [Test]
-        public async Task RunAsync_NullSyncRevRecordMatchesNullHgRev_Continue()
-        {
-            // The project sync record has no recorded PT hg repo revision that it imported from.
-            // The hg repo gives no revision either. Continue with sync.
-
-            var env = new TestEnvironment();
-            // project05 has a null DB SyncedToRepositoryVersion.
-            string projectSFId = "project05";
-            string userId = "user01";
-            SFProject project = env.SetupProjectWithExpectedImportedRev(
-                projectSFId,
-                startingDBSyncedToRepositoryVersion: null
-            );
-            env.ParatextService
-                .GetLatestSharedVersion(Arg.Any<UserSecret>(), project.ParatextId)
-                .Returns(default(string?));
-            Assert.That(
-                project.Sync.DataInSync,
-                Is.Not.Null,
-                "setup. We are not testing the special situation of DataInSync being null."
-            );
-            // SUT
-            await env.RunAndAssertContinuesAsync(projectSFId, userId, finalDBSyncedToRepositoryVersion: null);
-            // Shouldn't be setting repo rev.
-            env.ParatextService
-                .DidNotReceive()
-                .SetRepoToRevision(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<string>());
-        }
-
-        [Test]
-        public async Task RunAsync_NullSyncRevRecordNotMatchHgRev_Continue()
-        {
-            // The project sync record has no recorded PT hg repo revision that it imported from,
-            // yet the hg repo is there and has a revision. Continue with sync.
-
-            var env = new TestEnvironment();
-            // project05 has a null DB SyncedToRepositoryVersion.
-            string projectSFId = "project05";
-            string userId = "user01";
-            SFProject project = env.SetupProjectWithExpectedImportedRev(
-                projectSFId,
-                startingDBSyncedToRepositoryVersion: null
-            );
-            env.ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), project.ParatextId).Returns("v1");
-            Assert.That(
-                project.Sync.DataInSync,
-                Is.Not.Null,
-                "setup. We are not testing the special situation of DataInSync being null."
-            );
-            // SUT
-            await env.RunAndAssertContinuesAsync(projectSFId, userId, finalDBSyncedToRepositoryVersion: "v1");
-            // Shouldn't be setting repo rev.
-            env.ParatextService
-                .DidNotReceive()
-                .SetRepoToRevision(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<string>());
-        }
-
-        [Test]
-        public async Task RunAsync_SyncRevRecordNotMatchHgRev_AdjustAndContinue()
-        {
-            // The project sync record of PT hg repo revision that it imported from does not match the current
-            // hg repo revision. So we set the repo revision, and perform sync.
-
-            var env = new TestEnvironment();
-            // project01 has a non-null DB SyncedToRepositoryVersion.
-            string projectSFId = "project01";
-            string userId = "user01";
-            SFProject project = env.SetupProjectWithExpectedImportedRev(
-                projectSFId,
-                startingDBSyncedToRepositoryVersion: "beforeSR"
-            );
-            env.ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), project.ParatextId).Returns("v1");
-            // SUT
-            await env.RunAndAssertContinuesAsync(projectSFId, userId, finalDBSyncedToRepositoryVersion: "afterSR");
-            env.ParatextService.Received().SetRepoToRevision(Arg.Any<UserSecret>(), Arg.Any<string>(), "beforeSR");
-        }
-
-        [Test]
-        public async Task RunAsync_SyncRevRecordMatchesHgRev_Continue()
-        {
-            // The project sync record of PT hg repo revision that it imported from matches the current
-            // hg repo revision. Continue with sync.
-
-            var env = new TestEnvironment();
-            // project01 has a non-null DB SyncedToRepositoryVersion.
-            string projectSFId = "project01";
-            string userId = "user01";
-            SFProject project = env.SetupProjectWithExpectedImportedRev(
-                projectSFId,
-                startingDBSyncedToRepositoryVersion: "beforeSR"
-            );
-            env.ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), project.ParatextId).Returns(("beforeSR"));
-            // SUT
-            await env.RunAndAssertContinuesAsync(projectSFId, userId, finalDBSyncedToRepositoryVersion: "afterSR");
-            // And it doesn't matter if we set the hg repo to the rev or not.
-        }
-
-        [Test]
-        public async Task SyncAsync_TaskAbortedByExceptionWritesToLog()
-        {
-            // Set up the environment
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, false, false);
-            env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-            using var cancellationTokenSource = new CancellationTokenSource();
-
-            // Setup a trap to crash the task
-            env.NotesMapper
-                .When(
-                    x =>
-                        x.InitAsync(
-                            Arg.Any<UserSecret>(),
-                            Arg.Any<SFProjectSecret>(),
-                            Arg.Any<List<User>>(),
-                            Arg.Any<SFProject>(),
-                            Arg.Any<CancellationToken>()
-                        )
-                )
-                .Do(_ => throw new ArgumentException());
-
-            // Run the task
-            await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
-
-            // Check that the Exception was logged
-            env.MockLogger.AssertHasEvent((LogEvent logEvent) => logEvent.Exception != null);
-
-            // Check that the exception was logged in the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
-            StringAssert.StartsWith("System.ArgumentException", syncMetrics.ErrorDetails);
-
-            // Check that the task cancelled correctly
-            SFProject project = env.VerifyProjectSync(false);
-            Assert.That(project.Sync.DataInSync, Is.True); // Nothing was synced as this was cancelled OnInit()
-        }
-
-        [Test]
-        public async Task SyncAsync_DataInSyncTrueAfterRestore()
-        {
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, false, false);
-            env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-            // Simulate a successful backup to a hg repo at a revision not matching our project doc
-            // after a failed send/receive
-            env.ParatextService.BackupExists(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(true);
-            env.ParatextService.RestoreRepository(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(true);
-            env.ParatextService
-                .When(p => p.GetBookText(Arg.Any<UserSecret>(), "target", Arg.Any<int>()))
-                .Do(_ => throw new ArgumentException());
-
-            env.ParatextService
-                .When(p => p.RestoreRepository(Arg.Any<UserSecret>(), "target"))
-                .Do(
-                    _ =>
-                        env.ParatextService
-                            .GetLatestSharedVersion(Arg.Any<UserSecret>(), "target")
-                            .Returns("revNotMatchingVersion")
-                );
-
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            // Check that the failure was logged in the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
-            Assert.That(syncMetrics.RepositoryRestoredFromBackup, Is.True);
-
-            // Check that the sync restored correctly
-            env.ParatextService.Received(1).RestoreRepository(Arg.Any<UserSecret>(), "target");
-            SFProject project = env.VerifyProjectSync(false);
-            Assert.That(project.Sync.DataInSync, Is.True);
-        }
-
-        [Test]
-        public async Task SyncAsync_TaskCancelledByException()
-        {
-            // Set up the environment
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, false, false);
-            env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-            using var cancellationTokenSource = new CancellationTokenSource();
-
-            // Setup a trap to cancel the task
-            env.NotesMapper
-                .When(
-                    x =>
-                        x.InitAsync(
-                            Arg.Any<UserSecret>(),
-                            Arg.Any<SFProjectSecret>(),
-                            Arg.Any<List<User>>(),
-                            Arg.Any<SFProject>(),
-                            Arg.Any<CancellationToken>()
-                        )
-                )
-                .Do(_ =>
-                {
-                    cancellationTokenSource.Cancel();
-                    throw new TaskCanceledException();
-                });
-
-            // Run the task
-            await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
-
-            // The TaskCancelledException was not logged
-            Assert.That(
-                env.MockLogger.LogEvents.Count(
-                    (LogEvent logEvent) => logEvent.LogLevel == LogLevel.Error || logEvent.Exception != null
-                ),
-                Is.EqualTo(0)
-            );
-
-            // Check that the cancellation was logged in the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
-
-            // Check that the task cancelled correctly
-            SFProject project = env.VerifyProjectSync(false);
-            Assert.That(project.Sync.DataInSync, Is.True); // Nothing was synced as this was cancelled OnInit()
-        }
-
-        [Test]
-        public async Task SyncAsync_TaskCancelledMidway()
-        {
-            // Set up the environment
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, false, false);
-            env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-            using var cancellationTokenSource = new CancellationTokenSource();
-
-            // Setup a trap to cancel the task
-            env.ParatextService
-                .When(
-                    x =>
-                        x.SendReceiveAsync(
-                            Arg.Any<UserSecret>(),
-                            Arg.Any<string>(),
-                            Arg.Any<IProgress<ProgressState>>(),
-                            Arg.Any<CancellationToken>()
-                        )
-                )
-                .Do(_ => cancellationTokenSource.Cancel());
-
-            // Run the task
-            await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
-
-            // Check that the cancellation was logged in the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
-
-            // Check that the task cancelled correctly
-            SFProject project = env.VerifyProjectSync(false);
-            Assert.That(project.Sync.DataInSync, Is.False);
-        }
-
-        [Test]
-        public async Task SyncAsync_TaskCancelledAndRestoreFails_DataNotInSync()
-        {
-            var env = new TestEnvironment();
-            env.SetupSFData(true, false, true, false);
-            env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-            using var cancellationTokenSource = new CancellationTokenSource();
-            env.ParatextService.BackupExists(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(true);
-            env.ParatextService.RestoreRepository(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(false);
-
-            env.ParatextService
-                .When(
-                    x =>
-                        x.SendReceiveAsync(
-                            Arg.Any<UserSecret>(),
-                            Arg.Any<string>(),
-                            Arg.Any<IProgress<ProgressState>>(),
-                            Arg.Any<CancellationToken>()
-                        )
-                )
-                .Do(_ => cancellationTokenSource.Cancel());
-            await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
-            env.ParatextService.Received(1).RestoreRepository(Arg.Any<UserSecret>(), Arg.Any<string>());
-            SFProject project = env.VerifyProjectSync(false);
-
-            // Check that the cancellation was logged in the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
-
-            // Data is out of sync due to the failed restore
-            Assert.That(project.Sync.DataInSync, Is.False);
-        }
-
-        [Test]
-        public async Task SyncAsync_TaskCancelledPrematurely()
-        {
-            // Set up the environment
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, false, false);
-            env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-            using var cancellationTokenSource = new CancellationTokenSource();
-
-            // Cancel the token before awaiting the task
-            cancellationTokenSource.Cancel();
-
-            // Run the task
-            await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
-
-            // Check that the cancellation was logged in the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
-
-            // Check that the task was cancelled after awaiting the check above
-            SFProject project = env.VerifyProjectSync(false);
-            Assert.That(project.Sync.DataInSync, Is.True);
-        }
-
-        [Test]
-        public async Task SyncAsync_TaskCancelledExecutesRollback()
-        {
-            // Set up the environment
-            var env = new TestEnvironment(substituteRealtimeService: true);
-            env.SetupSFData(true, true, false, false);
-            env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-            using var cancellationTokenSource = new CancellationTokenSource();
-
-            // Return the project so InitAsync will execute successfully
-            var project = Substitute.For<IDocument<SFProject>>();
-            project.IsLoaded.Returns(true);
-            project.Data.Returns(env.GetProject());
-            env.Connection.Get<SFProject>("project01").Returns(project);
-
-            // The HTTP call throws this when a cancelled token is passed
-            env.ParatextService
-                .GetParatextUsernameMappingAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Any<SFProject>(),
-                    Arg.Any<CancellationToken>()
-                )
-                .ThrowsForAnyArgs(new OperationCanceledException());
-
-            // Setup a trap to cancel the task
-            env.ParatextService
-                .When(
-                    x =>
-                        x.SendReceiveAsync(
-                            Arg.Any<UserSecret>(),
-                            Arg.Any<string>(),
-                            Arg.Any<IProgress<ProgressState>>(),
-                            Arg.Any<CancellationToken>()
-                        )
-                )
-                .Do(_ => cancellationTokenSource.Cancel());
-
-            // Run the task
-            await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
-
-            // Check for RollbackTransaction being executed, to ensure
-            // that CompleteAsync executes to the end without exception
-            env.Connection.Received(1).RollbackTransaction();
-
-            // Check that the cancellation was logged in the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
-        }
-
-        [Test]
-        public async Task SyncAsync_ExcludesPropertiesFromTransactions()
-        {
-            // Set up the environment
-            var env = new TestEnvironment(substituteRealtimeService: true);
-            env.SetupSFData(true, true, false, false);
-            env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-            using var cancellationTokenSource = new CancellationTokenSource();
-
-            // Throw an TaskCanceledException in InitAsync after the exclusions have been called
-            // InitAsync calls the IConnection.FetchAsync() extension, which calls IConnection.Get()
-            env.Connection.Get<SFProject>("project01").Throws(new TaskCanceledException());
-
-            // Run the task
-            await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
-
-            // Only check for ExcludePropertyFromTransaction being executed,
-            // as the substitute RealtimeService will not update documents.
-            env.Connection
-                .Received(1)
-                .ExcludePropertyFromTransaction(
-                    Arg.Is<Expression<Func<SFProject, object>>>(
-                        ex => string.Join('.', new ObjectPath(ex).Items) == "Sync.QueuedCount"
-                    )
-                );
-            env.Connection
-                .Received(1)
-                .ExcludePropertyFromTransaction(
-                    Arg.Is<Expression<Func<SFProject, object>>>(
-                        ex => string.Join('.', new ObjectPath(ex).Items) == "Sync.DataInSync"
-                    )
-                );
-            env.Connection.Received(2).ExcludePropertyFromTransaction(Arg.Any<Expression<Func<SFProject, object>>>());
-        }
-
-        [Test]
-        public async Task SyncAsync_TaskCancelledTooLate()
-        {
-            // Set up the environment
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, false, false);
-            env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-            using var cancellationTokenSource = new CancellationTokenSource();
-
-            // Run the task
-            await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
-
-            // Cancel the token after awaiting the task
-            cancellationTokenSource.Cancel();
-
-            // Check that the sync was successful
-            SFProject project = env.VerifyProjectSync(true);
-            Assert.That(project.Sync.DataInSync, Is.True);
-        }
-
-        [Test]
-        public async Task FetchTextDocsAsync_FetchesExistingChapters()
-        {
-            var env = new TestEnvironment();
-            var numberChapters = 3;
-            var book = new Book("MAT", numberChapters, true);
-            env.SetupSFData(true, true, false, false, book);
-
-            // SUT
-            await env.Runner.InitAsync("project01", "user01", "project01", CancellationToken.None);
-            SortedList<int, IDocument<TextData>> targetFetch = await env.Runner.FetchTextDocsAsync(
-                env.TextInfoFromBook(book)
-            );
-            await env.Runner.InitAsync("project02", "user01", "project02", CancellationToken.None);
-            SortedList<int, IDocument<TextData>> sourceFetch = await env.Runner.FetchTextDocsAsync(
-                env.TextInfoFromBook(book)
-            );
-            env.Runner.CloseConnection();
-
-            // Fetched numberChapters chapters, none of which are missing their chapter content.
-            Assert.That(targetFetch.Count, Is.EqualTo(numberChapters));
-            Assert.That(sourceFetch.Count, Is.EqualTo(numberChapters));
-            Assert.That(targetFetch.Count(doc => doc.Value.Data == null), Is.EqualTo(0));
-            Assert.That(sourceFetch.Count(doc => doc.Value.Data == null), Is.EqualTo(0));
-        }
-
-        [Test]
-        public async Task FetchTextDocsAsync_MissingRequestedChapters()
-        {
-            // In production, the expected chapters list, used to specify
-            // what FetchTextDocsAsync() should fetch, comes from the
-            // SF DB project doc texts.chapters array. This array
-            // specifies what Target chapter text docs the SF DB should
-            // ave. Re-using the Target chapter list when fetching Source
-            // chapter text docs from the SF DB can lead to problems if
-            // FetchTextDocsAsync() does not omit ones that aren't
-            // actually in the DB.
-
-            var env = new TestEnvironment();
-            var highestChapter = 20;
-            var missingSourceChapters = new HashSet<int>() { 2, 3, 10, 12 };
-            var existingTargetChapters = Enumerable.Range(1, highestChapter);
-            var existingSourceChapters = Enumerable.Range(1, highestChapter).Except(missingSourceChapters);
-            Assert.That(
-                existingSourceChapters.Count(),
-                Is.EqualTo(highestChapter - missingSourceChapters.Count()),
-                "setup"
-            );
-            Assert.That(existingTargetChapters.Count(), Is.GreaterThan(existingSourceChapters.Count()), "setup");
-            var book = new Book("MAT", highestChapter, true) { MissingSourceChapters = missingSourceChapters };
-            env.SetupSFData(true, true, false, false, book);
-
-            // SUT
-            await env.Runner.InitAsync("project01", "user01", "project01", CancellationToken.None);
-            var targetFetch = await env.Runner.FetchTextDocsAsync(env.TextInfoFromBook(book));
-
-            await env.Runner.InitAsync("project02", "user01", "project02", CancellationToken.None);
-            var sourceFetch = await env.Runner.FetchTextDocsAsync(env.TextInfoFromBook(book));
-
-            env.Runner.CloseConnection();
-
-            // Fetched only non-missing chapters. None have null Data.
-            Assert.That(targetFetch.Keys.SequenceEqual(existingTargetChapters));
-            Assert.That(sourceFetch.Keys.SequenceEqual(existingSourceChapters));
-            Assert.That(targetFetch.Count(doc => doc.Value.Data == null), Is.EqualTo(0));
-            Assert.That(sourceFetch.Count(doc => doc.Value.Data == null), Is.EqualTo(0));
-        }
-
-        [Test]
-        public async Task GetChapterAuthors_FromMongoDB()
-        {
-            // Setup
-            // Note that the last modified userId is set to user05
-            // So the user id will be retrieved from GetLastModifiedUserIdAsync()
-            // But note that user05 must also be in the chapter permissions to be used
-            var env = new TestEnvironment();
-            TextInfo textInfo = env.SetupChapterAuthorsAndGetTextInfo(setChapterPermissions: false);
-            await env.Runner.InitAsync("project01", "user01", "project01", CancellationToken.None);
-            var textDocs = await env.Runner.FetchTextDocsAsync(textInfo);
-            textInfo.Chapters.First().Permissions.Add("user05", TextInfoPermission.Write);
-            env.RealtimeService.LastModifiedUserId = "user05";
-
-            // SUT
-            Dictionary<int, string> chapterAuthors = await env.Runner.GetChapterAuthorsAsync(textInfo, textDocs);
-            Assert.AreEqual(1, chapterAuthors.Count);
-            Assert.AreEqual(new KeyValuePair<int, string>(1, "user05"), chapterAuthors.First());
-        }
-
-        [Test]
-        public async Task GetChapterAuthors_FromUserSecret()
-        {
-            // Setup
-            // Note that the InitAsync() userId is user01, and setChapterPermissions is true,
-            // So the user id will be retrieved from the user secret
-            var env = new TestEnvironment();
-            TextInfo textInfo = env.SetupChapterAuthorsAndGetTextInfo(setChapterPermissions: true);
-            await env.Runner.InitAsync("project01", "user01", "project01", CancellationToken.None);
-            var textDocs = await env.Runner.FetchTextDocsAsync(textInfo);
-
-            // SUT
-            Dictionary<int, string> chapterAuthors = await env.Runner.GetChapterAuthorsAsync(textInfo, textDocs);
-            Assert.AreEqual(1, chapterAuthors.Count);
-            Assert.AreEqual(new KeyValuePair<int, string>(1, "user01"), chapterAuthors.First());
-        }
-
-        [Test]
-        public async Task GetChapterAuthors_FromChapterPermissions()
-        {
-            // Setup
-            // Note that the InitAsync() userId is user02, and setChapterPermissions is true,
-            // So the user id will be retrieved from the chapter permissions
-            var env = new TestEnvironment();
-            TextInfo textInfo = env.SetupChapterAuthorsAndGetTextInfo(setChapterPermissions: true);
-            await env.Runner.InitAsync("project01", "user02", "project01", CancellationToken.None);
-            var textDocs = await env.Runner.FetchTextDocsAsync(textInfo);
-
-            // SUT
-            Dictionary<int, string> chapterAuthors = await env.Runner.GetChapterAuthorsAsync(textInfo, textDocs);
-            Assert.AreEqual(1, chapterAuthors.Count);
-            Assert.AreEqual(new KeyValuePair<int, string>(1, "user01"), chapterAuthors.First());
-        }
-
-        [Test]
-        public async Task GetChapterAuthors_FromProjectDoc()
-        {
-            // Setup
-            // Note that the InitAsync() userId is user02, and setChapterPermissions is false,
-            // So the user id will be retrieved from the project doc
-            var env = new TestEnvironment();
-            TextInfo textInfo = env.SetupChapterAuthorsAndGetTextInfo(setChapterPermissions: false);
-            await env.Runner.InitAsync("project01", "user02", "project01", CancellationToken.None);
-            var textDocs = await env.Runner.FetchTextDocsAsync(textInfo);
-
-            // SUT
-            Dictionary<int, string> chapterAuthors = await env.Runner.GetChapterAuthorsAsync(textInfo, textDocs);
-            Assert.AreEqual(1, chapterAuthors.Count);
-            Assert.AreEqual(new KeyValuePair<int, string>(1, "user03"), chapterAuthors.First());
-        }
-
-        [Test]
-        public async Task GetChapterAuthors_ChecksLastModifiedUserPermission()
-        {
-            // Setup
-            // Note that the last modified userId is set to user06
-            // So the user id will be retrieved from GetLastModifiedUserIdAsync()
-            // But will not pass the chapter permissions test (only user05 has permission)
-            var env = new TestEnvironment();
-            TextInfo textInfo = env.SetupChapterAuthorsAndGetTextInfo(setChapterPermissions: false);
-            await env.Runner.InitAsync("project01", "user01", "project01", CancellationToken.None);
-            var textDocs = await env.Runner.FetchTextDocsAsync(textInfo);
-            textInfo.Chapters.First().Permissions.Add("user05", TextInfoPermission.Write);
-            env.RealtimeService.LastModifiedUserId = "user06";
-
-            // SUT
-            Dictionary<int, string> chapterAuthors = await env.Runner.GetChapterAuthorsAsync(textInfo, textDocs);
-            Assert.AreEqual(1, chapterAuthors.Count);
-            Assert.AreEqual(new KeyValuePair<int, string>(1, "user05"), chapterAuthors.First());
-        }
-
-        [Test]
-        public async Task GetChapterAuthors_ChecksLastModifiedUserWritePermission()
-        {
-            // Setup
-            // Note that the last modified userId is set to user05
-            // So the user id will be retrieved from GetLastModifiedUserIdAsync()
-            // But will not pass the chapter permissions test (user05 can only read)
-            // However, user03 will be used because they are the project administrator
-            var env = new TestEnvironment();
-            TextInfo textInfo = env.SetupChapterAuthorsAndGetTextInfo(setChapterPermissions: false);
-            await env.Runner.InitAsync("project01", "user01", "project01", CancellationToken.None);
-            var textDocs = await env.Runner.FetchTextDocsAsync(textInfo);
-            textInfo.Chapters.First().Permissions.Add("user05", TextInfoPermission.Read);
-            env.RealtimeService.LastModifiedUserId = "user05";
-
-            // SUT
-            Dictionary<int, string> chapterAuthors = await env.Runner.GetChapterAuthorsAsync(textInfo, textDocs);
-            Assert.AreEqual(1, chapterAuthors.Count);
-            Assert.AreEqual(new KeyValuePair<int, string>(1, "user03"), chapterAuthors.First());
-        }
-
-        [Test]
-        [Ignore("Not ready to sync notes back to paratext.")]
-        public async Task SyncAsync_UpdatesParatextComments()
-        {
-            var env = new TestEnvironment();
-            var book = new Book("MAT", 1, true);
-            env.SetupSFData(true, false, false, true, book);
-            env.SetupPTData(book);
-            env.SetupNoteChanges("thread01", "MAT 1:1", false);
-            await env.ParatextService.UpdateParatextCommentsAsync(
+        var env = new TestEnvironment();
+
+        // SUT
+        await env.Runner.RunAsync("project03", "user01", "project03", false, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task SyncAsync_UserDoesNotExist()
+    {
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, true, false);
+        env.ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), "target").Returns("beforeSR");
+
+        await env.Runner.RunAsync("project01", "user03", "project01", false, CancellationToken.None);
+
+        SFProject project = env.VerifyProjectSync(false);
+        Assert.That(project.Sync.DataInSync, Is.True);
+
+        // Check that the failure was logged in the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
+    }
+
+    [Test]
+    public async Task SyncAsync_Error()
+    {
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, false, false);
+        env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
+        env.DeltaUsxMapper.When(d => d.ToChapterDeltas(Arg.Any<XDocument>())).Do(x => throw new Exception());
+
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        SFProject project = env.VerifyProjectSync(false);
+        Assert.That(project.Sync.DataInSync, Is.False);
+
+        // Check that the failure was logged in the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
+    }
+
+    [Test]
+    public async Task SyncAsync_NewProjectTranslationSuggestionsAndCheckingDisabled()
+    {
+        var env = new TestEnvironment();
+        env.SetupSFData(false, false, false, false);
+        env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
+
+        await env.Runner.RunAsync("project01", "user01", "project01", true, CancellationToken.None);
+
+        Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
+        Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
+        Assert.That(env.ContainsText("project01", "MRK", 1), Is.True);
+        Assert.That(env.ContainsText("project01", "MRK", 2), Is.True);
+
+        Assert.That(env.ContainsText("project02", "MAT", 1), Is.False);
+        Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
+        Assert.That(env.ContainsText("project02", "MRK", 1), Is.False);
+        Assert.That(env.ContainsText("project02", "MRK", 2), Is.False);
+
+        Assert.That(env.ContainsQuestion("MAT", 1), Is.False);
+        Assert.That(env.ContainsQuestion("MAT", 2), Is.False);
+        Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
+        Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
+
+        await env.MachineProjectService
+            .DidNotReceive()
+            .BuildProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        env.VerifyProjectSync(true);
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 4, deleted: 0, updated: 0)));
+        syncMetrics = env.GetSyncMetrics("project02");
+        Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+    }
+
+    [Test]
+    public async Task SyncAsync_NewProjectTranslationSuggestionsAndCheckingEnabled()
+    {
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, false, false);
+        env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
+
+        await env.Runner.RunAsync("project02", "user01", "project02", true, CancellationToken.None);
+        await env.Runner.RunAsync("project01", "user01", "project01", true, CancellationToken.None);
+
+        Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
+        Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
+        Assert.That(env.ContainsText("project01", "MRK", 1), Is.True);
+        Assert.That(env.ContainsText("project01", "MRK", 2), Is.True);
+
+        Assert.That(env.ContainsText("project02", "MAT", 1), Is.True);
+        Assert.That(env.ContainsText("project02", "MAT", 2), Is.True);
+        Assert.That(env.ContainsText("project02", "MRK", 1), Is.False);
+        Assert.That(env.ContainsText("project02", "MRK", 2), Is.False);
+
+        Assert.That(env.ContainsQuestion("MAT", 1), Is.False);
+        Assert.That(env.ContainsQuestion("MAT", 2), Is.False);
+        Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
+        Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
+
+        await env.MachineProjectService.Received().BuildProjectAsync("user01", "project01", CancellationToken.None);
+        env.VerifyProjectSync(true);
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 4, deleted: 0, updated: 0)));
+        syncMetrics = env.GetSyncMetrics("project02");
+        Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
+    }
+
+    [Test]
+    public async Task SyncAsync_NewProjectOnlyTranslationSuggestionsEnabled()
+    {
+        var env = new TestEnvironment();
+        env.SetupSFData(true, false, false, false);
+        env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
+
+        await env.Runner.RunAsync("project02", "user01", "project02", true, CancellationToken.None);
+        await env.Runner.RunAsync("project01", "user01", "project01", true, CancellationToken.None);
+
+        Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
+        Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
+        Assert.That(env.ContainsText("project01", "MRK", 1), Is.True);
+        Assert.That(env.ContainsText("project01", "MRK", 2), Is.True);
+
+        Assert.That(env.ContainsText("project02", "MAT", 1), Is.True);
+        Assert.That(env.ContainsText("project02", "MAT", 2), Is.True);
+        Assert.That(env.ContainsText("project02", "MRK", 1), Is.False);
+        Assert.That(env.ContainsText("project02", "MRK", 2), Is.False);
+
+        Assert.That(env.ContainsQuestion("MAT", 1), Is.False);
+        Assert.That(env.ContainsQuestion("MAT", 2), Is.False);
+        Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
+        Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
+
+        await env.MachineProjectService.Received().BuildProjectAsync("user01", "project01", CancellationToken.None);
+        env.VerifyProjectSync(true);
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 4, deleted: 0, updated: 0)));
+        syncMetrics = env.GetSyncMetrics("project02");
+        Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
+    }
+
+    [Test]
+    public async Task SyncAsync_NewProjectOnlyCheckingEnabled()
+    {
+        var env = new TestEnvironment();
+        env.SetupSFData(false, true, false, false);
+        env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2, false));
+
+        await env.Runner.RunAsync("project01", "user01", "project01", true, CancellationToken.None);
+
+        Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
+        Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
+        Assert.That(env.ContainsText("project01", "MRK", 1), Is.True);
+        Assert.That(env.ContainsText("project01", "MRK", 2), Is.True);
+
+        Assert.That(env.ContainsText("project02", "MAT", 1), Is.False);
+        Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
+        Assert.That(env.ContainsText("project02", "MRK", 1), Is.False);
+        Assert.That(env.ContainsText("project02", "MRK", 2), Is.False);
+
+        Assert.That(env.ContainsQuestion("MAT", 1), Is.False);
+        Assert.That(env.ContainsQuestion("MAT", 2), Is.False);
+        Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
+        Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
+
+        await env.MachineProjectService
+            .DidNotReceive()
+            .BuildProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        env.VerifyProjectSync(true);
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 4, deleted: 0, updated: 0)));
+        syncMetrics = env.GetSyncMetrics("project02");
+        Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+    }
+
+    [Test]
+    public async Task SyncAsync_NewProjectOnlyNoMatchingSourceText_TranslationSuggestionEnabled()
+    {
+        var env = new TestEnvironment();
+        env.SetupSFData(true, false, false, false);
+        env.SetupPTData(new Book("MAT", 2, false));
+
+        await env.Runner.RunAsync("project02", "user01", "project02", true, CancellationToken.None);
+        await env.Runner.RunAsync("project01", "user01", "project01", true, CancellationToken.None);
+
+        Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
+        Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
+        Assert.That(env.ContainsText("project02", "MAT", 1), Is.False);
+        Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
+
+        await env.MachineProjectService
+            .DidNotReceive()
+            .BuildProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        env.VerifyProjectSync(true);
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
+        syncMetrics = env.GetSyncMetrics("project02");
+        Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+    }
+
+    [Test]
+    public async Task SyncAsync_DataNotChanged()
+    {
+        var env = new TestEnvironment();
+        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        env.SetupSFData(true, true, false, false, books);
+        env.SetupPTData(books);
+
+        // SUT
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        env.MockLogger.AssertEventCount(
+            (LogEvent logEvent) =>
+                logEvent.LogLevel == LogLevel.Information && Regex.IsMatch(logEvent.Message, "Starting"),
+            1
+        );
+
+        await env.ParatextService
+            .DidNotReceive()
+            .PutBookText(Arg.Any<UserSecret>(), "target", 40, Arg.Any<XDocument>());
+        await env.ParatextService
+            .DidNotReceive()
+            .PutBookText(Arg.Any<UserSecret>(), "target", 41, Arg.Any<XDocument>());
+
+        await env.ParatextService
+            .DidNotReceive()
+            .PutBookText(Arg.Any<UserSecret>(), "source", 40, Arg.Any<XDocument>());
+        await env.ParatextService
+            .DidNotReceive()
+            .PutBookText(Arg.Any<UserSecret>(), "source", 41, Arg.Any<XDocument>());
+
+        var delta = Delta.New().InsertText("text");
+        Assert.That(env.GetText("project01", "MAT", 1).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project01", "MAT", 2).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project01", "MRK", 1).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project01", "MRK", 2).DeepEquals(delta), Is.True);
+
+        Assert.That(env.GetText("project02", "MAT", 1).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project02", "MAT", 2).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project02", "MRK", 1).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project02", "MRK", 2).DeepEquals(delta), Is.True);
+
+        env.ParatextService.DidNotReceive().PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<XElement>());
+
+        SFProject project = env.VerifyProjectSync(true);
+        Assert.That(project.ParatextUsers.Count, Is.EqualTo(2));
+        Assert.That(project.UserRoles["user01"], Is.EqualTo(SFProjectRole.Administrator));
+        Assert.That(project.UserRoles["user02"], Is.EqualTo(SFProjectRole.Translator));
+    }
+
+    [Test]
+    public async Task SyncAsync_DataChangedTranslateAndCheckingEnabled()
+    {
+        var env = new TestEnvironment();
+        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        env.SetupSFData(true, true, true, false, books);
+        env.SetupPTData(books);
+
+        await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        await env.ParatextService
+            .Received()
+            .PutBookText(Arg.Any<UserSecret>(), "target", 40, Arg.Any<XDocument>(), Arg.Any<Dictionary<int, string>>());
+        await env.ParatextService
+            .Received()
+            .PutBookText(Arg.Any<UserSecret>(), "target", 41, Arg.Any<XDocument>(), Arg.Any<Dictionary<int, string>>());
+
+        await env.ParatextService
+            .Received()
+            .PutBookText(Arg.Any<UserSecret>(), "source", 40, Arg.Any<XDocument>(), Arg.Any<Dictionary<int, string>>());
+        await env.ParatextService
+            .Received()
+            .PutBookText(Arg.Any<UserSecret>(), "source", 41, Arg.Any<XDocument>(), Arg.Any<Dictionary<int, string>>());
+
+        var delta = Delta.New().InsertText("text");
+        Assert.That(env.GetText("project01", "MAT", 1).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project01", "MAT", 2).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project01", "MRK", 1).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project01", "MRK", 2).DeepEquals(delta), Is.True);
+
+        Assert.That(env.GetText("project02", "MAT", 1).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project02", "MAT", 2).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project02", "MRK", 1).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project02", "MRK", 2).DeepEquals(delta), Is.True);
+
+        env.ParatextService.Received(2).PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<XElement>());
+
+        SFProject project = env.GetProject();
+        Assert.That(project.ParatextUsers.Count, Is.EqualTo(2));
+        env.VerifyProjectSync(true);
+    }
+
+    [Test]
+    public async Task SyncAsync_DataChangedTranslateEnabledCheckingDisabled()
+    {
+        var env = new TestEnvironment();
+        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        env.SetupSFData(true, false, true, false, books);
+        env.SetupPTData(books);
+
+        await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        await env.ParatextService
+            .Received()
+            .PutBookText(Arg.Any<UserSecret>(), "target", 40, Arg.Any<XDocument>(), Arg.Any<Dictionary<int, string>>());
+        await env.ParatextService
+            .Received()
+            .PutBookText(Arg.Any<UserSecret>(), "target", 41, Arg.Any<XDocument>(), Arg.Any<Dictionary<int, string>>());
+
+        await env.ParatextService
+            .Received()
+            .PutBookText(Arg.Any<UserSecret>(), "source", 40, Arg.Any<XDocument>(), Arg.Any<Dictionary<int, string>>());
+        await env.ParatextService
+            .Received()
+            .PutBookText(Arg.Any<UserSecret>(), "source", 41, Arg.Any<XDocument>(), Arg.Any<Dictionary<int, string>>());
+
+        env.ParatextService.DidNotReceive().PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<XElement>());
+
+        var delta = Delta.New().InsertText("text");
+        Assert.That(env.GetText("project01", "MAT", 1).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project01", "MAT", 2).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project01", "MRK", 1).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project01", "MRK", 2).DeepEquals(delta), Is.True);
+
+        Assert.That(env.GetText("project02", "MAT", 1).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project02", "MAT", 2).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project02", "MRK", 1).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project02", "MRK", 2).DeepEquals(delta), Is.True);
+
+        SFProject project = env.GetProject();
+        Assert.That(project.ParatextUsers.Count, Is.EqualTo(2));
+        env.VerifyProjectSync(true);
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 2)));
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 4)));
+        syncMetrics = env.GetSyncMetrics("project02");
+        Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 2)));
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 4)));
+    }
+
+    [Test]
+    public async Task SyncAsync_ChaptersChanged()
+    {
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, false, false, new Book("MAT", 2), new Book("MRK", 2));
+        env.SetupPTData(new Book("MAT", 3), new Book("MRK", 1));
+        env.AddParatextNoteThreadData(new Book("MRK", 2));
+        Assert.That(env.ContainsNote(2), Is.True);
+
+        await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+        env.ParatextService
+            .Received()
+            .GetNoteThreadChanges(
                 Arg.Any<UserSecret>(),
-                default,
-                default,
-                Arg.Any<IEnumerable<IDocument<NoteThread>>>(),
-                Arg.Any<Dictionary<string, ParatextUserProfile>>(),
-                default
+                "target",
+                41,
+                Arg.Is<IEnumerable<IDocument<NoteThread>>>(threads => threads.Any(t => t.Id == "project01:thread02")),
+                Arg.Any<Dictionary<int, ChapterDelta>>(),
+                Arg.Any<Dictionary<string, ParatextUserProfile>>()
             );
 
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-            await env.ParatextService
-                .Received(1)
-                .UpdateParatextCommentsAsync(
-                    Arg.Any<UserSecret>(),
-                    "target",
-                    40,
-                    Arg.Is<IEnumerable<IDocument<NoteThread>>>(
-                        t => t.Count() == 1 && t.First().Id == "project01:thread01"
-                    ),
-                    Arg.Any<Dictionary<string, ParatextUserProfile>>(),
-                    Arg.Any<int>()
-                );
+        Assert.That(env.ContainsText("project01", "MAT", 3), Is.True);
+        Assert.That(env.ContainsText("project01", "MRK", 2), Is.False);
 
-            SFProject project = env.GetProject();
-            Assert.That(project.ParatextUsers.Select(u => u.Username), Is.EquivalentTo(new[] { "User 1", "User 2" }));
-        }
+        Assert.That(env.ContainsText("project02", "MAT", 3), Is.True);
+        Assert.That(env.ContainsText("project02", "MRK", 2), Is.False);
 
-        [Test]
-        public async Task SyncAsync_UpdatesParatextNoteThreadDoc()
+        Assert.That(env.ContainsQuestion("MAT", 2), Is.True);
+        Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
+        Assert.That(env.ContainsNote(2), Is.True);
+        env.VerifyProjectSync(true);
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 2)));
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 1, updated: 0)));
+        Assert.That(syncMetrics.Questions, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
+        syncMetrics = env.GetSyncMetrics("project02");
+        Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 2)));
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 1, updated: 0)));
+        Assert.That(syncMetrics.Questions, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
+    }
+
+    [Test]
+    public async Task SyncAsync_ChapterValidityChanged()
+    {
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, false, false, new Book("MAT", 2), new Book("MRK", 2) { InvalidChapters = { 1 } });
+        env.SetupPTData(new Book("MAT", 2) { InvalidChapters = { 2 } }, new Book("MRK", 2));
+
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        SFProject project = env.GetProject();
+        Assert.That(project.Texts[0].Chapters[0].IsValid, Is.True);
+        Assert.That(project.Texts[0].Chapters[1].IsValid, Is.False);
+        Assert.That(project.Texts[1].Chapters[0].IsValid, Is.True);
+        Assert.That(project.Texts[1].Chapters[1].IsValid, Is.True);
+        env.VerifyProjectSync(true);
+    }
+
+    [Test]
+    public async Task SyncAsync_BooksChanged()
+    {
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, false, false, new Book("MAT", 2), new Book("MRK", 2));
+        env.SetupPTData(new Book("MAT", 2), new Book("LUK", 2));
+        // Need to make sure we have notes BEFORE the sync
+        env.AddParatextNoteThreadData(new Book("MRK", 2));
+
+        // Expectations of setup
+        Assert.That(env.ContainsText("project01", "MRK", 1), Is.True);
+        Assert.That(env.ContainsText("project01", "MRK", 2), Is.True);
+        Assert.That(env.ContainsText("project01", "LUK", 1), Is.False);
+        Assert.That(env.ContainsText("project01", "LUK", 2), Is.False);
+
+        Assert.That(env.ContainsText("project02", "MRK", 1), Is.True);
+        Assert.That(env.ContainsText("project02", "MRK", 2), Is.True);
+        Assert.That(env.ContainsText("project02", "LUK", 1), Is.False);
+        Assert.That(env.ContainsText("project02", "LUK", 2), Is.False);
+
+        Assert.That(env.ContainsQuestion("MRK", 1), Is.True);
+        Assert.That(env.ContainsQuestion("MRK", 2), Is.True);
+        Assert.That(env.ContainsQuestion("MAT", 1), Is.True);
+        Assert.That(env.ContainsQuestion("MAT", 2), Is.True);
+
+        Assert.That(env.ContainsNote(2), Is.True);
+
+        // SUT
+        await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        Assert.That(env.ContainsText("project01", "MRK", 1), Is.False);
+        Assert.That(env.ContainsText("project01", "MRK", 2), Is.False);
+        Assert.That(env.ContainsText("project01", "LUK", 1), Is.True);
+        Assert.That(env.ContainsText("project01", "LUK", 2), Is.True);
+
+        Assert.That(env.ContainsText("project02", "MRK", 1), Is.False);
+        Assert.That(env.ContainsText("project02", "MRK", 2), Is.False);
+        Assert.That(env.ContainsText("project02", "LUK", 1), Is.True);
+        Assert.That(env.ContainsText("project02", "LUK", 2), Is.True);
+
+        Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
+        Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
+        Assert.That(env.ContainsQuestion("MAT", 1), Is.True);
+        Assert.That(env.ContainsQuestion("MAT", 2), Is.True);
+
+        Assert.That(env.ContainsNote(2), Is.False);
+        env.VerifyProjectSync(true);
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 1, updated: 1)));
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 2, updated: 0)));
+        Assert.That(
+            syncMetrics.Notes,
+            Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
+        );
+        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
+        Assert.That(syncMetrics.Questions, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 2, updated: 0)));
+        syncMetrics = env.GetSyncMetrics("project02");
+        Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 1, updated: 1)));
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 2, updated: 0)));
+        Assert.That(
+            syncMetrics.Notes,
+            Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
+        );
+        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+        Assert.That(syncMetrics.Questions, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 2, updated: 0)));
+    }
+
+    [Test]
+    public async Task SyncAsync_UserRoleChangedAndUserRemoved()
+    {
+        var env = new TestEnvironment();
+        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        env.SetupSFData(true, true, false, false, books);
+        env.SetupPTData(books);
+        var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Translator } };
+        env.ParatextService
+            .GetProjectRolesAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is((SFProject project) => project.ParatextId == "target"),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        SFProject project = env.VerifyProjectSync(true);
+        Assert.That(project.UserRoles["user01"], Is.EqualTo(SFProjectRole.Translator));
+        await env.SFProjectService.Received().RemoveUserWithoutPermissionsCheckAsync("user01", "project01", "user02");
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Users, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
+    }
+
+    [Test]
+    public async Task SyncAsync_SetsUserPermissions()
+    {
+        var env = new TestEnvironment();
+        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        env.SetupSFData(true, true, false, false, books);
+        env.SetupPTData(books);
+        var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Translator } };
+        env.ParatextService
+            .GetProjectRolesAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is((SFProject project) => project.ParatextId == "target"),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+
+        // SUT
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        await env.SFProjectService
+            .Received()
+            .UpdatePermissionsAsync(
+                "user01",
+                Arg.Is<IDocument<SFProject>>(
+                    (IDocument<SFProject> sfProjDoc) =>
+                        sfProjDoc.Data.Id == "project01" && sfProjDoc.Data.ParatextId == "target"
+                ),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Test]
+    public async Task SyncAsync_ProjectTextSetToNotEditable()
+    {
+        var env = new TestEnvironment();
+        Book[] books = { new Book("MAT", 1) };
+        env.SetupSFData(true, true, true, false, books);
+        env.SetupPTData(books);
+        SFProject project = env.GetProject("project01");
+        Assert.That(project.Editable, Is.True, "setup");
+        var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Administrator } };
+        env.ParatextService
+            .GetProjectRolesAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is((SFProject project) => project.ParatextId == "target"),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+
+        env.ParatextService
+            .GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
+            .Returns(new ParatextSettings { Editable = false });
+
+        // SUT
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+        await env.ParatextService.DidNotReceiveWithAnyArgs().PutBookText(default, default, default, default, default);
+        project = env.VerifyProjectSync(true);
+        Assert.That(project.Editable, Is.False);
+    }
+
+    [Test]
+    public async Task SyncAsync_CreatesNoteTagIcon()
+    {
+        var env = new TestEnvironment();
+        Book[] books = { new Book("MAT", 1) };
+        env.SetupSFData(true, true, false, true, books);
+        await env.SetupUndefinedNoteTag("project01");
+        SFProject project = env.GetProject();
+        Assert.That(project.TranslateConfig.DefaultNoteTagId, Is.Null);
+        // introduce a PT note thread
+        env.AddParatextNoteThreadData(books[0]);
+        env.SetupPTData(books);
+
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+        env.VerifyProjectSync(true, null, "project01");
+        // expect that we do not create a new note tag
+        env.ParatextService
+            .DidNotReceive()
+            .UpdateCommentTag(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<NoteTag>());
+
+        // introduce an SF note thread
+        env.AddParatextNoteThreadData(books[0], true);
+        env.ParatextService
+            .UpdateCommentTag(Arg.Any<UserSecret>(), "target", Arg.Any<NoteTag>())
+            .Returns(env.translateNoteTagId);
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+        project = env.VerifyProjectSync(true, null, "project01");
+        // expect that a new note tag is created
+        env.ParatextService.Received().UpdateCommentTag(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<NoteTag>());
+        Assert.That(project.TranslateConfig.DefaultNoteTagId, Is.EqualTo(env.translateNoteTagId));
+    }
+
+    [Test]
+    public async Task SyncAsync_UpdatesExistingNoteTags()
+    {
+        var env = new TestEnvironment();
+        Book[] books = { new Book("MAT", 1) };
+        env.SetupSFData(true, true, false, true, books);
+        var noteTags = new List<NoteTag>
         {
-            var env = new TestEnvironment();
-            var book = new Book("MAT", 1, true);
-            env.SetupSFData(true, false, false, true, book);
-            env.SetupPTData(book);
-            NoteThread thread01Before = env.GetNoteThread("project01", "thread01");
-            int startingNoteCount = 2;
-            Assert.That(thread01Before.Notes.Count, Is.EqualTo(startingNoteCount), "setup");
-            env.SetupNoteChanges("thread01");
-            // One note is added. One note is marked as Deleted but not actually removed.
-            int expectedNoteCountChange = 1;
-
-            // SUT
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            NoteThread thread01 = env.GetNoteThread("project01", "thread01");
-            int expectedNoteTagId = 3;
-            string threadExpected = "Context before Scripture text in project context after-Start:0-Length:0-MAT 1:1";
-            Assert.That(thread01.NoteThreadToString(), Is.EqualTo(threadExpected));
-            Assert.That(thread01.Assignment, Is.EqualTo(CommentThread.teamUser));
-            env.DeltaUsxMapper.ReceivedWithAnyArgs(2).ToChapterDeltas(default);
-            Assert.That(thread01.Notes.Count, Is.EqualTo(startingNoteCount + expectedNoteCountChange));
-            Assert.That(thread01.Notes[0].Content, Is.EqualTo("thread01 updated."));
-            Assert.That(thread01.Notes[0].Assignment, Is.EqualTo(CommentThread.teamUser));
-            Assert.That(thread01.Notes[1].Deleted, Is.True);
-            Assert.That(thread01.Notes[2].Content, Is.EqualTo("thread01 added."));
-            string expected = "thread01-syncuser03--thread01 added.-tag:" + expectedNoteTagId;
-            Assert.That(thread01.Notes[2].NoteToString(), Is.EqualTo(expected));
-            Assert.That(thread01.Notes[2].TagId, Is.EqualTo(expectedNoteTagId));
-            Assert.That(thread01.Notes[2].OwnerRef, Is.EqualTo("user03"));
-
-            SFProject project = env.GetProject();
-            // User 3 was added as a sync user
-            Assert.That(
-                project.ParatextUsers.Select(u => u.Username),
-                Is.EquivalentTo(new[] { "User 1", "User 2", "User 3" })
-            );
-            Assert.That(project.ParatextUsers.Single(u => u.Username == "User 1").SFUserId, Is.EqualTo("user01"));
-            Assert.That(project.ParatextUsers.Single(u => u.Username == "User 2").SFUserId, Is.EqualTo("user02"));
-            Assert.That(project.ParatextUsers.Single(u => u.Username == "User 3").SFUserId, Is.EqualTo("user03"));
-            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
-            Assert.That(
-                syncMetrics.Notes,
-                Is.EqualTo(new NoteSyncMetricInfo(added: 1, deleted: 1, updated: 1, removed: 0))
-            );
-            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 1)));
-        }
-
-        [Test]
-        public async Task SyncAsync_ParatextNoteThreadReattached()
-        {
-            var env = new TestEnvironment();
-            var book = new Book("MAT", 1, true);
-            env.SetupSFData(true, false, false, true, book);
-            env.SetupPTData(book);
-            string threadId = "thread01";
-            string verseStr = "MAT 1:5";
-            env.SetupNoteReattachedChange(threadId, verseStr);
-
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            NoteThread thread01 = env.GetNoteThread("project01", "thread01");
-            string[] reattachedParts = new[]
+            new NoteTag
             {
-                "MAT 1:5",
-                "reattach selected text",
-                "16",
-                "Reattach before ",
-                " reattach after."
-            };
-            string reattached = string.Join(PtxUtils.StringUtils.orcCharacter, reattachedParts);
-            string expected = "Context before Scripture text in project context after-" + $"Start:16-Length:22-MAT 1:1";
-            Assert.That(thread01.NoteThreadToString(), Is.EqualTo(expected));
-            Assert.That(thread01.Notes.Single(n => n.Reattached != null).Reattached, Is.EqualTo(reattached));
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
-            Assert.That(
-                syncMetrics.Notes,
-                Is.EqualTo(new NoteSyncMetricInfo(added: 1, deleted: 0, updated: 0, removed: 0))
-            );
-            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
-        }
-
-        [Test]
-        public async Task SyncAsync_AddParatextNoteThreadDoc()
+                TagId = 1,
+                Name = "To do",
+                Icon = NoteTag.defaultTagIcon
+            },
+            new NoteTag
+            {
+                TagId = 2,
+                Name = "Original tag",
+                Icon = "originalIcon"
+            },
+            new NoteTag
+            {
+                TagId = 3,
+                Name = "Tag to delete",
+                Icon = "delete"
+            }
+        };
+        await env.SetupProjectNoteTags("project01", noteTags);
+        env.SetupPTData(books);
+        var newNoteTags = new List<NoteTag>
         {
-            var env = new TestEnvironment();
-            var book = new Book("MAT", 3, true);
-            env.SetupSFData(true, false, false, true, book);
-            env.SetupPTData(book);
-            env.SetupNewNoteThreadChange("thread02", "syncuser01");
+            new NoteTag
+            {
+                TagId = 1,
+                Name = "To do",
+                Icon = NoteTag.defaultTagIcon
+            },
+            new NoteTag
+            {
+                TagId = 2,
+                Name = "Edited tag",
+                Icon = "editedIcon"
+            }
+        };
+        env.ParatextService
+            .GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
+            .Returns(new ParatextSettings { NoteTags = newNoteTags });
 
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+        SFProject project = env.VerifyProjectSync(true, null, "project01");
+        Assert.That(project.NoteTags.Select(t => t.Name), Is.EquivalentTo(newNoteTags.Select(t => t.Name)));
+    }
 
-            NoteThread thread02 = env.GetNoteThread("project01", "thread02");
-            string expected = "Context before Scripture text in project context after-" + "Start:0-Length:0-MAT 1:1";
-            Assert.That(thread02.NoteThreadToString(), Is.EqualTo(expected));
-            Assert.That(thread02.Notes.Count, Is.EqualTo(1));
-            Assert.That(thread02.Notes[0].Content, Is.EqualTo("New thread02 added."));
-            Assert.That(thread02.Notes[0].OwnerRef, Is.EqualTo("user01"));
-            Assert.That(thread02.Notes[0].Assignment, Is.EqualTo(CommentThread.teamUser));
-            Assert.That(thread02.Status, Is.EqualTo(NoteStatus.Todo.InternalValue));
-            Assert.That(thread02.Assignment, Is.EqualTo(CommentThread.teamUser));
-            SFProject project = env.GetProject();
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+    [Test]
+    public async Task SyncAsync_SetsProjectSettings()
+    {
+        var env = new TestEnvironment();
+        Book[] books = { new Book("MAT", 1) };
+        env.SetupSFData(true, true, true, false, books);
+        env.SetupPTData(books);
 
-            // Add a conflict note
-            env.SetupNewConflictNoteThreadChange("conflictthread01");
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            Assert.That(env.ContainsNoteThread("project01", "conflictthread01"), Is.True);
-            project = env.GetProject();
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
-            Assert.That(
-                syncMetrics.Notes,
-                Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
-            );
-            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
-        }
-
-        [Test]
-        public async Task SyncAsync_RemovesParatextNoteThreadDoc()
+        var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Administrator } };
+        env.ParatextService
+            .GetProjectRolesAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>(project => project.ParatextId == "target"),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+        int fontSize = 10;
+        string font = ProjectSettings.defaultFontName;
+        SFProject project = env.GetProject();
+        Assert.That(project.DefaultFontSize, Is.EqualTo(fontSize));
+        Assert.That(project.DefaultFont, Is.EqualTo(font));
+        int newFontSize = 16;
+        string newFont = "Doulos SIL";
+        string customIcon = "customIcon01";
+        List<NoteTag> noteTags = new List<NoteTag>
         {
-            var env = new TestEnvironment();
-            string sfProjectId = "project01";
-            string threadId = "thread01";
-            var book = new Book("MAT", 1, true);
-            env.SetupSFData(true, false, false, true, book);
-            List<Note> beginningNoteSet = env.GetNoteThread(sfProjectId, threadId).Notes;
-            beginningNoteSet.Add(
-                new Note
+            new NoteTag
+            {
+                TagId = env.translateNoteTagId,
+                Icon = customIcon,
+                Name = "Tag Name"
+            }
+        };
+        env.ParatextService
+            .GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
+            .Returns(
+                new ParatextSettings
                 {
-                    DataId = "n03",
-                    ThreadId = threadId,
-                    SyncUserRef = "syncuser02",
-                    ExtUserId = "user03",
-                    Content = "Paratext note 3.",
-                    DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc)
+                    DefaultFontSize = newFontSize,
+                    DefaultFont = newFont,
+                    NoteTags = noteTags
                 }
             );
-            await env.SetThreadNotesAsync(sfProjectId, threadId, beginningNoteSet);
-            env.SetupPTData(book);
-            env.SetupNoteRemovedChange(threadId, "n02");
-            NoteThread thread01 = env.GetNoteThread(sfProjectId, threadId);
-            Assert.That(
-                thread01.Notes.Select(n => n.DataId),
-                Is.EquivalentTo(new[] { "n01", "n02", "n03" }),
-                "setup: expecting several notes in doc"
-            );
-
-            // SUT 1
-            await env.Runner.RunAsync(sfProjectId, "user01", sfProjectId, false, CancellationToken.None);
-
-            thread01 = env.GetNoteThread(sfProjectId, threadId);
-            Assert.That(thread01.Notes.Select(n => n.DataId), Is.EquivalentTo(new[] { "n01", "n03" }));
-            SFProject project = env.GetProject();
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
-            Assert.That(
-                syncMetrics.Notes,
-                Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 1))
-            );
-            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
-
-            // Remove the entire thread
-            env.SetupNoteRemovedChange(threadId, null);
-
-            // SUT 2
-            await env.Runner.RunAsync(sfProjectId, "user01", "project01_alt", false, CancellationToken.None);
-
-            Assert.That(env.ContainsNoteThread(sfProjectId, threadId), Is.False);
-            project = env.GetProject();
-            Assert.That(project.Sync.LastSyncSuccessful, Is.True);
-
-            // Verify the sync metrics
-            syncMetrics = env.GetSyncMetrics("project01_alt");
-            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
-            Assert.That(
-                syncMetrics.Notes,
-                Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
-            );
-            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
-        }
-
-        [Test]
-        public async Task SyncAsync_NoteThreadsGetResolved()
-        {
-            var env = new TestEnvironment();
-            var book = new Book("MAT", 3, true);
-            env.SetupSFData(true, false, false, true, book);
-            env.SetupPTData(book);
-            env.SetupNewNoteThreadChange("thread02", "syncuser01");
-
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            // Default resolved status is false
-            NoteThread thread02 = env.GetNoteThread("project01", "thread02");
-            Assert.That(thread02.VerseRef.ToString(), Is.EqualTo("MAT 1:1"));
-            Assert.That(thread02.Status, Is.EqualTo(NoteStatus.Todo.InternalValue));
-
-            // Change resolve status to true
-            env.SetupNoteStatusChange("thread02", NoteStatus.Resolved.InternalValue);
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            thread02 = env.GetNoteThread("project01", "thread02");
-            Assert.That(thread02.VerseRef.ToString(), Is.EqualTo("MAT 1:1"));
-            Assert.That(thread02.Status, Is.EqualTo(NoteStatus.Resolved.InternalValue));
-
-            // Verify the sync metrics
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
-            Assert.That(
-                syncMetrics.Notes,
-                Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
-            );
-            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 1)));
-
-            // Change status back to false - happens if the note becomes unresolved again in Paratext
-            env.SetupNoteStatusChange("thread02", NoteStatus.Todo.InternalValue);
-            await env.Runner.RunAsync("project01", "user01", "project01_alt", false, CancellationToken.None);
-
-            thread02 = env.GetNoteThread("project01", "thread02");
-            Assert.That(thread02.VerseRef.ToString(), Is.EqualTo("MAT 1:1"));
-            Assert.That(thread02.Status, Is.EqualTo(NoteStatus.Todo.InternalValue));
-
-            // Verify the sync metrics
-            syncMetrics = env.GetSyncMetrics("project01_alt");
-            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
-            Assert.That(
-                syncMetrics.Notes,
-                Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
-            );
-            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 1)));
-        }
-
-        [Test]
-        public async Task SyncAsync_NoteChange_None()
-        {
-            var env = new TestEnvironment();
-            // Set up some PT and SF project data, including a Note.
-            string projectId = "project01";
-            var book = new Book("MAT", 3, true);
-            env.SetupSFData(true, false, false, true, book);
-            env.SetupPTData(book);
-            string threadId = $"thread03";
-            NoteThread thread03 = env.GetNoteThread(projectId, threadId);
-            Note note = thread03.Notes[0];
-            string origNoteData = note.NoteToString();
-
-            // Not setting up any actual changes. This test partly shows that the helper method does not create changes
-            // when the input is null.
-            env.SetupThreadAndNoteChange(threadId, null, null);
-
-            // SUT
-            await env.Runner.RunAsync(projectId, "user01", projectId, false, CancellationToken.None);
-
-            thread03 = env.GetNoteThread(projectId, threadId);
-            note = thread03.Notes[0];
-            // No incoming note changes mean no changes to the SF DB Notes.
-            // This is not a particularly thorough check, but is showing at least that a few pieces have not changed.
-            Assert.That(note.NoteToString(), Is.EqualTo(origNoteData), "Note data should not have been changed");
-
-            // Verify the sync metrics - the note data will be updated, even though it is not changed
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
-            Assert.That(
-                syncMetrics.Notes,
-                Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
-            );
-            Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
-        }
-
-        [Test]
-        public async Task SyncAsync_NoteChanges_SavedToSFDB()
-        {
-            // Note that there are multiple constructions of TestEnvironment, since
-            // ParatextService.GetLastSharedRevision() returns different values before and after SendReceive.
-
-            // Various changes to note properties, coming from PT, are recorded into the SF DB. For this to happen,
-            // the changes will need to be both detected, as well as saved.
-            // A PT Comment Content property was updated, which is detected and saved to SF DB.
-            await (new TestEnvironment()).SimpleNoteChangeAppliedCheckerAsync<string>(
-                (Note note) => note.Content,
-                (Note note, string newValue) => note.Content = newValue,
-                "new contents"
-            );
-            // A PT Comment Type property was updated, which is detected and saved to SF DB.
-            await (new TestEnvironment()).SimpleNoteChangeAppliedCheckerAsync<string>(
-                (Note note) => note.Type,
-                (Note note, string newValue) => note.Type = newValue,
-                NoteType.Conflict.InternalValue
-            );
-            // ConflictType property
-            await (new TestEnvironment()).SimpleNoteChangeAppliedCheckerAsync<string>(
-                (Note note) => note.ConflictType,
-                (Note note, string newValue) => note.ConflictType = newValue,
-                NoteConflictType.VerseTextConflict.InternalValue
-            );
-            // AcceptedChangeXml property
-            await (new TestEnvironment()).SimpleNoteChangeAppliedCheckerAsync<string>(
-                (Note note) => note.AcceptedChangeXml,
-                (Note note, string newValue) => note.AcceptedChangeXml = newValue,
-                "some xml"
-            );
-        }
-
-        [Test]
-        public async Task SyncAsync_ResourceChanged()
-        {
-            // Setup the environment so there will be Paratext changes
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, false, false, new Book("MAT", 2), new Book("MRK", 2));
-            env.SetupPTData(new Book("MAT", 3), new Book("MRK", 1));
-
-            // Setup the environment so the Paratext service will return that the resource has changed
-            env.ParatextService.IsResource(Arg.Any<string>()).Returns(true);
-            env.ParatextService
-                .ResourceDocsNeedUpdating(Arg.Any<SFProject>(), Arg.Any<ParatextResource>())
-                .Returns(true);
-            env.ParatextService
-                .SendReceiveAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Any<string>(),
-                    Arg.Any<IProgress<ProgressState>>(),
-                    Arg.Any<CancellationToken>()
-                )
-                .Returns(new ParatextResource());
-
-            // SUT
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            env.MockLogger.AssertEventCount(
-                (LogEvent logEvent) =>
-                    logEvent.LogLevel == LogLevel.Information && Regex.IsMatch(logEvent.Message, "Starting"),
-                1
-            );
-
-            // The book text is retrieved from Paratext as the resource has changed
-            env.ParatextService.Received().GetBookText(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<int>());
-
-            Assert.IsNotNull(env.GetProject().ResourceConfig);
-            Assert.That(env.ContainsText("project01", "MAT", 3), Is.True);
-            Assert.That(env.ContainsText("project01", "MRK", 2), Is.False);
-
-            // Check that the resource users metrics have been updated
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.ResourceUsers, Is.EqualTo(new SyncMetricInfo(2, 0, 0)));
-        }
-
-        [Test]
-        public async Task SyncAsync_ResourceNotChanged()
-        {
-            // Setup the environment so there will be no Paratext changes
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, false, false, new Book("MAT", 2), new Book("MRK", 2));
-            env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-
-            // Setup the environment so the Paratext service will return that the resource has not changed
-            env.ParatextService.IsResource(Arg.Any<string>()).Returns(true);
-            env.ParatextService
-                .ResourceDocsNeedUpdating(Arg.Any<SFProject>(), Arg.Any<ParatextResource>())
-                .Returns(false);
-            env.ParatextService
-                .SendReceiveAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Any<string>(),
-                    Arg.Any<IProgress<ProgressState>>(),
-                    Arg.Any<CancellationToken>()
-                )
-                .Returns(new ParatextResource());
-
-            // SUT
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            env.MockLogger.AssertEventCount(
-                (LogEvent logEvent) =>
-                    logEvent.LogLevel == LogLevel.Information && Regex.IsMatch(logEvent.Message, "Starting"),
-                1
-            );
-
-            // The book text is not retrieved from Paratext as the resource did not change
-            env.ParatextService.DidNotReceive().GetBookText(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<int>());
-
-            Assert.IsNull(env.GetProject().ResourceConfig);
-            Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
-            Assert.That(env.ContainsText("project01", "MRK", 2), Is.True);
-        }
-
-        [Test]
-        public async Task SyncAsync_SyncMetricsSetsDateStartedAndDateFinished()
-        {
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, true, false);
-
-            await env.Runner.RunAsync("project01", "user03", "project01", false, CancellationToken.None);
-
-            SFProject project = env.VerifyProjectSync(false);
-            Assert.That(project.Sync.DataInSync, Is.True);
-
-            // Check that the date started and date finished are set
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.DateStarted, Is.Not.Null);
-            Assert.That(syncMetrics.DateFinished, Is.Not.Null);
-        }
-
-        [Test]
-        public async Task SyncAsync_SyncMetricsRecordsLogs()
-        {
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, true, false);
-
-            await env.Runner.RunAsync("project01", "user03", "project01", false, CancellationToken.None);
-
-            SFProject project = env.VerifyProjectSync(false);
-            Assert.That(project.Sync.DataInSync, Is.True);
-
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.Log.Count, Is.Not.Zero);
-        }
-
-        [Test]
-        public async Task SyncAsync_SyncMetricsRecordsBackupCreated()
-        {
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, true, false, new Book("MAT", 2), new Book("MRK", 2));
-            env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
-
-            // Simulate that there is no backup, and that the backups are created successfully
-            env.ParatextService.BackupExists(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(false);
-            env.ParatextService.BackupRepository(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(true);
-
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            // A backup was created before and after the sync
-            env.ParatextService.Received(2).BackupRepository(Arg.Any<UserSecret>(), Arg.Any<string>());
-            SFProject project = env.VerifyProjectSync(true);
-            Assert.That(project.Sync.DataInSync, Is.True);
-
-            // Check that the metrics were updated
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.RepositoryBackupCreated, Is.True);
-        }
-
-        [Test]
-        public async Task SyncAsync_SyncMetricsRecordsParatextNotes()
-        {
-            var env = new TestEnvironment();
-            Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
-            env.SetupSFData(true, true, true, false, books);
-            env.SetupPTData(books);
-            var syncMetricInfo = new SyncMetricInfo(1, 2, 3);
-            env.ParatextService.PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<XElement>()).Returns(syncMetricInfo);
-
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            env.ParatextService.Received(2).PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<XElement>());
-
-            env.VerifyProjectSync(true);
-
-            // Check that as PutNotes was run twice, the metrics will be multiplied by two
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.ParatextNotes, Is.EqualTo(syncMetricInfo + syncMetricInfo));
-        }
-
-        [Test]
-        public async Task SyncAsync_SyncMetricsRecordsParatextBooks()
-        {
-            var env = new TestEnvironment();
-            Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
-            env.SetupSFData(true, true, true, false, books);
-            env.SetupPTData(books);
-            env.ParatextService
-                .PutBookText(
-                    Arg.Any<UserSecret>(),
-                    Arg.Any<string>(),
-                    Arg.Any<int>(),
-                    Arg.Any<XDocument>(),
-                    Arg.Any<Dictionary<int, string>>()
-                )
-                .Returns(1);
-
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            await env.ParatextService
-                .Received(2)
-                .PutBookText(
-                    Arg.Any<UserSecret>(),
-                    Arg.Any<string>(),
-                    Arg.Any<int>(),
-                    Arg.Any<XDocument>(),
-                    Arg.Any<Dictionary<int, string>>()
-                );
-            ;
-
-            SFProject project = env.GetProject();
-            Assert.That(project.ParatextUsers.Count, Is.EqualTo(2));
-            env.VerifyProjectSync(true);
-
-            // Check that as PutBookText was run twice, the metrics will be that two books are added
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.ParatextBooks, Is.EqualTo(new SyncMetricInfo(0, 0, 2)));
-        }
-
-        [Test]
-        public async Task SyncAsync_OnlyTargetParatextUsersAreGivenResourceAccess()
-        {
-            // Setup the environment so there will be Paratext changes
-            var env = new TestEnvironment();
-            env.SetupSFData(true, true, false, false, new Book("MAT", 2), new Book("MRK", 2));
-            env.SetupPTData(new Book("MAT", 3), new Book("MRK", 1));
-
-            // Make user02 an SF only user
-            await env.SetUserRole("user02", SFProjectRole.CommunityChecker);
-
-            // Setup the environment so the Paratext service will return that source is a resource
-            env.ParatextService.IsResource(Arg.Any<string>()).Returns(true);
-            env.ParatextService
-                .SendReceiveAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Any<string>(),
-                    Arg.Any<IProgress<ProgressState>>(),
-                    Arg.Any<CancellationToken>()
-                )
-                .Returns(new ParatextResource());
-
-            // Ensure that the source is project02, and has no users with access
-            Assert.AreEqual("project02", env.GetProject().TranslateConfig.Source.ProjectRef);
-            Assert.AreEqual(0, env.GetProject("project02").UserRoles.Count);
-
-            // SUT
-            await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-            env.MockLogger.AssertEventCount(
-                (LogEvent logEvent) =>
-                    logEvent.LogLevel == LogLevel.Information && Regex.IsMatch(logEvent.Message, "Starting"),
-                1
-            );
-
-            // Only one user should have been added, although two are present
-            Assert.AreEqual(2, env.GetProject().UserRoles.Count);
-            await env.SFProjectService
-                .Received(1)
-                .AddUserAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
-
-            // Check that the resource users metrics have been updated
-            SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
-            Assert.That(syncMetrics.ResourceUsers, Is.EqualTo(new SyncMetricInfo(1, 0, 0)));
-        }
-
-        private class Book
-        {
-            public Book(string bookId, int highestChapter, bool hasSource = true)
-                : this(bookId, highestChapter, hasSource ? highestChapter : 0) { }
-
-            public Book(string bookId, int highestTargetChapter, int highestSourceChapter)
-            {
-                Id = bookId;
-                HighestTargetChapter = highestTargetChapter;
-                HighestSourceChapter = highestSourceChapter;
-            }
-
-            public string Id { get; }
-            public int HighestTargetChapter { get; }
-            public int HighestSourceChapter { get; }
-
-            public HashSet<int> InvalidChapters { get; } = new HashSet<int>();
-            public HashSet<int> MissingTargetChapters { get; set; } = new HashSet<int>();
-            public HashSet<int> MissingSourceChapters { get; set; } = new HashSet<int>();
-        }
-
-        private class TestEnvironment
-        {
-            public readonly int translateNoteTagId = 5;
-            private readonly MemoryRepository<SFProjectSecret> _projectSecrets;
-            private readonly MemoryRepository<SyncMetrics> _syncMetrics;
-            private bool _sendReceivedCalled = false;
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="TestEnvironment" /> class.
-            /// </summary>
-            /// <param name="substituteRealtimeService">If set to <c>true</c> use a substitute realtime service rather
-            /// than the <see cref="SFMemoryRealtimeService" />.</param>
-            public TestEnvironment(bool substituteRealtimeService = false)
-            {
-                var userSecrets = new MemoryRepository<UserSecret>(
-                    new[]
-                    {
-                        new UserSecret { Id = "user01" },
-                        new UserSecret { Id = "user02" },
-                    }
-                );
-                _projectSecrets = new MemoryRepository<SFProjectSecret>(
-                    new[]
-                    {
-                        new SFProjectSecret
-                        {
-                            Id = "project01",
-                            JobIds = new List<string> { "test_jobid" },
-                        },
-                        new SFProjectSecret { Id = "project02" },
-                        new SFProjectSecret { Id = "project03" },
-                        new SFProjectSecret { Id = "project04" },
-                        new SFProjectSecret { Id = "project05" },
-                    }
-                );
-                _syncMetrics = new MemoryRepository<SyncMetrics>(
-                    new[]
-                    {
-                        new SyncMetrics { Id = "project01" },
-                        new SyncMetrics { Id = "project01_alt" },
-                        new SyncMetrics { Id = "project02" },
-                        new SyncMetrics { Id = "project03" },
-                        new SyncMetrics { Id = "project04" },
-                        new SyncMetrics { Id = "project05" },
-                    }
-                );
-                SFProjectService = Substitute.For<ISFProjectService>();
-                MachineProjectService = Substitute.For<IMachineProjectService>();
-                ParatextService = Substitute.For<IParatextService>();
-
-                var ptUserRoles = new Dictionary<string, string>
-                {
-                    { "pt01", SFProjectRole.Administrator },
-                    { "pt02", SFProjectRole.Translator }
-                };
-                ParatextService
-                    .GetProjectRolesAsync(
+
+        // SUT
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+        project = env.VerifyProjectSync(true);
+        Assert.That(project.DefaultFontSize, Is.EqualTo(newFontSize));
+        Assert.That(project.DefaultFont, Is.EqualTo(newFont));
+        Assert.That(project.NoteTags.Select(t => t.Icon), Is.EquivalentTo(new[] { customIcon }));
+    }
+
+    [Test]
+    public async Task SyncAsync_ProjectSettingsIsNull_SyncFailsAndTextNotUpdated()
+    {
+        var env = new TestEnvironment();
+        Book[] books = { new Book("MAT", 1) };
+        env.SetupSFData(true, true, true, false, books);
+        env.SetupPTData(books);
+
+        var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Administrator } };
+        env.ParatextService
+            .GetProjectRolesAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is((SFProject project) => project.ParatextId == "target"),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+        env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(x => null);
+
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+        env.VerifyProjectSync(false);
+        await env.ParatextService.DidNotReceiveWithAnyArgs().PutBookText(default, default, default, default, default);
+
+        // Check that the failure was logged in the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
+    }
+
+    [Test]
+    public async Task SyncAsync_CheckerWithPTAccountNotRemoved()
+    {
+        var env = new TestEnvironment();
+        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        env.SetupSFData(true, true, false, false, books);
+        env.SetupPTData(books);
+        var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Administrator } };
+        env.ParatextService
+            .GetProjectRolesAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is((SFProject project) => project.ParatextId == "target"),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+
+        await env.SetUserRole("user02", SFProjectRole.CommunityChecker);
+        SFProject project = env.GetProject();
+        Assert.That(project.UserRoles["user02"], Is.EqualTo(SFProjectRole.CommunityChecker));
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        env.VerifyProjectSync(true);
+        await env.SFProjectService.DidNotReceiveWithAnyArgs().RemoveUserAsync("user01", "project01", "user02");
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Users, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+    }
+
+    [Test]
+    public async Task SyncAsync_LanguageIsRightToLeft_ProjectPropertySet()
+    {
+        var env = new TestEnvironment();
+        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        env.SetupSFData(true, false, false, false, books);
+        env.SetupPTData(books);
+
+        env.ParatextService
+            .GetParatextSettings(Arg.Any<UserSecret>(), "target")
+            .Returns(new ParatextSettings { IsRightToLeft = true });
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        SFProject project = env.GetProject();
+        env.ParatextService.Received().GetParatextSettings(Arg.Any<UserSecret>(), "target");
+        env.ParatextService.Received().GetParatextSettings(Arg.Any<UserSecret>(), "source");
+        Assert.That(project.IsRightToLeft, Is.True);
+        Assert.That(project.TranslateConfig.Source.IsRightToLeft, Is.False);
+    }
+
+    [Test]
+    public async Task SyncAsync_FullName_ProjectPropertyNotSetIfNull()
+    {
+        var env = new TestEnvironment();
+        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        env.SetupSFData(true, false, false, false, books);
+        env.SetupPTData(books);
+
+        env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), "target").Returns(new ParatextSettings());
+
+        // SUT
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        SFProject project = env.GetProject();
+        env.ParatextService.Received().GetParatextSettings(Arg.Any<UserSecret>(), "target");
+        Assert.That(project.Name, Is.EqualTo("project01"));
+    }
+
+    [Test]
+    public async Task SyncAsync_FullName_ProjectPropertySet()
+    {
+        var env = new TestEnvironment();
+        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        env.SetupSFData(true, false, false, false, books);
+        env.SetupPTData(books);
+
+        string newFullName = "New Full Name";
+        env.ParatextService
+            .GetParatextSettings(Arg.Any<UserSecret>(), "target")
+            .Returns(new ParatextSettings { FullName = newFullName });
+
+        // SUT
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        SFProject project = env.GetProject();
+        env.ParatextService.Received().GetParatextSettings(Arg.Any<UserSecret>(), "target");
+        Assert.That(project.Name, Is.EqualTo(newFullName));
+    }
+
+    [Test]
+    public async Task SyncAsync_TextDocAlreadyExists()
+    {
+        var env = new TestEnvironment();
+        env.SetupSFData(false, false, false, false, new Book("MAT", 2), new Book("MRK", 2));
+        env.RealtimeService
+            .GetRepository<TextData>()
+            .Add(new TextData(Delta.New().InsertText("old text")) { Id = TextData.GetTextDocId("project01", 42, 1) });
+        env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2), new Book("LUK", 2));
+
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        var delta = Delta.New().InsertText("text");
+        Assert.That(env.GetText("project01", "MAT", 1).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project01", "MAT", 2).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project01", "MRK", 1).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project01", "MRK", 2).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project01", "LUK", 1).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project01", "LUK", 2).DeepEquals(delta), Is.True);
+        env.VerifyProjectSync(true);
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
+        syncMetrics = env.GetSyncMetrics("project02");
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+    }
+
+    [Test]
+    public async Task SyncAsync_DbMissingChapter()
+    {
+        // The project in the DB has a book, but a Source chapter is missing from that book.
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, false, false, new Book("MAT", 3, 3) { MissingSourceChapters = { 2 } });
+        env.SetupPTData(new Book("MAT", 3, true));
+
+        // DB should start with Target chapter 2 but without Source chapter 2.
+        Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
+        Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
+
+        // SUT
+        await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        // No errors or exceptions were logged
+        env.MockLogger.AssertNoEvent(
+            (LogEvent logEvent) => logEvent.LogLevel == LogLevel.Error || logEvent.Exception != null
+        );
+
+        var chapterContent = Delta.New().InsertText("text");
+        // DB should contain Source chapter 2 now from Paratext.
+        Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
+        Assert.That(env.ContainsText("project02", "MAT", 2), Is.True);
+        Assert.That(env.GetText("project01", "MAT", 2).DeepEquals(chapterContent), Is.True);
+        Assert.That(env.GetText("project02", "MAT", 2).DeepEquals(chapterContent), Is.True);
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+        syncMetrics = env.GetSyncMetrics("project02");
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
+    }
+
+    [Test]
+    public async Task SyncAsync_ParatextMissingChapter()
+    {
+        // The project in Paratext has a book, but a chapter is missing from that book.
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, false, false, new Book("MAT", 3, true));
+        env.SetupPTData(new Book("MAT", 3, 3) { MissingTargetChapters = { 2 }, MissingSourceChapters = { 2 } });
+
+        var chapterContent = Delta.New().InsertText("text");
+        Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
+        Assert.That(env.ContainsText("project02", "MAT", 1), Is.True);
+        // DB should start with a chapter 2.
+        Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
+        Assert.That(env.ContainsText("project02", "MAT", 2), Is.True);
+        Assert.That(env.GetText("project01", "MAT", 2).DeepEquals(chapterContent), Is.True);
+        Assert.That(env.GetText("project02", "MAT", 2).DeepEquals(chapterContent), Is.True);
+        Assert.That(env.ContainsText("project01", "MAT", 3), Is.True);
+        Assert.That(env.ContainsText("project02", "MAT", 3), Is.True);
+
+        // SUT
+        await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        // No errors or exceptions were logged
+        env.MockLogger.AssertNoEvent(
+            (LogEvent logEvent) => logEvent.LogLevel == LogLevel.Error || logEvent.Exception != null
+        );
+
+        // DB should now be missing chapter 2, but retain chapters 1 and 3.
+        Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
+        Assert.That(env.ContainsText("project02", "MAT", 1), Is.True);
+        Assert.That(env.ContainsText("project01", "MAT", 2), Is.False);
+        Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
+        Assert.That(env.ContainsText("project01", "MAT", 3), Is.True);
+        Assert.That(env.ContainsText("project02", "MAT", 3), Is.True);
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
+        syncMetrics = env.GetSyncMetrics("project02");
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
+    }
+
+    [Test]
+    public async Task SyncAsync_DbAndParatextMissingChapter()
+    {
+        // The project has a book, but a Source chapter is missing from that book. Both in the DB and in Paratext.
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, false, false, new Book("MAT", 3, 3) { MissingSourceChapters = { 2 } });
+        env.SetupPTData(new Book("MAT", 3, 3) { MissingSourceChapters = { 2 } });
+
+        // DB should start without Source chapter 2.
+        Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
+        Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
+
+        // SUT
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        // No errors or exceptions were logged
+        env.MockLogger.AssertNoEvent(
+            (LogEvent logEvent) => logEvent.LogLevel == LogLevel.Error || logEvent.Exception != null
+        );
+
+        // DB should still be missing Source chapter 2.
+        Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
+        Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+        syncMetrics = env.GetSyncMetrics("project02");
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+    }
+
+    [Test]
+    public async Task SyncAsync_ParatextMissingAllChapters()
+    {
+        // The project in PT has a book, but no chapters.
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, false, false, new Book("MAT", 3, true));
+        env.SetupPTData(new Book("MAT", 0, true));
+
+        var chapterContent = Delta.New().InsertText("text");
+        Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
+        Assert.That(env.ContainsText("project02", "MAT", 1), Is.True);
+        Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
+        Assert.That(env.ContainsText("project02", "MAT", 2), Is.True);
+        Assert.That(env.GetText("project01", "MAT", 2).DeepEquals(chapterContent), Is.True);
+        Assert.That(env.GetText("project02", "MAT", 2).DeepEquals(chapterContent), Is.True);
+        Assert.That(env.ContainsText("project01", "MAT", 3), Is.True);
+        Assert.That(env.ContainsText("project02", "MAT", 3), Is.True);
+
+        // SUT
+        await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        // No errors or exceptions were logged
+        env.MockLogger.AssertNoEvent(
+            (LogEvent logEvent) => logEvent.LogLevel == LogLevel.Error || logEvent.Exception != null
+        );
+
+        // DB should now be missing all chapters except for the first, implicit chapter.
+        Assert.That(env.ContainsText("project01", "MAT", 1), Is.True);
+        Assert.That(env.ContainsText("project02", "MAT", 1), Is.True);
+        Assert.That(env.ContainsText("project01", "MAT", 2), Is.False);
+        Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
+        Assert.That(env.ContainsText("project01", "MAT", 3), Is.False);
+        Assert.That(env.ContainsText("project02", "MAT", 3), Is.False);
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 2, updated: 1)));
+        syncMetrics = env.GetSyncMetrics("project02");
+        Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 2, updated: 1)));
+    }
+
+    [Test]
+    public async Task RunAsync_NoRecordOfSyncedToRepositoryVersion_DoesFullSync()
+    {
+        var env = new TestEnvironment();
+        string projectSFId = "project03";
+        string userId = "user01";
+
+        SFProject project = env.SetupProjectWithExpectedImportedRev(projectSFId, null);
+        Assert.That(project.Sync.DataInSync, Is.Null, "setup. Should be testing what happens when this is null.");
+        string projectPTId = project.ParatextId;
+        env.ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), projectPTId).Returns("1", "2");
+        // The expected after-sync repository version can be past the original, before-sync project version,
+        // even if there were no local changes, since there may be incoming changes from the PT Archives server.
+        string expectedRepositoryVersion = "2";
+        // SUT
+        await env.RunAndAssertContinuesAsync(projectSFId, userId, expectedRepositoryVersion);
+        // Shouldn't be setting repo rev.
+        env.ParatextService
+            .DidNotReceive()
+            .SetRepoToRevision(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task RunAsync_NullSyncRevRecordMatchesNullHgRev_Continue()
+    {
+        // The project sync record has no recorded PT hg repo revision that it imported from.
+        // The hg repo gives no revision either. Continue with sync.
+
+        var env = new TestEnvironment();
+        // project05 has a null DB SyncedToRepositoryVersion.
+        string projectSFId = "project05";
+        string userId = "user01";
+        SFProject project = env.SetupProjectWithExpectedImportedRev(
+            projectSFId,
+            startingDBSyncedToRepositoryVersion: null
+        );
+        env.ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), project.ParatextId).Returns(default(string?));
+        Assert.That(
+            project.Sync.DataInSync,
+            Is.Not.Null,
+            "setup. We are not testing the special situation of DataInSync being null."
+        );
+        // SUT
+        await env.RunAndAssertContinuesAsync(projectSFId, userId, finalDBSyncedToRepositoryVersion: null);
+        // Shouldn't be setting repo rev.
+        env.ParatextService
+            .DidNotReceive()
+            .SetRepoToRevision(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task RunAsync_NullSyncRevRecordNotMatchHgRev_Continue()
+    {
+        // The project sync record has no recorded PT hg repo revision that it imported from,
+        // yet the hg repo is there and has a revision. Continue with sync.
+
+        var env = new TestEnvironment();
+        // project05 has a null DB SyncedToRepositoryVersion.
+        string projectSFId = "project05";
+        string userId = "user01";
+        SFProject project = env.SetupProjectWithExpectedImportedRev(
+            projectSFId,
+            startingDBSyncedToRepositoryVersion: null
+        );
+        env.ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), project.ParatextId).Returns("v1");
+        Assert.That(
+            project.Sync.DataInSync,
+            Is.Not.Null,
+            "setup. We are not testing the special situation of DataInSync being null."
+        );
+        // SUT
+        await env.RunAndAssertContinuesAsync(projectSFId, userId, finalDBSyncedToRepositoryVersion: "v1");
+        // Shouldn't be setting repo rev.
+        env.ParatextService
+            .DidNotReceive()
+            .SetRepoToRevision(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task RunAsync_SyncRevRecordNotMatchHgRev_AdjustAndContinue()
+    {
+        // The project sync record of PT hg repo revision that it imported from does not match the current
+        // hg repo revision. So we set the repo revision, and perform sync.
+
+        var env = new TestEnvironment();
+        // project01 has a non-null DB SyncedToRepositoryVersion.
+        string projectSFId = "project01";
+        string userId = "user01";
+        SFProject project = env.SetupProjectWithExpectedImportedRev(
+            projectSFId,
+            startingDBSyncedToRepositoryVersion: "beforeSR"
+        );
+        env.ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), project.ParatextId).Returns("v1");
+        // SUT
+        await env.RunAndAssertContinuesAsync(projectSFId, userId, finalDBSyncedToRepositoryVersion: "afterSR");
+        env.ParatextService.Received().SetRepoToRevision(Arg.Any<UserSecret>(), Arg.Any<string>(), "beforeSR");
+    }
+
+    [Test]
+    public async Task RunAsync_SyncRevRecordMatchesHgRev_Continue()
+    {
+        // The project sync record of PT hg repo revision that it imported from matches the current
+        // hg repo revision. Continue with sync.
+
+        var env = new TestEnvironment();
+        // project01 has a non-null DB SyncedToRepositoryVersion.
+        string projectSFId = "project01";
+        string userId = "user01";
+        SFProject project = env.SetupProjectWithExpectedImportedRev(
+            projectSFId,
+            startingDBSyncedToRepositoryVersion: "beforeSR"
+        );
+        env.ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), project.ParatextId).Returns(("beforeSR"));
+        // SUT
+        await env.RunAndAssertContinuesAsync(projectSFId, userId, finalDBSyncedToRepositoryVersion: "afterSR");
+        // And it doesn't matter if we set the hg repo to the rev or not.
+    }
+
+    [Test]
+    public async Task SyncAsync_TaskAbortedByExceptionWritesToLog()
+    {
+        // Set up the environment
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, false, false);
+        env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        // Setup a trap to crash the task
+        env.NotesMapper
+            .When(
+                x =>
+                    x.InitAsync(
                         Arg.Any<UserSecret>(),
-                        Arg.Is((SFProject project) => project.ParatextId == "target"),
+                        Arg.Any<SFProjectSecret>(),
+                        Arg.Any<List<User>>(),
+                        Arg.Any<SFProject>(),
                         Arg.Any<CancellationToken>()
                     )
-                    .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
-                ParatextService
-                    .When(
-                        x =>
-                            x.SendReceiveAsync(
-                                Arg.Any<UserSecret>(),
-                                "target",
-                                Arg.Any<IProgress<ProgressState>>(),
-                                Arg.Any<CancellationToken>()
-                            )
+            )
+            .Do(_ => throw new ArgumentException());
+
+        // Run the task
+        await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
+
+        // Check that the Exception was logged
+        env.MockLogger.AssertHasEvent((LogEvent logEvent) => logEvent.Exception != null);
+
+        // Check that the exception was logged in the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
+        StringAssert.StartsWith("System.ArgumentException", syncMetrics.ErrorDetails);
+
+        // Check that the task cancelled correctly
+        SFProject project = env.VerifyProjectSync(false);
+        Assert.That(project.Sync.DataInSync, Is.True); // Nothing was synced as this was cancelled OnInit()
+    }
+
+    [Test]
+    public async Task SyncAsync_DataInSyncTrueAfterRestore()
+    {
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, false, false);
+        env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
+        // Simulate a successful backup to a hg repo at a revision not matching our project doc
+        // after a failed send/receive
+        env.ParatextService.BackupExists(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(true);
+        env.ParatextService.RestoreRepository(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(true);
+        env.ParatextService
+            .When(p => p.GetBookText(Arg.Any<UserSecret>(), "target", Arg.Any<int>()))
+            .Do(_ => throw new ArgumentException());
+
+        env.ParatextService
+            .When(p => p.RestoreRepository(Arg.Any<UserSecret>(), "target"))
+            .Do(
+                _ =>
+                    env.ParatextService
+                        .GetLatestSharedVersion(Arg.Any<UserSecret>(), "target")
+                        .Returns("revNotMatchingVersion")
+            );
+
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        // Check that the failure was logged in the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
+        Assert.That(syncMetrics.RepositoryRestoredFromBackup, Is.True);
+
+        // Check that the sync restored correctly
+        env.ParatextService.Received(1).RestoreRepository(Arg.Any<UserSecret>(), "target");
+        SFProject project = env.VerifyProjectSync(false);
+        Assert.That(project.Sync.DataInSync, Is.True);
+    }
+
+    [Test]
+    public async Task SyncAsync_TaskCancelledByException()
+    {
+        // Set up the environment
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, false, false);
+        env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        // Setup a trap to cancel the task
+        env.NotesMapper
+            .When(
+                x =>
+                    x.InitAsync(
+                        Arg.Any<UserSecret>(),
+                        Arg.Any<SFProjectSecret>(),
+                        Arg.Any<List<User>>(),
+                        Arg.Any<SFProject>(),
+                        Arg.Any<CancellationToken>()
                     )
-                    .Do(x =>
-                    {
-                        _sendReceivedCalled = true;
-                        ParatextService
-                            .GetLatestSharedVersion(Arg.Any<UserSecret>(), Arg.Any<string>())
-                            .Returns("afterSR");
-                    });
-
-                ParatextService.GetNotes(Arg.Any<UserSecret>(), "target", Arg.Any<int>()).Returns("<notes/>");
-                ParatextService.GetParatextUsername(Arg.Is<UserSecret>(u => u.Id == "user01")).Returns("User 1");
-                ParatextService
-                    .GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
-                    .Returns(
-                        x =>
-                            new ParatextSettings
-                            {
-                                FullName = (string)x[1],
-                                IsRightToLeft = false,
-                                Editable = true
-                            }
-                    );
-                ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), "target").Returns("beforeSR");
-                ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), "source").Returns("beforeSR", "afterSR");
-                RealtimeService = new SFMemoryRealtimeService();
-                Connection = Substitute.For<IConnection>();
-                SubstituteRealtimeService = Substitute.For<IRealtimeService>();
-                SubstituteRealtimeService.ConnectAsync().Returns(Task.FromResult(Connection));
-                DeltaUsxMapper = Substitute.For<IDeltaUsxMapper>();
-                NotesMapper = Substitute.For<IParatextNotesMapper>();
-                var hubContext = Substitute.For<IHubContext<NotificationHub, INotifier>>();
-                MockLogger = new MockLogger<ParatextSyncRunner>();
-
-                Runner = new ParatextSyncRunner(
-                    userSecrets,
-                    _projectSecrets,
-                    _syncMetrics,
-                    SFProjectService,
-                    MachineProjectService,
-                    ParatextService,
-                    substituteRealtimeService ? SubstituteRealtimeService : RealtimeService,
-                    DeltaUsxMapper,
-                    NotesMapper,
-                    hubContext,
-                    MockLogger
-                );
-            }
-
-            public ParatextSyncRunner Runner { get; }
-            public ISFProjectService SFProjectService { get; }
-            public IMachineProjectService MachineProjectService { get; }
-            public IParatextNotesMapper NotesMapper { get; }
-            public IParatextService ParatextService { get; }
-            public SFMemoryRealtimeService RealtimeService { get; }
-            public IRealtimeService SubstituteRealtimeService { get; }
-            public IDeltaUsxMapper DeltaUsxMapper { get; }
-            public MockLogger<ParatextSyncRunner> MockLogger { get; }
-
-            /// <summary>
-            /// Gets the connection to be used with <see cref="SubstituteRealtimeService"/>.
-            /// </summary>
-            public IConnection Connection { get; }
-
-            public SFProject GetProject(string projectSFId = "project01")
-            {
-                return RealtimeService.GetRepository<SFProject>().Get(projectSFId);
-            }
-
-            public SFProjectSecret GetProjectSecret(string projectId = "project01")
-            {
-                return _projectSecrets.Get(projectId);
-            }
-
-            public SFProjectUserConfig GetProjectUserConfig(string projectId, string userId)
-            {
-                return RealtimeService
-                    .GetRepository<SFProjectUserConfig>()
-                    .Get(SFProjectUserConfig.GetDocId(projectId, userId));
-            }
-
-            public bool ContainsText(string projectId, string bookId, int chapter)
-            {
-                return RealtimeService
-                    .GetRepository<TextData>()
-                    .Contains(TextData.GetTextDocId(projectId, Canon.BookIdToNumber(bookId), chapter));
-            }
-
-            public TextData GetText(string projectId, string bookId, int chapter)
-            {
-                return RealtimeService
-                    .GetRepository<TextData>()
-                    .Get(TextData.GetTextDocId(projectId, Canon.BookIdToNumber(bookId), chapter));
-            }
-
-            public bool ContainsQuestion(string bookId, int chapter)
-            {
-                return RealtimeService.GetRepository<Question>().Contains($"project01:question{bookId}{chapter}");
-            }
-
-            public bool ContainsNote(int chapter)
-            {
-                return RealtimeService.GetRepository<NoteThread>().Contains($"project01:thread0{chapter}");
-            }
-
-            public Question GetQuestion(string bookId, int chapter)
-            {
-                return RealtimeService.GetRepository<Question>().Get($"project01:question{bookId}{chapter}");
-            }
-
-            public bool ContainsNoteThread(string projectId, string threadId)
-            {
-                return RealtimeService.GetRepository<NoteThread>().Contains($"{projectId}:{threadId}");
-            }
-
-            public NoteThread GetNoteThread(string projectId, string threadId)
-            {
-                return RealtimeService.GetRepository<NoteThread>().Get($"{projectId}:{threadId}");
-            }
-
-            public SyncMetrics GetSyncMetrics(string projectId)
-            {
-                return _syncMetrics.Get(projectId);
-            }
-
-            public SFProject AssertDBSyncMetadata(
-                string projectSFId,
-                bool lastSyncSuccess,
-                string? syncedToRepositoryVersion
             )
+            .Do(_ =>
             {
-                SFProjectSecret projectSecret = GetProjectSecret(projectSFId);
-                Assert.That(projectSecret.JobIds.Count, Is.EqualTo(0));
-                SFProject project = GetProject(projectSFId);
-                Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
-                Assert.That(project.Sync.LastSyncSuccessful, Is.EqualTo(lastSyncSuccess));
-                Assert.That(project.Sync.SyncedToRepositoryVersion, Is.EqualTo(syncedToRepositoryVersion));
+                cancellationTokenSource.Cancel();
+                throw new TaskCanceledException();
+            });
 
-                // Check for the correct system metrics status
-                SyncMetrics syncMetrics = GetSyncMetrics(projectSFId);
-                if (lastSyncSuccess)
-                {
-                    Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
-                }
-                else
-                {
-                    Assert.That(syncMetrics.Status, Is.InRange(SyncStatus.Cancelled, SyncStatus.Failed));
-                }
+        // Run the task
+        await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
 
-                return project;
-            }
+        // The TaskCancelledException was not logged
+        Assert.That(
+            env.MockLogger.LogEvents.Count(
+                (LogEvent logEvent) => logEvent.LogLevel == LogLevel.Error || logEvent.Exception != null
+            ),
+            Is.EqualTo(0)
+        );
 
-            public SFProject VerifyProjectSync(
-                bool successful,
-                string? expectedRepoVersion = null,
-                string projectSFId = "project01"
-            )
-            {
-                string repoVersion = expectedRepoVersion ?? (successful ? "afterSR" : "beforeSR");
-                return AssertDBSyncMetadata(projectSFId, successful, repoVersion);
-            }
+        // Check that the cancellation was logged in the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
 
-            public TextInfo SetupChapterAuthorsAndGetTextInfo(bool setChapterPermissions)
-            {
-                string projectId = "project01";
-                int bookNum = 70;
-                int chapterNum = 1;
-                string id = TextData.GetTextDocId(projectId, bookNum, chapterNum);
-                Dictionary<string, string> chapterPermissions = new Dictionary<string, string>();
-                if (setChapterPermissions)
-                {
-                    chapterPermissions.Add("user01", TextInfoPermission.Write);
-                    chapterPermissions.Add("user02", TextInfoPermission.Read);
-                }
-                var textInfo = new TextInfo
-                {
-                    BookNum = bookNum,
-                    Chapters = new List<Chapter>
-                    {
-                        new Chapter { Number = chapterNum, Permissions = chapterPermissions, },
-                    },
-                };
-                RealtimeService.AddRepository(
-                    "users",
-                    OTType.Json0,
-                    new MemoryRepository<User>(new[] { new User { Id = "user01" }, })
-                );
-                RealtimeService.AddRepository(
-                    "texts",
-                    OTType.RichText,
-                    new MemoryRepository<TextData>(new[] { new TextData(Delta.New()) { Id = id }, })
-                );
-                SFProject[] sfProjects = new[]
-                {
-                    new SFProject
-                    {
-                        Id = projectId,
-                        UserRoles = new Dictionary<string, string>
-                        {
-                            { "user03", SFProjectRole.Administrator },
-                            { "user04", SFProjectRole.Translator },
-                        },
-                    },
-                };
-                RealtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(sfProjects));
-                MockProjectDirsExist(sfProjects.Select((SFProject proj) => proj.ParatextId));
+        // Check that the task cancelled correctly
+        SFProject project = env.VerifyProjectSync(false);
+        Assert.That(project.Sync.DataInSync, Is.True); // Nothing was synced as this was cancelled OnInit()
+    }
 
-                return textInfo;
-            }
+    [Test]
+    public async Task SyncAsync_TaskCancelledMidway()
+    {
+        // Set up the environment
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, false, false);
+        env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
+        using var cancellationTokenSource = new CancellationTokenSource();
 
-            public void SetupSFData(
-                bool translationSuggestionsEnabled,
-                bool checkingEnabled,
-                bool changed,
-                bool noteOnFirstBook,
-                params Book[] books
-            )
-            {
-                SetupSFData(
-                    "project01",
-                    "project02",
-                    translationSuggestionsEnabled,
-                    checkingEnabled,
-                    changed,
-                    noteOnFirstBook,
-                    books
-                );
-            }
-
-            public void SetupSFData(
-                string targetProjectSFId,
-                string sourceProjectSFId,
-                bool translationSuggestionsEnabled,
-                bool checkingEnabled,
-                bool changed,
-                bool noteOnFirstBook,
-                params Book[] books
-            )
-            {
-                RealtimeService.AddRepository(
-                    "users",
-                    OTType.Json0,
-                    new MemoryRepository<User>(
-                        new[]
-                        {
-                            new User { Id = "user01", ParatextId = "pt01" },
-                            new User { Id = "user02", ParatextId = "pt02" }
-                        }
+        // Setup a trap to cancel the task
+        env.ParatextService
+            .When(
+                x =>
+                    x.SendReceiveAsync(
+                        Arg.Any<UserSecret>(),
+                        Arg.Any<string>(),
+                        Arg.Any<IProgress<ProgressState>>(),
+                        Arg.Any<CancellationToken>()
                     )
-                );
-                // It is expected that if a user is on a project, there is a corresponding project-user-config doc.
-                RealtimeService.AddRepository(
-                    "sf_project_user_configs",
-                    OTType.Json0,
-                    new MemoryRepository<SFProjectUserConfig>(
-                        new[]
-                        {
-                            new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId("project01", "user01"), },
-                            new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId("project01", "user02"), }
-                        }
+            )
+            .Do(_ => cancellationTokenSource.Cancel());
+
+        // Run the task
+        await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
+
+        // Check that the cancellation was logged in the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
+
+        // Check that the task cancelled correctly
+        SFProject project = env.VerifyProjectSync(false);
+        Assert.That(project.Sync.DataInSync, Is.False);
+    }
+
+    [Test]
+    public async Task SyncAsync_TaskCancelledAndRestoreFails_DataNotInSync()
+    {
+        var env = new TestEnvironment();
+        env.SetupSFData(true, false, true, false);
+        env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
+        using var cancellationTokenSource = new CancellationTokenSource();
+        env.ParatextService.BackupExists(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(true);
+        env.ParatextService.RestoreRepository(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(false);
+
+        env.ParatextService
+            .When(
+                x =>
+                    x.SendReceiveAsync(
+                        Arg.Any<UserSecret>(),
+                        Arg.Any<string>(),
+                        Arg.Any<IProgress<ProgressState>>(),
+                        Arg.Any<CancellationToken>()
                     )
-                );
-                SFProject[] sfProjects = new[]
+            )
+            .Do(_ => cancellationTokenSource.Cancel());
+        await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
+        env.ParatextService.Received(1).RestoreRepository(Arg.Any<UserSecret>(), Arg.Any<string>());
+        SFProject project = env.VerifyProjectSync(false);
+
+        // Check that the cancellation was logged in the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
+
+        // Data is out of sync due to the failed restore
+        Assert.That(project.Sync.DataInSync, Is.False);
+    }
+
+    [Test]
+    public async Task SyncAsync_TaskCancelledPrematurely()
+    {
+        // Set up the environment
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, false, false);
+        env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        // Cancel the token before awaiting the task
+        cancellationTokenSource.Cancel();
+
+        // Run the task
+        await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
+
+        // Check that the cancellation was logged in the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
+
+        // Check that the task was cancelled after awaiting the check above
+        SFProject project = env.VerifyProjectSync(false);
+        Assert.That(project.Sync.DataInSync, Is.True);
+    }
+
+    [Test]
+    public async Task SyncAsync_TaskCancelledExecutesRollback()
+    {
+        // Set up the environment
+        var env = new TestEnvironment(substituteRealtimeService: true);
+        env.SetupSFData(true, true, false, false);
+        env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        // Return the project so InitAsync will execute successfully
+        var project = Substitute.For<IDocument<SFProject>>();
+        project.IsLoaded.Returns(true);
+        project.Data.Returns(env.GetProject());
+        env.Connection.Get<SFProject>("project01").Returns(project);
+
+        // The HTTP call throws this when a cancelled token is passed
+        env.ParatextService
+            .GetParatextUsernameMappingAsync(Arg.Any<UserSecret>(), Arg.Any<SFProject>(), Arg.Any<CancellationToken>())
+            .ThrowsForAnyArgs(new OperationCanceledException());
+
+        // Setup a trap to cancel the task
+        env.ParatextService
+            .When(
+                x =>
+                    x.SendReceiveAsync(
+                        Arg.Any<UserSecret>(),
+                        Arg.Any<string>(),
+                        Arg.Any<IProgress<ProgressState>>(),
+                        Arg.Any<CancellationToken>()
+                    )
+            )
+            .Do(_ => cancellationTokenSource.Cancel());
+
+        // Run the task
+        await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
+
+        // Check for RollbackTransaction being executed, to ensure
+        // that CompleteAsync executes to the end without exception
+        env.Connection.Received(1).RollbackTransaction();
+
+        // Check that the cancellation was logged in the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Cancelled));
+    }
+
+    [Test]
+    public async Task SyncAsync_ExcludesPropertiesFromTransactions()
+    {
+        // Set up the environment
+        var env = new TestEnvironment(substituteRealtimeService: true);
+        env.SetupSFData(true, true, false, false);
+        env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        // Throw an TaskCanceledException in InitAsync after the exclusions have been called
+        // InitAsync calls the IConnection.FetchAsync() extension, which calls IConnection.Get()
+        env.Connection.Get<SFProject>("project01").Throws(new TaskCanceledException());
+
+        // Run the task
+        await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
+
+        // Only check for ExcludePropertyFromTransaction being executed,
+        // as the substitute RealtimeService will not update documents.
+        env.Connection
+            .Received(1)
+            .ExcludePropertyFromTransaction(
+                Arg.Is<Expression<Func<SFProject, object>>>(
+                    ex => string.Join('.', new ObjectPath(ex).Items) == "Sync.QueuedCount"
+                )
+            );
+        env.Connection
+            .Received(1)
+            .ExcludePropertyFromTransaction(
+                Arg.Is<Expression<Func<SFProject, object>>>(
+                    ex => string.Join('.', new ObjectPath(ex).Items) == "Sync.DataInSync"
+                )
+            );
+        env.Connection.Received(2).ExcludePropertyFromTransaction(Arg.Any<Expression<Func<SFProject, object>>>());
+    }
+
+    [Test]
+    public async Task SyncAsync_TaskCancelledTooLate()
+    {
+        // Set up the environment
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, false, false);
+        env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        // Run the task
+        await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
+
+        // Cancel the token after awaiting the task
+        cancellationTokenSource.Cancel();
+
+        // Check that the sync was successful
+        SFProject project = env.VerifyProjectSync(true);
+        Assert.That(project.Sync.DataInSync, Is.True);
+    }
+
+    [Test]
+    public async Task FetchTextDocsAsync_FetchesExistingChapters()
+    {
+        var env = new TestEnvironment();
+        var numberChapters = 3;
+        var book = new Book("MAT", numberChapters, true);
+        env.SetupSFData(true, true, false, false, book);
+
+        // SUT
+        await env.Runner.InitAsync("project01", "user01", "project01", CancellationToken.None);
+        SortedList<int, IDocument<TextData>> targetFetch = await env.Runner.FetchTextDocsAsync(
+            TestEnvironment.TextInfoFromBook(book)
+        );
+        await env.Runner.InitAsync("project02", "user01", "project02", CancellationToken.None);
+        SortedList<int, IDocument<TextData>> sourceFetch = await env.Runner.FetchTextDocsAsync(
+            TestEnvironment.TextInfoFromBook(book)
+        );
+        env.Runner.CloseConnection();
+
+        // Fetched numberChapters chapters, none of which are missing their chapter content.
+        Assert.That(targetFetch.Count, Is.EqualTo(numberChapters));
+        Assert.That(sourceFetch.Count, Is.EqualTo(numberChapters));
+        Assert.That(targetFetch.Count(doc => doc.Value.Data == null), Is.EqualTo(0));
+        Assert.That(sourceFetch.Count(doc => doc.Value.Data == null), Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task FetchTextDocsAsync_MissingRequestedChapters()
+    {
+        // In production, the expected chapters list, used to specify
+        // what FetchTextDocsAsync() should fetch, comes from the
+        // SF DB project doc texts.chapters array. This array
+        // specifies what Target chapter text docs the SF DB should
+        // ave. Re-using the Target chapter list when fetching Source
+        // chapter text docs from the SF DB can lead to problems if
+        // FetchTextDocsAsync() does not omit ones that aren't
+        // actually in the DB.
+
+        var env = new TestEnvironment();
+        var highestChapter = 20;
+        var missingSourceChapters = new HashSet<int>() { 2, 3, 10, 12 };
+        var existingTargetChapters = Enumerable.Range(1, highestChapter);
+        var existingSourceChapters = Enumerable.Range(1, highestChapter).Except(missingSourceChapters);
+        Assert.That(existingSourceChapters.Count(), Is.EqualTo(highestChapter - missingSourceChapters.Count), "setup");
+        Assert.That(existingTargetChapters.Count(), Is.GreaterThan(existingSourceChapters.Count()), "setup");
+        var book = new Book("MAT", highestChapter, true) { MissingSourceChapters = missingSourceChapters };
+        env.SetupSFData(true, true, false, false, book);
+
+        // SUT
+        await env.Runner.InitAsync("project01", "user01", "project01", CancellationToken.None);
+        var targetFetch = await env.Runner.FetchTextDocsAsync(TestEnvironment.TextInfoFromBook(book));
+
+        await env.Runner.InitAsync("project02", "user01", "project02", CancellationToken.None);
+        var sourceFetch = await env.Runner.FetchTextDocsAsync(TestEnvironment.TextInfoFromBook(book));
+
+        env.Runner.CloseConnection();
+
+        // Fetched only non-missing chapters. None have null Data.
+        Assert.That(targetFetch.Keys.SequenceEqual(existingTargetChapters));
+        Assert.That(sourceFetch.Keys.SequenceEqual(existingSourceChapters));
+        Assert.That(targetFetch.Count(doc => doc.Value.Data == null), Is.EqualTo(0));
+        Assert.That(sourceFetch.Count(doc => doc.Value.Data == null), Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task GetChapterAuthors_FromMongoDB()
+    {
+        // Setup
+        // Note that the last modified userId is set to user05
+        // So the user id will be retrieved from GetLastModifiedUserIdAsync()
+        // But note that user05 must also be in the chapter permissions to be used
+        var env = new TestEnvironment();
+        TextInfo textInfo = env.SetupChapterAuthorsAndGetTextInfo(setChapterPermissions: false);
+        await env.Runner.InitAsync("project01", "user01", "project01", CancellationToken.None);
+        var textDocs = await env.Runner.FetchTextDocsAsync(textInfo);
+        textInfo.Chapters.First().Permissions.Add("user05", TextInfoPermission.Write);
+        env.RealtimeService.LastModifiedUserId = "user05";
+
+        // SUT
+        Dictionary<int, string> chapterAuthors = await env.Runner.GetChapterAuthorsAsync(textInfo, textDocs);
+        Assert.AreEqual(1, chapterAuthors.Count);
+        Assert.AreEqual(new KeyValuePair<int, string>(1, "user05"), chapterAuthors.First());
+    }
+
+    [Test]
+    public async Task GetChapterAuthors_FromUserSecret()
+    {
+        // Setup
+        // Note that the InitAsync() userId is user01, and setChapterPermissions is true,
+        // So the user id will be retrieved from the user secret
+        var env = new TestEnvironment();
+        TextInfo textInfo = env.SetupChapterAuthorsAndGetTextInfo(setChapterPermissions: true);
+        await env.Runner.InitAsync("project01", "user01", "project01", CancellationToken.None);
+        var textDocs = await env.Runner.FetchTextDocsAsync(textInfo);
+
+        // SUT
+        Dictionary<int, string> chapterAuthors = await env.Runner.GetChapterAuthorsAsync(textInfo, textDocs);
+        Assert.AreEqual(1, chapterAuthors.Count);
+        Assert.AreEqual(new KeyValuePair<int, string>(1, "user01"), chapterAuthors.First());
+    }
+
+    [Test]
+    public async Task GetChapterAuthors_FromChapterPermissions()
+    {
+        // Setup
+        // Note that the InitAsync() userId is user02, and setChapterPermissions is true,
+        // So the user id will be retrieved from the chapter permissions
+        var env = new TestEnvironment();
+        TextInfo textInfo = env.SetupChapterAuthorsAndGetTextInfo(setChapterPermissions: true);
+        await env.Runner.InitAsync("project01", "user02", "project01", CancellationToken.None);
+        var textDocs = await env.Runner.FetchTextDocsAsync(textInfo);
+
+        // SUT
+        Dictionary<int, string> chapterAuthors = await env.Runner.GetChapterAuthorsAsync(textInfo, textDocs);
+        Assert.AreEqual(1, chapterAuthors.Count);
+        Assert.AreEqual(new KeyValuePair<int, string>(1, "user01"), chapterAuthors.First());
+    }
+
+    [Test]
+    public async Task GetChapterAuthors_FromProjectDoc()
+    {
+        // Setup
+        // Note that the InitAsync() userId is user02, and setChapterPermissions is false,
+        // So the user id will be retrieved from the project doc
+        var env = new TestEnvironment();
+        TextInfo textInfo = env.SetupChapterAuthorsAndGetTextInfo(setChapterPermissions: false);
+        await env.Runner.InitAsync("project01", "user02", "project01", CancellationToken.None);
+        var textDocs = await env.Runner.FetchTextDocsAsync(textInfo);
+
+        // SUT
+        Dictionary<int, string> chapterAuthors = await env.Runner.GetChapterAuthorsAsync(textInfo, textDocs);
+        Assert.AreEqual(1, chapterAuthors.Count);
+        Assert.AreEqual(new KeyValuePair<int, string>(1, "user03"), chapterAuthors.First());
+    }
+
+    [Test]
+    public async Task GetChapterAuthors_ChecksLastModifiedUserPermission()
+    {
+        // Setup
+        // Note that the last modified userId is set to user06
+        // So the user id will be retrieved from GetLastModifiedUserIdAsync()
+        // But will not pass the chapter permissions test (only user05 has permission)
+        var env = new TestEnvironment();
+        TextInfo textInfo = env.SetupChapterAuthorsAndGetTextInfo(setChapterPermissions: false);
+        await env.Runner.InitAsync("project01", "user01", "project01", CancellationToken.None);
+        var textDocs = await env.Runner.FetchTextDocsAsync(textInfo);
+        textInfo.Chapters.First().Permissions.Add("user05", TextInfoPermission.Write);
+        env.RealtimeService.LastModifiedUserId = "user06";
+
+        // SUT
+        Dictionary<int, string> chapterAuthors = await env.Runner.GetChapterAuthorsAsync(textInfo, textDocs);
+        Assert.AreEqual(1, chapterAuthors.Count);
+        Assert.AreEqual(new KeyValuePair<int, string>(1, "user05"), chapterAuthors.First());
+    }
+
+    [Test]
+    public async Task GetChapterAuthors_ChecksLastModifiedUserWritePermission()
+    {
+        // Setup
+        // Note that the last modified userId is set to user05
+        // So the user id will be retrieved from GetLastModifiedUserIdAsync()
+        // But will not pass the chapter permissions test (user05 can only read)
+        // However, user03 will be used because they are the project administrator
+        var env = new TestEnvironment();
+        TextInfo textInfo = env.SetupChapterAuthorsAndGetTextInfo(setChapterPermissions: false);
+        await env.Runner.InitAsync("project01", "user01", "project01", CancellationToken.None);
+        var textDocs = await env.Runner.FetchTextDocsAsync(textInfo);
+        textInfo.Chapters.First().Permissions.Add("user05", TextInfoPermission.Read);
+        env.RealtimeService.LastModifiedUserId = "user05";
+
+        // SUT
+        Dictionary<int, string> chapterAuthors = await env.Runner.GetChapterAuthorsAsync(textInfo, textDocs);
+        Assert.AreEqual(1, chapterAuthors.Count);
+        Assert.AreEqual(new KeyValuePair<int, string>(1, "user03"), chapterAuthors.First());
+    }
+
+    [Test]
+    [Ignore("Not ready to sync notes back to paratext.")]
+    public async Task SyncAsync_UpdatesParatextComments()
+    {
+        var env = new TestEnvironment();
+        var book = new Book("MAT", 1, true);
+        env.SetupSFData(true, false, false, true, book);
+        env.SetupPTData(book);
+        env.SetupNoteChanges("thread01", "MAT 1:1", false);
+        await env.ParatextService.UpdateParatextCommentsAsync(
+            Arg.Any<UserSecret>(),
+            default,
+            default,
+            Arg.Any<IEnumerable<IDocument<NoteThread>>>(),
+            Arg.Any<Dictionary<string, ParatextUserProfile>>(),
+            default
+        );
+
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+        await env.ParatextService
+            .Received(1)
+            .UpdateParatextCommentsAsync(
+                Arg.Any<UserSecret>(),
+                "target",
+                40,
+                Arg.Is<IEnumerable<IDocument<NoteThread>>>(t => t.Count() == 1 && t.First().Id == "project01:thread01"),
+                Arg.Any<Dictionary<string, ParatextUserProfile>>(),
+                Arg.Any<int>()
+            );
+
+        SFProject project = env.GetProject();
+        Assert.That(project.ParatextUsers.Select(u => u.Username), Is.EquivalentTo(new[] { "User 1", "User 2" }));
+    }
+
+    [Test]
+    public async Task SyncAsync_UpdatesParatextNoteThreadDoc()
+    {
+        var env = new TestEnvironment();
+        var book = new Book("MAT", 1, true);
+        env.SetupSFData(true, false, false, true, book);
+        env.SetupPTData(book);
+        NoteThread thread01Before = env.GetNoteThread("project01", "thread01");
+        int startingNoteCount = 2;
+        Assert.That(thread01Before.Notes.Count, Is.EqualTo(startingNoteCount), "setup");
+        env.SetupNoteChanges("thread01");
+        // One note is added. One note is marked as Deleted but not actually removed.
+        int expectedNoteCountChange = 1;
+
+        // SUT
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        NoteThread thread01 = env.GetNoteThread("project01", "thread01");
+        int expectedNoteTagId = 3;
+        string threadExpected = "Context before Scripture text in project context after-Start:0-Length:0-MAT 1:1";
+        Assert.That(thread01.NoteThreadToString(), Is.EqualTo(threadExpected));
+        Assert.That(thread01.Assignment, Is.EqualTo(CommentThread.teamUser));
+        env.DeltaUsxMapper.ReceivedWithAnyArgs(2).ToChapterDeltas(default);
+        Assert.That(thread01.Notes.Count, Is.EqualTo(startingNoteCount + expectedNoteCountChange));
+        Assert.That(thread01.Notes[0].Content, Is.EqualTo("thread01 updated."));
+        Assert.That(thread01.Notes[0].Assignment, Is.EqualTo(CommentThread.teamUser));
+        Assert.That(thread01.Notes[1].Deleted, Is.True);
+        Assert.That(thread01.Notes[2].Content, Is.EqualTo("thread01 added."));
+        string expected = "thread01-syncuser03--thread01 added.-tag:" + expectedNoteTagId;
+        Assert.That(thread01.Notes[2].NoteToString(), Is.EqualTo(expected));
+        Assert.That(thread01.Notes[2].TagId, Is.EqualTo(expectedNoteTagId));
+        Assert.That(thread01.Notes[2].OwnerRef, Is.EqualTo("user03"));
+
+        SFProject project = env.GetProject();
+        // User 3 was added as a sync user
+        Assert.That(
+            project.ParatextUsers.Select(u => u.Username),
+            Is.EquivalentTo(new[] { "User 1", "User 2", "User 3" })
+        );
+        Assert.That(project.ParatextUsers.Single(u => u.Username == "User 1").SFUserId, Is.EqualTo("user01"));
+        Assert.That(project.ParatextUsers.Single(u => u.Username == "User 2").SFUserId, Is.EqualTo("user02"));
+        Assert.That(project.ParatextUsers.Single(u => u.Username == "User 3").SFUserId, Is.EqualTo("user03"));
+        Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
+        Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+        Assert.That(
+            syncMetrics.Notes,
+            Is.EqualTo(new NoteSyncMetricInfo(added: 1, deleted: 1, updated: 1, removed: 0))
+        );
+        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 1)));
+    }
+
+    [Test]
+    public async Task SyncAsync_ParatextNoteThreadReattached()
+    {
+        var env = new TestEnvironment();
+        var book = new Book("MAT", 1, true);
+        env.SetupSFData(true, false, false, true, book);
+        env.SetupPTData(book);
+        string threadId = "thread01";
+        string verseStr = "MAT 1:5";
+        env.SetupNoteReattachedChange(threadId, verseStr);
+
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        NoteThread thread01 = env.GetNoteThread("project01", "thread01");
+        string[] reattachedParts = new[]
+        {
+            "MAT 1:5",
+            "reattach selected text",
+            "16",
+            "Reattach before ",
+            " reattach after."
+        };
+        string reattached = string.Join(PtxUtils.StringUtils.orcCharacter, reattachedParts);
+        string expected = "Context before Scripture text in project context after-" + $"Start:16-Length:22-MAT 1:1";
+        Assert.That(thread01.NoteThreadToString(), Is.EqualTo(expected));
+        Assert.That(thread01.Notes.Single(n => n.Reattached != null).Reattached, Is.EqualTo(reattached));
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+        Assert.That(
+            syncMetrics.Notes,
+            Is.EqualTo(new NoteSyncMetricInfo(added: 1, deleted: 0, updated: 0, removed: 0))
+        );
+        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+    }
+
+    [Test]
+    public async Task SyncAsync_AddParatextNoteThreadDoc()
+    {
+        var env = new TestEnvironment();
+        var book = new Book("MAT", 3, true);
+        env.SetupSFData(true, false, false, true, book);
+        env.SetupPTData(book);
+        env.SetupNewNoteThreadChange("thread02", "syncuser01");
+
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        NoteThread thread02 = env.GetNoteThread("project01", "thread02");
+        string expected = "Context before Scripture text in project context after-" + "Start:0-Length:0-MAT 1:1";
+        Assert.That(thread02.NoteThreadToString(), Is.EqualTo(expected));
+        Assert.That(thread02.Notes.Count, Is.EqualTo(1));
+        Assert.That(thread02.Notes[0].Content, Is.EqualTo("New thread02 added."));
+        Assert.That(thread02.Notes[0].OwnerRef, Is.EqualTo("user01"));
+        Assert.That(thread02.Notes[0].Assignment, Is.EqualTo(CommentThread.teamUser));
+        Assert.That(thread02.Status, Is.EqualTo(NoteStatus.Todo.InternalValue));
+        Assert.That(thread02.Assignment, Is.EqualTo(CommentThread.teamUser));
+        SFProject project = env.GetProject();
+        Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+
+        // Add a conflict note
+        env.SetupNewConflictNoteThreadChange("conflictthread01");
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        Assert.That(env.ContainsNoteThread("project01", "conflictthread01"), Is.True);
+        project = env.GetProject();
+        Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+        Assert.That(
+            syncMetrics.Notes,
+            Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
+        );
+        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
+    }
+
+    [Test]
+    public async Task SyncAsync_RemovesParatextNoteThreadDoc()
+    {
+        var env = new TestEnvironment();
+        string sfProjectId = "project01";
+        string threadId = "thread01";
+        var book = new Book("MAT", 1, true);
+        env.SetupSFData(true, false, false, true, book);
+        List<Note> beginningNoteSet = env.GetNoteThread(sfProjectId, threadId).Notes;
+        beginningNoteSet.Add(
+            new Note
+            {
+                DataId = "n03",
+                ThreadId = threadId,
+                SyncUserRef = "syncuser02",
+                ExtUserId = "user03",
+                Content = "Paratext note 3.",
+                DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc)
+            }
+        );
+        await env.SetThreadNotesAsync(sfProjectId, threadId, beginningNoteSet);
+        env.SetupPTData(book);
+        env.SetupNoteRemovedChange(threadId, "n02");
+        NoteThread thread01 = env.GetNoteThread(sfProjectId, threadId);
+        Assert.That(
+            thread01.Notes.Select(n => n.DataId),
+            Is.EquivalentTo(new[] { "n01", "n02", "n03" }),
+            "setup: expecting several notes in doc"
+        );
+
+        // SUT 1
+        await env.Runner.RunAsync(sfProjectId, "user01", sfProjectId, false, CancellationToken.None);
+
+        thread01 = env.GetNoteThread(sfProjectId, threadId);
+        Assert.That(thread01.Notes.Select(n => n.DataId), Is.EquivalentTo(new[] { "n01", "n03" }));
+        SFProject project = env.GetProject();
+        Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+        Assert.That(
+            syncMetrics.Notes,
+            Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 1))
+        );
+        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+
+        // Remove the entire thread
+        env.SetupNoteRemovedChange(threadId, null);
+
+        // SUT 2
+        await env.Runner.RunAsync(sfProjectId, "user01", "project01_alt", false, CancellationToken.None);
+
+        Assert.That(env.ContainsNoteThread(sfProjectId, threadId), Is.False);
+        project = env.GetProject();
+        Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+
+        // Verify the sync metrics
+        syncMetrics = env.GetSyncMetrics("project01_alt");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+        Assert.That(
+            syncMetrics.Notes,
+            Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
+        );
+        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
+    }
+
+    [Test]
+    public async Task SyncAsync_NoteThreadsGetResolved()
+    {
+        var env = new TestEnvironment();
+        var book = new Book("MAT", 3, true);
+        env.SetupSFData(true, false, false, true, book);
+        env.SetupPTData(book);
+        env.SetupNewNoteThreadChange("thread02", "syncuser01");
+
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        // Default resolved status is false
+        NoteThread thread02 = env.GetNoteThread("project01", "thread02");
+        Assert.That(thread02.VerseRef.ToString(), Is.EqualTo("MAT 1:1"));
+        Assert.That(thread02.Status, Is.EqualTo(NoteStatus.Todo.InternalValue));
+
+        // Change resolve status to true
+        env.SetupNoteStatusChange("thread02", NoteStatus.Resolved.InternalValue);
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        thread02 = env.GetNoteThread("project01", "thread02");
+        Assert.That(thread02.VerseRef.ToString(), Is.EqualTo("MAT 1:1"));
+        Assert.That(thread02.Status, Is.EqualTo(NoteStatus.Resolved.InternalValue));
+
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+        Assert.That(
+            syncMetrics.Notes,
+            Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
+        );
+        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 1)));
+
+        // Change status back to false - happens if the note becomes unresolved again in Paratext
+        env.SetupNoteStatusChange("thread02", NoteStatus.Todo.InternalValue);
+        await env.Runner.RunAsync("project01", "user01", "project01_alt", false, CancellationToken.None);
+
+        thread02 = env.GetNoteThread("project01", "thread02");
+        Assert.That(thread02.VerseRef.ToString(), Is.EqualTo("MAT 1:1"));
+        Assert.That(thread02.Status, Is.EqualTo(NoteStatus.Todo.InternalValue));
+
+        // Verify the sync metrics
+        syncMetrics = env.GetSyncMetrics("project01_alt");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+        Assert.That(
+            syncMetrics.Notes,
+            Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
+        );
+        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 1)));
+    }
+
+    [Test]
+    public async Task SyncAsync_NoteChange_None()
+    {
+        var env = new TestEnvironment();
+        // Set up some PT and SF project data, including a Note.
+        string projectId = "project01";
+        var book = new Book("MAT", 3, true);
+        env.SetupSFData(true, false, false, true, book);
+        env.SetupPTData(book);
+        string threadId = $"thread03";
+        NoteThread thread03 = env.GetNoteThread(projectId, threadId);
+        Note note = thread03.Notes[0];
+        string origNoteData = note.NoteToString();
+
+        // Not setting up any actual changes. This test partly shows that the helper method does not create changes
+        // when the input is null.
+        env.SetupThreadAndNoteChange(threadId, null, null);
+
+        // SUT
+        await env.Runner.RunAsync(projectId, "user01", projectId, false, CancellationToken.None);
+
+        thread03 = env.GetNoteThread(projectId, threadId);
+        note = thread03.Notes[0];
+        // No incoming note changes mean no changes to the SF DB Notes.
+        // This is not a particularly thorough check, but is showing at least that a few pieces have not changed.
+        Assert.That(note.NoteToString(), Is.EqualTo(origNoteData), "Note data should not have been changed");
+
+        // Verify the sync metrics - the note data will be updated, even though it is not changed
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+        Assert.That(
+            syncMetrics.Notes,
+            Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
+        );
+        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+    }
+
+    [Test]
+    public async Task SyncAsync_NoteChanges_SavedToSFDB()
+    {
+        // Note that there are multiple constructions of TestEnvironment, since
+        // ParatextService.GetLastSharedRevision() returns different values before and after SendReceive.
+
+        // Various changes to note properties, coming from PT, are recorded into the SF DB. For this to happen,
+        // the changes will need to be both detected, as well as saved.
+        // A PT Comment Content property was updated, which is detected and saved to SF DB.
+        await (new TestEnvironment()).SimpleNoteChangeAppliedCheckerAsync<string>(
+            (Note note) => note.Content,
+            (Note note, string newValue) => note.Content = newValue,
+            "new contents"
+        );
+        // A PT Comment Type property was updated, which is detected and saved to SF DB.
+        await (new TestEnvironment()).SimpleNoteChangeAppliedCheckerAsync<string>(
+            (Note note) => note.Type,
+            (Note note, string newValue) => note.Type = newValue,
+            NoteType.Conflict.InternalValue
+        );
+        // ConflictType property
+        await (new TestEnvironment()).SimpleNoteChangeAppliedCheckerAsync<string>(
+            (Note note) => note.ConflictType,
+            (Note note, string newValue) => note.ConflictType = newValue,
+            NoteConflictType.VerseTextConflict.InternalValue
+        );
+        // AcceptedChangeXml property
+        await (new TestEnvironment()).SimpleNoteChangeAppliedCheckerAsync<string>(
+            (Note note) => note.AcceptedChangeXml,
+            (Note note, string newValue) => note.AcceptedChangeXml = newValue,
+            "some xml"
+        );
+    }
+
+    [Test]
+    public async Task SyncAsync_ResourceChanged()
+    {
+        // Setup the environment so there will be Paratext changes
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, false, false, new Book("MAT", 2), new Book("MRK", 2));
+        env.SetupPTData(new Book("MAT", 3), new Book("MRK", 1));
+
+        // Setup the environment so the Paratext service will return that the resource has changed
+        env.ParatextService.IsResource(Arg.Any<string>()).Returns(true);
+        env.ParatextService.ResourceDocsNeedUpdating(Arg.Any<SFProject>(), Arg.Any<ParatextResource>()).Returns(true);
+        env.ParatextService
+            .SendReceiveAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Any<string>(),
+                Arg.Any<IProgress<ProgressState>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(new ParatextResource());
+
+        // SUT
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        env.MockLogger.AssertEventCount(
+            (LogEvent logEvent) =>
+                logEvent.LogLevel == LogLevel.Information && Regex.IsMatch(logEvent.Message, "Starting"),
+            1
+        );
+
+        // The book text is retrieved from Paratext as the resource has changed
+        env.ParatextService.Received().GetBookText(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<int>());
+
+        Assert.IsNotNull(env.GetProject().ResourceConfig);
+        Assert.That(env.ContainsText("project01", "MAT", 3), Is.True);
+        Assert.That(env.ContainsText("project01", "MRK", 2), Is.False);
+
+        // Check that the resource users metrics have been updated
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.ResourceUsers, Is.EqualTo(new SyncMetricInfo(2, 0, 0)));
+    }
+
+    [Test]
+    public async Task SyncAsync_ResourceNotChanged()
+    {
+        // Setup the environment so there will be no Paratext changes
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, false, false, new Book("MAT", 2), new Book("MRK", 2));
+        env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
+
+        // Setup the environment so the Paratext service will return that the resource has not changed
+        env.ParatextService.IsResource(Arg.Any<string>()).Returns(true);
+        env.ParatextService.ResourceDocsNeedUpdating(Arg.Any<SFProject>(), Arg.Any<ParatextResource>()).Returns(false);
+        env.ParatextService
+            .SendReceiveAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Any<string>(),
+                Arg.Any<IProgress<ProgressState>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(new ParatextResource());
+
+        // SUT
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        env.MockLogger.AssertEventCount(
+            (LogEvent logEvent) =>
+                logEvent.LogLevel == LogLevel.Information && Regex.IsMatch(logEvent.Message, "Starting"),
+            1
+        );
+
+        // The book text is not retrieved from Paratext as the resource did not change
+        env.ParatextService.DidNotReceive().GetBookText(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<int>());
+
+        Assert.IsNull(env.GetProject().ResourceConfig);
+        Assert.That(env.ContainsText("project01", "MAT", 2), Is.True);
+        Assert.That(env.ContainsText("project01", "MRK", 2), Is.True);
+    }
+
+    [Test]
+    public async Task SyncAsync_SyncMetricsSetsDateStartedAndDateFinished()
+    {
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, true, false);
+
+        await env.Runner.RunAsync("project01", "user03", "project01", false, CancellationToken.None);
+
+        SFProject project = env.VerifyProjectSync(false);
+        Assert.That(project.Sync.DataInSync, Is.True);
+
+        // Check that the date started and date finished are set
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.DateStarted, Is.Not.Null);
+        Assert.That(syncMetrics.DateFinished, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task SyncAsync_SyncMetricsRecordsLogs()
+    {
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, true, false);
+
+        await env.Runner.RunAsync("project01", "user03", "project01", false, CancellationToken.None);
+
+        SFProject project = env.VerifyProjectSync(false);
+        Assert.That(project.Sync.DataInSync, Is.True);
+
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Log.Count, Is.Not.Zero);
+    }
+
+    [Test]
+    public async Task SyncAsync_SyncMetricsRecordsBackupCreated()
+    {
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, true, false, new Book("MAT", 2), new Book("MRK", 2));
+        env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
+
+        // Simulate that there is no backup, and that the backups are created successfully
+        env.ParatextService.BackupExists(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(false);
+        env.ParatextService.BackupRepository(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(true);
+
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        // A backup was created before and after the sync
+        env.ParatextService.Received(2).BackupRepository(Arg.Any<UserSecret>(), Arg.Any<string>());
+        SFProject project = env.VerifyProjectSync(true);
+        Assert.That(project.Sync.DataInSync, Is.True);
+
+        // Check that the metrics were updated
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.RepositoryBackupCreated, Is.True);
+    }
+
+    [Test]
+    public async Task SyncAsync_SyncMetricsRecordsParatextNotes()
+    {
+        var env = new TestEnvironment();
+        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        env.SetupSFData(true, true, true, false, books);
+        env.SetupPTData(books);
+        var syncMetricInfo = new SyncMetricInfo(1, 2, 3);
+        env.ParatextService.PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<XElement>()).Returns(syncMetricInfo);
+
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        env.ParatextService.Received(2).PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<XElement>());
+
+        env.VerifyProjectSync(true);
+
+        // Check that as PutNotes was run twice, the metrics will be multiplied by two
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.ParatextNotes, Is.EqualTo(syncMetricInfo + syncMetricInfo));
+    }
+
+    [Test]
+    public async Task SyncAsync_SyncMetricsRecordsParatextBooks()
+    {
+        var env = new TestEnvironment();
+        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        env.SetupSFData(true, true, true, false, books);
+        env.SetupPTData(books);
+        env.ParatextService
+            .PutBookText(
+                Arg.Any<UserSecret>(),
+                Arg.Any<string>(),
+                Arg.Any<int>(),
+                Arg.Any<XDocument>(),
+                Arg.Any<Dictionary<int, string>>()
+            )
+            .Returns(1);
+
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        await env.ParatextService
+            .Received(2)
+            .PutBookText(
+                Arg.Any<UserSecret>(),
+                Arg.Any<string>(),
+                Arg.Any<int>(),
+                Arg.Any<XDocument>(),
+                Arg.Any<Dictionary<int, string>>()
+            );
+        ;
+
+        SFProject project = env.GetProject();
+        Assert.That(project.ParatextUsers.Count, Is.EqualTo(2));
+        env.VerifyProjectSync(true);
+
+        // Check that as PutBookText was run twice, the metrics will be that two books are added
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.ParatextBooks, Is.EqualTo(new SyncMetricInfo(0, 0, 2)));
+    }
+
+    [Test]
+    public async Task SyncAsync_OnlyTargetParatextUsersAreGivenResourceAccess()
+    {
+        // Setup the environment so there will be Paratext changes
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, false, false, new Book("MAT", 2), new Book("MRK", 2));
+        env.SetupPTData(new Book("MAT", 3), new Book("MRK", 1));
+
+        // Make user02 an SF only user
+        await env.SetUserRole("user02", SFProjectRole.CommunityChecker);
+
+        // Setup the environment so the Paratext service will return that source is a resource
+        env.ParatextService.IsResource(Arg.Any<string>()).Returns(true);
+        env.ParatextService
+            .SendReceiveAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Any<string>(),
+                Arg.Any<IProgress<ProgressState>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(new ParatextResource());
+
+        // Ensure that the source is project02, and has no users with access
+        Assert.AreEqual("project02", env.GetProject().TranslateConfig.Source.ProjectRef);
+        Assert.AreEqual(0, env.GetProject("project02").UserRoles.Count);
+
+        // SUT
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        env.MockLogger.AssertEventCount(
+            (LogEvent logEvent) =>
+                logEvent.LogLevel == LogLevel.Information && Regex.IsMatch(logEvent.Message, "Starting"),
+            1
+        );
+
+        // Only one user should have been added, although two are present
+        Assert.AreEqual(2, env.GetProject().UserRoles.Count);
+        await env.SFProjectService.Received(1).AddUserAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
+
+        // Check that the resource users metrics have been updated
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.ResourceUsers, Is.EqualTo(new SyncMetricInfo(1, 0, 0)));
+    }
+
+    private class Book
+    {
+        public Book(string bookId, int highestChapter, bool hasSource = true)
+            : this(bookId, highestChapter, hasSource ? highestChapter : 0) { }
+
+        public Book(string bookId, int highestTargetChapter, int highestSourceChapter)
+        {
+            Id = bookId;
+            HighestTargetChapter = highestTargetChapter;
+            HighestSourceChapter = highestSourceChapter;
+        }
+
+        public string Id { get; }
+        public int HighestTargetChapter { get; }
+        public int HighestSourceChapter { get; }
+
+        public HashSet<int> InvalidChapters { get; } = new HashSet<int>();
+        public HashSet<int> MissingTargetChapters { get; set; } = new HashSet<int>();
+        public HashSet<int> MissingSourceChapters { get; set; } = new HashSet<int>();
+    }
+
+    private class TestEnvironment
+    {
+        public readonly int translateNoteTagId = 5;
+        private readonly MemoryRepository<SFProjectSecret> _projectSecrets;
+        private readonly MemoryRepository<SyncMetrics> _syncMetrics;
+        private bool _sendReceivedCalled = false;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestEnvironment" /> class.
+        /// </summary>
+        /// <param name="substituteRealtimeService">If set to <c>true</c> use a substitute realtime service rather
+        /// than the <see cref="SFMemoryRealtimeService" />.</param>
+        public TestEnvironment(bool substituteRealtimeService = false)
+        {
+            var userSecrets = new MemoryRepository<UserSecret>(
+                new[]
                 {
-                    new SFProject
+                    new UserSecret { Id = "user01" },
+                    new UserSecret { Id = "user02" },
+                }
+            );
+            _projectSecrets = new MemoryRepository<SFProjectSecret>(
+                new[]
+                {
+                    new SFProjectSecret
                     {
                         Id = "project01",
-                        Name = "project01",
-                        ShortName = "P01",
-                        UserRoles = new Dictionary<string, string>
-                        {
-                            { "user01", SFProjectRole.Administrator },
-                            { "user02", SFProjectRole.Translator }
-                        },
-                        ParatextId = "target",
-                        IsRightToLeft = false,
-                        DefaultFontSize = 10,
-                        DefaultFont = ProjectSettings.defaultFontName,
-                        TranslateConfig = new TranslateConfig
-                        {
-                            TranslationSuggestionsEnabled = translationSuggestionsEnabled,
-                            Source = new TranslateSource
-                            {
-                                ParatextId = "source",
-                                ProjectRef = "project02",
-                                Name = "Source",
-                                ShortName = "SRC",
-                                WritingSystem = new WritingSystem { Tag = "en" },
-                                IsRightToLeft = false
-                            },
-                            DefaultNoteTagId = translateNoteTagId
-                        },
-                        CheckingConfig = new CheckingConfig
-                        {
-                            CheckingEnabled = checkingEnabled,
-                            AnswerExportMethod = CheckingAnswerExport.MarkedForExport
-                        },
-                        Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
-                        Sync = new Sync
-                        {
-                            // QueuedCount is incremented before RunAsync() by SyncService.SyncAsync(). So set
-                            // it to 1 to simulate it being incremented.
-                            QueuedCount = 1,
-                            SyncedToRepositoryVersion = "beforeSR",
-                            DataInSync = true
-                        },
-                        ParatextUsers = new List<ParatextUserProfile>
-                        {
-                            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = "User 1" },
-                            new ParatextUserProfile { OpaqueUserId = "syncuser02", Username = "User 2" }
-                        },
-                        NoteTags = new List<NoteTag>()
+                        JobIds = new List<string> { "test_jobid" },
                     },
-                    new SFProject
-                    {
-                        Id = "project02",
-                        Name = "Source",
-                        ShortName = "SRC",
-                        UserRoles = new Dictionary<string, string>(),
-                        ParatextId = "source",
-                        IsRightToLeft = false,
-                        TranslateConfig = new TranslateConfig { TranslationSuggestionsEnabled = false },
-                        NoteTags = new List<NoteTag>(),
-                        CheckingConfig = new CheckingConfig
-                        {
-                            CheckingEnabled = checkingEnabled,
-                            AnswerExportMethod = CheckingAnswerExport.MarkedForExport
-                        },
-                        WritingSystem = new WritingSystem { Tag = "en" },
-                        Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
-                        Sync = new Sync { QueuedCount = 0, SyncedToRepositoryVersion = "beforeSR" }
-                    },
-                    new SFProject
-                    {
-                        // This project was not sync'd since we started tracking SyncedToRepositoryVersion when
-                        // a 2021-05-14 commit reached sf-live.
-                        Id = "project03",
-                        Name = "project03withNoSyncedToRepositoryVersion",
-                        ShortName = "P03",
-                        UserRoles = new Dictionary<string, string>
-                        {
-                            { "user01", SFProjectRole.Administrator },
-                            { "user02", SFProjectRole.Translator }
-                        },
-                        ParatextId = "paratext-project03",
-                        IsRightToLeft = false,
-                        TranslateConfig = new TranslateConfig
-                        {
-                            TranslationSuggestionsEnabled = translationSuggestionsEnabled,
-                            Source = new TranslateSource
-                            {
-                                ParatextId = "paratext-project04",
-                                ProjectRef = "project04",
-                                Name = "project04",
-                                ShortName = "P04",
-                                WritingSystem = new WritingSystem { Tag = "en" },
-                                IsRightToLeft = false
-                            }
-                        },
-                        CheckingConfig = new CheckingConfig
-                        {
-                            CheckingEnabled = checkingEnabled,
-                            AnswerExportMethod = CheckingAnswerExport.MarkedForExport
-                        },
-                        Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
-                        Sync = new Sync
-                        {
-                            QueuedCount = 1,
-                            // No SyncedToRepositoryVersion
-                            // No DataInSync
-                        },
-                    },
-                    new SFProject
-                    {
-                        Id = "project04",
-                        Name = "project04",
-                        ShortName = "P04",
-                        UserRoles = new Dictionary<string, string>(),
-                        ParatextId = "paratext-project04",
-                        IsRightToLeft = false,
-                        TranslateConfig = new TranslateConfig { TranslationSuggestionsEnabled = false },
-                        CheckingConfig = new CheckingConfig
-                        {
-                            CheckingEnabled = checkingEnabled,
-                            AnswerExportMethod = CheckingAnswerExport.MarkedForExport
-                        },
-                        WritingSystem = new WritingSystem { Tag = "en" },
-                        Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
-                        Sync = new Sync
-                        {
-                            QueuedCount = 0,
-                            // No SyncedToRepositoryVersion
-                            // No DataInSync
-                        }
-                    },
-                    new SFProject
-                    {
-                        // This project was sync'd after we started tracking SyncedToRepositoryVersion, but the
-                        // only sync attempt triggered a failure, and so only DataInSync was written to,
-                        // not SyncedToRepositoryVersion.
-                        Id = "project05",
-                        Name = "project05",
-                        ShortName = "P05",
-                        UserRoles = new Dictionary<string, string>
-                        {
-                            { "user01", SFProjectRole.Administrator },
-                            { "user02", SFProjectRole.Translator }
-                        },
-                        ParatextId = "paratext-project05",
-                        IsRightToLeft = false,
-                        TranslateConfig = new TranslateConfig
-                        {
-                            TranslationSuggestionsEnabled = translationSuggestionsEnabled,
-                            Source = new TranslateSource
-                            {
-                                ParatextId = "paratext-project04",
-                                ProjectRef = "project04",
-                                Name = "project04",
-                                ShortName = "P04",
-                                WritingSystem = new WritingSystem { Tag = "en" },
-                                IsRightToLeft = false
-                            }
-                        },
-                        CheckingConfig = new CheckingConfig
-                        {
-                            CheckingEnabled = checkingEnabled,
-                            AnswerExportMethod = CheckingAnswerExport.MarkedForExport
-                        },
-                        Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
-                        Sync = new Sync
-                        {
-                            QueuedCount = 1,
-                            DataInSync = false
-                            // No SyncedToRepositoryVersion
-                        },
-                    },
-                };
-                RealtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(sfProjects));
-                MockProjectDirsExist(sfProjects.Select((SFProject proj) => proj.ParatextId));
-
-                RealtimeService.AddRepository("texts", OTType.RichText, new MemoryRepository<TextData>());
-                RealtimeService.AddRepository("questions", OTType.Json0, new MemoryRepository<Question>());
-                if (noteOnFirstBook && books.Length > 0)
-                    AddParatextNoteThreadData(books[0]);
-                else
-                    SetupEmptyNoteThreads();
-                foreach (Book book in books)
-                {
-                    AddSFBook(
-                        targetProjectSFId,
-                        GetProject(targetProjectSFId).ParatextId,
-                        book.Id,
-                        book.HighestTargetChapter,
-                        changed,
-                        book.MissingTargetChapters
-                    );
-                    if (book.HighestSourceChapter > 0)
-                    {
-                        AddSFBook(
-                            sourceProjectSFId,
-                            GetProject(sourceProjectSFId).ParatextId,
-                            book.Id,
-                            book.HighestSourceChapter,
-                            changed,
-                            book.MissingSourceChapters
-                        );
-                    }
+                    new SFProjectSecret { Id = "project02" },
+                    new SFProjectSecret { Id = "project03" },
+                    new SFProjectSecret { Id = "project04" },
+                    new SFProjectSecret { Id = "project05" },
                 }
-
-                var notesElem = new XElement("notes");
-                if (changed)
+            );
+            _syncMetrics = new MemoryRepository<SyncMetrics>(
+                new[]
                 {
-                    notesElem.Add(new XElement("thread"));
+                    new SyncMetrics { Id = "project01" },
+                    new SyncMetrics { Id = "project01_alt" },
+                    new SyncMetrics { Id = "project02" },
+                    new SyncMetrics { Id = "project03" },
+                    new SyncMetrics { Id = "project04" },
+                    new SyncMetrics { Id = "project05" },
                 }
+            );
+            SFProjectService = Substitute.For<ISFProjectService>();
+            MachineProjectService = Substitute.For<IMachineProjectService>();
+            ParatextService = Substitute.For<IParatextService>();
 
-                NotesMapper
-                    .GetNotesChangelistAsync(
-                        Arg.Any<XElement>(),
-                        Arg.Any<IEnumerable<IDocument<Question>>>(),
-                        Arg.Any<Dictionary<string, ParatextUserProfile>>(),
-                        Arg.Any<Dictionary<string, string>>(),
-                        CheckingAnswerExport.MarkedForExport
-                    )
-                    .Returns(Task.FromResult(notesElem));
-            }
-
-            public TextInfo TextInfoFromBook(Book book)
+            var ptUserRoles = new Dictionary<string, string>
             {
-                return new TextInfo
-                {
-                    BookNum = Canon.BookIdToNumber(book.Id),
-                    Chapters = Enumerable
-                        .Range(1, book.HighestTargetChapter)
-                        .Select(
-                            c =>
-                                new Chapter
-                                {
-                                    Number = c,
-                                    LastVerse = 10,
-                                    IsValid = !book.InvalidChapters.Contains(c),
-                                    Permissions = { }
-                                }
-                        )
-                        .ToList(),
-                    HasSource = book.HighestSourceChapter > 0
-                };
-            }
-
-            public void SetupPTData(params Book[] books)
-            {
-                SetupPTDataForProjectIds("target", "source", books);
-            }
-
-            public void SetupPTData(string targetProjectPTId, params Book[] books)
-            {
-                SetupPTDataForProjectIds(targetProjectPTId, "sourceProjectPTId", books);
-            }
-
-            public void SetupPTDataForProjectIds(
-                string targetProjectPTId,
-                string sourceProjectPTId,
-                params Book[] books
-            )
-            {
-                ParatextService
-                    .GetBookList(Arg.Any<UserSecret>(), targetProjectPTId)
-                    .Returns(books.Select(b => Canon.BookIdToNumber(b.Id)).ToArray());
-                // Include book with Source even if there are no chapters, if there are also no chapters in Target. PT
-                // can actually have or not have books which do or do not have chapters more flexibly than this. But in
-                // this way, allow tests to request a Source book exist even with zero chapters.
-                ParatextService
-                    .GetBookList(Arg.Any<UserSecret>(), sourceProjectPTId)
-                    .Returns(
-                        books
-                            .Where(b => b.HighestSourceChapter > 0 || b.HighestSourceChapter == b.HighestTargetChapter)
-                            .Select(b => Canon.BookIdToNumber(b.Id))
-                            .ToArray()
-                    );
-                foreach (Book book in books)
-                {
-                    AddPTBook(
-                        targetProjectPTId,
-                        book.Id,
-                        book.HighestTargetChapter,
-                        book.MissingTargetChapters,
-                        book.InvalidChapters
-                    );
-                    if (book.HighestSourceChapter > 0 || book.HighestSourceChapter == book.HighestTargetChapter)
-                        AddPTBook(sourceProjectPTId, book.Id, book.HighestSourceChapter, book.MissingSourceChapters);
-                }
-            }
-
-            public Task SetUserRole(string userId, string role)
-            {
-                return RealtimeService
-                    .GetRepository<SFProject>()
-                    .UpdateAsync(p => p.Id == "project01", u => u.Set(pr => pr.UserRoles[userId], role));
-            }
-
-            public void SetupNoteChanges(string threadId, string verseRef = "MAT 1:1", bool fromParatext = true)
-            {
-                if (fromParatext)
-                {
-                    var noteThreadChange = new NoteThreadChange(
-                        threadId,
-                        verseRef,
-                        $"Scripture text in project",
-                        "Context before ",
-                        " context after",
-                        NoteStatus.Todo.InternalValue,
-                        ""
-                    );
-                    noteThreadChange.ThreadUpdated = true;
-                    noteThreadChange.Position = new TextAnchor { Start = 0, Length = 0 };
-                    noteThreadChange.Assignment = CommentThread.teamUser;
-                    noteThreadChange.AddChange(
-                        CreateNote(threadId, "n01", "syncuser01", $"{threadId} updated.", ChangeType.Updated),
-                        ChangeType.Updated
-                    );
-                    noteThreadChange.AddChange(
-                        CreateNote(threadId, "n02", "syncuser02", $"{threadId} deleted.", ChangeType.Deleted),
-                        ChangeType.Deleted
-                    );
-                    noteThreadChange.AddChange(
-                        CreateNote(threadId, "n03", "syncuser03", $"{threadId} added.", ChangeType.Added, 3),
-                        ChangeType.Added
-                    );
-
-                    ParatextService
-                        .GetNoteThreadChanges(
+                { "pt01", SFProjectRole.Administrator },
+                { "pt02", SFProjectRole.Translator }
+            };
+            ParatextService
+                .GetProjectRolesAsync(
+                    Arg.Any<UserSecret>(),
+                    Arg.Is((SFProject project) => project.ParatextId == "target"),
+                    Arg.Any<CancellationToken>()
+                )
+                .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+            ParatextService
+                .When(
+                    x =>
+                        x.SendReceiveAsync(
                             Arg.Any<UserSecret>(),
                             "target",
-                            40,
-                            Arg.Any<IEnumerable<IDocument<NoteThread>>>(),
-                            Arg.Any<Dictionary<int, ChapterDelta>>(),
-                            Arg.Any<Dictionary<string, ParatextUserProfile>>()
+                            Arg.Any<IProgress<ProgressState>>(),
+                            Arg.Any<CancellationToken>()
                         )
-                        .Returns(x =>
+                )
+                .Do(x =>
+                {
+                    _sendReceivedCalled = true;
+                    ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns("afterSR");
+                });
+
+            ParatextService.GetNotes(Arg.Any<UserSecret>(), "target", Arg.Any<int>()).Returns("<notes/>");
+            ParatextService.GetParatextUsername(Arg.Is<UserSecret>(u => u.Id == "user01")).Returns("User 1");
+            ParatextService
+                .GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
+                .Returns(
+                    x =>
+                        new ParatextSettings
                         {
-                            ((Dictionary<string, ParatextUserProfile>)x[5]).Add(
-                                "User 3",
-                                new ParatextUserProfile { OpaqueUserId = "syncuser03", Username = "User 3" }
-                            );
-                            return new[] { noteThreadChange };
-                        });
-                    Dictionary<string, string> userIdsToUsernames = new Dictionary<string, string>
+                            FullName = (string)x[1],
+                            IsRightToLeft = false,
+                            Editable = true
+                        }
+                );
+            ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), "target").Returns("beforeSR");
+            ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), "source").Returns("beforeSR", "afterSR");
+            RealtimeService = new SFMemoryRealtimeService();
+            Connection = Substitute.For<IConnection>();
+            SubstituteRealtimeService = Substitute.For<IRealtimeService>();
+            SubstituteRealtimeService.ConnectAsync().Returns(Task.FromResult(Connection));
+            DeltaUsxMapper = Substitute.For<IDeltaUsxMapper>();
+            NotesMapper = Substitute.For<IParatextNotesMapper>();
+            var hubContext = Substitute.For<IHubContext<NotificationHub, INotifier>>();
+            MockLogger = new MockLogger<ParatextSyncRunner>();
+
+            Runner = new ParatextSyncRunner(
+                userSecrets,
+                _projectSecrets,
+                _syncMetrics,
+                SFProjectService,
+                MachineProjectService,
+                ParatextService,
+                substituteRealtimeService ? SubstituteRealtimeService : RealtimeService,
+                DeltaUsxMapper,
+                NotesMapper,
+                hubContext,
+                MockLogger
+            );
+        }
+
+        public ParatextSyncRunner Runner { get; }
+        public ISFProjectService SFProjectService { get; }
+        public IMachineProjectService MachineProjectService { get; }
+        public IParatextNotesMapper NotesMapper { get; }
+        public IParatextService ParatextService { get; }
+        public SFMemoryRealtimeService RealtimeService { get; }
+        public IRealtimeService SubstituteRealtimeService { get; }
+        public IDeltaUsxMapper DeltaUsxMapper { get; }
+        public MockLogger<ParatextSyncRunner> MockLogger { get; }
+
+        /// <summary>
+        /// Gets the connection to be used with <see cref="SubstituteRealtimeService"/>.
+        /// </summary>
+        public IConnection Connection { get; }
+
+        public SFProject GetProject(string projectSFId = "project01") =>
+            RealtimeService.GetRepository<SFProject>().Get(projectSFId);
+
+        public SFProjectSecret GetProjectSecret(string projectId = "project01") => _projectSecrets.Get(projectId);
+
+        public SFProjectUserConfig GetProjectUserConfig(string projectId, string userId)
+        {
+            return RealtimeService
+                .GetRepository<SFProjectUserConfig>()
+                .Get(SFProjectUserConfig.GetDocId(projectId, userId));
+        }
+
+        public bool ContainsText(string projectId, string bookId, int chapter)
+        {
+            return RealtimeService
+                .GetRepository<TextData>()
+                .Contains(TextData.GetTextDocId(projectId, Canon.BookIdToNumber(bookId), chapter));
+        }
+
+        public TextData GetText(string projectId, string bookId, int chapter)
+        {
+            return RealtimeService
+                .GetRepository<TextData>()
+                .Get(TextData.GetTextDocId(projectId, Canon.BookIdToNumber(bookId), chapter));
+        }
+
+        public bool ContainsQuestion(string bookId, int chapter) =>
+            RealtimeService.GetRepository<Question>().Contains($"project01:question{bookId}{chapter}");
+
+        public bool ContainsNote(int chapter) =>
+            RealtimeService.GetRepository<NoteThread>().Contains($"project01:thread0{chapter}");
+
+        public Question GetQuestion(string bookId, int chapter) =>
+            RealtimeService.GetRepository<Question>().Get($"project01:question{bookId}{chapter}");
+
+        public bool ContainsNoteThread(string projectId, string threadId) =>
+            RealtimeService.GetRepository<NoteThread>().Contains($"{projectId}:{threadId}");
+
+        public NoteThread GetNoteThread(string projectId, string threadId) =>
+            RealtimeService.GetRepository<NoteThread>().Get($"{projectId}:{threadId}");
+
+        public SyncMetrics GetSyncMetrics(string projectId) => _syncMetrics.Get(projectId);
+
+        public SFProject AssertDBSyncMetadata(
+            string projectSFId,
+            bool lastSyncSuccess,
+            string? syncedToRepositoryVersion
+        )
+        {
+            SFProjectSecret projectSecret = GetProjectSecret(projectSFId);
+            Assert.That(projectSecret.JobIds.Count, Is.EqualTo(0));
+            SFProject project = GetProject(projectSFId);
+            Assert.That(project.Sync.QueuedCount, Is.EqualTo(0));
+            Assert.That(project.Sync.LastSyncSuccessful, Is.EqualTo(lastSyncSuccess));
+            Assert.That(project.Sync.SyncedToRepositoryVersion, Is.EqualTo(syncedToRepositoryVersion));
+
+            // Check for the correct system metrics status
+            SyncMetrics syncMetrics = GetSyncMetrics(projectSFId);
+            if (lastSyncSuccess)
+            {
+                Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+            }
+            else
+            {
+                Assert.That(syncMetrics.Status, Is.InRange(SyncStatus.Cancelled, SyncStatus.Failed));
+            }
+
+            return project;
+        }
+
+        public SFProject VerifyProjectSync(
+            bool successful,
+            string? expectedRepoVersion = null,
+            string projectSFId = "project01"
+        )
+        {
+            string repoVersion = expectedRepoVersion ?? (successful ? "afterSR" : "beforeSR");
+            return AssertDBSyncMetadata(projectSFId, successful, repoVersion);
+        }
+
+        public TextInfo SetupChapterAuthorsAndGetTextInfo(bool setChapterPermissions)
+        {
+            string projectId = "project01";
+            int bookNum = 70;
+            int chapterNum = 1;
+            string id = TextData.GetTextDocId(projectId, bookNum, chapterNum);
+            Dictionary<string, string> chapterPermissions = new Dictionary<string, string>();
+            if (setChapterPermissions)
+            {
+                chapterPermissions.Add("user01", TextInfoPermission.Write);
+                chapterPermissions.Add("user02", TextInfoPermission.Read);
+            }
+            var textInfo = new TextInfo
+            {
+                BookNum = bookNum,
+                Chapters = new List<Chapter>
+                {
+                    new Chapter { Number = chapterNum, Permissions = chapterPermissions, },
+                },
+            };
+            RealtimeService.AddRepository(
+                "users",
+                OTType.Json0,
+                new MemoryRepository<User>(new[] { new User { Id = "user01" }, })
+            );
+            RealtimeService.AddRepository(
+                "texts",
+                OTType.RichText,
+                new MemoryRepository<TextData>(new[] { new TextData(Delta.New()) { Id = id }, })
+            );
+            SFProject[] sfProjects = new[]
+            {
+                new SFProject
+                {
+                    Id = projectId,
+                    UserRoles = new Dictionary<string, string>
                     {
-                        { "user01", "User 1" },
-                        { "user02", "User 2" },
-                        { "user03", "User 3" },
-                    };
-                    ParatextService
-                        .GetParatextUsernameMappingAsync(
-                            Arg.Any<UserSecret>(),
-                            Arg.Any<SFProject>(),
-                            CancellationToken.None
-                        )
-                        .Returns(userIdsToUsernames);
+                        { "user03", SFProjectRole.Administrator },
+                        { "user04", SFProjectRole.Translator },
+                    },
+                },
+            };
+            RealtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(sfProjects));
+            MockProjectDirsExist(sfProjects.Select((SFProject proj) => proj.ParatextId));
+
+            return textInfo;
+        }
+
+        public void SetupSFData(
+            bool translationSuggestionsEnabled,
+            bool checkingEnabled,
+            bool changed,
+            bool noteOnFirstBook,
+            params Book[] books
+        )
+        {
+            SetupSFData(
+                "project01",
+                "project02",
+                translationSuggestionsEnabled,
+                checkingEnabled,
+                changed,
+                noteOnFirstBook,
+                books
+            );
+        }
+
+        public void SetupSFData(
+            string targetProjectSFId,
+            string sourceProjectSFId,
+            bool translationSuggestionsEnabled,
+            bool checkingEnabled,
+            bool changed,
+            bool noteOnFirstBook,
+            params Book[] books
+        )
+        {
+            RealtimeService.AddRepository(
+                "users",
+                OTType.Json0,
+                new MemoryRepository<User>(
+                    new[]
+                    {
+                        new User { Id = "user01", ParatextId = "pt01" },
+                        new User { Id = "user02", ParatextId = "pt02" }
+                    }
+                )
+            );
+            // It is expected that if a user is on a project, there is a corresponding project-user-config doc.
+            RealtimeService.AddRepository(
+                "sf_project_user_configs",
+                OTType.Json0,
+                new MemoryRepository<SFProjectUserConfig>(
+                    new[]
+                    {
+                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId("project01", "user01"), },
+                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId("project01", "user02"), }
+                    }
+                )
+            );
+            SFProject[] sfProjects = new[]
+            {
+                new SFProject
+                {
+                    Id = "project01",
+                    Name = "project01",
+                    ShortName = "P01",
+                    UserRoles = new Dictionary<string, string>
+                    {
+                        { "user01", SFProjectRole.Administrator },
+                        { "user02", SFProjectRole.Translator }
+                    },
+                    ParatextId = "target",
+                    IsRightToLeft = false,
+                    DefaultFontSize = 10,
+                    DefaultFont = ProjectSettings.defaultFontName,
+                    TranslateConfig = new TranslateConfig
+                    {
+                        TranslationSuggestionsEnabled = translationSuggestionsEnabled,
+                        Source = new TranslateSource
+                        {
+                            ParatextId = "source",
+                            ProjectRef = "project02",
+                            Name = "Source",
+                            ShortName = "SRC",
+                            WritingSystem = new WritingSystem { Tag = "en" },
+                            IsRightToLeft = false
+                        },
+                        DefaultNoteTagId = translateNoteTagId
+                    },
+                    CheckingConfig = new CheckingConfig
+                    {
+                        CheckingEnabled = checkingEnabled,
+                        AnswerExportMethod = CheckingAnswerExport.MarkedForExport
+                    },
+                    Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
+                    Sync = new Sync
+                    {
+                        // QueuedCount is incremented before RunAsync() by SyncService.SyncAsync(). So set
+                        // it to 1 to simulate it being incremented.
+                        QueuedCount = 1,
+                        SyncedToRepositoryVersion = "beforeSR",
+                        DataInSync = true
+                    },
+                    ParatextUsers = new List<ParatextUserProfile>
+                    {
+                        new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = "User 1" },
+                        new ParatextUserProfile { OpaqueUserId = "syncuser02", Username = "User 2" }
+                    },
+                    NoteTags = new List<NoteTag>()
+                },
+                new SFProject
+                {
+                    Id = "project02",
+                    Name = "Source",
+                    ShortName = "SRC",
+                    UserRoles = new Dictionary<string, string>(),
+                    ParatextId = "source",
+                    IsRightToLeft = false,
+                    TranslateConfig = new TranslateConfig { TranslationSuggestionsEnabled = false },
+                    NoteTags = new List<NoteTag>(),
+                    CheckingConfig = new CheckingConfig
+                    {
+                        CheckingEnabled = checkingEnabled,
+                        AnswerExportMethod = CheckingAnswerExport.MarkedForExport
+                    },
+                    WritingSystem = new WritingSystem { Tag = "en" },
+                    Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
+                    Sync = new Sync { QueuedCount = 0, SyncedToRepositoryVersion = "beforeSR" }
+                },
+                new SFProject
+                {
+                    // This project was not sync'd since we started tracking SyncedToRepositoryVersion when
+                    // a 2021-05-14 commit reached sf-live.
+                    Id = "project03",
+                    Name = "project03withNoSyncedToRepositoryVersion",
+                    ShortName = "P03",
+                    UserRoles = new Dictionary<string, string>
+                    {
+                        { "user01", SFProjectRole.Administrator },
+                        { "user02", SFProjectRole.Translator }
+                    },
+                    ParatextId = "paratext-project03",
+                    IsRightToLeft = false,
+                    TranslateConfig = new TranslateConfig
+                    {
+                        TranslationSuggestionsEnabled = translationSuggestionsEnabled,
+                        Source = new TranslateSource
+                        {
+                            ParatextId = "paratext-project04",
+                            ProjectRef = "project04",
+                            Name = "project04",
+                            ShortName = "P04",
+                            WritingSystem = new WritingSystem { Tag = "en" },
+                            IsRightToLeft = false
+                        }
+                    },
+                    CheckingConfig = new CheckingConfig
+                    {
+                        CheckingEnabled = checkingEnabled,
+                        AnswerExportMethod = CheckingAnswerExport.MarkedForExport
+                    },
+                    Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
+                    Sync = new Sync
+                    {
+                        QueuedCount = 1,
+                        // No SyncedToRepositoryVersion
+                        // No DataInSync
+                    },
+                },
+                new SFProject
+                {
+                    Id = "project04",
+                    Name = "project04",
+                    ShortName = "P04",
+                    UserRoles = new Dictionary<string, string>(),
+                    ParatextId = "paratext-project04",
+                    IsRightToLeft = false,
+                    TranslateConfig = new TranslateConfig { TranslationSuggestionsEnabled = false },
+                    CheckingConfig = new CheckingConfig
+                    {
+                        CheckingEnabled = checkingEnabled,
+                        AnswerExportMethod = CheckingAnswerExport.MarkedForExport
+                    },
+                    WritingSystem = new WritingSystem { Tag = "en" },
+                    Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
+                    Sync = new Sync
+                    {
+                        QueuedCount = 0,
+                        // No SyncedToRepositoryVersion
+                        // No DataInSync
+                    }
+                },
+                new SFProject
+                {
+                    // This project was sync'd after we started tracking SyncedToRepositoryVersion, but the
+                    // only sync attempt triggered a failure, and so only DataInSync was written to,
+                    // not SyncedToRepositoryVersion.
+                    Id = "project05",
+                    Name = "project05",
+                    ShortName = "P05",
+                    UserRoles = new Dictionary<string, string>
+                    {
+                        { "user01", SFProjectRole.Administrator },
+                        { "user02", SFProjectRole.Translator }
+                    },
+                    ParatextId = "paratext-project05",
+                    IsRightToLeft = false,
+                    TranslateConfig = new TranslateConfig
+                    {
+                        TranslationSuggestionsEnabled = translationSuggestionsEnabled,
+                        Source = new TranslateSource
+                        {
+                            ParatextId = "paratext-project04",
+                            ProjectRef = "project04",
+                            Name = "project04",
+                            ShortName = "P04",
+                            WritingSystem = new WritingSystem { Tag = "en" },
+                            IsRightToLeft = false
+                        }
+                    },
+                    CheckingConfig = new CheckingConfig
+                    {
+                        CheckingEnabled = checkingEnabled,
+                        AnswerExportMethod = CheckingAnswerExport.MarkedForExport
+                    },
+                    Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
+                    Sync = new Sync
+                    {
+                        QueuedCount = 1,
+                        DataInSync = false
+                        // No SyncedToRepositoryVersion
+                    },
+                },
+            };
+            RealtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(sfProjects));
+            MockProjectDirsExist(sfProjects.Select((SFProject proj) => proj.ParatextId));
+
+            RealtimeService.AddRepository("texts", OTType.RichText, new MemoryRepository<TextData>());
+            RealtimeService.AddRepository("questions", OTType.Json0, new MemoryRepository<Question>());
+            if (noteOnFirstBook && books.Length > 0)
+                AddParatextNoteThreadData(books[0]);
+            else
+                SetupEmptyNoteThreads();
+            foreach (Book book in books)
+            {
+                AddSFBook(
+                    targetProjectSFId,
+                    GetProject(targetProjectSFId).ParatextId,
+                    book.Id,
+                    book.HighestTargetChapter,
+                    changed,
+                    book.MissingTargetChapters
+                );
+                if (book.HighestSourceChapter > 0)
+                {
+                    AddSFBook(
+                        sourceProjectSFId,
+                        GetProject(sourceProjectSFId).ParatextId,
+                        book.Id,
+                        book.HighestSourceChapter,
+                        changed,
+                        book.MissingSourceChapters
+                    );
                 }
             }
 
-            public void SetupNoteStatusChange(string threadId, string status, string verseRef = "MAT 1:1")
+            var notesElem = new XElement("notes");
+            if (changed)
             {
-                var noteThreadChange = new NoteThreadChange(
-                    threadId,
-                    verseRef,
-                    $"{threadId} selected text.",
-                    "Context before ",
-                    " context after",
-                    status,
-                    ""
-                );
-                noteThreadChange.ThreadUpdated = true;
-                SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
+                notesElem.Add(new XElement("thread"));
             }
 
-            public void SetupNewNoteThreadChange(string threadId, string syncUserId, string verseRef = "MAT 1:1")
+            NotesMapper
+                .GetNotesChangelistAsync(
+                    Arg.Any<XElement>(),
+                    Arg.Any<IEnumerable<IDocument<Question>>>(),
+                    Arg.Any<Dictionary<string, ParatextUserProfile>>(),
+                    Arg.Any<Dictionary<string, string>>(),
+                    CheckingAnswerExport.MarkedForExport
+                )
+                .Returns(Task.FromResult(notesElem));
+        }
+
+        public static TextInfo TextInfoFromBook(Book book)
+        {
+            return new TextInfo
+            {
+                BookNum = Canon.BookIdToNumber(book.Id),
+                Chapters = Enumerable
+                    .Range(1, book.HighestTargetChapter)
+                    .Select(
+                        c =>
+                            new Chapter
+                            {
+                                Number = c,
+                                LastVerse = 10,
+                                IsValid = !book.InvalidChapters.Contains(c),
+                                Permissions = { }
+                            }
+                    )
+                    .ToList(),
+                HasSource = book.HighestSourceChapter > 0
+            };
+        }
+
+        public void SetupPTData(params Book[] books) => SetupPTDataForProjectIds("target", "source", books);
+
+        public void SetupPTData(string targetProjectPTId, params Book[] books) =>
+            SetupPTDataForProjectIds(targetProjectPTId, "sourceProjectPTId", books);
+
+        public void SetupPTDataForProjectIds(string targetProjectPTId, string sourceProjectPTId, params Book[] books)
+        {
+            ParatextService
+                .GetBookList(Arg.Any<UserSecret>(), targetProjectPTId)
+                .Returns(books.Select(b => Canon.BookIdToNumber(b.Id)).ToArray());
+            // Include book with Source even if there are no chapters, if there are also no chapters in Target. PT
+            // can actually have or not have books which do or do not have chapters more flexibly than this. But in
+            // this way, allow tests to request a Source book exist even with zero chapters.
+            ParatextService
+                .GetBookList(Arg.Any<UserSecret>(), sourceProjectPTId)
+                .Returns(
+                    books
+                        .Where(b => b.HighestSourceChapter > 0 || b.HighestSourceChapter == b.HighestTargetChapter)
+                        .Select(b => Canon.BookIdToNumber(b.Id))
+                        .ToArray()
+                );
+            foreach (Book book in books)
+            {
+                AddPTBook(
+                    targetProjectPTId,
+                    book.Id,
+                    book.HighestTargetChapter,
+                    book.MissingTargetChapters,
+                    book.InvalidChapters
+                );
+                if (book.HighestSourceChapter > 0 || book.HighestSourceChapter == book.HighestTargetChapter)
+                    AddPTBook(sourceProjectPTId, book.Id, book.HighestSourceChapter, book.MissingSourceChapters);
+            }
+        }
+
+        public Task SetUserRole(string userId, string role)
+        {
+            return RealtimeService
+                .GetRepository<SFProject>()
+                .UpdateAsync(p => p.Id == "project01", u => u.Set(pr => pr.UserRoles[userId], role));
+        }
+
+        public void SetupNoteChanges(string threadId, string verseRef = "MAT 1:1", bool fromParatext = true)
+        {
+            if (fromParatext)
             {
                 var noteThreadChange = new NoteThreadChange(
                     threadId,
@@ -3066,88 +2877,25 @@ namespace SIL.XForge.Scripture.Services
                     " context after",
                     NoteStatus.Todo.InternalValue,
                     ""
-                );
-                noteThreadChange.Position = new TextAnchor { Start = 0, Length = 0 };
-                noteThreadChange.Assignment = CommentThread.teamUser;
-                noteThreadChange.AddChange(
-                    CreateNote(threadId, "n01", syncUserId, $"New {threadId} added.", ChangeType.Added),
-                    ChangeType.Added
-                );
-                SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
-            }
-
-            public void SetupNewConflictNoteThreadChange(string threadId, string verseRef = "MAT 1:1")
-            {
-                var noteThreadChange = new NoteThreadChange(
-                    threadId,
-                    verseRef,
-                    null,
-                    null,
-                    null,
-                    NoteStatus.Todo.InternalValue,
-                    ""
-                );
-                noteThreadChange.Position = new TextAnchor { Start = 0, Length = 0 };
-                noteThreadChange.AddChange(
-                    CreateNote(
-                        threadId,
-                        "conflict1",
-                        "",
-                        "Conflict on note.",
-                        ChangeType.Added,
-                        CommentTag.conflictTagId
-                    ),
-                    ChangeType.Added
-                );
-                SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
-            }
-
-            public void SetupNoteRemovedChange(string threadId, string noteId, string verseRef = "MAT 1:1")
-            {
-                var noteThreadChange = new NoteThreadChange(
-                    threadId,
-                    verseRef,
-                    $"{threadId} selected text.",
-                    "Context before ",
-                    " context after",
-                    NoteStatus.Resolved.InternalValue,
-                    ""
-                );
-                if (noteId == null)
-                    noteThreadChange.ThreadRemoved = true;
-                else
-                    noteThreadChange.NoteIdsRemoved.Add(noteId);
-                SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
-            }
-
-            public void SetupNoteReattachedChange(string threadId, string verseRef)
-            {
-                var noteThreadChange = new NoteThreadChange(
-                    threadId,
-                    verseRef,
-                    $"{threadId} selected text.",
-                    "Context before ",
-                    " context after",
-                    "",
-                    ""
-                );
-                string before = "Reattach before ";
-                string reattachSelectedText = "reattach selected text";
-                int start = before.Length;
-                int length = reattachSelectedText.Length;
-                noteThreadChange.Position = new TextAnchor { Start = start, Length = length };
-                string[] reattachParts =
+                )
                 {
-                    verseRef,
-                    reattachSelectedText,
-                    start.ToString(),
-                    before,
-                    " reattach after."
+                    ThreadUpdated = true,
+                    Position = new TextAnchor { Start = 0, Length = 0 },
+                    Assignment = CommentThread.teamUser
                 };
-                string reattached = string.Join(PtxUtils.StringUtils.orcCharacter, reattachParts);
-                Note reattachedNote = CreateNote(threadId, "reattached01", "syncuser01", null, ChangeType.Added);
-                reattachedNote.Reattached = reattached;
-                noteThreadChange.AddChange(reattachedNote, ChangeType.Added);
+                noteThreadChange.AddChange(
+                    CreateNote(threadId, "n01", "syncuser01", $"{threadId} updated.", ChangeType.Updated),
+                    ChangeType.Updated
+                );
+                noteThreadChange.AddChange(
+                    CreateNote(threadId, "n02", "syncuser02", $"{threadId} deleted.", ChangeType.Deleted),
+                    ChangeType.Deleted
+                );
+                noteThreadChange.AddChange(
+                    CreateNote(threadId, "n03", "syncuser03", $"{threadId} added.", ChangeType.Added, 3),
+                    ChangeType.Added
+                );
+
                 ParatextService
                     .GetNoteThreadChanges(
                         Arg.Any<UserSecret>(),
@@ -3157,429 +2905,541 @@ namespace SIL.XForge.Scripture.Services
                         Arg.Any<Dictionary<int, ChapterDelta>>(),
                         Arg.Any<Dictionary<string, ParatextUserProfile>>()
                     )
-                    .Returns(new[] { noteThreadChange });
-            }
-
-            /// <summary>Prepare a change report to be provided when thread changes are asked for.</summary>
-            public void SetupThreadAndNoteChange(
-                string threadId,
-                Action<NoteThreadChange> modifyNoteThreadChange,
-                Action<Note> modifyNoteChange
-            )
-            {
-                string status = NoteStatus.Todo.InternalValue;
-                string verseRef = "MAT 1:1";
-                // Create a NoteThreadChange, and allow client to adjust it.
-                var noteThreadChange = new NoteThreadChange(threadId, verseRef, null, null, null, status, "");
-                if (modifyNoteThreadChange != null)
-                {
-                    modifyNoteThreadChange(noteThreadChange);
-                }
-                Note note = CreateNoteSimple(threadId, "n01");
-                if (modifyNoteChange != null)
-                {
-                    modifyNoteChange(note);
-                    ChangeType changeType = ChangeType.Updated;
-                    noteThreadChange.AddChange(note, changeType);
-                }
-
-                // Cause the created NoteThreadChange to be what is given when changes are asked for.
-                SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
-            }
-
-            /// <summary> Set the project's default comment tag to the a blank comment tag. </summary>
-            public Task SetupUndefinedNoteTag(string projectId)
-            {
-                return RealtimeService
-                    .GetRepository<SFProject>()
-                    .UpdateAsync(p => p.Id == projectId, u => u.Unset(p => p.TranslateConfig.DefaultNoteTagId));
-            }
-
-            public Task SetupProjectNoteTags(string projectId, List<NoteTag> noteTags)
-            {
-                return RealtimeService
-                    .GetRepository<SFProject>()
-                    .UpdateAsync(p => p.Id == projectId, u => u.Set(p => p.NoteTags, noteTags));
-            }
-
-            /// <summary>
-            /// Helper method to test the simple case of a note property change being received from PT, and getting
-            /// applied to the SF DB.
-            /// </summary>>
-            public async Task SimpleNoteChangeAppliedCheckerAsync<T>(
-                Func<Note, T> datumGetter,
-                Action<Note, T> datumSetter,
-                T newData
-            )
-            {
-                // Set up some PT and SF project data, including a note.
-                string projectId = "project01";
-                var book = new Book("MAT", 3, true);
-                SetupSFData(true, false, false, true, book);
-                SetupPTData(book);
-                string threadId = $"thread03";
-                NoteThread thread03 = GetNoteThread(projectId, threadId);
-                Note note = thread03.Notes[0];
-                // Check that the updated data that we will be checking for, is not already set in SF DB.
-                Assert.That(datumGetter(note), Is.Not.EqualTo(newData), "setup");
-
-                // Let the client code define the incoming note change from PT.
-                SetupThreadAndNoteChange(
-                    threadId,
-                    null,
-                    (Note note) =>
+                    .Returns(x =>
                     {
-                        datumSetter(note, newData);
-                    }
-                );
+                        ((Dictionary<string, ParatextUserProfile>)x[5]).Add(
+                            "User 3",
+                            new ParatextUserProfile { OpaqueUserId = "syncuser03", Username = "User 3" }
+                        );
+                        return new[] { noteThreadChange };
+                    });
+                Dictionary<string, string> userIdsToUsernames = new Dictionary<string, string>
+                {
+                    { "user01", "User 1" },
+                    { "user02", "User 2" },
+                    { "user03", "User 3" },
+                };
+                ParatextService
+                    .GetParatextUsernameMappingAsync(
+                        Arg.Any<UserSecret>(),
+                        Arg.Any<SFProject>(),
+                        CancellationToken.None
+                    )
+                    .Returns(userIdsToUsernames);
+            }
+        }
 
-                // SUT
-                await Runner.RunAsync(projectId, "user01", projectId, false, CancellationToken.None);
+        public void SetupNoteStatusChange(string threadId, string status, string verseRef = "MAT 1:1")
+        {
+            var noteThreadChange = new NoteThreadChange(
+                threadId,
+                verseRef,
+                $"{threadId} selected text.",
+                "Context before ",
+                " context after",
+                status,
+                ""
+            )
+            {
+                ThreadUpdated = true
+            };
+            SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
+        }
 
-                thread03 = GetNoteThread(projectId, threadId);
-                note = thread03.Notes[0];
-                // The Note in SF DB should have been updated as a result of the incoming change from PT.
-                Assert.That(datumGetter(note), Is.EqualTo(newData));
+        public void SetupNewNoteThreadChange(string threadId, string syncUserId, string verseRef = "MAT 1:1")
+        {
+            var noteThreadChange = new NoteThreadChange(
+                threadId,
+                verseRef,
+                $"Scripture text in project",
+                "Context before ",
+                " context after",
+                NoteStatus.Todo.InternalValue,
+                ""
+            )
+            {
+                Position = new TextAnchor { Start = 0, Length = 0 },
+                Assignment = CommentThread.teamUser
+            };
+            noteThreadChange.AddChange(
+                CreateNote(threadId, "n01", syncUserId, $"New {threadId} added.", ChangeType.Added),
+                ChangeType.Added
+            );
+            SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
+        }
+
+        public void SetupNewConflictNoteThreadChange(string threadId, string verseRef = "MAT 1:1")
+        {
+            var noteThreadChange = new NoteThreadChange(
+                threadId,
+                verseRef,
+                null,
+                null,
+                null,
+                NoteStatus.Todo.InternalValue,
+                ""
+            )
+            {
+                Position = new TextAnchor { Start = 0, Length = 0 }
+            };
+            noteThreadChange.AddChange(
+                CreateNote(threadId, "conflict1", "", "Conflict on note.", ChangeType.Added, CommentTag.conflictTagId),
+                ChangeType.Added
+            );
+            SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
+        }
+
+        public void SetupNoteRemovedChange(string threadId, string noteId, string verseRef = "MAT 1:1")
+        {
+            var noteThreadChange = new NoteThreadChange(
+                threadId,
+                verseRef,
+                $"{threadId} selected text.",
+                "Context before ",
+                " context after",
+                NoteStatus.Resolved.InternalValue,
+                ""
+            );
+            if (noteId == null)
+                noteThreadChange.ThreadRemoved = true;
+            else
+                noteThreadChange.NoteIdsRemoved.Add(noteId);
+            SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
+        }
+
+        public void SetupNoteReattachedChange(string threadId, string verseRef)
+        {
+            var noteThreadChange = new NoteThreadChange(
+                threadId,
+                verseRef,
+                $"{threadId} selected text.",
+                "Context before ",
+                " context after",
+                "",
+                ""
+            );
+            string before = "Reattach before ";
+            string reattachSelectedText = "reattach selected text";
+            int start = before.Length;
+            int length = reattachSelectedText.Length;
+            noteThreadChange.Position = new TextAnchor { Start = start, Length = length };
+            string[] reattachParts = { verseRef, reattachSelectedText, start.ToString(), before, " reattach after." };
+            string reattached = string.Join(PtxUtils.StringUtils.orcCharacter, reattachParts);
+            Note reattachedNote = CreateNote(threadId, "reattached01", "syncuser01", null, ChangeType.Added);
+            reattachedNote.Reattached = reattached;
+            noteThreadChange.AddChange(reattachedNote, ChangeType.Added);
+            ParatextService
+                .GetNoteThreadChanges(
+                    Arg.Any<UserSecret>(),
+                    "target",
+                    40,
+                    Arg.Any<IEnumerable<IDocument<NoteThread>>>(),
+                    Arg.Any<Dictionary<int, ChapterDelta>>(),
+                    Arg.Any<Dictionary<string, ParatextUserProfile>>()
+                )
+                .Returns(new[] { noteThreadChange });
+        }
+
+        /// <summary>Prepare a change report to be provided when thread changes are asked for.</summary>
+        public void SetupThreadAndNoteChange(
+            string threadId,
+            Action<NoteThreadChange> modifyNoteThreadChange,
+            Action<Note> modifyNoteChange
+        )
+        {
+            string status = NoteStatus.Todo.InternalValue;
+            string verseRef = "MAT 1:1";
+            // Create a NoteThreadChange, and allow client to adjust it.
+            var noteThreadChange = new NoteThreadChange(threadId, verseRef, null, null, null, status, "");
+            modifyNoteThreadChange?.Invoke(noteThreadChange);
+            Note note = CreateNoteSimple(threadId, "n01");
+            if (modifyNoteChange != null)
+            {
+                modifyNoteChange(note);
+                ChangeType changeType = ChangeType.Updated;
+                noteThreadChange.AddChange(note, changeType);
             }
 
-            public void AddParatextNoteThreadData(Book book, bool publishedToSF = false)
-            {
-                int chapter = book.HighestTargetChapter;
-                string threadId = $"thread0{chapter}";
-                int tagId = CommentTag.toDoTagId;
-                RealtimeService.AddRepository(
-                    "note_threads",
-                    OTType.Json0,
-                    new MemoryRepository<NoteThread>(
-                        new[]
+            // Cause the created NoteThreadChange to be what is given when changes are asked for.
+            SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
+        }
+
+        /// <summary> Set the project's default comment tag to the a blank comment tag. </summary>
+        public Task SetupUndefinedNoteTag(string projectId)
+        {
+            return RealtimeService
+                .GetRepository<SFProject>()
+                .UpdateAsync(p => p.Id == projectId, u => u.Unset(p => p.TranslateConfig.DefaultNoteTagId));
+        }
+
+        public Task SetupProjectNoteTags(string projectId, List<NoteTag> noteTags)
+        {
+            return RealtimeService
+                .GetRepository<SFProject>()
+                .UpdateAsync(p => p.Id == projectId, u => u.Set(p => p.NoteTags, noteTags));
+        }
+
+        /// <summary>
+        /// Helper method to test the simple case of a note property change being received from PT, and getting
+        /// applied to the SF DB.
+        /// </summary>>
+        public async Task SimpleNoteChangeAppliedCheckerAsync<T>(
+            Func<Note, T> datumGetter,
+            Action<Note, T> datumSetter,
+            T newData
+        )
+        {
+            // Set up some PT and SF project data, including a note.
+            string projectId = "project01";
+            var book = new Book("MAT", 3, true);
+            SetupSFData(true, false, false, true, book);
+            SetupPTData(book);
+            string threadId = $"thread03";
+            NoteThread thread03 = GetNoteThread(projectId, threadId);
+            Note note = thread03.Notes[0];
+            // Check that the updated data that we will be checking for, is not already set in SF DB.
+            Assert.That(datumGetter(note), Is.Not.EqualTo(newData), "setup");
+
+            // Let the client code define the incoming note change from PT.
+            SetupThreadAndNoteChange(threadId, null, (Note note) => datumSetter(note, newData));
+
+            // SUT
+            await Runner.RunAsync(projectId, "user01", projectId, false, CancellationToken.None);
+
+            thread03 = GetNoteThread(projectId, threadId);
+            note = thread03.Notes[0];
+            // The Note in SF DB should have been updated as a result of the incoming change from PT.
+            Assert.That(datumGetter(note), Is.EqualTo(newData));
+        }
+
+        public void AddParatextNoteThreadData(Book book, bool publishedToSF = false)
+        {
+            int chapter = book.HighestTargetChapter;
+            string threadId = $"thread0{chapter}";
+            int tagId = CommentTag.toDoTagId;
+            RealtimeService.AddRepository(
+                "note_threads",
+                OTType.Json0,
+                new MemoryRepository<NoteThread>(
+                    new[]
+                    {
+                        new NoteThread
                         {
-                            new NoteThread
+                            Id = $"project01:{threadId}",
+                            DataId = threadId,
+                            ProjectRef = "project01",
+                            OwnerRef = "user01",
+                            VerseRef = new VerseRefData(Canon.BookIdToNumber(book.Id), chapter, 1),
+                            OriginalContextBefore = "Context before ",
+                            OriginalContextAfter = " context after",
+                            OriginalSelectedText = "Scripture text in project",
+                            PublishedToSF = publishedToSF,
+                            Notes = new List<Note>()
                             {
-                                Id = $"project01:{threadId}",
-                                DataId = threadId,
-                                ProjectRef = "project01",
-                                OwnerRef = "user01",
-                                VerseRef = new VerseRefData(Canon.BookIdToNumber(book.Id), chapter, 1),
-                                OriginalContextBefore = "Context before ",
-                                OriginalContextAfter = " context after",
-                                OriginalSelectedText = "Scripture text in project",
-                                PublishedToSF = publishedToSF,
-                                Notes = new List<Note>()
+                                new Note
                                 {
-                                    new Note
-                                    {
-                                        DataId = "n01",
-                                        ThreadId = threadId,
-                                        SyncUserRef = "syncuser01",
-                                        ExtUserId = "user02",
-                                        Content = "Paratext note 1.",
-                                        TagId = tagId,
-                                        DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc)
-                                    },
-                                    new Note
-                                    {
-                                        DataId = "n02",
-                                        ThreadId = threadId,
-                                        SyncUserRef = "syncuser02",
-                                        ExtUserId = "user03",
-                                        Content = "Paratext note 2.",
-                                        TagId = tagId,
-                                        DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc)
-                                    },
-                                }
+                                    DataId = "n01",
+                                    ThreadId = threadId,
+                                    SyncUserRef = "syncuser01",
+                                    ExtUserId = "user02",
+                                    Content = "Paratext note 1.",
+                                    TagId = tagId,
+                                    DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc)
+                                },
+                                new Note
+                                {
+                                    DataId = "n02",
+                                    ThreadId = threadId,
+                                    SyncUserRef = "syncuser02",
+                                    ExtUserId = "user03",
+                                    Content = "Paratext note 2.",
+                                    TagId = tagId,
+                                    DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc)
+                                },
                             }
                         }
-                    )
-                );
-            }
-
-            public async Task SetThreadNotesAsync(string sfProjectId, string threadId, List<Note> notes)
-            {
-                string threadDocId = NoteThread.GetDocId(sfProjectId, threadId);
-                await RealtimeService
-                    .GetRepository<NoteThread>()
-                    .UpdateAsync(
-                        thread => thread.Id == threadDocId,
-                        update => update.Set(thread => thread.Notes, notes)
-                    );
-            }
-
-            public void SetupEmptyNoteThreads()
-            {
-                RealtimeService.AddRepository("note_threads", OTType.Json0, new MemoryRepository<NoteThread>());
-            }
-
-            public SFProject SetupProjectWithExpectedImportedRev(
-                string projectSFId,
-                string? startingDBSyncedToRepositoryVersion
-            )
-            {
-                Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
-                bool translationSuggestionsEnabled = false;
-                bool checkingEnabled = true;
-                bool changed = true;
-                bool hasNoteThreads = false;
-                SetupSFData(
-                    targetProjectSFId: projectSFId,
-                    sourceProjectSFId: "project04",
-                    translationSuggestionsEnabled,
-                    checkingEnabled,
-                    changed,
-                    hasNoteThreads,
-                    books
-                );
-                SFProject project = GetProject(projectSFId);
-                SetupPTDataForProjectIds(project.ParatextId, GetProject("project04").ParatextId, books);
-                Assert.That(
-                    project.Sync.SyncedToRepositoryVersion,
-                    Is.EqualTo(startingDBSyncedToRepositoryVersion),
-                    "setup"
-                );
-                return project;
-            }
-
-            public async Task RunAndAssertAbortAsync(
-                string projectSFId,
-                string userId,
-                string finalDBSyncedToRepositoryVersion
-            )
-            {
-                // SUT
-                await Runner.RunAsync(
-                    projectSFId,
-                    userId,
-                    syncMetricsId: projectSFId,
-                    trainEngine: false,
-                    token: CancellationToken.None
-                );
-
-                // We are in an out-of-sync situation and so should not be writing to PT.
-
-                // Should not be preparing to write data to the PT hg repo.
-                ParatextService.DidNotReceiveWithAnyArgs().GetBookText(default, default, default);
-                DeltaUsxMapper
-                    .DidNotReceiveWithAnyArgs()
-                    .ToUsx(Arg.Any<XDocument>(), Arg.Any<IEnumerable<ChapterDelta>>());
-                ParatextService.DidNotReceiveWithAnyArgs().GetNotes(default, default, default);
-                await NotesMapper
-                    .DidNotReceiveWithAnyArgs()
-                    .GetNotesChangelistAsync(
-                        Arg.Any<XElement>(),
-                        Arg.Any<IEnumerable<IDocument<Question>>>(),
-                        Arg.Any<Dictionary<string, ParatextUserProfile>>(),
-                        Arg.Any<Dictionary<string, string>>(),
-                        CheckingAnswerExport.MarkedForExport
-                    );
-
-                // Should not be performing a SR.
-                await ParatextService
-                    .DidNotReceiveWithAnyArgs()
-                    .SendReceiveAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<IProgress<ProgressState>>());
-
-                // Record of sync is of not success.
-                AssertDBSyncMetadata(
-                    projectSFId,
-                    lastSyncSuccess: false,
-                    syncedToRepositoryVersion: finalDBSyncedToRepositoryVersion
-                );
-            }
-
-            public async Task RunAndAssertContinuesAsync(
-                string projectSFId,
-                string userId,
-                string? finalDBSyncedToRepositoryVersion
-            )
-            {
-                // SUT
-                await Runner.RunAsync(
-                    projectSFId,
-                    userId,
-                    syncMetricsId: projectSFId,
-                    trainEngine: false,
-                    token: CancellationToken.None
-                );
-
-                // We are not in an out-of-sync situation and should proceed with the sync.
-
-                // Should be preparing to write data to the PT hg repo.
-                ParatextService.Received().GetBookText(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<int>());
-                DeltaUsxMapper.Received().ToUsx(Arg.Any<XDocument>(), Arg.Any<IEnumerable<ChapterDelta>>());
-                ParatextService.Received().GetNotes(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<int>());
-                await NotesMapper
-                    .Received()
-                    .GetNotesChangelistAsync(
-                        Arg.Any<XElement>(),
-                        Arg.Any<IEnumerable<IDocument<Question>>>(),
-                        Arg.Any<Dictionary<string, ParatextUserProfile>>(),
-                        Arg.Any<Dictionary<string, string>>(),
-                        CheckingAnswerExport.MarkedForExport
-                    );
-
-                // Should be performing a SR.
-                await ParatextService
-                    .Received(1)
-                    .SendReceiveAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<IProgress<ProgressState>>());
-
-                // Record of sync is of success.
-                AssertDBSyncMetadata(
-                    projectSFId,
-                    lastSyncSuccess: true,
-                    syncedToRepositoryVersion: finalDBSyncedToRepositoryVersion
-                );
-            }
-
-            /// <summary>Cause mocks to report that the project dirs exist for specified project
-            /// PT ids.</summary>
-            private void MockProjectDirsExist(IEnumerable<string> projectPTIds)
-            {
-                ParatextService
-                    .LocalProjectDirExists(Arg.Is<string>((string projectPTId) => projectPTIds.Contains(projectPTId)))
-                    .Returns(true);
-            }
-
-            private void AddPTBook(
-                string paratextId,
-                string bookId,
-                int highestChapter,
-                HashSet<int> missingChapters,
-                HashSet<int>? invalidChapters = null
-            )
-            {
-                MockGetBookText(paratextId, bookId);
-                Func<XDocument, bool> predicate = d =>
-                    (string)d?.Root?.Element("book")?.Attribute("code") == bookId
-                    && (string)d?.Root?.Element("book") == paratextId;
-                var chapterDeltas = new List<ChapterDelta>();
-                for (int i = 1; i <= highestChapter; i++)
-                {
-                    if (!missingChapters.Contains(i))
-                    {
-                        chapterDeltas.Add(
-                            new ChapterDelta(
-                                i,
-                                10,
-                                !(invalidChapters?.Contains(i) ?? false),
-                                Delta.New().InsertText("text")
-                            )
-                        );
                     }
-                }
+                )
+            );
+        }
 
-                if (!chapterDeltas.Any())
+        public async Task SetThreadNotesAsync(string sfProjectId, string threadId, List<Note> notes)
+        {
+            string threadDocId = NoteThread.GetDocId(sfProjectId, threadId);
+            await RealtimeService
+                .GetRepository<NoteThread>()
+                .UpdateAsync(thread => thread.Id == threadDocId, update => update.Set(thread => thread.Notes, notes));
+        }
+
+        public void SetupEmptyNoteThreads() =>
+            RealtimeService.AddRepository("note_threads", OTType.Json0, new MemoryRepository<NoteThread>());
+
+        public SFProject SetupProjectWithExpectedImportedRev(
+            string projectSFId,
+            string? startingDBSyncedToRepositoryVersion
+        )
+        {
+            Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+            bool translationSuggestionsEnabled = false;
+            bool checkingEnabled = true;
+            bool changed = true;
+            bool hasNoteThreads = false;
+            SetupSFData(
+                targetProjectSFId: projectSFId,
+                sourceProjectSFId: "project04",
+                translationSuggestionsEnabled,
+                checkingEnabled,
+                changed,
+                hasNoteThreads,
+                books
+            );
+            SFProject project = GetProject(projectSFId);
+            SetupPTDataForProjectIds(project.ParatextId, GetProject("project04").ParatextId, books);
+            Assert.That(
+                project.Sync.SyncedToRepositoryVersion,
+                Is.EqualTo(startingDBSyncedToRepositoryVersion),
+                "setup"
+            );
+            return project;
+        }
+
+        public async Task RunAndAssertAbortAsync(
+            string projectSFId,
+            string userId,
+            string finalDBSyncedToRepositoryVersion
+        )
+        {
+            // SUT
+            await Runner.RunAsync(
+                projectSFId,
+                userId,
+                syncMetricsId: projectSFId,
+                trainEngine: false,
+                token: CancellationToken.None
+            );
+
+            // We are in an out-of-sync situation and so should not be writing to PT.
+
+            // Should not be preparing to write data to the PT hg repo.
+            ParatextService.DidNotReceiveWithAnyArgs().GetBookText(default, default, default);
+            DeltaUsxMapper.DidNotReceiveWithAnyArgs().ToUsx(Arg.Any<XDocument>(), Arg.Any<IEnumerable<ChapterDelta>>());
+            ParatextService.DidNotReceiveWithAnyArgs().GetNotes(default, default, default);
+            await NotesMapper
+                .DidNotReceiveWithAnyArgs()
+                .GetNotesChangelistAsync(
+                    Arg.Any<XElement>(),
+                    Arg.Any<IEnumerable<IDocument<Question>>>(),
+                    Arg.Any<Dictionary<string, ParatextUserProfile>>(),
+                    Arg.Any<Dictionary<string, string>>(),
+                    CheckingAnswerExport.MarkedForExport
+                );
+
+            // Should not be performing a SR.
+            await ParatextService
+                .DidNotReceiveWithAnyArgs()
+                .SendReceiveAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<IProgress<ProgressState>>());
+
+            // Record of sync is of not success.
+            AssertDBSyncMetadata(
+                projectSFId,
+                lastSyncSuccess: false,
+                syncedToRepositoryVersion: finalDBSyncedToRepositoryVersion
+            );
+        }
+
+        public async Task RunAndAssertContinuesAsync(
+            string projectSFId,
+            string userId,
+            string? finalDBSyncedToRepositoryVersion
+        )
+        {
+            // SUT
+            await Runner.RunAsync(
+                projectSFId,
+                userId,
+                syncMetricsId: projectSFId,
+                trainEngine: false,
+                token: CancellationToken.None
+            );
+
+            // We are not in an out-of-sync situation and should proceed with the sync.
+
+            // Should be preparing to write data to the PT hg repo.
+            ParatextService.Received().GetBookText(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<int>());
+            DeltaUsxMapper.Received().ToUsx(Arg.Any<XDocument>(), Arg.Any<IEnumerable<ChapterDelta>>());
+            ParatextService.Received().GetNotes(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<int>());
+            await NotesMapper
+                .Received()
+                .GetNotesChangelistAsync(
+                    Arg.Any<XElement>(),
+                    Arg.Any<IEnumerable<IDocument<Question>>>(),
+                    Arg.Any<Dictionary<string, ParatextUserProfile>>(),
+                    Arg.Any<Dictionary<string, string>>(),
+                    CheckingAnswerExport.MarkedForExport
+                );
+
+            // Should be performing a SR.
+            await ParatextService
+                .Received(1)
+                .SendReceiveAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<IProgress<ProgressState>>());
+
+            // Record of sync is of success.
+            AssertDBSyncMetadata(
+                projectSFId,
+                lastSyncSuccess: true,
+                syncedToRepositoryVersion: finalDBSyncedToRepositoryVersion
+            );
+        }
+
+        /// <summary>Cause mocks to report that the project dirs exist for specified project
+        /// PT ids.</summary>
+        private void MockProjectDirsExist(IEnumerable<string> projectPTIds)
+        {
+            ParatextService
+                .LocalProjectDirExists(Arg.Is<string>((string projectPTId) => projectPTIds.Contains(projectPTId)))
+                .Returns(true);
+        }
+
+        private void AddPTBook(
+            string paratextId,
+            string bookId,
+            int highestChapter,
+            HashSet<int> missingChapters,
+            HashSet<int>? invalidChapters = null
+        )
+        {
+            MockGetBookText(paratextId, bookId);
+            Func<XDocument, bool> predicate = d =>
+                (string)d?.Root?.Element("book")?.Attribute("code") == bookId
+                && (string)d?.Root?.Element("book") == paratextId;
+            var chapterDeltas = new List<ChapterDelta>();
+            for (int i = 1; i <= highestChapter; i++)
+            {
+                if (!missingChapters.Contains(i))
                 {
-                    // Add implicit ChapterDelta, mimicking DeltaUsxMapper.ToChapterDeltas().
-                    chapterDeltas.Add(new ChapterDelta(1, 0, true, Delta.New()));
+                    chapterDeltas.Add(
+                        new ChapterDelta(
+                            i,
+                            10,
+                            !(invalidChapters?.Contains(i) ?? false),
+                            Delta.New().InsertText("text")
+                        )
+                    );
                 }
-
-                DeltaUsxMapper.ToChapterDeltas(Arg.Is<XDocument>(d => predicate(d))).Returns(chapterDeltas);
             }
 
-            private void AddSFBook(
-                string projectId,
-                string paratextId,
-                string bookId,
-                int highestChapter,
-                bool changed,
-                HashSet<int> missingChapters = null
-            )
+            if (!chapterDeltas.Any())
             {
-                MockGetBookText(paratextId, bookId);
-                int bookNum = Canon.BookIdToNumber(bookId);
-                string newBookText = GetBookText(paratextId, bookId, changed ? 2 : 1);
-                Func<XDocument, bool> predicate = d =>
-                    (string)d?.Root?.Element("book")?.Attribute("code") == bookId
-                    && (string)d?.Root?.Element("book") == paratextId;
-                DeltaUsxMapper
-                    .ToUsx(Arg.Is<XDocument>(d => predicate(d)), Arg.Any<IEnumerable<ChapterDelta>>())
-                    .Returns(XDocument.Parse(newBookText));
+                // Add implicit ChapterDelta, mimicking DeltaUsxMapper.ToChapterDeltas().
+                chapterDeltas.Add(new ChapterDelta(1, 0, true, Delta.New()));
+            }
 
-                for (int c = 1; c <= highestChapter; c++)
+            DeltaUsxMapper.ToChapterDeltas(Arg.Is<XDocument>(d => predicate(d))).Returns(chapterDeltas);
+        }
+
+        private void AddSFBook(
+            string projectId,
+            string paratextId,
+            string bookId,
+            int highestChapter,
+            bool changed,
+            HashSet<int> missingChapters = null
+        )
+        {
+            MockGetBookText(paratextId, bookId);
+            int bookNum = Canon.BookIdToNumber(bookId);
+            string newBookText = GetBookText(paratextId, bookId, changed ? 2 : 1);
+            Func<XDocument, bool> predicate = d =>
+                (string)d?.Root?.Element("book")?.Attribute("code") == bookId
+                && (string)d?.Root?.Element("book") == paratextId;
+            DeltaUsxMapper
+                .ToUsx(Arg.Is<XDocument>(d => predicate(d)), Arg.Any<IEnumerable<ChapterDelta>>())
+                .Returns(XDocument.Parse(newBookText));
+
+            for (int c = 1; c <= highestChapter; c++)
+            {
+                string id = TextData.GetTextDocId(projectId, bookNum, c);
+                if (!(missingChapters?.Contains(c) ?? false))
                 {
-                    string id = TextData.GetTextDocId(projectId, bookNum, c);
-                    if (!(missingChapters?.Contains(c) ?? false))
-                    {
-                        RealtimeService
-                            .GetRepository<TextData>()
-                            .Add(new TextData(Delta.New().InsertText(changed ? "changed" : "text")) { Id = id });
-                    }
                     RealtimeService
-                        .GetRepository<Question>()
-                        .Add(
-                            new[]
-                            {
-                                new Question
-                                {
-                                    Id = $"{projectId}:question{bookId}{c}",
-                                    DataId = $"question{bookId}{c}",
-                                    ProjectRef = projectId,
-                                    VerseRef = new VerseRefData(bookNum, c, 1)
-                                }
-                            }
-                        );
+                        .GetRepository<TextData>()
+                        .Add(new TextData(Delta.New().InsertText(changed ? "changed" : "text")) { Id = id });
                 }
+                RealtimeService
+                    .GetRepository<Question>()
+                    .Add(
+                        new[]
+                        {
+                            new Question
+                            {
+                                Id = $"{projectId}:question{bookId}{c}",
+                                DataId = $"question{bookId}{c}",
+                                ProjectRef = projectId,
+                                VerseRef = new VerseRefData(bookNum, c, 1)
+                            }
+                        }
+                    );
             }
+        }
 
-            private void MockGetBookText(string paratextId, string bookId)
-            {
-                string oldBookText = GetBookText(paratextId, bookId, 1);
-                string remoteBookText = GetBookText(paratextId, bookId, 3);
-                ParatextService
-                    .GetBookText(Arg.Any<UserSecret>(), paratextId, Canon.BookIdToNumber(bookId))
-                    .Returns(x => _sendReceivedCalled ? remoteBookText : oldBookText);
-            }
+        private void MockGetBookText(string paratextId, string bookId)
+        {
+            string oldBookText = GetBookText(paratextId, bookId, 1);
+            string remoteBookText = GetBookText(paratextId, bookId, 3);
+            ParatextService
+                .GetBookText(Arg.Any<UserSecret>(), paratextId, Canon.BookIdToNumber(bookId))
+                .Returns(x => _sendReceivedCalled ? remoteBookText : oldBookText);
+        }
 
-            private static string GetBookText(string paratextId, string bookId, int version)
-            {
-                return $"<usx version=\"2.5\"><book code=\"{bookId}\" style=\"id\">{paratextId}</book><content version=\"{version}\"/></usx>";
-            }
+        private static string GetBookText(string paratextId, string bookId, int version) =>
+            $"<usx version=\"2.5\"><book code=\"{bookId}\" style=\"id\">{paratextId}</book><content version=\"{version}\"/></usx>";
 
-            private void SetupNoteThreadChanges(NoteThreadChange[] noteThreadChanges, string projectId, int bookNum)
-            {
-                ParatextService
-                    .GetNoteThreadChanges(
-                        Arg.Any<UserSecret>(),
-                        projectId,
-                        bookNum,
-                        Arg.Any<IEnumerable<IDocument<NoteThread>>>(),
-                        Arg.Any<Dictionary<int, ChapterDelta>>(),
-                        Arg.Any<Dictionary<string, ParatextUserProfile>>()
-                    )
-                    .Returns(noteThreadChanges);
-            }
+        private void SetupNoteThreadChanges(NoteThreadChange[] noteThreadChanges, string projectId, int bookNum)
+        {
+            ParatextService
+                .GetNoteThreadChanges(
+                    Arg.Any<UserSecret>(),
+                    projectId,
+                    bookNum,
+                    Arg.Any<IEnumerable<IDocument<NoteThread>>>(),
+                    Arg.Any<Dictionary<int, ChapterDelta>>(),
+                    Arg.Any<Dictionary<string, ParatextUserProfile>>()
+                )
+                .Returns(noteThreadChanges);
+        }
 
-            private Note CreateNote(
-                string threadId,
-                string noteId,
-                string user,
-                string content,
-                ChangeType type,
-                int? tagId = null
-            )
+        private static Note CreateNote(
+            string threadId,
+            string noteId,
+            string user,
+            string content,
+            ChangeType type,
+            int? tagId = null
+        )
+        {
+            return new Note
             {
-                return new Note
-                {
-                    DataId = noteId,
-                    ThreadId = threadId,
-                    OwnerRef = "",
-                    SyncUserRef = user,
-                    Content = content,
-                    DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc),
-                    Deleted = type == ChangeType.Deleted,
-                    TagId = tagId,
-                    Assignment = CommentThread.teamUser
-                };
-            }
+                DataId = noteId,
+                ThreadId = threadId,
+                OwnerRef = "",
+                SyncUserRef = user,
+                Content = content,
+                DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc),
+                Deleted = type == ChangeType.Deleted,
+                TagId = tagId,
+                Assignment = CommentThread.teamUser
+            };
+        }
 
-            private Note CreateNoteSimple(string threadId, string noteId)
+        private static Note CreateNoteSimple(string threadId, string noteId)
+        {
+            return new Note
             {
-                return new Note
-                {
-                    DataId = noteId,
-                    ThreadId = threadId,
-                    OwnerRef = "",
-                    DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc),
-                };
-            }
+                DataId = noteId,
+                ThreadId = threadId,
+                OwnerRef = "",
+                DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc),
+            };
         }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/SFBiblicalTermsTextTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFBiblicalTermsTextTests.cs
@@ -4,105 +4,104 @@ using NUnit.Framework;
 using SIL.Machine.Corpora;
 using SIL.Machine.Tokenization;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class SFBiblicalTermsTextTests
 {
-    [TestFixture]
-    public class SFBiblicalTermsTextTests
+    [Test]
+    public void Segments_EmptyDoc()
     {
-        [Test]
-        public void Segments_EmptyDoc()
-        {
-            var tokenizer = new LatinWordTokenizer();
-            var doc = new XDocument(new XElement("TermRenderingsList"));
-            var text = new SFBiblicalTermsText(tokenizer, "project01", doc);
-            Assert.That(text.GetSegments(), Is.Empty);
-        }
+        var tokenizer = new LatinWordTokenizer();
+        var doc = new XDocument(new XElement("TermRenderingsList"));
+        var text = new SFBiblicalTermsText(tokenizer, "project01", doc);
+        Assert.That(text.GetSegments(), Is.Empty);
+    }
 
-        [Test]
-        public void Segments_EmptyRenderings()
-        {
-            var tokenizer = new LatinWordTokenizer();
-            var doc = new XDocument(
-                new XElement(
-                    "TermRenderingsList",
-                    TermRendering("term1", guess: false),
-                    TermRendering("term2", guess: false)
-                )
-            );
-            var text = new SFBiblicalTermsText(tokenizer, "project01", doc);
-            Assert.That(text.GetSegments(), Is.Empty);
-        }
+    [Test]
+    public void Segments_EmptyRenderings()
+    {
+        var tokenizer = new LatinWordTokenizer();
+        var doc = new XDocument(
+            new XElement(
+                "TermRenderingsList",
+                TermRendering("term1", guess: false),
+                TermRendering("term2", guess: false)
+            )
+        );
+        var text = new SFBiblicalTermsText(tokenizer, "project01", doc);
+        Assert.That(text.GetSegments(), Is.Empty);
+    }
 
-        [Test]
-        public void Segments_Guess()
-        {
-            var tokenizer = new LatinWordTokenizer();
-            var doc = new XDocument(
-                new XElement(
-                    "TermRenderingsList",
-                    TermRendering("term1", guess: true, "Term1"),
-                    TermRendering("term2", guess: true, "Term2")
-                )
-            );
-            var text = new SFBiblicalTermsText(tokenizer, "project01", doc);
-            Assert.That(text.GetSegments(), Is.Empty);
-        }
+    [Test]
+    public void Segments_Guess()
+    {
+        var tokenizer = new LatinWordTokenizer();
+        var doc = new XDocument(
+            new XElement(
+                "TermRenderingsList",
+                TermRendering("term1", guess: true, "Term1"),
+                TermRendering("term2", guess: true, "Term2")
+            )
+        );
+        var text = new SFBiblicalTermsText(tokenizer, "project01", doc);
+        Assert.That(text.GetSegments(), Is.Empty);
+    }
 
-        [Test]
-        public void Segments_Renderings()
-        {
-            var tokenizer = new LatinWordTokenizer();
-            var doc = new XDocument(
-                new XElement(
-                    "TermRenderingsList",
-                    TermRendering("term2", guess: false, "Term2"),
-                    TermRendering("term1", guess: false, "Term1")
-                )
-            );
-            var text = new SFBiblicalTermsText(tokenizer, "project01", doc);
-            TextSegment[] segments = text.GetSegments().ToArray();
-            Assert.That(segments.Length, Is.EqualTo(2));
-            Assert.That(segments[0].SegmentRef.ToString(), Is.EqualTo("term1"));
-            Assert.That(string.Join(" ", segments[0].Segment), Is.EqualTo("Term1"));
-            Assert.That(string.Join(" ", segments[1].Segment), Is.EqualTo("Term2"));
-        }
+    [Test]
+    public void Segments_Renderings()
+    {
+        var tokenizer = new LatinWordTokenizer();
+        var doc = new XDocument(
+            new XElement(
+                "TermRenderingsList",
+                TermRendering("term2", guess: false, "Term2"),
+                TermRendering("term1", guess: false, "Term1")
+            )
+        );
+        var text = new SFBiblicalTermsText(tokenizer, "project01", doc);
+        TextSegment[] segments = text.GetSegments().ToArray();
+        Assert.That(segments.Length, Is.EqualTo(2));
+        Assert.That(segments[0].SegmentRef.ToString(), Is.EqualTo("term1"));
+        Assert.That(string.Join(" ", segments[0].Segment), Is.EqualTo("Term1"));
+        Assert.That(string.Join(" ", segments[1].Segment), Is.EqualTo("Term2"));
+    }
 
-        [Test]
-        public void Segments_MultipleRenderings()
-        {
-            var tokenizer = new LatinWordTokenizer();
-            var doc = new XDocument(
-                new XElement(
-                    "TermRenderingsList",
-                    TermRendering("term2", guess: false, "Term2-1", "Term2-2"),
-                    TermRendering("term1", guess: false, "Term1")
-                )
-            );
-            var text = new SFBiblicalTermsText(tokenizer, "project01", doc);
-            TextSegment[] segments = text.GetSegments().ToArray();
-            Assert.That(segments.Length, Is.EqualTo(3));
-            Assert.That(string.Join(" ", segments[0].Segment), Is.EqualTo("Term1"));
-            Assert.That(segments[1].SegmentRef.ToString(), Is.EqualTo("term2"));
-            Assert.That(string.Join(" ", segments[1].Segment), Is.EqualTo("Term2-1"));
-            Assert.That(segments[2].SegmentRef.ToString(), Is.EqualTo("term2"));
-            Assert.That(string.Join(" ", segments[2].Segment), Is.EqualTo("Term2-2"));
-        }
+    [Test]
+    public void Segments_MultipleRenderings()
+    {
+        var tokenizer = new LatinWordTokenizer();
+        var doc = new XDocument(
+            new XElement(
+                "TermRenderingsList",
+                TermRendering("term2", guess: false, "Term2-1", "Term2-2"),
+                TermRendering("term1", guess: false, "Term1")
+            )
+        );
+        var text = new SFBiblicalTermsText(tokenizer, "project01", doc);
+        TextSegment[] segments = text.GetSegments().ToArray();
+        Assert.That(segments.Length, Is.EqualTo(3));
+        Assert.That(string.Join(" ", segments[0].Segment), Is.EqualTo("Term1"));
+        Assert.That(segments[1].SegmentRef.ToString(), Is.EqualTo("term2"));
+        Assert.That(string.Join(" ", segments[1].Segment), Is.EqualTo("Term2-1"));
+        Assert.That(segments[2].SegmentRef.ToString(), Is.EqualTo("term2"));
+        Assert.That(string.Join(" ", segments[2].Segment), Is.EqualTo("Term2-2"));
+    }
 
-        private static XElement TermRendering(string id, bool guess, params string[] renderings)
-        {
-            return new XElement(
-                "TermRendering",
-                new XAttribute("Id", id),
-                new XAttribute("Guess", guess),
-                new XElement(
-                    "Renderings",
-                    string.Join("||", renderings),
-                    new XElement("Glossary"),
-                    new XElement("Changes"),
-                    new XElement("Notes"),
-                    new XElement("Denials")
-                )
-            );
-        }
+    private static XElement TermRendering(string id, bool guess, params string[] renderings)
+    {
+        return new XElement(
+            "TermRendering",
+            new XAttribute("Id", id),
+            new XAttribute("Guess", guess),
+            new XElement(
+                "Renderings",
+                string.Join("||", renderings),
+                new XElement("Glossary"),
+                new XElement("Changes"),
+                new XElement("Notes"),
+                new XElement("Denials")
+            )
+        );
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -19,3150 +19,3055 @@ using SIL.XForge.Services;
 using SIL.XForge.Utils;
 using Options = Microsoft.Extensions.Options.Options;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class SFProjectServiceTests
 {
-    [TestFixture]
-    public class SFProjectServiceTests
+    private const string Project01 = "project01";
+    private const string Project02 = "project02";
+    private const string Project03 = "project03";
+    private const string Project04 = "project04";
+    private const string Project05 = "project05";
+    private const string Project06 = "project06";
+    private const string Resource01 = "resource_project";
+    private const string SourceOnly = "source_only";
+    private const string Resource01PTId = "resid_is_16_char";
+    private const string User01 = "user01";
+    private const string User02 = "user02";
+    private const string User03 = "user03";
+    private const string User04 = "user04";
+    private const string User05 = "user05";
+    private const string User06 = "user06";
+    private const string LinkExpiredUser = "linkexpireduser";
+    private const string SiteId = "xf";
+    private const string PTProjectIdNotYetInSF = "paratext_notYetInSF";
+
+    [Test]
+    public async Task InviteAsync_ProjectAdminSharingDisabled_UserInvited()
     {
-        private const string Project01 = "project01";
-        private const string Project02 = "project02";
-        private const string Project03 = "project03";
-        private const string Project04 = "project04";
-        private const string Project05 = "project05";
-        private const string Project06 = "project06";
-        private const string Resource01 = "resource_project";
-        private const string SourceOnly = "source_only";
-        private const string Resource01PTId = "resid_is_16_char";
-        private const string User01 = "user01";
-        private const string User02 = "user02";
-        private const string User03 = "user03";
-        private const string User04 = "user04";
-        private const string User05 = "user05";
-        private const string User06 = "user06";
-        private const string LinkExpiredUser = "linkexpireduser";
-        private const string SiteId = "xf";
-        private const string PTProjectIdNotYetInSF = "paratext_notYetInSF";
+        var env = new TestEnvironment();
+        const string email = "newuser@example.com";
+        const string role = SFProjectRole.CommunityChecker;
 
-        [Test]
-        public async Task InviteAsync_ProjectAdminSharingDisabled_UserInvited()
-        {
-            var env = new TestEnvironment();
-            const string email = "newuser@example.com";
-            const string role = SFProjectRole.CommunityChecker;
-
-            await env.Service.InviteAsync(User01, Project01, email, "en", role);
-            await env.EmailService
-                .Received(1)
-                .SendEmailAsync(
-                    email,
-                    Arg.Any<string>(),
-                    Arg.Is<string>(
-                        body =>
-                            body.Contains($"http://localhost/projects/{Project01}?sharing=true&shareKey=1234abc")
-                            && body.Contains("The project invitation link expires in 14 days")
-                    )
-                );
-            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project01);
-            Assert.That(projectSecret.ShareKeys.Single(sk => sk.Email == email).ProjectRole, Is.EqualTo(role));
-        }
-
-        [Test]
-        public async Task InviteAsync_SpecificSharingEnabled_UserInvited()
-        {
-            var env = new TestEnvironment();
-            const string email = "newuser@example.com";
-            const string role = SFProjectRole.CommunityChecker;
-
-            await env.Service.InviteAsync(User01, Project03, email, "en", role);
-            await env.EmailService
-                .Received(1)
-                .SendEmailAsync(
-                    email,
-                    Arg.Any<string>(),
-                    Arg.Is<string>(
-                        body =>
-                            body.Contains($"http://localhost/projects/{Project03}?sharing=true&shareKey=1234abc")
-                            && body.Contains("The project invitation link expires in 14 days")
-                    )
-                );
-
-            // Code was recorded in database and email address was encoded in ShareKeys
-            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
-            Assert.That(projectSecret.ShareKeys.Single(sk => sk.Email == email).Key, Is.EqualTo("1234abc"));
-            Assert.That(projectSecret.ShareKeys.Single(sk => sk.Email == email).ProjectRole, Is.EqualTo(role));
-        }
-
-        [Test]
-        public async Task InviteAsync_SpecificSharingEnabled_InvitedWithTranslateRoles()
-        {
-            var env = new TestEnvironment();
-            const string observerEmail = "sf_observer@example.com";
-            const string observerKey = "sfobserverkey";
-            env.SecurityService.GenerateKey().Returns(observerKey);
-            await env.Service.InviteAsync(User02, Project04, observerEmail, "en", SFProjectRole.SFObserver);
-            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project04);
-            Assert.That(
-                projectSecret.ShareKeys.Any(
-                    s => s.Email == observerEmail && s.Key == observerKey && s.ProjectRole == SFProjectRole.SFObserver
-                ),
-                Is.True
-            );
-            await env.EmailService
-                .Received(1)
-                .SendEmailAsync(
-                    observerEmail,
-                    Arg.Any<string>(),
-                    Arg.Is<string>(
-                        body =>
-                            body.Contains($"http://localhost/projects/{Project04}?sharing=true&shareKey={observerKey}")
-                    )
-                );
-
-            const string reviewerEmail = "reviewer@example.com";
-            const string reviewerKey = "reviewerKey";
-            env.SecurityService.GenerateKey().Returns(reviewerKey);
-            await env.Service.InviteAsync(User02, Project04, reviewerEmail, "en", SFProjectRole.Reviewer);
-            projectSecret = env.ProjectSecrets.Get(Project04);
-            Assert.That(
-                projectSecret.ShareKeys.Any(
-                    s => s.Email == reviewerEmail && s.Key == reviewerKey && s.ProjectRole == SFProjectRole.Reviewer
-                ),
-                Is.True
-            );
-            await env.EmailService
-                .Received(1)
-                .SendEmailAsync(
-                    reviewerEmail,
-                    Arg.Any<string>(),
-                    Arg.Is<string>(
-                        body =>
-                            body.Contains($"http://localhost/projects/{Project04}?sharing=true&shareKey={reviewerKey}")
-                    )
-                );
-        }
-
-        [Test]
-        public async Task InviteAsync_SpecificSharingEnabled_UserInvitedTwiceButWithSameCode()
-        {
-            var env = new TestEnvironment();
-            const string email = "bob@example.com";
-            const string initialRole = SFProjectRole.CommunityChecker;
-            const string endingRole = SFProjectRole.SFObserver;
-
-            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
-            Assert.That(
-                projectSecret.ShareKeys.Single(sk => sk.Email == email).ExpirationTime,
-                Is.LessThan(DateTime.UtcNow.AddDays(2)),
-                "setup"
-            );
-            var invitees = await env.Service.InvitedUsersAsync(User01, Project03);
-            Assert.That(
-                invitees.Select(i => i.Email),
-                Is.EquivalentTo(
-                    new[] { "bob@example.com", "expired@example.com", "user03@example.com", "bill@example.com" }
-                ),
-                "setup"
-            );
-            Assert.That(invitees[0].Role == initialRole);
-
-            await env.Service.InviteAsync(User01, Project03, email, "en", endingRole);
-            // Invitation email was resent but with original code and updated time
-            await env.EmailService
-                .Received(1)
-                .SendEmailAsync(
-                    Arg.Is(email),
-                    Arg.Any<string>(),
-                    Arg.Is<string>(
-                        body => body.Contains($"http://localhost/projects/{Project03}?sharing=true&shareKey=key1111")
-                    )
-                );
-
-            projectSecret = env.ProjectSecrets.Get(Project03);
-            Assert.That(
-                projectSecret.ShareKeys.Single(sk => sk.Email == email).Key,
-                Is.EqualTo("key1111"),
-                "Code should not have been changed"
-            );
-            Assert.That(
-                projectSecret.ShareKeys.Single(sk => sk.Email == email).ExpirationTime,
-                Is.GreaterThan(DateTime.UtcNow.AddDays(13))
-            );
-            Assert.That(projectSecret.ShareKeys.Single(sk => sk.Email == email).ProjectRole, Is.EqualTo(endingRole));
-
-            invitees = await env.Service.InvitedUsersAsync(User01, Project03);
-            Assert.That(
-                invitees.Select(i => i.Email),
-                Is.EquivalentTo(
-                    new[] { "bob@example.com", "expired@example.com", "user03@example.com", "bill@example.com" }
+        await env.Service.InviteAsync(User01, Project01, email, "en", role);
+        await env.EmailService
+            .Received(1)
+            .SendEmailAsync(
+                email,
+                Arg.Any<string>(),
+                Arg.Is<string>(
+                    body =>
+                        body.Contains($"http://localhost/projects/{Project01}?sharing=true&shareKey=1234abc")
+                        && body.Contains("The project invitation link expires in 14 days")
                 )
             );
-        }
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project01);
+        Assert.That(projectSecret.ShareKeys.Single(sk => sk.Email == email).ProjectRole, Is.EqualTo(role));
+    }
 
-        [Test]
-        public async Task InviteAsync_SpecificSharingEnabledCodeExpired_UserInvitedWithNewCode()
-        {
-            var env = new TestEnvironment();
-            const string email = "expired@example.com";
-            const string role = SFProjectRole.CommunityChecker;
+    [Test]
+    public async Task InviteAsync_SpecificSharingEnabled_UserInvited()
+    {
+        var env = new TestEnvironment();
+        const string email = "newuser@example.com";
+        const string role = SFProjectRole.CommunityChecker;
 
-            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
-            Assert.That(
-                projectSecret.ShareKeys.Any(sk => sk.Email == email && sk.ExpirationTime < DateTime.UtcNow),
-                Is.True,
-                "setup"
-            );
-
-            env.SecurityService.GenerateKey().Returns("newkey");
-            await env.Service.InviteAsync(User01, Project03, email, "en", role);
-            // Invitation email was sent with a new code
-            await env.EmailService
-                .Received(1)
-                .SendEmailAsync(
-                    Arg.Is(email),
-                    Arg.Any<string>(),
-                    Arg.Is<string>(
-                        body => body.Contains($"http://localhost/projects/{Project03}?sharing=true&shareKey=newkey")
-                    )
-                );
-
-            projectSecret = env.ProjectSecrets.Get(Project03);
-            Assert.That(
-                projectSecret.ShareKeys.Single(sk => sk.Email == email).Key,
-                Is.EqualTo("newkey"),
-                "Code should not have been changed"
-            );
-            Assert.That(projectSecret.ShareKeys.Single(sk => sk.Email == email).ProjectRole, Is.EqualTo(role));
-        }
-
-        [Test]
-        public async Task InviteAsync_LinkSharingEnabled_UserInvited()
-        {
-            var env = new TestEnvironment();
-            SFProject project = env.GetProject(Project02);
-            Assert.That(project.CheckingConfig.ShareEnabled, Is.True, "setup");
-            Assert.That(
-                project.CheckingConfig.ShareLevel,
-                Is.EqualTo(CheckingShareLevel.Anyone),
-                "setup: link sharing should be enabled"
-            );
-            const string email = "newuser@example.com";
-            const string role = SFProjectRole.CommunityChecker;
-            // SUT
-            await env.Service.InviteAsync(User02, Project02, email, "en", role);
-            await env.EmailService
-                .Received(1)
-                .SendEmailAsync(
-                    email,
-                    Arg.Any<string>(),
-                    Arg.Is<string>(
-                        body => body.Contains($"http://localhost/projects/{Project02}?sharing=true&shareKey=1234abc")
-                    )
-                );
-            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project02);
-            Assert.That(projectSecret.ShareKeys.Single(sk => sk.Key == "1234abc").ProjectRole, Is.EqualTo(role));
-        }
-
-        [Test]
-        public async Task InviteAsync_SharingDisabled_ForbiddenError()
-        {
-            var env = new TestEnvironment();
-            Assert.ThrowsAsync<ForbiddenException>(
-                () =>
-                    env.Service.InviteAsync(
-                        User02,
-                        Project01,
-                        "newuser@example.com",
-                        "en",
-                        SFProjectRole.CommunityChecker
-                    )
-            );
-            await env.EmailService.DidNotReceiveWithAnyArgs().SendEmailAsync(default, default, default);
-        }
-
-        [Test]
-        public async Task InviteAsync_SpecificSharingEnabled_ProjectUserNotInvited()
-        {
-            var env = new TestEnvironment();
-            const string email = "user02@example.com";
-            const string role = SFProjectRole.CommunityChecker;
-            SFProject project = env.GetProject(Project03);
-            Assert.That(project.UserRoles.TryGetValue(User02, out string userRole), Is.True);
-            Assert.That(userRole, Is.EqualTo(role), "setup - user should already be a project user");
-
-            Assert.That(await env.Service.InviteAsync(User01, Project03, email, "en", role), Is.False);
-            project = env.GetProject(Project03);
-            Assert.That(project.UserRoles.ContainsKey(User02), Is.True, "user should still be a project user");
-
-            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
-            Assert.That(
-                projectSecret.ShareKeys.Any(sk => sk.Email == email),
-                Is.False,
-                "no sharekey should have been added"
-            );
-
-            // Email should not have been sent
-            await env.EmailService.DidNotReceiveWithAnyArgs().SendEmailAsync(null, default, default);
-        }
-
-        [Test]
-        public void InviteAsync_UserNotOnProject_ForbiddenError()
-        {
-            var env = new TestEnvironment();
-            const string email = "newuser@example.com";
-            const string role = SFProjectRole.CommunityChecker;
-            Assert.DoesNotThrowAsync(() => env.Service.InviteAsync(User02, Project03, email, "en", role));
-            Assert.ThrowsAsync<ForbiddenException>(() => env.Service.InviteAsync(User03, Project03, email, "en", role));
-        }
-
-        [Test]
-        public async Task GetLinkSharingKeyAsync_LinkDoesNotExist_NewShareKeyCreated()
-        {
-            var env = new TestEnvironment();
-            await env.Service.UpdateSettingsAsync(
-                User01,
-                Project03,
-                new SFProjectSettings { CheckingShareLevel = CheckingShareLevel.Anyone }
-            );
-            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
-            Assert.That(projectSecret.ShareKeys.Any(sk => sk.Email == null), Is.False);
-            env.SecurityService.GenerateKey().Returns("newkey");
-
-            string shareLink = await env.Service.GetLinkSharingKeyAsync(
-                User02,
-                Project03,
-                SFProjectRole.CommunityChecker
-            );
-            Assert.That(shareLink, Is.EqualTo("newkey"));
-            projectSecret = env.ProjectSecrets.Get(Project03);
-            Assert.That(
-                projectSecret.ShareKeys.Single(sk => sk.Email == null && sk.ExpirationTime == null).Key,
-                Is.EqualTo("newkey")
-            );
-        }
-
-        [Test]
-        public async Task GetLinkSharingKeyAsync_LinkExists_ReturnsExistingKey()
-        {
-            var env = new TestEnvironment();
-            const string role = SFProjectRole.CommunityChecker;
-            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project02);
-
-            Assert.That(
-                projectSecret.ShareKeys.Any(sk => sk.Email == null && sk.ProjectRole == role),
-                Is.True,
-                "setup - a link sharing key should exist"
-            );
-            string shareLink = await env.Service.GetLinkSharingKeyAsync(User02, Project02, role);
-            Assert.That(shareLink, Is.EqualTo("linksharing02"));
-        }
-
-        [Test]
-        public async Task GetLinkSharingKeyAsync_LinkSharingDisabled_ForbiddenError()
-        {
-            var env = new TestEnvironment();
-            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project01);
-            Assert.That(projectSecret.ShareKeys.Count, Is.EqualTo(0));
-            string key = await env.Service.GetLinkSharingKeyAsync(User02, Project01, SFProjectRole.CommunityChecker);
-            Assert.That(key, Is.Null);
-            projectSecret = env.ProjectSecrets.Get(Project01);
-            Assert.That(projectSecret.ShareKeys.Count, Is.EqualTo(0));
-        }
-
-        [Test]
-        public async Task GetLinkSharingKeyAsync_UserInvitesObserver_SucceedsForUsersWithRights()
-        {
-            var env = new TestEnvironment();
-            string key = await env.Service.GetLinkSharingKeyAsync(User01, Project01, SFProjectRole.SFObserver);
-            Assert.That(key, Is.Not.Null);
-            // An sf observer should have rights to invite another observer
-            key = await env.Service.GetLinkSharingKeyAsync(User06, Project01, SFProjectRole.SFObserver);
-            Assert.That(key, Is.Not.Null);
-            Assert.ThrowsAsync<ForbiddenException>(
-                () => env.Service.GetLinkSharingKeyAsync(User02, Project01, SFProjectRole.SFObserver)
-            );
-        }
-
-        [Test]
-        public async Task GetLinkSharingKeyAsync_UserInvitesReviewer_SucceedsForAdmins()
-        {
-            var env = new TestEnvironment();
-            string key = await env.Service.GetLinkSharingKeyAsync(User01, Project01, SFProjectRole.Reviewer);
-            Assert.That(key, Is.Not.Null);
-            Assert.ThrowsAsync<ForbiddenException>(
-                () => env.Service.GetLinkSharingKeyAsync(User02, Project01, SFProjectRole.Reviewer)
-            );
-        }
-
-        [Test]
-        public void CheckLinkSharingAsync_LinkSharingDisabledAndUserOnProject_Success()
-        {
-            var env = new TestEnvironment();
-            SFProject project = env.GetProject(Project01);
-            Assert.That(project.UserRoles.ContainsKey(User02), Is.True, "setup");
-            Assert.DoesNotThrowAsync(() => env.Service.CheckLinkSharingAsync(User02, Project01, "abcd"));
-        }
-
-        [Test]
-        public async Task CheckLinkSharingAsync_LinkSharingDisabledAndUserNotOnProject_Forbidden()
-        {
-            var env = new TestEnvironment();
-            SFProject project = env.GetProject(Project02);
-            Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
-            await env.Service.UpdateSettingsAsync(
-                User02,
-                Project02,
-                new SFProjectSettings { CheckingShareEnabled = false }
-            );
-            Assert.ThrowsAsync<ForbiddenException>(
-                () => env.Service.CheckLinkSharingAsync(User03, Project02, "linksharing02")
-            );
-        }
-
-        [Test]
-        public async Task CheckLinkSharingAsync_LinkSharingEnabled_UserJoined()
-        {
-            var env = new TestEnvironment();
-            SFProject project = env.GetProject(Project02);
-            Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
-
-            await env.Service.CheckLinkSharingAsync(User03, Project02, "linksharing02");
-            project = env.GetProject(Project02);
-            Assert.That(project.UserRoles.TryGetValue(User03, out string userRole), Is.True);
-            Assert.That(userRole, Is.EqualTo(SFProjectRole.CommunityChecker));
-            User user = env.GetUser(User03);
-            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project02));
-        }
-
-        [Test]
-        public async Task CheckLinkSharingAsync_LinkSharingEnabledAndUserHasPTRole_UserJoined()
-        {
-            var env = new TestEnvironment();
-            SFProject project = env.GetProject(Project04);
-            Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
-            env.ParatextService
-                .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), CancellationToken.None)
-                .Returns(Task.FromResult(new Attempt<string>(SFProjectRole.Translator)));
-
-            await env.Service.CheckLinkSharingAsync(User03, Project04, "linksharing04");
-            project = env.GetProject(Project04);
-            Assert.That(project.UserRoles.TryGetValue(User03, out string userRole), Is.True);
-            Assert.That(userRole, Is.EqualTo(SFProjectRole.Translator));
-            User user = env.GetUser(User03);
-            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project04));
-        }
-
-        [Test]
-        public async Task CheckLinkSharingAsync_LinkSharingEnabledAndShareKeyExists_UserJoinedAndKeyRemoved()
-        {
-            var env = new TestEnvironment();
-            SFProject project = env.GetProject(Project02);
-            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project02);
-
-            Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
-            Assert.That(projectSecret.ShareKeys.Any(sk => sk.Key == "existingkeyuser03"), Is.True, "setup");
-
-            await env.Service.CheckLinkSharingAsync(User03, Project02, "existingkeyuser03");
-            project = env.GetProject(Project02);
-            projectSecret = env.ProjectSecrets.Get(Project02);
-            Assert.That(project.UserRoles.ContainsKey(User03), Is.True, "User should have been added to project");
-            Assert.That(
-                projectSecret.ShareKeys.Any(sk => sk.Key == "existingkeyuser03"),
-                Is.False,
-                "Key should have been removed from project"
-            );
-        }
-
-        [Test]
-        public async Task CheckLinkSharingAsync_SpecificSharingAlternateUser_UserJoined()
-        {
-            var env = new TestEnvironment();
-            SFProject project = env.GetProject(Project03);
-
-            Assert.That(project.UserRoles.ContainsKey(User04), Is.False, "setup");
-            var invitees = await env.Service.InvitedUsersAsync(User01, Project03);
-            Assert.That(
-                invitees.Select(i => i.Email),
-                Is.EquivalentTo(
-                    new[] { "bob@example.com", "expired@example.com", "user03@example.com", "bill@example.com" }
-                ),
-                "setup"
-            );
-
-            // Use the sharekey linked to user03
-            await env.Service.CheckLinkSharingAsync(User04, Project03, "key1234");
-            project = env.GetProject(Project03);
-            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
-            Assert.That(project.UserRoles.ContainsKey(User04), Is.True, "User should have been added to project");
-            Assert.That(
-                projectSecret.ShareKeys.Any(sk => sk.Key == "key1234"),
-                Is.False,
-                "Key should have been removed from project"
-            );
-
-            invitees = await env.Service.InvitedUsersAsync(User01, Project03);
-            Assert.That(
-                invitees.Select(i => i.Email),
-                Is.EquivalentTo(new[] { "bob@example.com", "expired@example.com", "bill@example.com" })
-            );
-        }
-
-        [Test]
-        public async Task CheckLinkSharingAsync_SpecificSharingLinkExpired_ForbiddenError()
-        {
-            var env = new TestEnvironment();
-            SFProject project = env.GetProject(Project03);
-            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
-
-            Assert.That(project.UserRoles.ContainsKey(LinkExpiredUser), Is.False, "setup");
-            Assert.That(projectSecret.ShareKeys.Any(sk => sk.Email == "expired@example.com"), Is.True, "setup");
-
-            Assert.ThrowsAsync<ForbiddenException>(
-                () => env.Service.CheckLinkSharingAsync(LinkExpiredUser, Project03, "keyexp"),
-                "The user should be forbidden to join the project: Email was in ShareKeys, but code was expired."
-            );
-
-            var invitees = await env.Service.InvitedUsersAsync(User01, Project03);
-            Assert.That(
-                invitees.Select(i => i.Email),
-                Is.EquivalentTo(
-                    new[] { "bob@example.com", "expired@example.com", "user03@example.com", "bill@example.com" }
+        await env.Service.InviteAsync(User01, Project03, email, "en", role);
+        await env.EmailService
+            .Received(1)
+            .SendEmailAsync(
+                email,
+                Arg.Any<string>(),
+                Arg.Is<string>(
+                    body =>
+                        body.Contains($"http://localhost/projects/{Project03}?sharing=true&shareKey=1234abc")
+                        && body.Contains("The project invitation link expires in 14 days")
                 )
             );
-        }
 
-        [Test]
-        public void CheckLinkSharingAsync_SpecificSharingAndWrongCode_ForbiddenError()
+        // Code was recorded in database and email address was encoded in ShareKeys
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
+        Assert.That(projectSecret.ShareKeys.Single(sk => sk.Email == email).Key, Is.EqualTo("1234abc"));
+        Assert.That(projectSecret.ShareKeys.Single(sk => sk.Email == email).ProjectRole, Is.EqualTo(role));
+    }
+
+    [Test]
+    public async Task InviteAsync_SpecificSharingEnabled_InvitedWithTranslateRoles()
+    {
+        var env = new TestEnvironment();
+        const string observerEmail = "sf_observer@example.com";
+        const string observerKey = "sfobserverkey";
+        env.SecurityService.GenerateKey().Returns(observerKey);
+        await env.Service.InviteAsync(User02, Project04, observerEmail, "en", SFProjectRole.SFObserver);
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project04);
+        Assert.That(
+            projectSecret.ShareKeys.Any(
+                s => s.Email == observerEmail && s.Key == observerKey && s.ProjectRole == SFProjectRole.SFObserver
+            ),
+            Is.True
+        );
+        await env.EmailService
+            .Received(1)
+            .SendEmailAsync(
+                observerEmail,
+                Arg.Any<string>(),
+                Arg.Is<string>(
+                    body => body.Contains($"http://localhost/projects/{Project04}?sharing=true&shareKey={observerKey}")
+                )
+            );
+
+        const string reviewerEmail = "reviewer@example.com";
+        const string reviewerKey = "reviewerKey";
+        env.SecurityService.GenerateKey().Returns(reviewerKey);
+        await env.Service.InviteAsync(User02, Project04, reviewerEmail, "en", SFProjectRole.Reviewer);
+        projectSecret = env.ProjectSecrets.Get(Project04);
+        Assert.That(
+            projectSecret.ShareKeys.Any(
+                s => s.Email == reviewerEmail && s.Key == reviewerKey && s.ProjectRole == SFProjectRole.Reviewer
+            ),
+            Is.True
+        );
+        await env.EmailService
+            .Received(1)
+            .SendEmailAsync(
+                reviewerEmail,
+                Arg.Any<string>(),
+                Arg.Is<string>(
+                    body => body.Contains($"http://localhost/projects/{Project04}?sharing=true&shareKey={reviewerKey}")
+                )
+            );
+    }
+
+    [Test]
+    public async Task InviteAsync_SpecificSharingEnabled_UserInvitedTwiceButWithSameCode()
+    {
+        var env = new TestEnvironment();
+        const string email = "bob@example.com";
+        const string initialRole = SFProjectRole.CommunityChecker;
+        const string endingRole = SFProjectRole.SFObserver;
+
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
+        Assert.That(
+            projectSecret.ShareKeys.Single(sk => sk.Email == email).ExpirationTime,
+            Is.LessThan(DateTime.UtcNow.AddDays(2)),
+            "setup"
+        );
+        var invitees = await env.Service.InvitedUsersAsync(User01, Project03);
+        Assert.That(
+            invitees.Select(i => i.Email),
+            Is.EquivalentTo(
+                new[] { "bob@example.com", "expired@example.com", "user03@example.com", "bill@example.com" }
+            ),
+            "setup"
+        );
+        Assert.That(invitees[0].Role == initialRole);
+
+        await env.Service.InviteAsync(User01, Project03, email, "en", endingRole);
+        // Invitation email was resent but with original code and updated time
+        await env.EmailService
+            .Received(1)
+            .SendEmailAsync(
+                Arg.Is(email),
+                Arg.Any<string>(),
+                Arg.Is<string>(
+                    body => body.Contains($"http://localhost/projects/{Project03}?sharing=true&shareKey=key1111")
+                )
+            );
+
+        projectSecret = env.ProjectSecrets.Get(Project03);
+        Assert.That(
+            projectSecret.ShareKeys.Single(sk => sk.Email == email).Key,
+            Is.EqualTo("key1111"),
+            "Code should not have been changed"
+        );
+        Assert.That(
+            projectSecret.ShareKeys.Single(sk => sk.Email == email).ExpirationTime,
+            Is.GreaterThan(DateTime.UtcNow.AddDays(13))
+        );
+        Assert.That(projectSecret.ShareKeys.Single(sk => sk.Email == email).ProjectRole, Is.EqualTo(endingRole));
+
+        invitees = await env.Service.InvitedUsersAsync(User01, Project03);
+        Assert.That(
+            invitees.Select(i => i.Email),
+            Is.EquivalentTo(
+                new[] { "bob@example.com", "expired@example.com", "user03@example.com", "bill@example.com" }
+            )
+        );
+    }
+
+    [Test]
+    public async Task InviteAsync_SpecificSharingEnabledCodeExpired_UserInvitedWithNewCode()
+    {
+        var env = new TestEnvironment();
+        const string email = "expired@example.com";
+        const string role = SFProjectRole.CommunityChecker;
+
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
+        Assert.That(
+            projectSecret.ShareKeys.Any(sk => sk.Email == email && sk.ExpirationTime < DateTime.UtcNow),
+            Is.True,
+            "setup"
+        );
+
+        env.SecurityService.GenerateKey().Returns("newkey");
+        await env.Service.InviteAsync(User01, Project03, email, "en", role);
+        // Invitation email was sent with a new code
+        await env.EmailService
+            .Received(1)
+            .SendEmailAsync(
+                Arg.Is(email),
+                Arg.Any<string>(),
+                Arg.Is<string>(
+                    body => body.Contains($"http://localhost/projects/{Project03}?sharing=true&shareKey=newkey")
+                )
+            );
+
+        projectSecret = env.ProjectSecrets.Get(Project03);
+        Assert.That(
+            projectSecret.ShareKeys.Single(sk => sk.Email == email).Key,
+            Is.EqualTo("newkey"),
+            "Code should not have been changed"
+        );
+        Assert.That(projectSecret.ShareKeys.Single(sk => sk.Email == email).ProjectRole, Is.EqualTo(role));
+    }
+
+    [Test]
+    public async Task InviteAsync_LinkSharingEnabled_UserInvited()
+    {
+        var env = new TestEnvironment();
+        SFProject project = env.GetProject(Project02);
+        Assert.That(project.CheckingConfig.ShareEnabled, Is.True, "setup");
+        Assert.That(
+            project.CheckingConfig.ShareLevel,
+            Is.EqualTo(CheckingShareLevel.Anyone),
+            "setup: link sharing should be enabled"
+        );
+        const string email = "newuser@example.com";
+        const string role = SFProjectRole.CommunityChecker;
+        // SUT
+        await env.Service.InviteAsync(User02, Project02, email, "en", role);
+        await env.EmailService
+            .Received(1)
+            .SendEmailAsync(
+                email,
+                Arg.Any<string>(),
+                Arg.Is<string>(
+                    body => body.Contains($"http://localhost/projects/{Project02}?sharing=true&shareKey=1234abc")
+                )
+            );
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project02);
+        Assert.That(projectSecret.ShareKeys.Single(sk => sk.Key == "1234abc").ProjectRole, Is.EqualTo(role));
+    }
+
+    [Test]
+    public async Task InviteAsync_SharingDisabled_ForbiddenError()
+    {
+        var env = new TestEnvironment();
+        Assert.ThrowsAsync<ForbiddenException>(
+            () =>
+                env.Service.InviteAsync(User02, Project01, "newuser@example.com", "en", SFProjectRole.CommunityChecker)
+        );
+        await env.EmailService.DidNotReceiveWithAnyArgs().SendEmailAsync(default, default, default);
+    }
+
+    [Test]
+    public async Task InviteAsync_SpecificSharingEnabled_ProjectUserNotInvited()
+    {
+        var env = new TestEnvironment();
+        const string email = "user02@example.com";
+        const string role = SFProjectRole.CommunityChecker;
+        SFProject project = env.GetProject(Project03);
+        Assert.That(project.UserRoles.TryGetValue(User02, out string userRole), Is.True);
+        Assert.That(userRole, Is.EqualTo(role), "setup - user should already be a project user");
+
+        Assert.That(await env.Service.InviteAsync(User01, Project03, email, "en", role), Is.False);
+        project = env.GetProject(Project03);
+        Assert.That(project.UserRoles.ContainsKey(User02), Is.True, "user should still be a project user");
+
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
+        Assert.That(
+            projectSecret.ShareKeys.Any(sk => sk.Email == email),
+            Is.False,
+            "no sharekey should have been added"
+        );
+
+        // Email should not have been sent
+        await env.EmailService.DidNotReceiveWithAnyArgs().SendEmailAsync(null, default, default);
+    }
+
+    [Test]
+    public void InviteAsync_UserNotOnProject_ForbiddenError()
+    {
+        var env = new TestEnvironment();
+        const string email = "newuser@example.com";
+        const string role = SFProjectRole.CommunityChecker;
+        Assert.DoesNotThrowAsync(() => env.Service.InviteAsync(User02, Project03, email, "en", role));
+        Assert.ThrowsAsync<ForbiddenException>(() => env.Service.InviteAsync(User03, Project03, email, "en", role));
+    }
+
+    [Test]
+    public async Task GetLinkSharingKeyAsync_LinkDoesNotExist_NewShareKeyCreated()
+    {
+        var env = new TestEnvironment();
+        await env.Service.UpdateSettingsAsync(
+            User01,
+            Project03,
+            new SFProjectSettings { CheckingShareLevel = CheckingShareLevel.Anyone }
+        );
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
+        Assert.That(projectSecret.ShareKeys.Any(sk => sk.Email == null), Is.False);
+        env.SecurityService.GenerateKey().Returns("newkey");
+
+        string shareLink = await env.Service.GetLinkSharingKeyAsync(User02, Project03, SFProjectRole.CommunityChecker);
+        Assert.That(shareLink, Is.EqualTo("newkey"));
+        projectSecret = env.ProjectSecrets.Get(Project03);
+        Assert.That(
+            projectSecret.ShareKeys.Single(sk => sk.Email == null && sk.ExpirationTime == null).Key,
+            Is.EqualTo("newkey")
+        );
+    }
+
+    [Test]
+    public async Task GetLinkSharingKeyAsync_LinkExists_ReturnsExistingKey()
+    {
+        var env = new TestEnvironment();
+        const string role = SFProjectRole.CommunityChecker;
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project02);
+
+        Assert.That(
+            projectSecret.ShareKeys.Any(sk => sk.Email == null && sk.ProjectRole == role),
+            Is.True,
+            "setup - a link sharing key should exist"
+        );
+        string shareLink = await env.Service.GetLinkSharingKeyAsync(User02, Project02, role);
+        Assert.That(shareLink, Is.EqualTo("linksharing02"));
+    }
+
+    [Test]
+    public async Task GetLinkSharingKeyAsync_LinkSharingDisabled_ForbiddenError()
+    {
+        var env = new TestEnvironment();
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project01);
+        Assert.That(projectSecret.ShareKeys.Count, Is.EqualTo(0));
+        string key = await env.Service.GetLinkSharingKeyAsync(User02, Project01, SFProjectRole.CommunityChecker);
+        Assert.That(key, Is.Null);
+        projectSecret = env.ProjectSecrets.Get(Project01);
+        Assert.That(projectSecret.ShareKeys.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task GetLinkSharingKeyAsync_UserInvitesObserver_SucceedsForUsersWithRights()
+    {
+        var env = new TestEnvironment();
+        string key = await env.Service.GetLinkSharingKeyAsync(User01, Project01, SFProjectRole.SFObserver);
+        Assert.That(key, Is.Not.Null);
+        // An sf observer should have rights to invite another observer
+        key = await env.Service.GetLinkSharingKeyAsync(User06, Project01, SFProjectRole.SFObserver);
+        Assert.That(key, Is.Not.Null);
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.GetLinkSharingKeyAsync(User02, Project01, SFProjectRole.SFObserver)
+        );
+    }
+
+    [Test]
+    public async Task GetLinkSharingKeyAsync_UserInvitesReviewer_SucceedsForAdmins()
+    {
+        var env = new TestEnvironment();
+        string key = await env.Service.GetLinkSharingKeyAsync(User01, Project01, SFProjectRole.Reviewer);
+        Assert.That(key, Is.Not.Null);
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.GetLinkSharingKeyAsync(User02, Project01, SFProjectRole.Reviewer)
+        );
+    }
+
+    [Test]
+    public void CheckLinkSharingAsync_LinkSharingDisabledAndUserOnProject_Success()
+    {
+        var env = new TestEnvironment();
+        SFProject project = env.GetProject(Project01);
+        Assert.That(project.UserRoles.ContainsKey(User02), Is.True, "setup");
+        Assert.DoesNotThrowAsync(() => env.Service.CheckLinkSharingAsync(User02, Project01, "abcd"));
+    }
+
+    [Test]
+    public async Task CheckLinkSharingAsync_LinkSharingDisabledAndUserNotOnProject_Forbidden()
+    {
+        var env = new TestEnvironment();
+        SFProject project = env.GetProject(Project02);
+        Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
+        await env.Service.UpdateSettingsAsync(
+            User02,
+            Project02,
+            new SFProjectSettings { CheckingShareEnabled = false }
+        );
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.CheckLinkSharingAsync(User03, Project02, "linksharing02")
+        );
+    }
+
+    [Test]
+    public async Task CheckLinkSharingAsync_LinkSharingEnabled_UserJoined()
+    {
+        var env = new TestEnvironment();
+        SFProject project = env.GetProject(Project02);
+        Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
+
+        await env.Service.CheckLinkSharingAsync(User03, Project02, "linksharing02");
+        project = env.GetProject(Project02);
+        Assert.That(project.UserRoles.TryGetValue(User03, out string userRole), Is.True);
+        Assert.That(userRole, Is.EqualTo(SFProjectRole.CommunityChecker));
+        User user = env.GetUser(User03);
+        Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project02));
+    }
+
+    [Test]
+    public async Task CheckLinkSharingAsync_LinkSharingEnabledAndUserHasPTRole_UserJoined()
+    {
+        var env = new TestEnvironment();
+        SFProject project = env.GetProject(Project04);
+        Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
+        env.ParatextService
+            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), CancellationToken.None)
+            .Returns(Task.FromResult(new Attempt<string>(SFProjectRole.Translator)));
+
+        await env.Service.CheckLinkSharingAsync(User03, Project04, "linksharing04");
+        project = env.GetProject(Project04);
+        Assert.That(project.UserRoles.TryGetValue(User03, out string userRole), Is.True);
+        Assert.That(userRole, Is.EqualTo(SFProjectRole.Translator));
+        User user = env.GetUser(User03);
+        Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project04));
+    }
+
+    [Test]
+    public async Task CheckLinkSharingAsync_LinkSharingEnabledAndShareKeyExists_UserJoinedAndKeyRemoved()
+    {
+        var env = new TestEnvironment();
+        SFProject project = env.GetProject(Project02);
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project02);
+
+        Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
+        Assert.That(projectSecret.ShareKeys.Any(sk => sk.Key == "existingkeyuser03"), Is.True, "setup");
+
+        await env.Service.CheckLinkSharingAsync(User03, Project02, "existingkeyuser03");
+        project = env.GetProject(Project02);
+        projectSecret = env.ProjectSecrets.Get(Project02);
+        Assert.That(project.UserRoles.ContainsKey(User03), Is.True, "User should have been added to project");
+        Assert.That(
+            projectSecret.ShareKeys.Any(sk => sk.Key == "existingkeyuser03"),
+            Is.False,
+            "Key should have been removed from project"
+        );
+    }
+
+    [Test]
+    public async Task CheckLinkSharingAsync_SpecificSharingAlternateUser_UserJoined()
+    {
+        var env = new TestEnvironment();
+        SFProject project = env.GetProject(Project03);
+
+        Assert.That(project.UserRoles.ContainsKey(User04), Is.False, "setup");
+        var invitees = await env.Service.InvitedUsersAsync(User01, Project03);
+        Assert.That(
+            invitees.Select(i => i.Email),
+            Is.EquivalentTo(
+                new[] { "bob@example.com", "expired@example.com", "user03@example.com", "bill@example.com" }
+            ),
+            "setup"
+        );
+
+        // Use the sharekey linked to user03
+        await env.Service.CheckLinkSharingAsync(User04, Project03, "key1234");
+        project = env.GetProject(Project03);
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
+        Assert.That(project.UserRoles.ContainsKey(User04), Is.True, "User should have been added to project");
+        Assert.That(
+            projectSecret.ShareKeys.Any(sk => sk.Key == "key1234"),
+            Is.False,
+            "Key should have been removed from project"
+        );
+
+        invitees = await env.Service.InvitedUsersAsync(User01, Project03);
+        Assert.That(
+            invitees.Select(i => i.Email),
+            Is.EquivalentTo(new[] { "bob@example.com", "expired@example.com", "bill@example.com" })
+        );
+    }
+
+    [Test]
+    public async Task CheckLinkSharingAsync_SpecificSharingLinkExpired_ForbiddenError()
+    {
+        var env = new TestEnvironment();
+        SFProject project = env.GetProject(Project03);
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
+
+        Assert.That(project.UserRoles.ContainsKey(LinkExpiredUser), Is.False, "setup");
+        Assert.That(projectSecret.ShareKeys.Any(sk => sk.Email == "expired@example.com"), Is.True, "setup");
+
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.CheckLinkSharingAsync(LinkExpiredUser, Project03, "keyexp"),
+            "The user should be forbidden to join the project: Email was in ShareKeys, but code was expired."
+        );
+
+        var invitees = await env.Service.InvitedUsersAsync(User01, Project03);
+        Assert.That(
+            invitees.Select(i => i.Email),
+            Is.EquivalentTo(
+                new[] { "bob@example.com", "expired@example.com", "user03@example.com", "bill@example.com" }
+            )
+        );
+    }
+
+    [Test]
+    public void CheckLinkSharingAsync_SpecificSharingAndWrongCode_ForbiddenError()
+    {
+        var env = new TestEnvironment();
+        SFProject project = env.GetProject(Project03);
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
+
+        Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
+        Assert.That(projectSecret.ShareKeys.Any(sk => sk.Email == "user03@example.com"), Is.True, "setup");
+
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.CheckLinkSharingAsync(User03, Project03, "badcode"),
+            "The user should be forbidden to join the project: Email address was in ShareKeys list, but wrong code was given."
+        );
+    }
+
+    [Test]
+    public async Task CheckLinkSharingAsync_SpecificSharingAndRightKey_UserJoined()
+    {
+        var env = new TestEnvironment();
+        SFProject project = env.GetProject(Project03);
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
+
+        Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
+        Assert.That(projectSecret.ShareKeys.Any(sk => sk.Key == "key1234"), Is.True, "setup");
+        Assert.That(projectSecret.ShareKeys.Count, Is.EqualTo(4), "setup");
+
+        await env.Service.CheckLinkSharingAsync(User03, Project03, "key1234");
+
+        project = env.GetProject(Project03);
+        projectSecret = env.ProjectSecrets.Get(Project03);
+        Assert.That(project.UserRoles.ContainsKey(User03), Is.True, "User should have been added to project");
+        Assert.That(
+            projectSecret.ShareKeys.Any(sk => sk.Key == "key1234"),
+            Is.False,
+            "Key should have been removed from project"
+        );
+    }
+
+    [Test]
+    public async Task CheckLinkSharingAsync_ShareDisabledAndKeyValid_UserJoined()
+    {
+        var env = new TestEnvironment();
+        SFProject project = env.GetProject(Project03);
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
+
+        Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
+        Assert.That(projectSecret.ShareKeys.Any(sk => sk.Key == "key1234"), Is.True, "setup");
+        Assert.That(projectSecret.ShareKeys.Count, Is.EqualTo(4), "setup");
+
+        await env.Service.UpdateSettingsAsync(
+            User01,
+            Project03,
+            new SFProjectSettings { CheckingShareEnabled = false }
+        );
+        project = env.GetProject(Project03);
+        Assert.That(project.CheckingConfig.ShareEnabled, Is.False, "setup");
+        await env.Service.CheckLinkSharingAsync(User03, Project03, "key1234");
+
+        project = env.GetProject(Project03);
+        projectSecret = env.ProjectSecrets.Get(Project03);
+        Assert.That(project.UserRoles.ContainsKey(User03), Is.True, "User should have been added to project");
+        Assert.That(
+            projectSecret.ShareKeys.Any(sk => sk.Key == "key1234"),
+            Is.False,
+            "Key should have been removed from project"
+        );
+    }
+
+    [Test]
+    public async Task CheckLinkSharingAsync_PTUserHasPTPermissions()
+    {
+        // If a user is invited to a project, and goes to the invitation link, the user being added to the project
+        // should have their PT permissions for text books and chapters.
+
+        var env = new TestEnvironment();
+        string project05PTId = "paratext_" + Project05;
+        SFProject project = env.GetProject(Project05);
+        SFProject resource = env.GetProject(Resource01);
+
+        Assert.That(env.UserSecrets.Contains(User03), Is.True, "setup. PT user should have user secrets.");
+        User user = env.GetUser(User03);
+        Assert.That(user.ParatextId, Is.Not.Null, "setup. PT user should have a PT User ID.");
+
+        string userRoleOnPTProject = SFProjectRole.Translator;
+        Assert.That(
+            userRoleOnPTProject,
+            Is.Not.EqualTo(SFProjectRole.CommunityChecker),
+            "setup. role should be different than community checker for purposes of part of what this test is testing."
+        );
+        string shareKeyCode = "key12345";
+        ShareKey shareKeyForUserInvitation = env.ProjectSecrets
+            .Get(project.Id)
+            .ShareKeys.First((ShareKey shareKey) => shareKey.Key == shareKeyCode);
+        Assert.That(
+            shareKeyForUserInvitation.ProjectRole,
+            Is.EqualTo(SFProjectRole.CommunityChecker),
+            "setup. the user should be being invited as a community checker."
+        );
+        env.ParatextService
+            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Attempt.Success(userRoleOnPTProject)));
+        string userDBLPermissionForResource = TextInfoPermission.Read;
+        env.ParatextService
+            .GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
+            .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
+
+        Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
+        Assert.That(project.Texts.First().Permissions.ContainsKey(User03), Is.False, "setup");
+        Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
+        Assert.That(resource.UserRoles.ContainsKey(User03), Is.False, "setup");
+        Assert.That(project.Texts.First().Permissions.ContainsKey(User03), Is.False, "setup");
+        Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
+
+        var bookList = new List<int>() { 40, 41 };
+        env.ParatextService.GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(bookList);
+
+        // PT will answer with these permissions.
+        var ptBookPermissions = new Dictionary<string, string>()
         {
-            var env = new TestEnvironment();
-            SFProject project = env.GetProject(Project03);
-            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
-
-            Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
-            Assert.That(projectSecret.ShareKeys.Any(sk => sk.Email == "user03@example.com"), Is.True, "setup");
-
-            Assert.ThrowsAsync<ForbiddenException>(
-                () => env.Service.CheckLinkSharingAsync(User03, Project03, "badcode"),
-                "The user should be forbidden to join the project: Email address was in ShareKeys list, but wrong code was given."
-            );
-        }
-
-        [Test]
-        public async Task CheckLinkSharingAsync_SpecificSharingAndRightKey_UserJoined()
+            { User03, TextInfoPermission.Read },
+            { User01, TextInfoPermission.Read },
+        };
+        var ptChapterPermissions = new Dictionary<string, string>()
         {
-            var env = new TestEnvironment();
-            SFProject project = env.GetProject(Project03);
-            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
-
-            Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
-            Assert.That(projectSecret.ShareKeys.Any(sk => sk.Key == "key1234"), Is.True, "setup");
-            Assert.That(projectSecret.ShareKeys.Count, Is.EqualTo(4), "setup");
-
-            await env.Service.CheckLinkSharingAsync(User03, Project03, "key1234");
-
-            project = env.GetProject(Project03);
-            projectSecret = env.ProjectSecrets.Get(Project03);
-            Assert.That(project.UserRoles.ContainsKey(User03), Is.True, "User should have been added to project");
-            Assert.That(
-                projectSecret.ShareKeys.Any(sk => sk.Key == "key1234"),
-                Is.False,
-                "Key should have been removed from project"
-            );
-        }
-
-        [Test]
-        public async Task CheckLinkSharingAsync_ShareDisabledAndKeyValid_UserJoined()
+            { User03, TextInfoPermission.Write },
+            { User01, TextInfoPermission.Read },
+        };
+        var ptSourcePermissions = new Dictionary<string, string>()
         {
-            var env = new TestEnvironment();
-            SFProject project = env.GetProject(Project03);
-            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
+            { User03, userDBLPermissionForResource },
+            { User01, TextInfoPermission.None },
+        };
+        const int bookValueToIndicateWholeResource = 0;
+        const int chapterValueToIndicateWholeBook = 0;
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                chapterValueToIndicateWholeBook
+            )
+            .Returns(Task.FromResult(ptBookPermissions));
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                Arg.Is<int>((int arg) => arg > 0)
+            )
+            .Returns(Task.FromResult(ptChapterPermissions));
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                bookValueToIndicateWholeResource,
+                chapterValueToIndicateWholeBook
+            )
+            .Returns(Task.FromResult(ptSourcePermissions));
 
-            Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
-            Assert.That(projectSecret.ShareKeys.Any(sk => sk.Key == "key1234"), Is.True, "setup");
-            Assert.That(projectSecret.ShareKeys.Count, Is.EqualTo(4), "setup");
+        // SUT
+        await env.Service.CheckLinkSharingAsync(User03, Project05, shareKeyCode);
 
-            await env.Service.UpdateSettingsAsync(
-                User01,
-                Project03,
-                new SFProjectSettings { CheckingShareEnabled = false }
+        project = env.GetProject(Project05);
+        Assert.That(
+            project.UserRoles.TryGetValue(User03, out string userRole),
+            Is.True,
+            "user should be added to project"
+        );
+        // This user was invited as a community checker (according to the share key). But their project role and
+        // permissions will reflect what is set on the PT project. The user will have a translator role rather than
+        // a community checker role.
+        Assert.That(userRole, Is.EqualTo(userRoleOnPTProject));
+        user = env.GetUser(User03);
+        Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project05));
+
+        Assert.That(project.Texts.First().Permissions[User03], Is.EqualTo(TextInfoPermission.Read));
+        Assert.That(project.Texts.First().Chapters.First().Permissions[User03], Is.EqualTo(TextInfoPermission.Write));
+
+        resource = env.GetProject(Resource01);
+        Assert.That(
+            resource.UserRoles.TryGetValue(User03, out string resourceUserRole),
+            Is.True,
+            "user should have been added to resource"
+        );
+        Assert.That(resourceUserRole, Is.EqualTo(SFProjectRole.PTObserver), "user role not set correctly on resource");
+        Assert.That(user.Sites[SiteId].Projects, Contains.Item(Resource01), "user not added to resource correctly");
+        Assert.That(resource.Texts.First().Permissions[User03], Is.EqualTo(userDBLPermissionForResource));
+        Assert.That(
+            resource.Texts.First().Chapters.First().Permissions[User03],
+            Is.EqualTo(userDBLPermissionForResource)
+        );
+    }
+
+    [Test]
+    public async Task CheckLinkSharingAsync_NonPTUser()
+    {
+        var env = new TestEnvironment();
+        SFProject project = env.GetProject(Project05);
+
+        Assert.That(
+            env.UserSecrets.Contains(User04),
+            Is.False,
+            "setup. Non-PT user is not expected to have user secrets."
+        );
+        User user = env.GetUser(User04);
+        Assert.That(user.ParatextId, Is.Null, "setup. Non-PT user should not have a PT User ID.");
+
+        Assert.That(project.UserRoles.ContainsKey(User04), Is.False, "setup");
+        Assert.That(project.Texts.First().Permissions.ContainsKey(User04), Is.False, "setup");
+        Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User04), Is.False, "setup");
+
+        // SUT
+        await env.Service.CheckLinkSharingAsync(User04, Project05, "key12345");
+
+        project = env.GetProject(Project05);
+        Assert.That(project.UserRoles.TryGetValue(User04, out string userRole), Is.True, "user was added to project");
+        Assert.That(userRole, Is.EqualTo(SFProjectRole.CommunityChecker));
+        user = env.GetUser(User04);
+        Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project05));
+
+        Assert.That(
+            project.Texts.First().Permissions.ContainsKey(User04),
+            Is.False,
+            "no permissions should have been specified for user"
+        );
+        Assert.That(
+            project.Texts.First().Chapters.First().Permissions.ContainsKey(User04),
+            Is.False,
+            "no permissions should have been specified for user"
+        );
+
+        // The get permission methods shouldn't have even been called.
+        await env.ParatextService
+            .DidNotReceiveWithAnyArgs()
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Any<SFProject>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                Arg.Any<int>()
             );
-            project = env.GetProject(Project03);
-            Assert.That(project.CheckingConfig.ShareEnabled, Is.False, "setup");
-            await env.Service.CheckLinkSharingAsync(User03, Project03, "key1234");
+        await env.ParatextService
+            .DidNotReceiveWithAnyArgs()
+            .GetResourcePermissionAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
 
-            project = env.GetProject(Project03);
-            projectSecret = env.ProjectSecrets.Get(Project03);
-            Assert.That(project.UserRoles.ContainsKey(User03), Is.True, "User should have been added to project");
-            Assert.That(
-                projectSecret.ShareKeys.Any(sk => sk.Key == "key1234"),
-                Is.False,
-                "Key should have been removed from project"
+    [Test]
+    public async Task CheckLinkSharingAsync_PTUserButNotOfThisProjectAndCannotReadResource()
+    {
+        // The user joining the project _is_ a PT user, but they do not have a PT role on this particular project.
+        // Further, they do not have permission to read the DBL resource.
+
+        var env = new TestEnvironment();
+        string project05PTId = "paratext_" + Project05;
+        SFProject project = env.GetProject(Project05);
+        SFProject resource = env.GetProject(Resource01);
+
+        Assert.That(
+            env.UserSecrets.Contains(User03),
+            Is.True,
+            "setup. This is a PT user and is expected to have user secrets."
+        );
+        User user = env.GetUser(User03);
+        Assert.That(user.ParatextId, Is.Not.Null, "setup. PT user should have a PT User ID.");
+
+        Assert.That(
+            project.UserRoles.ContainsKey(User03),
+            Is.False,
+            "setup. User should not already be on the project."
+        );
+        Assert.That(
+            project.Texts.First().Permissions.ContainsKey(User03),
+            Is.False,
+            "setup. User should not already have permissions on the project."
+        );
+        Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
+        Assert.That(
+            resource.UserRoles.ContainsKey(User03),
+            Is.False,
+            "setup. User should not already be on the project."
+        );
+        Assert.That(
+            resource.Texts.First().Permissions.ContainsKey(User03),
+            Is.False,
+            "setup. User should not have permissions."
+        );
+        Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
+
+        // If the user is not a member of the paratext project, then
+        // "GET https://registry-dev.paratext.org/api8/projects/PT_PROJECT_ID/members" will return a 404 Not Found,
+        // and in ParatextService.CallApiAsync() there originates a System.Net.Http.HttpRequestException or perhaps
+        // EdjCase.JsonRpc.Common.RpcException. Our test should not end up doing down a path that causes this
+        // exception.
+        env.ParatextService
+            .GetParatextUsernameMappingAsync(
+                Arg.Is<UserSecret>((UserSecret userSecret) => userSecret.Id == User03),
+                Arg.Is((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(
+                Task.FromException<IReadOnlyDictionary<string, string>>(new System.Net.Http.HttpRequestException())
             );
-        }
 
-        [Test]
-        public async Task CheckLinkSharingAsync_PTUserHasPTPermissions()
+        string userRoleOnPTProject = null;
+        env.ParatextService
+            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Attempt.Failure(userRoleOnPTProject)));
+        string userDBLPermissionForResource = TextInfoPermission.None;
+        env.ParatextService
+            .GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
+            .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
+
+        env.ParatextService
+            .GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>())
+            .Returns(x => throw new Exception("Probably can not do this."));
+
+        // PT could answer with these permissions.
+        var ptBookPermissions = new Dictionary<string, string>()
         {
-            // If a user is invited to a project, and goes to the invitation link, the user being added to the project
-            // should have their PT permissions for text books and chapters.
+            { User02, TextInfoPermission.Read },
+            { User01, TextInfoPermission.Read },
+        };
+        var ptChapterPermissions = new Dictionary<string, string>()
+        {
+            { User02, TextInfoPermission.Write },
+            { User01, TextInfoPermission.Read },
+        };
+        var ptSourcePermissions = new Dictionary<string, string>()
+        {
+            { User02, TextInfoPermission.Read },
+            { User01, TextInfoPermission.Read },
+        };
+        const int bookValueToIndicateWholeResource = 0;
+        const int chapterValueToIndicateWholeBook = 0;
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                chapterValueToIndicateWholeBook
+            )
+            .Returns(Task.FromResult(ptBookPermissions));
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                Arg.Is<int>((int arg) => arg > 0)
+            )
+            .Returns(Task.FromResult(ptChapterPermissions));
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                bookValueToIndicateWholeResource,
+                chapterValueToIndicateWholeBook
+            )
+            .Returns(Task.FromResult(ptSourcePermissions));
 
-            var env = new TestEnvironment();
-            string project05PTId = "paratext_" + Project05;
-            SFProject project = env.GetProject(Project05);
-            SFProject resource = env.GetProject(Resource01);
+        // SUT
+        await env.Service.CheckLinkSharingAsync(User03, Project05, "key12345");
 
-            Assert.That(env.UserSecrets.Contains(User03), Is.True, "setup. PT user should have user secrets.");
-            User user = env.GetUser(User03);
-            Assert.That(user.ParatextId, Is.Not.Null, "setup. PT user should have a PT User ID.");
+        project = env.GetProject(Project05);
+        Assert.That(
+            project.UserRoles.TryGetValue(User03, out string userRole),
+            Is.True,
+            "user should have been added to project"
+        );
+        Assert.That(userRole, Is.EqualTo(SFProjectRole.CommunityChecker));
+        user = env.GetUser(User03);
+        Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project05), "user not added to project correctly");
 
-            string userRoleOnPTProject = SFProjectRole.Translator;
-            Assert.That(
-                userRoleOnPTProject,
-                Is.Not.EqualTo(SFProjectRole.CommunityChecker),
-                "setup. role should be different than community checker for purposes of part of what this test is testing."
+        Assert.That(
+            project.Texts.First().Permissions.ContainsKey(User03),
+            Is.False,
+            "no project permissions should have been specified for user"
+        );
+        Assert.That(
+            project.Texts.First().Chapters.First().Permissions.ContainsKey(User03),
+            Is.False,
+            "no project permissions should have been specified for user"
+        );
+
+        // User03 is not added to the target or source, nor do they have any permissions listed in the source.
+        resource = env.GetProject(Resource01);
+        Assert.That(
+            resource.UserRoles.ContainsKey(User03),
+            Is.False,
+            "user should not have been added to resource project"
+        );
+        Assert.That(
+            resource.Texts.First().Permissions.ContainsKey(User03),
+            Is.False,
+            "user should not have permissions to resource"
+        );
+        Assert.That(
+            resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03),
+            Is.False,
+            "user should not have permissions to resource"
+        );
+        Assert.That(user.Sites[SiteId].Projects, Does.Not.Contain(Resource01), "user should not have been added to");
+
+        // With the current implementation, both ParatextService.GetPermissionsAsync(for the source resource) and
+        // ParatextService.GetPermissionsAsync(for the target project) should be called never. In a future change to
+        // the SUT, it's okay if it is called, as long as the permissions don't get applied. But for now, not
+        // getting called is a helpful indication of expected operation.
+        // The mocks above regarding env.ParatextService.GetPermissionsAsync(for the target project) are left in
+        // place in case they begin to be used.
+        await env.ParatextService
+            .DidNotReceive()
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject sfProject) => sfProject.Id == Project05),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                Arg.Any<int>()
             );
-            string shareKeyCode = "key12345";
-            ShareKey shareKeyForUserInvitation = env.ProjectSecrets
-                .Get(project.Id)
-                .ShareKeys.First((ShareKey shareKey) => shareKey.Key == shareKeyCode);
-            Assert.That(
-                shareKeyForUserInvitation.ProjectRole,
-                Is.EqualTo(SFProjectRole.CommunityChecker),
-                "setup. the user should be being invited as a community checker."
+        await env.ParatextService
+            .DidNotReceive()
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject sfProject) => sfProject.Id == Resource01),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                Arg.Any<int>()
             );
-            env.ParatextService
-                .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(Attempt.Success(userRoleOnPTProject)));
-            string userDBLPermissionForResource = TextInfoPermission.Read;
-            env.ParatextService
-                .GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
-                .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
 
-            Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
-            Assert.That(project.Texts.First().Permissions.ContainsKey(User03), Is.False, "setup");
-            Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
-            Assert.That(resource.UserRoles.ContainsKey(User03), Is.False, "setup");
-            Assert.That(project.Texts.First().Permissions.ContainsKey(User03), Is.False, "setup");
-            Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
+        // We may not be able to query a book list for the target project without the user having a PT project role,
+        // or of the DBL resource, without the user having read permission.
+        env.ParatextService.DidNotReceive().GetBookList(Arg.Any<UserSecret>(), project05PTId);
+        env.ParatextService.DidNotReceive().GetBookList(Arg.Any<UserSecret>(), Resource01PTId);
+    }
 
-            var bookList = new List<int>() { 40, 41 };
-            env.ParatextService.GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(bookList);
+    [Test]
+    public async Task CheckLinkSharingAsync_PTUserButNotOfThisProjectYetReadsResource()
+    {
+        // The user joining the project _is_ a PT user, but they do not have a PT role on this particular project.
+        // Though they do have permission to read the DBL resource.
 
-            // PT will answer with these permissions.
-            var ptBookPermissions = new Dictionary<string, string>()
+        var env = new TestEnvironment();
+        string project05PTId = "paratext_" + Project05;
+        SFProject project = env.GetProject(Project05);
+        SFProject resource = env.GetProject(Resource01);
+
+        Assert.That(
+            env.UserSecrets.Contains(User03),
+            Is.True,
+            "setup. This is a PT user and is expected to have user secrets."
+        );
+        User user = env.GetUser(User03);
+        Assert.That(user.ParatextId, Is.Not.Null, "setup. PT user should have a PT User ID.");
+
+        Assert.That(
+            project.UserRoles.ContainsKey(User03),
+            Is.False,
+            "setup. User should not already be on the project."
+        );
+        Assert.That(
+            project.Texts.First().Permissions.ContainsKey(User03),
+            Is.False,
+            "setup. User should not already have permissions on the project."
+        );
+        Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
+        Assert.That(
+            resource.UserRoles.ContainsKey(User03),
+            Is.False,
+            "setup. User should not already be on the project, for purposes of testing that they are later."
+        );
+        Assert.That(
+            resource.Texts.First().Permissions.ContainsKey(User03),
+            Is.False,
+            "setup. User should not already have permissions."
+        );
+        Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
+
+        env.ParatextService
+            .GetParatextUsernameMappingAsync(
+                Arg.Is<UserSecret>((UserSecret userSecret) => userSecret.Id == User03),
+                Arg.Is((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(
+                Task.FromException<IReadOnlyDictionary<string, string>>(new System.Net.Http.HttpRequestException())
+            );
+
+        string userRoleOnPTProject = null;
+        env.ParatextService
+            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Attempt.Failure(userRoleOnPTProject)));
+        string userDBLPermissionForResource = TextInfoPermission.Read;
+        env.ParatextService
+            .GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
+            .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
+
+        var bookList = new List<int>() { 40, 41 };
+        env.ParatextService.GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(bookList);
+
+        // PT could answer with these permissions.
+        var ptBookPermissions = new Dictionary<string, string>()
+        {
+            { User02, TextInfoPermission.Read },
+            { User01, TextInfoPermission.Read },
+        };
+        var ptChapterPermissions = new Dictionary<string, string>()
+        {
+            { User02, TextInfoPermission.Write },
+            { User01, TextInfoPermission.Read },
+        };
+        var ptSourcePermissions = new Dictionary<string, string>()
+        {
+            { User03, userDBLPermissionForResource },
+            { User02, TextInfoPermission.Read },
+            { User01, TextInfoPermission.Read },
+        };
+        const int bookValueToIndicateWholeResource = 0;
+        const int chapterValueToIndicateWholeBook = 0;
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                chapterValueToIndicateWholeBook
+            )
+            .Returns(Task.FromResult(ptBookPermissions));
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                Arg.Is<int>((int arg) => arg > 0)
+            )
+            .Returns(Task.FromResult(ptChapterPermissions));
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                bookValueToIndicateWholeResource,
+                chapterValueToIndicateWholeBook
+            )
+            .Returns(Task.FromResult(ptSourcePermissions));
+
+        // SUT
+        await env.Service.CheckLinkSharingAsync(User03, Project05, "key12345");
+
+        project = env.GetProject(Project05);
+        Assert.That(
+            project.UserRoles.TryGetValue(User03, out string userRole),
+            Is.True,
+            "user should have been added to project"
+        );
+        Assert.That(userRole, Is.EqualTo(SFProjectRole.CommunityChecker));
+        user = env.GetUser(User03);
+        Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project05), "user not added to project correctly");
+
+        Assert.That(
+            project.Texts.First().Permissions.ContainsKey(User03),
+            Is.False,
+            "no project permissions should have been specified for user"
+        );
+        Assert.That(
+            project.Texts.First().Chapters.First().Permissions.ContainsKey(User03),
+            Is.False,
+            "no project permissions should have been specified for user"
+        );
+
+        // User03 is not on project project05PTId, but they have access to the source resource. So
+        // UpdatePermissionsAsync() should be inquiring about this and setting permissions as appropriate.
+        await env.ParatextService
+            .Received()
+            .GetResourcePermissionAsync(Resource01PTId, User03, Arg.Any<CancellationToken>());
+        resource = env.GetProject(Resource01);
+        Assert.That(
+            resource.Texts.First().Permissions[User03],
+            Is.EqualTo(userDBLPermissionForResource),
+            "resource permissions should have been set for joining project user"
+        );
+        Assert.That(
+            resource.Texts.First().Chapters.First().Permissions[User03],
+            Is.EqualTo(userDBLPermissionForResource),
+            "resource permissions should have been set for joining project user"
+        );
+        Assert.That(
+            resource.UserRoles.TryGetValue(User03, out string resourceUserRole),
+            Is.True,
+            "user should have been added to resource"
+        );
+        Assert.That(resourceUserRole, Is.EqualTo(SFProjectRole.PTObserver), "user role not set correctly on resource");
+        Assert.That(user.Sites[SiteId].Projects, Contains.Item(Resource01), "user not added to resource correctly");
+
+        // With the current implementation, ParatextService.GetPermissionsAsync(for the source resource) should be
+        // called once, but ParatextService.GetPermissionsAsync(for the target project) should be called never. In
+        // a future change to the SUT, it's okay if it is called for the target project, as long as the permissions
+        // don't get applied. But for now, not getting called is a helpful indication of expected operation.
+        // The mocks above regarding env.ParatextService.GetPermissionsAsync(for the target project) are left in
+        // place in case they begin to be used.
+        await env.ParatextService
+            .DidNotReceive()
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject sfProject) => sfProject.Id == Project05),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                Arg.Any<int>()
+            );
+        await env.ParatextService
+            .Received(1)
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject sfProject) => sfProject.Id == Resource01),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                Arg.Any<int>()
+            );
+
+        // We may not be able to query a book list for the target project without the user having a PT project role.
+        env.ParatextService.DidNotReceive().GetBookList(Arg.Any<UserSecret>(), project05PTId);
+        env.ParatextService.Received(1).GetBookList(Arg.Any<UserSecret>(), Resource01PTId);
+    }
+
+    [Test]
+    public void CheckLinkSharingAsync_ObserverInvitedToProject_AddedToProject()
+    {
+        var env = new TestEnvironment();
+        SFProject project = env.GetProject(Project04);
+        Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
+
+        Assert.DoesNotThrowAsync(() => env.Service.CheckLinkSharingAsync(User03, Project04, "linksharing04"));
+        project = env.GetProject(Project04);
+        Assert.That(project.UserRoles.ContainsKey(User03), Is.True, "user should be added to project");
+    }
+
+    [Test]
+    public async Task IsAlreadyInvitedAsync_BadInput_False()
+    {
+        var env = new TestEnvironment();
+
+        Assert.That(await env.Service.IsAlreadyInvitedAsync(User01, Project03, null), Is.False);
+
+        Assert.That(await env.Service.IsAlreadyInvitedAsync(User01, Project03, ""), Is.False);
+
+        Assert.That(await env.Service.IsAlreadyInvitedAsync(User01, Project03, "junk"), Is.False);
+
+        Assert.That(await env.Service.IsAlreadyInvitedAsync(User02, Project02, "nothing"), Is.False);
+    }
+
+    [Test]
+    public async Task IsAlreadyInvitedAsync_IsInvited_True()
+    {
+        var env = new TestEnvironment();
+
+        Assert.That(await env.Service.IsAlreadyInvitedAsync(User01, Project03, "bob@example.com"), Is.True);
+    }
+
+    [Test]
+    public async Task IsAlreadyInvitedAsync_NotInvitedButOnProject_False()
+    {
+        var env = new TestEnvironment();
+        Assert.That(
+            env.GetProject(Project03).UserRoles.GetValueOrDefault(User01, null),
+            Is.EqualTo(SFProjectRole.Administrator)
+        );
+        Assert.That(await env.Service.IsAlreadyInvitedAsync(User01, Project03, "user01@example.com"), Is.False);
+        Assert.That(
+            env.GetProject(Project02).UserRoles.GetValueOrDefault(User04, null),
+            Is.EqualTo(SFProjectRole.CommunityChecker)
+        );
+        Assert.That(await env.Service.IsAlreadyInvitedAsync(User04, Project02, "user01@example.com"), Is.False);
+    }
+
+    [Test]
+    public async Task IsAlreadyInvitedAsync_NotInvitedOrOnProject_False()
+    {
+        var env = new TestEnvironment();
+
+        Assert.That(await env.Service.IsAlreadyInvitedAsync(User01, Project03, "unheardof@example.com"), Is.False);
+        Assert.That(await env.Service.IsAlreadyInvitedAsync(User04, Project02, "nobody@example.com"), Is.False);
+    }
+
+    [Test]
+    public void IsAlreadyInvitedAsync_CheckingDisabledButCheckingSharingEnabled_Forbidden()
+    {
+        var env = new TestEnvironment();
+        Assert.That(env.GetProject(Project06).CheckingConfig.CheckingEnabled, Is.False);
+        Assert.That(env.GetProject(Project06).CheckingConfig.ShareEnabled, Is.True);
+        Assert.That(
+            env.GetProject(Project06).UserRoles.GetValueOrDefault(User01, null),
+            Is.EqualTo(SFProjectRole.CommunityChecker)
+        );
+
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.IsAlreadyInvitedAsync(User01, Project06, "user@example.com")
+        );
+    }
+
+    [Test]
+    public async Task IsAlreadyInvitedAsync_CheckingSharingDisabledTranslateSharingEnabled_False()
+    {
+        var env = new TestEnvironment();
+        Assert.That(env.GetProject(Project04).CheckingConfig.ShareEnabled, Is.False);
+        Assert.That(env.GetProject(Project04).TranslateConfig.ShareEnabled, Is.True);
+        Assert.That(await env.Service.IsAlreadyInvitedAsync(User01, Project04, "user@example.com"), Is.False);
+    }
+
+    [Test]
+    public void IsAlreadyInvitedAsync_InvitingUserNotOnProject_Forbidden()
+    {
+        var env = new TestEnvironment();
+        Assert.That(env.GetProject(Project02).CheckingConfig.CheckingEnabled, Is.True);
+        Assert.That(env.GetProject(Project02).CheckingConfig.ShareEnabled, Is.True);
+        Assert.That(env.GetProject(Project02).UserRoles.GetValueOrDefault(User01, null), Is.Null);
+
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.IsAlreadyInvitedAsync(User01, Project02, "user@example.com")
+        );
+    }
+
+    [Test]
+    public async Task InvitedUsers_Reports()
+    {
+        var env = new TestEnvironment();
+        // Project with no outstanding invitations
+        Assert.That((await env.Service.InvitedUsersAsync(User01, Project01)).Count, Is.EqualTo(0));
+
+        // Project with one specific shareKey and one link sharing shareKey record
+        IReadOnlyList<InviteeStatus> invitees = await env.Service.InvitedUsersAsync(User02, Project02);
+        Assert.That(invitees.Count, Is.EqualTo(1));
+        Assert.That(invitees.Select(i => i.Email), Is.EquivalentTo(new string[] { "user03@example.com" }));
+
+        // Project with several outstanding invitations
+        invitees = await env.Service.InvitedUsersAsync(User01, Project03);
+        Assert.That(invitees.Count, Is.EqualTo(4));
+        string[] expectedEmailList =
+        {
+            "bob@example.com",
+            "expired@example.com",
+            "user03@example.com",
+            "bill@example.com"
+        };
+        Assert.That(invitees.Select(i => i.Email), Is.EquivalentTo(expectedEmailList));
+    }
+
+    [Test]
+    public void InvitedUsers_SystemAdmin_NoSpecialAccess()
+    {
+        var env = new TestEnvironment();
+
+        // User04 is a system admin, but not a project-admin or even a user on Project03
+        Assert.That(env.GetProject(Project03).UserRoles.ContainsKey(User04), Is.False, "test setup");
+        Assert.That(env.GetUser(User04).Role, Is.EqualTo(SystemRole.SystemAdmin), "test setup");
+
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => (env.Service.InvitedUsersAsync(User04, Project03)),
+            "should have been forbidden"
+        );
+    }
+
+    [Test]
+    public void InvitedUsers_NonProjectAdmin_Forbidden()
+    {
+        var env = new TestEnvironment();
+        // User02 is not an admin on Project01
+        Assert.That(
+            env.GetProject(Project01).UserRoles[User02],
+            Is.Not.EqualTo(SFProjectRole.Administrator),
+            "test setup"
+        );
+        Assert.That(env.GetUser(User02).Role, Is.Not.EqualTo(SystemRole.SystemAdmin), "test setup");
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.InvitedUsersAsync(User02, Project01),
+            "should have been forbidden"
+        );
+    }
+
+    [Test]
+    public void InvitedUsers_BadProject_Error()
+    {
+        var env = new TestEnvironment();
+
+        Assert.ThrowsAsync<DataNotFoundException>(() => env.Service.InvitedUsersAsync(User02, "bad-project-id"));
+    }
+
+    [Test]
+    public void InvitedUsers_BadUser_Forbidden()
+    {
+        var env = new TestEnvironment();
+
+        Assert.ThrowsAsync<ForbiddenException>(() => env.Service.InvitedUsersAsync("bad-user-id", Project01));
+    }
+
+    [Test]
+    public void UninviteUser_BadProject_Error()
+    {
+        var env = new TestEnvironment();
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.UninviteUserAsync(User02, "nonexistent-project", "some@email.com")
+        );
+    }
+
+    [Test]
+    public void UninviteUser_NonProjectAdmin_Error()
+    {
+        var env = new TestEnvironment();
+        // User02 is not an admin on Project01
+        Assert.That(
+            env.GetProject(Project01).UserRoles[User02],
+            Is.Not.EqualTo(SFProjectRole.Administrator),
+            "test setup"
+        );
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.UninviteUserAsync(User02, Project01, "some@email.com"),
+            "should have been forbidden"
+        );
+    }
+
+    [Test]
+    public async Task UninviteUser_BadEmail_Ignored()
+    {
+        var env = new TestEnvironment();
+        var initialInvitationCount = 4;
+        Assert.That(
+            (await env.ProjectSecrets.GetAsync(Project03)).ShareKeys.Count,
+            Is.EqualTo(initialInvitationCount),
+            "test setup"
+        );
+
+        await env.Service.UninviteUserAsync(User01, Project03, "unknown@email.com");
+        Assert.That(
+            (await env.ProjectSecrets.GetAsync(Project03)).ShareKeys.Count,
+            Is.EqualTo(initialInvitationCount),
+            "should not have changed"
+        );
+    }
+
+    [Test]
+    public async Task UninviteUser_RemovesInvitation()
+    {
+        var env = new TestEnvironment();
+        var initialInvitationCount = 4;
+        Assert.That(
+            (await env.ProjectSecrets.GetAsync(Project03)).ShareKeys.Count,
+            Is.EqualTo(initialInvitationCount),
+            "test setup"
+        );
+        Assert.That(
+            (await env.ProjectSecrets.GetAsync(Project03)).ShareKeys.Any(sk => sk.Email == "bob@example.com"),
+            Is.True,
+            "test setup"
+        );
+        Assert.That(
+            (await env.ProjectSecrets.GetAsync(Project03)).ShareKeys.Count,
+            Is.EqualTo(initialInvitationCount),
+            "test setup"
+        );
+
+        await env.Service.UninviteUserAsync(User01, Project03, "bob@example.com");
+        Assert.That(
+            (await env.ProjectSecrets.GetAsync(Project03)).ShareKeys.Count,
+            Is.EqualTo(initialInvitationCount - 1),
+            "unexpected number of outstanding invitations"
+        );
+        Assert.That(
+            (await env.ProjectSecrets.GetAsync(Project03)).ShareKeys.Any(sk => sk.Email == "bob@example.com"),
+            Is.False,
+            "should not still have uninvited email address"
+        );
+    }
+
+    [Test]
+    public void UninviteUser_SystemAdmin_NoSpecialAccess()
+    {
+        var env = new TestEnvironment();
+        // User04 is a system admin, but not a project-admin or even a user on Project03
+        Assert.That(env.GetProject(Project03).UserRoles.ContainsKey(User04), Is.False, "test setup");
+        Assert.That(env.GetUser(User04).Role, Is.EqualTo(SystemRole.SystemAdmin), "test setup");
+
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.UninviteUserAsync(User04, Project03, "bob@example.com"),
+            "should have been forbidden"
+        );
+    }
+
+    [Test]
+    public async Task AddUserAsync_ShareKeyExists_AddsUserAndRemovesKey()
+    {
+        var env = new TestEnvironment();
+        SFProject project = env.GetProject(Project03);
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
+
+        Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
+        Assert.That(projectSecret.ShareKeys.Any(sk => sk.Key == "key1234"), Is.True, "setup");
+        env.ParatextService
+            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Translator)));
+
+        await env.Service.AddUserAsync(User03, Project03, null);
+        project = env.GetProject(Project03);
+        projectSecret = env.ProjectSecrets.Get(Project03);
+        Assert.That(project.UserRoles.ContainsKey(User03), Is.True, "User should have been added to project");
+        Assert.That(
+            projectSecret.ShareKeys.Any(sk => sk.Key == "key1234"),
+            Is.False,
+            "Key should have been removed from project"
+        );
+    }
+
+    [Test]
+    public void AddUserAsync_SourceProjectUnavailable_SkipProject()
+    {
+        var env = new TestEnvironment();
+        env.ParatextService
+            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), CancellationToken.None)
+            .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Translator)));
+        Assert.DoesNotThrowAsync(() => env.Service.AddUserAsync(User03, Project04, SFProjectRole.Translator));
+        var project = env.GetProject(Project04);
+        Assert.That(project.UserRoles[User03], Is.EqualTo(SFProjectRole.Translator));
+    }
+
+    [Test]
+    public async Task AddUserAsync_PTUserHasPTPermissions()
+    {
+        // If a user connects to an existing project from the Connect Project page, project text permissions should
+        // be updated, so that the connecting user has permissions set that are from PT.
+
+        var env = new TestEnvironment();
+        string project05PTId = "paratext_" + Project05;
+        SFProject project = env.GetProject(Project05);
+        SFProject resource = env.GetProject(Resource01);
+
+        Assert.That(env.UserSecrets.Contains(User03), Is.True, "setup. PT user should have user secrets.");
+        User user = env.GetUser(User03);
+        Assert.That(user.ParatextId, Is.Not.Null, "setup. PT user should have a PT User ID.");
+
+        Assert.That(
+            project.UserRoles.ContainsKey(User03),
+            Is.False,
+            "setup. User should not already be on the project."
+        );
+        Assert.That(
+            project.Texts.First().Permissions.ContainsKey(User03),
+            Is.False,
+            "setup. User should not already have permissions on the project."
+        );
+        Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
+        Assert.That(
+            resource.UserRoles.ContainsKey(User03),
+            Is.False,
+            "setup. User should not already be on the project, for purposes of testing that they are later."
+        );
+        Assert.That(
+            resource.Texts.First().Permissions.ContainsKey(User03),
+            Is.False,
+            "setup. User should not already have permissions."
+        );
+        Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
+
+        string userRoleOnPTProject = SFProjectRole.Translator;
+        env.ParatextService
+            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Attempt.Success(userRoleOnPTProject)));
+        string userDBLPermissionForResource = TextInfoPermission.Read;
+        env.ParatextService
+            .GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
+            .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
+
+        var bookList = new List<int>() { 40, 41 };
+        env.ParatextService.GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(bookList);
+
+        // PT will answer with these permissions.
+        var ptBookPermissions = new Dictionary<string, string>()
+        {
+            { User03, TextInfoPermission.Read },
+            { User01, TextInfoPermission.Read },
+        };
+        var ptChapterPermissions = new Dictionary<string, string>()
+        {
+            { User03, TextInfoPermission.Write },
+            { User01, TextInfoPermission.Read },
+        };
+        var ptSourcePermissions = new Dictionary<string, string>()
+        {
+            { User03, TextInfoPermission.Read },
+            { User01, TextInfoPermission.None },
+        };
+        const int bookValueToIndicateWholeResource = 0;
+        const int chapterValueToIndicateWholeBook = 0;
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                chapterValueToIndicateWholeBook
+            )
+            .Returns(Task.FromResult(ptBookPermissions));
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                Arg.Is<int>((int arg) => arg > 0)
+            )
+            .Returns(Task.FromResult(ptChapterPermissions));
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                bookValueToIndicateWholeResource,
+                chapterValueToIndicateWholeBook
+            )
+            .Returns(Task.FromResult(ptSourcePermissions));
+
+        string projectRoleSpecifiedFromConnectProjectPage = null;
+
+        // SUT
+        await env.Service.AddUserAsync(User03, Project05, projectRoleSpecifiedFromConnectProjectPage);
+
+        project = env.GetProject(Project05);
+        Assert.That(
+            project.UserRoles.TryGetValue(User03, out string userRole),
+            Is.True,
+            "user should be added to project"
+        );
+        Assert.That(userRole, Is.EqualTo(userRoleOnPTProject));
+        user = env.GetUser(User03);
+        Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project05));
+
+        Assert.That(project.Texts.First().Permissions[User03], Is.EqualTo(TextInfoPermission.Read));
+        Assert.That(project.Texts.First().Chapters.First().Permissions[User03], Is.EqualTo(TextInfoPermission.Write));
+
+        resource = env.GetProject(Resource01);
+        Assert.That(resource.Texts.First().Permissions[User03], Is.EqualTo(userDBLPermissionForResource));
+        Assert.That(
+            resource.Texts.First().Chapters.First().Permissions[User03],
+            Is.EqualTo(userDBLPermissionForResource)
+        );
+        Assert.That(
+            resource.UserRoles.TryGetValue(User03, out string resourceUserRole),
+            Is.True,
+            "user should have been added to resource"
+        );
+        Assert.That(resourceUserRole, Is.EqualTo(SFProjectRole.PTObserver), "user role not set correctly on resource");
+        Assert.That(user.Sites[SiteId].Projects, Contains.Item(Resource01), "user not added to resource correctly");
+    }
+
+    [Test]
+    public async Task AddUserAsync_HasSourceProjectRole_AddedToSourceProject()
+    {
+        var env = new TestEnvironment();
+        SFProject project03 = env.GetProject(Project03);
+        SFProject source = env.GetProject(SourceOnly);
+        Assert.That(project03.UserRoles.ContainsKey(User03), Is.False, "setup");
+        Assert.That(source.UserRoles.ContainsKey(User03), Is.False, "setup");
+        User user = env.GetUser(User03);
+        Assert.That(user.Sites[SiteId].Projects, Is.Empty);
+        env.ParatextService
+            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), CancellationToken.None)
+            .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Translator)));
+
+        await env.Service.AddUserAsync(User03, Project03, SFProjectRole.Translator);
+        project03 = env.GetProject(Project03);
+        source = env.GetProject(SourceOnly);
+        Assert.That(project03.UserRoles.ContainsKey(User03));
+        Assert.That(source.UserRoles.ContainsKey(User03));
+        user = env.GetUser(User03);
+        Assert.That(user.Sites[SiteId].Projects, Is.EquivalentTo(new[] { Project03, SourceOnly }));
+    }
+
+    [Test]
+    public async Task UpdatePermissionsAsync_SkipsBookNotInDB()
+    {
+        // If a user connects a new project, and we seek to set permissions for the user before actually
+        // synchronizing the Scripture text, then we are missing texts on which to set permissions when running
+        // UpdatePermissionsAsync(). So silently ignore missing books.
+        // It also is conceivable that a race could occur where (1) a book is added in Paratext and SendReceived
+        // to the Paratext servers, (2) a SF user clicks Synchronize in SF, (3) SF RunAsync() gets as far as
+        // running ParatextService.SendReceiveAsync(), but doesn't yet add the new book from PT into the SF DB.
+        // (4) Another SF user joins the SF project, causing UpdatePermissionsAsync() to be called.
+        // (5) UpdatePermissionsAsync() queries for ParatextService.GetBookList(), and then tries to find the
+        // books (including the new book) in the SF project. (6) It doesn't find the new book in SF.
+        // Silently ignoring this situation will prevent a crash from 6. And whether the new user will have
+        // permissions for the new book and its chapters will depend on how smart ParatextSyncRunner's project doc
+        // is.
+
+        string project01PTId = "paratext_" + Project01;
+        var env = new TestEnvironment();
+        SFProject sfProject = env.GetProject(Project01);
+        // The SF DB should only have 2 books
+        Assert.That(sfProject.Texts.Count, Is.LessThan(3), "setup");
+
+        // But PT reports that there are 3 books.
+        env.ParatextService.GetBookList(Arg.Any<UserSecret>(), project01PTId).Returns(new List<int>() { 40, 41, 42 });
+
+        var ptBookPermissions = new Dictionary<string, string>()
+        {
+            { User01, TextInfoPermission.Read },
+            { User02, TextInfoPermission.Write },
+        };
+        var ptChapterPermissions = new Dictionary<string, string>()
+        {
+            { User01, TextInfoPermission.Write },
+            { User02, TextInfoPermission.Read },
+        };
+        const int chapterValueToIndicateWholeBook = 0;
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                chapterValueToIndicateWholeBook
+            )
+            .Returns(Task.FromResult(ptBookPermissions));
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                Arg.Is<int>((int arg) => arg > 0)
+            )
+            .Returns(Task.FromResult(ptChapterPermissions));
+
+        sfProject = env.GetProject(Project01);
+        Assert.That(sfProject.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
+        Assert.That(sfProject.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
+
+        await using IConnection conn = await env.RealtimeService.ConnectAsync(User01);
+        IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
+
+        // SUT
+        await env.Service.UpdatePermissionsAsync(User01, project01Doc, CancellationToken.None);
+
+        // Permissions were set for the books and chapters that we were able to handle.
+        sfProject = env.GetProject(Project01);
+        Assert.That(sfProject.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
+        Assert.That(sfProject.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Write));
+        Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Write));
+        Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Read));
+
+        // SF should still only have the 2 books.
+        Assert.That(sfProject.Texts.Count, Is.LessThan(3), "surprise");
+    }
+
+    [Test]
+    public async Task UpdatePermissionsAsync_ThrowsIfUserHasNoSecrets()
+    {
+        string project01PTId = "paratext_" + Project01;
+        var env = new TestEnvironment();
+        env.ParatextService.GetBookList(Arg.Any<UserSecret>(), project01PTId).Returns(new List<int>() { 40, 41 });
+        Assert.That(env.ProjectSecrets.Contains(User04), Is.False, "setup");
+
+        await using IConnection conn = await env.RealtimeService.ConnectAsync(User04);
+        IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.UpdatePermissionsAsync(User04, project01Doc, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public async Task UpdatePermissionsAsync_SetsBookAndChapterPermissions()
+    {
+        var env = new TestEnvironment();
+        string project01PTId = "paratext_" + Project01;
+
+        env.ParatextService.GetBookList(Arg.Any<UserSecret>(), project01PTId).Returns(new List<int>() { 40, 41 });
+
+        var ptBookPermissions = new Dictionary<string, string>
+        {
+            { User01, TextInfoPermission.Read },
+            { User02, TextInfoPermission.Write },
+        };
+        var ptChapterPermissions = new Dictionary<string, string>
+        {
+            { User01, TextInfoPermission.Write },
+            { User02, TextInfoPermission.Read },
+        };
+        const int chapterValueToIndicateWholeBook = 0;
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                chapterValueToIndicateWholeBook
+            )
+            .Returns(Task.FromResult(ptBookPermissions));
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                Arg.Is<int>((int arg) => arg > 0)
+            )
+            .Returns(Task.FromResult(ptChapterPermissions));
+
+        SFProject sfProject = env.GetProject(Project01);
+        Assert.That(sfProject.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
+        Assert.That(sfProject.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
+
+        await using IConnection conn = await env.RealtimeService.ConnectAsync(User01);
+        IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
+
+        // SUT
+        await env.Service.UpdatePermissionsAsync(User01, project01Doc, CancellationToken.None);
+
+        sfProject = env.GetProject(Project01);
+        Assert.That(sfProject.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
+        Assert.That(sfProject.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Write));
+        Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Write));
+        Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Read));
+    }
+
+    [Test]
+    public async Task UpdatePermissionsAsync_UserHasNoChapterPermission()
+    {
+        var env = new TestEnvironment();
+        string project01PTId = "paratext_" + Project01;
+
+        env.ParatextService.GetBookList(Arg.Any<UserSecret>(), project01PTId).Returns(new List<int>() { 40, 41 });
+
+        var ptBookPermissions = new Dictionary<string, string>
+        {
+            { User01, TextInfoPermission.Read },
+            { User02, TextInfoPermission.None },
+        };
+        var ptChapterPermissions = new Dictionary<string, string>
+        {
+            { User01, TextInfoPermission.Read },
+            { User02, TextInfoPermission.None },
+        };
+        const int chapterValueToIndicateWholeBook = 0;
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                chapterValueToIndicateWholeBook
+            )
+            .Returns(Task.FromResult(ptBookPermissions));
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                Arg.Is<int>((int arg) => arg > 0)
+            )
+            .Returns(Task.FromResult(ptChapterPermissions));
+
+        SFProject sfProject = env.GetProject(Project01);
+        Assert.That(sfProject.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
+        Assert.That(sfProject.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
+
+        await using IConnection conn = await env.RealtimeService.ConnectAsync(User01);
+        IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
+
+        // SUT
+        await env.Service.UpdatePermissionsAsync(User01, project01Doc, CancellationToken.None);
+
+        sfProject = env.GetProject(Project01);
+        Assert.That(sfProject.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
+        Assert.That(sfProject.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.None));
+        Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
+        Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User02], Is.EqualTo(TextInfoPermission.None));
+    }
+
+    [Test]
+    public async Task UpdatePermissionsAsync_SetsResourcePermissions()
+    {
+        var env = new TestEnvironment();
+        string project01PTId = "paratext_" + Project01;
+
+        var bookList = new List<int> { 40, 41 };
+        env.ParatextService.GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(bookList);
+
+        var ptBookPermissions = new Dictionary<string, string>
+        {
+            { User01, TextInfoPermission.Write },
+            { User02, TextInfoPermission.Write },
+        };
+        var ptChapterPermissions = new Dictionary<string, string>
+        {
+            { User01, TextInfoPermission.Write },
+            { User02, TextInfoPermission.Write },
+        };
+        var ptSourcePermissions = new Dictionary<string, string>
+        {
+            { User01, TextInfoPermission.Read },
+            { User02, TextInfoPermission.None },
+        };
+        const int bookValueToIndicateWholeResource = 0;
+        const int chapterValueToIndicateWholeBook = 0;
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                chapterValueToIndicateWholeBook
+            )
+            .Returns(Task.FromResult(ptBookPermissions));
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                Arg.Is<int>((int arg) => arg > 0)
+            )
+            .Returns(Task.FromResult(ptChapterPermissions));
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                bookValueToIndicateWholeResource,
+                chapterValueToIndicateWholeBook
+            )
+            .Returns(Task.FromResult(ptSourcePermissions));
+
+        SFProject sfProject = env.GetProject(Project01);
+        Assert.That(sfProject.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
+        Assert.That(sfProject.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
+
+        SFProject resource = env.GetProject(Resource01);
+        Assert.That(resource.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
+        Assert.That(resource.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
+
+        await using IConnection conn = await env.RealtimeService.ConnectAsync(User01);
+        IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
+        IDocument<SFProject> resource01Doc = await conn.FetchAsync<SFProject>(Resource01);
+
+        // SUT 1 - Setting target project permissions continues to work as expected.
+        await env.Service.UpdatePermissionsAsync(User01, project01Doc, CancellationToken.None);
+        // SUT 2 - Resource permissions are set.
+        await env.Service.UpdatePermissionsAsync(User01, resource01Doc, CancellationToken.None);
+
+        sfProject = env.GetProject(Project01);
+        resource = env.GetProject(Resource01);
+        Assert.That(sfProject.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Write));
+        Assert.That(sfProject.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Write));
+        Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Write));
+        Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Write));
+        Assert.That(resource.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
+        Assert.That(resource.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.None));
+        Assert.That(resource.Texts.First().Chapters.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
+        Assert.That(resource.Texts.First().Chapters.First().Permissions[User02], Is.EqualTo(TextInfoPermission.None));
+    }
+
+    [Test]
+    public void IsSourceProject_TrueWhenProjectIsATranslationSource()
+    {
+        var env = new TestEnvironment();
+        Assert.That(env.Service.IsSourceProject(Resource01), Is.True);
+        Assert.That(env.Service.IsSourceProject(Project01), Is.False);
+        Assert.That(env.Service.IsSourceProject(SourceOnly), Is.True);
+        Assert.That(env.Service.IsSourceProject("Bad project"), Is.False);
+    }
+
+    [Test]
+    public async Task UpdateSettingsAsync_ChangeSourceProject_RecreateMachineProjectAndSync()
+    {
+        var env = new TestEnvironment();
+
+        await env.Service.UpdateSettingsAsync(
+            User01,
+            Project01,
+            new SFProjectSettings { SourceParatextId = "changedId", TranslationSuggestionsEnabled = true }
+        );
+
+        SFProject project = env.GetProject(Project01);
+        Assert.That(project.TranslateConfig.Source.ParatextId, Is.EqualTo("changedId"));
+        Assert.That(project.TranslateConfig.Source.Name, Is.EqualTo("NewSource"));
+
+        await env.MachineProjectService.Received().RemoveProjectAsync(User01, Project01, CancellationToken.None);
+        await env.MachineProjectService.Received().AddProjectAsync(User01, Project01, CancellationToken.None);
+        await env.SyncService.Received().SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
+    }
+
+    [Test]
+    public async Task UpdateSettingsAsync_SelectSourceProject_NoMachineProjectAndSync()
+    {
+        var env = new TestEnvironment();
+        await env.Service.UpdateSettingsAsync(
+            User02,
+            Project02,
+            new SFProjectSettings { SourceParatextId = "changedId" }
+        );
+
+        SFProject project = env.GetProject(Project02);
+        Assert.That(project.TranslateConfig.TranslationSuggestionsEnabled, Is.False);
+        Assert.That(project.TranslateConfig.Source.ParatextId, Is.EqualTo("changedId"));
+        Assert.That(project.TranslateConfig.Source.Name, Is.EqualTo("NewSource"));
+
+        await env.MachineProjectService
+            .DidNotReceive()
+            .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await env.MachineProjectService
+            .DidNotReceive()
+            .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await env.SyncService.Received().SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
+    }
+
+    [Test]
+    public async Task UpdateSettingsAsync_EnableTranslate_CreateMachineProjectAndSync()
+    {
+        var env = new TestEnvironment();
+        await env.Service.UpdateSettingsAsync(
+            User01,
+            Project03,
+            new SFProjectSettings { TranslationSuggestionsEnabled = true }
+        );
+
+        SFProject project = env.GetProject(Project03);
+        Assert.That(project.TranslateConfig.TranslationSuggestionsEnabled, Is.True);
+        Assert.That(project.TranslateConfig.Source.Name, Is.EqualTo("Source Only Project"));
+
+        await env.MachineProjectService
+            .DidNotReceive()
+            .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await env.MachineProjectService.Received().AddProjectAsync(User01, Project03, CancellationToken.None);
+        await env.SyncService.Received().SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
+    }
+
+    [Test]
+    public async Task UpdateSettingsAsync_UnsetSourceProject_RemoveMachineProjectAndSync()
+    {
+        var env = new TestEnvironment();
+        await env.Service.UpdateSettingsAsync(
+            User01,
+            Project01,
+            new SFProjectSettings
             {
-                { User03, TextInfoPermission.Read },
-                { User01, TextInfoPermission.Read },
-            };
-            var ptChapterPermissions = new Dictionary<string, string>()
+                SourceParatextId = SFProjectService.ProjectSettingValueUnset,
+                TranslationSuggestionsEnabled = false
+            }
+        );
+
+        SFProject project = env.GetProject(Project01);
+        Assert.That(project.TranslateConfig.TranslationSuggestionsEnabled, Is.False);
+        Assert.That(project.TranslateConfig.Source, Is.Null);
+
+        await env.MachineProjectService.Received().RemoveProjectAsync(User01, Project01, CancellationToken.None);
+        await env.MachineProjectService
+            .DidNotReceive()
+            .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await env.SyncService.Received().SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
+    }
+
+    [Test]
+    public async Task UpdateSettingsAsync_EnableChecking_Sync()
+    {
+        var env = new TestEnvironment();
+
+        await env.Service.UpdateSettingsAsync(User01, Project01, new SFProjectSettings { CheckingEnabled = true });
+
+        SFProject project = env.GetProject(Project01);
+        Assert.That(project.CheckingConfig.CheckingEnabled, Is.True);
+
+        await env.MachineProjectService
+            .DidNotReceive()
+            .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await env.MachineProjectService
+            .DidNotReceive()
+            .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await env.SyncService.Received().SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
+    }
+
+    [Test]
+    public async Task UpdateSettingsAsync_EnableSharing_NoSync()
+    {
+        var env = new TestEnvironment();
+
+        await env.Service.UpdateSettingsAsync(User01, Project01, new SFProjectSettings { CheckingShareEnabled = true });
+
+        SFProject project = env.GetProject(Project01);
+        Assert.That(project.CheckingConfig.ShareEnabled, Is.True);
+
+        await env.MachineProjectService
+            .DidNotReceive()
+            .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await env.MachineProjectService
+            .DidNotReceive()
+            .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await env.SyncService.DidNotReceive().SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
+    }
+
+    [Test]
+    public async Task DeleteAsync()
+    {
+        var env = new TestEnvironment();
+        string ptProjectDir = Path.Combine("xforge", "sync", "paratext_" + Project01);
+        env.FileSystemService.DirectoryExists(ptProjectDir).Returns(true);
+        Assert.That(env.ProjectSecrets.Contains(Project01), Is.True, "setup");
+        // SUT
+        await env.Service.DeleteProjectAsync(User01, Project01);
+
+        Assert.That(env.ContainsProject(Project01), Is.False);
+        User user = env.GetUser(User01);
+        Assert.That(user.Sites[SiteId].Projects, Does.Not.Contain(Project01));
+        await env.MachineProjectService.Received().RemoveProjectAsync(User01, Project01, CancellationToken.None);
+        env.FileSystemService.Received().DeleteDirectory(ptProjectDir);
+        Assert.That(env.ProjectSecrets.Contains(Project01), Is.False);
+
+        ptProjectDir = Path.Combine("xforge", "sync", "pt_source_no_suggestions");
+        env.FileSystemService.DirectoryExists(ptProjectDir).Returns(true);
+        Assert.That(env.GetProject(Project03).TranslateConfig.Source, Is.Not.Null);
+        await env.Service.DeleteProjectAsync(User01, SourceOnly);
+
+        await env.SyncService.Received().CancelSyncAsync(User01, SourceOnly);
+        await env.MachineProjectService.Received().RemoveProjectAsync(User01, SourceOnly, CancellationToken.None);
+        env.FileSystemService.Received().DeleteDirectory(ptProjectDir);
+        Assert.That(env.ContainsProject(SourceOnly), Is.False);
+        Assert.That(env.GetUser(User01).Sites[SiteId].Projects, Does.Not.Contain(SourceOnly));
+        Assert.That(env.GetProject(Project02).TranslateConfig.Source, Is.Null);
+    }
+
+    [Test]
+    public async Task CreateProjectAsync_NotExisting_Created()
+    {
+        var env = new TestEnvironment();
+        int projectCount = env.RealtimeService.GetRepository<SFProject>().Query().Count();
+        env.ParatextService
+            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Administrator)));
+        // SUT
+        string sfProjectId = await env.Service.CreateProjectAsync(
+            User01,
+            new SFProjectCreateSettings() { ParatextId = "ptProject123" }
+        );
+        Assert.That(env.ContainsProject(sfProjectId), Is.True);
+        Assert.That(
+            env.RealtimeService.GetRepository<SFProject>().Query().Count(),
+            Is.EqualTo(projectCount + 1),
+            "should have increased"
+        );
+        SFProject newProject = env.RealtimeService.GetRepository<SFProject>().Get(sfProjectId);
+        Assert.That(newProject.CheckingConfig.ShareEnabled, Is.False, "Should default to not shared (SF-1142)");
+    }
+
+    [Test]
+    public async Task CreateProjectAsync_Target_Created_Before_Source()
+    {
+        var env = new TestEnvironment();
+        int projectCount = env.RealtimeService.GetRepository<SFProject>().Query().Count();
+        env.ParatextService
+            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Administrator)));
+        env.ParatextService
+            .GetResourcePermissionAsync(Arg.Any<string>(), User01, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(TextInfoPermission.Read));
+        // SUT
+        string sfProjectId = await env.Service.CreateProjectAsync(
+            User01,
+            new SFProjectCreateSettings()
             {
-                { User03, TextInfoPermission.Write },
-                { User01, TextInfoPermission.Read },
-            };
-            var ptSourcePermissions = new Dictionary<string, string>()
+                ParatextId = "ptProject123",
+                SourceParatextId = "resource_project",
+                TranslationSuggestionsEnabled = true,
+            }
+        );
+        Assert.That(env.ContainsProject(sfProjectId), Is.True);
+        Assert.That(
+            env.RealtimeService.GetRepository<SFProject>().Query().Count(),
+            Is.EqualTo(projectCount + 2),
+            "should have increased"
+        );
+
+        // The source should have a later ID than the target in the project repository
+        var projects = env.RealtimeService
+            .GetRepository<SFProject>()
+            .Query()
+            .Where(p => p.ParatextId == "ptProject123" || p.ParatextId == "resource_project")
+            .OrderBy(p => p.Id);
+        Assert.That(projects.First().ParatextId, Is.EqualTo("ptProject123"), "target has the first id");
+        Assert.That(projects.Last().ParatextId, Is.EqualTo("resource_project"), "source has the last id");
+
+        // The source should appear after the target in the user's project array
+        User user = env.GetUser(User01);
+        Assert.That(user.Sites[SiteId].Projects.Skip(3).First(), Is.EqualTo(projects.First().Id), "target is first");
+        Assert.That(user.Sites[SiteId].Projects.Last(), Is.EqualTo(projects.Last().Id), "source is last");
+    }
+
+    [Test]
+    public void CreateProjectAsync_AlreadyExists_Error()
+    {
+        var env = new TestEnvironment();
+        int projectCount = env.RealtimeService.GetRepository<SFProject>().Query().Count();
+        env.ParatextService
+            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Administrator)));
+        SFProject existingSfProject = env.GetProject(Project01);
+        // SUT
+        InvalidOperationException thrown = Assert.ThrowsAsync<InvalidOperationException>(
+            () =>
+                env.Service.CreateProjectAsync(
+                    User01,
+                    new SFProjectCreateSettings() { ParatextId = existingSfProject.ParatextId }
+                )
+        );
+        Assert.That(thrown.Message, Does.Contain(SFProjectService.ErrorAlreadyConnectedKey));
+        Assert.That(
+            env.RealtimeService.GetRepository<SFProject>().Query().Count(),
+            Is.EqualTo(projectCount),
+            "should not have changed"
+        );
+    }
+
+    [Test]
+    public async Task CreateProjectAsync_RequestingPTUserHasPTPermissions()
+    {
+        // If a user connects a project that was not yet in SF via the Connect Project page, project text
+        // permissions should be set so that the connecting user has permissions set that are from PT.
+
+        var env = new TestEnvironment();
+        string targetProjectPTId = PTProjectIdNotYetInSF;
+        string sourceProjectPTId = Resource01PTId;
+        SFProject resource = env.GetProject(Resource01);
+
+        Assert.That(env.UserSecrets.Contains(User03), Is.True, "setup. PT user should have user secrets.");
+        User user = env.GetUser(User03);
+        Assert.That(user.ParatextId, Is.Not.Null, "setup. PT user should have a PT User ID.");
+        Assert.That(env.ContainsProject(targetProjectPTId), Is.False, "setup. No such SF should exist yet.");
+
+        Assert.That(
+            resource.UserRoles.ContainsKey(User03),
+            Is.False,
+            "setup. User should not already be on the project, for purposes of testing that they are later."
+        );
+        Assert.That(resource.Texts.First().Permissions.ContainsKey(User03), Is.False, "setup");
+        Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
+
+        string userRoleOnPTProject = SFProjectRole.Administrator;
+        env.ParatextService
+            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Attempt.Success(userRoleOnPTProject)));
+        string userDBLPermissionForResource = TextInfoPermission.Read;
+        env.ParatextService
+            .GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
+            .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
+
+        var bookList = new List<int>() { 40, 41 };
+        env.ParatextService.GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(bookList);
+
+        // PT will answer with these permissions.
+        // Note that in the case of checking permissions for the target project, SF won't actually get to the
+        // point where it queries for the PT permissions. But leaving these settings here in case
+        // UpdatePermissionsAsync() is later modified and it starts doing that.
+        var ptBookPermissions = new Dictionary<string, string>()
+        {
+            { User03, TextInfoPermission.Read },
+            { User01, TextInfoPermission.Read },
+        };
+        var ptChapterPermissions = new Dictionary<string, string>()
+        {
+            { User03, TextInfoPermission.Write },
+            { User01, TextInfoPermission.Read },
+        };
+        var ptSourcePermissions = new Dictionary<string, string>()
+        {
+            { User03, userDBLPermissionForResource },
+            { User01, TextInfoPermission.None },
+        };
+        const int bookValueToIndicateWholeResource = 0;
+        const int chapterValueToIndicateWholeBook = 0;
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == targetProjectPTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                chapterValueToIndicateWholeBook
+            )
+            .Returns(Task.FromResult(ptBookPermissions));
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == targetProjectPTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                Arg.Any<int>(),
+                Arg.Is<int>((int arg) => arg > 0)
+            )
+            .Returns(Task.FromResult(ptChapterPermissions));
+        env.ParatextService
+            .GetPermissionsAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>((SFProject project) => project.ParatextId == sourceProjectPTId),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                bookValueToIndicateWholeResource,
+                chapterValueToIndicateWholeBook
+            )
+            .Returns(Task.FromResult(ptSourcePermissions));
+
+        resource = env.GetProject(Resource01);
+        Assert.That(
+            resource.Texts.First().Permissions.Count,
+            Is.EqualTo(0),
+            "setup. User should not have permissions on resource yet."
+        );
+        Assert.That(resource.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
+
+        // SUT
+        string sfProjectId = await env.Service.CreateProjectAsync(
+            User03,
+            new SFProjectCreateSettings()
             {
-                { User03, userDBLPermissionForResource },
-                { User01, TextInfoPermission.None },
-            };
-            const int bookValueToIndicateWholeResource = 0;
-            const int chapterValueToIndicateWholeBook = 0;
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    chapterValueToIndicateWholeBook
-                )
-                .Returns(Task.FromResult(ptBookPermissions));
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    Arg.Is<int>((int arg) => arg > 0)
-                )
-                .Returns(Task.FromResult(ptChapterPermissions));
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    bookValueToIndicateWholeResource,
-                    chapterValueToIndicateWholeBook
-                )
-                .Returns(Task.FromResult(ptSourcePermissions));
+                ParatextId = targetProjectPTId,
+                SourceParatextId = sourceProjectPTId,
+                TranslationSuggestionsEnabled = true,
+            }
+        );
 
-            // SUT
-            await env.Service.CheckLinkSharingAsync(User03, Project05, shareKeyCode);
+        SFProject project = env.GetProject(sfProjectId);
+        Assert.That(
+            project.UserRoles.TryGetValue(User03, out string userRole),
+            Is.True,
+            "user should be added to project"
+        );
+        Assert.That(userRole, Is.EqualTo(userRoleOnPTProject));
+        user = env.GetUser(User03);
+        Assert.That(user.Sites[SiteId].Projects, Contains.Item(sfProjectId), "user not added to project correctly");
 
-            project = env.GetProject(Project05);
-            Assert.That(
-                project.UserRoles.TryGetValue(User03, out string userRole),
-                Is.True,
-                "user should be added to project"
-            );
-            // This user was invited as a community checker (according to the share key). But their project role and
-            // permissions will reflect what is set on the PT project. The user will have a translator role rather than
-            // a community checker role.
-            Assert.That(userRole, Is.EqualTo(userRoleOnPTProject));
-            user = env.GetUser(User03);
-            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project05));
+        // Initially connecting a project should have called Sync, or SF is not going to fetch books and set
+        // permissions on them.
+        await env.SyncService.Received().SyncAsync(User03, sfProjectId, Arg.Any<bool>());
 
-            Assert.That(project.Texts.First().Permissions[User03], Is.EqualTo(TextInfoPermission.Read));
-            Assert.That(
-                project.Texts.First().Chapters.First().Permissions[User03],
-                Is.EqualTo(TextInfoPermission.Write)
-            );
+        // Don't check that permissions were added to the target project, because we mock the Sync functionality.
+        // But we can show that source resource permissions were set:
 
-            resource = env.GetProject(Resource01);
-            Assert.That(
-                resource.UserRoles.TryGetValue(User03, out string resourceUserRole),
-                Is.True,
-                "user should have been added to resource"
-            );
-            Assert.That(
-                resourceUserRole,
-                Is.EqualTo(SFProjectRole.PTObserver),
-                "user role not set correctly on resource"
-            );
-            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Resource01), "user not added to resource correctly");
-            Assert.That(resource.Texts.First().Permissions[User03], Is.EqualTo(userDBLPermissionForResource));
-            Assert.That(
-                resource.Texts.First().Chapters.First().Permissions[User03],
-                Is.EqualTo(userDBLPermissionForResource)
-            );
-        }
+        resource = env.GetProject(Resource01);
+        Assert.That(resource.Texts.First().Permissions[User03], Is.EqualTo(userDBLPermissionForResource));
+        Assert.That(
+            resource.Texts.First().Chapters.First().Permissions[User03],
+            Is.EqualTo(userDBLPermissionForResource)
+        );
+        Assert.That(
+            resource.UserRoles.TryGetValue(User03, out string resourceUserRole),
+            Is.True,
+            "user should have been added to resource"
+        );
+        Assert.That(resourceUserRole, Is.EqualTo(SFProjectRole.PTObserver), "user role not set correctly on resource");
+        Assert.That(user.Sites[SiteId].Projects, Contains.Item(Resource01), "user not added to resource correctly");
+    }
 
-        [Test]
-        public async Task CheckLinkSharingAsync_NonPTUser()
+    [Test]
+    public async Task CreateResourceProjectAsync_NotExisting_Created()
+    {
+        var env = new TestEnvironment();
+        int projectCount = env.RealtimeService.GetRepository<SFProject>().Query().Count();
+        // SUT
+        string sfProjectId = await env.Service.CreateResourceProjectAsync(User01, "resource_project");
+        Assert.That(env.ContainsProject(sfProjectId), Is.True);
+        Assert.That(
+            env.RealtimeService.GetRepository<SFProject>().Query().Count(),
+            Is.EqualTo(projectCount + 1),
+            "should have increased"
+        );
+    }
+
+    [Test]
+    public void CreateResourceProjectAsync_AlreadyExists_Error()
+    {
+        var env = new TestEnvironment();
+        int projectCount = env.RealtimeService.GetRepository<SFProject>().Query().Count();
+        SFProject existingSfProject = env.GetProject(Resource01);
+        // SUT
+        InvalidOperationException thrown = Assert.ThrowsAsync<InvalidOperationException>(
+            () => env.Service.CreateResourceProjectAsync(User01, existingSfProject.ParatextId)
+        );
+        Assert.That(thrown.Message, Does.Contain(SFProjectService.ErrorAlreadyConnectedKey));
+        Assert.That(
+            env.RealtimeService.GetRepository<SFProject>().Query().Count(),
+            Is.EqualTo(projectCount),
+            "should not have changed"
+        );
+    }
+
+    [Test]
+    public async Task AddUserToResourceProjectAsync_UserResourcePermission()
+    {
+        var env = new TestEnvironment();
+        env.ParatextService
+            .GetResourcePermissionAsync(Arg.Any<string>(), User01, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(TextInfoPermission.Read));
+
+        User user = env.GetUser(User01);
+        Assert.That(user.Sites[SiteId].Projects.Contains(Resource01), Is.False, "setup");
+
+        await env.Service.AddUserAsync(User01, Resource01, null);
+
+        user = env.GetUser(User01);
+        Assert.That(user.Sites[SiteId].Projects.Contains(Resource01), Is.True, "User can access resource");
+    }
+
+    [Test]
+    public void AddUserToResourceProjectAsync_UserResourceNoPermission()
+    {
+        var env = new TestEnvironment();
+        env.ParatextService
+            .GetResourcePermissionAsync(Arg.Any<string>(), User01, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(TextInfoPermission.None));
+
+        User user = env.GetUser(User01);
+        Assert.That(user.Sites[SiteId].Projects.Contains(Resource01), Is.False, "setup");
+
+        Assert.ThrowsAsync<ForbiddenException>(() => env.Service.AddUserAsync(User01, Resource01, null));
+
+        user = env.GetUser(User01);
+        Assert.That(user.Sites[SiteId].Projects.Contains(Resource01), Is.False, "user cannot access resource");
+    }
+
+    [Test]
+    public void CancelSyncAsync_AdministratorsCanCancelSync()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.DoesNotThrowAsync(() => env.Service.CancelSyncAsync(User01, Project01));
+    }
+
+    [Test]
+    public void CancelSyncAsync_TranslatorsCanCancelSync()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.DoesNotThrowAsync(() => env.Service.CancelSyncAsync(User05, Project01));
+    }
+
+    [Test]
+    public void CancelSyncAsync_ObserversCannotCancelSync()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(() => env.Service.CancelSyncAsync(User02, Project01));
+    }
+
+    [Test]
+    public void CancelSyncAsync_UsersNotInProjectCannotCancelSync()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(() => env.Service.CancelSyncAsync(User03, Project01));
+    }
+
+    [Test]
+    public void SyncAsync_AdministratorsCanSync()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.DoesNotThrowAsync(() => env.Service.SyncAsync(User01, Project01));
+    }
+
+    [Test]
+    public void SyncAsync_TranslatorsCanSync()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.DoesNotThrowAsync(() => env.Service.SyncAsync(User05, Project01));
+    }
+
+    [Test]
+    public void SyncAsync_ObserversCannotSync()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(() => env.Service.SyncAsync(User02, Project01));
+    }
+
+    [Test]
+    public async Task EnsureWritingSystemTagIsSetAsync_DoesNotUpdateIfNoChanges()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        await env.Service.EnsureWritingSystemTagIsSetAsync(User01, Project01);
+
+        // If the writing system tags are updated, the projects must be retrieved
+        // We check that this is not called, to ensure that it was not updated
+        await env.ParatextService.DidNotReceive().GetProjectsAsync(Arg.Any<UserSecret>());
+    }
+
+    [Test]
+    public async Task EnsureWritingSystemTagIsSetAsync_DoesNotUpdateIfNotInRegistry()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        IReadOnlyList<ParatextProject> ptProjects = Array.Empty<ParatextProject>();
+        env.ParatextService.GetProjectsAsync(Arg.Any<UserSecret>()).Returns(Task.FromResult(ptProjects));
+
+        // SUT
+        await env.Service.EnsureWritingSystemTagIsSetAsync(User01, Project04);
+
+        // Ensure that our mock GetProjectsAsync created above is called
+        await env.ParatextService.Received(1).GetProjectsAsync(Arg.Any<UserSecret>());
+
+        Assert.IsNull(env.GetProject(Project04).WritingSystem.Tag);
+        Assert.IsNull(env.GetProject(Project04).TranslateConfig.Source.WritingSystem.Tag);
+    }
+
+    [Test]
+    public async Task EnsureWritingSystemTagIsSetAsync_UpdatesTagsIfMissing()
+    {
+        // Setup
+        const string languageTag01 = "languageTag01";
+        const string languageTag02 = "languageTag02";
+        var env = new TestEnvironment();
+        IReadOnlyList<ParatextProject> ptProjects = new[]
         {
-            var env = new TestEnvironment();
-            SFProject project = env.GetProject(Project05);
-
-            Assert.That(
-                env.UserSecrets.Contains(User04),
-                Is.False,
-                "setup. Non-PT user is not expected to have user secrets."
-            );
-            User user = env.GetUser(User04);
-            Assert.That(user.ParatextId, Is.Null, "setup. Non-PT user should not have a PT User ID.");
-
-            Assert.That(project.UserRoles.ContainsKey(User04), Is.False, "setup");
-            Assert.That(project.Texts.First().Permissions.ContainsKey(User04), Is.False, "setup");
-            Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User04), Is.False, "setup");
-
-            // SUT
-            await env.Service.CheckLinkSharingAsync(User04, Project05, "key12345");
-
-            project = env.GetProject(Project05);
-            Assert.That(
-                project.UserRoles.TryGetValue(User04, out string userRole),
-                Is.True,
-                "user was added to project"
-            );
-            Assert.That(userRole, Is.EqualTo(SFProjectRole.CommunityChecker));
-            user = env.GetUser(User04);
-            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project05));
-
-            Assert.That(
-                project.Texts.First().Permissions.ContainsKey(User04),
-                Is.False,
-                "no permissions should have been specified for user"
-            );
-            Assert.That(
-                project.Texts.First().Chapters.First().Permissions.ContainsKey(User04),
-                Is.False,
-                "no permissions should have been specified for user"
-            );
-
-            // The get permission methods shouldn't have even been called.
-            await env.ParatextService
-                .DidNotReceiveWithAnyArgs()
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Any<SFProject>(),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    Arg.Any<int>()
-                );
-            await env.ParatextService
-                .DidNotReceiveWithAnyArgs()
-                .GetResourcePermissionAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-        }
-
-        [Test]
-        public async Task CheckLinkSharingAsync_PTUserButNotOfThisProjectAndCannotReadResource()
-        {
-            // The user joining the project _is_ a PT user, but they do not have a PT role on this particular project.
-            // Further, they do not have permission to read the DBL resource.
-
-            var env = new TestEnvironment();
-            string project05PTId = "paratext_" + Project05;
-            SFProject project = env.GetProject(Project05);
-            SFProject resource = env.GetProject(Resource01);
-
-            Assert.That(
-                env.UserSecrets.Contains(User03),
-                Is.True,
-                "setup. This is a PT user and is expected to have user secrets."
-            );
-            User user = env.GetUser(User03);
-            Assert.That(user.ParatextId, Is.Not.Null, "setup. PT user should have a PT User ID.");
-
-            Assert.That(
-                project.UserRoles.ContainsKey(User03),
-                Is.False,
-                "setup. User should not already be on the project."
-            );
-            Assert.That(
-                project.Texts.First().Permissions.ContainsKey(User03),
-                Is.False,
-                "setup. User should not already have permissions on the project."
-            );
-            Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
-            Assert.That(
-                resource.UserRoles.ContainsKey(User03),
-                Is.False,
-                "setup. User should not already be on the project."
-            );
-            Assert.That(
-                resource.Texts.First().Permissions.ContainsKey(User03),
-                Is.False,
-                "setup. User should not have permissions."
-            );
-            Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
-
-            // If the user is not a member of the paratext project, then
-            // "GET https://registry-dev.paratext.org/api8/projects/PT_PROJECT_ID/members" will return a 404 Not Found,
-            // and in ParatextService.CallApiAsync() there originates a System.Net.Http.HttpRequestException or perhaps
-            // EdjCase.JsonRpc.Common.RpcException. Our test should not end up doing down a path that causes this
-            // exception.
-            env.ParatextService
-                .GetParatextUsernameMappingAsync(
-                    Arg.Is<UserSecret>((UserSecret userSecret) => userSecret.Id == User03),
-                    Arg.Is((SFProject project) => project.ParatextId == project05PTId),
-                    Arg.Any<CancellationToken>()
-                )
-                .Returns(
-                    Task.FromException<IReadOnlyDictionary<string, string>>(new System.Net.Http.HttpRequestException())
-                );
-
-            string userRoleOnPTProject = null;
-            env.ParatextService
-                .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(Attempt.Failure(userRoleOnPTProject)));
-            string userDBLPermissionForResource = TextInfoPermission.None;
-            env.ParatextService
-                .GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
-                .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
-
-            env.ParatextService
-                .GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>())
-                .Returns(x => throw new Exception("Probably can not do this."));
-
-            // PT could answer with these permissions.
-            var ptBookPermissions = new Dictionary<string, string>()
+            new ParatextProject { ProjectId = Project04, LanguageTag = languageTag01 },
+            new ParatextProject
             {
-                { User02, TextInfoPermission.Read },
-                { User01, TextInfoPermission.Read },
-            };
-            var ptChapterPermissions = new Dictionary<string, string>()
-            {
-                { User02, TextInfoPermission.Write },
-                { User01, TextInfoPermission.Read },
-            };
-            var ptSourcePermissions = new Dictionary<string, string>()
-            {
-                { User02, TextInfoPermission.Read },
-                { User01, TextInfoPermission.Read },
-            };
-            const int bookValueToIndicateWholeResource = 0;
-            const int chapterValueToIndicateWholeBook = 0;
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    chapterValueToIndicateWholeBook
-                )
-                .Returns(Task.FromResult(ptBookPermissions));
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    Arg.Is<int>((int arg) => arg > 0)
-                )
-                .Returns(Task.FromResult(ptChapterPermissions));
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    bookValueToIndicateWholeResource,
-                    chapterValueToIndicateWholeBook
-                )
-                .Returns(Task.FromResult(ptSourcePermissions));
+                ParatextId = env.GetProject(Project04).TranslateConfig.Source.ParatextId,
+                LanguageTag = languageTag02,
+            },
+        };
+        env.ParatextService.GetProjectsAsync(Arg.Any<UserSecret>()).Returns(Task.FromResult(ptProjects));
 
-            // SUT
-            await env.Service.CheckLinkSharingAsync(User03, Project05, "key12345");
+        // SUT
+        await env.Service.EnsureWritingSystemTagIsSetAsync(User01, Project04);
 
-            project = env.GetProject(Project05);
-            Assert.That(
-                project.UserRoles.TryGetValue(User03, out string userRole),
-                Is.True,
-                "user should have been added to project"
-            );
-            Assert.That(userRole, Is.EqualTo(SFProjectRole.CommunityChecker));
-            user = env.GetUser(User03);
-            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project05), "user not added to project correctly");
+        // Ensure that our mock GetProjectsAsync created above is called
+        await env.ParatextService.Received(1).GetProjectsAsync(Arg.Any<UserSecret>());
 
-            Assert.That(
-                project.Texts.First().Permissions.ContainsKey(User03),
-                Is.False,
-                "no project permissions should have been specified for user"
-            );
-            Assert.That(
-                project.Texts.First().Chapters.First().Permissions.ContainsKey(User03),
-                Is.False,
-                "no project permissions should have been specified for user"
-            );
+        Assert.AreEqual(languageTag01, env.GetProject(Project04).WritingSystem.Tag);
+        Assert.AreEqual(languageTag02, env.GetProject(Project04).TranslateConfig.Source.WritingSystem.Tag);
+    }
 
-            // User03 is not added to the target or source, nor do they have any permissions listed in the source.
-            resource = env.GetProject(Resource01);
-            Assert.That(
-                resource.UserRoles.ContainsKey(User03),
-                Is.False,
-                "user should not have been added to resource project"
-            );
-            Assert.That(
-                resource.Texts.First().Permissions.ContainsKey(User03),
-                Is.False,
-                "user should not have permissions to resource"
-            );
-            Assert.That(
-                resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03),
-                Is.False,
-                "user should not have permissions to resource"
-            );
-            Assert.That(
-                user.Sites[SiteId].Projects,
-                Does.Not.Contain(Resource01),
-                "user should not have been added to"
-            );
-
-            // With the current implementation, both ParatextService.GetPermissionsAsync(for the source resource) and
-            // ParatextService.GetPermissionsAsync(for the target project) should be called never. In a future change to
-            // the SUT, it's okay if it is called, as long as the permissions don't get applied. But for now, not
-            // getting called is a helpful indication of expected operation.
-            // The mocks above regarding env.ParatextService.GetPermissionsAsync(for the target project) are left in
-            // place in case they begin to be used.
-            await env.ParatextService
-                .DidNotReceive()
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject sfProject) => sfProject.Id == Project05),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    Arg.Any<int>()
-                );
-            await env.ParatextService
-                .DidNotReceive()
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject sfProject) => sfProject.Id == Resource01),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    Arg.Any<int>()
-                );
-
-            // We may not be able to query a book list for the target project without the user having a PT project role,
-            // or of the DBL resource, without the user having read permission.
-            env.ParatextService.DidNotReceive().GetBookList(Arg.Any<UserSecret>(), project05PTId);
-            env.ParatextService.DidNotReceive().GetBookList(Arg.Any<UserSecret>(), Resource01PTId);
-        }
-
-        [Test]
-        public async Task CheckLinkSharingAsync_PTUserButNotOfThisProjectYetReadsResource()
+    private class TestEnvironment
+    {
+        public TestEnvironment()
         {
-            // The user joining the project _is_ a PT user, but they do not have a PT role on this particular project.
-            // Though they do have permission to read the DBL resource.
-
-            var env = new TestEnvironment();
-            string project05PTId = "paratext_" + Project05;
-            SFProject project = env.GetProject(Project05);
-            SFProject resource = env.GetProject(Resource01);
-
-            Assert.That(
-                env.UserSecrets.Contains(User03),
-                Is.True,
-                "setup. This is a PT user and is expected to have user secrets."
-            );
-            User user = env.GetUser(User03);
-            Assert.That(user.ParatextId, Is.Not.Null, "setup. PT user should have a PT User ID.");
-
-            Assert.That(
-                project.UserRoles.ContainsKey(User03),
-                Is.False,
-                "setup. User should not already be on the project."
-            );
-            Assert.That(
-                project.Texts.First().Permissions.ContainsKey(User03),
-                Is.False,
-                "setup. User should not already have permissions on the project."
-            );
-            Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
-            Assert.That(
-                resource.UserRoles.ContainsKey(User03),
-                Is.False,
-                "setup. User should not already be on the project, for purposes of testing that they are later."
-            );
-            Assert.That(
-                resource.Texts.First().Permissions.ContainsKey(User03),
-                Is.False,
-                "setup. User should not already have permissions."
-            );
-            Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
-
-            env.ParatextService
-                .GetParatextUsernameMappingAsync(
-                    Arg.Is<UserSecret>((UserSecret userSecret) => userSecret.Id == User03),
-                    Arg.Is((SFProject project) => project.ParatextId == project05PTId),
-                    Arg.Any<CancellationToken>()
-                )
-                .Returns(
-                    Task.FromException<IReadOnlyDictionary<string, string>>(new System.Net.Http.HttpRequestException())
-                );
-
-            string userRoleOnPTProject = null;
-            env.ParatextService
-                .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(Attempt.Failure(userRoleOnPTProject)));
-            string userDBLPermissionForResource = TextInfoPermission.Read;
-            env.ParatextService
-                .GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
-                .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
-
-            var bookList = new List<int>() { 40, 41 };
-            env.ParatextService.GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(bookList);
-
-            // PT could answer with these permissions.
-            var ptBookPermissions = new Dictionary<string, string>()
-            {
-                { User02, TextInfoPermission.Read },
-                { User01, TextInfoPermission.Read },
-            };
-            var ptChapterPermissions = new Dictionary<string, string>()
-            {
-                { User02, TextInfoPermission.Write },
-                { User01, TextInfoPermission.Read },
-            };
-            var ptSourcePermissions = new Dictionary<string, string>()
-            {
-                { User03, userDBLPermissionForResource },
-                { User02, TextInfoPermission.Read },
-                { User01, TextInfoPermission.Read },
-            };
-            const int bookValueToIndicateWholeResource = 0;
-            const int chapterValueToIndicateWholeBook = 0;
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    chapterValueToIndicateWholeBook
-                )
-                .Returns(Task.FromResult(ptBookPermissions));
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    Arg.Is<int>((int arg) => arg > 0)
-                )
-                .Returns(Task.FromResult(ptChapterPermissions));
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    bookValueToIndicateWholeResource,
-                    chapterValueToIndicateWholeBook
-                )
-                .Returns(Task.FromResult(ptSourcePermissions));
-
-            // SUT
-            await env.Service.CheckLinkSharingAsync(User03, Project05, "key12345");
-
-            project = env.GetProject(Project05);
-            Assert.That(
-                project.UserRoles.TryGetValue(User03, out string userRole),
-                Is.True,
-                "user should have been added to project"
-            );
-            Assert.That(userRole, Is.EqualTo(SFProjectRole.CommunityChecker));
-            user = env.GetUser(User03);
-            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project05), "user not added to project correctly");
-
-            Assert.That(
-                project.Texts.First().Permissions.ContainsKey(User03),
-                Is.False,
-                "no project permissions should have been specified for user"
-            );
-            Assert.That(
-                project.Texts.First().Chapters.First().Permissions.ContainsKey(User03),
-                Is.False,
-                "no project permissions should have been specified for user"
-            );
-
-            // User03 is not on project project05PTId, but they have access to the source resource. So
-            // UpdatePermissionsAsync() should be inquiring about this and setting permissions as appropriate.
-            await env.ParatextService
-                .Received()
-                .GetResourcePermissionAsync(Resource01PTId, User03, Arg.Any<CancellationToken>());
-            resource = env.GetProject(Resource01);
-            Assert.That(
-                resource.Texts.First().Permissions[User03],
-                Is.EqualTo(userDBLPermissionForResource),
-                "resource permissions should have been set for joining project user"
-            );
-            Assert.That(
-                resource.Texts.First().Chapters.First().Permissions[User03],
-                Is.EqualTo(userDBLPermissionForResource),
-                "resource permissions should have been set for joining project user"
-            );
-            Assert.That(
-                resource.UserRoles.TryGetValue(User03, out string resourceUserRole),
-                Is.True,
-                "user should have been added to resource"
-            );
-            Assert.That(
-                resourceUserRole,
-                Is.EqualTo(SFProjectRole.PTObserver),
-                "user role not set correctly on resource"
-            );
-            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Resource01), "user not added to resource correctly");
-
-            // With the current implementation, ParatextService.GetPermissionsAsync(for the source resource) should be
-            // called once, but ParatextService.GetPermissionsAsync(for the target project) should be called never. In
-            // a future change to the SUT, it's okay if it is called for the target project, as long as the permissions
-            // don't get applied. But for now, not getting called is a helpful indication of expected operation.
-            // The mocks above regarding env.ParatextService.GetPermissionsAsync(for the target project) are left in
-            // place in case they begin to be used.
-            await env.ParatextService
-                .DidNotReceive()
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject sfProject) => sfProject.Id == Project05),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    Arg.Any<int>()
-                );
-            await env.ParatextService
-                .Received(1)
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject sfProject) => sfProject.Id == Resource01),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    Arg.Any<int>()
-                );
-
-            // We may not be able to query a book list for the target project without the user having a PT project role.
-            env.ParatextService.DidNotReceive().GetBookList(Arg.Any<UserSecret>(), project05PTId);
-            env.ParatextService.Received(1).GetBookList(Arg.Any<UserSecret>(), Resource01PTId);
-        }
-
-        [Test]
-        public void CheckLinkSharingAsync_ObserverInvitedToProject_AddedToProject()
-        {
-            var env = new TestEnvironment();
-            SFProject project = env.GetProject(Project04);
-            Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
-
-            Assert.DoesNotThrowAsync(() => env.Service.CheckLinkSharingAsync(User03, Project04, "linksharing04"));
-            project = env.GetProject(Project04);
-            Assert.That(project.UserRoles.ContainsKey(User03), Is.True, "user should be added to project");
-        }
-
-        [Test]
-        public async Task IsAlreadyInvitedAsync_BadInput_False()
-        {
-            var env = new TestEnvironment();
-
-            Assert.That(await env.Service.IsAlreadyInvitedAsync(User01, Project03, null), Is.False);
-
-            Assert.That(await env.Service.IsAlreadyInvitedAsync(User01, Project03, ""), Is.False);
-
-            Assert.That(await env.Service.IsAlreadyInvitedAsync(User01, Project03, "junk"), Is.False);
-
-            Assert.That(await env.Service.IsAlreadyInvitedAsync(User02, Project02, "nothing"), Is.False);
-        }
-
-        [Test]
-        public async Task IsAlreadyInvitedAsync_IsInvited_True()
-        {
-            var env = new TestEnvironment();
-
-            Assert.That(await env.Service.IsAlreadyInvitedAsync(User01, Project03, "bob@example.com"), Is.True);
-        }
-
-        [Test]
-        public async Task IsAlreadyInvitedAsync_NotInvitedButOnProject_False()
-        {
-            var env = new TestEnvironment();
-            Assert.That(
-                env.GetProject(Project03).UserRoles.GetValueOrDefault(User01, null),
-                Is.EqualTo(SFProjectRole.Administrator)
-            );
-            Assert.That(await env.Service.IsAlreadyInvitedAsync(User01, Project03, "user01@example.com"), Is.False);
-            Assert.That(
-                env.GetProject(Project02).UserRoles.GetValueOrDefault(User04, null),
-                Is.EqualTo(SFProjectRole.CommunityChecker)
-            );
-            Assert.That(await env.Service.IsAlreadyInvitedAsync(User04, Project02, "user01@example.com"), Is.False);
-        }
-
-        [Test]
-        public async Task IsAlreadyInvitedAsync_NotInvitedOrOnProject_False()
-        {
-            var env = new TestEnvironment();
-
-            Assert.That(await env.Service.IsAlreadyInvitedAsync(User01, Project03, "unheardof@example.com"), Is.False);
-            Assert.That(await env.Service.IsAlreadyInvitedAsync(User04, Project02, "nobody@example.com"), Is.False);
-        }
-
-        [Test]
-        public void IsAlreadyInvitedAsync_CheckingDisabledButCheckingSharingEnabled_Forbidden()
-        {
-            var env = new TestEnvironment();
-            Assert.That(env.GetProject(Project06).CheckingConfig.CheckingEnabled, Is.False);
-            Assert.That(env.GetProject(Project06).CheckingConfig.ShareEnabled, Is.True);
-            Assert.That(
-                env.GetProject(Project06).UserRoles.GetValueOrDefault(User01, null),
-                Is.EqualTo(SFProjectRole.CommunityChecker)
-            );
-
-            Assert.ThrowsAsync<ForbiddenException>(
-                () => env.Service.IsAlreadyInvitedAsync(User01, Project06, "user@example.com")
-            );
-        }
-
-        [Test]
-        public async Task IsAlreadyInvitedAsync_CheckingSharingDisabledTranslateSharingEnabled_False()
-        {
-            var env = new TestEnvironment();
-            Assert.That(env.GetProject(Project04).CheckingConfig.ShareEnabled, Is.False);
-            Assert.That(env.GetProject(Project04).TranslateConfig.ShareEnabled, Is.True);
-            Assert.That(await env.Service.IsAlreadyInvitedAsync(User01, Project04, "user@example.com"), Is.False);
-        }
-
-        [Test]
-        public void IsAlreadyInvitedAsync_InvitingUserNotOnProject_Forbidden()
-        {
-            var env = new TestEnvironment();
-            Assert.That(env.GetProject(Project02).CheckingConfig.CheckingEnabled, Is.True);
-            Assert.That(env.GetProject(Project02).CheckingConfig.ShareEnabled, Is.True);
-            Assert.That(env.GetProject(Project02).UserRoles.GetValueOrDefault(User01, null), Is.Null);
-
-            Assert.ThrowsAsync<ForbiddenException>(
-                () => env.Service.IsAlreadyInvitedAsync(User01, Project02, "user@example.com")
-            );
-        }
-
-        [Test]
-        public async Task InvitedUsers_Reports()
-        {
-            var env = new TestEnvironment();
-            // Project with no outstanding invitations
-            Assert.That((await env.Service.InvitedUsersAsync(User01, Project01)).Count, Is.EqualTo(0));
-
-            // Project with one specific shareKey and one link sharing shareKey record
-            IReadOnlyList<InviteeStatus> invitees = await env.Service.InvitedUsersAsync(User02, Project02);
-            Assert.That(invitees.Count, Is.EqualTo(1));
-            Assert.That(invitees.Select(i => i.Email), Is.EquivalentTo(new string[] { "user03@example.com" }));
-
-            // Project with several outstanding invitations
-            invitees = await env.Service.InvitedUsersAsync(User01, Project03);
-            Assert.That(invitees.Count, Is.EqualTo(4));
-            string[] expectedEmailList =
-            {
-                "bob@example.com",
-                "expired@example.com",
-                "user03@example.com",
-                "bill@example.com"
-            };
-            Assert.That(invitees.Select(i => i.Email), Is.EquivalentTo(expectedEmailList));
-        }
-
-        [Test]
-        public void InvitedUsers_SystemAdmin_NoSpecialAccess()
-        {
-            var env = new TestEnvironment();
-
-            // User04 is a system admin, but not a project-admin or even a user on Project03
-            Assert.That(env.GetProject(Project03).UserRoles.ContainsKey(User04), Is.False, "test setup");
-            Assert.That(env.GetUser(User04).Role, Is.EqualTo(SystemRole.SystemAdmin), "test setup");
-
-            Assert.ThrowsAsync<ForbiddenException>(
-                () => (env.Service.InvitedUsersAsync(User04, Project03)),
-                "should have been forbidden"
-            );
-        }
-
-        [Test]
-        public void InvitedUsers_NonProjectAdmin_Forbidden()
-        {
-            var env = new TestEnvironment();
-            // User02 is not an admin on Project01
-            Assert.That(
-                env.GetProject(Project01).UserRoles[User02],
-                Is.Not.EqualTo(SFProjectRole.Administrator),
-                "test setup"
-            );
-            Assert.That(env.GetUser(User02).Role, Is.Not.EqualTo(SystemRole.SystemAdmin), "test setup");
-            Assert.ThrowsAsync<ForbiddenException>(
-                () => env.Service.InvitedUsersAsync(User02, Project01),
-                "should have been forbidden"
-            );
-        }
-
-        [Test]
-        public void InvitedUsers_BadProject_Error()
-        {
-            var env = new TestEnvironment();
-
-            Assert.ThrowsAsync<DataNotFoundException>(() => env.Service.InvitedUsersAsync(User02, "bad-project-id"));
-        }
-
-        [Test]
-        public void InvitedUsers_BadUser_Forbidden()
-        {
-            var env = new TestEnvironment();
-
-            Assert.ThrowsAsync<ForbiddenException>(() => env.Service.InvitedUsersAsync("bad-user-id", Project01));
-        }
-
-        [Test]
-        public void UninviteUser_BadProject_Error()
-        {
-            var env = new TestEnvironment();
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.UninviteUserAsync(User02, "nonexistent-project", "some@email.com")
-            );
-        }
-
-        [Test]
-        public void UninviteUser_NonProjectAdmin_Error()
-        {
-            var env = new TestEnvironment();
-            // User02 is not an admin on Project01
-            Assert.That(
-                env.GetProject(Project01).UserRoles[User02],
-                Is.Not.EqualTo(SFProjectRole.Administrator),
-                "test setup"
-            );
-            Assert.ThrowsAsync<ForbiddenException>(
-                () => env.Service.UninviteUserAsync(User02, Project01, "some@email.com"),
-                "should have been forbidden"
-            );
-        }
-
-        [Test]
-        public async Task UninviteUser_BadEmail_Ignored()
-        {
-            var env = new TestEnvironment();
-            var initialInvitationCount = 4;
-            Assert.That(
-                (await env.ProjectSecrets.GetAsync(Project03)).ShareKeys.Count,
-                Is.EqualTo(initialInvitationCount),
-                "test setup"
-            );
-
-            await env.Service.UninviteUserAsync(User01, Project03, "unknown@email.com");
-            Assert.That(
-                (await env.ProjectSecrets.GetAsync(Project03)).ShareKeys.Count,
-                Is.EqualTo(initialInvitationCount),
-                "should not have changed"
-            );
-        }
-
-        [Test]
-        public async Task UninviteUser_RemovesInvitation()
-        {
-            var env = new TestEnvironment();
-            var initialInvitationCount = 4;
-            Assert.That(
-                (await env.ProjectSecrets.GetAsync(Project03)).ShareKeys.Count,
-                Is.EqualTo(initialInvitationCount),
-                "test setup"
-            );
-            Assert.That(
-                (await env.ProjectSecrets.GetAsync(Project03)).ShareKeys.Any(sk => sk.Email == "bob@example.com"),
-                Is.True,
-                "test setup"
-            );
-            Assert.That(
-                (await env.ProjectSecrets.GetAsync(Project03)).ShareKeys.Count,
-                Is.EqualTo(initialInvitationCount),
-                "test setup"
-            );
-
-            await env.Service.UninviteUserAsync(User01, Project03, "bob@example.com");
-            Assert.That(
-                (await env.ProjectSecrets.GetAsync(Project03)).ShareKeys.Count,
-                Is.EqualTo(initialInvitationCount - 1),
-                "unexpected number of outstanding invitations"
-            );
-            Assert.That(
-                (await env.ProjectSecrets.GetAsync(Project03)).ShareKeys.Any(sk => sk.Email == "bob@example.com"),
-                Is.False,
-                "should not still have uninvited email address"
-            );
-        }
-
-        [Test]
-        public void UninviteUser_SystemAdmin_NoSpecialAccess()
-        {
-            var env = new TestEnvironment();
-            // User04 is a system admin, but not a project-admin or even a user on Project03
-            Assert.That(env.GetProject(Project03).UserRoles.ContainsKey(User04), Is.False, "test setup");
-            Assert.That(env.GetUser(User04).Role, Is.EqualTo(SystemRole.SystemAdmin), "test setup");
-
-            Assert.ThrowsAsync<ForbiddenException>(
-                () => env.Service.UninviteUserAsync(User04, Project03, "bob@example.com"),
-                "should have been forbidden"
-            );
-        }
-
-        [Test]
-        public async Task AddUserAsync_ShareKeyExists_AddsUserAndRemovesKey()
-        {
-            var env = new TestEnvironment();
-            SFProject project = env.GetProject(Project03);
-            SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
-
-            Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
-            Assert.That(projectSecret.ShareKeys.Any(sk => sk.Key == "key1234"), Is.True, "setup");
-            env.ParatextService
-                .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Translator)));
-
-            await env.Service.AddUserAsync(User03, Project03, null);
-            project = env.GetProject(Project03);
-            projectSecret = env.ProjectSecrets.Get(Project03);
-            Assert.That(project.UserRoles.ContainsKey(User03), Is.True, "User should have been added to project");
-            Assert.That(
-                projectSecret.ShareKeys.Any(sk => sk.Key == "key1234"),
-                Is.False,
-                "Key should have been removed from project"
-            );
-        }
-
-        [Test]
-        public void AddUserAsync_SourceProjectUnavailable_SkipProject()
-        {
-            var env = new TestEnvironment();
-            env.ParatextService
-                .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), CancellationToken.None)
-                .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Translator)));
-            Assert.DoesNotThrowAsync(() => env.Service.AddUserAsync(User03, Project04, SFProjectRole.Translator));
-            var project = env.GetProject(Project04);
-            Assert.That(project.UserRoles[User03], Is.EqualTo(SFProjectRole.Translator));
-        }
-
-        [Test]
-        public async Task AddUserAsync_PTUserHasPTPermissions()
-        {
-            // If a user connects to an existing project from the Connect Project page, project text permissions should
-            // be updated, so that the connecting user has permissions set that are from PT.
-
-            var env = new TestEnvironment();
-            string project05PTId = "paratext_" + Project05;
-            SFProject project = env.GetProject(Project05);
-            SFProject resource = env.GetProject(Resource01);
-
-            Assert.That(env.UserSecrets.Contains(User03), Is.True, "setup. PT user should have user secrets.");
-            User user = env.GetUser(User03);
-            Assert.That(user.ParatextId, Is.Not.Null, "setup. PT user should have a PT User ID.");
-
-            Assert.That(
-                project.UserRoles.ContainsKey(User03),
-                Is.False,
-                "setup. User should not already be on the project."
-            );
-            Assert.That(
-                project.Texts.First().Permissions.ContainsKey(User03),
-                Is.False,
-                "setup. User should not already have permissions on the project."
-            );
-            Assert.That(project.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
-            Assert.That(
-                resource.UserRoles.ContainsKey(User03),
-                Is.False,
-                "setup. User should not already be on the project, for purposes of testing that they are later."
-            );
-            Assert.That(
-                resource.Texts.First().Permissions.ContainsKey(User03),
-                Is.False,
-                "setup. User should not already have permissions."
-            );
-            Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
-
-            string userRoleOnPTProject = SFProjectRole.Translator;
-            env.ParatextService
-                .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(Attempt.Success(userRoleOnPTProject)));
-            string userDBLPermissionForResource = TextInfoPermission.Read;
-            env.ParatextService
-                .GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
-                .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
-
-            var bookList = new List<int>() { 40, 41 };
-            env.ParatextService.GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(bookList);
-
-            // PT will answer with these permissions.
-            var ptBookPermissions = new Dictionary<string, string>()
-            {
-                { User03, TextInfoPermission.Read },
-                { User01, TextInfoPermission.Read },
-            };
-            var ptChapterPermissions = new Dictionary<string, string>()
-            {
-                { User03, TextInfoPermission.Write },
-                { User01, TextInfoPermission.Read },
-            };
-            var ptSourcePermissions = new Dictionary<string, string>()
-            {
-                { User03, TextInfoPermission.Read },
-                { User01, TextInfoPermission.None },
-            };
-            const int bookValueToIndicateWholeResource = 0;
-            const int chapterValueToIndicateWholeBook = 0;
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    chapterValueToIndicateWholeBook
-                )
-                .Returns(Task.FromResult(ptBookPermissions));
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    Arg.Is<int>((int arg) => arg > 0)
-                )
-                .Returns(Task.FromResult(ptChapterPermissions));
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    bookValueToIndicateWholeResource,
-                    chapterValueToIndicateWholeBook
-                )
-                .Returns(Task.FromResult(ptSourcePermissions));
-
-            string projectRoleSpecifiedFromConnectProjectPage = null;
-
-            // SUT
-            await env.Service.AddUserAsync(User03, Project05, projectRoleSpecifiedFromConnectProjectPage);
-
-            project = env.GetProject(Project05);
-            Assert.That(
-                project.UserRoles.TryGetValue(User03, out string userRole),
-                Is.True,
-                "user should be added to project"
-            );
-            Assert.That(userRole, Is.EqualTo(userRoleOnPTProject));
-            user = env.GetUser(User03);
-            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project05));
-
-            Assert.That(project.Texts.First().Permissions[User03], Is.EqualTo(TextInfoPermission.Read));
-            Assert.That(
-                project.Texts.First().Chapters.First().Permissions[User03],
-                Is.EqualTo(TextInfoPermission.Write)
-            );
-
-            resource = env.GetProject(Resource01);
-            Assert.That(resource.Texts.First().Permissions[User03], Is.EqualTo(userDBLPermissionForResource));
-            Assert.That(
-                resource.Texts.First().Chapters.First().Permissions[User03],
-                Is.EqualTo(userDBLPermissionForResource)
-            );
-            Assert.That(
-                resource.UserRoles.TryGetValue(User03, out string resourceUserRole),
-                Is.True,
-                "user should have been added to resource"
-            );
-            Assert.That(
-                resourceUserRole,
-                Is.EqualTo(SFProjectRole.PTObserver),
-                "user role not set correctly on resource"
-            );
-            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Resource01), "user not added to resource correctly");
-        }
-
-        [Test]
-        public async Task AddUserAsync_HasSourceProjectRole_AddedToSourceProject()
-        {
-            var env = new TestEnvironment();
-            SFProject project03 = env.GetProject(Project03);
-            SFProject source = env.GetProject(SourceOnly);
-            Assert.That(project03.UserRoles.ContainsKey(User03), Is.False, "setup");
-            Assert.That(source.UserRoles.ContainsKey(User03), Is.False, "setup");
-            User user = env.GetUser(User03);
-            Assert.That(user.Sites[SiteId].Projects, Is.Empty);
-            env.ParatextService
-                .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), CancellationToken.None)
-                .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Translator)));
-
-            await env.Service.AddUserAsync(User03, Project03, SFProjectRole.Translator);
-            project03 = env.GetProject(Project03);
-            source = env.GetProject(SourceOnly);
-            Assert.That(project03.UserRoles.ContainsKey(User03));
-            Assert.That(source.UserRoles.ContainsKey(User03));
-            user = env.GetUser(User03);
-            Assert.That(user.Sites[SiteId].Projects, Is.EquivalentTo(new[] { Project03, SourceOnly }));
-        }
-
-        [Test]
-        public async Task UpdatePermissionsAsync_SkipsBookNotInDB()
-        {
-            // If a user connects a new project, and we seek to set permissions for the user before actually
-            // synchronizing the Scripture text, then we are missing texts on which to set permissions when running
-            // UpdatePermissionsAsync(). So silently ignore missing books.
-            // It also is conceivable that a race could occur where (1) a book is added in Paratext and SendReceived
-            // to the Paratext servers, (2) a SF user clicks Synchronize in SF, (3) SF RunAsync() gets as far as
-            // running ParatextService.SendReceiveAsync(), but doesn't yet add the new book from PT into the SF DB.
-            // (4) Another SF user joins the SF project, causing UpdatePermissionsAsync() to be called.
-            // (5) UpdatePermissionsAsync() queries for ParatextService.GetBookList(), and then tries to find the
-            // books (including the new book) in the SF project. (6) It doesn't find the new book in SF.
-            // Silently ignoring this situation will prevent a crash from 6. And whether the new user will have
-            // permissions for the new book and its chapters will depend on how smart ParatextSyncRunner's project doc
-            // is.
-
-            string project01PTId = "paratext_" + Project01;
-            var env = new TestEnvironment();
-            SFProject sfProject = env.GetProject(Project01);
-            // The SF DB should only have 2 books
-            Assert.That(sfProject.Texts.Count, Is.LessThan(3), "setup");
-
-            // But PT reports that there are 3 books.
-            env.ParatextService
-                .GetBookList(Arg.Any<UserSecret>(), project01PTId)
-                .Returns(new List<int>() { 40, 41, 42 });
-
-            var ptBookPermissions = new Dictionary<string, string>()
-            {
-                { User01, TextInfoPermission.Read },
-                { User02, TextInfoPermission.Write },
-            };
-            var ptChapterPermissions = new Dictionary<string, string>()
-            {
-                { User01, TextInfoPermission.Write },
-                { User02, TextInfoPermission.Read },
-            };
-            const int chapterValueToIndicateWholeBook = 0;
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    chapterValueToIndicateWholeBook
-                )
-                .Returns(Task.FromResult(ptBookPermissions));
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    Arg.Is<int>((int arg) => arg > 0)
-                )
-                .Returns(Task.FromResult(ptChapterPermissions));
-
-            sfProject = env.GetProject(Project01);
-            Assert.That(sfProject.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
-            Assert.That(sfProject.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
-
-            await using IConnection conn = await env.RealtimeService.ConnectAsync(User01);
-            IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
-
-            // SUT
-            await env.Service.UpdatePermissionsAsync(User01, project01Doc, CancellationToken.None);
-
-            // Permissions were set for the books and chapters that we were able to handle.
-            sfProject = env.GetProject(Project01);
-            Assert.That(sfProject.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
-            Assert.That(sfProject.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Write));
-            Assert.That(
-                sfProject.Texts.First().Chapters.First().Permissions[User01],
-                Is.EqualTo(TextInfoPermission.Write)
-            );
-            Assert.That(
-                sfProject.Texts.First().Chapters.First().Permissions[User02],
-                Is.EqualTo(TextInfoPermission.Read)
-            );
-
-            // SF should still only have the 2 books.
-            Assert.That(sfProject.Texts.Count, Is.LessThan(3), "surprise");
-        }
-
-        [Test]
-        public async Task UpdatePermissionsAsync_ThrowsIfUserHasNoSecrets()
-        {
-            string project01PTId = "paratext_" + Project01;
-            var env = new TestEnvironment();
-            env.ParatextService.GetBookList(Arg.Any<UserSecret>(), project01PTId).Returns(new List<int>() { 40, 41 });
-            Assert.That(env.ProjectSecrets.Contains(User04), Is.False, "setup");
-
-            await using IConnection conn = await env.RealtimeService.ConnectAsync(User04);
-            IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
-
-            // SUT
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.UpdatePermissionsAsync(User04, project01Doc, CancellationToken.None)
-            );
-        }
-
-        [Test]
-        public async Task UpdatePermissionsAsync_SetsBookAndChapterPermissions()
-        {
-            var env = new TestEnvironment();
-            string project01PTId = "paratext_" + Project01;
-
-            env.ParatextService.GetBookList(Arg.Any<UserSecret>(), project01PTId).Returns(new List<int>() { 40, 41 });
-
-            var ptBookPermissions = new Dictionary<string, string>
-            {
-                { User01, TextInfoPermission.Read },
-                { User02, TextInfoPermission.Write },
-            };
-            var ptChapterPermissions = new Dictionary<string, string>
-            {
-                { User01, TextInfoPermission.Write },
-                { User02, TextInfoPermission.Read },
-            };
-            const int chapterValueToIndicateWholeBook = 0;
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    chapterValueToIndicateWholeBook
-                )
-                .Returns(Task.FromResult(ptBookPermissions));
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    Arg.Is<int>((int arg) => arg > 0)
-                )
-                .Returns(Task.FromResult(ptChapterPermissions));
-
-            SFProject sfProject = env.GetProject(Project01);
-            Assert.That(sfProject.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
-            Assert.That(sfProject.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
-
-            await using IConnection conn = await env.RealtimeService.ConnectAsync(User01);
-            IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
-
-            // SUT
-            await env.Service.UpdatePermissionsAsync(User01, project01Doc, CancellationToken.None);
-
-            sfProject = env.GetProject(Project01);
-            Assert.That(sfProject.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
-            Assert.That(sfProject.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Write));
-            Assert.That(
-                sfProject.Texts.First().Chapters.First().Permissions[User01],
-                Is.EqualTo(TextInfoPermission.Write)
-            );
-            Assert.That(
-                sfProject.Texts.First().Chapters.First().Permissions[User02],
-                Is.EqualTo(TextInfoPermission.Read)
-            );
-        }
-
-        [Test]
-        public async Task UpdatePermissionsAsync_UserHasNoChapterPermission()
-        {
-            var env = new TestEnvironment();
-            string project01PTId = "paratext_" + Project01;
-
-            env.ParatextService.GetBookList(Arg.Any<UserSecret>(), project01PTId).Returns(new List<int>() { 40, 41 });
-
-            var ptBookPermissions = new Dictionary<string, string>
-            {
-                { User01, TextInfoPermission.Read },
-                { User02, TextInfoPermission.None },
-            };
-            var ptChapterPermissions = new Dictionary<string, string>
-            {
-                { User01, TextInfoPermission.Read },
-                { User02, TextInfoPermission.None },
-            };
-            const int chapterValueToIndicateWholeBook = 0;
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    chapterValueToIndicateWholeBook
-                )
-                .Returns(Task.FromResult(ptBookPermissions));
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    Arg.Is<int>((int arg) => arg > 0)
-                )
-                .Returns(Task.FromResult(ptChapterPermissions));
-
-            SFProject sfProject = env.GetProject(Project01);
-            Assert.That(sfProject.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
-            Assert.That(sfProject.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
-
-            await using IConnection conn = await env.RealtimeService.ConnectAsync(User01);
-            IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
-
-            // SUT
-            await env.Service.UpdatePermissionsAsync(User01, project01Doc, CancellationToken.None);
-
-            sfProject = env.GetProject(Project01);
-            Assert.That(sfProject.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
-            Assert.That(sfProject.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.None));
-            Assert.That(
-                sfProject.Texts.First().Chapters.First().Permissions[User01],
-                Is.EqualTo(TextInfoPermission.Read)
-            );
-            Assert.That(
-                sfProject.Texts.First().Chapters.First().Permissions[User02],
-                Is.EqualTo(TextInfoPermission.None)
-            );
-        }
-
-        [Test]
-        public async Task UpdatePermissionsAsync_SetsResourcePermissions()
-        {
-            var env = new TestEnvironment();
-            string project01PTId = "paratext_" + Project01;
-
-            var bookList = new List<int> { 40, 41 };
-            env.ParatextService.GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(bookList);
-
-            var ptBookPermissions = new Dictionary<string, string>
-            {
-                { User01, TextInfoPermission.Write },
-                { User02, TextInfoPermission.Write },
-            };
-            var ptChapterPermissions = new Dictionary<string, string>
-            {
-                { User01, TextInfoPermission.Write },
-                { User02, TextInfoPermission.Write },
-            };
-            var ptSourcePermissions = new Dictionary<string, string>
-            {
-                { User01, TextInfoPermission.Read },
-                { User02, TextInfoPermission.None },
-            };
-            const int bookValueToIndicateWholeResource = 0;
-            const int chapterValueToIndicateWholeBook = 0;
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    chapterValueToIndicateWholeBook
-                )
-                .Returns(Task.FromResult(ptBookPermissions));
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    Arg.Is<int>((int arg) => arg > 0)
-                )
-                .Returns(Task.FromResult(ptChapterPermissions));
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    bookValueToIndicateWholeResource,
-                    chapterValueToIndicateWholeBook
-                )
-                .Returns(Task.FromResult(ptSourcePermissions));
-
-            SFProject sfProject = env.GetProject(Project01);
-            Assert.That(sfProject.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
-            Assert.That(sfProject.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
-
-            SFProject resource = env.GetProject(Resource01);
-            Assert.That(resource.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
-            Assert.That(resource.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
-
-            await using IConnection conn = await env.RealtimeService.ConnectAsync(User01);
-            IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
-            IDocument<SFProject> resource01Doc = await conn.FetchAsync<SFProject>(Resource01);
-
-            // SUT 1 - Setting target project permissions continues to work as expected.
-            await env.Service.UpdatePermissionsAsync(User01, project01Doc, CancellationToken.None);
-            // SUT 2 - Resource permissions are set.
-            await env.Service.UpdatePermissionsAsync(User01, resource01Doc, CancellationToken.None);
-
-            sfProject = env.GetProject(Project01);
-            resource = env.GetProject(Resource01);
-            Assert.That(sfProject.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Write));
-            Assert.That(sfProject.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Write));
-            Assert.That(
-                sfProject.Texts.First().Chapters.First().Permissions[User01],
-                Is.EqualTo(TextInfoPermission.Write)
-            );
-            Assert.That(
-                sfProject.Texts.First().Chapters.First().Permissions[User02],
-                Is.EqualTo(TextInfoPermission.Write)
-            );
-            Assert.That(resource.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
-            Assert.That(resource.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.None));
-            Assert.That(
-                resource.Texts.First().Chapters.First().Permissions[User01],
-                Is.EqualTo(TextInfoPermission.Read)
-            );
-            Assert.That(
-                resource.Texts.First().Chapters.First().Permissions[User02],
-                Is.EqualTo(TextInfoPermission.None)
-            );
-        }
-
-        [Test]
-        public void IsSourceProject_TrueWhenProjectIsATranslationSource()
-        {
-            var env = new TestEnvironment();
-            Assert.That(env.Service.IsSourceProject(Resource01), Is.True);
-            Assert.That(env.Service.IsSourceProject(Project01), Is.False);
-            Assert.That(env.Service.IsSourceProject(SourceOnly), Is.True);
-            Assert.That(env.Service.IsSourceProject("Bad project"), Is.False);
-        }
-
-        [Test]
-        public async Task UpdateSettingsAsync_ChangeSourceProject_RecreateMachineProjectAndSync()
-        {
-            var env = new TestEnvironment();
-
-            await env.Service.UpdateSettingsAsync(
-                User01,
-                Project01,
-                new SFProjectSettings { SourceParatextId = "changedId", TranslationSuggestionsEnabled = true }
-            );
-
-            SFProject project = env.GetProject(Project01);
-            Assert.That(project.TranslateConfig.Source.ParatextId, Is.EqualTo("changedId"));
-            Assert.That(project.TranslateConfig.Source.Name, Is.EqualTo("NewSource"));
-
-            await env.MachineProjectService.Received().RemoveProjectAsync(User01, Project01, CancellationToken.None);
-            await env.MachineProjectService.Received().AddProjectAsync(User01, Project01, CancellationToken.None);
-            await env.SyncService.Received().SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
-        }
-
-        [Test]
-        public async Task UpdateSettingsAsync_SelectSourceProject_NoMachineProjectAndSync()
-        {
-            var env = new TestEnvironment();
-            await env.Service.UpdateSettingsAsync(
-                User02,
-                Project02,
-                new SFProjectSettings { SourceParatextId = "changedId" }
-            );
-
-            SFProject project = env.GetProject(Project02);
-            Assert.That(project.TranslateConfig.TranslationSuggestionsEnabled, Is.False);
-            Assert.That(project.TranslateConfig.Source.ParatextId, Is.EqualTo("changedId"));
-            Assert.That(project.TranslateConfig.Source.Name, Is.EqualTo("NewSource"));
-
-            await env.MachineProjectService
-                .DidNotReceive()
-                .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-            await env.MachineProjectService
-                .DidNotReceive()
-                .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-            await env.SyncService.Received().SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
-        }
-
-        [Test]
-        public async Task UpdateSettingsAsync_EnableTranslate_CreateMachineProjectAndSync()
-        {
-            var env = new TestEnvironment();
-            await env.Service.UpdateSettingsAsync(
-                User01,
-                Project03,
-                new SFProjectSettings { TranslationSuggestionsEnabled = true }
-            );
-
-            SFProject project = env.GetProject(Project03);
-            Assert.That(project.TranslateConfig.TranslationSuggestionsEnabled, Is.True);
-            Assert.That(project.TranslateConfig.Source.Name, Is.EqualTo("Source Only Project"));
-
-            await env.MachineProjectService
-                .DidNotReceive()
-                .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-            await env.MachineProjectService.Received().AddProjectAsync(User01, Project03, CancellationToken.None);
-            await env.SyncService.Received().SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
-        }
-
-        [Test]
-        public async Task UpdateSettingsAsync_UnsetSourceProject_RemoveMachineProjectAndSync()
-        {
-            var env = new TestEnvironment();
-            await env.Service.UpdateSettingsAsync(
-                User01,
-                Project01,
-                new SFProjectSettings
-                {
-                    SourceParatextId = SFProjectService.ProjectSettingValueUnset,
-                    TranslationSuggestionsEnabled = false
-                }
-            );
-
-            SFProject project = env.GetProject(Project01);
-            Assert.That(project.TranslateConfig.TranslationSuggestionsEnabled, Is.False);
-            Assert.That(project.TranslateConfig.Source, Is.Null);
-
-            await env.MachineProjectService.Received().RemoveProjectAsync(User01, Project01, CancellationToken.None);
-            await env.MachineProjectService
-                .DidNotReceive()
-                .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-            await env.SyncService.Received().SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
-        }
-
-        [Test]
-        public async Task UpdateSettingsAsync_EnableChecking_Sync()
-        {
-            var env = new TestEnvironment();
-
-            await env.Service.UpdateSettingsAsync(User01, Project01, new SFProjectSettings { CheckingEnabled = true });
-
-            SFProject project = env.GetProject(Project01);
-            Assert.That(project.CheckingConfig.CheckingEnabled, Is.True);
-
-            await env.MachineProjectService
-                .DidNotReceive()
-                .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-            await env.MachineProjectService
-                .DidNotReceive()
-                .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-            await env.SyncService.Received().SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
-        }
-
-        [Test]
-        public async Task UpdateSettingsAsync_EnableSharing_NoSync()
-        {
-            var env = new TestEnvironment();
-
-            await env.Service.UpdateSettingsAsync(
-                User01,
-                Project01,
-                new SFProjectSettings { CheckingShareEnabled = true }
-            );
-
-            SFProject project = env.GetProject(Project01);
-            Assert.That(project.CheckingConfig.ShareEnabled, Is.True);
-
-            await env.MachineProjectService
-                .DidNotReceive()
-                .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-            await env.MachineProjectService
-                .DidNotReceive()
-                .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-            await env.SyncService.DidNotReceive().SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
-        }
-
-        [Test]
-        public async Task DeleteAsync()
-        {
-            var env = new TestEnvironment();
-            string ptProjectDir = Path.Combine("xforge", "sync", "paratext_" + Project01);
-            env.FileSystemService.DirectoryExists(ptProjectDir).Returns(true);
-            Assert.That(env.ProjectSecrets.Contains(Project01), Is.True, "setup");
-            // SUT
-            await env.Service.DeleteProjectAsync(User01, Project01);
-
-            Assert.That(env.ContainsProject(Project01), Is.False);
-            User user = env.GetUser(User01);
-            Assert.That(user.Sites[SiteId].Projects, Does.Not.Contain(Project01));
-            await env.MachineProjectService.Received().RemoveProjectAsync(User01, Project01, CancellationToken.None);
-            env.FileSystemService.Received().DeleteDirectory(ptProjectDir);
-            Assert.That(env.ProjectSecrets.Contains(Project01), Is.False);
-
-            ptProjectDir = Path.Combine("xforge", "sync", "pt_source_no_suggestions");
-            env.FileSystemService.DirectoryExists(ptProjectDir).Returns(true);
-            Assert.That(env.GetProject(Project03).TranslateConfig.Source, Is.Not.Null);
-            await env.Service.DeleteProjectAsync(User01, SourceOnly);
-
-            await env.SyncService.Received().CancelSyncAsync(User01, SourceOnly);
-            await env.MachineProjectService.Received().RemoveProjectAsync(User01, SourceOnly, CancellationToken.None);
-            env.FileSystemService.Received().DeleteDirectory(ptProjectDir);
-            Assert.That(env.ContainsProject(SourceOnly), Is.False);
-            Assert.That(env.GetUser(User01).Sites[SiteId].Projects, Does.Not.Contain(SourceOnly));
-            Assert.That(env.GetProject(Project02).TranslateConfig.Source, Is.Null);
-        }
-
-        [Test]
-        public async Task CreateProjectAsync_NotExisting_Created()
-        {
-            var env = new TestEnvironment();
-            int projectCount = env.RealtimeService.GetRepository<SFProject>().Query().Count();
-            env.ParatextService
-                .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Administrator)));
-            // SUT
-            string sfProjectId = await env.Service.CreateProjectAsync(
-                User01,
-                new SFProjectCreateSettings() { ParatextId = "ptProject123" }
-            );
-            Assert.That(env.ContainsProject(sfProjectId), Is.True);
-            Assert.That(
-                env.RealtimeService.GetRepository<SFProject>().Query().Count(),
-                Is.EqualTo(projectCount + 1),
-                "should have increased"
-            );
-            SFProject newProject = env.RealtimeService.GetRepository<SFProject>().Get(sfProjectId);
-            Assert.That(newProject.CheckingConfig.ShareEnabled, Is.False, "Should default to not shared (SF-1142)");
-        }
-
-        [Test]
-        public async Task CreateProjectAsync_Target_Created_Before_Source()
-        {
-            var env = new TestEnvironment();
-            int projectCount = env.RealtimeService.GetRepository<SFProject>().Query().Count();
-            env.ParatextService
-                .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Administrator)));
-            env.ParatextService
-                .GetResourcePermissionAsync(Arg.Any<string>(), User01, Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(TextInfoPermission.Read));
-            // SUT
-            string sfProjectId = await env.Service.CreateProjectAsync(
-                User01,
-                new SFProjectCreateSettings()
-                {
-                    ParatextId = "ptProject123",
-                    SourceParatextId = "resource_project",
-                    TranslationSuggestionsEnabled = true,
-                }
-            );
-            Assert.That(env.ContainsProject(sfProjectId), Is.True);
-            Assert.That(
-                env.RealtimeService.GetRepository<SFProject>().Query().Count(),
-                Is.EqualTo(projectCount + 2),
-                "should have increased"
-            );
-
-            // The source should have a later ID than the target in the project repository
-            var projects = env.RealtimeService
-                .GetRepository<SFProject>()
-                .Query()
-                .Where(p => p.ParatextId == "ptProject123" || p.ParatextId == "resource_project")
-                .OrderBy(p => p.Id);
-            Assert.That(projects.First().ParatextId, Is.EqualTo("ptProject123"), "target has the first id");
-            Assert.That(projects.Last().ParatextId, Is.EqualTo("resource_project"), "source has the last id");
-
-            // The source should appear after the target in the user's project array
-            User user = env.GetUser(User01);
-            Assert.That(
-                user.Sites[SiteId].Projects.Skip(3).First(),
-                Is.EqualTo(projects.First().Id),
-                "target is first"
-            );
-            Assert.That(user.Sites[SiteId].Projects.Last(), Is.EqualTo(projects.Last().Id), "source is last");
-        }
-
-        [Test]
-        public void CreateProjectAsync_AlreadyExists_Error()
-        {
-            var env = new TestEnvironment();
-            int projectCount = env.RealtimeService.GetRepository<SFProject>().Query().Count();
-            env.ParatextService
-                .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Administrator)));
-            SFProject existingSfProject = env.GetProject(Project01);
-            // SUT
-            InvalidOperationException thrown = Assert.ThrowsAsync<InvalidOperationException>(
-                () =>
-                    env.Service.CreateProjectAsync(
-                        User01,
-                        new SFProjectCreateSettings() { ParatextId = existingSfProject.ParatextId }
-                    )
-            );
-            Assert.That(thrown.Message, Does.Contain(SFProjectService.ErrorAlreadyConnectedKey));
-            Assert.That(
-                env.RealtimeService.GetRepository<SFProject>().Query().Count(),
-                Is.EqualTo(projectCount),
-                "should not have changed"
-            );
-        }
-
-        [Test]
-        public async Task CreateProjectAsync_RequestingPTUserHasPTPermissions()
-        {
-            // If a user connects a project that was not yet in SF via the Connect Project page, project text
-            // permissions should be set so that the connecting user has permissions set that are from PT.
-
-            var env = new TestEnvironment();
-            string targetProjectPTId = PTProjectIdNotYetInSF;
-            string sourceProjectPTId = Resource01PTId;
-            SFProject resource = env.GetProject(Resource01);
-
-            Assert.That(env.UserSecrets.Contains(User03), Is.True, "setup. PT user should have user secrets.");
-            User user = env.GetUser(User03);
-            Assert.That(user.ParatextId, Is.Not.Null, "setup. PT user should have a PT User ID.");
-            Assert.That(env.ContainsProject(targetProjectPTId), Is.False, "setup. No such SF should exist yet.");
-
-            Assert.That(
-                resource.UserRoles.ContainsKey(User03),
-                Is.False,
-                "setup. User should not already be on the project, for purposes of testing that they are later."
-            );
-            Assert.That(resource.Texts.First().Permissions.ContainsKey(User03), Is.False, "setup");
-            Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
-
-            string userRoleOnPTProject = SFProjectRole.Administrator;
-            env.ParatextService
-                .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(Attempt.Success(userRoleOnPTProject)));
-            string userDBLPermissionForResource = TextInfoPermission.Read;
-            env.ParatextService
-                .GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
-                .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
-
-            var bookList = new List<int>() { 40, 41 };
-            env.ParatextService.GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(bookList);
-
-            // PT will answer with these permissions.
-            // Note that in the case of checking permissions for the target project, SF won't actually get to the
-            // point where it queries for the PT permissions. But leaving these settings here in case
-            // UpdatePermissionsAsync() is later modified and it starts doing that.
-            var ptBookPermissions = new Dictionary<string, string>()
-            {
-                { User03, TextInfoPermission.Read },
-                { User01, TextInfoPermission.Read },
-            };
-            var ptChapterPermissions = new Dictionary<string, string>()
-            {
-                { User03, TextInfoPermission.Write },
-                { User01, TextInfoPermission.Read },
-            };
-            var ptSourcePermissions = new Dictionary<string, string>()
-            {
-                { User03, userDBLPermissionForResource },
-                { User01, TextInfoPermission.None },
-            };
-            const int bookValueToIndicateWholeResource = 0;
-            const int chapterValueToIndicateWholeBook = 0;
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == targetProjectPTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    chapterValueToIndicateWholeBook
-                )
-                .Returns(Task.FromResult(ptBookPermissions));
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == targetProjectPTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    Arg.Any<int>(),
-                    Arg.Is<int>((int arg) => arg > 0)
-                )
-                .Returns(Task.FromResult(ptChapterPermissions));
-            env.ParatextService
-                .GetPermissionsAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Is<SFProject>((SFProject project) => project.ParatextId == sourceProjectPTId),
-                    Arg.Any<IReadOnlyDictionary<string, string>>(),
-                    bookValueToIndicateWholeResource,
-                    chapterValueToIndicateWholeBook
-                )
-                .Returns(Task.FromResult(ptSourcePermissions));
-
-            resource = env.GetProject(Resource01);
-            Assert.That(
-                resource.Texts.First().Permissions.Count,
-                Is.EqualTo(0),
-                "setup. User should not have permissions on resource yet."
-            );
-            Assert.That(resource.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
-
-            // SUT
-            string sfProjectId = await env.Service.CreateProjectAsync(
-                User03,
-                new SFProjectCreateSettings()
-                {
-                    ParatextId = targetProjectPTId,
-                    SourceParatextId = sourceProjectPTId,
-                    TranslationSuggestionsEnabled = true,
-                }
-            );
-
-            SFProject project = env.GetProject(sfProjectId);
-            Assert.That(
-                project.UserRoles.TryGetValue(User03, out string userRole),
-                Is.True,
-                "user should be added to project"
-            );
-            Assert.That(userRole, Is.EqualTo(userRoleOnPTProject));
-            user = env.GetUser(User03);
-            Assert.That(user.Sites[SiteId].Projects, Contains.Item(sfProjectId), "user not added to project correctly");
-
-            // Initially connecting a project should have called Sync, or SF is not going to fetch books and set
-            // permissions on them.
-            await env.SyncService.Received().SyncAsync(User03, sfProjectId, Arg.Any<bool>());
-
-            // Don't check that permissions were added to the target project, because we mock the Sync functionality.
-            // But we can show that source resource permissions were set:
-
-            resource = env.GetProject(Resource01);
-            Assert.That(resource.Texts.First().Permissions[User03], Is.EqualTo(userDBLPermissionForResource));
-            Assert.That(
-                resource.Texts.First().Chapters.First().Permissions[User03],
-                Is.EqualTo(userDBLPermissionForResource)
-            );
-            Assert.That(
-                resource.UserRoles.TryGetValue(User03, out string resourceUserRole),
-                Is.True,
-                "user should have been added to resource"
-            );
-            Assert.That(
-                resourceUserRole,
-                Is.EqualTo(SFProjectRole.PTObserver),
-                "user role not set correctly on resource"
-            );
-            Assert.That(user.Sites[SiteId].Projects, Contains.Item(Resource01), "user not added to resource correctly");
-        }
-
-        [Test]
-        public async Task CreateResourceProjectAsync_NotExisting_Created()
-        {
-            var env = new TestEnvironment();
-            int projectCount = env.RealtimeService.GetRepository<SFProject>().Query().Count();
-            // SUT
-            string sfProjectId = await env.Service.CreateResourceProjectAsync(User01, "resource_project");
-            Assert.That(env.ContainsProject(sfProjectId), Is.True);
-            Assert.That(
-                env.RealtimeService.GetRepository<SFProject>().Query().Count(),
-                Is.EqualTo(projectCount + 1),
-                "should have increased"
-            );
-        }
-
-        [Test]
-        public void CreateResourceProjectAsync_AlreadyExists_Error()
-        {
-            var env = new TestEnvironment();
-            int projectCount = env.RealtimeService.GetRepository<SFProject>().Query().Count();
-            SFProject existingSfProject = env.GetProject(Resource01);
-            // SUT
-            InvalidOperationException thrown = Assert.ThrowsAsync<InvalidOperationException>(
-                () => env.Service.CreateResourceProjectAsync(User01, existingSfProject.ParatextId)
-            );
-            Assert.That(thrown.Message, Does.Contain(SFProjectService.ErrorAlreadyConnectedKey));
-            Assert.That(
-                env.RealtimeService.GetRepository<SFProject>().Query().Count(),
-                Is.EqualTo(projectCount),
-                "should not have changed"
-            );
-        }
-
-        [Test]
-        public async Task AddUserToResourceProjectAsync_UserResourcePermission()
-        {
-            var env = new TestEnvironment();
-            env.ParatextService
-                .GetResourcePermissionAsync(Arg.Any<string>(), User01, Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(TextInfoPermission.Read));
-
-            User user = env.GetUser(User01);
-            Assert.That(user.Sites[SiteId].Projects.Contains(Resource01), Is.False, "setup");
-
-            await env.Service.AddUserAsync(User01, Resource01, null);
-
-            user = env.GetUser(User01);
-            Assert.That(user.Sites[SiteId].Projects.Contains(Resource01), Is.True, "User can access resource");
-        }
-
-        [Test]
-        public void AddUserToResourceProjectAsync_UserResourceNoPermission()
-        {
-            var env = new TestEnvironment();
-            env.ParatextService
-                .GetResourcePermissionAsync(Arg.Any<string>(), User01, Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(TextInfoPermission.None));
-
-            User user = env.GetUser(User01);
-            Assert.That(user.Sites[SiteId].Projects.Contains(Resource01), Is.False, "setup");
-
-            Assert.ThrowsAsync<ForbiddenException>(() => env.Service.AddUserAsync(User01, Resource01, null));
-
-            user = env.GetUser(User01);
-            Assert.That(user.Sites[SiteId].Projects.Contains(Resource01), Is.False, "user cannot access resource");
-        }
-
-        [Test]
-        public void CancelSyncAsync_AdministratorsCanCancelSync()
-        {
-            // Setup
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.DoesNotThrowAsync(() => env.Service.CancelSyncAsync(User01, Project01));
-        }
-
-        [Test]
-        public void CancelSyncAsync_TranslatorsCanCancelSync()
-        {
-            // Setup
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.DoesNotThrowAsync(() => env.Service.CancelSyncAsync(User05, Project01));
-        }
-
-        [Test]
-        public void CancelSyncAsync_ObserversCannotCancelSync()
-        {
-            // Setup
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.ThrowsAsync<ForbiddenException>(() => env.Service.CancelSyncAsync(User02, Project01));
-        }
-
-        [Test]
-        public void CancelSyncAsync_UsersNotInProjectCannotCancelSync()
-        {
-            // Setup
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.ThrowsAsync<ForbiddenException>(() => env.Service.CancelSyncAsync(User03, Project01));
-        }
-
-        [Test]
-        public void SyncAsync_AdministratorsCanSync()
-        {
-            // Setup
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.DoesNotThrowAsync(() => env.Service.SyncAsync(User01, Project01));
-        }
-
-        [Test]
-        public void SyncAsync_TranslatorsCanSync()
-        {
-            // Setup
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.DoesNotThrowAsync(() => env.Service.SyncAsync(User05, Project01));
-        }
-
-        [Test]
-        public void SyncAsync_ObserversCannotSync()
-        {
-            // Setup
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.ThrowsAsync<ForbiddenException>(() => env.Service.SyncAsync(User02, Project01));
-        }
-
-        [Test]
-        public async Task EnsureWritingSystemTagIsSetAsync_DoesNotUpdateIfNoChanges()
-        {
-            // Setup
-            var env = new TestEnvironment();
-
-            // SUT
-            await env.Service.EnsureWritingSystemTagIsSetAsync(User01, Project01);
-
-            // If the writing system tags are updated, the projects must be retrieved
-            // We check that this is not called, to ensure that it was not updated
-            await env.ParatextService.DidNotReceive().GetProjectsAsync(Arg.Any<UserSecret>());
-        }
-
-        [Test]
-        public async Task EnsureWritingSystemTagIsSetAsync_DoesNotUpdateIfNotInRegistry()
-        {
-            // Setup
-            var env = new TestEnvironment();
-            IReadOnlyList<ParatextProject> ptProjects = Array.Empty<ParatextProject>();
-            env.ParatextService.GetProjectsAsync(Arg.Any<UserSecret>()).Returns(Task.FromResult(ptProjects));
-
-            // SUT
-            await env.Service.EnsureWritingSystemTagIsSetAsync(User01, Project04);
-
-            // Ensure that our mock GetProjectsAsync created above is called
-            await env.ParatextService.Received(1).GetProjectsAsync(Arg.Any<UserSecret>());
-
-            Assert.IsNull(env.GetProject(Project04).WritingSystem.Tag);
-            Assert.IsNull(env.GetProject(Project04).TranslateConfig.Source.WritingSystem.Tag);
-        }
-
-        [Test]
-        public async Task EnsureWritingSystemTagIsSetAsync_UpdatesTagsIfMissing()
-        {
-            // Setup
-            const string languageTag01 = "languageTag01";
-            const string languageTag02 = "languageTag02";
-            var env = new TestEnvironment();
-            IReadOnlyList<ParatextProject> ptProjects = new[]
-            {
-                new ParatextProject { ProjectId = Project04, LanguageTag = languageTag01 },
-                new ParatextProject
-                {
-                    ParatextId = env.GetProject(Project04).TranslateConfig.Source.ParatextId,
-                    LanguageTag = languageTag02,
-                },
-            };
-            env.ParatextService.GetProjectsAsync(Arg.Any<UserSecret>()).Returns(Task.FromResult(ptProjects));
-
-            // SUT
-            await env.Service.EnsureWritingSystemTagIsSetAsync(User01, Project04);
-
-            // Ensure that our mock GetProjectsAsync created above is called
-            await env.ParatextService.Received(1).GetProjectsAsync(Arg.Any<UserSecret>());
-
-            Assert.AreEqual(languageTag01, env.GetProject(Project04).WritingSystem.Tag);
-            Assert.AreEqual(languageTag02, env.GetProject(Project04).TranslateConfig.Source.WritingSystem.Tag);
-        }
-
-        private class TestEnvironment
-        {
-            public TestEnvironment()
-            {
-                RealtimeService = new SFMemoryRealtimeService();
-                RealtimeService.AddRepository(
-                    "users",
-                    OTType.Json0,
-                    new MemoryRepository<User>(
-                        new[]
-                        {
-                            new User
-                            {
-                                Id = User01,
-                                Email = "user01@example.com",
-                                ParatextId = "pt-user01",
-                                Role = SystemRole.User,
-                                Sites = new Dictionary<string, Site>
-                                {
-                                    {
-                                        SiteId,
-                                        new Site { Projects = { Project01, Project03, SourceOnly } }
-                                    }
-                                }
-                            },
-                            new User
-                            {
-                                Id = User02,
-                                Email = "user02@example.com",
-                                ParatextId = "pt-user02",
-                                Role = SystemRole.User,
-                                Sites = new Dictionary<string, Site>
-                                {
-                                    {
-                                        SiteId,
-                                        new Site { Projects = { Project01, Project02, Project03, Project04 } }
-                                    }
-                                }
-                            },
-                            new User
-                            {
-                                Id = User03,
-                                Email = "user03@example.com",
-                                ParatextId = "pt-user03",
-                                Role = SystemRole.User,
-                                Sites = new Dictionary<string, Site> { { SiteId, new Site() } }
-                            },
-                            new User
-                            {
-                                Id = User04,
-                                Email = "user04@example.com",
-                                Sites = new Dictionary<string, Site> { { SiteId, new Site() } },
-                                Role = SystemRole.SystemAdmin
-                            },
-                            new User
-                            {
-                                Id = LinkExpiredUser,
-                                Email = "expired@example.com",
-                                Role = SystemRole.User,
-                                Sites = new Dictionary<string, Site> { { SiteId, new Site() } }
-                            },
-                            new User
-                            {
-                                Id = User05,
-                                Email = "user05@example.com",
-                                ParatextId = "pt-user05",
-                                Role = SystemRole.User,
-                                Sites = new Dictionary<string, Site>
-                                {
-                                    {
-                                        SiteId,
-                                        new Site { Projects = { Project01 } }
-                                    }
-                                }
-                            },
-                            new User
-                            {
-                                Id = User06,
-                                Email = "user06@example.com",
-                                Role = SystemRole.User,
-                                Sites = new Dictionary<string, Site>
-                                {
-                                    {
-                                        SiteId,
-                                        new Site { Projects = { Project01 } }
-                                    }
-                                }
-                            }
-                        }
-                    )
-                );
-                RealtimeService.AddRepository(
-                    "sf_projects",
-                    OTType.Json0,
-                    new MemoryRepository<SFProject>(
-                        new[]
-                        {
-                            new SFProject
-                            {
-                                Id = Project01,
-                                ParatextId = "paratext_" + Project01,
-                                Name = "project01",
-                                ShortName = "P01",
-                                TranslateConfig = new TranslateConfig
-                                {
-                                    TranslationSuggestionsEnabled = true,
-                                    ShareEnabled = true,
-                                    ShareLevel = TranslateShareLevel.Anyone,
-                                    Source = new TranslateSource
-                                    {
-                                        ProjectRef = Resource01,
-                                        ParatextId = Resource01PTId,
-                                        Name = "resource project",
-                                        ShortName = "RES",
-                                        WritingSystem = new WritingSystem { Tag = "qaa" }
-                                    }
-                                },
-                                CheckingConfig = new CheckingConfig { CheckingEnabled = true, ShareEnabled = false },
-                                UserRoles = new Dictionary<string, string>
-                                {
-                                    { User01, SFProjectRole.Administrator },
-                                    { User02, SFProjectRole.CommunityChecker },
-                                    { User05, SFProjectRole.Translator },
-                                    { User06, SFProjectRole.SFObserver }
-                                },
-                                Texts =
-                                {
-                                    new TextInfo
-                                    {
-                                        BookNum = 40,
-                                        Chapters =
-                                        {
-                                            new Chapter
-                                            {
-                                                Number = 1,
-                                                LastVerse = 3,
-                                                IsValid = true,
-                                                Permissions = { }
-                                            }
-                                        }
-                                    },
-                                    new TextInfo
-                                    {
-                                        BookNum = 41,
-                                        Chapters =
-                                        {
-                                            new Chapter
-                                            {
-                                                Number = 1,
-                                                LastVerse = 3,
-                                                IsValid = true,
-                                                Permissions = { }
-                                            },
-                                            new Chapter
-                                            {
-                                                Number = 2,
-                                                LastVerse = 3,
-                                                IsValid = true,
-                                                Permissions = { }
-                                            }
-                                        }
-                                    }
-                                },
-                                WritingSystem = new WritingSystem { Tag = "qaa" },
-                            },
-                            new SFProject
-                            {
-                                Id = Project02,
-                                Name = "project02",
-                                ShortName = "P02",
-                                ParatextId = "paratext_" + Project02,
-                                CheckingConfig = new CheckingConfig
-                                {
-                                    CheckingEnabled = true,
-                                    ShareEnabled = true,
-                                    ShareLevel = CheckingShareLevel.Anyone
-                                },
-                                UserRoles =
-                                {
-                                    { User02, SFProjectRole.Administrator },
-                                    { User04, SFProjectRole.CommunityChecker }
-                                },
-                            },
-                            new SFProject
-                            {
-                                Id = Project03,
-                                Name = "project03",
-                                ShortName = "P03",
-                                ParatextId = "paratext_" + Project03,
-                                CheckingConfig = new CheckingConfig
-                                {
-                                    CheckingEnabled = true,
-                                    ShareEnabled = true,
-                                    ShareLevel = CheckingShareLevel.Specific
-                                },
-                                TranslateConfig =
-                                {
-                                    TranslationSuggestionsEnabled = false,
-                                    Source = new TranslateSource
-                                    {
-                                        ProjectRef = SourceOnly,
-                                        ParatextId = "pt_source_no_suggestions",
-                                        Name = "Source Only Project"
-                                    }
-                                },
-                                UserRoles =
-                                {
-                                    { User01, SFProjectRole.Administrator },
-                                    { User02, SFProjectRole.CommunityChecker }
-                                }
-                            },
-                            new SFProject
-                            {
-                                Id = Project04,
-                                Name = "project04",
-                                ParatextId = "paratext_" + Project04,
-                                TranslateConfig = new TranslateConfig
-                                {
-                                    TranslationSuggestionsEnabled = true,
-                                    Source = new TranslateSource { ProjectRef = "Invalid_Source", ParatextId = "P04" },
-                                    ShareEnabled = true,
-                                    ShareLevel = TranslateShareLevel.Anyone
-                                },
-                                UserRoles =
-                                {
-                                    { User01, SFProjectRole.CommunityChecker },
-                                    { User02, SFProjectRole.Administrator }
-                                }
-                            },
-                            new SFProject
-                            {
-                                Id = Project05,
-                                ParatextId = "paratext_" + Project05,
-                                Name = "Project05",
-                                ShortName = "P05",
-                                TranslateConfig = new TranslateConfig
-                                {
-                                    TranslationSuggestionsEnabled = true,
-                                    Source = new TranslateSource
-                                    {
-                                        ProjectRef = Resource01,
-                                        ParatextId = Resource01PTId,
-                                        Name = "resource project",
-                                        ShortName = "RES",
-                                        WritingSystem = new WritingSystem { Tag = "qaa" }
-                                    }
-                                },
-                                CheckingConfig = new CheckingConfig { CheckingEnabled = true, ShareEnabled = false },
-                                UserRoles = new Dictionary<string, string>
-                                {
-                                    { User01, SFProjectRole.Administrator },
-                                    { User02, SFProjectRole.CommunityChecker }
-                                },
-                                Texts =
-                                {
-                                    new TextInfo
-                                    {
-                                        BookNum = 40,
-                                        Chapters =
-                                        {
-                                            new Chapter
-                                            {
-                                                Number = 1,
-                                                LastVerse = 3,
-                                                IsValid = true,
-                                                Permissions = { }
-                                            }
-                                        }
-                                    },
-                                    new TextInfo
-                                    {
-                                        BookNum = 41,
-                                        Chapters =
-                                        {
-                                            new Chapter
-                                            {
-                                                Number = 1,
-                                                LastVerse = 3,
-                                                IsValid = true,
-                                                Permissions = { }
-                                            },
-                                            new Chapter
-                                            {
-                                                Number = 2,
-                                                LastVerse = 3,
-                                                IsValid = true,
-                                                Permissions = { }
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            new SFProject
-                            {
-                                Id = Project06,
-                                Name = "project06",
-                                ParatextId = "paratext_" + Project06,
-                                CheckingConfig = new CheckingConfig
-                                {
-                                    CheckingEnabled = false,
-                                    ShareEnabled = true,
-                                    ShareLevel = TranslateShareLevel.Anyone
-                                },
-                                UserRoles = { { User01, SFProjectRole.CommunityChecker } }
-                            },
-                            new SFProject
-                            {
-                                Id = Resource01,
-                                ParatextId = Resource01PTId,
-                                Name = "resource project",
-                                ShortName = "RES",
-                                Texts =
-                                {
-                                    new TextInfo
-                                    {
-                                        BookNum = 40,
-                                        Chapters =
-                                        {
-                                            new Chapter
-                                            {
-                                                Number = 1,
-                                                LastVerse = 3,
-                                                IsValid = true,
-                                                Permissions = { }
-                                            }
-                                        }
-                                    },
-                                    new TextInfo
-                                    {
-                                        BookNum = 41,
-                                        Chapters =
-                                        {
-                                            new Chapter
-                                            {
-                                                Number = 1,
-                                                LastVerse = 3,
-                                                IsValid = true,
-                                                Permissions = { }
-                                            },
-                                            new Chapter
-                                            {
-                                                Number = 2,
-                                                LastVerse = 3,
-                                                IsValid = true,
-                                                Permissions = { }
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            new SFProject
-                            {
-                                Id = SourceOnly,
-                                ParatextId = "pt_source_no_suggestions",
-                                Name = "Source Only Project",
-                                ShortName = "DSP",
-                                UserRoles = { { User01, SFProjectRole.Administrator } }
-                            }
-                        }
-                    )
-                );
-                RealtimeService.AddRepository(
-                    "sf_project_user_configs",
-                    OTType.Json0,
-                    new MemoryRepository<SFProjectUserConfig>(
-                        new[]
-                        {
-                            new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project01, User01) },
-                            new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project01, User02) },
-                            new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project01, User05) },
-                            new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project01, User06) },
-                            new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project02, User02) },
-                            new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project03, User01) },
-                            new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project03, User02) },
-                            new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project04, User01) },
-                            new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project04, User02) },
-                            new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project05, User01) },
-                            new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project05, User02) },
-                            new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project06, User01) },
-                            new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(SourceOnly, User01) }
-                        }
-                    )
-                );
-
-                RealtimeService.AddRepository(
-                    "paratext_note_threads",
-                    OTType.Json0,
-                    new MemoryRepository<NoteThread>(
-                        new[]
-                        {
-                            new NoteThread
-                            {
-                                Id = "project01:thread01",
-                                DataId = "thread01",
-                                Notes = new List<Note>()
-                                {
-                                    new Note { DataId = "thread01:PT01", SyncUserRef = "PT01" },
-                                    new Note { DataId = "thread01:PT01", SyncUserRef = "PT02" }
-                                }
-                            },
-                            new NoteThread
-                            {
-                                Id = "project01:thread02",
-                                DataId = "thread02",
-                                Notes = new List<Note>()
-                                {
-                                    new Note { DataId = "thread02:PT01", SyncUserRef = "PT01" },
-                                    new Note { DataId = "thread02:PT02", SyncUserRef = "PT02" }
-                                }
-                            },
-                        }
-                    )
-                );
-                var siteOptions = Substitute.For<IOptions<SiteOptions>>();
-                siteOptions.Value.Returns(
-                    new SiteOptions
-                    {
-                        Id = SiteId,
-                        Name = "xForge",
-                        Origin = new Uri("http://localhost"),
-                        SiteDir = "xforge"
-                    }
-                );
-                var audioService = Substitute.For<IAudioService>();
-                EmailService = Substitute.For<IEmailService>();
-                var currentTime = DateTime.Now;
-                ProjectSecrets = new MemoryRepository<SFProjectSecret>(
+            RealtimeService = new SFMemoryRealtimeService();
+            RealtimeService.AddRepository(
+                "users",
+                OTType.Json0,
+                new MemoryRepository<User>(
                     new[]
                     {
-                        new SFProjectSecret
+                        new User
+                        {
+                            Id = User01,
+                            Email = "user01@example.com",
+                            ParatextId = "pt-user01",
+                            Role = SystemRole.User,
+                            Sites = new Dictionary<string, Site>
+                            {
+                                {
+                                    SiteId,
+                                    new Site { Projects = { Project01, Project03, SourceOnly } }
+                                }
+                            }
+                        },
+                        new User
+                        {
+                            Id = User02,
+                            Email = "user02@example.com",
+                            ParatextId = "pt-user02",
+                            Role = SystemRole.User,
+                            Sites = new Dictionary<string, Site>
+                            {
+                                {
+                                    SiteId,
+                                    new Site { Projects = { Project01, Project02, Project03, Project04 } }
+                                }
+                            }
+                        },
+                        new User
+                        {
+                            Id = User03,
+                            Email = "user03@example.com",
+                            ParatextId = "pt-user03",
+                            Role = SystemRole.User,
+                            Sites = new Dictionary<string, Site> { { SiteId, new Site() } }
+                        },
+                        new User
+                        {
+                            Id = User04,
+                            Email = "user04@example.com",
+                            Sites = new Dictionary<string, Site> { { SiteId, new Site() } },
+                            Role = SystemRole.SystemAdmin
+                        },
+                        new User
+                        {
+                            Id = LinkExpiredUser,
+                            Email = "expired@example.com",
+                            Role = SystemRole.User,
+                            Sites = new Dictionary<string, Site> { { SiteId, new Site() } }
+                        },
+                        new User
+                        {
+                            Id = User05,
+                            Email = "user05@example.com",
+                            ParatextId = "pt-user05",
+                            Role = SystemRole.User,
+                            Sites = new Dictionary<string, Site>
+                            {
+                                {
+                                    SiteId,
+                                    new Site { Projects = { Project01 } }
+                                }
+                            }
+                        },
+                        new User
+                        {
+                            Id = User06,
+                            Email = "user06@example.com",
+                            Role = SystemRole.User,
+                            Sites = new Dictionary<string, Site>
+                            {
+                                {
+                                    SiteId,
+                                    new Site { Projects = { Project01 } }
+                                }
+                            }
+                        }
+                    }
+                )
+            );
+            RealtimeService.AddRepository(
+                "sf_projects",
+                OTType.Json0,
+                new MemoryRepository<SFProject>(
+                    new[]
+                    {
+                        new SFProject
                         {
                             Id = Project01,
-                            ShareKeys = new List<ShareKey> { }
+                            ParatextId = "paratext_" + Project01,
+                            Name = "project01",
+                            ShortName = "P01",
+                            TranslateConfig = new TranslateConfig
+                            {
+                                TranslationSuggestionsEnabled = true,
+                                ShareEnabled = true,
+                                ShareLevel = TranslateShareLevel.Anyone,
+                                Source = new TranslateSource
+                                {
+                                    ProjectRef = Resource01,
+                                    ParatextId = Resource01PTId,
+                                    Name = "resource project",
+                                    ShortName = "RES",
+                                    WritingSystem = new WritingSystem { Tag = "qaa" }
+                                }
+                            },
+                            CheckingConfig = new CheckingConfig { CheckingEnabled = true, ShareEnabled = false },
+                            UserRoles = new Dictionary<string, string>
+                            {
+                                { User01, SFProjectRole.Administrator },
+                                { User02, SFProjectRole.CommunityChecker },
+                                { User05, SFProjectRole.Translator },
+                                { User06, SFProjectRole.SFObserver }
+                            },
+                            Texts =
+                            {
+                                new TextInfo
+                                {
+                                    BookNum = 40,
+                                    Chapters =
+                                    {
+                                        new Chapter
+                                        {
+                                            Number = 1,
+                                            LastVerse = 3,
+                                            IsValid = true,
+                                            Permissions = { }
+                                        }
+                                    }
+                                },
+                                new TextInfo
+                                {
+                                    BookNum = 41,
+                                    Chapters =
+                                    {
+                                        new Chapter
+                                        {
+                                            Number = 1,
+                                            LastVerse = 3,
+                                            IsValid = true,
+                                            Permissions = { }
+                                        },
+                                        new Chapter
+                                        {
+                                            Number = 2,
+                                            LastVerse = 3,
+                                            IsValid = true,
+                                            Permissions = { }
+                                        }
+                                    }
+                                }
+                            },
+                            WritingSystem = new WritingSystem { Tag = "qaa" },
                         },
-                        new SFProjectSecret
+                        new SFProject
                         {
                             Id = Project02,
-                            ShareKeys = new List<ShareKey>
+                            Name = "project02",
+                            ShortName = "P02",
+                            ParatextId = "paratext_" + Project02,
+                            CheckingConfig = new CheckingConfig
                             {
-                                new ShareKey { Key = "linksharing02", ProjectRole = SFProjectRole.CommunityChecker },
-                                new ShareKey
-                                {
-                                    Email = "user03@example.com",
-                                    Key = "existingkeyuser03",
-                                    ExpirationTime = currentTime.AddDays(1),
-                                    ProjectRole = SFProjectRole.CommunityChecker
-                                }
-                            }
+                                CheckingEnabled = true,
+                                ShareEnabled = true,
+                                ShareLevel = CheckingShareLevel.Anyone
+                            },
+                            UserRoles =
+                            {
+                                { User02, SFProjectRole.Administrator },
+                                { User04, SFProjectRole.CommunityChecker }
+                            },
                         },
-                        new SFProjectSecret
+                        new SFProject
                         {
                             Id = Project03,
-                            ShareKeys = new List<ShareKey>
+                            Name = "project03",
+                            ShortName = "P03",
+                            ParatextId = "paratext_" + Project03,
+                            CheckingConfig = new CheckingConfig
                             {
-                                new ShareKey
+                                CheckingEnabled = true,
+                                ShareEnabled = true,
+                                ShareLevel = CheckingShareLevel.Specific
+                            },
+                            TranslateConfig =
+                            {
+                                TranslationSuggestionsEnabled = false,
+                                Source = new TranslateSource
                                 {
-                                    Email = "bob@example.com",
-                                    Key = "key1111",
-                                    ExpirationTime = currentTime.AddDays(1),
-                                    ProjectRole = SFProjectRole.CommunityChecker
-                                },
-                                new ShareKey
-                                {
-                                    Email = "expired@example.com",
-                                    Key = "keyexp",
-                                    ExpirationTime = currentTime.AddDays(-1),
-                                    ProjectRole = SFProjectRole.CommunityChecker,
-                                },
-                                new ShareKey
-                                {
-                                    Email = "user03@example.com",
-                                    Key = "key1234",
-                                    ExpirationTime = currentTime.AddDays(1),
-                                    ProjectRole = SFProjectRole.CommunityChecker
-                                },
-                                new ShareKey
-                                {
-                                    Email = "bill@example.com",
-                                    Key = "key2222",
-                                    ExpirationTime = currentTime.AddDays(1),
-                                    ProjectRole = SFProjectRole.CommunityChecker
+                                    ProjectRef = SourceOnly,
+                                    ParatextId = "pt_source_no_suggestions",
+                                    Name = "Source Only Project"
                                 }
+                            },
+                            UserRoles =
+                            {
+                                { User01, SFProjectRole.Administrator },
+                                { User02, SFProjectRole.CommunityChecker }
                             }
                         },
-                        new SFProjectSecret
+                        new SFProject
                         {
                             Id = Project04,
-                            ShareKeys = new List<ShareKey>
+                            Name = "project04",
+                            ParatextId = "paratext_" + Project04,
+                            TranslateConfig = new TranslateConfig
                             {
-                                new ShareKey { Key = "linksharing04", ProjectRole = SFProjectRole.SFObserver },
+                                TranslationSuggestionsEnabled = true,
+                                Source = new TranslateSource { ProjectRef = "Invalid_Source", ParatextId = "P04" },
+                                ShareEnabled = true,
+                                ShareLevel = TranslateShareLevel.Anyone
+                            },
+                            UserRoles =
+                            {
+                                { User01, SFProjectRole.CommunityChecker },
+                                { User02, SFProjectRole.Administrator }
                             }
                         },
-                        new SFProjectSecret
+                        new SFProject
                         {
                             Id = Project05,
-                            ShareKeys = new List<ShareKey>
+                            ParatextId = "paratext_" + Project05,
+                            Name = "Project05",
+                            ShortName = "P05",
+                            TranslateConfig = new TranslateConfig
                             {
-                                new ShareKey
+                                TranslationSuggestionsEnabled = true,
+                                Source = new TranslateSource
                                 {
-                                    Email = "user03@example.com",
-                                    Key = "key12345",
-                                    ExpirationTime = currentTime.AddDays(1),
-                                    ProjectRole = SFProjectRole.CommunityChecker
+                                    ProjectRef = Resource01,
+                                    ParatextId = Resource01PTId,
+                                    Name = "resource project",
+                                    ShortName = "RES",
+                                    WritingSystem = new WritingSystem { Tag = "qaa" }
+                                }
+                            },
+                            CheckingConfig = new CheckingConfig { CheckingEnabled = true, ShareEnabled = false },
+                            UserRoles = new Dictionary<string, string>
+                            {
+                                { User01, SFProjectRole.Administrator },
+                                { User02, SFProjectRole.CommunityChecker }
+                            },
+                            Texts =
+                            {
+                                new TextInfo
+                                {
+                                    BookNum = 40,
+                                    Chapters =
+                                    {
+                                        new Chapter
+                                        {
+                                            Number = 1,
+                                            LastVerse = 3,
+                                            IsValid = true,
+                                            Permissions = { }
+                                        }
+                                    }
+                                },
+                                new TextInfo
+                                {
+                                    BookNum = 41,
+                                    Chapters =
+                                    {
+                                        new Chapter
+                                        {
+                                            Number = 1,
+                                            LastVerse = 3,
+                                            IsValid = true,
+                                            Permissions = { }
+                                        },
+                                        new Chapter
+                                        {
+                                            Number = 2,
+                                            LastVerse = 3,
+                                            IsValid = true,
+                                            Permissions = { }
+                                        }
+                                    }
                                 }
                             }
                         },
+                        new SFProject
+                        {
+                            Id = Project06,
+                            Name = "project06",
+                            ParatextId = "paratext_" + Project06,
+                            CheckingConfig = new CheckingConfig
+                            {
+                                CheckingEnabled = false,
+                                ShareEnabled = true,
+                                ShareLevel = TranslateShareLevel.Anyone
+                            },
+                            UserRoles = { { User01, SFProjectRole.CommunityChecker } }
+                        },
+                        new SFProject
+                        {
+                            Id = Resource01,
+                            ParatextId = Resource01PTId,
+                            Name = "resource project",
+                            ShortName = "RES",
+                            Texts =
+                            {
+                                new TextInfo
+                                {
+                                    BookNum = 40,
+                                    Chapters =
+                                    {
+                                        new Chapter
+                                        {
+                                            Number = 1,
+                                            LastVerse = 3,
+                                            IsValid = true,
+                                            Permissions = { }
+                                        }
+                                    }
+                                },
+                                new TextInfo
+                                {
+                                    BookNum = 41,
+                                    Chapters =
+                                    {
+                                        new Chapter
+                                        {
+                                            Number = 1,
+                                            LastVerse = 3,
+                                            IsValid = true,
+                                            Permissions = { }
+                                        },
+                                        new Chapter
+                                        {
+                                            Number = 2,
+                                            LastVerse = 3,
+                                            IsValid = true,
+                                            Permissions = { }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        new SFProject
+                        {
+                            Id = SourceOnly,
+                            ParatextId = "pt_source_no_suggestions",
+                            Name = "Source Only Project",
+                            ShortName = "DSP",
+                            UserRoles = { { User01, SFProjectRole.Administrator } }
+                        }
                     }
-                );
-                MachineProjectService = Substitute.For<IMachineProjectService>();
-                SyncService = Substitute.For<ISyncService>();
-                SyncService
-                    .SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>())
-                    .Returns(Task.CompletedTask);
-                ParatextService = Substitute.For<IParatextService>();
-                IReadOnlyList<ParatextProject> ptProjects = new[]
-                {
-                    new ParatextProject
-                    {
-                        ParatextId = "changedId",
-                        Name = "NewSource",
-                        LanguageTag = "qaa"
-                    },
-                    new ParatextProject { ParatextId = GetProject(Project01).ParatextId },
-                    new ParatextProject { ParatextId = PTProjectIdNotYetInSF },
-                    new ParatextProject { ParatextId = "ptProject123" }
-                };
-                ParatextService.GetProjectsAsync(Arg.Any<UserSecret>()).Returns(Task.FromResult(ptProjects));
-                IReadOnlyList<ParatextResource> ptResources = new[]
-                {
-                    new ParatextResource
-                    {
-                        ParatextId = "resource_project",
-                        Name = "ResourceProject",
-                        LanguageTag = "qaa"
-                    },
-                    new ParatextResource { ParatextId = GetProject(Resource01).ParatextId }
-                };
-                ParatextService.GetResourcesAsync(Arg.Any<string>()).Returns(ptResources);
-                UserSecrets = new MemoryRepository<UserSecret>(
+                )
+            );
+            RealtimeService.AddRepository(
+                "sf_project_user_configs",
+                OTType.Json0,
+                new MemoryRepository<SFProjectUserConfig>(
                     new[]
                     {
-                        new UserSecret { Id = User01 },
-                        new UserSecret { Id = User02 },
-                        new UserSecret { Id = User03 }
+                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project01, User01) },
+                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project01, User02) },
+                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project01, User05) },
+                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project01, User06) },
+                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project02, User02) },
+                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project03, User01) },
+                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project03, User02) },
+                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project04, User01) },
+                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project04, User02) },
+                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project05, User01) },
+                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project05, User02) },
+                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project06, User01) },
+                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(SourceOnly, User01) }
                     }
+                )
+            );
+
+            RealtimeService.AddRepository(
+                "paratext_note_threads",
+                OTType.Json0,
+                new MemoryRepository<NoteThread>(
+                    new[]
+                    {
+                        new NoteThread
+                        {
+                            Id = "project01:thread01",
+                            DataId = "thread01",
+                            Notes = new List<Note>()
+                            {
+                                new Note { DataId = "thread01:PT01", SyncUserRef = "PT01" },
+                                new Note { DataId = "thread01:PT01", SyncUserRef = "PT02" }
+                            }
+                        },
+                        new NoteThread
+                        {
+                            Id = "project01:thread02",
+                            DataId = "thread02",
+                            Notes = new List<Note>()
+                            {
+                                new Note { DataId = "thread02:PT01", SyncUserRef = "PT01" },
+                                new Note { DataId = "thread02:PT02", SyncUserRef = "PT02" }
+                            }
+                        },
+                    }
+                )
+            );
+            var siteOptions = Substitute.For<IOptions<SiteOptions>>();
+            siteOptions.Value.Returns(
+                new SiteOptions
+                {
+                    Id = SiteId,
+                    Name = "xForge",
+                    Origin = new Uri("http://localhost"),
+                    SiteDir = "xforge"
+                }
+            );
+            var audioService = Substitute.For<IAudioService>();
+            EmailService = Substitute.For<IEmailService>();
+            var currentTime = DateTime.Now;
+            ProjectSecrets = new MemoryRepository<SFProjectSecret>(
+                new[]
+                {
+                    new SFProjectSecret
+                    {
+                        Id = Project01,
+                        ShareKeys = new List<ShareKey> { }
+                    },
+                    new SFProjectSecret
+                    {
+                        Id = Project02,
+                        ShareKeys = new List<ShareKey>
+                        {
+                            new ShareKey { Key = "linksharing02", ProjectRole = SFProjectRole.CommunityChecker },
+                            new ShareKey
+                            {
+                                Email = "user03@example.com",
+                                Key = "existingkeyuser03",
+                                ExpirationTime = currentTime.AddDays(1),
+                                ProjectRole = SFProjectRole.CommunityChecker
+                            }
+                        }
+                    },
+                    new SFProjectSecret
+                    {
+                        Id = Project03,
+                        ShareKeys = new List<ShareKey>
+                        {
+                            new ShareKey
+                            {
+                                Email = "bob@example.com",
+                                Key = "key1111",
+                                ExpirationTime = currentTime.AddDays(1),
+                                ProjectRole = SFProjectRole.CommunityChecker
+                            },
+                            new ShareKey
+                            {
+                                Email = "expired@example.com",
+                                Key = "keyexp",
+                                ExpirationTime = currentTime.AddDays(-1),
+                                ProjectRole = SFProjectRole.CommunityChecker,
+                            },
+                            new ShareKey
+                            {
+                                Email = "user03@example.com",
+                                Key = "key1234",
+                                ExpirationTime = currentTime.AddDays(1),
+                                ProjectRole = SFProjectRole.CommunityChecker
+                            },
+                            new ShareKey
+                            {
+                                Email = "bill@example.com",
+                                Key = "key2222",
+                                ExpirationTime = currentTime.AddDays(1),
+                                ProjectRole = SFProjectRole.CommunityChecker
+                            }
+                        }
+                    },
+                    new SFProjectSecret
+                    {
+                        Id = Project04,
+                        ShareKeys = new List<ShareKey>
+                        {
+                            new ShareKey { Key = "linksharing04", ProjectRole = SFProjectRole.SFObserver },
+                        }
+                    },
+                    new SFProjectSecret
+                    {
+                        Id = Project05,
+                        ShareKeys = new List<ShareKey>
+                        {
+                            new ShareKey
+                            {
+                                Email = "user03@example.com",
+                                Key = "key12345",
+                                ExpirationTime = currentTime.AddDays(1),
+                                ProjectRole = SFProjectRole.CommunityChecker
+                            }
+                        }
+                    },
+                }
+            );
+            MachineProjectService = Substitute.For<IMachineProjectService>();
+            SyncService = Substitute.For<ISyncService>();
+            SyncService.SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>()).Returns(Task.CompletedTask);
+            ParatextService = Substitute.For<IParatextService>();
+            IReadOnlyList<ParatextProject> ptProjects = new[]
+            {
+                new ParatextProject
+                {
+                    ParatextId = "changedId",
+                    Name = "NewSource",
+                    LanguageTag = "qaa"
+                },
+                new ParatextProject { ParatextId = GetProject(Project01).ParatextId },
+                new ParatextProject { ParatextId = PTProjectIdNotYetInSF },
+                new ParatextProject { ParatextId = "ptProject123" }
+            };
+            ParatextService.GetProjectsAsync(Arg.Any<UserSecret>()).Returns(Task.FromResult(ptProjects));
+            IReadOnlyList<ParatextResource> ptResources = new[]
+            {
+                new ParatextResource
+                {
+                    ParatextId = "resource_project",
+                    Name = "ResourceProject",
+                    LanguageTag = "qaa"
+                },
+                new ParatextResource { ParatextId = GetProject(Resource01).ParatextId }
+            };
+            ParatextService.GetResourcesAsync(Arg.Any<string>()).Returns(ptResources);
+            UserSecrets = new MemoryRepository<UserSecret>(
+                new[]
+                {
+                    new UserSecret { Id = User01 },
+                    new UserSecret { Id = User02 },
+                    new UserSecret { Id = User03 }
+                }
+            );
+            var translateMetrics = new MemoryRepository<TranslateMetrics>();
+            FileSystemService = Substitute.For<IFileSystemService>();
+            var options = Options.Create(new LocalizationOptions { ResourcesPath = "Resources" });
+            var factory = new ResourceManagerStringLocalizerFactory(options, NullLoggerFactory.Instance);
+            Localizer = new StringLocalizer<SharedResource>(factory);
+            SecurityService = Substitute.For<ISecurityService>();
+            SecurityService.GenerateKey().Returns("1234abc");
+            var transceleratorService = Substitute.For<ITransceleratorService>();
+
+            ParatextService
+                .IsResource(Arg.Any<string>())
+                .Returns(
+                    callInfo => callInfo.ArgAt<string>(0).Length == SFInstallableDblResource.ResourceIdentifierLength
                 );
-                var translateMetrics = new MemoryRepository<TranslateMetrics>();
-                FileSystemService = Substitute.For<IFileSystemService>();
-                var options = Options.Create(new LocalizationOptions { ResourcesPath = "Resources" });
-                var factory = new ResourceManagerStringLocalizerFactory(options, NullLoggerFactory.Instance);
-                Localizer = new StringLocalizer<SharedResource>(factory);
-                SecurityService = Substitute.For<ISecurityService>();
-                SecurityService.GenerateKey().Returns("1234abc");
-                var transceleratorService = Substitute.For<ITransceleratorService>();
 
-                ParatextService
-                    .IsResource(Arg.Any<string>())
-                    .Returns(
-                        callInfo =>
-                            callInfo.ArgAt<string>(0).Length == SFInstallableDblResource.ResourceIdentifierLength
-                    );
-
-                Service = new SFProjectService(
-                    RealtimeService,
-                    siteOptions,
-                    audioService,
-                    EmailService,
-                    ProjectSecrets,
-                    SecurityService,
-                    FileSystemService,
-                    MachineProjectService,
-                    SyncService,
-                    ParatextService,
-                    UserSecrets,
-                    translateMetrics,
-                    Localizer,
-                    transceleratorService
-                );
-            }
-
-            public SFProjectService Service { get; }
-            public IMachineProjectService MachineProjectService { get; }
-            public ISyncService SyncService { get; }
-            public SFMemoryRealtimeService RealtimeService { get; }
-            public IFileSystemService FileSystemService { get; }
-            public MemoryRepository<SFProjectSecret> ProjectSecrets { get; }
-            public IEmailService EmailService { get; }
-            public ISecurityService SecurityService { get; }
-            public IParatextService ParatextService { get; }
-            public IStringLocalizer<SharedResource> Localizer { get; }
-            public MemoryRepository<UserSecret> UserSecrets { get; }
-
-            public SFProject GetProject(string id)
-            {
-                return RealtimeService.GetRepository<SFProject>().Get(id);
-            }
-
-            public bool ContainsProject(string id)
-            {
-                return RealtimeService.GetRepository<SFProject>().Contains(id);
-            }
-
-            public User GetUser(string id)
-            {
-                return RealtimeService.GetRepository<User>().Get(id);
-            }
+            Service = new SFProjectService(
+                RealtimeService,
+                siteOptions,
+                audioService,
+                EmailService,
+                ProjectSecrets,
+                SecurityService,
+                FileSystemService,
+                MachineProjectService,
+                SyncService,
+                ParatextService,
+                UserSecrets,
+                translateMetrics,
+                Localizer,
+                transceleratorService
+            );
         }
+
+        public SFProjectService Service { get; }
+        public IMachineProjectService MachineProjectService { get; }
+        public ISyncService SyncService { get; }
+        public SFMemoryRealtimeService RealtimeService { get; }
+        public IFileSystemService FileSystemService { get; }
+        public MemoryRepository<SFProjectSecret> ProjectSecrets { get; }
+        public IEmailService EmailService { get; }
+        public ISecurityService SecurityService { get; }
+        public IParatextService ParatextService { get; }
+        public IStringLocalizer<SharedResource> Localizer { get; }
+        public MemoryRepository<UserSecret> UserSecrets { get; }
+
+        public SFProject GetProject(string id) => RealtimeService.GetRepository<SFProject>().Get(id);
+
+        public bool ContainsProject(string id) => RealtimeService.GetRepository<SFProject>().Contains(id);
+
+        public User GetUser(string id) => RealtimeService.GetRepository<User>().Get(id);
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/SFScriptureTextTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFScriptureTextTests.cs
@@ -4,192 +4,191 @@ using MongoDB.Bson;
 using NUnit.Framework;
 using SIL.Machine.Tokenization;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class SFScriptureTextTests
 {
-    [TestFixture]
-    public class SFScriptureTextTests
+    [Test]
+    public void Create_HasDocOps_HasSegments()
     {
-        [Test]
-        public void Create_HasDocOps_HasSegments()
+        // Make a BsonDocument that looks like data
+        // from SF DB - xforge - texts.
+        var doc = new BsonDocument
         {
-            // Make a BsonDocument that looks like data
-            // from SF DB - xforge - texts.
-            var doc = new BsonDocument
+            { "_id", "abc123:MAT:1:target" },
             {
-                { "_id", "abc123:MAT:1:target" },
+                "ops",
+                new BsonArray
                 {
-                    "ops",
-                    new BsonArray
+                    new BsonDocument
                     {
-                        new BsonDocument
                         {
+                            "insert",
+                            new BsonDocument
                             {
-                                "insert",
-                                new BsonDocument
                                 {
-                                    {
-                                        "chapter",
-                                        new BsonDocument { { "number", "1" }, { "style", "c" } }
-                                    }
-                                }
-                            }
-                        },
-                        new BsonDocument
-                        {
-                            {
-                                "insert",
-                                new BsonDocument
-                                {
-                                    {
-                                        "verse",
-                                        new BsonDocument { { "number", "1" }, { "style", "v" } }
-                                    }
-                                }
-                            }
-                        },
-                        new BsonDocument
-                        {
-                            { "insert", "First verse text here" },
-                            {
-                                "attributes",
-                                new BsonDocument { { "segment", "verse_1_1" } }
-                            }
-                        }
-                    }
-                }
-            };
-            var numberOps = 3;
-            var numberSegments = 1;
-            var bookNumber = 40;
-            var chapterNumber = 1;
-            var projectId = "myProject";
-            Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
-            var tokenizer = new LatinWordTokenizer();
-
-            // SUT
-            var text = new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc);
-
-            Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
-            Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
-        }
-
-        [Test]
-        public void Create_NoSegments_EmptySegments()
-        {
-            var doc = new BsonDocument
-            {
-                { "_id", "abc123:MAT:1:target" },
-                {
-                    "ops",
-                    new BsonArray
-                    {
-                        new BsonDocument
-                        {
-                            {
-                                "insert",
-                                new BsonDocument
-                                {
-                                    {
-                                        "chapter",
-                                        new BsonDocument { { "number", "1" }, { "style", "c" } }
-                                    }
-                                }
-                            }
-                        },
-                        new BsonDocument
-                        {
-                            {
-                                "insert",
-                                new BsonDocument
-                                {
-                                    {
-                                        "verse",
-                                        new BsonDocument { { "number", "1" }, { "style", "v" } }
-                                    }
+                                    "chapter",
+                                    new BsonDocument { { "number", "1" }, { "style", "c" } }
                                 }
                             }
                         }
-                        // No verse text inserts with a segment reference.
-                    }
-                }
-            };
-            var numberOps = 2;
-            var numberSegments = 0;
-            var bookNumber = 40;
-            var chapterNumber = 1;
-            var projectId = "myProject";
-            Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
-            var tokenizer = new LatinWordTokenizer();
-
-            // SUT
-            var text = new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc);
-
-            Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
-            Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
-        }
-
-        [Test]
-        public void Create_EmptyOps_EmptySegments()
-        {
-            var doc = new BsonDocument
-            {
-                { "_id", "abc123:MAT:1:target" },
-                {
-                    "ops",
-                    new BsonArray
+                    },
+                    new BsonDocument
                     {
-                        // Empty ops array
+                        {
+                            "insert",
+                            new BsonDocument
+                            {
+                                {
+                                    "verse",
+                                    new BsonDocument { { "number", "1" }, { "style", "v" } }
+                                }
+                            }
+                        }
+                    },
+                    new BsonDocument
+                    {
+                        { "insert", "First verse text here" },
+                        {
+                            "attributes",
+                            new BsonDocument { { "segment", "verse_1_1" } }
+                        }
                     }
                 }
-            };
-            var numberOps = 0;
-            var numberSegments = 0;
-            var bookNumber = 40;
-            var chapterNumber = 1;
-            var projectId = "myProject";
-            Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
-            var tokenizer = new LatinWordTokenizer();
+            }
+        };
+        var numberOps = 3;
+        var numberSegments = 1;
+        var bookNumber = 40;
+        var chapterNumber = 1;
+        var projectId = "myProject";
+        Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
+        var tokenizer = new LatinWordTokenizer();
 
-            // SUT
-            var text = new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc);
+        // SUT
+        var text = new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc);
 
-            Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
-            Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
-        }
+        Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
+    }
 
-        [Test]
-        public void Create_NullDoc_Crash()
+    [Test]
+    public void Create_NoSegments_EmptySegments()
+    {
+        var doc = new BsonDocument
         {
-            BsonDocument doc = null;
-            var bookNumber = 40;
-            var chapterNumber = 1;
-            var projectId = "myProject";
-            var tokenizer = new LatinWordTokenizer();
-
-            // SUT
-            Assert.Throws<ArgumentNullException>(
-                () => new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc)
-            );
-        }
-
-        [Test]
-        public void Create_MissingOps_Crash()
-        {
-            var doc = new BsonDocument
+            { "_id", "abc123:MAT:1:target" },
             {
-                { "_id", "abc123:MAT:1:target" },
-                // Missing ops
-            };
-            var bookNumber = 40;
-            var chapterNumber = 1;
-            var projectId = "myProject";
-            Assert.That(doc.Contains("ops"), Is.False, "Setup");
-            var tokenizer = new LatinWordTokenizer();
+                "ops",
+                new BsonArray
+                {
+                    new BsonDocument
+                    {
+                        {
+                            "insert",
+                            new BsonDocument
+                            {
+                                {
+                                    "chapter",
+                                    new BsonDocument { { "number", "1" }, { "style", "c" } }
+                                }
+                            }
+                        }
+                    },
+                    new BsonDocument
+                    {
+                        {
+                            "insert",
+                            new BsonDocument
+                            {
+                                {
+                                    "verse",
+                                    new BsonDocument { { "number", "1" }, { "style", "v" } }
+                                }
+                            }
+                        }
+                    }
+                    // No verse text inserts with a segment reference.
+                }
+            }
+        };
+        var numberOps = 2;
+        var numberSegments = 0;
+        var bookNumber = 40;
+        var chapterNumber = 1;
+        var projectId = "myProject";
+        Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
+        var tokenizer = new LatinWordTokenizer();
 
-            // SUT
-            Assert.Throws<ArgumentException>(
-                () => new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc)
-            );
-        }
+        // SUT
+        var text = new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc);
+
+        Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
+    }
+
+    [Test]
+    public void Create_EmptyOps_EmptySegments()
+    {
+        var doc = new BsonDocument
+        {
+            { "_id", "abc123:MAT:1:target" },
+            {
+                "ops",
+                new BsonArray
+                {
+                    // Empty ops array
+                }
+            }
+        };
+        var numberOps = 0;
+        var numberSegments = 0;
+        var bookNumber = 40;
+        var chapterNumber = 1;
+        var projectId = "myProject";
+        Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
+        var tokenizer = new LatinWordTokenizer();
+
+        // SUT
+        var text = new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc);
+
+        Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
+    }
+
+    [Test]
+    public void Create_NullDoc_Crash()
+    {
+        BsonDocument doc = null;
+        var bookNumber = 40;
+        var chapterNumber = 1;
+        var projectId = "myProject";
+        var tokenizer = new LatinWordTokenizer();
+
+        // SUT
+        Assert.Throws<ArgumentNullException>(
+            () => new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc)
+        );
+    }
+
+    [Test]
+    public void Create_MissingOps_Crash()
+    {
+        var doc = new BsonDocument
+        {
+            { "_id", "abc123:MAT:1:target" },
+            // Missing ops
+        };
+        var bookNumber = 40;
+        var chapterNumber = 1;
+        var projectId = "myProject";
+        Assert.That(doc.Contains("ops"), Is.False, "Setup");
+        var tokenizer = new LatinWordTokenizer();
+
+        // SUT
+        Assert.Throws<ArgumentException>(
+            () => new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc)
+        );
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/SfScrTextCollectionTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SfScrTextCollectionTests.cs
@@ -1,18 +1,17 @@
 using NUnit.Framework;
 using Paratext.Data;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class SFScrTextCollectionTests
 {
-    [TestFixture]
-    public class SFScrTextCollectionTests
+    [Test]
+    public void SetsSettingsDirectory()
     {
-        [Test]
-        public void SetsSettingsDirectory()
-        {
-            ScrTextCollection.Implementation = new SFScrTextCollection();
-            ScrTextCollection.Initialize("/srv/scriptureforge/projects");
-            string dir = ScrTextCollection.SettingsDirectory;
-            Assert.That(dir, Is.EqualTo("/srv/scriptureforge/projects"));
-        }
+        ScrTextCollection.Implementation = new SFScrTextCollection();
+        ScrTextCollection.Initialize("/srv/scriptureforge/projects");
+        string dir = ScrTextCollection.SettingsDirectory;
+        Assert.That(dir, Is.EqualTo("/srv/scriptureforge/projects"));
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
@@ -14,578 +14,577 @@ using SIL.XForge.Scripture.Models;
 using SIL.XForge.Scripture.Realtime;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class SyncServiceTests
 {
-    [TestFixture]
-    public class SyncServiceTests
+    private const string Project01 = "project01";
+    private const string Project02 = "project02";
+    private const string Project03 = "project03";
+
+    [Test]
+    public async Task SyncAsync_CancelSourceAndTarget()
     {
-        private const string Project01 = "project01";
-        private const string Project02 = "project02";
-        private const string Project03 = "project03";
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
 
-        [Test]
-        public async Task SyncAsync_CancelSourceAndTarget()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
+        // Run sync
+        await env.Service.SyncAsync("userid", Project03, false);
 
-            // Run sync
-            await env.Service.SyncAsync("userid", Project03, false);
+        // Verify that the jobs were queued correctly
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(1));
+        Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
+        Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(1));
+        Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
+        Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+        Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.EqualTo(1));
 
-            // Verify that the jobs were queued correctly
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(1));
-            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
-            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(1));
-            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
-            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
-            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.EqualTo(1));
+        // Cancel sync
+        await env.Service.CancelSyncAsync("userid", Project03);
 
-            // Cancel sync
-            await env.Service.CancelSyncAsync("userid", Project03);
+        // Verify that the job was cancelled correctly
+        env.BackgroundJobClient.Received(2).ChangeState("jobid", Arg.Any<DeletedState>(), null); // Same as Delete()
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(0));
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Is.Empty);
+        Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+        Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.EqualTo(1));
+    }
 
-            // Verify that the job was cancelled correctly
-            env.BackgroundJobClient.Received(2).ChangeState("jobid", Arg.Any<DeletedState>(), null); // Same as Delete()
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Is.Empty);
-            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
-            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.EqualTo(1));
-        }
+    [Test]
+    public async Task SyncAsync_CancelSourceNotTarget()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
 
-        [Test]
-        public async Task SyncAsync_CancelSourceNotTarget()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
+        // Run sync
+        await env.Service.SyncAsync("userid", Project03, false);
 
-            // Run sync
-            await env.Service.SyncAsync("userid", Project03, false);
+        // Verify that the jobs were queued correctly
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(1));
+        Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
+        Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(1));
+        Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
+        Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+        Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.EqualTo(1));
 
-            // Verify that the jobs were queued correctly
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(1));
-            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
-            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(1));
-            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
-            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
-            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.EqualTo(1));
+        // Cancel sync
+        await env.Service.CancelSyncAsync("userid", Project01);
 
-            // Cancel sync
-            await env.Service.CancelSyncAsync("userid", Project01);
+        // Verify that the job was cancelled correctly
+        env.BackgroundJobClient.Received(1).ChangeState("jobid", Arg.Any<DeletedState>(), null); // Same as Delete()
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(0));
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(1));
+        Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(1));
+        Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Is.Empty);
+        Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+        Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.EqualTo(1));
+    }
 
-            // Verify that the job was cancelled correctly
-            env.BackgroundJobClient.Received(1).ChangeState("jobid", Arg.Any<DeletedState>(), null); // Same as Delete()
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(1));
-            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(1));
-            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Is.Empty);
-            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
-            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.EqualTo(1));
-        }
+    [Test]
+    public async Task SyncAsync_CancelTargetWithoutSource()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
 
-        [Test]
-        public async Task SyncAsync_CancelTargetWithoutSource()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
+        // Run sync
+        await env.Service.SyncAsync("userid", Project01, false);
 
-            // Run sync
-            await env.Service.SyncAsync("userid", Project01, false);
+        // Verify that the job was queued correctly
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
+        Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
+        Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+        Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.Zero);
 
-            // Verify that the job was queued correctly
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
-            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
-            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
-            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.Zero);
+        // Cancel sync
+        await env.Service.CancelSyncAsync("userid", Project01);
 
-            // Cancel sync
-            await env.Service.CancelSyncAsync("userid", Project01);
+        // Verify that the job was cancelled correctly
+        env.BackgroundJobClient.Received(1).ChangeState("jobid", Arg.Any<DeletedState>(), null); // Same as Delete()
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(0));
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Is.Empty);
+        Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+        Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.Zero);
+    }
 
-            // Verify that the job was cancelled correctly
-            env.BackgroundJobClient.Received(1).ChangeState("jobid", Arg.Any<DeletedState>(), null); // Same as Delete()
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Is.Empty);
-            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
-            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.Zero);
-        }
+    [Test]
+    public void SyncAsync_Enqueues()
+    {
+        var env = new TestEnvironment();
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).SyncDisabled, Is.False);
+        // SUT
+        Assert.DoesNotThrowAsync(() => env.Service.SyncAsync("userid", Project01, false));
+    }
 
-        [Test]
-        public void SyncAsync_Enqueues()
-        {
-            var env = new TestEnvironment();
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).SyncDisabled, Is.False);
-            // SUT
-            Assert.DoesNotThrowAsync(() => env.Service.SyncAsync("userid", Project01, false));
-        }
+    [Test]
+    public async Task SyncAsync_EnqueuesSourceAndTarget()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
 
-        [Test]
-        public async Task SyncAsync_EnqueuesSourceAndTarget()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
+        // Run sync
+        await env.Service.SyncAsync("userid", Project03, false);
 
-            // Run sync
-            await env.Service.SyncAsync("userid", Project03, false);
+        // Verify that the jobs were queued correctly
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(1));
+        Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
+        Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(1));
+        Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
+        Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+        Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.EqualTo(1));
+    }
 
-            // Verify that the jobs were queued correctly
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(1));
-            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
-            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(1));
-            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
-            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
-            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.EqualTo(1));
-        }
-
-        [Test]
-        public async Task SyncAsync_EnqueueSourceIfTranslationSuggestionsDisabled()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
-            await env.RealtimeService
-                .GetRepository<SFProject>()
-                .UpdateAsync(
-                    p => p.Id == "project03",
-                    u => u.Set(pr => pr.TranslateConfig.TranslationSuggestionsEnabled, false)
-                );
-
-            // Run sync
-            await env.Service.SyncAsync("userid", Project03, false);
-
-            // Verify that the jobs were queued correctly
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(1));
-            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
-            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(1));
-            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
-            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
-            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.EqualTo(1));
-        }
-
-        [Test]
-        public async Task SyncAsync_EnqueuedTargetWithoutSource()
-        {
-            // Set up test environment
-            var env = new TestEnvironment();
-            env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
-
-            // Run sync
-            await env.Service.SyncAsync("userid", Project01, false);
-
-            // Verify that the job was queued correctly
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
-            Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(0));
-            Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
-            Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
-            Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
-            Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.Zero);
-        }
-
-        [Test]
-        public async Task SyncAsync_SourceProjectSecretsRecordsSyncMetricsId()
-        {
-            var env = new TestEnvironment();
-
-            await env.Service.SyncAsync("userid", Project01, false);
-
-            // Verify that the sync metrics ids are recorded in the project secrets
-            string syncMetricsId = env.ProjectSecrets.Get(Project01).SyncMetricsIds.First();
-            Assert.That(env.SyncMetrics.Get(syncMetricsId), Is.Not.Null);
-            Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
-            Assert.That(env.ProjectSecrets.Get(Project03).SyncMetricsIds, Is.Empty);
-
-            await env.Service.CancelSyncAsync("userid", Project01);
-
-            // Verify that the sync metrics are cleared from the project secrets
-            Assert.That(env.ProjectSecrets.Get(Project01).SyncMetricsIds, Is.Empty);
-            Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
-            Assert.That(env.ProjectSecrets.Get(Project03).SyncMetricsIds, Is.Empty);
-        }
-
-        [Test]
-        public async Task SyncAsync_SourceAndTargetProjectSecretsRecordsSyncMetricsId()
-        {
-            var env = new TestEnvironment();
-
-            await env.Service.SyncAsync("userid", Project03, false);
-
-            // Verify that the sync metrics ids are recorded in the project secrets
-            string syncMetricsId01 = env.ProjectSecrets.Get(Project01).SyncMetricsIds.First();
-            string syncMetricsId03 = env.ProjectSecrets.Get(Project03).SyncMetricsIds.First();
-            Assert.That(env.SyncMetrics.Get(syncMetricsId01), Is.Not.Null);
-            Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
-            Assert.That(env.SyncMetrics.Get(syncMetricsId03), Is.Not.Null);
-
-            await env.Service.CancelSyncAsync("userid", Project03);
-
-            // Verify that the sync metrics are cleared from the project secrets
-            Assert.That(env.ProjectSecrets.Get(Project01).SyncMetricsIds, Is.Empty);
-            Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
-            Assert.That(env.ProjectSecrets.Get(Project03).SyncMetricsIds, Is.Empty);
-        }
-
-        [Test]
-        public async Task SyncAsync_SourceWithCancelledTargetProjectSecretsRecordsSyncMetricsId()
-        {
-            var env = new TestEnvironment();
-
-            await env.Service.SyncAsync("userid", Project03, false);
-
-            // Verify that the sync metrics ids are recorded in the project secrets
-            string syncMetricsId01 = env.ProjectSecrets.Get(Project01).SyncMetricsIds.First();
-            string syncMetricsId03 = env.ProjectSecrets.Get(Project03).SyncMetricsIds.First();
-            Assert.That(env.SyncMetrics.Get(syncMetricsId01), Is.Not.Null);
-            Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
-            Assert.That(env.SyncMetrics.Get(syncMetricsId03), Is.Not.Null);
-
-            await env.Service.CancelSyncAsync("userid", Project01);
-
-            // Verify that the sync metrics are only cleared from the target project secrets
-            Assert.That(env.ProjectSecrets.Get(Project01).SyncMetricsIds, Is.Empty);
-            Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
-            Assert.That(env.SyncMetrics.Get(env.ProjectSecrets.Get(Project03).SyncMetricsIds.First()), Is.Not.Null);
-        }
-
-        [Test]
-        public async Task SyncAsync_SyncMetricsSourceAndTargetCancelled()
-        {
-            var env = new TestEnvironment();
-            Assert.That(env.SyncMetrics.Query().Any(), Is.False);
-
-            await env.Service.SyncAsync("userid", Project03, false);
-
-            // Verify the sync metrics as queued
-            Assert.That(
-                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
-                Is.EqualTo(SyncStatus.Queued)
-            );
-            Assert.That(
-                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project03).Status,
-                Is.EqualTo(SyncStatus.Queued)
+    [Test]
+    public async Task SyncAsync_EnqueueSourceIfTranslationSuggestionsDisabled()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
+        await env.RealtimeService
+            .GetRepository<SFProject>()
+            .UpdateAsync(
+                p => p.Id == "project03",
+                u => u.Set(pr => pr.TranslateConfig.TranslationSuggestionsEnabled, false)
             );
 
-            await env.Service.CancelSyncAsync("userid", Project03);
+        // Run sync
+        await env.Service.SyncAsync("userid", Project03, false);
 
-            // Verify the sync metrics as cancelled
-            Assert.That(
-                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
-                Is.EqualTo(SyncStatus.Cancelled)
-            );
-            Assert.That(
-                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project03).Status,
-                Is.EqualTo(SyncStatus.Cancelled)
-            );
-        }
+        // Verify that the jobs were queued correctly
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(1));
+        Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
+        Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(1));
+        Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
+        Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+        Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Contains.Item("jobid"));
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.EqualTo(1));
+    }
 
-        [Test]
-        public async Task SyncAsync_SyncMetricsSourceAndTargetQueued()
+    [Test]
+    public async Task SyncAsync_EnqueuedTargetWithoutSource()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
+
+        // Run sync
+        await env.Service.SyncAsync("userid", Project01, false);
+
+        // Verify that the job was queued correctly
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project01).Sync.QueuedCount, Is.EqualTo(1));
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).Sync.QueuedCount, Is.EqualTo(0));
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project03).Sync.QueuedCount, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project01).JobIds.Count, Is.EqualTo(1));
+        Assert.That(env.ProjectSecrets.Get(Project02).JobIds.Count, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project03).JobIds.Count, Is.EqualTo(0));
+        Assert.That(env.ProjectSecrets.Get(Project01).JobIds, Contains.Item("jobid"));
+        Assert.That(env.ProjectSecrets.Get(Project02).JobIds, Is.Empty);
+        Assert.That(env.ProjectSecrets.Get(Project03).JobIds, Is.Empty);
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project01), Is.EqualTo(1));
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project02), Is.Zero);
+        Assert.That(env.SyncMetrics.Query().Count(s => s.ProjectRef == Project03), Is.Zero);
+    }
+
+    [Test]
+    public async Task SyncAsync_SourceProjectSecretsRecordsSyncMetricsId()
+    {
+        var env = new TestEnvironment();
+
+        await env.Service.SyncAsync("userid", Project01, false);
+
+        // Verify that the sync metrics ids are recorded in the project secrets
+        string syncMetricsId = env.ProjectSecrets.Get(Project01).SyncMetricsIds.First();
+        Assert.That(env.SyncMetrics.Get(syncMetricsId), Is.Not.Null);
+        Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
+        Assert.That(env.ProjectSecrets.Get(Project03).SyncMetricsIds, Is.Empty);
+
+        await env.Service.CancelSyncAsync("userid", Project01);
+
+        // Verify that the sync metrics are cleared from the project secrets
+        Assert.That(env.ProjectSecrets.Get(Project01).SyncMetricsIds, Is.Empty);
+        Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
+        Assert.That(env.ProjectSecrets.Get(Project03).SyncMetricsIds, Is.Empty);
+    }
+
+    [Test]
+    public async Task SyncAsync_SourceAndTargetProjectSecretsRecordsSyncMetricsId()
+    {
+        var env = new TestEnvironment();
+
+        await env.Service.SyncAsync("userid", Project03, false);
+
+        // Verify that the sync metrics ids are recorded in the project secrets
+        string syncMetricsId01 = env.ProjectSecrets.Get(Project01).SyncMetricsIds.First();
+        string syncMetricsId03 = env.ProjectSecrets.Get(Project03).SyncMetricsIds.First();
+        Assert.That(env.SyncMetrics.Get(syncMetricsId01), Is.Not.Null);
+        Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
+        Assert.That(env.SyncMetrics.Get(syncMetricsId03), Is.Not.Null);
+
+        await env.Service.CancelSyncAsync("userid", Project03);
+
+        // Verify that the sync metrics are cleared from the project secrets
+        Assert.That(env.ProjectSecrets.Get(Project01).SyncMetricsIds, Is.Empty);
+        Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
+        Assert.That(env.ProjectSecrets.Get(Project03).SyncMetricsIds, Is.Empty);
+    }
+
+    [Test]
+    public async Task SyncAsync_SourceWithCancelledTargetProjectSecretsRecordsSyncMetricsId()
+    {
+        var env = new TestEnvironment();
+
+        await env.Service.SyncAsync("userid", Project03, false);
+
+        // Verify that the sync metrics ids are recorded in the project secrets
+        string syncMetricsId01 = env.ProjectSecrets.Get(Project01).SyncMetricsIds.First();
+        string syncMetricsId03 = env.ProjectSecrets.Get(Project03).SyncMetricsIds.First();
+        Assert.That(env.SyncMetrics.Get(syncMetricsId01), Is.Not.Null);
+        Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
+        Assert.That(env.SyncMetrics.Get(syncMetricsId03), Is.Not.Null);
+
+        await env.Service.CancelSyncAsync("userid", Project01);
+
+        // Verify that the sync metrics are only cleared from the target project secrets
+        Assert.That(env.ProjectSecrets.Get(Project01).SyncMetricsIds, Is.Empty);
+        Assert.That(env.ProjectSecrets.Get(Project02).SyncMetricsIds, Is.Empty);
+        Assert.That(env.SyncMetrics.Get(env.ProjectSecrets.Get(Project03).SyncMetricsIds.First()), Is.Not.Null);
+    }
+
+    [Test]
+    public async Task SyncAsync_SyncMetricsSourceAndTargetCancelled()
+    {
+        var env = new TestEnvironment();
+        Assert.That(env.SyncMetrics.Query().Any(), Is.False);
+
+        await env.Service.SyncAsync("userid", Project03, false);
+
+        // Verify the sync metrics as queued
+        Assert.That(
+            env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
+            Is.EqualTo(SyncStatus.Queued)
+        );
+        Assert.That(
+            env.SyncMetrics.Query().Single(s => s.ProjectRef == Project03).Status,
+            Is.EqualTo(SyncStatus.Queued)
+        );
+
+        await env.Service.CancelSyncAsync("userid", Project03);
+
+        // Verify the sync metrics as cancelled
+        Assert.That(
+            env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
+            Is.EqualTo(SyncStatus.Cancelled)
+        );
+        Assert.That(
+            env.SyncMetrics.Query().Single(s => s.ProjectRef == Project03).Status,
+            Is.EqualTo(SyncStatus.Cancelled)
+        );
+    }
+
+    [Test]
+    public async Task SyncAsync_SyncMetricsSourceAndTargetQueued()
+    {
+        var env = new TestEnvironment();
+        Assert.That(env.SyncMetrics.Query().Any(), Is.False);
+
+        await env.Service.SyncAsync("userid", Project03, false);
+
+        // Verify the sync metrics
+        Assert.That(
+            env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
+            Is.EqualTo(SyncStatus.Queued)
+        );
+        Assert.That(
+            env.SyncMetrics.Query().Single(s => s.ProjectRef == Project03).Status,
+            Is.EqualTo(SyncStatus.Queued)
+        );
+    }
+
+    [Test]
+    public async Task SyncAsync_SyncMetricsSourceNotTargetCancelled()
+    {
+        var env = new TestEnvironment();
+        Assert.That(env.SyncMetrics.Query().Any(), Is.False);
+
+        await env.Service.SyncAsync("userid", Project03, false);
+
+        // Verify the sync metrics as queued
+        Assert.That(
+            env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
+            Is.EqualTo(SyncStatus.Queued)
+        );
+        Assert.That(
+            env.SyncMetrics.Query().Single(s => s.ProjectRef == Project03).Status,
+            Is.EqualTo(SyncStatus.Queued)
+        );
+
+        await env.Service.CancelSyncAsync("userid", Project01);
+
+        // Verify the sync metrics as cancelled
+        Assert.That(
+            env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
+            Is.EqualTo(SyncStatus.Cancelled)
+        );
+        Assert.That(
+            env.SyncMetrics.Query().Single(s => s.ProjectRef == Project03).Status,
+            Is.EqualTo(SyncStatus.Queued)
+        );
+    }
+
+    [Test]
+    public async Task SyncAsync_SyncMetricsSourceRequiresTarget()
+    {
+        var env = new TestEnvironment();
+        Assert.That(env.SyncMetrics.Query().Any(), Is.False);
+
+        await env.Service.SyncAsync("userid", Project03, false);
+
+        // Verify the sync metrics
+        string sourceId = env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Id;
+        string requiresId = env.SyncMetrics.Query().Single(s => s.ProjectRef == Project03).RequiresId;
+        Assert.That(string.IsNullOrWhiteSpace(requiresId), Is.False);
+        Assert.That(requiresId, Is.EqualTo(sourceId));
+    }
+
+    [Test]
+    public async Task SyncAsync_SyncMetricsSpecifiesDateQueued()
+    {
+        var env = new TestEnvironment();
+        DateTime beforeSync = DateTime.UtcNow;
+        Assert.That(env.SyncMetrics.Query().Any(), Is.False);
+
+        await env.Service.SyncAsync("userid", Project01, false);
+        DateTime afterSync = DateTime.UtcNow;
+
+        // Verify the sync metrics
+        var syncMetrics = env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01);
+        Assert.That(syncMetrics.DateQueued, Is.GreaterThanOrEqualTo(beforeSync));
+        Assert.That(syncMetrics.DateQueued, Is.LessThanOrEqualTo(afterSync));
+        Assert.That(syncMetrics.DateStarted, Is.Null);
+        Assert.That(syncMetrics.DateFinished, Is.Null);
+    }
+
+    [Test]
+    public async Task SyncAsync_SyncMetricsSpecifiesUser()
+    {
+        var env = new TestEnvironment();
+        Assert.That(env.SyncMetrics.Query().Any(), Is.False);
+        string curUserId = "userid";
+
+        await env.Service.SyncAsync(curUserId, Project01, false);
+
+        // Verify the sync metrics
+        Assert.That(env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).UserRef, Is.EqualTo(curUserId));
+    }
+
+    [Test]
+    public async Task SyncAsync_SyncMetricsTargetOnlyCancelled()
+    {
+        var env = new TestEnvironment();
+        Assert.That(env.SyncMetrics.Query().Any(), Is.False);
+
+        await env.Service.SyncAsync("userid", Project01, false);
+
+        // Verify the sync metrics as queued
+        Assert.That(
+            env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
+            Is.EqualTo(SyncStatus.Queued)
+        );
+
+        await env.Service.CancelSyncAsync("userid", Project01);
+
+        // Verify the sync metrics as cancelled
+        Assert.That(
+            env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
+            Is.EqualTo(SyncStatus.Cancelled)
+        );
+    }
+
+    [Test]
+    public async Task SyncAsync_SyncMetricsTargetOnlyQueued()
+    {
+        var env = new TestEnvironment();
+        Assert.That(env.SyncMetrics.Query().Any(), Is.False);
+
+        await env.Service.SyncAsync("userid", Project01, false);
+
+        // Verify the sync metrics
+        Assert.That(
+            env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
+            Is.EqualTo(SyncStatus.Queued)
+        );
+    }
+
+    [Test]
+    public void SyncAsync_NotIfSyncDisabled()
+    {
+        var env = new TestEnvironment();
+        Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).SyncDisabled, Is.True, "setup");
+        Assert.ThrowsAsync<ForbiddenException>(() => env.Service.SyncAsync("userid", Project02, false));
+    }
+
+    [Test]
+    public void SyncAsync_WarnIfAnomalousQueuedCount()
+    {
+        var env = new TestEnvironment();
+
+        env.Service.WarnIfAnomalousQueuedCount(0, "");
+        env.MockLogger.AssertNoEvent(
+            (LogEvent logEvent) => logEvent.Message.Contains("QueuedCount"),
+            "No warning should have been logged for reasonable queued count 0."
+        );
+
+        env.Service.WarnIfAnomalousQueuedCount(1, "");
+        env.MockLogger.AssertNoEvent(
+            (LogEvent logEvent) => logEvent.Message.Contains("QueuedCount"),
+            "No warning should have been logged for reasonable queued count 1."
+        );
+
+        env.Service.WarnIfAnomalousQueuedCount(-1, "");
+        env.MockLogger.AssertHasEvent(
+            (LogEvent logEvent) => logEvent.Message.Contains("QueuedCount"),
+            "Warn for unexpected queued count -1."
+        );
+
+        env.Service.WarnIfAnomalousQueuedCount(2, "");
+        env.MockLogger.AssertHasEvent(
+            (LogEvent logEvent) => logEvent.Message.Contains("QueuedCount"),
+            "Warn for less expected queued count 2."
+        );
+    }
+
+    private class TestEnvironment
+    {
+        public MockLogger<SyncService> MockLogger { get; }
+
+        public TestEnvironment()
         {
-            var env = new TestEnvironment();
-            Assert.That(env.SyncMetrics.Query().Any(), Is.False);
-
-            await env.Service.SyncAsync("userid", Project03, false);
-
-            // Verify the sync metrics
-            Assert.That(
-                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
-                Is.EqualTo(SyncStatus.Queued)
+            BackgroundJobClient = Substitute.For<IBackgroundJobClient>();
+            var hubContext = Substitute.For<IHubContext<NotificationHub, INotifier>>();
+            ProjectSecrets = new MemoryRepository<SFProjectSecret>(
+                new[]
+                {
+                    new SFProjectSecret { Id = "project01" },
+                    new SFProjectSecret { Id = "project02" },
+                    new SFProjectSecret { Id = "project03" },
+                }
             );
-            Assert.That(
-                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project03).Status,
-                Is.EqualTo(SyncStatus.Queued)
-            );
-        }
+            SyncMetrics = new MemoryRepository<SyncMetrics>();
+            RealtimeService = new SFMemoryRealtimeService();
 
-        [Test]
-        public async Task SyncAsync_SyncMetricsSourceNotTargetCancelled()
-        {
-            var env = new TestEnvironment();
-            Assert.That(env.SyncMetrics.Query().Any(), Is.False);
-
-            await env.Service.SyncAsync("userid", Project03, false);
-
-            // Verify the sync metrics as queued
-            Assert.That(
-                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
-                Is.EqualTo(SyncStatus.Queued)
-            );
-            Assert.That(
-                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project03).Status,
-                Is.EqualTo(SyncStatus.Queued)
-            );
-
-            await env.Service.CancelSyncAsync("userid", Project01);
-
-            // Verify the sync metrics as cancelled
-            Assert.That(
-                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
-                Is.EqualTo(SyncStatus.Cancelled)
-            );
-            Assert.That(
-                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project03).Status,
-                Is.EqualTo(SyncStatus.Queued)
-            );
-        }
-
-        [Test]
-        public async Task SyncAsync_SyncMetricsSourceRequiresTarget()
-        {
-            var env = new TestEnvironment();
-            Assert.That(env.SyncMetrics.Query().Any(), Is.False);
-
-            await env.Service.SyncAsync("userid", Project03, false);
-
-            // Verify the sync metrics
-            string sourceId = env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Id;
-            string requiresId = env.SyncMetrics.Query().Single(s => s.ProjectRef == Project03).RequiresId;
-            Assert.That(string.IsNullOrWhiteSpace(requiresId), Is.False);
-            Assert.That(requiresId, Is.EqualTo(sourceId));
-        }
-
-        [Test]
-        public async Task SyncAsync_SyncMetricsSpecifiesDateQueued()
-        {
-            var env = new TestEnvironment();
-            DateTime beforeSync = DateTime.UtcNow;
-            Assert.That(env.SyncMetrics.Query().Any(), Is.False);
-
-            await env.Service.SyncAsync("userid", Project01, false);
-            DateTime afterSync = DateTime.UtcNow;
-
-            // Verify the sync metrics
-            var syncMetrics = env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01);
-            Assert.That(syncMetrics.DateQueued, Is.GreaterThanOrEqualTo(beforeSync));
-            Assert.That(syncMetrics.DateQueued, Is.LessThanOrEqualTo(afterSync));
-            Assert.That(syncMetrics.DateStarted, Is.Null);
-            Assert.That(syncMetrics.DateFinished, Is.Null);
-        }
-
-        [Test]
-        public async Task SyncAsync_SyncMetricsSpecifiesUser()
-        {
-            var env = new TestEnvironment();
-            Assert.That(env.SyncMetrics.Query().Any(), Is.False);
-            string curUserId = "userid";
-
-            await env.Service.SyncAsync(curUserId, Project01, false);
-
-            // Verify the sync metrics
-            Assert.That(env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).UserRef, Is.EqualTo(curUserId));
-        }
-
-        [Test]
-        public async Task SyncAsync_SyncMetricsTargetOnlyCancelled()
-        {
-            var env = new TestEnvironment();
-            Assert.That(env.SyncMetrics.Query().Any(), Is.False);
-
-            await env.Service.SyncAsync("userid", Project01, false);
-
-            // Verify the sync metrics as queued
-            Assert.That(
-                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
-                Is.EqualTo(SyncStatus.Queued)
-            );
-
-            await env.Service.CancelSyncAsync("userid", Project01);
-
-            // Verify the sync metrics as cancelled
-            Assert.That(
-                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
-                Is.EqualTo(SyncStatus.Cancelled)
-            );
-        }
-
-        [Test]
-        public async Task SyncAsync_SyncMetricsTargetOnlyQueued()
-        {
-            var env = new TestEnvironment();
-            Assert.That(env.SyncMetrics.Query().Any(), Is.False);
-
-            await env.Service.SyncAsync("userid", Project01, false);
-
-            // Verify the sync metrics
-            Assert.That(
-                env.SyncMetrics.Query().Single(s => s.ProjectRef == Project01).Status,
-                Is.EqualTo(SyncStatus.Queued)
-            );
-        }
-
-        [Test]
-        public void SyncAsync_NotIfSyncDisabled()
-        {
-            var env = new TestEnvironment();
-            Assert.That(env.RealtimeService.GetRepository<SFProject>().Get(Project02).SyncDisabled, Is.True, "setup");
-            Assert.ThrowsAsync<ForbiddenException>(() => env.Service.SyncAsync("userid", Project02, false));
-        }
-
-        [Test]
-        public void SyncAsync_WarnIfAnomalousQueuedCount()
-        {
-            var env = new TestEnvironment();
-
-            env.Service.WarnIfAnomalousQueuedCount(0, "");
-            env.MockLogger.AssertNoEvent(
-                (LogEvent logEvent) => logEvent.Message.Contains("QueuedCount"),
-                "No warning should have been logged for reasonable queued count 0."
-            );
-
-            env.Service.WarnIfAnomalousQueuedCount(1, "");
-            env.MockLogger.AssertNoEvent(
-                (LogEvent logEvent) => logEvent.Message.Contains("QueuedCount"),
-                "No warning should have been logged for reasonable queued count 1."
-            );
-
-            env.Service.WarnIfAnomalousQueuedCount(-1, "");
-            env.MockLogger.AssertHasEvent(
-                (LogEvent logEvent) => logEvent.Message.Contains("QueuedCount"),
-                "Warn for unexpected queued count -1."
-            );
-
-            env.Service.WarnIfAnomalousQueuedCount(2, "");
-            env.MockLogger.AssertHasEvent(
-                (LogEvent logEvent) => logEvent.Message.Contains("QueuedCount"),
-                "Warn for less expected queued count 2."
-            );
-        }
-
-        private class TestEnvironment
-        {
-            public MockLogger<SyncService> MockLogger { get; }
-
-            public TestEnvironment()
-            {
-                BackgroundJobClient = Substitute.For<IBackgroundJobClient>();
-                var hubContext = Substitute.For<IHubContext<NotificationHub, INotifier>>();
-                ProjectSecrets = new MemoryRepository<SFProjectSecret>(
+            RealtimeService.AddRepository(
+                "sf_projects",
+                OTType.Json0,
+                new MemoryRepository<SFProject>(
                     new[]
                     {
-                        new SFProjectSecret { Id = "project01" },
-                        new SFProjectSecret { Id = "project02" },
-                        new SFProjectSecret { Id = "project03" },
-                    }
-                );
-                SyncMetrics = new MemoryRepository<SyncMetrics>();
-                RealtimeService = new SFMemoryRealtimeService();
-
-                RealtimeService.AddRepository(
-                    "sf_projects",
-                    OTType.Json0,
-                    new MemoryRepository<SFProject>(
-                        new[]
+                        new SFProject
                         {
-                            new SFProject
+                            Id = Project01,
+                            Name = "project01",
+                            ShortName = "P01",
+                            CheckingConfig = new CheckingConfig { ShareEnabled = false },
+                            UserRoles = new Dictionary<string, string> { },
+                        },
+                        new SFProject
+                        {
+                            Id = Project02,
+                            Name = "project02",
+                            ShortName = "P02",
+                            CheckingConfig = new CheckingConfig { ShareEnabled = false },
+                            UserRoles = new Dictionary<string, string> { },
+                            SyncDisabled = true
+                        },
+                        new SFProject
+                        {
+                            Id = Project03,
+                            Name = "project03",
+                            ShortName = "P03",
+                            CheckingConfig = new CheckingConfig { ShareEnabled = false },
+                            UserRoles = new Dictionary<string, string> { },
+                            TranslateConfig = new TranslateConfig
                             {
-                                Id = Project01,
-                                Name = "project01",
-                                ShortName = "P01",
-                                CheckingConfig = new CheckingConfig { ShareEnabled = false },
-                                UserRoles = new Dictionary<string, string> { },
-                            },
-                            new SFProject
-                            {
-                                Id = Project02,
-                                Name = "project02",
-                                ShortName = "P02",
-                                CheckingConfig = new CheckingConfig { ShareEnabled = false },
-                                UserRoles = new Dictionary<string, string> { },
-                                SyncDisabled = true
-                            },
-                            new SFProject
-                            {
-                                Id = Project03,
-                                Name = "project03",
-                                ShortName = "P03",
-                                CheckingConfig = new CheckingConfig { ShareEnabled = false },
-                                UserRoles = new Dictionary<string, string> { },
-                                TranslateConfig = new TranslateConfig
-                                {
-                                    TranslationSuggestionsEnabled = true,
-                                    Source = new TranslateSource { ProjectRef = Project01 }
-                                }
+                                TranslationSuggestionsEnabled = true,
+                                Source = new TranslateSource { ProjectRef = Project01 }
                             }
                         }
-                    )
-                );
+                    }
+                )
+            );
 
-                MockLogger = new MockLogger<SyncService>();
+            MockLogger = new MockLogger<SyncService>();
 
-                Service = new SyncService(
-                    BackgroundJobClient,
-                    hubContext,
-                    ProjectSecrets,
-                    SyncMetrics,
-                    RealtimeService,
-                    MockLogger
-                );
-            }
-
-            public SyncService Service { get; }
-            public IBackgroundJobClient BackgroundJobClient { get; }
-            public MemoryRepository<SFProjectSecret> ProjectSecrets { get; }
-            public SFMemoryRealtimeService RealtimeService { get; }
-            public MemoryRepository<SyncMetrics> SyncMetrics { get; }
+            Service = new SyncService(
+                BackgroundJobClient,
+                hubContext,
+                ProjectSecrets,
+                SyncMetrics,
+                RealtimeService,
+                MockLogger
+            );
         }
+
+        public SyncService Service { get; }
+        public IBackgroundJobClient BackgroundJobClient { get; }
+        public MemoryRepository<SFProjectSecret> ProjectSecrets { get; }
+        public SFMemoryRealtimeService RealtimeService { get; }
+        public MemoryRepository<SyncMetrics> SyncMetrics { get; }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/TestGuidService.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/TestGuidService.cs
@@ -1,21 +1,14 @@
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// This class generates IDs that are predictable and repeatable, i.e. are testable.
+/// </summary>
+public class TestGuidService : IGuidService
 {
-    /// <summary>
-    /// This class generates IDs that are predictable and repeatable, i.e. are testable.
-    /// </summary>
-    public class TestGuidService : IGuidService
-    {
-        private int _charID = 1;
-        private int _objID = 2;
+    private int _charID = 1;
+    private int _objID = 2;
 
-        public string Generate()
-        {
-            return $"{_charID++}";
-        }
+    public string Generate() => $"{_charID++}";
 
-        public string NewObjectId()
-        {
-            return "syncuser0" + _objID++;
-        }
-    }
+    public string NewObjectId() => "syncuser0" + _objID++;
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/TransceleratorServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/TransceleratorServiceTests.cs
@@ -1,72 +1,72 @@
-using NUnit.Framework;
-using NSubstitute;
 using System.Linq;
 using Microsoft.Extensions.Options;
+using NSubstitute;
+using NUnit.Framework;
 using SIL.XForge.Configuration;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Scripture.Services
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class TransceleratorServiceTests
 {
-    [TestFixture]
-    public class TransceleratorServiceTests
+    private const string Project01 = "project01";
+
+    [Test]
+    public void TransceleratorService_Questions()
     {
-        private const string Project01 = "project01";
+        var env = new TestEnvironment();
+        env.FileSystemService.DirectoryExists(Arg.Any<string>()).Returns(true);
+        env.FileSystemService
+            .EnumerateFiles(Arg.Any<string>())
+            .Returns(new string[] { "Translated Checking Questions for GEN.xml" });
+        env.FileSystemService.FileReadText(Arg.Any<string>()).Returns(TestEnvironment.XmlFileText("1.1"));
 
-        [Test]
-        public void TransceleratorService_Questions()
+        var questions = env.Service.Questions(Project01).ToArray();
+        Assert.AreEqual(questions.Length, 1);
+        Assert.AreEqual(questions[0].Book, "GEN");
+        Assert.AreEqual(questions[0].StartChapter, "1");
+        Assert.AreEqual(questions[0].StartVerse, "1");
+        Assert.AreEqual(questions[0].EndChapter, "2");
+        Assert.AreEqual(questions[0].EndVerse, "3");
+        Assert.AreEqual(questions[0].Text, "What are the main events recorded in this passage?");
+        Assert.AreEqual(questions[0].Id, "Tell [me] the main events recorded in this passage.");
+    }
+
+    [Test]
+    public void TransceleratorService_Questions_VersionError()
+    {
+        var env = new TestEnvironment();
+        env.FileSystemService.DirectoryExists(Arg.Any<string>()).Returns(true);
+        env.FileSystemService
+            .EnumerateFiles(Arg.Any<string>())
+            .Returns(new string[] { "Translated Checking Questions for GEN.xml" });
+        env.FileSystemService.FileReadText(Arg.Any<string>()).Returns(TestEnvironment.XmlFileText("1.0"));
+        Assert.Throws<DataNotFoundException>(() => env.Service.Questions(Project01));
+        env.FileSystemService.FileReadText(Arg.Any<string>()).Returns(TestEnvironment.XmlFileText("1.1.0"));
+        Assert.DoesNotThrow(() => env.Service.Questions(Project01));
+    }
+
+    private class TestEnvironment
+    {
+        public TestEnvironment()
         {
-            var env = new TestEnvironment();
-            env.FileSystemService.DirectoryExists(Arg.Any<string>()).Returns(true);
-            env.FileSystemService
-                .EnumerateFiles(Arg.Any<string>())
-                .Returns(new string[] { "Translated Checking Questions for GEN.xml" });
-            env.FileSystemService.FileReadText(Arg.Any<string>()).Returns(env.XmlFileText("1.1"));
-
-            var questions = env.Service.Questions(Project01).ToArray();
-            Assert.AreEqual(questions.Length, 1);
-            Assert.AreEqual(questions[0].Book, "GEN");
-            Assert.AreEqual(questions[0].StartChapter, "1");
-            Assert.AreEqual(questions[0].StartVerse, "1");
-            Assert.AreEqual(questions[0].EndChapter, "2");
-            Assert.AreEqual(questions[0].EndVerse, "3");
-            Assert.AreEqual(questions[0].Text, "What are the main events recorded in this passage?");
-            Assert.AreEqual(questions[0].Id, "Tell [me] the main events recorded in this passage.");
+            FileSystemService = Substitute.For<IFileSystemService>();
+            IOptions<SiteOptions> siteOptions = Microsoft.Extensions.Options.Options.Create(
+                new SiteOptions() { SiteDir = "scriptureforge" }
+            );
+            Service = new TransceleratorService(FileSystemService, siteOptions);
         }
 
-        [Test]
-        public void TransceleratorService_Questions_VersionError()
+        public TransceleratorService Service { get; }
+        public IFileSystemService FileSystemService { get; }
+
+        public static string XmlFileText(string version)
         {
-            var env = new TestEnvironment();
-            env.FileSystemService.DirectoryExists(Arg.Any<string>()).Returns(true);
-            env.FileSystemService
-                .EnumerateFiles(Arg.Any<string>())
-                .Returns(new string[] { "Translated Checking Questions for GEN.xml" });
-            env.FileSystemService.FileReadText(Arg.Any<string>()).Returns(env.XmlFileText("1.0"));
-            Assert.Throws<DataNotFoundException>(() => env.Service.Questions(Project01));
-            env.FileSystemService.FileReadText(Arg.Any<string>()).Returns(env.XmlFileText("1.1.0"));
-            Assert.DoesNotThrow(() => env.Service.Questions(Project01));
-        }
-
-        private class TestEnvironment
-        {
-            public TestEnvironment()
-            {
-                FileSystemService = Substitute.For<IFileSystemService>();
-                IOptions<SiteOptions> siteOptions = Microsoft.Extensions.Options.Options.Create(
-                    new SiteOptions() { SiteDir = "scriptureforge" }
-                );
-                Service = new TransceleratorService(FileSystemService, siteOptions);
-            }
-
-            public TransceleratorService Service { get; }
-            public IFileSystemService FileSystemService { get; }
-
-            public string XmlFileText(string version)
-            {
-                return @"<?xml version=""1.0"" encoding=""utf-8""?>
+            return @"<?xml version=""1.0"" encoding=""utf-8""?>
 <ComprehensionCheckingQuestionsForBook xml:lang=""en"" version="""
-                    + version
-                    + @""" book=""GEN"">
+                + version
+                + @""" book=""GEN"">
 	<Question id=""Tell [me] the main events recorded in this passage."" overview=""true"" startChapter=""1"" endChapter=""2"" startVerse=""1"" endVerse=""3"">
 		<Q>
 			<StringAlt xml:lang=""en"">What are the main events recorded in this passage?</StringAlt>
@@ -87,7 +87,6 @@ namespace SIL.XForge.Scripture.Services
 		</Notes>
 	</Question>
 </ComprehensionCheckingQuestionsForBook>";
-            }
         }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/StartupTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/StartupTests.cs
@@ -6,99 +6,98 @@ using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NUnit.Framework;
 
-namespace SIL.XForge.Scripture
+namespace SIL.XForge.Scripture;
+
+[TestFixture]
+public class StartupTests
 {
-    [TestFixture]
-    public class StartupTests
+    private IConfiguration _configuration;
+    private IWebHostEnvironment _env;
+    private ILoggerFactory _loggerFactory;
+    private Startup _startup;
+    private HttpContext _context;
+
+    [SetUp]
+    public void Init()
     {
-        private IConfiguration _configuration;
-        private IWebHostEnvironment _env;
-        private ILoggerFactory _loggerFactory;
-        private Startup _startup;
-        private HttpContext _context;
+        _configuration = Substitute.For<IConfiguration>();
+        _env = Substitute.For<IWebHostEnvironment>();
+        _loggerFactory = Substitute.For<ILoggerFactory>();
+        _startup = new Startup(_configuration, _env, _loggerFactory);
+        Assert.NotNull(_startup, "Setup");
+        _context = Substitute.For<HttpContext>();
+        _context.Request.Method = HttpMethods.Get;
+    }
 
-        [SetUp]
-        public void Init()
-        {
-            _configuration = Substitute.For<IConfiguration>();
-            _env = Substitute.For<IWebHostEnvironment>();
-            _loggerFactory = Substitute.For<ILoggerFactory>();
-            _startup = new Startup(_configuration, _env, _loggerFactory);
-            Assert.NotNull(_startup, "Setup");
-            _context = Substitute.For<HttpContext>();
-            _context.Request.Method = HttpMethods.Get;
-        }
+    [Test]
+    public void IsSpaRoute_MethodNotGet_NotRoute()
+    {
+        _context.Request.Method = HttpMethods.Post;
+        _context.Request.Path = new PathString("/system-administration");
 
-        [Test]
-        public void IsSpaRoute_MethodNotGet_NotRoute()
-        {
-            _context.Request.Method = HttpMethods.Post;
-            _context.Request.Path = new PathString("/system-administration");
+        Assert.IsFalse(_startup.IsSpaRoute(_context));
+    }
 
-            Assert.IsFalse(_startup.IsSpaRoute(_context));
-        }
+    [Test]
+    public void IsSpaRoute_RootPath_NotRoute()
+    {
+        _context.Request.Path = new PathString("/");
 
-        [Test]
-        public void IsSpaRoute_RootPath_NotRoute()
-        {
-            _context.Request.Path = new PathString("/");
+        Assert.IsFalse(_startup.IsSpaRoute(_context));
+    }
 
-            Assert.IsFalse(_startup.IsSpaRoute(_context));
-        }
+    [Test]
+    public void IsSpaRoute_InvalidPath_NotRoute()
+    {
+        _context.Request.Path = new PathString("/invalid-path");
 
-        [Test]
-        public void IsSpaRoute_InvalidPath_NotRoute()
-        {
-            _context.Request.Path = new PathString("/invalid-path");
+        Assert.IsFalse(_startup.IsSpaRoute(_context));
+    }
 
-            Assert.IsFalse(_startup.IsSpaRoute(_context));
-        }
+    [Test]
+    public void IsSpaRoute_ValidPath_IsRoute()
+    {
+        _context.Request.Path = new PathString("/system-administration");
 
-        [Test]
-        public void IsSpaRoute_ValidPath_IsRoute()
-        {
-            _context.Request.Path = new PathString("/system-administration");
+        Assert.IsTrue(_startup.IsSpaRoute(_context));
+    }
 
-            Assert.IsTrue(_startup.IsSpaRoute(_context));
-        }
+    [Test]
+    public void IsSpaRoute_ValidMultiPath_IsRoute()
+    {
+        _context.Request.Path = new PathString("/system-administration/more");
 
-        [Test]
-        public void IsSpaRoute_ValidMultiPath_IsRoute()
-        {
-            _context.Request.Path = new PathString("/system-administration/more");
+        Assert.IsTrue(_startup.IsSpaRoute(_context));
+    }
 
-            Assert.IsTrue(_startup.IsSpaRoute(_context));
-        }
+    [Test]
+    public void IsSpaRoute_DevelopmentPath_IsRoute()
+    {
+        _env.EnvironmentName = Environments.Development;
+        _startup = new Startup(_configuration, _env, _loggerFactory);
+        _context.Request.Path = new PathString("/sockjs-node");
 
-        [Test]
-        public void IsSpaRoute_DevelopmentPath_IsRoute()
-        {
-            _env.EnvironmentName = Environments.Development;
-            _startup = new Startup(_configuration, _env, _loggerFactory);
-            _context.Request.Path = new PathString("/sockjs-node");
+        Assert.IsTrue(_startup.IsSpaRoute(_context));
+    }
 
-            Assert.IsTrue(_startup.IsSpaRoute(_context));
-        }
+    [Test]
+    public void IsSpaRoute_DevelopmentPathValidPost_IsRoute()
+    {
+        _env.EnvironmentName = Environments.Development;
+        _startup = new Startup(_configuration, _env, _loggerFactory);
+        _context.Request.Method = HttpMethods.Post;
+        _context.Request.Path = new PathString("/sockjs-node");
 
-        [Test]
-        public void IsSpaRoute_DevelopmentPathValidPost_IsRoute()
-        {
-            _env.EnvironmentName = Environments.Development;
-            _startup = new Startup(_configuration, _env, _loggerFactory);
-            _context.Request.Method = HttpMethods.Post;
-            _context.Request.Path = new PathString("/sockjs-node");
+        Assert.IsTrue(_startup.IsSpaRoute(_context));
+    }
 
-            Assert.IsTrue(_startup.IsSpaRoute(_context));
-        }
+    [Test]
+    public void IsSpaRoute_ProductionPath_IsRoute()
+    {
+        _env.EnvironmentName = Environments.Production;
+        _startup = new Startup(_configuration, _env, _loggerFactory);
+        _context.Request.Path = new PathString("/styles.a2f070be0b37085d72ba.css");
 
-        [Test]
-        public void IsSpaRoute_ProductionPath_IsRoute()
-        {
-            _env.EnvironmentName = Environments.Production;
-            _startup = new Startup(_configuration, _env, _loggerFactory);
-            _context.Request.Path = new PathString("/styles.a2f070be0b37085d72ba.css");
-
-            Assert.IsTrue(_startup.IsSpaRoute(_context));
-        }
+        Assert.IsTrue(_startup.IsSpaRoute(_context));
     }
 }

--- a/test/SIL.XForge.Tests/DataAccess/MemoryUpdateBuilderTests.cs
+++ b/test/SIL.XForge.Tests/DataAccess/MemoryUpdateBuilderTests.cs
@@ -2,148 +2,147 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.DataAccess
+namespace SIL.XForge.DataAccess;
+
+[TestFixture]
+public class MemoryUpdateBuilderTests
 {
-    [TestFixture]
-    public class MemoryUpdateBuilderTests
+    [Test]
+    public void MemoryUpdateBuilder_Add()
     {
-        [Test]
-        public void MemoryUpdateBuilder_Add()
+        // Setup environment
+        var env = new TestEnvironment();
+        int oldCount = env.TestEntity.TestChildCollection.Count;
+
+        // Test collection add
+        env.MemoryUpdateBuilder.Add(e => e.TestChildCollection, new TestEntity { Id = "test_id_3" });
+        Assert.AreEqual(oldCount + 1, env.TestEntity.TestChildCollection.Count);
+    }
+
+    [Test]
+    public void MemoryUpdateBuilder_Inc()
+    {
+        var env = new TestEnvironment();
+        int oldValue = env.TestEntity.TestChildCollection.Count;
+
+        // Test increment
+        env.MemoryUpdateBuilder.Inc(e => e.TestNumber, 1);
+        Assert.AreEqual(oldValue + 1, env.TestEntity.TestNumber);
+
+        // Test decrement
+        env.MemoryUpdateBuilder.Inc(e => e.TestNumber, -1);
+        Assert.AreEqual(oldValue, env.TestEntity.TestNumber);
+    }
+
+    [Test]
+    public void MemoryUpdateBuilder_Remove()
+    {
+        // Setup environment
+        var env = new TestEnvironment();
+        int oldCount = env.TestEntity.TestStringCollection.Count;
+
+        // Test string collection remove
+        env.MemoryUpdateBuilder.Remove(e => e.TestStringCollection, "test_value_2");
+        Assert.AreEqual(oldCount - 1, env.TestEntity.TestStringCollection.Count);
+    }
+
+    [Test]
+    public void MemoryUpdateBuilder_RemoveAll()
+    {
+        // Setup environment
+        var env = new TestEnvironment();
+        int oldCount = env.TestEntity.TestChildCollection.Count;
+
+        // Test string collection remove all
+        env.MemoryUpdateBuilder.RemoveAll(e => e.TestChildCollection, e => e.Id == "test_id_2");
+        Assert.AreEqual(oldCount - 1, env.TestEntity.TestChildCollection.Count);
+    }
+
+    [Test]
+    public void MemoryUpdateBuilder_Set()
+    {
+        // Setup environment
+        var env = new TestEnvironment();
+        string expected = "updated_test_value";
+
+        // Test string field set
+        Assert.AreNotEqual(expected, env.TestEntity.TestStringField);
+        env.MemoryUpdateBuilder.Set(e => e.TestStringField, expected);
+        Assert.AreEqual(expected, env.TestEntity.TestStringField);
+    }
+
+    [Test]
+    public void MemoryUpdateBuilder_SetOnInsertDisabled()
+    {
+        // Setup environment
+        var env = new TestEnvironment(false);
+        string oldValue = env.TestEntity.TestStringField;
+        string expected = "updated_test_value";
+
+        // Test string field set
+        Assert.AreNotEqual(expected, env.TestEntity.TestStringField);
+        env.MemoryUpdateBuilder.SetOnInsert(e => e.TestStringField, expected);
+        Assert.AreEqual(oldValue, env.TestEntity.TestStringField);
+    }
+
+    [Test]
+    public void MemoryUpdateBuilder_SetOnInsertEnabled()
+    {
+        // Setup environment
+        var env = new TestEnvironment(true);
+        string expected = "updated_test_value";
+
+        // Test string field set
+        Assert.AreNotEqual(expected, env.TestEntity.TestStringField);
+        env.MemoryUpdateBuilder.SetOnInsert(e => e.TestStringField, expected);
+        Assert.AreEqual(expected, env.TestEntity.TestStringField);
+    }
+
+    [Test]
+    public void MemoryUpdateBuilder_Unset()
+    {
+        // Setup environment
+        var env = new TestEnvironment();
+        string expected = null;
+
+        // Test string field unset
+        Assert.AreNotEqual(expected, env.TestEntity.TestStringField);
+        env.MemoryUpdateBuilder.Unset(e => e.TestStringField);
+        Assert.AreEqual(expected, env.TestEntity.TestStringField);
+    }
+
+    private class TestEntity : IIdentifiable
+    {
+        public string Id { get; set; }
+        public int TestNumber { get; set; }
+        public List<TestEntity> TestChildCollection { get; set; } = new List<TestEntity>();
+        public List<string> TestStringCollection { get; set; } = new List<string>();
+        public string TestStringField { get; set; }
+    }
+
+    private class TestEnvironment
+    {
+        public TestEnvironment(bool setOnInsert = false)
         {
-            // Setup environment
-            var env = new TestEnvironment();
-            int oldCount = env.TestEntity.TestChildCollection.Count;
-
-            // Test collection add
-            env.MemoryUpdateBuilder.Add(e => e.TestChildCollection, new TestEntity { Id = "test_id_3" });
-            Assert.AreEqual(oldCount + 1, env.TestEntity.TestChildCollection.Count);
-        }
-
-        [Test]
-        public void MemoryUpdateBuilder_Inc()
-        {
-            var env = new TestEnvironment();
-            int oldValue = env.TestEntity.TestChildCollection.Count;
-
-            // Test increment
-            env.MemoryUpdateBuilder.Inc(e => e.TestNumber, 1);
-            Assert.AreEqual(oldValue + 1, env.TestEntity.TestNumber);
-
-            // Test decrement
-            env.MemoryUpdateBuilder.Inc(e => e.TestNumber, -1);
-            Assert.AreEqual(oldValue, env.TestEntity.TestNumber);
-        }
-
-        [Test]
-        public void MemoryUpdateBuilder_Remove()
-        {
-            // Setup environment
-            var env = new TestEnvironment();
-            int oldCount = env.TestEntity.TestStringCollection.Count;
-
-            // Test string collection remove
-            env.MemoryUpdateBuilder.Remove(e => e.TestStringCollection, "test_value_2");
-            Assert.AreEqual(oldCount - 1, env.TestEntity.TestStringCollection.Count);
-        }
-
-        [Test]
-        public void MemoryUpdateBuilder_RemoveAll()
-        {
-            // Setup environment
-            var env = new TestEnvironment();
-            int oldCount = env.TestEntity.TestChildCollection.Count;
-
-            // Test string collection remove all
-            env.MemoryUpdateBuilder.RemoveAll(e => e.TestChildCollection, e => e.Id == "test_id_2");
-            Assert.AreEqual(oldCount - 1, env.TestEntity.TestChildCollection.Count);
-        }
-
-        [Test]
-        public void MemoryUpdateBuilder_Set()
-        {
-            // Setup environment
-            var env = new TestEnvironment();
-            string expected = "updated_test_value";
-
-            // Test string field set
-            Assert.AreNotEqual(expected, env.TestEntity.TestStringField);
-            env.MemoryUpdateBuilder.Set(e => e.TestStringField, expected);
-            Assert.AreEqual(expected, env.TestEntity.TestStringField);
-        }
-
-        [Test]
-        public void MemoryUpdateBuilder_SetOnInsertDisabled()
-        {
-            // Setup environment
-            var env = new TestEnvironment(false);
-            string oldValue = env.TestEntity.TestStringField;
-            string expected = "updated_test_value";
-
-            // Test string field set
-            Assert.AreNotEqual(expected, env.TestEntity.TestStringField);
-            env.MemoryUpdateBuilder.SetOnInsert(e => e.TestStringField, expected);
-            Assert.AreEqual(oldValue, env.TestEntity.TestStringField);
-        }
-
-        [Test]
-        public void MemoryUpdateBuilder_SetOnInsertEnabled()
-        {
-            // Setup environment
-            var env = new TestEnvironment(true);
-            string expected = "updated_test_value";
-
-            // Test string field set
-            Assert.AreNotEqual(expected, env.TestEntity.TestStringField);
-            env.MemoryUpdateBuilder.SetOnInsert(e => e.TestStringField, expected);
-            Assert.AreEqual(expected, env.TestEntity.TestStringField);
-        }
-
-        [Test]
-        public void MemoryUpdateBuilder_Unset()
-        {
-            // Setup environment
-            var env = new TestEnvironment();
-            string expected = null;
-
-            // Test string field unset
-            Assert.AreNotEqual(expected, env.TestEntity.TestStringField);
-            env.MemoryUpdateBuilder.Unset(e => e.TestStringField);
-            Assert.AreEqual(expected, env.TestEntity.TestStringField);
-        }
-
-        private class TestEntity : IIdentifiable
-        {
-            public string Id { get; set; }
-            public int TestNumber { get; set; }
-            public List<TestEntity> TestChildCollection { get; set; } = new List<TestEntity>();
-            public List<string> TestStringCollection { get; set; } = new List<string>();
-            public string TestStringField { get; set; }
-        }
-
-        private class TestEnvironment
-        {
-            public TestEnvironment(bool setOnInsert = false)
+            // Set up the test entity
+            TestEntity = new TestEntity
             {
-                // Set up the test entity
-                TestEntity = new TestEntity
-                {
-                    Id = "test_id_1",
-                    TestChildCollection = new List<TestEntity> { new TestEntity { Id = "test_id_2" }, },
-                    TestNumber = 1,
-                    TestStringCollection = new List<string> { "test_value_1", "test_value_2", },
-                    TestStringField = "test_value",
-                };
+                Id = "test_id_1",
+                TestChildCollection = new List<TestEntity> { new TestEntity { Id = "test_id_2" }, },
+                TestNumber = 1,
+                TestStringCollection = new List<string> { "test_value_1", "test_value_2", },
+                TestStringField = "test_value",
+            };
 
-                // Set up the memory update builder for the test entity
-                MemoryUpdateBuilder = new MemoryUpdateBuilder<TestEntity>(
-                    e => e.Id == TestEntity.Id,
-                    TestEntity,
-                    setOnInsert
-                );
-            }
-
-            public MemoryUpdateBuilder<TestEntity> MemoryUpdateBuilder { get; }
-            public TestEntity TestEntity { get; }
+            // Set up the memory update builder for the test entity
+            MemoryUpdateBuilder = new MemoryUpdateBuilder<TestEntity>(
+                e => e.Id == TestEntity.Id,
+                TestEntity,
+                setOnInsert
+            );
         }
+
+        public MemoryUpdateBuilder<TestEntity> MemoryUpdateBuilder { get; }
+        public TestEntity TestEntity { get; }
     }
 }

--- a/test/SIL.XForge.Tests/Models/TestProject.cs
+++ b/test/SIL.XForge.Tests/Models/TestProject.cs
@@ -1,4 +1,3 @@
-namespace SIL.XForge.Models
-{
-    public class TestProject : Project { }
-}
+namespace SIL.XForge.Models;
+
+public class TestProject : Project { }

--- a/test/SIL.XForge.Tests/Models/TestProjectRole.cs
+++ b/test/SIL.XForge.Tests/Models/TestProjectRole.cs
@@ -1,10 +1,9 @@
-namespace SIL.XForge.Models
+namespace SIL.XForge.Models;
+
+public class TestProjectRole
 {
-    public class TestProjectRole
-    {
-        public const string Manager = "manager";
-        public const string Contributor = "contributor";
-        public const string Administrator = "administrator";
-        public const string Reviewer = "reviewer";
-    }
+    public const string Manager = "manager";
+    public const string Contributor = "contributor";
+    public const string Administrator = "administrator";
+    public const string Reviewer = "reviewer";
 }

--- a/test/SIL.XForge.Tests/Models/TestProjectSecret.cs
+++ b/test/SIL.XForge.Tests/Models/TestProjectSecret.cs
@@ -1,4 +1,3 @@
-namespace SIL.XForge.Models
-{
-    public class TestProjectSecret : ProjectSecret { }
-}
+namespace SIL.XForge.Models;
+
+public class TestProjectSecret : ProjectSecret { }

--- a/test/SIL.XForge.Tests/Models/TokensTests.cs
+++ b/test/SIL.XForge.Tests/Models/TokensTests.cs
@@ -2,65 +2,64 @@ using System;
 using NUnit.Framework;
 using SIL.XForge.Services;
 
-namespace SIL.XForge.Models
+namespace SIL.XForge.Models;
+
+[TestFixture]
+public class TokensTests
 {
-    [TestFixture]
-    public class TokensTests
+    [Test]
+    public void IssuedAt_MinValueIfNullAccessToken()
     {
-        [Test]
-        public void IssuedAt_MinValueIfNullAccessToken()
+        var tokens = new Tokens();
+        Assert.That(tokens.AccessToken, Is.Null);
+        // SUT
+        Assert.That(tokens.IssuedAt, Is.EqualTo(DateTime.MinValue));
+
+        tokens.RefreshToken = "refresh-token-123";
+        // SUT 2, where RefreshToken is not null.
+        Assert.That(tokens.IssuedAt, Is.EqualTo(DateTime.MinValue));
+    }
+
+    [Test]
+    public void ValidateLifetime_FalseIfNullAccessToken()
+    {
+        var tokens = new Tokens();
+        Assert.That(tokens.AccessToken, Is.Null);
+        // SUT
+        Assert.That(tokens.ValidateLifetime(), Is.False);
+
+        tokens.RefreshToken = "refresh-token-123";
+        // SUT 2, where RefreshToken is not null.
+        Assert.That(tokens.ValidateLifetime(), Is.False);
+    }
+
+    [Test]
+    public void ValidateLifetime_FalseIfAboutToExpire()
+    {
+        var issuedAt = DateTime.Now;
+        var expiration = issuedAt + TimeSpan.FromSeconds(119);
+        var tokens = new Tokens()
         {
-            var tokens = new Tokens();
-            Assert.That(tokens.AccessToken, Is.Null);
-            // SUT
-            Assert.That(tokens.IssuedAt, Is.EqualTo(DateTime.MinValue));
+            AccessToken = TokenHelper.CreateAccessToken(issuedAt, expiration, "paratext01"),
+            RefreshToken = null
+        };
 
-            tokens.RefreshToken = "refresh-token-123";
-            // SUT 2, where RefreshToken is not null.
-            Assert.That(tokens.IssuedAt, Is.EqualTo(DateTime.MinValue));
-        }
+        // SUT
+        Assert.That(tokens.ValidateLifetime(), Is.False);
+    }
 
-        [Test]
-        public void ValidateLifetime_FalseIfNullAccessToken()
+    [Test]
+    public void ValidateLifetime_TrueIfUnexpired()
+    {
+        var issuedAt = DateTime.Now;
+        var expiration = issuedAt + TimeSpan.FromSeconds(121);
+        var tokens = new Tokens()
         {
-            var tokens = new Tokens();
-            Assert.That(tokens.AccessToken, Is.Null);
-            // SUT
-            Assert.That(tokens.ValidateLifetime(), Is.False);
+            AccessToken = TokenHelper.CreateAccessToken(issuedAt, expiration, "paratext01"),
+            RefreshToken = null
+        };
 
-            tokens.RefreshToken = "refresh-token-123";
-            // SUT 2, where RefreshToken is not null.
-            Assert.That(tokens.ValidateLifetime(), Is.False);
-        }
-
-        [Test]
-        public void ValidateLifetime_FalseIfAboutToExpire()
-        {
-            var issuedAt = DateTime.Now;
-            var expiration = issuedAt + TimeSpan.FromSeconds(119);
-            var tokens = new Tokens()
-            {
-                AccessToken = TokenHelper.CreateAccessToken(issuedAt, expiration, "paratext01"),
-                RefreshToken = null
-            };
-
-            // SUT
-            Assert.That(tokens.ValidateLifetime(), Is.False);
-        }
-
-        [Test]
-        public void ValidateLifetime_TrueIfUnexpired()
-        {
-            var issuedAt = DateTime.Now;
-            var expiration = issuedAt + TimeSpan.FromSeconds(121);
-            var tokens = new Tokens()
-            {
-                AccessToken = TokenHelper.CreateAccessToken(issuedAt, expiration, "paratext01"),
-                RefreshToken = null
-            };
-
-            // SUT
-            Assert.That(tokens.ValidateLifetime(), Is.True);
-        }
+        // SUT
+        Assert.That(tokens.ValidateLifetime(), Is.True);
     }
 }

--- a/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
@@ -11,446 +11,429 @@ using SIL.XForge.Models;
 using SIL.XForge.Realtime.Json0;
 using Options = Microsoft.Extensions.Options.Options;
 
-namespace SIL.XForge.Realtime
+namespace SIL.XForge.Realtime;
+
+[TestFixture]
+public class ConnectionTests
 {
-    [TestFixture]
-    public class ConnectionTests
+    [Test]
+    public async Task CommitTransactionAsync_ClearsExcludedProperties()
     {
-        [Test]
-        public async Task CommitTransactionAsync_ClearsExcludedProperties()
+        // Setup
+        var env = new TestEnvironment();
+        string collection = "test_project";
+        string id = "id1";
+
+        // Set up excluded operations and queue
+        env.Service.BeginTransaction();
+        env.Service.ExcludePropertyFromTransaction<TestProject>(op => op.SyncDisabled);
+        await env.Service.DeleteDocAsync(collection, id);
+
+        // Verify excluded operations and queue
+        Assert.AreEqual(env.Service.ExcludedProperties.Count, 1);
+        Assert.AreEqual(env.Service.QueuedOperations.Count, 1);
+
+        // SUT
+        await env.Service.CommitTransactionAsync();
+
+        // Verify the clear
+        Assert.AreEqual(env.Service.ExcludedProperties.Count, 0);
+        Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
+
+        // Verify that the call was passed to the underlying realtime server
+        await env.RealtimeService.Server
+            .Received(1)
+            .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Test]
+    public void CommitTransactionAsync_RequiresBeginTransaction()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<ArgumentException>(() => env.Service.CommitTransactionAsync());
+    }
+
+    [Test]
+    public async Task CommitTransactionAsync_UsesUnderlyingRealtimeServerOnCommit()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        string collection = "test_project";
+        string id = "id1";
+        string otTypeName = OTType.Json0;
+        var snapshot = new Snapshot<TestProject>
         {
-            // Setup
-            var env = new TestEnvironment();
-            string collection = "test_project";
-            string id = "id1";
+            Data = new TestProject() { Id = id, SyncDisabled = false, },
+            Version = 1,
+        };
+        var builder = new Json0OpBuilder<TestProject>(snapshot.Data);
+        builder.Set(p => p.SyncDisabled, true);
+        List<Json0Op> op = builder.Op;
+        var updatedData = new TestProject() { Id = id, SyncDisabled = true, };
 
-            // Set up excluded operations and queue
-            env.Service.BeginTransaction();
-            env.Service.ExcludePropertyFromTransaction<TestProject>(op => op.SyncDisabled);
-            await env.Service.DeleteDocAsync(collection, id);
+        env.RealtimeService.Server
+            .FetchDocAsync<TestProject>(Arg.Any<int>(), collection, id)
+            .Returns(Task.FromResult(snapshot));
+        env.RealtimeService.Server.ApplyOpAsync(otTypeName, snapshot.Data, op).Returns(Task.FromResult(updatedData));
 
-            // Verify excluded operations and queue
-            Assert.AreEqual(env.Service.ExcludedProperties.Count, 1);
-            Assert.AreEqual(env.Service.QueuedOperations.Count, 1);
+        // Setup Queue
+        env.Service.BeginTransaction();
+        await env.Service.CreateDocAsync(collection, id, snapshot.Data, otTypeName);
+        await env.Service.SubmitOpAsync(collection, id, op, snapshot.Data, snapshot.Version);
+        await env.Service.DeleteDocAsync(collection, id);
 
-            // SUT
-            await env.Service.CommitTransactionAsync();
+        // Verify Queue
+        Assert.AreEqual(env.Service.QueuedOperations.First().Action, QueuedAction.Create);
+        Assert.AreEqual(env.Service.QueuedOperations.Skip(1).First().Action, QueuedAction.Submit);
+        Assert.AreEqual(env.Service.QueuedOperations.Last().Action, QueuedAction.Delete);
 
-            // Verify the clear
-            Assert.AreEqual(env.Service.ExcludedProperties.Count, 0);
-            Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
+        // SUT
+        await env.Service.CommitTransactionAsync();
 
-            // Verify that the call was passed to the underlying realtime server
-            await env.RealtimeService.Server
-                .Received(1)
-                .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
-        }
+        // Verify Submit Operations
+        await env.RealtimeService.Server
+            .Received(1)
+            .CreateDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<string>());
+        await env.RealtimeService.Server
+            .Received(1)
+            .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
+        await env.RealtimeService.Server
+            .Received(1)
+            .SubmitOpAsync<object>(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>());
+    }
 
-        [Test]
-        public void CommitTransactionAsync_RequiresBeginTransaction()
-        {
-            // Setup
-            var env = new TestEnvironment();
+    [Test]
+    public async Task CreateDocAsync_QueuesAction()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        string collection = "test_project";
+        string id = "id1";
+        var data = new TestProject { Id = id, Name = "Test Project 1", };
+        string otTypeName = OTType.Json0;
 
-            // SUT
-            Assert.ThrowsAsync<ArgumentException>(() => env.Service.CommitTransactionAsync());
-        }
+        // SUT
+        env.Service.BeginTransaction();
+        var result = await env.Service.CreateDocAsync(collection, id, data, otTypeName);
 
-        [Test]
-        public async Task CommitTransactionAsync_UsesUnderlyingRealtimeServerOnCommit()
-        {
-            // Setup
-            var env = new TestEnvironment();
-            string collection = "test_project";
-            string id = "id1";
-            string otTypeName = OTType.Json0;
-            var snapshot = new Snapshot<TestProject>
-            {
-                Data = new TestProject() { Id = id, SyncDisabled = false, },
-                Version = 1,
-            };
-            var builder = new Json0OpBuilder<TestProject>(snapshot.Data);
-            builder.Set(p => p.SyncDisabled, true);
-            List<Json0Op> op = builder.Op;
-            var updatedData = new TestProject() { Id = id, SyncDisabled = true, };
+        // Verify result
+        Assert.AreEqual(result.Version, 1);
+        Assert.AreEqual(result.Data, data);
 
-            env.RealtimeService.Server
-                .FetchDocAsync<TestProject>(Arg.Any<int>(), collection, id)
-                .Returns(Task.FromResult(snapshot));
-            env.RealtimeService.Server
-                .ApplyOpAsync(otTypeName, snapshot.Data, op)
-                .Returns(Task.FromResult(updatedData));
+        // Verify queue
+        Assert.AreEqual(env.Service.QueuedOperations.Count, 1);
+        QueuedOperation queuedOperation = env.Service.QueuedOperations.First();
+        Assert.AreEqual(queuedOperation.Action, QueuedAction.Create);
+        Assert.AreEqual(queuedOperation.Collection, collection);
+        Assert.AreEqual(queuedOperation.Data, data);
+        Assert.AreEqual(queuedOperation.Id, id);
+        Assert.AreEqual(queuedOperation.OtTypeName, otTypeName);
 
-            // Setup Queue
-            env.Service.BeginTransaction();
-            await env.Service.CreateDocAsync(collection, id, snapshot.Data, otTypeName);
-            await env.Service.SubmitOpAsync(collection, id, op, snapshot.Data, snapshot.Version);
-            await env.Service.DeleteDocAsync(collection, id);
+        // Verify that the call was not passed to the underlying realtime server
+        await env.RealtimeService.Server
+            .Received(0)
+            .CreateDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<string>());
+    }
 
-            // Verify Queue
-            Assert.AreEqual(env.Service.QueuedOperations.First().Action, QueuedAction.Create);
-            Assert.AreEqual(env.Service.QueuedOperations.Skip(1).First().Action, QueuedAction.Submit);
-            Assert.AreEqual(env.Service.QueuedOperations.Last().Action, QueuedAction.Delete);
+    [Test]
+    public async Task CreateDocAsync_UsesUnderlyingRealtimeServerOutsideOfATransaction()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        string collection = "test_project";
+        string id = "id1";
+        var data = new TestProject { Id = id, Name = "Test Project 1", };
+        string otTypeName = OTType.Json0;
 
-            // SUT
-            await env.Service.CommitTransactionAsync();
+        // SUT
+        await env.Service.CreateDocAsync(collection, id, data, otTypeName);
 
-            // Verify Submit Operations
-            await env.RealtimeService.Server
-                .Received(1)
-                .CreateDocAsync(
-                    Arg.Any<int>(),
-                    Arg.Any<string>(),
-                    Arg.Any<string>(),
-                    Arg.Any<object>(),
-                    Arg.Any<string>()
-                );
-            await env.RealtimeService.Server
-                .Received(1)
-                .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
-            await env.RealtimeService.Server
-                .Received(1)
-                .SubmitOpAsync<object>(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>());
-        }
+        // Verify queue is empty
+        Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
 
-        [Test]
-        public async Task CreateDocAsync_QueuesAction()
-        {
-            // Setup
-            var env = new TestEnvironment();
-            string collection = "test_project";
-            string id = "id1";
-            var data = new TestProject { Id = id, Name = "Test Project 1", };
-            string otTypeName = OTType.Json0;
-
-            // SUT
-            env.Service.BeginTransaction();
-            var result = await env.Service.CreateDocAsync(collection, id, data, otTypeName);
-
-            // Verify result
-            Assert.AreEqual(result.Version, 1);
-            Assert.AreEqual(result.Data, data);
-
-            // Verify queue
-            Assert.AreEqual(env.Service.QueuedOperations.Count, 1);
-            QueuedOperation queuedOperation = env.Service.QueuedOperations.First();
-            Assert.AreEqual(queuedOperation.Action, QueuedAction.Create);
-            Assert.AreEqual(queuedOperation.Collection, collection);
-            Assert.AreEqual(queuedOperation.Data, data);
-            Assert.AreEqual(queuedOperation.Id, id);
-            Assert.AreEqual(queuedOperation.OtTypeName, otTypeName);
-
-            // Verify that the call was not passed to the underlying realtime server
-            await env.RealtimeService.Server
-                .Received(0)
-                .CreateDocAsync(
-                    Arg.Any<int>(),
-                    Arg.Any<string>(),
-                    Arg.Any<string>(),
-                    Arg.Any<object>(),
-                    Arg.Any<string>()
-                );
-        }
-
-        [Test]
-        public async Task CreateDocAsync_UsesUnderlyingRealtimeServerOutsideOfATransaction()
-        {
-            // Setup
-            var env = new TestEnvironment();
-            string collection = "test_project";
-            string id = "id1";
-            var data = new TestProject { Id = id, Name = "Test Project 1", };
-            string otTypeName = OTType.Json0;
-
-            // SUT
-            await env.Service.CreateDocAsync(collection, id, data, otTypeName);
-
-            // Verify queue is empty
-            Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
-
-            // Verify that the call was not passed to the underlying realtime server
-            await env.RealtimeService.Server
-                .Received(1)
-                .CreateDocAsync(
-                    Arg.Any<int>(),
-                    Arg.Any<string>(),
-                    Arg.Any<string>(),
-                    Arg.Any<TestProject>(),
-                    Arg.Any<string>()
-                );
-        }
-
-        [Test]
-        public async Task DeleteDocAsync_QueuesAction()
-        {
-            // Setup
-            var env = new TestEnvironment();
-            string collection = "test_project";
-            string id = "id1";
-
-            // SUT
-            env.Service.BeginTransaction();
-            await env.Service.DeleteDocAsync(collection, id);
-
-            // Verify queue
-            Assert.AreEqual(env.Service.QueuedOperations.Count, 1);
-            QueuedOperation queuedOperation = env.Service.QueuedOperations.First();
-            Assert.AreEqual(queuedOperation.Action, QueuedAction.Delete);
-            Assert.AreEqual(queuedOperation.Collection, collection);
-            Assert.AreEqual(queuedOperation.Id, id);
-
-            // Verify that the call was not passed to the underlying realtime server
-            await env.RealtimeService.Server
-                .Received(0)
-                .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
-        }
-
-        [Test]
-        public async Task DeleteDocAsync_UsesUnderlyingRealtimeServerOutsideOfATransaction()
-        {
-            // Setup
-            var env = new TestEnvironment();
-            string collection = "test_project";
-            string id = "id1";
-
-            // SUT
-            await env.Service.DeleteDocAsync(collection, id);
-
-            // Verify queue is empty
-            Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
-
-            // Verify that the call was not passed to the underlying realtime server
-            await env.RealtimeService.Server
-                .Received(1)
-                .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
-        }
-
-        [Test]
-        public void ExcludePropertyFromTransaction_DeconstructsTheProperty()
-        {
-            // Setup
-            var env = new TestEnvironment();
-            env.Service.BeginTransaction();
-
-            // SUT
-            env.Service.ExcludePropertyFromTransaction<TestProject>(op => op.SyncDisabled);
-
-            // Verify
-            Assert.AreEqual(env.Service.ExcludedProperties.Count, 1);
-            Assert.AreEqual(env.Service.ExcludedProperties.First(), "testproject.syncdisabled");
-        }
-
-        [Test]
-        public void ExcludePropertyFromTransaction_RequiresBeginTransaction()
-        {
-            // Setup
-            var env = new TestEnvironment();
-
-            // SUT
-            Assert.Throws<ArgumentException>(
-                () => env.Service.ExcludePropertyFromTransaction<TestProject>(op => op.SyncDisabled)
+        // Verify that the call was not passed to the underlying realtime server
+        await env.RealtimeService.Server
+            .Received(1)
+            .CreateDocAsync(
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<TestProject>(),
+                Arg.Any<string>()
             );
-        }
+    }
 
-        [Test]
-        public async Task FetchDocAsync_UsesUnderlyingRealtimeServer()
+    [Test]
+    public async Task DeleteDocAsync_QueuesAction()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        string collection = "test_project";
+        string id = "id1";
+
+        // SUT
+        env.Service.BeginTransaction();
+        await env.Service.DeleteDocAsync(collection, id);
+
+        // Verify queue
+        Assert.AreEqual(env.Service.QueuedOperations.Count, 1);
+        QueuedOperation queuedOperation = env.Service.QueuedOperations.First();
+        Assert.AreEqual(queuedOperation.Action, QueuedAction.Delete);
+        Assert.AreEqual(queuedOperation.Collection, collection);
+        Assert.AreEqual(queuedOperation.Id, id);
+
+        // Verify that the call was not passed to the underlying realtime server
+        await env.RealtimeService.Server
+            .Received(0)
+            .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task DeleteDocAsync_UsesUnderlyingRealtimeServerOutsideOfATransaction()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        string collection = "test_project";
+        string id = "id1";
+
+        // SUT
+        await env.Service.DeleteDocAsync(collection, id);
+
+        // Verify queue is empty
+        Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
+
+        // Verify that the call was not passed to the underlying realtime server
+        await env.RealtimeService.Server
+            .Received(1)
+            .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Test]
+    public void ExcludePropertyFromTransaction_DeconstructsTheProperty()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        env.Service.BeginTransaction();
+
+        // SUT
+        env.Service.ExcludePropertyFromTransaction<TestProject>(op => op.SyncDisabled);
+
+        // Verify
+        Assert.AreEqual(env.Service.ExcludedProperties.Count, 1);
+        Assert.AreEqual(env.Service.ExcludedProperties.First(), "testproject.syncdisabled");
+    }
+
+    [Test]
+    public void ExcludePropertyFromTransaction_RequiresBeginTransaction()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.Throws<ArgumentException>(
+            () => env.Service.ExcludePropertyFromTransaction<TestProject>(op => op.SyncDisabled)
+        );
+    }
+
+    [Test]
+    public async Task FetchDocAsync_UsesUnderlyingRealtimeServer()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        string collection = "test_project";
+        string id = "id1";
+
+        // SUT
+        await env.Service.FetchDocAsync<TestProject>(collection, id);
+
+        // Verify
+        await env.RealtimeService.Server.Received(1).FetchDocAsync<TestProject>(Arg.Any<int>(), collection, id);
+    }
+
+    [Test]
+    public async Task RollbackTransaction_ClearsQueuedOperationsAndExcludedProperties()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        string collection = "test_project";
+        string id = "id1";
+
+        // Set up excluded operations and queue
+        env.Service.BeginTransaction();
+        env.Service.ExcludePropertyFromTransaction<TestProject>(op => op.SyncDisabled);
+        await env.Service.DeleteDocAsync(collection, id);
+
+        // Verify excluded operations and queue
+        Assert.AreEqual(env.Service.ExcludedProperties.Count, 1);
+        Assert.AreEqual(env.Service.QueuedOperations.Count, 1);
+
+        // SUT
+        env.Service.RollbackTransaction();
+
+        // Verify the clear
+        Assert.AreEqual(env.Service.ExcludedProperties.Count, 0);
+        Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
+
+        // Verify that the call was not passed to the underlying realtime server
+        await env.RealtimeService.Server
+            .Received(0)
+            .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Test]
+    public void RollbackTransaction_RequiresBeginTransaction()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.Throws<ArgumentException>(() => env.Service.RollbackTransaction());
+    }
+
+    [Test]
+    public async Task SubmitOpAsync_ExecutesExcludedAction()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        string collection = "test_project";
+        string id = "id1";
+        var data = new TestProject { Id = id, SyncDisabled = false };
+        var snapshot = new Snapshot<TestProject>
         {
-            // Setup
-            var env = new TestEnvironment();
-            string collection = "test_project";
-            string id = "id1";
+            Data = new TestProject { Id = id, SyncDisabled = true },
+            Version = 2,
+        };
+        var expected = new Snapshot<TestProject> { Data = snapshot.Data, Version = 3, };
+        var builder = new Json0OpBuilder<TestProject>(data);
+        builder.Set(p => p.SyncDisabled, true);
+        List<Json0Op> op = builder.Op;
+        env.RealtimeService.Server
+            .ApplyOpAsync(Arg.Any<string>(), Arg.Any<TestProject>(), Arg.Any<object>())
+            .Returns(Task.FromResult(snapshot.Data));
 
-            // SUT
-            await env.Service.FetchDocAsync<TestProject>(collection, id);
+        // SUT
+        env.Service.BeginTransaction();
+        env.Service.ExcludePropertyFromTransaction<TestProject>(p => p.SyncDisabled);
+        var result = await env.Service.SubmitOpAsync(collection, id, op, snapshot.Data, snapshot.Version);
 
-            // Verify
-            await env.RealtimeService.Server.Received(1).FetchDocAsync<TestProject>(Arg.Any<int>(), collection, id);
-        }
+        Assert.AreEqual(expected.Version, result.Version);
+        Assert.AreEqual(expected.Data, result.Data);
 
-        [Test]
-        public async Task RollbackTransaction_ClearsQueuedOperationsAndExcludedProperties()
+        // Verify queue
+        Assert.Zero(env.Service.QueuedOperations.Count);
+
+        // Verify that the call was passed to the underlying realtime server
+        await env.RealtimeService.Server
+            .Received(1)
+            .SubmitOpAsync<TestProject>(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>());
+    }
+
+    [Test]
+    public async Task SubmitOpAsync_QueuesAction()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        string collection = "test_project";
+        string id = "id1";
+        string otTypeName = OTType.Json0;
+        var snapshot = new Snapshot<TestProject>
         {
-            // Setup
-            var env = new TestEnvironment();
-            string collection = "test_project";
-            string id = "id1";
+            Data = new TestProject() { Id = id, SyncDisabled = false, },
+            Version = 1,
+        };
+        var builder = new Json0OpBuilder<TestProject>(snapshot.Data);
+        builder.Set(p => p.SyncDisabled, true);
+        List<Json0Op> op = builder.Op;
+        var updatedData = new TestProject() { Id = id, SyncDisabled = true, };
 
-            // Set up excluded operations and queue
-            env.Service.BeginTransaction();
-            env.Service.ExcludePropertyFromTransaction<TestProject>(op => op.SyncDisabled);
-            await env.Service.DeleteDocAsync(collection, id);
+        env.RealtimeService.Server
+            .FetchDocAsync<TestProject>(Arg.Any<int>(), collection, id)
+            .Returns(Task.FromResult(snapshot));
+        env.RealtimeService.Server.ApplyOpAsync(otTypeName, snapshot.Data, op).Returns(Task.FromResult(updatedData));
 
-            // Verify excluded operations and queue
-            Assert.AreEqual(env.Service.ExcludedProperties.Count, 1);
-            Assert.AreEqual(env.Service.QueuedOperations.Count, 1);
+        // SUT
+        env.Service.BeginTransaction();
+        var result = await env.Service.SubmitOpAsync(collection, id, op, snapshot.Data, snapshot.Version);
 
-            // SUT
-            env.Service.RollbackTransaction();
+        // Verify result
+        Assert.AreEqual(result.Version, 2);
+        Assert.AreEqual(result.Data, updatedData);
 
-            // Verify the clear
-            Assert.AreEqual(env.Service.ExcludedProperties.Count, 0);
-            Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
+        // Verify queue
+        Assert.AreEqual(env.Service.QueuedOperations.Count, 1);
+        QueuedOperation queuedOperation = env.Service.QueuedOperations.First();
+        Assert.AreEqual(queuedOperation.Action, QueuedAction.Submit);
+        Assert.AreEqual(queuedOperation.Collection, collection);
+        Assert.AreEqual(queuedOperation.Op, op);
 
-            // Verify that the call was not passed to the underlying realtime server
-            await env.RealtimeService.Server
-                .Received(0)
-                .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
-        }
+        // Verify that the call was not passed to the underlying realtime server
+        await env.RealtimeService.Server
+            .Received(0)
+            .SubmitOpAsync<TestProject>(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>());
+    }
 
-        [Test]
-        public void RollbackTransaction_RequiresBeginTransaction()
+    [Test]
+    public async Task SubmitOpAsync_UsesUnderlyingRealtimeServerOutsideOfATransaction()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        string collection = "test_project";
+        string id = "id1";
+        var snapshot = new Snapshot<TestProject>
         {
-            // Setup
-            var env = new TestEnvironment();
+            Data = new TestProject() { Id = id, SyncDisabled = false, },
+            Version = 1,
+        };
+        var builder = new Json0OpBuilder<TestProject>(snapshot.Data);
+        builder.Set(p => p.SyncDisabled, true);
+        List<Json0Op> op = builder.Op;
 
-            // SUT
-            Assert.Throws<ArgumentException>(() => env.Service.RollbackTransaction());
-        }
+        // SUT
+        await env.Service.SubmitOpAsync(collection, id, op, snapshot.Data, snapshot.Version);
 
-        [Test]
-        public async Task SubmitOpAsync_ExecutesExcludedAction()
+        // Verify queue
+        Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
+
+        // Verify that the call was not passed to the underlying realtime server
+        await env.RealtimeService.Server
+            .Received(1)
+            .SubmitOpAsync<TestProject>(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>());
+    }
+
+    private class TestEnvironment
+    {
+        public readonly Connection Service;
+        public readonly RealtimeService RealtimeService;
+
+        public TestEnvironment()
         {
-            // Setup
-            var env = new TestEnvironment();
-            string collection = "test_project";
-            string id = "id1";
-            var data = new TestProject { Id = id, SyncDisabled = false };
-            var snapshot = new Snapshot<TestProject>
-            {
-                Data = new TestProject { Id = id, SyncDisabled = true },
-                Version = 2,
-            };
-            var expected = new Snapshot<TestProject> { Data = snapshot.Data, Version = 3, };
-            var builder = new Json0OpBuilder<TestProject>(data);
-            builder.Set(p => p.SyncDisabled, true);
-            List<Json0Op> op = builder.Op;
-            env.RealtimeService.Server
-                .ApplyOpAsync(Arg.Any<string>(), Arg.Any<TestProject>(), Arg.Any<object>())
-                .Returns(Task.FromResult(snapshot.Data));
-
-            // SUT
-            env.Service.BeginTransaction();
-            env.Service.ExcludePropertyFromTransaction<TestProject>(p => p.SyncDisabled);
-            var result = await env.Service.SubmitOpAsync(collection, id, op, snapshot.Data, snapshot.Version);
-
-            Assert.AreEqual(expected.Version, result.Version);
-            Assert.AreEqual(expected.Data, result.Data);
-
-            // Verify queue
-            Assert.Zero(env.Service.QueuedOperations.Count);
-
-            // Verify that the call was passed to the underlying realtime server
-            await env.RealtimeService.Server
-                .Received(1)
-                .SubmitOpAsync<TestProject>(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>());
-        }
-
-        [Test]
-        public async Task SubmitOpAsync_QueuesAction()
-        {
-            // Setup
-            var env = new TestEnvironment();
-            string collection = "test_project";
-            string id = "id1";
-            string otTypeName = OTType.Json0;
-            var snapshot = new Snapshot<TestProject>
-            {
-                Data = new TestProject() { Id = id, SyncDisabled = false, },
-                Version = 1,
-            };
-            var builder = new Json0OpBuilder<TestProject>(snapshot.Data);
-            builder.Set(p => p.SyncDisabled, true);
-            List<Json0Op> op = builder.Op;
-            var updatedData = new TestProject() { Id = id, SyncDisabled = true, };
-
-            env.RealtimeService.Server
-                .FetchDocAsync<TestProject>(Arg.Any<int>(), collection, id)
-                .Returns(Task.FromResult(snapshot));
-            env.RealtimeService.Server
-                .ApplyOpAsync(otTypeName, snapshot.Data, op)
-                .Returns(Task.FromResult(updatedData));
-
-            // SUT
-            env.Service.BeginTransaction();
-            var result = await env.Service.SubmitOpAsync(collection, id, op, snapshot.Data, snapshot.Version);
-
-            // Verify result
-            Assert.AreEqual(result.Version, 2);
-            Assert.AreEqual(result.Data, updatedData);
-
-            // Verify queue
-            Assert.AreEqual(env.Service.QueuedOperations.Count, 1);
-            QueuedOperation queuedOperation = env.Service.QueuedOperations.First();
-            Assert.AreEqual(queuedOperation.Action, QueuedAction.Submit);
-            Assert.AreEqual(queuedOperation.Collection, collection);
-            Assert.AreEqual(queuedOperation.Op, op);
-
-            // Verify that the call was not passed to the underlying realtime server
-            await env.RealtimeService.Server
-                .Received(0)
-                .SubmitOpAsync<TestProject>(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>());
-        }
-
-        [Test]
-        public async Task SubmitOpAsync_UsesUnderlyingRealtimeServerOutsideOfATransaction()
-        {
-            // Setup
-            var env = new TestEnvironment();
-            string collection = "test_project";
-            string id = "id1";
-            var snapshot = new Snapshot<TestProject>
-            {
-                Data = new TestProject() { Id = id, SyncDisabled = false, },
-                Version = 1,
-            };
-            var builder = new Json0OpBuilder<TestProject>(snapshot.Data);
-            builder.Set(p => p.SyncDisabled, true);
-            List<Json0Op> op = builder.Op;
-
-            // SUT
-            await env.Service.SubmitOpAsync(collection, id, op, snapshot.Data, snapshot.Version);
-
-            // Verify queue
-            Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
-
-            // Verify that the call was not passed to the underlying realtime server
-            await env.RealtimeService.Server
-                .Received(1)
-                .SubmitOpAsync<TestProject>(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>());
-        }
-
-        private class TestEnvironment
-        {
-            public readonly Connection Service;
-            public readonly RealtimeService RealtimeService;
-
-            public TestEnvironment()
-            {
-                var realtimeServer = Substitute.For<IRealtimeServer>();
-                var siteOptions = Options.Create(Substitute.For<SiteOptions>());
-                var dataAccessOptions = Options.Create(Substitute.For<DataAccessOptions>());
-                var realtimeOptions = Options.Create(
-                    new RealtimeOptions()
-                    {
-                        ProjectDoc = new DocConfig("some_projects", typeof(Project)),
-                        ProjectDataDocs = new List<DocConfig>(),
-                        UserDataDocs = new List<DocConfig>(),
-                    }
-                );
-                var authOptions = Options.Create(Substitute.For<AuthOptions>());
-                var mongoClient = Substitute.For<IMongoClient>();
-                var configuration = Substitute.For<IConfiguration>();
-                RealtimeService = new RealtimeService(
-                    realtimeServer,
-                    siteOptions,
-                    dataAccessOptions,
-                    realtimeOptions,
-                    authOptions,
-                    mongoClient,
-                    configuration
-                );
-                Service = new Connection(RealtimeService);
-            }
+            var realtimeServer = Substitute.For<IRealtimeServer>();
+            var siteOptions = Options.Create(Substitute.For<SiteOptions>());
+            var dataAccessOptions = Options.Create(Substitute.For<DataAccessOptions>());
+            var realtimeOptions = Options.Create(
+                new RealtimeOptions()
+                {
+                    ProjectDoc = new DocConfig("some_projects", typeof(Project)),
+                    ProjectDataDocs = new List<DocConfig>(),
+                    UserDataDocs = new List<DocConfig>(),
+                }
+            );
+            var authOptions = Options.Create(Substitute.For<AuthOptions>());
+            var mongoClient = Substitute.For<IMongoClient>();
+            var configuration = Substitute.For<IConfiguration>();
+            RealtimeService = new RealtimeService(
+                realtimeServer,
+                siteOptions,
+                dataAccessOptions,
+                realtimeOptions,
+                authOptions,
+                mongoClient,
+                configuration
+            );
+            Service = new Connection(RealtimeService);
         }
     }
 }

--- a/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
@@ -1,257 +1,243 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using NSubstitute;
 using NUnit.Framework;
 using SIL.XForge.Configuration;
-using System.Collections.Generic;
-using System;
-using System.Threading.Tasks;
-using MongoDB.Bson;
 using SIL.XForge.Models;
 
-namespace SIL.XForge.Realtime
+namespace SIL.XForge.Realtime;
+
+[TestFixture]
+public class RealtimeServiceTests
 {
-    [TestFixture]
-    public class RealtimeServiceTests
+    [Test]
+    public void DeleteProjectAsync_BadArguments()
     {
-        [Test]
-        public void DeleteProjectAsync_BadArguments()
-        {
-            var env = new TestEnvironment();
-            Assert.ThrowsAsync<ArgumentException>(() => env.Service.DeleteProjectAsync(null));
-            Assert.ThrowsAsync<ArgumentException>(() => env.Service.DeleteProjectAsync(""));
-        }
+        var env = new TestEnvironment();
+        Assert.ThrowsAsync<ArgumentException>(() => env.Service.DeleteProjectAsync(null));
+        Assert.ThrowsAsync<ArgumentException>(() => env.Service.DeleteProjectAsync(""));
+    }
 
-        [Test]
-        public async Task DeleteProjectAsync_RequestsDocRemovalsInCollections()
-        {
-            var env = new TestEnvironment();
-            string projectId = "project1id";
+    [Test]
+    public async Task DeleteProjectAsync_RequestsDocRemovalsInCollections()
+    {
+        var env = new TestEnvironment();
+        string projectId = "project1id";
 
-            // Set of collections that should be filtered thru to remove matching docs. This set could be different
-            // per application (like Scripture Forge, Language Forge, etc.), and the set used here should match what
-            // is defined in TestEnvironment.
-            Dictionary<string, IMongoCollection<BsonDocument>> collectionsToBePruned =
-                new Dictionary<string, IMongoCollection<BsonDocument>>();
-            foreach (
-                string collectionName in (
-                    new string[]
-                    {
-                        "some_projects",
-                        "favorite_numbers",
-                        "favorite_things",
-                        "favorite_verses",
-                        "o_some_projects",
-                        "o_favorite_numbers",
-                        "o_favorite_things",
-                        "o_favorite_verses",
-                    }
-                )
+        // Set of collections that should be filtered thru to remove matching docs. This set could be different
+        // per application (like Scripture Forge, Language Forge, etc.), and the set used here should match what
+        // is defined in TestEnvironment.
+        Dictionary<string, IMongoCollection<BsonDocument>> collectionsToBePruned =
+            new Dictionary<string, IMongoCollection<BsonDocument>>();
+        foreach (
+            string collectionName in (
+                new string[]
+                {
+                    "some_projects",
+                    "favorite_numbers",
+                    "favorite_things",
+                    "favorite_verses",
+                    "o_some_projects",
+                    "o_favorite_numbers",
+                    "o_favorite_things",
+                    "o_favorite_verses",
+                }
             )
-            {
-                IMongoCollection<BsonDocument> collection = Substitute.For<IMongoCollection<BsonDocument>>();
-                collectionsToBePruned.Add(collectionName, collection);
-                env.MongoDatabase
-                    .GetCollection<BsonDocument>(collectionName)
-                    .Returns<IMongoCollection<BsonDocument>>(collection);
-            }
-            // SUT
-            await env.Service.DeleteProjectAsync(projectId);
-            foreach (IMongoCollection<BsonDocument> collectionToPrune in collectionsToBePruned.Values)
-            {
-                // A further enhancement would be checking that the filter._value is the desired regex.
-                await collectionToPrune.Received(1).DeleteManyAsync(Arg.Any<FilterDefinition<BsonDocument>>());
-            }
-        }
-
-        [Test]
-        public void DeleteUserAsync_BadArguments()
+        )
         {
-            var env = new TestEnvironment();
-            Assert.ThrowsAsync<ArgumentException>(() => env.Service.DeleteUserAsync(null));
-            Assert.ThrowsAsync<ArgumentException>(() => env.Service.DeleteUserAsync(""));
-        }
-
-        [Test]
-        public async Task DeleteUserAsync_RequestsDocRemovalsInCollections()
-        {
-            var env = new TestEnvironment();
-            string projectId = "project1id";
-
-            // Set of collections that should be filtered thru to remove matching docs.
-            // This set could be different
-            // per application (like Scripture Forge, Language Forge, etc.), and the set used here should match what
-            // is defined in TestEnvironment.
-            Dictionary<string, IMongoCollection<BsonDocument>> collectionsToBePruned =
-                new Dictionary<string, IMongoCollection<BsonDocument>>();
-            string[] collectionNames = new string[] { "users", "o_users", "favorite_animals", "o_favorite_animals", };
-            foreach (string collectionName in collectionNames)
-            {
-                IMongoCollection<BsonDocument> collection = Substitute.For<IMongoCollection<BsonDocument>>();
-                collectionsToBePruned.Add(collectionName, collection);
-                env.MongoDatabase
-                    .GetCollection<BsonDocument>(collectionName)
-                    .Returns<IMongoCollection<BsonDocument>>(collection);
-            }
-            // SUT
-            await env.Service.DeleteUserAsync(projectId);
-            foreach (IMongoCollection<BsonDocument> collectionToPrune in collectionsToBePruned.Values)
-            {
-                // A further enhancement would be checking that the filter._value is the desired regex.
-                await collectionToPrune.Received(1).DeleteManyAsync(Arg.Any<FilterDefinition<BsonDocument>>());
-            }
-            env.MongoDatabase.Received(collectionNames.Length).GetCollection<BsonDocument>(Arg.Any<string>());
-        }
-
-        [Test]
-        public async Task GetLastModifiedUserIdAsync_NoMetadata()
-        {
-            // Setup environment
-            var env = new TestEnvironment();
-            string id = "123456";
-            int version = -1;
-            var doc = BsonDocument.Parse("{}");
-
-            // Setup MongoDB mock
-            var cursorMock = Substitute.For<IAsyncCursor<BsonDocument>>();
-            cursorMock.MoveNextAsync().Returns(Task.FromResult(true), Task.FromResult(false));
-            cursorMock.Current.Returns(new[] { doc });
+            IMongoCollection<BsonDocument> collection = Substitute.For<IMongoCollection<BsonDocument>>();
+            collectionsToBePruned.Add(collectionName, collection);
             env.MongoDatabase
-                .GetCollection<BsonDocument>("o_users")
-                .FindAsync(
-                    Arg.Any<FilterDefinition<BsonDocument>>(),
-                    Arg.Any<FindOptions<BsonDocument, BsonDocument>>()
-                )
-                .Returns(Task.FromResult(cursorMock));
-
-            // SUT
-            string userId = await env.Service.GetLastModifiedUserIdAsync<User>(id, version);
-            Assert.IsNull(userId);
+                .GetCollection<BsonDocument>(collectionName)
+                .Returns<IMongoCollection<BsonDocument>>(collection);
         }
-
-        [Test]
-        public async Task GetLastModifiedUserIdAsync_NoUserId()
+        // SUT
+        await env.Service.DeleteProjectAsync(projectId);
+        foreach (IMongoCollection<BsonDocument> collectionToPrune in collectionsToBePruned.Values)
         {
-            // Setup environment
-            var env = new TestEnvironment();
-            string id = "123456";
-            int version = -1;
-            var doc = BsonDocument.Parse("{ m: {} }");
+            // A further enhancement would be checking that the filter._value is the desired regex.
+            await collectionToPrune.Received(1).DeleteManyAsync(Arg.Any<FilterDefinition<BsonDocument>>());
+        }
+    }
 
-            // Setup MongoDB mock
-            var cursorMock = Substitute.For<IAsyncCursor<BsonDocument>>();
-            cursorMock.MoveNextAsync().Returns(Task.FromResult(true), Task.FromResult(false));
-            cursorMock.Current.Returns(new[] { doc });
+    [Test]
+    public void DeleteUserAsync_BadArguments()
+    {
+        var env = new TestEnvironment();
+        Assert.ThrowsAsync<ArgumentException>(() => env.Service.DeleteUserAsync(null));
+        Assert.ThrowsAsync<ArgumentException>(() => env.Service.DeleteUserAsync(""));
+    }
+
+    [Test]
+    public async Task DeleteUserAsync_RequestsDocRemovalsInCollections()
+    {
+        var env = new TestEnvironment();
+        string projectId = "project1id";
+
+        // Set of collections that should be filtered thru to remove matching docs.
+        // This set could be different
+        // per application (like Scripture Forge, Language Forge, etc.), and the set used here should match what
+        // is defined in TestEnvironment.
+        Dictionary<string, IMongoCollection<BsonDocument>> collectionsToBePruned =
+            new Dictionary<string, IMongoCollection<BsonDocument>>();
+        string[] collectionNames = new string[] { "users", "o_users", "favorite_animals", "o_favorite_animals", };
+        foreach (string collectionName in collectionNames)
+        {
+            IMongoCollection<BsonDocument> collection = Substitute.For<IMongoCollection<BsonDocument>>();
+            collectionsToBePruned.Add(collectionName, collection);
             env.MongoDatabase
-                .GetCollection<BsonDocument>("o_users")
-                .FindAsync(
-                    Arg.Any<FilterDefinition<BsonDocument>>(),
-                    Arg.Any<FindOptions<BsonDocument, BsonDocument>>()
-                )
-                .Returns(Task.FromResult(cursorMock));
-
-            // SUT
-            string userId = await env.Service.GetLastModifiedUserIdAsync<User>(id, version);
-            Assert.IsNull(userId);
+                .GetCollection<BsonDocument>(collectionName)
+                .Returns<IMongoCollection<BsonDocument>>(collection);
         }
-
-        [Test]
-        public async Task GetLastModifiedUserIdAsync_UserIdPresent()
+        // SUT
+        await env.Service.DeleteUserAsync(projectId);
+        foreach (IMongoCollection<BsonDocument> collectionToPrune in collectionsToBePruned.Values)
         {
-            // Setup environment
-            var env = new TestEnvironment();
-            string id = "123456";
-            int version = -1;
-            var doc = BsonDocument.Parse("{ m: { uId: 'abcdef' } }");
-
-            // Setup MongoDB mock
-            var cursorMock = Substitute.For<IAsyncCursor<BsonDocument>>();
-            cursorMock.MoveNextAsync().Returns(Task.FromResult(true), Task.FromResult(false));
-            cursorMock.Current.Returns(new[] { doc });
-            env.MongoDatabase
-                .GetCollection<BsonDocument>("o_users")
-                .FindAsync(
-                    Arg.Any<FilterDefinition<BsonDocument>>(),
-                    Arg.Any<FindOptions<BsonDocument, BsonDocument>>()
-                )
-                .Returns(Task.FromResult(cursorMock));
-
-            // SUT
-            string userId = await env.Service.GetLastModifiedUserIdAsync<User>(id, version);
-            Assert.AreEqual("abcdef", userId);
+            // A further enhancement would be checking that the filter._value is the desired regex.
+            await collectionToPrune.Received(1).DeleteManyAsync(Arg.Any<FilterDefinition<BsonDocument>>());
         }
+        env.MongoDatabase.Received(collectionNames.Length).GetCollection<BsonDocument>(Arg.Any<string>());
+    }
 
-        [Test]
-        public async Task GetLastModifiedUserIdAsync_ChecksMostRecentVersion()
+    [Test]
+    public async Task GetLastModifiedUserIdAsync_NoMetadata()
+    {
+        // Setup environment
+        var env = new TestEnvironment();
+        string id = "123456";
+        int version = -1;
+        var doc = BsonDocument.Parse("{}");
+
+        // Setup MongoDB mock
+        var cursorMock = Substitute.For<IAsyncCursor<BsonDocument>>();
+        cursorMock.MoveNextAsync().Returns(Task.FromResult(true), Task.FromResult(false));
+        cursorMock.Current.Returns(new[] { doc });
+        env.MongoDatabase
+            .GetCollection<BsonDocument>("o_users")
+            .FindAsync(Arg.Any<FilterDefinition<BsonDocument>>(), Arg.Any<FindOptions<BsonDocument, BsonDocument>>())
+            .Returns(Task.FromResult(cursorMock));
+
+        // SUT
+        string userId = await env.Service.GetLastModifiedUserIdAsync<User>(id, version);
+        Assert.IsNull(userId);
+    }
+
+    [Test]
+    public async Task GetLastModifiedUserIdAsync_NoUserId()
+    {
+        // Setup environment
+        var env = new TestEnvironment();
+        string id = "123456";
+        int version = -1;
+        var doc = BsonDocument.Parse("{ m: {} }");
+
+        // Setup MongoDB mock
+        var cursorMock = Substitute.For<IAsyncCursor<BsonDocument>>();
+        cursorMock.MoveNextAsync().Returns(Task.FromResult(true), Task.FromResult(false));
+        cursorMock.Current.Returns(new[] { doc });
+        env.MongoDatabase
+            .GetCollection<BsonDocument>("o_users")
+            .FindAsync(Arg.Any<FilterDefinition<BsonDocument>>(), Arg.Any<FindOptions<BsonDocument, BsonDocument>>())
+            .Returns(Task.FromResult(cursorMock));
+
+        // SUT
+        string userId = await env.Service.GetLastModifiedUserIdAsync<User>(id, version);
+        Assert.IsNull(userId);
+    }
+
+    [Test]
+    public async Task GetLastModifiedUserIdAsync_UserIdPresent()
+    {
+        // Setup environment
+        var env = new TestEnvironment();
+        string id = "123456";
+        int version = -1;
+        var doc = BsonDocument.Parse("{ m: { uId: 'abcdef' } }");
+
+        // Setup MongoDB mock
+        var cursorMock = Substitute.For<IAsyncCursor<BsonDocument>>();
+        cursorMock.MoveNextAsync().Returns(Task.FromResult(true), Task.FromResult(false));
+        cursorMock.Current.Returns(new[] { doc });
+        env.MongoDatabase
+            .GetCollection<BsonDocument>("o_users")
+            .FindAsync(Arg.Any<FilterDefinition<BsonDocument>>(), Arg.Any<FindOptions<BsonDocument, BsonDocument>>())
+            .Returns(Task.FromResult(cursorMock));
+
+        // SUT
+        string userId = await env.Service.GetLastModifiedUserIdAsync<User>(id, version);
+        Assert.AreEqual("abcdef", userId);
+    }
+
+    [Test]
+    public async Task GetLastModifiedUserIdAsync_ChecksMostRecentVersion()
+    {
+        // Setup environment
+        var env = new TestEnvironment();
+        string id = "123456";
+        int version = 3;
+        var doc1 = BsonDocument.Parse("{ v: 1, m: { uId: 'abcdef' } }");
+        var doc2 = BsonDocument.Parse("{ v: 2, m: { uId: 'ghijkl' } }");
+
+        // Setup MongoDB mock
+        var cursorMock = Substitute.For<IAsyncCursor<BsonDocument>>();
+        cursorMock.MoveNextAsync().Returns(Task.FromResult(true), Task.FromResult(false));
+        cursorMock.Current.Returns(new[] { doc2, doc1 });
+        env.MongoDatabase
+            .GetCollection<BsonDocument>("o_users")
+            .FindAsync(Arg.Any<FilterDefinition<BsonDocument>>(), Arg.Any<FindOptions<BsonDocument, BsonDocument>>())
+            .Returns(Task.FromResult(cursorMock));
+
+        // SUT
+        string userId = await env.Service.GetLastModifiedUserIdAsync<User>(id, version);
+        Assert.AreEqual("ghijkl", userId);
+    }
+
+    private class TestEnvironment
+    {
+        public readonly RealtimeService Service;
+        public readonly IMongoDatabase MongoDatabase = Substitute.For<IMongoDatabase>();
+
+        public TestEnvironment()
         {
-            // Setup environment
-            var env = new TestEnvironment();
-            string id = "123456";
-            int version = 3;
-            var doc1 = BsonDocument.Parse("{ v: 1, m: { uId: 'abcdef' } }");
-            var doc2 = BsonDocument.Parse("{ v: 2, m: { uId: 'ghijkl' } }");
-
-            // Setup MongoDB mock
-            var cursorMock = Substitute.For<IAsyncCursor<BsonDocument>>();
-            cursorMock.MoveNextAsync().Returns(Task.FromResult(true), Task.FromResult(false));
-            cursorMock.Current.Returns(new[] { doc2, doc1 });
-            env.MongoDatabase
-                .GetCollection<BsonDocument>("o_users")
-                .FindAsync(
-                    Arg.Any<FilterDefinition<BsonDocument>>(),
-                    Arg.Any<FindOptions<BsonDocument, BsonDocument>>()
-                )
-                .Returns(Task.FromResult(cursorMock));
-
-            // SUT
-            string userId = await env.Service.GetLastModifiedUserIdAsync<User>(id, version);
-            Assert.AreEqual("ghijkl", userId);
-        }
-
-        private class TestEnvironment
-        {
-            public readonly RealtimeService Service;
-            public readonly IMongoDatabase MongoDatabase = Substitute.For<IMongoDatabase>();
-
-            public TestEnvironment()
-            {
-                IRealtimeServer realtimeServer = Substitute.For<IRealtimeServer>();
-                IOptions<SiteOptions> siteOptions = Substitute.For<IOptions<SiteOptions>>();
-                IOptions<DataAccessOptions> dataAccessOptions =
-                    Microsoft.Extensions.Options.Options.Create<DataAccessOptions>(
-                        new DataAccessOptions() { MongoDatabaseName = "mongoDatabaseName" }
-                    );
-                IOptions<RealtimeOptions> realtimeOptions =
-                    Microsoft.Extensions.Options.Options.Create<RealtimeOptions>(
-                        new RealtimeOptions()
-                        {
-                            ProjectDoc = new DocConfig("some_projects", typeof(Project)),
-                            ProjectDataDocs = new List<DocConfig>
-                            {
-                                new DocConfig("favorite_numbers", typeof(int)),
-                                new DocConfig("favorite_things", typeof(object)),
-                                new DocConfig("favorite_verses", typeof(string))
-                            },
-                            UserDataDocs = new List<DocConfig> { new DocConfig("favorite_animals", typeof(object)), }
-                        }
-                    );
-                IOptions<AuthOptions> authOptions = Substitute.For<IOptions<AuthOptions>>();
-
-                IMongoClient mongoClient = Substitute.For<IMongoClient>();
-                mongoClient.GetDatabase(Arg.Any<string>()).Returns(MongoDatabase);
-                IConfiguration configuration = Substitute.For<IConfiguration>();
-
-                Service = new RealtimeService(
-                    realtimeServer,
-                    siteOptions,
-                    dataAccessOptions,
-                    realtimeOptions,
-                    authOptions,
-                    mongoClient,
-                    configuration
+            IRealtimeServer realtimeServer = Substitute.For<IRealtimeServer>();
+            IOptions<SiteOptions> siteOptions = Substitute.For<IOptions<SiteOptions>>();
+            IOptions<DataAccessOptions> dataAccessOptions =
+                Microsoft.Extensions.Options.Options.Create<DataAccessOptions>(
+                    new DataAccessOptions() { MongoDatabaseName = "mongoDatabaseName" }
                 );
-            }
+            IOptions<RealtimeOptions> realtimeOptions = Microsoft.Extensions.Options.Options.Create<RealtimeOptions>(
+                new RealtimeOptions()
+                {
+                    ProjectDoc = new DocConfig("some_projects", typeof(Project)),
+                    ProjectDataDocs = new List<DocConfig>
+                    {
+                        new DocConfig("favorite_numbers", typeof(int)),
+                        new DocConfig("favorite_things", typeof(object)),
+                        new DocConfig("favorite_verses", typeof(string))
+                    },
+                    UserDataDocs = new List<DocConfig> { new DocConfig("favorite_animals", typeof(object)), }
+                }
+            );
+            IOptions<AuthOptions> authOptions = Substitute.For<IOptions<AuthOptions>>();
+
+            IMongoClient mongoClient = Substitute.For<IMongoClient>();
+            mongoClient.GetDatabase(Arg.Any<string>()).Returns(MongoDatabase);
+            IConfiguration configuration = Substitute.For<IConfiguration>();
+
+            Service = new RealtimeService(
+                realtimeServer,
+                siteOptions,
+                dataAccessOptions,
+                realtimeOptions,
+                authOptions,
+                mongoClient,
+                configuration
+            );
         }
     }
 }

--- a/test/SIL.XForge.Tests/Realtime/RichText/DeltaTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/RichText/DeltaTests.cs
@@ -1,841 +1,798 @@
-using Newtonsoft.Json.Linq;
-using NUnit.Framework;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
 
-namespace SIL.XForge.Realtime.RichText
+namespace SIL.XForge.Realtime.RichText;
+
+[TestFixture]
+public class DeltaTests
 {
-    [TestFixture]
-    public class DeltaTests
+    [Test]
+    public void Insert_EmptyText_EmptyOps()
     {
-        [Test]
-        public void Insert_EmptyText_EmptyOps()
-        {
-            var delta = Delta.New().Insert("");
-            Assert.That(delta.Ops, Is.Empty);
-        }
+        var delta = Delta.New().Insert("");
+        Assert.That(delta.Ops, Is.Empty);
+    }
 
-        [Test]
-        public void Insert_Text_OneOp()
-        {
-            var delta = Delta.New().Insert("test");
-            Assert.That(delta.Ops, Is.EqualTo(Objs(new { insert = "test" })));
-        }
+    [Test]
+    public void Insert_Text_OneOp()
+    {
+        var delta = Delta.New().Insert("test");
+        Assert.That(delta.Ops, Is.EqualTo(Objs(new { insert = "test" })));
+    }
 
-        [Test]
-        public void Insert_ConsecutiveTexts_MergeOps()
-        {
-            var delta = Delta.New().Insert("a").Insert("b");
-            Assert.That(delta.Ops, Is.EqualTo(Objs(new { insert = "ab" })));
-        }
+    [Test]
+    public void Insert_ConsecutiveTexts_MergeOps()
+    {
+        var delta = Delta.New().Insert("a").Insert("b");
+        Assert.That(delta.Ops, Is.EqualTo(Objs(new { insert = "ab" })));
+    }
 
-        [Test]
-        public void Insert_ConsecutiveTextsMatchingAttrs_MergeOps()
-        {
-            var delta = Delta.New().Insert("a", new { bold = true }).Insert("b", new { bold = true });
-            Assert.That(delta.Ops, Is.EqualTo(Objs(new { insert = "ab", attributes = new { bold = true } })));
-        }
+    [Test]
+    public void Insert_ConsecutiveTextsMatchingAttrs_MergeOps()
+    {
+        var delta = Delta.New().Insert("a", new { bold = true }).Insert("b", new { bold = true });
+        Assert.That(delta.Ops, Is.EqualTo(Objs(new { insert = "ab", attributes = new { bold = true } })));
+    }
 
-        [Test]
-        public void Insert_ConsecutiveTextsDifferentAttrs_TwoOps()
-        {
-            var delta = Delta.New().Insert("a", new { bold = true }).Insert("b");
-            Assert.That(
-                delta.Ops,
-                Is.EqualTo(Objs(new { insert = "a", attributes = new { bold = true } }, new { insert = "b" }))
-            );
-        }
+    [Test]
+    public void Insert_ConsecutiveTextsDifferentAttrs_TwoOps()
+    {
+        var delta = Delta.New().Insert("a", new { bold = true }).Insert("b");
+        Assert.That(
+            delta.Ops,
+            Is.EqualTo(Objs(new { insert = "a", attributes = new { bold = true } }, new { insert = "b" }))
+        );
+    }
 
-        [Test]
-        public void Insert_ConsecutiveEmbedsMatchingAttrs_TwoOps()
-        {
-            var delta = Delta
-                .New()
-                .Insert(1, new { alt = "Description" })
-                .Insert(new { url = "http://quilljs.com" }, new { alt = "Description" });
-            Assert.That(
-                delta.Ops,
-                Is.EqualTo(
-                    Objs(
-                        new { insert = 1, attributes = new { alt = "Description" } },
-                        new { insert = new { url = "http://quilljs.com" }, attributes = new { alt = "Description" } }
-                    )
+    [Test]
+    public void Insert_ConsecutiveEmbedsMatchingAttrs_TwoOps()
+    {
+        var delta = Delta
+            .New()
+            .Insert(1, new { alt = "Description" })
+            .Insert(new { url = "http://quilljs.com" }, new { alt = "Description" });
+        Assert.That(
+            delta.Ops,
+            Is.EqualTo(
+                Objs(
+                    new { insert = 1, attributes = new { alt = "Description" } },
+                    new { insert = new { url = "http://quilljs.com" }, attributes = new { alt = "Description" } }
                 )
+            )
+        );
+    }
+
+    [Test]
+    public void Insert_TextAttributes_OneOp()
+    {
+        var attrs = new { bold = true };
+        var delta = Delta.New().Insert("test", attrs);
+        Assert.That(delta.Ops, Is.EqualTo(Objs(new { insert = "test", attributes = attrs })));
+    }
+
+    [Test]
+    public void Insert_Embed_OneOp()
+    {
+        var delta = Delta.New().Insert(1);
+        Assert.That(delta.Ops, Is.EqualTo(Objs(new { insert = 1 })));
+    }
+
+    [Test]
+    public void Insert_EmbedAttributes_OneOp()
+    {
+        var attrs = new { url = "http://quilljs.com", alt = "Quill" };
+        var delta = Delta.New().Insert(1, attrs);
+        Assert.That(delta.Ops, Is.EqualTo(Objs(new { insert = 1, attributes = attrs })));
+    }
+
+    [Test]
+    public void Insert_ObjEmbedAttributes_OneOp()
+    {
+        var embed = new { url = "http://quilljs.com" };
+        var attrs = new { alt = "Quill" };
+        var delta = Delta.New().Insert(embed, attrs);
+        Assert.That(delta.Ops, Is.EqualTo(Objs(new { insert = embed, attributes = attrs })));
+    }
+
+    [Test]
+    public void Insert_AfterDelete_SwapOps()
+    {
+        var delta = Delta.New().Delete(1).Insert("a");
+        var expected = Delta.New().Insert("a").Delete(1);
+        Assert.That(delta, Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Insert_AfterDeleteWithMerge_MergeOps()
+    {
+        var delta = Delta.New().Insert("a").Delete(1).Insert("b");
+        var expected = Delta.New().Insert("ab").Delete(1);
+        Assert.That(delta, Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Insert_AfterDeleteNoMerge_SwapOps()
+    {
+        var delta = Delta.New().Insert(1).Delete(1).Insert("a");
+        var expected = Delta.New().Insert(1).Insert("a").Delete(1);
+        Assert.That(delta, Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Insert_EmptyAttributes_IgnoreAttributes()
+    {
+        var delta = Delta.New().Insert("a", new { });
+        var expected = Delta.New().Insert("a");
+        Assert.That(delta, Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Retain_Zero_EmptyOps()
+    {
+        var delta = Delta.New().Retain(0);
+        Assert.That(delta.Ops, Is.Empty);
+    }
+
+    [Test]
+    public void Retain_Positive_OneOp()
+    {
+        var delta = Delta.New().Retain(2);
+        Assert.That(delta.Ops, Is.EqualTo(Objs(new { retain = 2 })));
+    }
+
+    [Test]
+    public void Retain_Attributes_OneOp()
+    {
+        var attrs = new { bold = true };
+        var delta = Delta.New().Retain(1, attrs);
+        Assert.That(delta.Ops, Is.EqualTo(Objs(new { retain = 1, attributes = attrs })));
+    }
+
+    [Test]
+    public void Retain_ConsecutiveRetainsMatchingAttrs_MergeOps()
+    {
+        var delta = Delta.New().Retain(1, new { bold = true }).Retain(3, new { bold = true });
+        Assert.That(delta.Ops, Is.EqualTo(Objs(new { retain = 4, attributes = new { bold = true } })));
+    }
+
+    [Test]
+    public void Retain_ConsecutiveRetainsDifferentAttrs_TwoOps()
+    {
+        var delta = Delta.New().Retain(1, new { bold = true }).Retain(3);
+        Assert.That(
+            delta.Ops,
+            Is.EqualTo(Objs(new { retain = 1, attributes = new { bold = true } }, new { retain = 3 }))
+        );
+    }
+
+    [Test]
+    public void Retain_EmptyAttributes_IgnoreAttributes()
+    {
+        var delta = Delta.New().Retain(2, new { }).Delete(1);
+        var expected = Delta.New().Retain(2).Delete(1);
+        Assert.That(delta, Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Delete_Zero_EmptyOps()
+    {
+        var delta = Delta.New().Delete(0);
+        Assert.That(delta.Ops, Is.Empty);
+    }
+
+    [Test]
+    public void Delete_Positive_OneOp()
+    {
+        var delta = Delta.New().Delete(1);
+        Assert.That(delta.Ops, Is.EqualTo(Objs(new { delete = 1 })));
+    }
+
+    [Test]
+    public void Delete_ConsecutiveDeletes_MergeOps()
+    {
+        var delta = Delta.New().Delete(2).Delete(3);
+        Assert.That(delta.Ops, Is.EqualTo(Objs(new { delete = 5 })));
+    }
+
+    [Test]
+    public void Compose_InsertInsert_TwoOps()
+    {
+        var a = Delta.New().Insert("A");
+        var b = Delta.New().Insert("B");
+        var expected = Delta.New().Insert("B").Insert("A");
+        Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Compose_InsertRetain_MergeOps()
+    {
+        var a = Delta.New().Insert("A");
+        var b = Delta
+            .New()
+            .Retain(
+                1,
+                new
+                {
+                    bold = true,
+                    color = "red",
+                    font = default(string?),
+                }
             );
-        }
+        var expected = Delta.New().Insert("A", new { bold = true, color = "red" });
+        Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
 
-        [Test]
-        public void Insert_TextAttributes_OneOp()
-        {
-            var attrs = new { bold = true };
-            var delta = Delta.New().Insert("test", attrs);
-            Assert.That(delta.Ops, Is.EqualTo(Objs(new { insert = "test", attributes = attrs })));
-        }
+    [Test]
+    public void Compose_InsertDelete_MergeOps()
+    {
+        var a = Delta.New().Insert("A");
+        var b = Delta.New().Delete(1);
+        var expected = Delta.New();
+        Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
 
-        [Test]
-        public void Insert_Embed_OneOp()
-        {
-            var delta = Delta.New().Insert(1);
-            Assert.That(delta.Ops, Is.EqualTo(Objs(new { insert = 1 })));
-        }
+    [Test]
+    public void Compose_DeleteInsert_TwoOps()
+    {
+        var a = Delta.New().Delete(1);
+        var b = Delta.New().Insert("B");
+        var expected = Delta.New().Insert("B").Delete(1);
+        Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
 
-        [Test]
-        public void Insert_EmbedAttributes_OneOp()
-        {
-            var attrs = new { url = "http://quilljs.com", alt = "Quill" };
-            var delta = Delta.New().Insert(1, attrs);
-            Assert.That(delta.Ops, Is.EqualTo(Objs(new { insert = 1, attributes = attrs })));
-        }
+    [Test]
+    public void Compose_DeleteRetain_TwoOps()
+    {
+        var a = Delta.New().Delete(1);
+        var b = Delta.New().Retain(1, new { bold = true, color = "red" });
+        var expected = Delta.New().Delete(1).Retain(1, new { bold = true, color = "red" });
+        Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
 
-        [Test]
-        public void Insert_ObjEmbedAttributes_OneOp()
-        {
-            var embed = new { url = "http://quilljs.com" };
-            var attrs = new { alt = "Quill" };
-            var delta = Delta.New().Insert(embed, attrs);
-            Assert.That(delta.Ops, Is.EqualTo(Objs(new { insert = embed, attributes = attrs })));
-        }
+    [Test]
+    public void Compose_DeleteDelete_MergeOps()
+    {
+        var a = Delta.New().Delete(1);
+        var b = Delta.New().Delete(1);
+        var expected = Delta.New().Delete(2);
+        Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
 
-        [Test]
-        public void Insert_AfterDelete_SwapOps()
-        {
-            var delta = Delta.New().Delete(1).Insert("a");
-            var expected = Delta.New().Insert("a").Delete(1);
-            Assert.That(delta, Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
+    [Test]
+    public void Compose_RetainInsert_TwoOps()
+    {
+        var a = Delta.New().Retain(1, new { color = "blue" });
+        var b = Delta.New().Insert("B");
+        var expected = Delta.New().Insert("B").Retain(1, new { color = "blue" });
+        Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
 
-        [Test]
-        public void Insert_AfterDeleteWithMerge_MergeOps()
-        {
-            var delta = Delta.New().Insert("a").Delete(1).Insert("b");
-            var expected = Delta.New().Insert("ab").Delete(1);
-            Assert.That(delta, Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Insert_AfterDeleteNoMerge_SwapOps()
-        {
-            var delta = Delta.New().Insert(1).Delete(1).Insert("a");
-            var expected = Delta.New().Insert(1).Insert("a").Delete(1);
-            Assert.That(delta, Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Insert_EmptyAttributes_IgnoreAttributes()
-        {
-            var delta = Delta.New().Insert("a", new { });
-            var expected = Delta.New().Insert("a");
-            Assert.That(delta, Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Retain_Zero_EmptyOps()
-        {
-            var delta = Delta.New().Retain(0);
-            Assert.That(delta.Ops, Is.Empty);
-        }
-
-        [Test]
-        public void Retain_Positive_OneOp()
-        {
-            var delta = Delta.New().Retain(2);
-            Assert.That(delta.Ops, Is.EqualTo(Objs(new { retain = 2 })));
-        }
-
-        [Test]
-        public void Retain_Attributes_OneOp()
-        {
-            var attrs = new { bold = true };
-            var delta = Delta.New().Retain(1, attrs);
-            Assert.That(delta.Ops, Is.EqualTo(Objs(new { retain = 1, attributes = attrs })));
-        }
-
-        [Test]
-        public void Retain_ConsecutiveRetainsMatchingAttrs_MergeOps()
-        {
-            var delta = Delta.New().Retain(1, new { bold = true }).Retain(3, new { bold = true });
-            Assert.That(delta.Ops, Is.EqualTo(Objs(new { retain = 4, attributes = new { bold = true } })));
-        }
-
-        [Test]
-        public void Retain_ConsecutiveRetainsDifferentAttrs_TwoOps()
-        {
-            var delta = Delta.New().Retain(1, new { bold = true }).Retain(3);
-            Assert.That(
-                delta.Ops,
-                Is.EqualTo(Objs(new { retain = 1, attributes = new { bold = true } }, new { retain = 3 }))
+    [Test]
+    public void Compose_RetainRetain_MergeOps()
+    {
+        var a = Delta.New().Retain(1, new { color = "blue" });
+        var b = Delta
+            .New()
+            .Retain(
+                1,
+                new
+                {
+                    bold = true,
+                    color = "red",
+                    font = default(string?),
+                }
             );
-        }
-
-        [Test]
-        public void Retain_EmptyAttributes_IgnoreAttributes()
-        {
-            var delta = Delta.New().Retain(2, new { }).Delete(1);
-            var expected = Delta.New().Retain(2).Delete(1);
-            Assert.That(delta, Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Delete_Zero_EmptyOps()
-        {
-            var delta = Delta.New().Delete(0);
-            Assert.That(delta.Ops, Is.Empty);
-        }
-
-        [Test]
-        public void Delete_Positive_OneOp()
-        {
-            var delta = Delta.New().Delete(1);
-            Assert.That(delta.Ops, Is.EqualTo(Objs(new { delete = 1 })));
-        }
-
-        [Test]
-        public void Delete_ConsecutiveDeletes_MergeOps()
-        {
-            var delta = Delta.New().Delete(2).Delete(3);
-            Assert.That(delta.Ops, Is.EqualTo(Objs(new { delete = 5 })));
-        }
-
-        [Test]
-        public void Compose_InsertInsert_TwoOps()
-        {
-            var a = Delta.New().Insert("A");
-            var b = Delta.New().Insert("B");
-            var expected = Delta.New().Insert("B").Insert("A");
-            Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Compose_InsertRetain_MergeOps()
-        {
-            var a = Delta.New().Insert("A");
-            var b = Delta
-                .New()
-                .Retain(
-                    1,
-                    new
-                    {
-                        bold = true,
-                        color = "red",
-                        font = default(string?),
-                    }
-                );
-            var expected = Delta.New().Insert("A", new { bold = true, color = "red" });
-            Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Compose_InsertDelete_MergeOps()
-        {
-            var a = Delta.New().Insert("A");
-            var b = Delta.New().Delete(1);
-            var expected = Delta.New();
-            Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Compose_DeleteInsert_TwoOps()
-        {
-            var a = Delta.New().Delete(1);
-            var b = Delta.New().Insert("B");
-            var expected = Delta.New().Insert("B").Delete(1);
-            Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Compose_DeleteRetain_TwoOps()
-        {
-            var a = Delta.New().Delete(1);
-            var b = Delta.New().Retain(1, new { bold = true, color = "red" });
-            var expected = Delta.New().Delete(1).Retain(1, new { bold = true, color = "red" });
-            Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Compose_DeleteDelete_MergeOps()
-        {
-            var a = Delta.New().Delete(1);
-            var b = Delta.New().Delete(1);
-            var expected = Delta.New().Delete(2);
-            Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Compose_RetainInsert_TwoOps()
-        {
-            var a = Delta.New().Retain(1, new { color = "blue" });
-            var b = Delta.New().Insert("B");
-            var expected = Delta.New().Insert("B").Retain(1, new { color = "blue" });
-            Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Compose_RetainRetain_MergeOps()
-        {
-            var a = Delta.New().Retain(1, new { color = "blue" });
-            var b = Delta
-                .New()
-                .Retain(
-                    1,
-                    new
-                    {
-                        bold = true,
-                        color = "red",
-                        font = default(string?),
-                    }
-                );
-            var expected = Delta
-                .New()
-                .Retain(
-                    1,
-                    new
-                    {
-                        bold = true,
-                        color = "red",
-                        font = default(string?),
-                    }
-                );
-            Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Compose_RetainDelete_MergeOps()
-        {
-            var a = Delta.New().Retain(1, new { color = "blue" });
-            var b = Delta.New().Delete(1);
-            var expected = Delta.New().Delete(1);
-            Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Compose_InsertInMiddle_MergeOps()
-        {
-            var a = Delta.New().Insert("Hello");
-            var b = Delta.New().Retain(3).Insert("X");
-            var expected = Delta.New().Insert("HelXlo");
-            Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Compose_InsertDeleteOrdering_MergeOps()
-        {
-            var a = Delta.New().Insert("Hello");
-            var b = Delta.New().Insert("Hello");
-            var insertFirst = Delta.New().Retain(3).Insert("X").Delete(1);
-            var deleteFirst = Delta.New().Retain(3).Delete(1).Insert("X");
-            var expected = Delta.New().Insert("HelXo");
-            Assert.That(a.Compose(insertFirst), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-            Assert.That(b.Compose(deleteFirst), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Compose_InsertEmbedRetain_MergeOps()
-        {
-            var a = Delta.New().Insert(1, new { src = "http://quilljs.com/image.png" });
-            var b = Delta.New().Retain(1, new { alt = "logo" });
-            var expected = Delta.New().Insert(1, new { src = "http://quilljs.com/image.png", alt = "logo" });
-            Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Compose_DeleteEntireText_MergeOps()
-        {
-            var a = Delta.New().Retain(4).Insert("Hello");
-            var b = Delta.New().Delete(9);
-            var expected = Delta.New().Delete(4);
-            Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Compose_RetainMoreThanText_MergeOps()
-        {
-            var a = Delta.New().Insert("Hello");
-            var b = Delta.New().Retain(10);
-            var expected = Delta.New().Insert("Hello");
-            Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Compose_RetainEmbed_MergeOps()
-        {
-            var a = Delta.New().Insert(1);
-            var b = Delta.New().Retain(1);
-            var expected = Delta.New().Insert(1);
-            Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Compose_RemoveAttributes_MergeOps()
-        {
-            var a = Delta.New().Insert("A", new { bold = true });
-            var b = Delta.New().Retain(1, new { bold = default(bool?) });
-            var expected = Delta.New().Insert("A");
-            Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Compose_RemoveEmbedAttributes_MergeOps()
-        {
-            var a = Delta.New().Insert(2, new { bold = true });
-            var b = Delta.New().Retain(1, new { bold = default(bool?) });
-            var expected = Delta.New().Insert(2);
-            Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Compose_Immutability()
-        {
-            JToken attr1 = Obj(new { bold = true });
-            JToken attr2 = Obj(new { bold = true });
-            var a1 = Delta.New().Insert("Test", attr1);
-            var a2 = Delta.New().Insert("Test", attr1);
-            var b1 = Delta.New().Retain(1, new { color = "red" }).Delete(2);
-            var b2 = Delta.New().Retain(1, new { color = "red" }).Delete(2);
-            var expected = Delta.New().Insert("T", new { color = "red", bold = true }).Insert("t", attr1);
-            Assert.That(a1.Compose(b1), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-            Assert.That(a1, Is.EqualTo(a2).Using(Delta.EqualityComparer));
-            Assert.That(b1, Is.EqualTo(b2).Using(Delta.EqualityComparer));
-            Assert.That(attr1, Is.EqualTo(attr2));
-        }
-
-        [Test]
-        public void Diff_Insert()
-        {
-            var a = Delta.New().Insert("A");
-            var b = Delta.New().Insert("AB");
-            var expected = Delta.New().Retain(1).Insert("B");
-            Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Diff_Delete()
-        {
-            var a = Delta.New().Insert("AB");
-            var b = Delta.New().Insert("A");
-            var expected = Delta.New().Retain("A".Length).Delete("B".Length);
-            Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Diff_Empty()
-        {
-            var a = Delta.New().Insert("AB");
-            var b = Delta.New();
-            var expected = Delta.New().Delete("AB".Length);
-            Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Diff_Null()
-        {
-            var a = Delta.New().Insert("AB");
-            Delta b = null;
-            Assert.That(() => a.Diff(b), Throws.ArgumentNullException);
-        }
-
-        [Test]
-        public void Diff_Retain()
-        {
-            var a = Delta.New().Insert("A");
-            var b = Delta.New().Insert("A");
-            var expected = Delta.New();
-            Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Diff_Format()
-        {
-            var a = Delta.New().Insert("A");
-            var b = Delta.New().Insert("A", new { bold = true });
-            var expected = Delta.New().Retain(1, new { bold = true });
-            Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Diff_ObjectAttributes()
-        {
-            var a = Delta.New().Insert("A", new { font = new { family = "Helvetica", size = "15px" } });
-            var b = Delta.New().Insert("A", new { font = new { family = "Helvetica", size = "15px" } });
-            var expected = Delta.New();
-            Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Diff_EmbedIntegerMatch()
-        {
-            var a = Delta.New().Insert(1);
-            var b = Delta.New().Insert(1);
-            var expected = Delta.New();
-            Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Diff_EmbedIntegerMismatch()
-        {
-            var a = Delta.New().Insert(1);
-            var b = Delta.New().Insert(2);
-            var expected = Delta.New().Delete(1).Insert(2);
-            Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Diff_EmbedObjectMatch()
-        {
-            var a = Delta.New().Insert(new { image = "http://quilljs.com" });
-            var b = Delta.New().Insert(new { image = "http://quilljs.com" });
-            var expected = Delta.New();
-            Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Diff_EmbedObjectMismatch()
-        {
-            var a = Delta.New().Insert(new { image = "http://quilljs.com", alt = "Overwrite" });
-            var b = Delta.New().Insert(new { image = "http://quilljs.com" });
-            var expected = Delta.New().Insert(new { image = "http://quilljs.com" }).Delete(1);
-            Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Diff_EmbedObjectChange()
-        {
-            JObject embed = Obj(new { image = "http://quilljs.com" });
-            var a = Delta.New().Insert(embed);
-            embed["image"] = "http://github.com";
-            var b = Delta.New().Insert(embed);
-            var expected = Delta.New().Insert(new { image = "http://github.com" }).Delete(1);
-            Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Diff_EmbedFalsePositive()
-        {
-            var a = Delta.New().Insert(1);
-            var b = Delta.New().Insert("\0");
-            var expected = Delta.New().Insert("\0").Delete(1);
-            Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Diff_ThrowsOnNonDocuments()
-        {
-            var a = Delta.New().Insert("A");
-            var b = Delta.New().Retain(1).Insert("B");
-            Assert.That(() => a.Diff(b), Throws.InvalidOperationException);
-            Assert.That(() => b.Diff(a), Throws.InvalidOperationException);
-        }
-
-        [Test]
-        public void Diff_InconvenientIndices()
-        {
-            var a = Delta.New().Insert("12", new { bold = true }).Insert("34", new { italic = true });
-            var b = Delta.New().Insert("123", new { color = "red" });
-            var expected = Delta
-                .New()
-                .Retain(2, new { bold = default(bool?), color = "red" })
-                .Retain(1, new { italic = default(bool?), color = "red" })
-                .Delete(1);
-            Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Diff_Combination()
-        {
-            var a = Delta.New().Insert("Bad", new { color = "red" }).Insert("cat", new { color = "blue" });
-            var b = Delta.New().Insert("Good", new { bold = true }).Insert("dog", new { italic = true });
-            var expected = Delta
-                .New()
-                .Insert("Good", new { bold = true })
-                .Delete(2)
-                .Retain(1, new { italic = true, color = default(string?) })
-                .Delete(3)
-                .Insert("og", new { italic = true });
-            Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Diff_SameDocument()
-        {
-            var a = Delta.New().Insert("A").Insert("B", new { bold = true });
-            var expected = Delta.New();
-            Assert.That(a.Diff(a), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Diff_Immutability()
-        {
-            JToken attr1 = Obj(new { color = "red" });
-            JToken attr2 = Obj(new { color = "red" });
-            var a1 = Delta.New().Insert("A", attr1);
-            var a2 = Delta.New().Insert("A", attr1);
-            var b1 = Delta.New().Insert("A", new { bold = true }).Insert("B");
-            var b2 = Delta.New().Insert("A", new { bold = true }).Insert("B");
-            var expected = Delta.New().Retain(1, new { bold = true, color = default(string?) }).Insert("B");
-            Assert.That(a1.Diff(b1), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-            Assert.That(a1, Is.EqualTo(a2).Using(Delta.EqualityComparer));
-            Assert.That(b1, Is.EqualTo(b2).Using(Delta.EqualityComparer));
-            Assert.That(attr1, Is.EqualTo(attr2));
-        }
-
-        [Test]
-        public void Diff_CharAttributeObject()
-        {
-            JObject charObjA = new JObject(new JProperty("char", new JObject(new JProperty("cid", "123"))));
-            JObject charObjB = new JObject(new JProperty("char", new JObject(new JProperty("cid", "456"))));
-            var a = Delta.New().Insert("A", charObjA);
-            var b = Delta.New().Insert("A", charObjB);
-            var expected = Delta.New();
-            Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
-
-        [Test]
-        public void Diff_CharAttributeObjectChanged()
-        {
-            JObject charObjA = new JObject(
-                new JProperty("char", new JObject(new JProperty("style", "it"), new JProperty("cid", "123")))
+        var expected = Delta
+            .New()
+            .Retain(
+                1,
+                new
+                {
+                    bold = true,
+                    color = "red",
+                    font = default(string?),
+                }
             );
-            JObject charObjB = new JObject(
-                new JProperty("char", new JObject(new JProperty("style", "fr"), new JProperty("cid", "456")))
-            );
-            var a = Delta.New().Insert("A", charObjA);
-            var b = Delta.New().Insert("A", charObjB);
-            var expected = Delta.New().Retain(1, charObjB);
-            Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
+        Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
 
-        [Test]
-        public void Diff_ArrayOfCharAttributeObjects()
-        {
-            // The path to the cid can look like insert.note.contents.ops[i].attributes.char.cid
-            JObject a1 = new JObject(
-                new JProperty("insert", "text1"),
-                new JProperty(
-                    "attributes",
-                    new JObject(new JProperty("char", new JObject(new JProperty("cid", "123"))))
+    [Test]
+    public void Compose_RetainDelete_MergeOps()
+    {
+        var a = Delta.New().Retain(1, new { color = "blue" });
+        var b = Delta.New().Delete(1);
+        var expected = Delta.New().Delete(1);
+        Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Compose_InsertInMiddle_MergeOps()
+    {
+        var a = Delta.New().Insert("Hello");
+        var b = Delta.New().Retain(3).Insert("X");
+        var expected = Delta.New().Insert("HelXlo");
+        Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Compose_InsertDeleteOrdering_MergeOps()
+    {
+        var a = Delta.New().Insert("Hello");
+        var b = Delta.New().Insert("Hello");
+        var insertFirst = Delta.New().Retain(3).Insert("X").Delete(1);
+        var deleteFirst = Delta.New().Retain(3).Delete(1).Insert("X");
+        var expected = Delta.New().Insert("HelXo");
+        Assert.That(a.Compose(insertFirst), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+        Assert.That(b.Compose(deleteFirst), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Compose_InsertEmbedRetain_MergeOps()
+    {
+        var a = Delta.New().Insert(1, new { src = "http://quilljs.com/image.png" });
+        var b = Delta.New().Retain(1, new { alt = "logo" });
+        var expected = Delta.New().Insert(1, new { src = "http://quilljs.com/image.png", alt = "logo" });
+        Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Compose_DeleteEntireText_MergeOps()
+    {
+        var a = Delta.New().Retain(4).Insert("Hello");
+        var b = Delta.New().Delete(9);
+        var expected = Delta.New().Delete(4);
+        Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Compose_RetainMoreThanText_MergeOps()
+    {
+        var a = Delta.New().Insert("Hello");
+        var b = Delta.New().Retain(10);
+        var expected = Delta.New().Insert("Hello");
+        Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Compose_RetainEmbed_MergeOps()
+    {
+        var a = Delta.New().Insert(1);
+        var b = Delta.New().Retain(1);
+        var expected = Delta.New().Insert(1);
+        Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Compose_RemoveAttributes_MergeOps()
+    {
+        var a = Delta.New().Insert("A", new { bold = true });
+        var b = Delta.New().Retain(1, new { bold = default(bool?) });
+        var expected = Delta.New().Insert("A");
+        Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Compose_RemoveEmbedAttributes_MergeOps()
+    {
+        var a = Delta.New().Insert(2, new { bold = true });
+        var b = Delta.New().Retain(1, new { bold = default(bool?) });
+        var expected = Delta.New().Insert(2);
+        Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Compose_Immutability()
+    {
+        JToken attr1 = Obj(new { bold = true });
+        JToken attr2 = Obj(new { bold = true });
+        var a1 = Delta.New().Insert("Test", attr1);
+        var a2 = Delta.New().Insert("Test", attr1);
+        var b1 = Delta.New().Retain(1, new { color = "red" }).Delete(2);
+        var b2 = Delta.New().Retain(1, new { color = "red" }).Delete(2);
+        var expected = Delta.New().Insert("T", new { color = "red", bold = true }).Insert("t", attr1);
+        Assert.That(a1.Compose(b1), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+        Assert.That(a1, Is.EqualTo(a2).Using(Delta.EqualityComparer));
+        Assert.That(b1, Is.EqualTo(b2).Using(Delta.EqualityComparer));
+        Assert.That(attr1, Is.EqualTo(attr2));
+    }
+
+    [Test]
+    public void Diff_Insert()
+    {
+        var a = Delta.New().Insert("A");
+        var b = Delta.New().Insert("AB");
+        var expected = Delta.New().Retain(1).Insert("B");
+        Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Diff_Delete()
+    {
+        var a = Delta.New().Insert("AB");
+        var b = Delta.New().Insert("A");
+        var expected = Delta.New().Retain("A".Length).Delete("B".Length);
+        Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Diff_Empty()
+    {
+        var a = Delta.New().Insert("AB");
+        var b = Delta.New();
+        var expected = Delta.New().Delete("AB".Length);
+        Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Diff_Null()
+    {
+        var a = Delta.New().Insert("AB");
+        Delta b = null;
+        Assert.That(() => a.Diff(b), Throws.ArgumentNullException);
+    }
+
+    [Test]
+    public void Diff_Retain()
+    {
+        var a = Delta.New().Insert("A");
+        var b = Delta.New().Insert("A");
+        var expected = Delta.New();
+        Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Diff_Format()
+    {
+        var a = Delta.New().Insert("A");
+        var b = Delta.New().Insert("A", new { bold = true });
+        var expected = Delta.New().Retain(1, new { bold = true });
+        Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Diff_ObjectAttributes()
+    {
+        var a = Delta.New().Insert("A", new { font = new { family = "Helvetica", size = "15px" } });
+        var b = Delta.New().Insert("A", new { font = new { family = "Helvetica", size = "15px" } });
+        var expected = Delta.New();
+        Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Diff_EmbedIntegerMatch()
+    {
+        var a = Delta.New().Insert(1);
+        var b = Delta.New().Insert(1);
+        var expected = Delta.New();
+        Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Diff_EmbedIntegerMismatch()
+    {
+        var a = Delta.New().Insert(1);
+        var b = Delta.New().Insert(2);
+        var expected = Delta.New().Delete(1).Insert(2);
+        Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Diff_EmbedObjectMatch()
+    {
+        var a = Delta.New().Insert(new { image = "http://quilljs.com" });
+        var b = Delta.New().Insert(new { image = "http://quilljs.com" });
+        var expected = Delta.New();
+        Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Diff_EmbedObjectMismatch()
+    {
+        var a = Delta.New().Insert(new { image = "http://quilljs.com", alt = "Overwrite" });
+        var b = Delta.New().Insert(new { image = "http://quilljs.com" });
+        var expected = Delta.New().Insert(new { image = "http://quilljs.com" }).Delete(1);
+        Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Diff_EmbedObjectChange()
+    {
+        JObject embed = Obj(new { image = "http://quilljs.com" });
+        var a = Delta.New().Insert(embed);
+        embed["image"] = "http://github.com";
+        var b = Delta.New().Insert(embed);
+        var expected = Delta.New().Insert(new { image = "http://github.com" }).Delete(1);
+        Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Diff_EmbedFalsePositive()
+    {
+        var a = Delta.New().Insert(1);
+        var b = Delta.New().Insert("\0");
+        var expected = Delta.New().Insert("\0").Delete(1);
+        Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Diff_ThrowsOnNonDocuments()
+    {
+        var a = Delta.New().Insert("A");
+        var b = Delta.New().Retain(1).Insert("B");
+        Assert.That(() => a.Diff(b), Throws.InvalidOperationException);
+        Assert.That(() => b.Diff(a), Throws.InvalidOperationException);
+    }
+
+    [Test]
+    public void Diff_InconvenientIndices()
+    {
+        var a = Delta.New().Insert("12", new { bold = true }).Insert("34", new { italic = true });
+        var b = Delta.New().Insert("123", new { color = "red" });
+        var expected = Delta
+            .New()
+            .Retain(2, new { bold = default(bool?), color = "red" })
+            .Retain(1, new { italic = default(bool?), color = "red" })
+            .Delete(1);
+        Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Diff_Combination()
+    {
+        var a = Delta.New().Insert("Bad", new { color = "red" }).Insert("cat", new { color = "blue" });
+        var b = Delta.New().Insert("Good", new { bold = true }).Insert("dog", new { italic = true });
+        var expected = Delta
+            .New()
+            .Insert("Good", new { bold = true })
+            .Delete(2)
+            .Retain(1, new { italic = true, color = default(string?) })
+            .Delete(3)
+            .Insert("og", new { italic = true });
+        Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Diff_SameDocument()
+    {
+        var a = Delta.New().Insert("A").Insert("B", new { bold = true });
+        var expected = Delta.New();
+        Assert.That(a.Diff(a), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Diff_Immutability()
+    {
+        JToken attr1 = Obj(new { color = "red" });
+        JToken attr2 = Obj(new { color = "red" });
+        var a1 = Delta.New().Insert("A", attr1);
+        var a2 = Delta.New().Insert("A", attr1);
+        var b1 = Delta.New().Insert("A", new { bold = true }).Insert("B");
+        var b2 = Delta.New().Insert("A", new { bold = true }).Insert("B");
+        var expected = Delta.New().Retain(1, new { bold = true, color = default(string?) }).Insert("B");
+        Assert.That(a1.Diff(b1), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+        Assert.That(a1, Is.EqualTo(a2).Using(Delta.EqualityComparer));
+        Assert.That(b1, Is.EqualTo(b2).Using(Delta.EqualityComparer));
+        Assert.That(attr1, Is.EqualTo(attr2));
+    }
+
+    [Test]
+    public void Diff_CharAttributeObject()
+    {
+        JObject charObjA = new JObject(new JProperty("char", new JObject(new JProperty("cid", "123"))));
+        JObject charObjB = new JObject(new JProperty("char", new JObject(new JProperty("cid", "456"))));
+        var a = Delta.New().Insert("A", charObjA);
+        var b = Delta.New().Insert("A", charObjB);
+        var expected = Delta.New();
+        Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Diff_CharAttributeObjectChanged()
+    {
+        JObject charObjA = new JObject(
+            new JProperty("char", new JObject(new JProperty("style", "it"), new JProperty("cid", "123")))
+        );
+        JObject charObjB = new JObject(
+            new JProperty("char", new JObject(new JProperty("style", "fr"), new JProperty("cid", "456")))
+        );
+        var a = Delta.New().Insert("A", charObjA);
+        var b = Delta.New().Insert("A", charObjB);
+        var expected = Delta.New().Retain(1, charObjB);
+        Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Diff_ArrayOfCharAttributeObjects()
+    {
+        // The path to the cid can look like insert.note.contents.ops[i].attributes.char.cid
+        JObject a1 = new JObject(
+            new JProperty("insert", "text1"),
+            new JProperty("attributes", new JObject(new JProperty("char", new JObject(new JProperty("cid", "123")))))
+        );
+        JObject b1 = new JObject(
+            new JProperty("attributes", new JObject(new JProperty("char", new JObject(new JProperty("cid", "456")))))
+        );
+        JObject a2 = new JObject(
+            new JProperty("insert", "text1"),
+            new JProperty("attributes", new JObject(new JProperty("char", new JObject(new JProperty("cid", "234")))))
+        );
+        JObject b2 = new JObject(
+            new JProperty("attributes", new JObject(new JProperty("char", new JObject(new JProperty("cid", "567")))))
+        );
+
+        JObject obj1 = new JObject(new JProperty("ops", new JArray(a1, b1)));
+        JObject obj2 = new JObject(new JProperty("ops", new JArray(a2, b2)));
+        var del1 = Delta.New().Insert(obj1);
+        var del2 = Delta.New().Insert(obj2);
+        var expected = Delta.New();
+        Assert.That(del1.Diff(del2), Is.EqualTo(expected).Using(Delta.EqualityComparer));
+    }
+
+    [Test]
+    public void Diff_ArrayOfCharAttributeObjectsChanged()
+    {
+        // The path to the cid can look like insert.note.contents.ops[i].attributes.char.cid
+        JObject a1 = new JObject(
+            new JProperty("insert", "text1"),
+            new JProperty("attributes", new JObject(new JProperty("char", new JObject(new JProperty("cid", "123")))))
+        );
+        JObject b1 = new JObject(
+            new JProperty("attributes", new JObject(new JProperty("char", new JObject(new JProperty("cid", "456")))))
+        );
+        JObject a2 = new JObject(
+            new JProperty("insert", "text2"),
+            new JProperty("attributes", new JObject(new JProperty("char", new JObject(new JProperty("cid", "234")))))
+        );
+        JObject b2 = new JObject(
+            new JProperty("attributes", new JObject(new JProperty("char", new JObject(new JProperty("cid", "567")))))
+        );
+
+        JObject obj1 = new JObject(new JProperty("ops", new JArray(a1, b1)));
+        JObject obj2 = new JObject(new JProperty("ops", new JArray(a2, b2)));
+        var del1 = Delta.New().Insert(obj1);
+        var del2 = Delta.New().Insert(obj2);
+        JObject expectedObj = new JObject(
+            new JProperty("insert", "text2"),
+            new JProperty("attributes", new JObject(new JProperty("char", new JObject(new JProperty("cid", "234")))))
+        );
+        Delta result = del1.Diff(del2);
+        JToken resultToken = ((JObject)result.Ops.First(o => o.Type == JTokenType.Object))["insert"]["ops"];
+        Assert.That(JToken.DeepEquals(resultToken[0], expectedObj));
+    }
+
+    [Test]
+    public void Diff_CharIdUpdatedForTextInsertDiffDelta()
+    {
+        // The path to the cid can look like attributes.char.cid for usfm text formatting
+        JObject obj1Attr = new JObject(new JProperty("char", new JObject(new JProperty("cid", "123"))));
+        JObject obj2Attr = new JObject(new JProperty("char", new JObject(new JProperty("cid", "456"))));
+
+        var oldDel = Delta.New().Insert("text1", obj1Attr);
+        var newDel = Delta.New().Insert("text with edits 1", obj2Attr);
+
+        var length1 = "text".Length;
+        var length3 = "1".Length;
+        JObject expectedObj1 = new JObject(
+            new JProperty("retain", length1),
+            new JProperty("attributes", new JObject(new JProperty("char", new JObject(new JProperty("cid", "456")))))
+        );
+        JObject expectedObj2 = new JObject(
+            new JProperty("insert", " with edits "),
+            new JProperty("attributes", new JObject(new JProperty("char", new JObject(new JProperty("cid", "456")))))
+        );
+        JObject expectedObj3 = new JObject(
+            new JProperty("retain", length3),
+            new JProperty("attributes", new JObject(new JProperty("char", new JObject(new JProperty("cid", "456")))))
+        );
+
+        Delta result = oldDel.Diff(newDel);
+        Assert.That(result.Ops.Count, Is.EqualTo(3));
+        Assert.That(JToken.DeepEquals(result.Ops[0], expectedObj1), Is.True);
+        Assert.That(JToken.DeepEquals(result.Ops[1], expectedObj2), Is.True);
+        Assert.That(JToken.DeepEquals(result.Ops[2], expectedObj3), Is.True);
+    }
+
+    [Test]
+    public void Diff_CharIdUpdatedForTextFormattingDiffDelta()
+    {
+        // The path to the cid can look like attributes.char[0].cid for usfm text formatting
+        JObject obj1Attr = new JObject(
+            new JProperty("char", new JObject(new JProperty("cid", "123"), new JProperty("style", "wj")))
+        );
+        JObject obj2Attr1 = new JObject(
+            new JProperty("char", new JObject(new JProperty("cid", "456"), new JProperty("style", "wj")))
+        );
+        JObject obj2Attr2 = new JObject(
+            new JProperty(
+                "char",
+                new JArray(
+                    new JObject(new JProperty("cid", "456"), new JProperty("style", "wj")),
+                    new JObject(new JProperty("cid", "789"), new JProperty("style", "w"))
                 )
-            );
-            JObject b1 = new JObject(
-                new JProperty(
-                    "attributes",
-                    new JObject(new JProperty("char", new JObject(new JProperty("cid", "456"))))
-                )
-            );
-            JObject a2 = new JObject(
-                new JProperty("insert", "text1"),
-                new JProperty(
-                    "attributes",
-                    new JObject(new JProperty("char", new JObject(new JProperty("cid", "234"))))
-                )
-            );
-            JObject b2 = new JObject(
-                new JProperty(
-                    "attributes",
-                    new JObject(new JProperty("char", new JObject(new JProperty("cid", "567"))))
-                )
-            );
+            )
+        );
 
-            JObject obj1 = new JObject(new JProperty("ops", new JArray(a1, b1)));
-            JObject obj2 = new JObject(new JProperty("ops", new JArray(a2, b2)));
-            var del1 = Delta.New().Insert(obj1);
-            var del2 = Delta.New().Insert(obj2);
-            var expected = Delta.New();
-            Assert.That(del1.Diff(del2), Is.EqualTo(expected).Using(Delta.EqualityComparer));
-        }
+        var oldDel = Delta.New().Insert("Words of Jesus.", obj1Attr);
+        var newDel = Delta.New().Insert("Words of ", obj2Attr1).Insert("Jesus", obj2Attr2).Insert(".", obj2Attr1);
 
-        [Test]
-        public void Diff_ArrayOfCharAttributeObjectsChanged()
-        {
-            // The path to the cid can look like insert.note.contents.ops[i].attributes.char.cid
-            JObject a1 = new JObject(
-                new JProperty("insert", "text1"),
-                new JProperty(
-                    "attributes",
-                    new JObject(new JProperty("char", new JObject(new JProperty("cid", "123"))))
+        var length1 = "Words of ".Length;
+        var length2 = "Jesus".Length;
+        var length3 = ".".Length;
+        JObject expectedObj1 = new JObject(
+            new JProperty("retain", length1),
+            new JProperty(
+                "attributes",
+                new JObject(
+                    new JProperty("char", new JObject(new JProperty("cid", "456"), new JProperty("style", "wj")))
                 )
-            );
-            JObject b1 = new JObject(
-                new JProperty(
-                    "attributes",
-                    new JObject(new JProperty("char", new JObject(new JProperty("cid", "456"))))
-                )
-            );
-            JObject a2 = new JObject(
-                new JProperty("insert", "text2"),
-                new JProperty(
-                    "attributes",
-                    new JObject(new JProperty("char", new JObject(new JProperty("cid", "234"))))
-                )
-            );
-            JObject b2 = new JObject(
-                new JProperty(
-                    "attributes",
-                    new JObject(new JProperty("char", new JObject(new JProperty("cid", "567"))))
-                )
-            );
-
-            JObject obj1 = new JObject(new JProperty("ops", new JArray(a1, b1)));
-            JObject obj2 = new JObject(new JProperty("ops", new JArray(a2, b2)));
-            var del1 = Delta.New().Insert(obj1);
-            var del2 = Delta.New().Insert(obj2);
-            JObject expectedObj = new JObject(
-                new JProperty("insert", "text2"),
-                new JProperty(
-                    "attributes",
-                    new JObject(new JProperty("char", new JObject(new JProperty("cid", "234"))))
-                )
-            );
-            Delta result = del1.Diff(del2);
-            JToken resultToken = ((JObject)result.Ops.First(o => o.Type == JTokenType.Object))["insert"]["ops"];
-            Assert.That(JToken.DeepEquals(resultToken[0], expectedObj));
-        }
-
-        [Test]
-        public void Diff_CharIdUpdatedForTextInsertDiffDelta()
-        {
-            // The path to the cid can look like attributes.char.cid for usfm text formatting
-            JObject obj1Attr = new JObject(new JProperty("char", new JObject(new JProperty("cid", "123"))));
-            JObject obj2Attr = new JObject(new JProperty("char", new JObject(new JProperty("cid", "456"))));
-
-            var oldDel = Delta.New().Insert("text1", obj1Attr);
-            var newDel = Delta.New().Insert("text with edits 1", obj2Attr);
-
-            var length1 = "text".Length;
-            var length3 = "1".Length;
-            JObject expectedObj1 = new JObject(
-                new JProperty("retain", length1),
-                new JProperty(
-                    "attributes",
-                    new JObject(new JProperty("char", new JObject(new JProperty("cid", "456"))))
-                )
-            );
-            JObject expectedObj2 = new JObject(
-                new JProperty("insert", " with edits "),
-                new JProperty(
-                    "attributes",
-                    new JObject(new JProperty("char", new JObject(new JProperty("cid", "456"))))
-                )
-            );
-            JObject expectedObj3 = new JObject(
-                new JProperty("retain", length3),
-                new JProperty(
-                    "attributes",
-                    new JObject(new JProperty("char", new JObject(new JProperty("cid", "456"))))
-                )
-            );
-
-            Delta result = oldDel.Diff(newDel);
-            Assert.That(result.Ops.Count, Is.EqualTo(3));
-            Assert.That(JToken.DeepEquals(result.Ops[0], expectedObj1), Is.True);
-            Assert.That(JToken.DeepEquals(result.Ops[1], expectedObj2), Is.True);
-            Assert.That(JToken.DeepEquals(result.Ops[2], expectedObj3), Is.True);
-        }
-
-        [Test]
-        public void Diff_CharIdUpdatedForTextFormattingDiffDelta()
-        {
-            // The path to the cid can look like attributes.char[0].cid for usfm text formatting
-            JObject obj1Attr = new JObject(
-                new JProperty("char", new JObject(new JProperty("cid", "123"), new JProperty("style", "wj")))
-            );
-            JObject obj2Attr1 = new JObject(
-                new JProperty("char", new JObject(new JProperty("cid", "456"), new JProperty("style", "wj")))
-            );
-            JObject obj2Attr2 = new JObject(
-                new JProperty(
-                    "char",
-                    new JArray(
-                        new JObject(new JProperty("cid", "456"), new JProperty("style", "wj")),
-                        new JObject(new JProperty("cid", "789"), new JProperty("style", "w"))
-                    )
-                )
-            );
-
-            var oldDel = Delta.New().Insert("Words of Jesus.", obj1Attr);
-            var newDel = Delta.New().Insert("Words of ", obj2Attr1).Insert("Jesus", obj2Attr2).Insert(".", obj2Attr1);
-
-            var length1 = "Words of ".Length;
-            var length2 = "Jesus".Length;
-            var length3 = ".".Length;
-            JObject expectedObj1 = new JObject(
-                new JProperty("retain", length1),
-                new JProperty(
-                    "attributes",
-                    new JObject(
-                        new JProperty("char", new JObject(new JProperty("cid", "456"), new JProperty("style", "wj")))
-                    )
-                )
-            );
-            JObject expectedObj2 = new JObject(
-                new JProperty("retain", length2),
-                new JProperty(
-                    "attributes",
-                    new JObject(
-                        new JProperty(
-                            "char",
-                            new JArray(
-                                new JObject(new JProperty("cid", "456"), new JProperty("style", "wj")),
-                                new JObject(new JProperty("cid", "789"), new JProperty("style", "w"))
-                            )
+            )
+        );
+        JObject expectedObj2 = new JObject(
+            new JProperty("retain", length2),
+            new JProperty(
+                "attributes",
+                new JObject(
+                    new JProperty(
+                        "char",
+                        new JArray(
+                            new JObject(new JProperty("cid", "456"), new JProperty("style", "wj")),
+                            new JObject(new JProperty("cid", "789"), new JProperty("style", "w"))
                         )
                     )
                 )
-            );
-            JObject expectedObj3 = new JObject(
-                new JProperty("retain", length3),
-                new JProperty(
-                    "attributes",
-                    new JObject(
-                        new JProperty("char", new JObject(new JProperty("cid", "456"), new JProperty("style", "wj")))
-                    )
+            )
+        );
+        JObject expectedObj3 = new JObject(
+            new JProperty("retain", length3),
+            new JProperty(
+                "attributes",
+                new JObject(
+                    new JProperty("char", new JObject(new JProperty("cid", "456"), new JProperty("style", "wj")))
                 )
-            );
+            )
+        );
 
-            Delta result = oldDel.Diff(newDel);
-            Assert.That(result.Ops.Count, Is.EqualTo(3));
-            Assert.That(JToken.DeepEquals(result.Ops[0], expectedObj1), Is.True);
-            Assert.That(JToken.DeepEquals(result.Ops[1], expectedObj2), Is.True);
-            Assert.That(JToken.DeepEquals(result.Ops[2], expectedObj3), Is.True);
-        }
-
-        [Test]
-        public void GetLength_ReturnsOpLength()
-        {
-            var del = Delta.New();
-            Assert.That(del.GetLength(), Is.EqualTo(0));
-            del.Insert("A");
-            Assert.That(del.GetLength(), Is.EqualTo(1));
-        }
-
-        [Test]
-        public void DeepEquals_ExaminesEquality()
-        {
-            var a = Delta.New().Insert("A");
-            var b = Delta.New().Insert("A").Insert("B");
-            Assert.That(a.DeepEquals(b), Is.False);
-            a.Insert("B", new { color = "red" });
-            Assert.That(a.DeepEquals(b), Is.False);
-            Delta c = b.Compose(Delta.New().Retain(1).Retain(1, new { color = "red" }));
-            Assert.That(a.DeepEquals(c), Is.True);
-        }
-
-        [Test]
-        public void ToString_ReturnsString()
-        {
-            var del = Delta.New().Insert("A").Insert("B", new { color = "red" });
-            string str = del.ToString();
-            Assert.That(str.Contains("\"insert\": \"A\""));
-            Assert.That(str.Contains("\"insert\": \"B\""));
-            Assert.That(str.Contains("\"color\": \"red\""));
-        }
-
-        private static IEnumerable<JObject> Objs(params object[] objs)
-        {
-            return objs.Select(Obj);
-        }
-
-        private static JObject Obj(object obj)
-        {
-            return JObject.FromObject(obj);
-        }
+        Delta result = oldDel.Diff(newDel);
+        Assert.That(result.Ops.Count, Is.EqualTo(3));
+        Assert.That(JToken.DeepEquals(result.Ops[0], expectedObj1), Is.True);
+        Assert.That(JToken.DeepEquals(result.Ops[1], expectedObj2), Is.True);
+        Assert.That(JToken.DeepEquals(result.Ops[2], expectedObj3), Is.True);
     }
+
+    [Test]
+    public void GetLength_ReturnsOpLength()
+    {
+        var del = Delta.New();
+        Assert.That(del.GetLength(), Is.EqualTo(0));
+        del.Insert("A");
+        Assert.That(del.GetLength(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void DeepEquals_ExaminesEquality()
+    {
+        var a = Delta.New().Insert("A");
+        var b = Delta.New().Insert("A").Insert("B");
+        Assert.That(a.DeepEquals(b), Is.False);
+        a.Insert("B", new { color = "red" });
+        Assert.That(a.DeepEquals(b), Is.False);
+        Delta c = b.Compose(Delta.New().Retain(1).Retain(1, new { color = "red" }));
+        Assert.That(a.DeepEquals(c), Is.True);
+    }
+
+    [Test]
+    public void ToString_ReturnsString()
+    {
+        var del = Delta.New().Insert("A").Insert("B", new { color = "red" });
+        string str = del.ToString();
+        Assert.That(str.Contains("\"insert\": \"A\""));
+        Assert.That(str.Contains("\"insert\": \"B\""));
+        Assert.That(str.Contains("\"color\": \"red\""));
+    }
+
+    private static IEnumerable<JObject> Objs(params object[] objs) => objs.Select(Obj);
+
+    private static JObject Obj(object obj) => JObject.FromObject(obj);
 }

--- a/test/SIL.XForge.Tests/Services/MockLogger.cs
+++ b/test/SIL.XForge.Tests/Services/MockLogger.cs
@@ -1,125 +1,113 @@
-using System.Collections.Generic;
-using Microsoft.Extensions.Logging;
 using System;
-using NUnit.Framework;
+using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+/// <summary>
+/// An occurrence of something being logged. For use by unit tests.
+/// </summary>
+public class LogEvent
+{
+    public LogLevel LogLevel { get; set; }
+    public EventId EventId { get; set; }
+    public object State { get; set; }
+    public Exception Exception { get; set; }
+    public string Message => State.ToString();
+
+    public override string ToString()
+    {
+        string summary = $"LogEvent {EventId} {LogLevel}: {Message}";
+        if (Exception != null)
+        {
+            summary += $" ({Exception})";
+        }
+        return summary;
+    }
+}
+
+/// <summary>
+/// Mock for ILogger since it's difficult to mock with NSubstitute. To help with unit tests.
+/// </summary>
+public class MockLogger<T> : ILogger<T>
 {
     /// <summary>
-    /// An occurrence of something being logged. For use by unit tests.
+    /// Stores logged events.
     /// </summary>
-    public class LogEvent
-    {
-        public LogLevel LogLevel { get; set; }
-        public EventId EventId { get; set; }
-        public object State { get; set; }
-        public Exception Exception { get; set; }
-        public string Message
-        {
-            get { return State.ToString(); }
-        }
+    public readonly List<LogEvent> LogEvents = new List<LogEvent>();
 
-        public override string ToString()
-        {
-            string summary = $"LogEvent {EventId} {LogLevel}: {Message}";
-            if (Exception != null)
+    public MockLogger() { }
+
+    public IDisposable BeginScope<TState>(TState state) => throw new NotImplementedException();
+
+    public bool IsEnabled(LogLevel logLevel) => throw new NotImplementedException();
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception exception,
+        Func<TState, Exception, string> formatter
+    )
+    {
+        LogEvents.Add(
+            new LogEvent
             {
-                summary += $" ({Exception})";
+                LogLevel = logLevel,
+                EventId = eventId,
+                State = state,
+                Exception = exception
             }
-            return summary;
-        }
+        );
     }
 
     /// <summary>
-    /// Mock for ILogger since it's difficult to mock with NSubstitute. To help with unit tests.
+    /// Assert that at least one event was logged that matches <param name="predicate"/>.
     /// </summary>
-    public class MockLogger<T> : ILogger<T>
+    public void AssertHasEvent(Func<LogEvent, bool> predicate, string explanation = null)
     {
-        /// <summary>
-        /// Stores logged events.
-        /// </summary>
-        public readonly List<LogEvent> LogEvents = new List<LogEvent>();
-
-        public MockLogger() { }
-
-        public IDisposable BeginScope<TState>(TState state)
+        bool has = LogEvents.Any<LogEvent>(predicate);
+        if (!has)
         {
-            throw new NotImplementedException();
-        }
-
-        public bool IsEnabled(LogLevel logLevel)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void Log<TState>(
-            LogLevel logLevel,
-            EventId eventId,
-            TState state,
-            Exception exception,
-            Func<TState, Exception, string> formatter
-        )
-        {
-            LogEvents.Add(
-                new LogEvent
-                {
-                    LogLevel = logLevel,
-                    EventId = eventId,
-                    State = state,
-                    Exception = exception
-                }
-            );
-        }
-
-        /// <summary>
-        /// Assert that at least one event was logged that matches <param name="predicate"/>.
-        /// </summary>
-        public void AssertHasEvent(Func<LogEvent, bool> predicate, string explanation = null)
-        {
-            bool has = LogEvents.Any<LogEvent>(predicate);
-            if (!has)
+            if (LogEvents.Count == 0)
             {
-                if (LogEvents.Count == 0)
-                {
-                    Console.WriteLine("Event log is empty.");
-                }
-                else
-                {
-                    Console.WriteLine("Event log contains:");
-                    LogEvents.ForEach(Console.WriteLine);
-                }
+                Console.WriteLine("Event log is empty.");
             }
-            Assert.That(has, Is.True, explanation);
-        }
-
-        /// <summary>
-        /// Assert that no event was logged that matches <param name="predicate"/>.
-        /// </summary>
-        public void AssertNoEvent(Func<LogEvent, bool> predicate, string explanation = null)
-        {
-            AssertEventCount(predicate, 0, explanation);
-        }
-
-        /// <summary>
-        /// Assert that exactly <param name="expectedCount"/> events were logged that match <param name="predicate"/>.
-        /// </summary>
-        public void AssertEventCount(Func<LogEvent, bool> predicate, int expectedCount, string explanation = null)
-        {
-            int actualCount = LogEvents.Count<LogEvent>(predicate);
-            if (expectedCount != actualCount)
+            else
             {
-                if (LogEvents.Count == 0)
-                {
-                    Console.WriteLine("Event log is empty.");
-                }
-                else
-                {
-                    Console.WriteLine("Event log contains:");
-                    LogEvents.ForEach(Console.WriteLine);
-                }
+                Console.WriteLine("Event log contains:");
+                LogEvents.ForEach(Console.WriteLine);
             }
-            Assert.That(actualCount, Is.EqualTo(expectedCount), explanation);
         }
+        Assert.That(has, Is.True, explanation);
+    }
+
+    /// <summary>
+    /// Assert that no event was logged that matches <param name="predicate"/>.
+    /// </summary>
+    public void AssertNoEvent(Func<LogEvent, bool> predicate, string explanation = null) =>
+        AssertEventCount(predicate, 0, explanation);
+
+    /// <summary>
+    /// Assert that exactly <param name="expectedCount"/> events were logged that match <param name="predicate"/>.
+    /// </summary>
+    public void AssertEventCount(Func<LogEvent, bool> predicate, int expectedCount, string explanation = null)
+    {
+        int actualCount = LogEvents.Count<LogEvent>(predicate);
+        if (expectedCount != actualCount)
+        {
+            if (LogEvents.Count == 0)
+            {
+                Console.WriteLine("Event log is empty.");
+            }
+            else
+            {
+                Console.WriteLine("Event log contains:");
+                LogEvents.ForEach(Console.WriteLine);
+            }
+        }
+        Assert.That(actualCount, Is.EqualTo(expectedCount), explanation);
     }
 }

--- a/test/SIL.XForge.Tests/Services/ProjectServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/ProjectServiceTests.cs
@@ -1,6 +1,6 @@
-using System.IO;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -10,461 +10,448 @@ using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
 using SIL.XForge.Realtime;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+[TestFixture]
+public class ProjectServiceTests
 {
-    [TestFixture]
-    public class ProjectServiceTests
+    private const string Project01 = "project01";
+    private const string Project02 = "project02";
+    private const string User01 = "user01";
+    private const string User02 = "user02";
+    private const string User03 = "user03";
+    private const string SiteId = "xf";
+
+    [Test]
+    public async Task SaveAudioAsync_NonMp3File_AudioConverted()
     {
-        private const string Project01 = "project01";
-        private const string Project02 = "project02";
-        private const string User01 = "user01";
-        private const string User02 = "user02";
-        private const string User03 = "user03";
-        private const string SiteId = "xf";
+        var env = new TestEnvironment();
+        const string dataId = "507f1f77bcf86cd799439011";
+        string filePath = Path.Combine("site", "audio", Project01, $"{User01}_{dataId}.mp3");
+        env.FileSystemService.OpenFile(Arg.Any<string>(), FileMode.Create).Returns(new MemoryStream());
+        env.FileSystemService.FileExists(filePath).Returns(true);
 
-        [Test]
-        public async Task SaveAudioAsync_NonMp3File_AudioConverted()
+        using var stream = new MemoryStream();
+        Uri uri = await env.Service.SaveAudioAsync(User01, Project01, dataId, ".wav", stream);
+        Assert.That(
+            uri.ToString().StartsWith($"http://localhost/assets/audio/project01/user01_{dataId}.mp3?t="),
+            Is.True
+        );
+        await env.AudioService.Received().ConvertToMp3Async(Arg.Any<string>(), filePath);
+    }
+
+    [Test]
+    public async Task SaveAudioAsync_Mp3File_AudioSaved()
+    {
+        var env = new TestEnvironment();
+        const string dataId = "507f1f77bcf86cd799439011";
+        string filePath = Path.Combine("site", "audio", Project01, $"{User01}_{dataId}.mp3");
+        env.FileSystemService.OpenFile(Arg.Any<string>(), FileMode.Create).Returns(new MemoryStream());
+        env.FileSystemService.FileExists(filePath).Returns(true);
+
+        using var stream = new MemoryStream();
+        Uri uri = await env.Service.SaveAudioAsync(User01, Project01, dataId, ".mp3", stream);
+        Assert.That(
+            uri.ToString().StartsWith($"http://localhost/assets/audio/project01/user01_{dataId}.mp3?t="),
+            Is.True
+        );
+        env.FileSystemService.Received().OpenFile(filePath, FileMode.Create);
+        await env.AudioService.DidNotReceive().ConvertToMp3Async(Arg.Any<string>(), filePath);
+    }
+
+    [Test]
+    public void SaveAudioAsync_InvalidDataId_FormatError()
+    {
+        var env = new TestEnvironment();
+
+        using var stream = new MemoryStream();
+        Assert.ThrowsAsync<FormatException>(
+            () => env.Service.SaveAudioAsync(User01, Project01, "/../test/abc.txt", ".wav", stream)
+        );
+    }
+
+    [Test]
+    public void SaveAudioAsync_InvalidProjectId_NotFoundError()
+    {
+        var env = new TestEnvironment();
+
+        using var stream = new MemoryStream();
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.SaveAudioAsync(User01, "/../abc.txt", "507f1f77bcf86cd799439011", ".wav", stream)
+        );
+    }
+
+    [Test]
+    public async Task DeleteAudioAsync_NonAdminUser_FileDeleted()
+    {
+        var env = new TestEnvironment();
+        const string dataId = "507f1f77bcf86cd799439011";
+        string filePath = Path.Combine("site", "audio", Project01, $"{User02}_{dataId}.mp3");
+        env.FileSystemService.FileExists(filePath).Returns(true);
+
+        await env.Service.DeleteAudioAsync(User02, Project01, User02, dataId);
+        env.FileSystemService.Received().DeleteFile(filePath);
+    }
+
+    [Test]
+    public async Task DeleteAudioAsync_AdminUser_FileDeleted()
+    {
+        var env = new TestEnvironment();
+        const string dataId = "507f1f77bcf86cd799439011";
+        string filePath = Path.Combine("site", "audio", Project01, $"{User02}_{dataId}.mp3");
+        env.FileSystemService.FileExists(filePath).Returns(true);
+
+        await env.Service.DeleteAudioAsync(User01, Project01, User02, dataId);
+        env.FileSystemService.Received().DeleteFile(filePath);
+    }
+
+    [Test]
+    public void DeleteAudioAsync_NotOwner_ForbiddenError()
+    {
+        var env = new TestEnvironment();
+        const string dataId = "507f1f77bcf86cd799439011";
+        string filePath = Path.Combine("site", "audio", Project01, $"{User01}_{dataId}.mp3");
+        env.FileSystemService.FileExists(filePath).Returns(true);
+
+        Assert.ThrowsAsync<ForbiddenException>(() => env.Service.DeleteAudioAsync(User02, Project01, User01, dataId));
+    }
+
+    [Test]
+    public void DeleteAudioAsync_InvalidDataId_FormatError()
+    {
+        var env = new TestEnvironment();
+
+        Assert.ThrowsAsync<FormatException>(
+            () => env.Service.DeleteAudioAsync(User02, Project01, User01, "/../test/abc.txt")
+        );
+    }
+
+    [Test]
+    public void DeleteAudioAsync_InvalidProjectId_NotFoundError()
+    {
+        var env = new TestEnvironment();
+
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.DeleteAudioAsync(User02, "/../test/abc.txt", User01, "507f1f77bcf86cd799439011")
+        );
+    }
+
+    [Test]
+    public async Task GetProjectRoleAsync_InvalidProjectId_ReturnsNull()
+    {
+        var env = new TestEnvironment();
+        var role = await env.Service.GetProjectRoleAsync(User02, "invalid_project_id");
+        Assert.That(role, Is.Null);
+    }
+
+    [Test]
+    public async Task UpdateRoleAsync_SystemAdmin_RoleUpdated()
+    {
+        var env = new TestEnvironment();
+
+        await env.Service.UpdateRoleAsync(User02, SystemRole.SystemAdmin, Project01, TestProjectRole.Administrator);
+        TestProject project = env.GetProject(Project01);
+        Assert.That(project.UserRoles[User02], Is.EqualTo(TestProjectRole.Administrator));
+    }
+
+    [Test]
+    public void UpdateRoleAsync_NormalUser_ForbiddenError()
+    {
+        var env = new TestEnvironment();
+
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.UpdateRoleAsync(User02, SystemRole.User, Project01, TestProjectRole.Administrator)
+        );
+    }
+
+    [Test]
+    public void SetSyncDisabled_RequiresSysAdmin()
+    {
+        var env = new TestEnvironment();
+        // SUT 1
+        Assert.ThrowsAsync<ForbiddenException>(
+            async () => await env.Service.SetSyncDisabledAsync(User03, SystemRole.User, Project01, false)
+        );
+        // SUT 2
+        Assert.ThrowsAsync<ForbiddenException>(
+            async () => await env.Service.SetSyncDisabledAsync(User03, SystemRole.None, Project01, false)
+        );
+        // SUT 3
+        Assert.DoesNotThrowAsync(
+            async () => await env.Service.SetSyncDisabledAsync(User03, SystemRole.SystemAdmin, Project01, false)
+        );
+    }
+
+    [Test]
+    public async Task SetSyncDisabled_Works()
+    {
+        var env = new TestEnvironment();
+
+        Assert.That(env.GetProject(Project01).SyncDisabled, Is.EqualTo(false));
+        // SUT 1
+        await env.Service.SetSyncDisabledAsync(User01, SystemRole.SystemAdmin, Project01, true);
+        Assert.That(env.GetProject(Project01).SyncDisabled, Is.EqualTo(true));
+
+        Assert.That(env.GetProject(Project02).SyncDisabled, Is.EqualTo(true));
+        // SUT 2
+        await env.Service.SetSyncDisabledAsync(User01, SystemRole.SystemAdmin, Project02, false);
+        Assert.That(env.GetProject(Project02).SyncDisabled, Is.EqualTo(false));
+    }
+
+    [Test]
+    public void RemoveUserFromProjectAsync_BadArguments()
+    {
+        var env = new TestEnvironment();
+        IConnection connection = Substitute.For<IConnection>();
+        IDocument<TestProject> projectDoc = Substitute.For<IDocument<TestProject>>();
+        IDocument<User> userDoc = Substitute.For<IDocument<User>>();
+        Assert.ThrowsAsync<ArgumentNullException>(
+            () => env.Service.RemoveUserFromProjectAsync(null, projectDoc, userDoc)
+        );
+        Assert.ThrowsAsync<ArgumentNullException>(
+            () => env.Service.RemoveUserFromProjectAsync(connection, null, userDoc)
+        );
+        Assert.ThrowsAsync<ArgumentNullException>(
+            () => env.Service.RemoveUserFromProjectAsync(connection, projectDoc, null)
+        );
+    }
+
+    [Test]
+    public void RemoveUserAsync_BadArguments()
+    {
+        var env = new TestEnvironment();
+        Assert.ThrowsAsync<ArgumentNullException>(
+            () => env.Service.RemoveUserAsync(null, "projectId", "projectUserId")
+        );
+        Assert.ThrowsAsync<ArgumentNullException>(
+            () => env.Service.RemoveUserAsync("curUserId", null, "projectUserId")
+        );
+        Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.RemoveUserAsync("curUserId", "projectId", null));
+    }
+
+    [Test]
+    public async Task RemoveUserAsync_DisassociatesUserAndProject()
+    {
+        var env = new TestEnvironment();
+        string requestingUser = User01;
+        string project = Project01;
+        string userToDisassociate = User02;
+        await env.Service.SetUserProjectPermissions(User01, Project01, User02, new string[] { "questions.edit" });
+        Assert.AreEqual(1, env.GetProject(project).UserPermissions.Count);
+        Assert.That(env.GetProject(project).UserRoles, Does.ContainKey(userToDisassociate), "setup");
+        Assert.That(env.GetProject(project).UserPermissions, Does.ContainKey(userToDisassociate), "setup");
+        Site userSite = env.GetUser(userToDisassociate).Sites[SiteId];
+        Assert.That(userSite.Projects, Does.Contain(project), "setup");
+        Assert.That(userSite.CurrentProjectId, Is.EqualTo(Project01));
+        // SUT
+        await env.Service.RemoveUserAsync(requestingUser, project, userToDisassociate);
+        Assert.That(env.GetProject(project).UserRoles, Does.Not.ContainKey(userToDisassociate));
+        Assert.That(env.GetProject(project).UserPermissions, Does.Not.ContainKey(userToDisassociate));
+        userSite = env.GetUser(userToDisassociate).Sites[SiteId];
+        Assert.That(userSite.Projects, Does.Not.Contain(project));
+        Assert.That(userSite.CurrentProjectId, Is.Null);
+    }
+
+    [Test]
+    public void RemoveUserFromAllProjectsAsync_BadArguments()
+    {
+        var env = new TestEnvironment();
+        Assert.ThrowsAsync<ArgumentNullException>(
+            () => env.Service.RemoveUserFromAllProjectsAsync(null, "projectUserId")
+        );
+        Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.RemoveUserFromAllProjectsAsync("curUserId", null));
+    }
+
+    [Test]
+    public async Task RemoveUserFromAllProjectsAsync_DisassociatesUserAndProjects()
+    {
+        var env = new TestEnvironment();
+        string requestingUser = User02;
+        string userToDisassociate = User01;
+
+        Assert.That(
+            env.GetProject(Project01).UserRoles[requestingUser] != TestProjectRole.Administrator,
+            "setup: user requesting deletion should not be a project administrator to demonstrate the "
+                + "functionality"
+        );
+        Assert.That(
+            env.GetProject(Project02).UserRoles[requestingUser] != TestProjectRole.Administrator,
+            "setup: user requesting deletion should not be a project administrator to demonstrate the "
+                + "functionality"
+        );
+        Assert.That(requestingUser, Is.Not.EqualTo(userToDisassociate), "setup: not demonstrating functionality");
+
+        Assert.That(env.GetProject(Project01).UserRoles, Does.ContainKey(userToDisassociate), "setup");
+        Assert.That(env.GetUser(userToDisassociate).Sites[SiteId].Projects, Does.Contain(Project01), "setup");
+        Assert.That(env.GetProject(Project02).UserRoles, Does.ContainKey(userToDisassociate), "setup");
+        Assert.That(env.GetUser(userToDisassociate).Sites[SiteId].Projects, Does.Contain(Project02), "setup");
+        // SUT
+        await env.Service.RemoveUserFromAllProjectsAsync(requestingUser, userToDisassociate);
+        Assert.That(env.GetProject(Project01).UserRoles, Does.Not.ContainKey(userToDisassociate));
+        Assert.That(env.GetUser(userToDisassociate).Sites[SiteId].Projects, Does.Not.Contain(Project01));
+        Assert.That(env.GetProject(Project02).UserRoles, Does.Not.ContainKey(userToDisassociate));
+        Assert.That(env.GetUser(userToDisassociate).Sites[SiteId].Projects, Does.Not.Contain(Project02));
+    }
+
+    [Test]
+    public async Task SetUserProjectPermissions_AdminHasPermission()
+    {
+        var env = new TestEnvironment();
+        var permissions = new string[] { "questions.create", "questions.edit" };
+
+        Project project = env.GetProject(Project01);
+        Assert.AreEqual(0, project.UserPermissions.Count, "setup");
+
+        // Admin can give user question permission
+        await env.Service.SetUserProjectPermissions(User01, Project01, User02, permissions);
+        project = env.GetProject(Project01);
+        Assert.AreEqual(1, project.UserPermissions.Count);
+        project.UserPermissions.TryGetValue(User02, out string[] value);
+        Assert.AreEqual(permissions, value);
+
+        // Admin can revoke permission, which removes the key value pair from the userPermissions property
+        await env.Service.SetUserProjectPermissions(User01, Project01, User02, Array.Empty<string>());
+        project = env.GetProject(Project01);
+        Assert.AreEqual(0, project.UserPermissions.Count);
+    }
+
+    [Test]
+    public void SetUserProjectPermissions_NonAdminDoesNotHavePermission()
+    {
+        var env = new TestEnvironment();
+        var permissions = new string[] { "questions.create", "questions.edit" };
+
+        Project project = env.GetProject(Project01);
+        Assert.AreEqual(0, project.UserPermissions.Count, "setup");
+
+        // Translator user cannot give permission to self
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.SetUserProjectPermissions(User02, Project01, User02, permissions)
+        );
+
+        // Permissions are not updated
+        project = env.GetProject(Project01);
+        Assert.AreEqual(0, project.UserPermissions.Count);
+    }
+
+    private class TestEnvironment
+    {
+        public TestEnvironment(bool isResetLinkExpired = false)
         {
-            var env = new TestEnvironment();
-            const string dataId = "507f1f77bcf86cd799439011";
-            string filePath = Path.Combine("site", "audio", Project01, $"{User01}_{dataId}.mp3");
-            env.FileSystemService.OpenFile(Arg.Any<string>(), FileMode.Create).Returns(new MemoryStream());
-            env.FileSystemService.FileExists(filePath).Returns(true);
-
-            using var stream = new MemoryStream();
-            Uri uri = await env.Service.SaveAudioAsync(User01, Project01, dataId, ".wav", stream);
-            Assert.That(
-                uri.ToString().StartsWith($"http://localhost/assets/audio/project01/user01_{dataId}.mp3?t="),
-                Is.True
-            );
-            await env.AudioService.Received().ConvertToMp3Async(Arg.Any<string>(), filePath);
-        }
-
-        [Test]
-        public async Task SaveAudioAsync_Mp3File_AudioSaved()
-        {
-            var env = new TestEnvironment();
-            const string dataId = "507f1f77bcf86cd799439011";
-            string filePath = Path.Combine("site", "audio", Project01, $"{User01}_{dataId}.mp3");
-            env.FileSystemService.OpenFile(Arg.Any<string>(), FileMode.Create).Returns(new MemoryStream());
-            env.FileSystemService.FileExists(filePath).Returns(true);
-
-            using var stream = new MemoryStream();
-            Uri uri = await env.Service.SaveAudioAsync(User01, Project01, dataId, ".mp3", stream);
-            Assert.That(
-                uri.ToString().StartsWith($"http://localhost/assets/audio/project01/user01_{dataId}.mp3?t="),
-                Is.True
-            );
-            env.FileSystemService.Received().OpenFile(filePath, FileMode.Create);
-            await env.AudioService.DidNotReceive().ConvertToMp3Async(Arg.Any<string>(), filePath);
-        }
-
-        [Test]
-        public void SaveAudioAsync_InvalidDataId_FormatError()
-        {
-            var env = new TestEnvironment();
-
-            using var stream = new MemoryStream();
-            Assert.ThrowsAsync<FormatException>(
-                () => env.Service.SaveAudioAsync(User01, Project01, "/../test/abc.txt", ".wav", stream)
-            );
-        }
-
-        [Test]
-        public void SaveAudioAsync_InvalidProjectId_NotFoundError()
-        {
-            var env = new TestEnvironment();
-
-            using var stream = new MemoryStream();
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.SaveAudioAsync(User01, "/../abc.txt", "507f1f77bcf86cd799439011", ".wav", stream)
-            );
-        }
-
-        [Test]
-        public async Task DeleteAudioAsync_NonAdminUser_FileDeleted()
-        {
-            var env = new TestEnvironment();
-            const string dataId = "507f1f77bcf86cd799439011";
-            string filePath = Path.Combine("site", "audio", Project01, $"{User02}_{dataId}.mp3");
-            env.FileSystemService.FileExists(filePath).Returns(true);
-
-            await env.Service.DeleteAudioAsync(User02, Project01, User02, dataId);
-            env.FileSystemService.Received().DeleteFile(filePath);
-        }
-
-        [Test]
-        public async Task DeleteAudioAsync_AdminUser_FileDeleted()
-        {
-            var env = new TestEnvironment();
-            const string dataId = "507f1f77bcf86cd799439011";
-            string filePath = Path.Combine("site", "audio", Project01, $"{User02}_{dataId}.mp3");
-            env.FileSystemService.FileExists(filePath).Returns(true);
-
-            await env.Service.DeleteAudioAsync(User01, Project01, User02, dataId);
-            env.FileSystemService.Received().DeleteFile(filePath);
-        }
-
-        [Test]
-        public void DeleteAudioAsync_NotOwner_ForbiddenError()
-        {
-            var env = new TestEnvironment();
-            const string dataId = "507f1f77bcf86cd799439011";
-            string filePath = Path.Combine("site", "audio", Project01, $"{User01}_{dataId}.mp3");
-            env.FileSystemService.FileExists(filePath).Returns(true);
-
-            Assert.ThrowsAsync<ForbiddenException>(
-                () => env.Service.DeleteAudioAsync(User02, Project01, User01, dataId)
-            );
-        }
-
-        [Test]
-        public void DeleteAudioAsync_InvalidDataId_FormatError()
-        {
-            var env = new TestEnvironment();
-
-            Assert.ThrowsAsync<FormatException>(
-                () => env.Service.DeleteAudioAsync(User02, Project01, User01, "/../test/abc.txt")
-            );
-        }
-
-        [Test]
-        public void DeleteAudioAsync_InvalidProjectId_NotFoundError()
-        {
-            var env = new TestEnvironment();
-
-            Assert.ThrowsAsync<DataNotFoundException>(
-                () => env.Service.DeleteAudioAsync(User02, "/../test/abc.txt", User01, "507f1f77bcf86cd799439011")
-            );
-        }
-
-        [Test]
-        public async Task GetProjectRoleAsync_InvalidProjectId_ReturnsNull()
-        {
-            var env = new TestEnvironment();
-            var role = await env.Service.GetProjectRoleAsync(User02, "invalid_project_id");
-            Assert.That(role, Is.Null);
-        }
-
-        [Test]
-        public async Task UpdateRoleAsync_SystemAdmin_RoleUpdated()
-        {
-            var env = new TestEnvironment();
-
-            await env.Service.UpdateRoleAsync(User02, SystemRole.SystemAdmin, Project01, TestProjectRole.Administrator);
-            TestProject project = env.GetProject(Project01);
-            Assert.That(project.UserRoles[User02], Is.EqualTo(TestProjectRole.Administrator));
-        }
-
-        [Test]
-        public void UpdateRoleAsync_NormalUser_ForbiddenError()
-        {
-            var env = new TestEnvironment();
-
-            Assert.ThrowsAsync<ForbiddenException>(
-                () => env.Service.UpdateRoleAsync(User02, SystemRole.User, Project01, TestProjectRole.Administrator)
-            );
-        }
-
-        [Test]
-        public void SetSyncDisabled_RequiresSysAdmin()
-        {
-            var env = new TestEnvironment();
-            // SUT 1
-            Assert.ThrowsAsync<ForbiddenException>(
-                async () => await env.Service.SetSyncDisabledAsync(User03, SystemRole.User, Project01, false)
-            );
-            // SUT 2
-            Assert.ThrowsAsync<ForbiddenException>(
-                async () => await env.Service.SetSyncDisabledAsync(User03, SystemRole.None, Project01, false)
-            );
-            // SUT 3
-            Assert.DoesNotThrowAsync(
-                async () => await env.Service.SetSyncDisabledAsync(User03, SystemRole.SystemAdmin, Project01, false)
-            );
-        }
-
-        [Test]
-        public async Task SetSyncDisabled_Works()
-        {
-            var env = new TestEnvironment();
-
-            Assert.That(env.GetProject(Project01).SyncDisabled, Is.EqualTo(false));
-            // SUT 1
-            await env.Service.SetSyncDisabledAsync(User01, SystemRole.SystemAdmin, Project01, true);
-            Assert.That(env.GetProject(Project01).SyncDisabled, Is.EqualTo(true));
-
-            Assert.That(env.GetProject(Project02).SyncDisabled, Is.EqualTo(true));
-            // SUT 2
-            await env.Service.SetSyncDisabledAsync(User01, SystemRole.SystemAdmin, Project02, false);
-            Assert.That(env.GetProject(Project02).SyncDisabled, Is.EqualTo(false));
-        }
-
-        [Test]
-        public void RemoveUserFromProjectAsync_BadArguments()
-        {
-            var env = new TestEnvironment();
-            IConnection connection = Substitute.For<IConnection>();
-            IDocument<TestProject> projectDoc = Substitute.For<IDocument<TestProject>>();
-            IDocument<User> userDoc = Substitute.For<IDocument<User>>();
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => env.Service.RemoveUserFromProjectAsync(null, projectDoc, userDoc)
-            );
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => env.Service.RemoveUserFromProjectAsync(connection, null, userDoc)
-            );
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => env.Service.RemoveUserFromProjectAsync(connection, projectDoc, null)
-            );
-        }
-
-        [Test]
-        public void RemoveUserAsync_BadArguments()
-        {
-            var env = new TestEnvironment();
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => env.Service.RemoveUserAsync(null, "projectId", "projectUserId")
-            );
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => env.Service.RemoveUserAsync("curUserId", null, "projectUserId")
-            );
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => env.Service.RemoveUserAsync("curUserId", "projectId", null)
-            );
-        }
-
-        [Test]
-        public async Task RemoveUserAsync_DisassociatesUserAndProject()
-        {
-            var env = new TestEnvironment();
-            string requestingUser = User01;
-            string project = Project01;
-            string userToDisassociate = User02;
-            await env.Service.SetUserProjectPermissions(User01, Project01, User02, new string[] { "questions.edit" });
-            Assert.AreEqual(1, env.GetProject(project).UserPermissions.Count);
-            Assert.That(env.GetProject(project).UserRoles, Does.ContainKey(userToDisassociate), "setup");
-            Assert.That(env.GetProject(project).UserPermissions, Does.ContainKey(userToDisassociate), "setup");
-            Site userSite = env.GetUser(userToDisassociate).Sites[SiteId];
-            Assert.That(userSite.Projects, Does.Contain(project), "setup");
-            Assert.That(userSite.CurrentProjectId, Is.EqualTo(Project01));
-            // SUT
-            await env.Service.RemoveUserAsync(requestingUser, project, userToDisassociate);
-            Assert.That(env.GetProject(project).UserRoles, Does.Not.ContainKey(userToDisassociate));
-            Assert.That(env.GetProject(project).UserPermissions, Does.Not.ContainKey(userToDisassociate));
-            userSite = env.GetUser(userToDisassociate).Sites[SiteId];
-            Assert.That(userSite.Projects, Does.Not.Contain(project));
-            Assert.That(userSite.CurrentProjectId, Is.Null);
-        }
-
-        [Test]
-        public void RemoveUserFromAllProjectsAsync_BadArguments()
-        {
-            var env = new TestEnvironment();
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => env.Service.RemoveUserFromAllProjectsAsync(null, "projectUserId")
-            );
-            Assert.ThrowsAsync<ArgumentNullException>(
-                () => env.Service.RemoveUserFromAllProjectsAsync("curUserId", null)
-            );
-        }
-
-        [Test]
-        public async Task RemoveUserFromAllProjectsAsync_DisassociatesUserAndProjects()
-        {
-            var env = new TestEnvironment();
-            string requestingUser = User02;
-            string userToDisassociate = User01;
-
-            Assert.That(
-                env.GetProject(Project01).UserRoles[requestingUser] != TestProjectRole.Administrator,
-                "setup: user requesting deletion should not be a project administrator to demonstrate the "
-                    + "functionality"
-            );
-            Assert.That(
-                env.GetProject(Project02).UserRoles[requestingUser] != TestProjectRole.Administrator,
-                "setup: user requesting deletion should not be a project administrator to demonstrate the "
-                    + "functionality"
-            );
-            Assert.That(requestingUser, Is.Not.EqualTo(userToDisassociate), "setup: not demonstrating functionality");
-
-            Assert.That(env.GetProject(Project01).UserRoles, Does.ContainKey(userToDisassociate), "setup");
-            Assert.That(env.GetUser(userToDisassociate).Sites[SiteId].Projects, Does.Contain(Project01), "setup");
-            Assert.That(env.GetProject(Project02).UserRoles, Does.ContainKey(userToDisassociate), "setup");
-            Assert.That(env.GetUser(userToDisassociate).Sites[SiteId].Projects, Does.Contain(Project02), "setup");
-            // SUT
-            await env.Service.RemoveUserFromAllProjectsAsync(requestingUser, userToDisassociate);
-            Assert.That(env.GetProject(Project01).UserRoles, Does.Not.ContainKey(userToDisassociate));
-            Assert.That(env.GetUser(userToDisassociate).Sites[SiteId].Projects, Does.Not.Contain(Project01));
-            Assert.That(env.GetProject(Project02).UserRoles, Does.Not.ContainKey(userToDisassociate));
-            Assert.That(env.GetUser(userToDisassociate).Sites[SiteId].Projects, Does.Not.Contain(Project02));
-        }
-
-        [Test]
-        public async Task SetUserProjectPermissions_AdminHasPermission()
-        {
-            var env = new TestEnvironment();
-            var permissions = new string[] { "questions.create", "questions.edit" };
-
-            Project project = env.GetProject(Project01);
-            Assert.AreEqual(0, project.UserPermissions.Count, "setup");
-
-            // Admin can give user question permission
-            await env.Service.SetUserProjectPermissions(User01, Project01, User02, permissions);
-            project = env.GetProject(Project01);
-            Assert.AreEqual(1, project.UserPermissions.Count);
-            project.UserPermissions.TryGetValue(User02, out string[] value);
-            Assert.AreEqual(permissions, value);
-
-            // Admin can revoke permission, which removes the key value pair from the userPermissions property
-            await env.Service.SetUserProjectPermissions(User01, Project01, User02, new string[] { });
-            project = env.GetProject(Project01);
-            Assert.AreEqual(0, project.UserPermissions.Count);
-        }
-
-        [Test]
-        public void SetUserProjectPermissions_NonAdminDoesNotHavePermission()
-        {
-            var env = new TestEnvironment();
-            var permissions = new string[] { "questions.create", "questions.edit" };
-
-            Project project = env.GetProject(Project01);
-            Assert.AreEqual(0, project.UserPermissions.Count, "setup");
-
-            // Translator user cannot give permission to self
-            Assert.ThrowsAsync<ForbiddenException>(
-                () => env.Service.SetUserProjectPermissions(User02, Project01, User02, permissions)
-            );
-
-            // Permissions are not updated
-            project = env.GetProject(Project01);
-            Assert.AreEqual(0, project.UserPermissions.Count);
-        }
-
-        private class TestEnvironment
-        {
-            public TestEnvironment(bool isResetLinkExpired = false)
-            {
-                RealtimeService = new MemoryRealtimeService();
-                RealtimeService.AddRepository(
-                    "users",
-                    OTType.Json0,
-                    new MemoryRepository<User>(
-                        new[]
-                        {
-                            new User
-                            {
-                                Id = User01,
-                                Email = "user01@example.com",
-                                Sites = new Dictionary<string, Site>
-                                {
-                                    {
-                                        SiteId,
-                                        new Site()
-                                        {
-                                            CurrentProjectId = Project01,
-                                            Projects = new List<String>() { Project01, Project02 }
-                                        }
-                                    }
-                                }
-                            },
-                            new User
-                            {
-                                Id = User02,
-                                Email = "user02@example.com",
-                                Sites = new Dictionary<string, Site>
-                                {
-                                    {
-                                        SiteId,
-                                        new Site()
-                                        {
-                                            CurrentProjectId = Project01,
-                                            Projects = new List<String>() { Project01, Project02 }
-                                        }
-                                    }
-                                }
-                            },
-                            new User
-                            {
-                                Id = User03,
-                                Email = "user03@example.com",
-                                Sites = new Dictionary<string, Site> { { SiteId, new Site() } }
-                            }
-                        }
-                    )
-                );
-                RealtimeService.AddRepository(
-                    "projects",
-                    OTType.Json0,
-                    new MemoryRepository<TestProject>(
-                        new[]
-                        {
-                            new TestProject
-                            {
-                                Id = Project01,
-                                Name = "Project 1",
-                                UserRoles =
-                                {
-                                    { User01, TestProjectRole.Administrator },
-                                    { User02, TestProjectRole.Reviewer }
-                                }
-                            },
-                            new TestProject
-                            {
-                                Id = Project02,
-                                Name = "Project 2",
-                                UserRoles =
-                                {
-                                    { User01, TestProjectRole.Administrator },
-                                    { User02, TestProjectRole.Reviewer }
-                                },
-                                SyncDisabled = true
-                            },
-                        }
-                    )
-                );
-
-                var siteOptions = Substitute.For<IOptions<SiteOptions>>();
-                siteOptions.Value.Returns(
-                    new SiteOptions
+            RealtimeService = new MemoryRealtimeService();
+            RealtimeService.AddRepository(
+                "users",
+                OTType.Json0,
+                new MemoryRepository<User>(
+                    new[]
                     {
-                        Id = SiteId,
-                        Name = "xForge",
-                        Origin = new Uri("http://localhost"),
-                        SiteDir = "site"
+                        new User
+                        {
+                            Id = User01,
+                            Email = "user01@example.com",
+                            Sites = new Dictionary<string, Site>
+                            {
+                                {
+                                    SiteId,
+                                    new Site()
+                                    {
+                                        CurrentProjectId = Project01,
+                                        Projects = new List<String>() { Project01, Project02 }
+                                    }
+                                }
+                            }
+                        },
+                        new User
+                        {
+                            Id = User02,
+                            Email = "user02@example.com",
+                            Sites = new Dictionary<string, Site>
+                            {
+                                {
+                                    SiteId,
+                                    new Site()
+                                    {
+                                        CurrentProjectId = Project01,
+                                        Projects = new List<String>() { Project01, Project02 }
+                                    }
+                                }
+                            }
+                        },
+                        new User
+                        {
+                            Id = User03,
+                            Email = "user03@example.com",
+                            Sites = new Dictionary<string, Site> { { SiteId, new Site() } }
+                        }
                     }
-                );
-                AudioService = Substitute.For<IAudioService>();
+                )
+            );
+            RealtimeService.AddRepository(
+                "projects",
+                OTType.Json0,
+                new MemoryRepository<TestProject>(
+                    new[]
+                    {
+                        new TestProject
+                        {
+                            Id = Project01,
+                            Name = "Project 1",
+                            UserRoles =
+                            {
+                                { User01, TestProjectRole.Administrator },
+                                { User02, TestProjectRole.Reviewer }
+                            }
+                        },
+                        new TestProject
+                        {
+                            Id = Project02,
+                            Name = "Project 2",
+                            UserRoles =
+                            {
+                                { User01, TestProjectRole.Administrator },
+                                { User02, TestProjectRole.Reviewer }
+                            },
+                            SyncDisabled = true
+                        },
+                    }
+                )
+            );
 
-                ProjectSecrets = new MemoryRepository<TestProjectSecret>(
-                    new[] { new TestProjectSecret { Id = Project01 } }
-                );
+            var siteOptions = Substitute.For<IOptions<SiteOptions>>();
+            siteOptions.Value.Returns(
+                new SiteOptions
+                {
+                    Id = SiteId,
+                    Name = "xForge",
+                    Origin = new Uri("http://localhost"),
+                    SiteDir = "site"
+                }
+            );
+            AudioService = Substitute.For<IAudioService>();
 
-                FileSystemService = Substitute.For<IFileSystemService>();
+            ProjectSecrets = new MemoryRepository<TestProjectSecret>(
+                new[] { new TestProjectSecret { Id = Project01 } }
+            );
 
-                Service = new TestProjectService(
-                    RealtimeService,
-                    siteOptions,
-                    AudioService,
-                    ProjectSecrets,
-                    FileSystemService
-                );
-            }
+            FileSystemService = Substitute.For<IFileSystemService>();
 
-            public TestProjectService Service { get; }
-            public MemoryRealtimeService RealtimeService { get; }
-            public MemoryRepository<TestProjectSecret> ProjectSecrets { get; }
-            public IFileSystemService FileSystemService { get; }
-            public IAudioService AudioService { get; }
-
-            public TestProject GetProject(string id)
-            {
-                return RealtimeService.GetRepository<TestProject>().Get(id);
-            }
-
-            public User GetUser(string id)
-            {
-                return RealtimeService.GetRepository<User>().Get(id);
-            }
+            Service = new TestProjectService(
+                RealtimeService,
+                siteOptions,
+                AudioService,
+                ProjectSecrets,
+                FileSystemService
+            );
         }
+
+        public TestProjectService Service { get; }
+        public MemoryRealtimeService RealtimeService { get; }
+        public MemoryRepository<TestProjectSecret> ProjectSecrets { get; }
+        public IFileSystemService FileSystemService { get; }
+        public IAudioService AudioService { get; }
+
+        public TestProject GetProject(string id) => RealtimeService.GetRepository<TestProject>().Get(id);
+
+        public User GetUser(string id) => RealtimeService.GetRepository<User>().Get(id);
     }
 }

--- a/test/SIL.XForge.Tests/Services/SecurityServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/SecurityServiceTests.cs
@@ -1,19 +1,18 @@
 using NUnit.Framework;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+[TestFixture]
+public class SecurityServiceTests
 {
-    [TestFixture]
-    public class SecurityServiceTests
+    [Test]
+    public void GenerateKey_GeneratesDifferentKeys()
     {
-        [Test]
-        public void GenerateKey_GeneratesDifferentKeys()
-        {
-            var security = new SecurityService();
-            var first = security.GenerateKey();
-            var second = security.GenerateKey();
-            Assert.That(first, Is.Not.EqualTo(0), "unlikely");
-            Assert.That(first, Is.Not.EqualTo(second), "unlikely");
-            Assert.That(first.Length, Is.EqualTo(16), "unexpected length");
-        }
+        var security = new SecurityService();
+        var first = security.GenerateKey();
+        var second = security.GenerateKey();
+        Assert.That(first, Is.Not.EqualTo(0), "unlikely");
+        Assert.That(first, Is.Not.EqualTo(second), "unlikely");
+        Assert.That(first.Length, Is.EqualTo(16), "unexpected length");
     }
 }

--- a/test/SIL.XForge.Tests/Services/TestProjectService.cs
+++ b/test/SIL.XForge.Tests/Services/TestProjectService.cs
@@ -6,23 +6,21 @@ using SIL.XForge.Models;
 using SIL.XForge.Realtime;
 using SIL.XForge.Utils;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+public class TestProjectService : ProjectService<TestProject, TestProjectSecret>
 {
-    public class TestProjectService : ProjectService<TestProject, TestProjectSecret>
-    {
-        public TestProjectService(
-            IRealtimeService realtimeService,
-            IOptions<SiteOptions> siteOptions,
-            IAudioService audioService,
-            IRepository<TestProjectSecret> projectSecrets,
-            IFileSystemService fileSystemService
-        ) : base(realtimeService, siteOptions, audioService, projectSecrets, fileSystemService) { }
+    public TestProjectService(
+        IRealtimeService realtimeService,
+        IOptions<SiteOptions> siteOptions,
+        IAudioService audioService,
+        IRepository<TestProjectSecret> projectSecrets,
+        IFileSystemService fileSystemService
+    )
+        : base(realtimeService, siteOptions, audioService, projectSecrets, fileSystemService) { }
 
-        protected override string ProjectAdminRole => TestProjectRole.Administrator;
+    protected override string ProjectAdminRole => TestProjectRole.Administrator;
 
-        protected override Task<Attempt<string>> TryGetProjectRoleAsync(TestProject project, string userId)
-        {
-            return Task.FromResult(Attempt.Success(TestProjectRole.Reviewer));
-        }
-    }
+    protected override Task<Attempt<string>> TryGetProjectRoleAsync(TestProject project, string userId) =>
+        Task.FromResult(Attempt.Success(TestProjectRole.Reviewer));
 }

--- a/test/SIL.XForge.Tests/Services/TokenHelper.cs
+++ b/test/SIL.XForge.Tests/Services/TokenHelper.cs
@@ -4,37 +4,31 @@ using System.Security.Claims;
 using IdentityModel;
 using Microsoft.IdentityModel.Tokens;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+/// <summary>
+/// Helper for unit tests using access tokens
+/// </summary>
+public class TokenHelper
 {
-    /// <summary>
-    /// Helper for unit tests using access tokens
-    /// </summary>
-    public class TokenHelper
+    public static string CreateAccessToken(DateTime issuedAt, DateTime expiration, string paratextUserId)
     {
-        public static string CreateAccessToken(DateTime issuedAt, DateTime expiration, string paratextUserId)
-        {
-            var token = new JwtSecurityToken(
-                "ptreg_rsa",
-                "pt-api",
-                new[]
-                {
-                    new Claim(JwtClaimTypes.Subject, paratextUserId),
-                    new Claim(JwtClaimTypes.IssuedAt, EpochTime.GetIntDate(issuedAt).ToString())
-                },
-                expires: expiration
-            );
-            var handler = new JwtSecurityTokenHandler();
-            return handler.WriteToken(token);
-        }
-
-        public static string CreateAccessToken(DateTime issuedAt)
-        {
-            return CreateAccessToken(issuedAt, issuedAt + TimeSpan.FromMinutes(5), "paratext01");
-        }
-
-        public static string CreateNewAccessToken()
-        {
-            return CreateAccessToken(DateTime.Now);
-        }
+        var token = new JwtSecurityToken(
+            "ptreg_rsa",
+            "pt-api",
+            new[]
+            {
+                new Claim(JwtClaimTypes.Subject, paratextUserId),
+                new Claim(JwtClaimTypes.IssuedAt, EpochTime.GetIntDate(issuedAt).ToString())
+            },
+            expires: expiration
+        );
+        var handler = new JwtSecurityTokenHandler();
+        return handler.WriteToken(token);
     }
+
+    public static string CreateAccessToken(DateTime issuedAt) =>
+        CreateAccessToken(issuedAt, issuedAt + TimeSpan.FromMinutes(5), "paratext01");
+
+    public static string CreateNewAccessToken() => CreateAccessToken(DateTime.Now);
 }

--- a/test/SIL.XForge.Tests/Services/UserServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/UserServiceTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;
 using NSubstitute;
@@ -12,399 +11,400 @@ using SIL.XForge.Realtime;
 using SIL.XForge.Realtime.Json0;
 using SIL.XForge.Utils;
 
-namespace SIL.XForge.Services
+namespace SIL.XForge.Services;
+
+[TestFixture]
+public class UserServiceTests
 {
-    [TestFixture]
-    public class UserServiceTests
+    [Test]
+    public async Task UpdateUserFromProfileAsync_ExistingUser_OldParatextTokens()
     {
-        [Test]
-        public async Task UpdateUserFromProfileAsync_ExistingUser_OldParatextTokens()
+        var env = new TestEnvironment();
+
+        JObject userProfile = TestEnvironment.CreateUserProfile(
+            "user01",
+            "auth01",
+            env.IssuedAt - TimeSpan.FromMinutes(5)
+        );
+        // SUT
+        await env.Service.UpdateUserFromProfileAsync("user01", userProfile.ToString());
+        User user1 = env.GetUser("user01");
+        Assert.That(user1.Sites.ContainsKey("xf"), Is.True);
+        UserSecret userSecret = env.UserSecrets.Get("user01");
+        Assert.That(
+            userSecret.ParatextTokens.RefreshToken,
+            Is.EqualTo("refresh_token"),
+            "incoming older refresh token is ignored"
+        );
+        env.Logger.AssertHasEvent(
+            (LogEvent ev) => ev.Message.Contains("earlier than") && ev.Message.Contains("ignoring"),
+            "but we make a note of this potentially problematic situation"
+        );
+    }
+
+    [Test]
+    public async Task UpdateUserFromProfileAsync_ExistingUser_NewParatextTokens()
+    {
+        var env = new TestEnvironment();
+
+        JObject userProfile = TestEnvironment.CreateUserProfile(
+            "user01",
+            "auth01",
+            env.IssuedAt + TimeSpan.FromMinutes(5)
+        );
+        await env.Service.UpdateUserFromProfileAsync("user01", userProfile.ToString());
+        User user1 = env.GetUser("user01");
+        Assert.That(user1.Sites.ContainsKey("xf"), Is.True);
+        UserSecret userSecret = env.UserSecrets.Get("user01");
+        Assert.That(userSecret.ParatextTokens.RefreshToken, Is.EqualTo("new_refresh_token"));
+    }
+
+    [Test]
+    public async Task UpdateUserFromProfileAsync_NewUser()
+    {
+        var env = new TestEnvironment();
+
+        JObject userProfile = TestEnvironment.CreateUserProfile("user03", "auth03", env.IssuedAt);
+        await env.Service.UpdateUserFromProfileAsync("user03", userProfile.ToString());
+        Assert.That(env.ContainsUser("user03"), Is.True);
+        UserSecret userSecret = env.UserSecrets.Get("user03");
+        Assert.That(userSecret.ParatextTokens.RefreshToken, Is.EqualTo("new_refresh_token"));
+    }
+
+    [Test]
+    public async Task PushAuthUserProfile_NewUser_NickNameExtracted()
+    {
+        var env = new TestEnvironment();
+
+        JObject userProfile = TestEnvironment.CreateUserProfile("user03", "auth03", env.IssuedAt);
+        userProfile["name"] = "usernew@example.com";
+        userProfile["nickname"] = "usernew";
+        await env.Service.UpdateUserFromProfileAsync("user03", userProfile.ToString());
+        User user3 = env.GetUser("user03");
+        Assert.That(user3.DisplayName, Is.EqualTo("usernew"));
+        UserSecret userSecret = env.UserSecrets.Get("user03");
+        Assert.That(userSecret.ParatextTokens.RefreshToken, Is.EqualTo("new_refresh_token"));
+    }
+
+    [Test]
+    public async Task PushAuthUserProfile_NewUser_NameExtracted()
+    {
+        var env = new TestEnvironment();
+
+        JObject userProfile = TestEnvironment.CreateUserProfile("user03", "auth03", env.IssuedAt);
+        userProfile["name"] = "User New";
+        userProfile["nickname"] = "usernew";
+        await env.Service.UpdateUserFromProfileAsync("user03", userProfile.ToString());
+        User user3 = env.GetUser("user03");
+        Assert.That(user3.DisplayName, Is.EqualTo("User New"));
+        UserSecret userSecret = env.UserSecrets.Get("user03");
+        Assert.That(userSecret.ParatextTokens.RefreshToken, Is.EqualTo("new_refresh_token"));
+    }
+
+    [Test]
+    public async Task LinkParatextAccountAsync()
+    {
+        var env = new TestEnvironment();
+        env.AuthService.LinkAccounts("auth02", "paratext|paratext01").Returns(Task.CompletedTask);
+        JObject userProfile = TestEnvironment.CreateUserProfile("user02", "auth02", env.IssuedAt);
+        env.AuthService.GetUserAsync("auth02").Returns(Task.FromResult(userProfile.ToString()));
+        JObject ptProfile = TestEnvironment.CreateUserProfile("newPtProfile", "paratext|paratext01", env.IssuedAt);
+        env.AuthService.GetUserAsync("paratext|paratext01").Returns(Task.FromResult(ptProfile.ToString()));
+
+        await env.Service.LinkParatextAccountAsync("auth02", "paratext|paratext01");
+        User user2 = env.GetUser("user02");
+        Assert.That(user2.ParatextId, Is.EqualTo("paratext01"));
+        UserSecret userSecret = env.UserSecrets.Get("user02");
+        Assert.That(userSecret.ParatextTokens.RefreshToken, Is.EqualTo("new_refresh_token"));
+    }
+
+    [Test]
+    public void LinkParatextAccountAsync_ParatextLoginUsingExistingSFUserEmail_ThrowsError()
+    {
+        var env = new TestEnvironment();
+        JObject userProfile = TestEnvironment.CreateUserProfile("user03", "notPt03", env.IssuedAt);
+        env.AuthService.GetUserAsync("notPt03").Returns(Task.FromResult(userProfile.ToString()));
+
+        Assert.ThrowsAsync<ArgumentException>(() => env.Service.LinkParatextAccountAsync("auth02", "notPt03"));
+    }
+
+    [Test]
+    public async Task UpdateAvatarFromDisplayNameAsync()
+    {
+        var env = new TestEnvironment();
+        var userId = "user04";
+        var userAuth = "auth04";
+        await using IConnection conn = await env.RealtimeService.ConnectAsync(userId);
+        IDocument<User> userDoc = await conn.FetchAsync<User>(userId);
+
+        string[,] expectedInitials =
         {
-            var env = new TestEnvironment();
+            { "User Name", "UN" },
+            { "Username", "U" },
+            { "User Middle Name", "UN" },
+            { "User M Name", "UN" },
+            { "U Name", "N" },
+            { "1 Number", "N" },
+            { "11 Number", "N" },
+            { "U", "example" } // Should not change from what is already set
+        };
+        var expectedAvatarUrl = "";
+        User user;
 
-            JObject userProfile = env.CreateUserProfile("user01", "auth01", env.IssuedAt - TimeSpan.FromMinutes(5));
-            // SUT
-            await env.Service.UpdateUserFromProfileAsync("user01", userProfile.ToString());
-            User user1 = env.GetUser("user01");
-            Assert.That(user1.Sites.ContainsKey("xf"), Is.True);
-            UserSecret userSecret = env.UserSecrets.Get("user01");
-            Assert.That(
-                userSecret.ParatextTokens.RefreshToken,
-                Is.EqualTo("refresh_token"),
-                "incoming older refresh token is ignored"
-            );
-            env.Logger.AssertHasEvent(
-                (LogEvent ev) => ev.Message.Contains("earlier than") && ev.Message.Contains("ignoring"),
-                "but we make a note of this potentially problematic situation"
-            );
-        }
-
-        [Test]
-        public async Task UpdateUserFromProfileAsync_ExistingUser_NewParatextTokens()
+        // Check avatar URL is updated - only happens if the existing URL is one set by Auth0
+        for (int i = 0; i < expectedInitials.GetLength(0); i++)
         {
-            var env = new TestEnvironment();
-
-            JObject userProfile = env.CreateUserProfile("user01", "auth01", env.IssuedAt + TimeSpan.FromMinutes(5));
-            await env.Service.UpdateUserFromProfileAsync("user01", userProfile.ToString());
-            User user1 = env.GetUser("user01");
-            Assert.That(user1.Sites.ContainsKey("xf"), Is.True);
-            UserSecret userSecret = env.UserSecrets.Get("user01");
-            Assert.That(userSecret.ParatextTokens.RefreshToken, Is.EqualTo("new_refresh_token"));
-        }
-
-        [Test]
-        public async Task UpdateUserFromProfileAsync_NewUser()
-        {
-            var env = new TestEnvironment();
-
-            JObject userProfile = env.CreateUserProfile("user03", "auth03", env.IssuedAt);
-            await env.Service.UpdateUserFromProfileAsync("user03", userProfile.ToString());
-            Assert.That(env.ContainsUser("user03"), Is.True);
-            UserSecret userSecret = env.UserSecrets.Get("user03");
-            Assert.That(userSecret.ParatextTokens.RefreshToken, Is.EqualTo("new_refresh_token"));
-        }
-
-        [Test]
-        public async Task PushAuthUserProfile_NewUser_NickNameExtracted()
-        {
-            var env = new TestEnvironment();
-
-            JObject userProfile = env.CreateUserProfile("user03", "auth03", env.IssuedAt);
-            userProfile["name"] = "usernew@example.com";
-            userProfile["nickname"] = "usernew";
-            await env.Service.UpdateUserFromProfileAsync("user03", userProfile.ToString());
-            User user3 = env.GetUser("user03");
-            Assert.That(user3.DisplayName, Is.EqualTo("usernew"));
-            UserSecret userSecret = env.UserSecrets.Get("user03");
-            Assert.That(userSecret.ParatextTokens.RefreshToken, Is.EqualTo("new_refresh_token"));
-        }
-
-        [Test]
-        public async Task PushAuthUserProfile_NewUser_NameExtracted()
-        {
-            var env = new TestEnvironment();
-
-            JObject userProfile = env.CreateUserProfile("user03", "auth03", env.IssuedAt);
-            userProfile["name"] = "User New";
-            userProfile["nickname"] = "usernew";
-            await env.Service.UpdateUserFromProfileAsync("user03", userProfile.ToString());
-            User user3 = env.GetUser("user03");
-            Assert.That(user3.DisplayName, Is.EqualTo("User New"));
-            UserSecret userSecret = env.UserSecrets.Get("user03");
-            Assert.That(userSecret.ParatextTokens.RefreshToken, Is.EqualTo("new_refresh_token"));
-        }
-
-        [Test]
-        public async Task LinkParatextAccountAsync()
-        {
-            var env = new TestEnvironment();
-            env.AuthService.LinkAccounts("auth02", "paratext|paratext01").Returns(Task.CompletedTask);
-            JObject userProfile = env.CreateUserProfile("user02", "auth02", env.IssuedAt);
-            env.AuthService.GetUserAsync("auth02").Returns(Task.FromResult(userProfile.ToString()));
-            JObject ptProfile = env.CreateUserProfile("newPtProfile", "paratext|paratext01", env.IssuedAt);
-            env.AuthService.GetUserAsync("paratext|paratext01").Returns(Task.FromResult(ptProfile.ToString()));
-
-            await env.Service.LinkParatextAccountAsync("auth02", "paratext|paratext01");
-            User user2 = env.GetUser("user02");
-            Assert.That(user2.ParatextId, Is.EqualTo("paratext01"));
-            UserSecret userSecret = env.UserSecrets.Get("user02");
-            Assert.That(userSecret.ParatextTokens.RefreshToken, Is.EqualTo("new_refresh_token"));
-        }
-
-        [Test]
-        public void LinkParatextAccountAsync_ParatextLoginUsingExistingSFUserEmail_ThrowsError()
-        {
-            var env = new TestEnvironment();
-            JObject userProfile = env.CreateUserProfile("user03", "notPt03", env.IssuedAt);
-            env.AuthService.GetUserAsync("notPt03").Returns(Task.FromResult(userProfile.ToString()));
-
-            Assert.ThrowsAsync<ArgumentException>(() => env.Service.LinkParatextAccountAsync("auth02", "notPt03"));
-        }
-
-        [Test]
-        public async Task UpdateAvatarFromDisplayNameAsync()
-        {
-            var env = new TestEnvironment();
-            var userId = "user04";
-            var userAuth = "auth04";
-            await using IConnection conn = await env.RealtimeService.ConnectAsync(userId);
-            IDocument<User> userDoc = await conn.FetchAsync<User>(userId);
-
-            string[,] expectedInitials =
-            {
-                { "User Name", "UN" },
-                { "Username", "U" },
-                { "User Middle Name", "UN" },
-                { "User M Name", "UN" },
-                { "U Name", "N" },
-                { "1 Number", "N" },
-                { "11 Number", "N" },
-                { "U", "example" } // Should not change from what is already set
-            };
-            var expectedAvatarUrl = "";
-            User user;
-
-            // Check avatar URL is updated - only happens if the existing URL is one set by Auth0
-            for (int i = 0; i < expectedInitials.GetLength(0); i++)
-            {
-                await userDoc.SubmitJson0OpAsync(op => op.Set(u => u.DisplayName, expectedInitials[i, 0]));
-                await env.Service.UpdateAvatarFromDisplayNameAsync(userId, userAuth);
-                expectedAvatarUrl = $"https://cdn.auth0.com/avatars/{expectedInitials[i, 1].ToLower()}.png";
-                user = env.GetUser(userId);
-                Assert.That(user.AvatarUrl, Is.EqualTo(expectedAvatarUrl));
-            }
-
-            // Check avatar is not updated if the existing Url is not from Auth0
-            expectedAvatarUrl = "https://cdn.google.com/avatars/example.png";
-            await userDoc.SubmitJson0OpAsync(op =>
-            {
-                op.Set(u => u.DisplayName, expectedInitials[0, 0]);
-                op.Set(u => u.AvatarUrl, expectedAvatarUrl);
-            });
+            await userDoc.SubmitJson0OpAsync(op => op.Set(u => u.DisplayName, expectedInitials[i, 0]));
             await env.Service.UpdateAvatarFromDisplayNameAsync(userId, userAuth);
-            user = env.GetUser(userId);
-            Assert.That(user.AvatarUrl, Is.EqualTo(expectedAvatarUrl));
-
-            // Check avatar Url supports Gravatar if an email is available
-            await userDoc.SubmitJson0OpAsync(op =>
-            {
-                op.Set(u => u.DisplayName, expectedInitials[0, 0]);
-                op.Set(u => u.AvatarUrl, "https://cdn.auth0.com/avatars/example.png");
-                op.Set(u => u.Email, "example@example.com");
-            });
-            await env.Service.UpdateAvatarFromDisplayNameAsync(userId, userAuth);
-            var emailHash = StringUtils.ComputeMd5Hash(userDoc.Data.Email);
-            expectedAvatarUrl = "https://cdn.auth0.com/avatars/un.png";
-            var auth0Fallback = System.Web.HttpUtility.UrlEncode(expectedAvatarUrl);
-            expectedAvatarUrl = $"https://www.gravatar.com/avatar/{emailHash}?s=480&r=pg&d={auth0Fallback}";
+            expectedAvatarUrl = $"https://cdn.auth0.com/avatars/{expectedInitials[i, 1].ToLower()}.png";
             user = env.GetUser(userId);
             Assert.That(user.AvatarUrl, Is.EqualTo(expectedAvatarUrl));
         }
 
-        [Test]
-        public async Task UpdateInterfaceLanguageAsync()
+        // Check avatar is not updated if the existing Url is not from Auth0
+        expectedAvatarUrl = "https://cdn.google.com/avatars/example.png";
+        await userDoc.SubmitJson0OpAsync(op =>
         {
-            var env = new TestEnvironment();
-            env.AuthService.UpdateInterfaceLanguage("auth02", "mri").Returns(Task.CompletedTask);
-            JObject userProfile = env.CreateUserProfile("user02", "auth02", env.IssuedAt);
-            env.AuthService.GetUserAsync("auth02").Returns(Task.FromResult(userProfile.ToString()));
+            op.Set(u => u.DisplayName, expectedInitials[0, 0]);
+            op.Set(u => u.AvatarUrl, expectedAvatarUrl);
+        });
+        await env.Service.UpdateAvatarFromDisplayNameAsync(userId, userAuth);
+        user = env.GetUser(userId);
+        Assert.That(user.AvatarUrl, Is.EqualTo(expectedAvatarUrl));
 
-            await env.Service.UpdateInterfaceLanguageAsync("user02", "auth02", "mri");
-            User user2 = env.GetUser("user02");
-            Assert.That(user2.InterfaceLanguage, Is.EqualTo("mri"));
-        }
-
-        [Test]
-        public void DeleteAsync_BadArguments()
+        // Check avatar Url supports Gravatar if an email is available
+        await userDoc.SubmitJson0OpAsync(op =>
         {
-            var env = new TestEnvironment();
-            Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.DeleteAsync(null, "systemRole", "userId"));
-            Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.DeleteAsync("curUserId", null, "userId"));
-            Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.DeleteAsync("curUserId", "systemRole", null));
-        }
+            op.Set(u => u.DisplayName, expectedInitials[0, 0]);
+            op.Set(u => u.AvatarUrl, "https://cdn.auth0.com/avatars/example.png");
+            op.Set(u => u.Email, "example@example.com");
+        });
+        await env.Service.UpdateAvatarFromDisplayNameAsync(userId, userAuth);
+        var emailHash = StringUtils.ComputeMd5Hash(userDoc.Data.Email);
+        expectedAvatarUrl = "https://cdn.auth0.com/avatars/un.png";
+        var auth0Fallback = System.Web.HttpUtility.UrlEncode(expectedAvatarUrl);
+        expectedAvatarUrl = $"https://www.gravatar.com/avatar/{emailHash}?s=480&r=pg&d={auth0Fallback}";
+        user = env.GetUser(userId);
+        Assert.That(user.AvatarUrl, Is.EqualTo(expectedAvatarUrl));
+    }
 
-        [Test]
-        public void DeleteAsync_UserCannotDeleteAnotherUser()
+    [Test]
+    public async Task UpdateInterfaceLanguageAsync()
+    {
+        var env = new TestEnvironment();
+        env.AuthService.UpdateInterfaceLanguage("auth02", "mri").Returns(Task.CompletedTask);
+        JObject userProfile = TestEnvironment.CreateUserProfile("user02", "auth02", env.IssuedAt);
+        env.AuthService.GetUserAsync("auth02").Returns(Task.FromResult(userProfile.ToString()));
+
+        await env.Service.UpdateInterfaceLanguageAsync("user02", "auth02", "mri");
+        User user2 = env.GetUser("user02");
+        Assert.That(user2.InterfaceLanguage, Is.EqualTo("mri"));
+    }
+
+    [Test]
+    public void DeleteAsync_BadArguments()
+    {
+        var env = new TestEnvironment();
+        Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.DeleteAsync(null, "systemRole", "userId"));
+        Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.DeleteAsync("curUserId", null, "userId"));
+        Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.DeleteAsync("curUserId", "systemRole", null));
+    }
+
+    [Test]
+    public void DeleteAsync_UserCannotDeleteAnotherUser()
+    {
+        var env = new TestEnvironment();
+        string curUserId = "user01";
+        // Role is not a system admin
+        string curUserSystemRole = SystemRole.User;
+        string userIdToDelete = "user02";
+        Assert.That(env.ContainsUser(userIdToDelete), Is.True);
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete)
+        );
+        Assert.That(env.RealtimeService.CallCountDeleteUserAsync, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task DeleteAsync_UserCanDeleteSelf()
+    {
+        var env = new TestEnvironment();
+        string curUserId = "user01";
+        // Role is not a system admin
+        string curUserSystemRole = SystemRole.User;
+        string userIdToDelete = "user01";
+        Assert.That(env.ContainsUser(userIdToDelete), Is.True);
+        // SUT
+        await env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete);
+        Assert.That(env.RealtimeService.CallCountDeleteUserAsync, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task DeleteAsync_SysAdminCanDeleteUser()
+    {
+        var env = new TestEnvironment();
+        string curUserId = "user01";
+        string curUserSystemRole = SystemRole.SystemAdmin;
+        string userIdToDelete = "user02";
+        Assert.That(env.ContainsUser(userIdToDelete), Is.True);
+        // SUT
+        await env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete);
+        Assert.That(env.RealtimeService.CallCountDeleteUserAsync, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task DeleteAsync_SysAdminCanDeleteSelf()
+    {
+        var env = new TestEnvironment();
+        string curUserId = "user01";
+        string curUserSystemRole = SystemRole.SystemAdmin;
+        string userIdToDelete = "user01";
+        Assert.That(env.ContainsUser(userIdToDelete), Is.True);
+        // SUT
+        await env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete);
+        Assert.That(env.RealtimeService.CallCountDeleteUserAsync, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task DeleteAsync_DisassociatesFromProjects()
+    {
+        var env = new TestEnvironment();
+        string curUserId = "user01";
+        string curUserSystemRole = SystemRole.User;
+        string userIdToDelete = "user01";
+        // SUT
+        await env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete);
+        await env.ProjectService.Received(1).RemoveUserFromAllProjectsAsync(curUserId, userIdToDelete);
+    }
+
+    [Test]
+    public async Task DeleteAsync_RemovesUserSecret()
+    {
+        var env = new TestEnvironment();
+        string curUserId = "user01";
+        string curUserSystemRole = SystemRole.User;
+        string userIdToDelete = "user01";
+        Assert.That(env.UserSecrets.Contains(userIdToDelete), Is.True);
+        // SUT
+        await env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete);
+        Assert.That(env.UserSecrets.Contains(userIdToDelete), Is.False);
+    }
+
+    [Test]
+    public async Task DeleteAsync_RequestsDocDeletion()
+    {
+        // Before just removing the user docs from the database, first call IDocument<User>.DeleteAsync(). This way,
+        // clients can be notified of and handle the change. For example, redirecting a deleted user to a landing
+        // page.
+        var env = new TestEnvironment();
+        string curUserId = "user01";
+        string curUserSystemRole = SystemRole.User;
+        string userIdToDelete = "user01";
+        Assert.That(env.ContainsUser(userIdToDelete), Is.True);
+        // SUT
+        await env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete);
+        Assert.That(env.ContainsUser(userIdToDelete), Is.False);
+    }
+
+    private class TestEnvironment
+    {
+        public UserService Service { get; }
+        public MemoryRepository<UserSecret> UserSecrets { get; }
+        public MemoryRealtimeService RealtimeService { get; }
+        public readonly IAuthService AuthService = Substitute.For<IAuthService>();
+        public readonly DateTime IssuedAt = DateTime.UtcNow;
+        public readonly IProjectService ProjectService = Substitute.For<IProjectService>();
+        public readonly MockLogger<UserService> Logger = new MockLogger<UserService>();
+
+        public TestEnvironment()
         {
-            var env = new TestEnvironment();
-            string curUserId = "user01";
-            // Role is not a system admin
-            string curUserSystemRole = SystemRole.User;
-            string userIdToDelete = "user02";
-            Assert.That(env.ContainsUser(userIdToDelete), Is.True);
-            // SUT
-            Assert.ThrowsAsync<ForbiddenException>(
-                () => env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete)
+            UserSecrets = new MemoryRepository<UserSecret>(
+                new[]
+                {
+                    new UserSecret
+                    {
+                        Id = "user01",
+                        ParatextTokens = new Tokens
+                        {
+                            AccessToken = TokenHelper.CreateAccessToken(IssuedAt),
+                            RefreshToken = "refresh_token"
+                        }
+                    }
+                }
             );
-            Assert.That(env.RealtimeService.CallCountDeleteUserAsync, Is.EqualTo(0));
-        }
 
-        [Test]
-        public async Task DeleteAsync_UserCanDeleteSelf()
-        {
-            var env = new TestEnvironment();
-            string curUserId = "user01";
-            // Role is not a system admin
-            string curUserSystemRole = SystemRole.User;
-            string userIdToDelete = "user01";
-            Assert.That(env.ContainsUser(userIdToDelete), Is.True);
-            // SUT
-            await env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete);
-            Assert.That(env.RealtimeService.CallCountDeleteUserAsync, Is.EqualTo(1));
-        }
-
-        [Test]
-        public async Task DeleteAsync_SysAdminCanDeleteUser()
-        {
-            var env = new TestEnvironment();
-            string curUserId = "user01";
-            string curUserSystemRole = SystemRole.SystemAdmin;
-            string userIdToDelete = "user02";
-            Assert.That(env.ContainsUser(userIdToDelete), Is.True);
-            // SUT
-            await env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete);
-            Assert.That(env.RealtimeService.CallCountDeleteUserAsync, Is.EqualTo(1));
-        }
-
-        [Test]
-        public async Task DeleteAsync_SysAdminCanDeleteSelf()
-        {
-            var env = new TestEnvironment();
-            string curUserId = "user01";
-            string curUserSystemRole = SystemRole.SystemAdmin;
-            string userIdToDelete = "user01";
-            Assert.That(env.ContainsUser(userIdToDelete), Is.True);
-            // SUT
-            await env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete);
-            Assert.That(env.RealtimeService.CallCountDeleteUserAsync, Is.EqualTo(1));
-        }
-
-        [Test]
-        public async Task DeleteAsync_DisassociatesFromProjects()
-        {
-            var env = new TestEnvironment();
-            string curUserId = "user01";
-            string curUserSystemRole = SystemRole.User;
-            string userIdToDelete = "user01";
-            // SUT
-            await env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete);
-            await env.ProjectService.Received(1).RemoveUserFromAllProjectsAsync(curUserId, userIdToDelete);
-        }
-
-        [Test]
-        public async Task DeleteAsync_RemovesUserSecret()
-        {
-            var env = new TestEnvironment();
-            string curUserId = "user01";
-            string curUserSystemRole = SystemRole.User;
-            string userIdToDelete = "user01";
-            Assert.That(env.UserSecrets.Contains(userIdToDelete), Is.True);
-            // SUT
-            await env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete);
-            Assert.That(env.UserSecrets.Contains(userIdToDelete), Is.False);
-        }
-
-        [Test]
-        public async Task DeleteAsync_RequestsDocDeletion()
-        {
-            // Before just removing the user docs from the database, first call IDocument<User>.DeleteAsync(). This way,
-            // clients can be notified of and handle the change. For example, redirecting a deleted user to a landing
-            // page.
-            var env = new TestEnvironment();
-            string curUserId = "user01";
-            string curUserSystemRole = SystemRole.User;
-            string userIdToDelete = "user01";
-            Assert.That(env.ContainsUser(userIdToDelete), Is.True);
-            // SUT
-            await env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete);
-            Assert.That(env.ContainsUser(userIdToDelete), Is.False);
-        }
-
-        private class TestEnvironment
-        {
-            public UserService Service { get; }
-            public MemoryRepository<UserSecret> UserSecrets { get; }
-            public MemoryRealtimeService RealtimeService { get; }
-            public readonly IAuthService AuthService = Substitute.For<IAuthService>();
-            public readonly DateTime IssuedAt = DateTime.UtcNow;
-            public readonly IProjectService ProjectService = Substitute.For<IProjectService>();
-            public readonly MockLogger<UserService> Logger = new MockLogger<UserService>();
-
-            public TestEnvironment()
-            {
-                UserSecrets = new MemoryRepository<UserSecret>(
+            RealtimeService = new MemoryRealtimeService();
+            RealtimeService.AddRepository(
+                "users",
+                OTType.Json0,
+                new MemoryRepository<User>(
                     new[]
                     {
-                        new UserSecret
+                        new User
                         {
                             Id = "user01",
-                            ParatextTokens = new Tokens
-                            {
-                                AccessToken = TokenHelper.CreateAccessToken(IssuedAt),
-                                RefreshToken = "refresh_token"
-                            }
-                        }
-                    }
-                );
-
-                RealtimeService = new MemoryRealtimeService();
-                RealtimeService.AddRepository(
-                    "users",
-                    OTType.Json0,
-                    new MemoryRepository<User>(
-                        new[]
+                            AvatarUrl = "http://example.com/avatar.png",
+                            AuthId = "auth01",
+                            ParatextId = "paratext01"
+                        },
+                        new User
                         {
-                            new User
-                            {
-                                Id = "user01",
-                                AvatarUrl = "http://example.com/avatar.png",
-                                AuthId = "auth01",
-                                ParatextId = "paratext01"
-                            },
-                            new User
-                            {
-                                Id = "user02",
-                                AvatarUrl = "http://example.com/avatar2.png",
-                                AuthId = "auth02"
-                            },
-                            new User
-                            {
-                                Id = "user04",
-                                AvatarUrl = "https://cdn.auth0.com/avatars/example.png",
-                                AuthId = "auth04"
-                            }
+                            Id = "user02",
+                            AvatarUrl = "http://example.com/avatar2.png",
+                            AuthId = "auth02"
+                        },
+                        new User
+                        {
+                            Id = "user04",
+                            AvatarUrl = "https://cdn.auth0.com/avatars/example.png",
+                            AuthId = "auth04"
                         }
-                    )
-                );
-
-                var options = Substitute.For<IOptions<SiteOptions>>();
-                options.Value.Returns(
-                    new SiteOptions
-                    {
-                        Id = "xf",
-                        Name = "xForge",
-                        Origin = new Uri("http://localhost")
                     }
-                );
+                )
+            );
 
-                Service = new UserService(RealtimeService, options, UserSecrets, AuthService, ProjectService, Logger);
-            }
+            var options = Substitute.For<IOptions<SiteOptions>>();
+            options.Value.Returns(
+                new SiteOptions
+                {
+                    Id = "xf",
+                    Name = "xForge",
+                    Origin = new Uri("http://localhost")
+                }
+            );
 
-            public User GetUser(string id)
-            {
-                return RealtimeService.GetRepository<User>().Get(id);
-            }
+            Service = new UserService(RealtimeService, options, UserSecrets, AuthService, ProjectService, Logger);
+        }
 
-            public bool ContainsUser(string id)
-            {
-                return RealtimeService.GetRepository<User>().Contains(id);
-            }
+        public User GetUser(string id) => RealtimeService.GetRepository<User>().Get(id);
 
-            public JObject CreateUserProfile(string userId, string authId, DateTime issuedAt)
-            {
-                return new JObject(
-                    new JProperty("user_id", authId),
-                    new JProperty("name", "New User Name"),
-                    new JProperty("email", "usernew@example.com"),
-                    new JProperty("picture", "http://example.com/new-avatar.png"),
-                    new JProperty(
-                        "app_metadata",
-                        new JObject(new JProperty("xf_user_id", userId), new JProperty("xf_role", "user"))
-                    ),
-                    new JProperty(
-                        "identities",
-                        new JArray(
-                            new JObject(
-                                new JProperty("connection", "paratext"),
-                                new JProperty("user_id", "paratext|paratext01"),
-                                new JProperty("access_token", TokenHelper.CreateAccessToken(issuedAt)),
-                                new JProperty("refresh_token", "new_refresh_token")
-                            )
+        public bool ContainsUser(string id) => RealtimeService.GetRepository<User>().Contains(id);
+
+        public static JObject CreateUserProfile(string userId, string authId, DateTime issuedAt)
+        {
+            return new JObject(
+                new JProperty("user_id", authId),
+                new JProperty("name", "New User Name"),
+                new JProperty("email", "usernew@example.com"),
+                new JProperty("picture", "http://example.com/new-avatar.png"),
+                new JProperty(
+                    "app_metadata",
+                    new JObject(new JProperty("xf_user_id", userId), new JProperty("xf_role", "user"))
+                ),
+                new JProperty(
+                    "identities",
+                    new JArray(
+                        new JObject(
+                            new JProperty("connection", "paratext"),
+                            new JProperty("user_id", "paratext|paratext01"),
+                            new JProperty("access_token", TokenHelper.CreateAccessToken(issuedAt)),
+                            new JProperty("refresh_token", "new_refresh_token")
                         )
-                    ),
-                    new JProperty("logins_count", 1)
-                );
-            }
+                    )
+                ),
+                new JProperty("logins_count", 1)
+            );
         }
     }
 }


### PR DESCRIPTION
This Pull Request exists as a discussion point on using `dotnet format` with CSharpier.

### Overview

.NET 6.0 now includes a built in tool for code formatting called [dotnet format](https://github.com/dotnet/format).

This tool is more comprehensive than [CSharpier](https://csharpier.com/), and is completely configurable via .editorconfig, which means it applies any of your IDE code formatting warnings when the tool run.

`dotnet format` is lacking primarily in the regions of line length and spacing.

Although no tool comes close to prettier, and each tool has its pros and cons (e.g. CSharpier does line length, while `dotnet format` has many more options).

### Key Formatting Changes

 * Remove and sort usings
 * File level namespaces
 * Use expression bodies when possible
 * Use readonly fields when possible
 * Use expression bodies only when one line
 * Prefer using statements without curly braces

...and many more (see `.editorconfig` for details).

### Other Changes

 * Updating CSharpier to 0.22.1 (see release notes at https://github.com/belav/csharpier/releases/tag/0.22.1)
 * Updated the pre-commit hook to work with `dotnet format`

### FAQ

**Q. Why run `dotnet format style` and `dotnet format analyzers`?**
A. As per the documentation at https://csharpier.com/docs/IntegratingWithLinters, these two commands avoid the `dotnet format` rules that involve whitespace, and so there is no conflict between the output of `dotnet format` and CSharpier.

**Q. Wouldn't merging this make my currently open PR difficult to merge?**
A. Yes, it would. It is suggested that this PR is only merged if there are no other C# Pull Requests. Before merging, the commit ed4b20f0eaf8f29dc97bc6d00a8e923804540a99 should be dropped, `dotnet format` run from the repository root directory, and finally a new "C# modifications from dotnet format and CSharpier" commit created.

**Q. I don't like a specific formatting change - can we remove it?**
A. We can configure all of the changes made through the `.editorconfig` file. The best method would be to downgrade an option from `warning` to `suggestion` (to make it an IDE suggestion) or `silent` to suppress it. If we definitely want the inverse of the configuration option, then change the appropriate option to `true` or `false`.

**Q. How did you select what formatting rules to configure?**
I initially ran `dotnet format --severity info --report` on the solution to see what changes were made if all suggestions were implemented. I then enabled the matching rules to the suggestions, making sure I did not enable rules that `dotnet format` reported that it was unable to fix. The remaining rules I tweaked based on the [documentation](https://github.com/dotnet/format/blob/main/docs/Supported-.editorconfig-options.md).

**Q. Are any additional plugins required?**
A. No. Visual Studio uses `.editorconfig` for the IDE error list, and Visual Studio Code's C# extension is configured via `.vscode/settings.json`.

**Q. Why are there 100 CodeQL issues for this Pull Request?**
A. Because of the extensive reformatting of the source files. No new CodeQL issues should have been introduced that were not already present in the codebase. If this is an issue, we should resolve the CodeQL issues in the `master` branch before merging this Pull Request.

**Q. Help! This is impossible to review!**
A. To make it easier to review the scope and style of the C# code changes, I recommend selecting the "Hide whitespace" option when viewing the "Files Changed" tab in GitHub:
![image](https://user-images.githubusercontent.com/8665431/208554752-2cc05d75-fe3f-4fdf-92a5-06e474a20411.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1649)
<!-- Reviewable:end -->
