### PR TITLE
Configure Jering to use HTTP/2

### DIFF
--- a/src/SIL.XForge/Realtime/RealtimeServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Realtime/RealtimeServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Net;
 using System.Reflection;
 using Jering.Javascript.NodeJS;
 using Microsoft.Extensions.Configuration;
@@ -20,9 +21,10 @@ namespace Microsoft.Extensions.DependencyInjection
         )
         {
             services.AddNodeJS();
+            services.Configure<HttpNodeJSServiceOptions>(options => options.Version = HttpVersion.Version20);
             services.Configure<NodeJSProcessOptions>(options =>
             {
-                options.ProjectPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                options.ProjectPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
                 if (!string.IsNullOrWhiteSpace(nodeOptions))
                 {
                     options.NodeAndV8Options = nodeOptions;


### PR DESCRIPTION
Now that we have upgraded to Jering 6.0, Jering now supports HTTP/2 for communication between .NET and Node.

In my testing, this reduced the thread count by at least 10%, which I attribute to the lack of HTTP connections being opened in separate threads (HTTP/2 is much more efficient at this - .NET 6.0 only has one connection open per server, with up to 100 streams of data for that connection).

The [source code for Jering](https://github.com/JeringTech/Javascript.NodeJS/blob/master/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSServiceOptions.cs) states that HTTP/2 may be more stable, but will be slower (I imagine due to the compression and mandatory encryption in http/2), however my testing did not show a speed decrease. The HTTP/2 server implementation in Jering will, unlike the HTTP/1.1 server, begin streaming data sooner, so this will offset the overhead, especially for larger responses from the RealtimeServer.

This should not affect the RealtimeServer's connection to the web frontend, as that is done via WebSockets (a different protocol on a different port to the one used by Jering to talk with .NET).

The minor code change on line 27 is to clear a "possible null assignment to non-nullable entity" warning.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1651)
<!-- Reviewable:end -->
