### PR TITLE
Update the RealtimeServer Connection to be IAsyncDisposable

### DIFF
--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
@@ -43,17 +43,15 @@ namespace SIL.XForge.Scripture.Controllers
         {
             try
             {
-                using (Stream stream = file.OpenReadStream())
-                {
-                    Uri uri = await _projectService.SaveAudioAsync(
-                        _userAccessor.UserId,
-                        projectId,
-                        dataId,
-                        Path.GetExtension(file.FileName),
-                        stream
-                    );
-                    return Created(uri.PathAndQuery, Path.GetFileName(uri.AbsolutePath));
-                }
+                await using Stream stream = file.OpenReadStream();
+                Uri uri = await _projectService.SaveAudioAsync(
+                    _userAccessor.UserId,
+                    projectId,
+                    dataId,
+                    Path.GetExtension(file.FileName),
+                    stream
+                );
+                return Created(uri.PathAndQuery, Path.GetFileName(uri.AbsolutePath));
             }
             catch (ForbiddenException)
             {

--- a/src/SIL.XForge.Scripture/Services/SFBuildHandler.cs
+++ b/src/SIL.XForge.Scripture/Services/SFBuildHandler.cs
@@ -25,7 +25,7 @@ namespace SIL.XForge.Scripture.Services
 
         public override async Task OnCompleted(BuildContext context)
         {
-            using (IConnection conn = await _realtimeService.ConnectAsync())
+            await using (IConnection conn = await _realtimeService.ConnectAsync())
             {
                 IDocument<SFProject> project = await conn.FetchAsync<SFProject>(context.Engine.Projects.First());
                 if (!project.IsLoaded)

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -106,7 +106,7 @@ namespace SIL.XForge.Scripture.Services
                 throw new ForbiddenException();
 
             string projectId = ObjectId.GenerateNewId().ToString();
-            using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
             {
                 if (
                     this.RealtimeService
@@ -196,7 +196,7 @@ namespace SIL.XForge.Scripture.Services
             await _syncService.CancelSyncAsync(curUserId, projectId);
 
             string ptProjectId;
-            using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
             {
                 IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
                 if (!projectDoc.IsLoaded)
@@ -242,7 +242,7 @@ namespace SIL.XForge.Scripture.Services
 
         public async Task UpdateSettingsAsync(string curUserId, string projectId, SFProjectSettings settings)
         {
-            using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
             {
                 IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
                 if (!projectDoc.IsLoaded)
@@ -604,7 +604,7 @@ namespace SIL.XForge.Scripture.Services
         /// <summary> Check that a share link is valid for a project and add the user to the project. </summary>
         public async Task CheckLinkSharingAsync(string curUserId, string projectId, string shareKey)
         {
-            using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
             {
                 IDocument<SFProject> projectDoc = await GetProjectDocAsync(projectId, conn);
                 SFProject project = projectDoc.Data;
@@ -692,7 +692,7 @@ namespace SIL.XForge.Scripture.Services
             string projectId
         )
         {
-            using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
             {
                 IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
                 if (!projectDoc.IsLoaded)
@@ -1022,7 +1022,7 @@ namespace SIL.XForge.Scripture.Services
 
             // Create the new project using the realtime service
             string projectId = ObjectId.GenerateNewId().ToString();
-            using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
             {
                 if (
                     this.RealtimeService

--- a/src/SIL.XForge.Scripture/Services/SFTextCorpusFactory.cs
+++ b/src/SIL.XForge.Scripture/Services/SFTextCorpusFactory.cs
@@ -104,7 +104,7 @@ namespace SIL.XForge.Scripture.Services
                 );
                 if (_fileSystemService.FileExists(termRenderingsFileName))
                 {
-                    using var stream = _fileSystemService.OpenFile(termRenderingsFileName, FileMode.Open);
+                    await using Stream stream = _fileSystemService.OpenFile(termRenderingsFileName, FileMode.Open);
                     XDocument termRenderingsDoc = await XDocument.LoadAsync(
                         stream,
                         LoadOptions.None,

--- a/src/SIL.XForge.Scripture/Services/SyncService.cs
+++ b/src/SIL.XForge.Scripture/Services/SyncService.cs
@@ -42,7 +42,7 @@ namespace SIL.XForge.Scripture.Services
 
         public async Task SyncAsync(string curUserId, string projectId, bool trainEngine)
         {
-            using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
             {
                 // Load the project document
                 IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
@@ -240,7 +240,7 @@ namespace SIL.XForge.Scripture.Services
 
         public async Task CancelSyncAsync(string curUserId, string projectId)
         {
-            using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
             {
                 IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
                 if (projectDoc.Data.Sync.QueuedCount > 0)

--- a/src/SIL.XForge/Realtime/Connection.cs
+++ b/src/SIL.XForge/Realtime/Connection.cs
@@ -372,6 +372,12 @@ namespace SIL.XForge.Realtime
             }
         }
 
+        public async ValueTask DisposeAsync()
+        {
+            await _realtimeService.Server.DisconnectAsync(_handle);
+            GC.SuppressFinalize(this);
+        }
+
         /// <summary>
         /// Starts the realtime server asynchronously.
         /// </summary>
@@ -387,12 +393,6 @@ namespace SIL.XForge.Realtime
         protected override void DisposeManagedResources()
         {
             _realtimeService.Server.Disconnect(_handle);
-        }
-
-        public async ValueTask DisposeAsync()
-        {
-            await _realtimeService.Server.DisconnectAsync(_handle);
-            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/SIL.XForge/Realtime/Connection.cs
+++ b/src/SIL.XForge/Realtime/Connection.cs
@@ -388,5 +388,11 @@ namespace SIL.XForge.Realtime
         {
             _realtimeService.Server.Disconnect(_handle);
         }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _realtimeService.Server.DisconnectAsync(_handle);
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/src/SIL.XForge/Realtime/IConnection.cs
+++ b/src/SIL.XForge/Realtime/IConnection.cs
@@ -5,7 +5,7 @@ using SIL.XForge.Models;
 
 namespace SIL.XForge.Realtime
 {
-    public interface IConnection : IDisposable
+    public interface IConnection : IDisposable, IAsyncDisposable
     {
         void BeginTransaction();
         Task CommitTransactionAsync();

--- a/src/SIL.XForge/Realtime/IRealtimeServer.cs
+++ b/src/SIL.XForge/Realtime/IRealtimeServer.cs
@@ -9,6 +9,7 @@ namespace SIL.XForge.Realtime
         Task<Snapshot<T>> CreateDocAsync<T>(int handle, string collection, string id, T data, string otTypeName);
         Task DeleteDocAsync(int handle, string collection, string id);
         void Disconnect(int handle);
+        Task DisconnectAsync(int handle);
         Task<Snapshot<T>> FetchDocAsync<T>(int handle, string collection, string id);
         void Start(object options);
         void Stop();

--- a/src/SIL.XForge/Realtime/MemoryConnection.cs
+++ b/src/SIL.XForge/Realtime/MemoryConnection.cs
@@ -65,7 +65,16 @@ namespace SIL.XForge.Realtime
             throw new NotImplementedException();
         }
 
-        public void Dispose() { }
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            GC.SuppressFinalize(this);
+            return ValueTask.CompletedTask;
+        }
 
         /// <summary>
         /// Excludes the field from the transaction.

--- a/src/SIL.XForge/Realtime/RealtimeServer.cs
+++ b/src/SIL.XForge/Realtime/RealtimeServer.cs
@@ -64,6 +64,11 @@ namespace SIL.XForge.Realtime
             InvokeExportAsync<object>("disconnect", handle).GetAwaiter().GetResult();
         }
 
+        public Task DisconnectAsync(int handle)
+        {
+            return InvokeExportAsync<object>("disconnect", handle);
+        }
+
         public Task<T> ApplyOpAsync<T>(string otTypeName, T data, object op)
         {
             return InvokeExportAsync<T>("applyOp", otTypeName, data, op);

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -194,15 +194,15 @@ namespace SIL.XForge.Services
             string outputPath = Path.Combine(audioDir, $"{curUserId}_{dataId}.mp3");
             if (string.Equals(extension, ".mp3", StringComparison.InvariantCultureIgnoreCase))
             {
-                using (Stream fileStream = FileSystemService.OpenFile(outputPath, FileMode.Create))
-                    await inputStream.CopyToAsync(fileStream);
+                await using Stream fileStream = FileSystemService.OpenFile(outputPath, FileMode.Create);
+                await inputStream.CopyToAsync(fileStream);
             }
             else
             {
                 string tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + extension);
                 try
                 {
-                    using (Stream fileStream = FileSystemService.OpenFile(tempPath, FileMode.Create))
+                    await using (Stream fileStream = FileSystemService.OpenFile(tempPath, FileMode.Create))
                         await inputStream.CopyToAsync(fileStream);
                     await _audioService.ConvertToMp3Async(tempPath, outputPath);
                 }

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -45,7 +45,7 @@ namespace SIL.XForge.Services
 
         public async Task AddUserAsync(string curUserId, string projectId, string projectRole)
         {
-            using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
             {
                 IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
 
@@ -71,7 +71,7 @@ namespace SIL.XForge.Services
             {
                 throw new ArgumentNullException();
             }
-            using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
             {
                 IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
 
@@ -94,7 +94,7 @@ namespace SIL.XForge.Services
             {
                 throw new ArgumentNullException();
             }
-            using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
             {
                 await RemoveUserCoreAsync(conn, curUserId, projectId, projectUserId);
             }
@@ -129,7 +129,7 @@ namespace SIL.XForge.Services
             {
                 throw new ArgumentNullException();
             }
-            using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
             {
                 IDocument<User> userDoc = await GetUserDocAsync(projectUserId, conn);
                 IEnumerable<Task> removalTasks = userDoc.Data.Sites[SiteOptions.Value.Id].Projects.Select(
@@ -164,7 +164,7 @@ namespace SIL.XForge.Services
             if (systemRole != SystemRole.SystemAdmin)
                 throw new ForbiddenException();
 
-            using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
             {
                 IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
 
@@ -241,7 +241,7 @@ namespace SIL.XForge.Services
             if (systemRole != SystemRole.SystemAdmin)
                 throw new ForbiddenException();
 
-            using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
             {
                 IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
                 await projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.SyncDisabled, isDisabled));
@@ -255,7 +255,7 @@ namespace SIL.XForge.Services
             string[] permissions
         )
         {
-            using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
             {
                 IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
                 if (!projectDoc.IsLoaded)

--- a/src/SIL.XForge/Services/UserService.cs
+++ b/src/SIL.XForge/Services/UserService.cs
@@ -50,7 +50,7 @@ namespace SIL.XForge.Services
                 .OfType<JObject>()
                 .FirstOrDefault(i => (string)i["connection"] == "paratext");
             Regex emailRegex = new Regex(EMAIL_PATTERN);
-            using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
             {
                 string name = (string)userProfile["name"];
                 IDocument<User> userDoc = await conn.FetchOrCreateAsync<User>(
@@ -139,7 +139,7 @@ namespace SIL.XForge.Services
                 true
             );
 
-            using (IConnection conn = await _realtimeService.ConnectAsync(primaryUserId))
+            await using (IConnection conn = await _realtimeService.ConnectAsync(primaryUserId))
             {
                 IDocument<User> userDoc = await conn.FetchAsync<User>(primaryUserId);
                 await userDoc.SubmitJson0OpAsync(op => op.Set(u => u.ParatextId, GetIdpIdFromAuthId(ptId)));
@@ -151,7 +151,7 @@ namespace SIL.XForge.Services
         /// </summary>
         public async Task UpdateAvatarFromDisplayNameAsync(string curUserId, string authId)
         {
-            using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
             {
                 IDocument<User> userDoc = await conn.FetchAsync<User>(curUserId);
                 // Only overwrite the avatar for allowed domains so as not to overwrite an avatar provided by a social connection
@@ -198,7 +198,7 @@ namespace SIL.XForge.Services
         {
             await _authService.UpdateInterfaceLanguage(authId, language);
 
-            using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
             {
                 IDocument<User> userDoc = await conn.FetchAsync<User>(curUserId);
                 await userDoc.SubmitJson0OpAsync(op => op.Set(u => u.InterfaceLanguage, language));
@@ -221,7 +221,7 @@ namespace SIL.XForge.Services
 
             await _projectService.RemoveUserFromAllProjectsAsync(curUserId, userId);
             await _userSecrets.DeleteAsync(userId);
-            using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
             {
                 IDocument<User> userDoc = await conn.FetchAsync<User>(userId);
                 await userDoc.DeleteAsync();
@@ -232,7 +232,7 @@ namespace SIL.XForge.Services
 
         public async Task<string> GetUsernameFromUserId(string curUserId, string userId)
         {
-            using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
+            await using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
             {
                 IDocument<User> userDoc = await conn.FetchAsync<User>(userId);
                 return userDoc.Data.DisplayName;

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
@@ -30,7 +30,7 @@ namespace SIL.XForge.Scripture.Services
             await env.InitMapperAsync(false, true);
             env.AddData(null, null, null, null);
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 const string oldNotesText =
                     @"
@@ -136,7 +136,7 @@ namespace SIL.XForge.Scripture.Services
             await env.InitMapperAsync(false, false);
             env.AddData(null, null, null, null);
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 const string oldNotesText = @"<notes version=""1.1""></notes>";
                 Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(
@@ -225,7 +225,7 @@ namespace SIL.XForge.Scripture.Services
             await env.InitMapperAsync(false, true);
             env.AddData(null, null, null, null, true);
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 const string oldNotesText =
                     @"
@@ -330,7 +330,7 @@ namespace SIL.XForge.Scripture.Services
             await env.InitMapperAsync(false, true);
             env.AddData(null, null, null, null);
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 const string oldNotesText =
                     @"
@@ -440,7 +440,7 @@ namespace SIL.XForge.Scripture.Services
             await env.InitMapperAsync(true, true);
             env.AddData("syncuser01", "syncuser03", null, "syncuser03");
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 const string oldNotesText =
                     @"
@@ -542,7 +542,7 @@ namespace SIL.XForge.Scripture.Services
             await env.InitMapperAsync(true, true);
             env.AddData("syncuser01", "syncuser03", "syncuser03", "syncuser03");
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 const string oldNotesText =
                     @"
@@ -660,7 +660,7 @@ namespace SIL.XForge.Scripture.Services
             await env.InitMapperAsync(false, true);
             env.AddData(null, null, null, null);
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 const string oldNotesText = @"<notes version=""1.1""></notes>";
                 Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(
@@ -740,7 +740,7 @@ namespace SIL.XForge.Scripture.Services
             await env.InitMapperAsync(false, true);
             env.AddData(null, null, null, null);
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 const string oldNotesText = @"<notes version=""1.1""></notes>";
                 Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(
@@ -767,7 +767,7 @@ namespace SIL.XForge.Scripture.Services
             await env.InitMapperAsync(false, true);
             env.AddData(null, null, null, null);
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 const string oldNotesText = @"<notes version=""1.1""></notes>";
                 Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -717,7 +717,7 @@ namespace SIL.XForge.Scripture.Services
                 }
             );
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 IEnumerable<IDocument<NoteThread>> noteThreadDocs = await env.GetNoteThreadDocsAsync(
                     conn,
@@ -792,7 +792,7 @@ namespace SIL.XForge.Scripture.Services
                 }
             );
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 IEnumerable<IDocument<NoteThread>> noteThreadDocs = await env.GetNoteThreadDocsAsync(
                     conn,
@@ -907,7 +907,7 @@ namespace SIL.XForge.Scripture.Services
                     }
                 }
             );
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 IEnumerable<IDocument<NoteThread>> noteThreadDocs = await env.GetNoteThreadDocsAsync(
                     conn,
@@ -1045,7 +1045,7 @@ namespace SIL.XForge.Scripture.Services
             };
             env.AddParatextComment(comment);
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 // But we have no SF notes.
                 IEnumerable<IDocument<NoteThread>> noteThreadDocs = await env.GetNoteThreadDocsAsync(
@@ -1120,7 +1120,7 @@ namespace SIL.XForge.Scripture.Services
             };
             env.AddParatextComment(comment);
 
-            using (await env.RealtimeService.ConnectAsync())
+            await using (await env.RealtimeService.ConnectAsync())
             {
                 IEnumerable<IDocument<NoteThread>> noteThreadDocs = new IDocument<NoteThread>[0];
                 Dictionary<int, ChapterDelta> chapterDeltas = new Dictionary<int, ChapterDelta>();
@@ -1259,7 +1259,7 @@ namespace SIL.XForge.Scripture.Services
             string commentId = commentThread.Comments[0].Id;
             Assert.That(commentThread.Comments.Where(c => c.Id == commentId).Count, Is.EqualTo(2));
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 IEnumerable<IDocument<NoteThread>> noteThreadDocs = await env.GetNoteThreadDocsAsync(
                     conn,
@@ -1403,7 +1403,7 @@ namespace SIL.XForge.Scripture.Services
                 }
             );
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 IEnumerable<IDocument<NoteThread>> noteThreadDocs = await env.GetNoteThreadDocsAsync(
                     conn,
@@ -1591,7 +1591,7 @@ namespace SIL.XForge.Scripture.Services
                 }
             );
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 // SUT
                 IEnumerable<IDocument<NoteThread>> noteThreadDocs = await env.GetNoteThreadDocsAsync(
@@ -1711,7 +1711,7 @@ namespace SIL.XForge.Scripture.Services
                 }
             );
 
-            using (await env.RealtimeService.ConnectAsync())
+            await using (await env.RealtimeService.ConnectAsync())
             {
                 var deltas = env.GetChapterDeltasByBook(
                     env.Project01,
@@ -1845,7 +1845,7 @@ namespace SIL.XForge.Scripture.Services
                 }
             );
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 IEnumerable<IDocument<NoteThread>> noteThreadDocs = await env.GetNoteThreadDocsAsync(
                     conn,
@@ -1936,7 +1936,7 @@ namespace SIL.XForge.Scripture.Services
                     }
                 }
             );
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 CommentThread thread = env.ProjectCommentManager.FindThread(threadId);
                 Assert.That(thread, Is.Null);
@@ -2002,7 +2002,7 @@ namespace SIL.XForge.Scripture.Services
                 }
             );
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 IDocument<NoteThread> noteThreadDoc = await env.GetNoteThreadDocAsync(conn, threadId);
                 // Edit a comment
@@ -2070,7 +2070,7 @@ namespace SIL.XForge.Scripture.Services
                 }
             );
 
-            using (IConnection conn = await env.RealtimeService.ConnectAsync())
+            await using (IConnection conn = await env.RealtimeService.ConnectAsync())
             {
                 IDocument<NoteThread> noteThreadDoc = await env.GetNoteThreadDocAsync(conn, threadId);
 
@@ -4142,7 +4142,7 @@ namespace SIL.XForge.Scripture.Services
                 modifyComment(comment);
                 env.AddParatextComment(comment);
 
-                using (IConnection conn = await env.RealtimeService.ConnectAsync())
+                await using (IConnection conn = await env.RealtimeService.ConnectAsync())
                 {
                     IEnumerable<IDocument<NoteThread>> noteThreadDocs = await env.GetNoteThreadDocsAsync(
                         conn,

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -1696,7 +1696,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(sfProject.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
             Assert.That(sfProject.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
 
-            using IConnection conn = await env.RealtimeService.ConnectAsync(User01);
+            await using IConnection conn = await env.RealtimeService.ConnectAsync(User01);
             IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
 
             // SUT
@@ -1727,7 +1727,7 @@ namespace SIL.XForge.Scripture.Services
             env.ParatextService.GetBookList(Arg.Any<UserSecret>(), project01PTId).Returns(new List<int>() { 40, 41 });
             Assert.That(env.ProjectSecrets.Contains(User04), Is.False, "setup");
 
-            using IConnection conn = await env.RealtimeService.ConnectAsync(User04);
+            await using IConnection conn = await env.RealtimeService.ConnectAsync(User04);
             IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
 
             // SUT
@@ -1778,7 +1778,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(sfProject.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
             Assert.That(sfProject.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
 
-            using IConnection conn = await env.RealtimeService.ConnectAsync(User01);
+            await using IConnection conn = await env.RealtimeService.ConnectAsync(User01);
             IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
 
             // SUT
@@ -1839,7 +1839,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(sfProject.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
             Assert.That(sfProject.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
 
-            using IConnection conn = await env.RealtimeService.ConnectAsync(User01);
+            await using IConnection conn = await env.RealtimeService.ConnectAsync(User01);
             IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
 
             // SUT
@@ -1920,7 +1920,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(resource.Texts.First().Permissions.Count, Is.EqualTo(0), "setup");
             Assert.That(resource.Texts.First().Chapters.First().Permissions.Count, Is.EqualTo(0), "setup");
 
-            using IConnection conn = await env.RealtimeService.ConnectAsync(User01);
+            await using IConnection conn = await env.RealtimeService.ConnectAsync(User01);
             IDocument<SFProject> project01Doc = await conn.FetchAsync<SFProject>(Project01);
             IDocument<SFProject> resource01Doc = await conn.FetchAsync<SFProject>(Resource01);
 

--- a/test/SIL.XForge.Tests/Services/UserServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/UserServiceTests.cs
@@ -117,7 +117,7 @@ namespace SIL.XForge.Services
             var env = new TestEnvironment();
             var userId = "user04";
             var userAuth = "auth04";
-            using IConnection conn = await env.RealtimeService.ConnectAsync(userId);
+            await using IConnection conn = await env.RealtimeService.ConnectAsync(userId);
             IDocument<User> userDoc = await conn.FetchAsync<User>(userId);
 
             string[,] expectedInitials =


### PR DESCRIPTION
The `Dispose()` method of the `Connection` class calls the `Disconnect()` method in the RealtimeServer in a synchronous manner. As this code is supposed to be asynchronous (as an `HttpClient` is utilized by Jering to talk to the RealtimeServer), it will block the thread until the call is completed. If there are issues, this could result in thread pool starvation or worst case, a possible deadlock.

C# 8.0 added `IAsyncDisposable`, which means that classes that implement it can be disposed asynchronously by changing:

```C#
using IConnection conn = await _realtimeService.ConnectAsync();
```

to:

```C#
await using IConnection conn = await _realtimeService.ConnectAsync();
```

This Pull Request adds support for the `IConnection` interface to be `IAsyncDisposable` and updates `using` statements that connect to the RealtimeService to be `await using`.

In addition, I have updated 4 other places which open Streams that can be disposed asynchronously, to help improve concurrency.

Finally, I have not updated the RealtimeService to implement `IAsyncDisposable` because that class is a singleton.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1652)
<!-- Reviewable:end -->
