### PR TITLE
Fix remaining CodeQL issues in Unit Tests

### DIFF
--- a/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
@@ -153,6 +153,7 @@ namespace SIL.XForge.Scripture.Services
             return projects == null ? null : projects.Select(p => new ProjectMetadata((JObject)p)).ToList();
         }
 
+        /// <summary>Gets the client.</summary>
         /// <remarks>Helps unit tests</remarks>
         public virtual RESTClient GetClient()
         {

--- a/src/SIL.XForge.Scripture/Services/SFScriptureText.cs
+++ b/src/SIL.XForge.Scripture/Services/SFScriptureText.cs
@@ -14,6 +14,9 @@ namespace SIL.XForge.Scripture.Services
     {
         private IEnumerable<TextSegment> _segments;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SFScriptureText"/> class.
+        /// </summary>
         /// <remarks>Builds segments from texts and references.
         /// Will use ops in doc that have an insert and a segment attribute providing reference information.
         /// For example,

--- a/test/SIL.XForge.Scripture.Tests/Services/ComparableProjectPermissionManager.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ComparableProjectPermissionManager.cs
@@ -10,7 +10,7 @@ namespace SIL.XForge.Scripture.Services
     /// </summary>
     /// <seealso cref="ProjectPermissionManager" />
     /// <seealso cref="IEquatable{ComparableProjectPermissionManager}" />
-    public class ComparableProjectPermissionManager
+    public sealed class ComparableProjectPermissionManager
         : ProjectPermissionManager,
             IEquatable<ComparableProjectPermissionManager>
     {
@@ -24,6 +24,16 @@ namespace SIL.XForge.Scripture.Services
         /// </remarks>
         private string XmlData => Memento.ToXmlString(Data, false, true);
 
-        public bool Equals(ComparableProjectPermissionManager other) => this.XmlData == other?.XmlData;
+        public bool Equals(ComparableProjectPermissionManager? other) => XmlData == other?.XmlData;
+
+        public override bool Equals(object? obj)
+        {
+            return Equals(obj as ComparableProjectPermissionManager);
+        }
+
+        public override int GetHashCode()
+        {
+            return XmlData.GetHashCode();
+        }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
@@ -55,7 +55,7 @@ namespace SIL.XForge.Scripture.Services
                     RefreshToken = "refresh_token01"
                 }
             };
-            env.MockJwtTokenHelper.GetParatextUsername(Arg.Any<UserSecret>()).Returns((string)null);
+            env.MockJwtTokenHelper.GetParatextUsername(Arg.Any<UserSecret>()).Returns(default(string?));
             Assert.Throws<Exception>(() => env.Provider.GetSource(userSecret, "srServer", "regServer"));
         }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -2170,10 +2170,7 @@ namespace SIL.XForge.Scripture.Services
             env.SetupProject(env.Project01, associatedPtUser);
             UserSecret user01Secret = env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
 
-            IInternetSharedRepositorySource mockSource = env.SetSharedRepositorySource(
-                user01Secret,
-                UserRoles.Administrator
-            );
+            env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
 
             ArgumentException ex = Assert.ThrowsAsync<ArgumentException>(
                 () => env.Service.SendReceiveAsync(user01Secret, "badProjectId", null)
@@ -2876,7 +2873,7 @@ namespace SIL.XForge.Scripture.Services
                 "the user secret does not have usable content"
             );
 
-            var unauthorizedHttpResponseMessage = new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            using var unauthorizedHttpResponseMessage = new HttpResponseMessage(HttpStatusCode.Unauthorized)
             {
                 RequestMessage = new HttpRequestMessage(HttpMethod.Get, "some-request-uri"),
                 Content = new ByteArrayContent(Encoding.UTF8.GetBytes("big problem"))
@@ -2894,7 +2891,7 @@ namespace SIL.XForge.Scripture.Services
                 "authorization token is not accepted by server. unauthorized."
             );
 
-            var okHttpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            using var okHttpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
             {
                 RequestMessage = new HttpRequestMessage(HttpMethod.Get, "some-request-uri"),
                 Content = new ByteArrayContent(
@@ -3241,7 +3238,7 @@ namespace SIL.XForge.Scripture.Services
             public readonly string AlternateAfter = " alternate after.";
             public readonly string ReattachedSelectedText = "reattached text";
 
-            private string ruthBookUsfm =
+            private readonly string ruthBookUsfm =
                 "\\id RUT - ProjectNameHere\n" + "\\c 1\n" + "\\v 1 Verse 1 here.\n" + "\\v 2 Verse 2 here.";
 
             public readonly IWebHostEnvironment MockWebHostEnvironment;

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1051,7 +1051,7 @@ namespace SIL.XForge.Scripture.Services
             );
             env.ParatextService
                 .GetLatestSharedVersion(Arg.Any<UserSecret>(), project.ParatextId)
-                .Returns((string?)null);
+                .Returns(default(string?));
             Assert.That(
                 project.Sync.DataInSync,
                 Is.Not.Null,
@@ -3302,11 +3302,12 @@ namespace SIL.XForge.Scripture.Services
                                 !(invalidChapters?.Contains(c) ?? false),
                                 Delta.New().InsertText("text")
                             )
-                    );
-                if (chapterDeltas.Count() == 0)
+                    )
+                    .ToList();
+                if (!chapterDeltas.Any())
                 {
                     // Add implicit ChapterDelta, mimicing DeltaUsxMapper.ToChapterDeltas().
-                    chapterDeltas = chapterDeltas.Append(new ChapterDelta(1, 0, true, Delta.New()));
+                    chapterDeltas.Add(new ChapterDelta(1, 0, true, Delta.New()));
                 }
                 DeltaUsxMapper.ToChapterDeltas(Arg.Is<XDocument>(d => predicate(d))).Returns(chapterDeltas);
             }

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -848,7 +848,7 @@ namespace SIL.XForge.Scripture.Services
                     Task.FromException<IReadOnlyDictionary<string, string>>(new System.Net.Http.HttpRequestException())
                 );
 
-            string userRoleOnPTProject = (string)null;
+            string userRoleOnPTProject = null;
             env.ParatextService
                 .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult(Attempt.Failure(userRoleOnPTProject)));
@@ -1037,7 +1037,7 @@ namespace SIL.XForge.Scripture.Services
                     Task.FromException<IReadOnlyDictionary<string, string>>(new System.Net.Http.HttpRequestException())
                 );
 
-            string userRoleOnPTProject = (string)null;
+            string userRoleOnPTProject = null;
             env.ParatextService
                 .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult(Attempt.Failure(userRoleOnPTProject)));

--- a/test/SIL.XForge.Tests/Realtime/RichText/DeltaTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/RichText/DeltaTests.cs
@@ -217,7 +217,7 @@ namespace SIL.XForge.Realtime.RichText
                     {
                         bold = true,
                         color = "red",
-                        font = (string)null
+                        font = default(string?),
                     }
                 );
             var expected = Delta.New().Insert("A", new { bold = true, color = "red" });
@@ -281,7 +281,7 @@ namespace SIL.XForge.Realtime.RichText
                     {
                         bold = true,
                         color = "red",
-                        font = (string)null
+                        font = default(string?),
                     }
                 );
             var expected = Delta
@@ -292,7 +292,7 @@ namespace SIL.XForge.Realtime.RichText
                     {
                         bold = true,
                         color = "red",
-                        font = (string)null
+                        font = default(string?),
                     }
                 );
             Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
@@ -368,7 +368,7 @@ namespace SIL.XForge.Realtime.RichText
         public void Compose_RemoveAttributes_MergeOps()
         {
             var a = Delta.New().Insert("A", new { bold = true });
-            var b = Delta.New().Retain(1, new { bold = (bool?)null });
+            var b = Delta.New().Retain(1, new { bold = default(bool?) });
             var expected = Delta.New().Insert("A");
             Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
         }
@@ -377,7 +377,7 @@ namespace SIL.XForge.Realtime.RichText
         public void Compose_RemoveEmbedAttributes_MergeOps()
         {
             var a = Delta.New().Insert(2, new { bold = true });
-            var b = Delta.New().Retain(1, new { bold = (bool?)null });
+            var b = Delta.New().Retain(1, new { bold = default(bool?) });
             var expected = Delta.New().Insert(2);
             Assert.That(a.Compose(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
         }
@@ -532,8 +532,8 @@ namespace SIL.XForge.Realtime.RichText
             var b = Delta.New().Insert("123", new { color = "red" });
             var expected = Delta
                 .New()
-                .Retain(2, new { bold = (bool?)null, color = "red" })
-                .Retain(1, new { italic = (bool?)null, color = "red" })
+                .Retain(2, new { bold = default(bool?), color = "red" })
+                .Retain(1, new { italic = default(bool?), color = "red" })
                 .Delete(1);
             Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
         }
@@ -547,7 +547,7 @@ namespace SIL.XForge.Realtime.RichText
                 .New()
                 .Insert("Good", new { bold = true })
                 .Delete(2)
-                .Retain(1, new { italic = true, color = (string)null })
+                .Retain(1, new { italic = true, color = default(string?) })
                 .Delete(3)
                 .Insert("og", new { italic = true });
             Assert.That(a.Diff(b), Is.EqualTo(expected).Using(Delta.EqualityComparer));
@@ -570,7 +570,7 @@ namespace SIL.XForge.Realtime.RichText
             var a2 = Delta.New().Insert("A", attr1);
             var b1 = Delta.New().Insert("A", new { bold = true }).Insert("B");
             var b2 = Delta.New().Insert("A", new { bold = true }).Insert("B");
-            var expected = Delta.New().Retain(1, new { bold = true, color = (string)null }).Insert("B");
+            var expected = Delta.New().Retain(1, new { bold = true, color = default(string?) }).Insert("B");
             Assert.That(a1.Diff(b1), Is.EqualTo(expected).Using(Delta.EqualityComparer));
             Assert.That(a1, Is.EqualTo(a2).Using(Delta.EqualityComparer));
             Assert.That(b1, Is.EqualTo(b2).Using(Delta.EqualityComparer));


### PR DESCRIPTION
Due to the sheer number of CodeQL warnings, many were missed in the unit tests. This PR fixes the remaining CodeQL messages in the unit tests, as well as two minor documentation related warnings in the main project.

After this PR is merged, the CodeQL count should be below 100, and the CodeQL warnings in the non-test projects can be addressed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1650)
<!-- Reviewable:end -->
