### PR TITLE
SF-1844 Use SignalR for Sync Progress

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/sync.ts
+++ b/src/RealtimeServer/scriptureforge/models/sync.ts
@@ -1,6 +1,5 @@
 export interface Sync {
   queuedCount: number;
-  percentCompleted?: number;
   lastSyncSuccessful?: boolean;
   dateLastSuccessfulSync?: string;
   syncedToRepositoryVersion?: string;

--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -25,6 +25,7 @@
         "@auth0/auth0-spa-js": "^1.21.0",
         "@bugsnag/js": "^7.16.5",
         "@bugsnag/plugin-angular": "^7.16.5",
+        "@microsoft/signalr": "^7.0.0",
         "@ngneat/transloco": "^3.2.0",
         "@ngneat/transloco-locale": "^3.0.1",
         "@sillsdev/machine": "^2.2.3",
@@ -10794,6 +10795,38 @@
         "@material/theme": "^5.1.0"
       }
     },
+    "node_modules/@microsoft/signalr": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-7.0.0.tgz",
+      "integrity": "sha512-9bHYqc0cjN0fL1KnK+MhlN0Qd/rp8Na4pzKYSV3wP8VC8p7188dvvmRTreYLXXh0srRLf9aMBj0ZbdZQwfnL/A==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "eventsource": "^2.0.2",
+        "fetch-cookie": "^2.0.3",
+        "node-fetch": "^2.6.7",
+        "ws": "^7.4.5"
+      }
+    },
+    "node_modules/@microsoft/signalr/node_modules/ws": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@ngneat/transloco": {
       "version": "3.2.0",
       "license": "MIT",
@@ -11988,6 +12021,17 @@
       "version": "1.1.1",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
     },
     "node_modules/abortcontroller-polyfill": {
       "version": "1.7.3",
@@ -14946,6 +14990,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter-asyncresource": {
       "version": "1.0.0",
       "dev": true,
@@ -14962,6 +15014,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/execa": {
@@ -15221,6 +15281,15 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fetch-cookie": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-2.1.0.tgz",
+      "integrity": "sha512-39+cZRbWfbibmj22R2Jy6dmTbAWC+oqun1f1FzQaNurkPDUP4C38jpeZbiXCR88RKRVDp8UcDrbFXkNhN+NjYg==",
+      "dependencies": {
+        "set-cookie-parser": "^2.4.8",
+        "tough-cookie": "^4.0.0"
       }
     },
     "node_modules/figures": {
@@ -18169,7 +18238,6 @@
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -22396,6 +22464,11 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "license": "MIT",
@@ -22431,6 +22504,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -22850,7 +22928,6 @@
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -23304,6 +23381,11 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
+      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -24126,9 +24208,30 @@
         "node": ">=6"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
+      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tree-kill": {
@@ -24440,6 +24543,15 @@
       "version": "4.0.1",
       "license": "MIT"
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/urlgrey": {
       "version": "1.0.0",
       "dev": true,
@@ -24537,7 +24649,6 @@
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
@@ -24954,7 +25065,6 @@
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -27718,6 +27828,25 @@
         "@material/theme": "^5.1.0"
       }
     },
+    "@microsoft/signalr": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-7.0.0.tgz",
+      "integrity": "sha512-9bHYqc0cjN0fL1KnK+MhlN0Qd/rp8Na4pzKYSV3wP8VC8p7188dvvmRTreYLXXh0srRLf9aMBj0ZbdZQwfnL/A==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "eventsource": "^2.0.2",
+        "fetch-cookie": "^2.0.3",
+        "node-fetch": "^2.6.7",
+        "ws": "^7.4.5"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.5.9",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
+        }
+      }
+    },
     "@ngneat/transloco": {
       "version": "3.2.0",
       "requires": {
@@ -28502,6 +28631,14 @@
     "abbrev": {
       "version": "1.1.1",
       "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "abortcontroller-polyfill": {
       "version": "1.7.3"
@@ -30353,6 +30490,11 @@
       "version": "1.8.1",
       "dev": true
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "eventemitter-asyncresource": {
       "version": "1.0.0",
       "dev": true
@@ -30364,6 +30506,11 @@
     "events": {
       "version": "3.3.0",
       "dev": true
+    },
+    "eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA=="
     },
     "execa": {
       "version": "6.1.0",
@@ -30549,6 +30696,15 @@
       "dev": true,
       "requires": {
         "websocket-driver": ">=0.5.1"
+      }
+    },
+    "fetch-cookie": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-2.1.0.tgz",
+      "integrity": "sha512-39+cZRbWfbibmj22R2Jy6dmTbAWC+oqun1f1FzQaNurkPDUP4C38jpeZbiXCR88RKRVDp8UcDrbFXkNhN+NjYg==",
+      "requires": {
+        "set-cookie-parser": "^2.4.8",
+        "tough-cookie": "^4.0.0"
       }
     },
     "figures": {
@@ -32375,7 +32531,6 @@
     },
     "node-fetch": {
       "version": "2.6.7",
-      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -35094,6 +35249,11 @@
       "dev": true,
       "optional": true
     },
+    "psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+    },
     "pump": {
       "version": "3.0.0",
       "requires": {
@@ -35113,6 +35273,11 @@
       "requires": {
         "side-channel": "^1.0.4"
       }
+    },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -40087,8 +40252,7 @@
       "version": "2.0.2"
     },
     "requires-port": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "resolve": {
       "version": "1.22.1",
@@ -40377,6 +40541,11 @@
     "set-blocking": {
       "version": "2.0.0",
       "dev": true
+    },
+    "set-cookie-parser": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
+      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ=="
     },
     "setprototypeof": {
       "version": "1.2.0",
@@ -40900,9 +41069,26 @@
       "version": "1.1.0",
       "dev": true
     },
+    "tough-cookie": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
+      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "requires": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+          "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="
+        }
+      }
+    },
     "tr46": {
-      "version": "0.0.3",
-      "dev": true
+      "version": "0.0.3"
     },
     "tree-kill": {
       "version": "1.2.2",
@@ -41085,6 +41271,15 @@
     "url-join": {
       "version": "4.0.1"
     },
+    "url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "urlgrey": {
       "version": "1.0.0",
       "dev": true,
@@ -41151,8 +41346,7 @@
       }
     },
     "webidl-conversions": {
-      "version": "3.0.1",
-      "dev": true
+      "version": "3.0.1"
     },
     "webpack": {
       "version": "5.74.0",
@@ -41393,7 +41587,6 @@
     },
     "whatwg-url": {
       "version": "5.0.0",
-      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -38,6 +38,7 @@
     "@auth0/auth0-spa-js": "^1.21.0",
     "@bugsnag/js": "^7.16.5",
     "@bugsnag/plugin-angular": "^7.16.5",
+    "@microsoft/signalr": "^7.0.0",
     "@ngneat/transloco": "^3.2.0",
     "@ngneat/transloco-locale": "^3.0.1",
     "@sillsdev/machine": "^2.2.3",

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
@@ -263,7 +263,7 @@ describe('ConnectProjectComponent', () => {
     expect(env.component.state).toEqual('connecting');
     expect(env.submitButton).toBeNull();
     expect(env.progressBar).not.toBeNull();
-    env.emitSyncProgress();
+    env.setQueuedCount();
     env.emitSyncComplete();
 
     const settings: SFProjectCreateSettings = {
@@ -290,7 +290,7 @@ describe('ConnectProjectComponent', () => {
 
     expect(env.component.state).toEqual('connecting');
     expect(env.progressBar).not.toBeNull();
-    env.emitSyncProgress();
+    env.setQueuedCount();
     env.emitSyncComplete();
 
     const project: SFProjectCreateSettings = {
@@ -356,7 +356,7 @@ describe('ConnectProjectComponent', () => {
     env.clickElement(env.submitButton);
 
     expect(env.component.state).toEqual('connecting');
-    env.emitSyncProgress();
+    env.setQueuedCount();
     env.emitSyncComplete();
 
     const settings: SFProjectCreateSettings = {
@@ -556,7 +556,7 @@ class TestEnvironment {
     return element.nativeElement.querySelector('input') as HTMLInputElement;
   }
 
-  emitSyncProgress(): void {
+  setQueuedCount(): void {
     const projectDoc = this.realtimeService.get<SFProjectDoc>(SFProjectDoc.COLLECTION, 'project01');
     projectDoc.submitJson0Op(op => op.set<number>(p => p.sync.queuedCount, 1), false);
     tick();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/project-notification.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/project-notification.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { HubConnection, HubConnectionBuilder } from '@microsoft/signalr';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ProjectNotificationService {
+  private connection: HubConnection;
+
+  constructor() {
+    this.connection = new HubConnectionBuilder().withUrl('/project-notifications').build();
+  }
+
+  setNotifySyncProgressHandler(handler: any): void {
+    this.connection.on('notifySyncProgress', handler);
+  }
+
+  async start(): Promise<void> {
+    await this.connection.start();
+  }
+
+  async stop(): Promise<void> {
+    await this.connection.stop();
+  }
+
+  async subscribeToProject(projectId: string): Promise<void> {
+    await this.connection.send('subscribeToProject', projectId);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.spec.ts
@@ -45,7 +45,7 @@ describe('SyncProgressComponent', () => {
     const env = new TestEnvironment({ userId: 'user01', sourceProject: 'invalid_source' });
     env.setupProjectDoc();
     verify(mockedProjectService.onlineGetProjectRole('invalid_source')).once();
-    env.emitSyncProgress(0.5, 'testProject01');
+    env.updateSyncProgress(0.5, 'testProject01');
     expect(env.host.inProgress).toBe(true);
     expect(env.host.syncProgress.syncProgressPercent).toEqual(50);
     env.emitSyncComplete(true, 'testProject01');
@@ -56,12 +56,12 @@ describe('SyncProgressComponent', () => {
     const env = new TestEnvironment({ userId: 'user01' });
     env.setupProjectDoc();
     // Simulate sync starting
-    env.emitSyncProgress(0, 'testProject01');
+    env.updateSyncProgress(0, 'testProject01');
     expect(env.progressBar).not.toBeNull();
     expect(env.host.syncProgress.mode).toBe('indeterminate');
     verify(mockedProjectService.onlineGetProjectRole('sourceProject02')).never();
     // Simulate sync in progress
-    env.emitSyncProgress(0.5, 'testProject01');
+    env.updateSyncProgress(0.5, 'testProject01');
     expect(env.host.syncProgress.mode).toBe('determinate');
     // Simulate sync completed
     env.emitSyncComplete(true, 'testProject01');
@@ -91,11 +91,11 @@ describe('SyncProgressComponent', () => {
   it('does not access source project if user does not have a paratext role', fakeAsync(() => {
     const env = new TestEnvironment({ userId: 'user01' });
     env.setupProjectDoc();
-    env.emitSyncProgress(0, 'testProject01');
-    env.emitSyncProgress(0, 'sourceProject02');
+    env.updateSyncProgress(0, 'testProject01');
+    env.updateSyncProgress(0, 'sourceProject02');
     verify(mockedProjectService.get('sourceProject02')).never();
     env.emitSyncComplete(true, 'sourceProject02');
-    env.emitSyncProgress(0.5, 'testProject01');
+    env.updateSyncProgress(0.5, 'testProject01');
     expect(env.host.syncProgress.syncProgressPercent).toEqual(50);
     env.emitSyncComplete(true, 'testProject01');
   }));
@@ -233,7 +233,7 @@ class TestEnvironment {
     return this.fixture.nativeElement.querySelector('mat-progress-bar');
   }
 
-  emitSyncProgress(percentCompleted: number, projectId: string): void {
+  updateSyncProgress(percentCompleted: number, projectId: string): void {
     const projectDoc = this.realtimeService.get<SFProjectDoc>(SFProjectDoc.COLLECTION, projectId);
     projectDoc.submitJson0Op(ops => {
       ops.set<number>(p => p.sync.queuedCount, 1);
@@ -265,19 +265,19 @@ class TestEnvironment {
   }
 
   checkCombinedProgress(): void {
-    this.emitSyncProgress(0, 'testProject01');
-    this.emitSyncProgress(0, 'sourceProject02');
+    this.updateSyncProgress(0, 'testProject01');
+    this.updateSyncProgress(0, 'sourceProject02');
     verify(mockedProjectService.onlineGetProjectRole('sourceProject02')).once();
     verify(mockedProjectService.get('sourceProject02')).once();
     expect(this.progressBar).not.toBeNull();
     expect(this.host.syncProgress.mode).toBe('indeterminate');
-    this.emitSyncProgress(0.8, 'sourceProject02');
+    this.updateSyncProgress(0.8, 'sourceProject02');
     expect(this.host.syncProgress.syncProgressPercent).toEqual(40);
     expect(this.host.syncProgress.mode).toBe('determinate');
     this.emitSyncComplete(true, 'sourceProject02');
     expect(this.host.syncProgress.syncProgressPercent).toEqual(50);
     expect(this.host.syncProgress.mode).toBe('determinate');
-    this.emitSyncProgress(0.8, 'testProject01');
+    this.updateSyncProgress(0.8, 'testProject01');
     expect(this.host.syncProgress.syncProgressPercent).toEqual(90);
     this.emitSyncComplete(true, 'testProject01');
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.spec.ts
@@ -276,7 +276,7 @@ class TestEnvironment {
     expect(this.host.syncProgress.mode).toBe('determinate');
     this.emitSyncComplete(true, 'sourceProject02');
     expect(this.host.syncProgress.syncProgressPercent).toEqual(50);
-    expect(this.host.syncProgress.mode).toBe('indeterminate');
+    expect(this.host.syncProgress.mode).toBe('determinate');
     this.emitSyncProgress(0.8, 'testProject01');
     expect(this.host.syncProgress.syncProgressPercent).toEqual(90);
     this.emitSyncComplete(true, 'testProject01');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
@@ -48,10 +48,8 @@ export class SyncProgressComponent extends SubscriptionDisposable {
   }
 
   get mode(): ProgressBarMode {
-    // Show indeterminate at the beginning and at the halfway point if a source project was synced
-    const sourceSyncCompleted = this.sourceProjectDoc?.data != null && this.sourceProjectDoc.data.sync.queuedCount < 1;
-    const isDeterminate = sourceSyncCompleted ? this.syncProgressPercent > 50 : this.syncProgressPercent > 0;
-    return isDeterminate ? 'determinate' : 'indeterminate';
+    // Show indeterminate only at the beginning, as the sync has not yet started
+    return this.syncProgressPercent > 0 ? 'determinate' : 'indeterminate';
   }
 
   async initialize(): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
@@ -89,20 +89,11 @@ export class SyncProgressComponent extends SubscriptionDisposable {
   }
 
   public updateProgressState(projectId: string, progressState: ProgressState) {
-    if (this.sourceProjectDoc?.data == null) {
-      // There is no source project, so only check the target
-      if (this._projectDoc?.id === projectId) {
-        this.progressPercent = progressState.progressValue;
-      }
-    } else {
-      if (this.sourceProjectDoc.data.sync.queuedCount > 0 && this.sourceProjectDoc.id === projectId) {
-        // We are syncing the source project
-        this.progressPercent = progressState.progressValue * 0.5;
-      } else if (this._projectDoc?.id === projectId) {
-        // We are syncing the target project
-        // The source project has synchronized so this is the midway point
-        this.progressPercent = 0.5 + progressState.progressValue * 0.5;
-      }
+    const hasSourceProject = this.sourceProjectDoc?.data != null;
+    if (projectId === this._projectDoc?.id) {
+      this.progressPercent = hasSourceProject ? 0.5 + progressState.progressValue * 0.5 : progressState.progressValue;
+    } else if (hasSourceProject && projectId === this.sourceProjectDoc?.id) {
+      this.progressPercent = progressState.progressValue * 0.5;
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
@@ -123,7 +123,7 @@ describe('SyncComponent', () => {
     expect(env.component.syncActive).toBe(true);
     expect(env.progressBar).not.toBeNull();
     // Simulate sync in progress
-    env.emitSyncProgress(env.projectId);
+    env.setQueuedCount(env.projectId);
 
     // Simulate sync error
     env.emitSyncComplete(false, env.projectId);
@@ -191,7 +191,7 @@ describe('SyncComponent', () => {
     verify(mockedProjectService.onlineSync(env.projectId)).once();
     expect(env.component.syncActive).toBe(true);
     expect(env.progressBar).not.toBeNull();
-    env.emitSyncProgress(env.projectId);
+    env.setQueuedCount(env.projectId);
 
     env.clickElement(env.cancelButton);
     env.emitSyncComplete(false, env.projectId);
@@ -246,7 +246,7 @@ class TestEnvironment {
     const ptUsername = isParatextAccountConnected ? 'Paratext User01' : '';
     when(mockedParatextService.getParatextUsername()).thenReturn(of(ptUsername));
     when(mockedProjectService.onlineSync(anything()))
-      .thenCall(id => this.emitSyncProgress(id))
+      .thenCall(id => this.setQueuedCount(id))
       .thenResolve();
     when(mockedNoticeService.loadingStarted()).thenCall(() => (this.isLoading = true));
     when(mockedNoticeService.loadingFinished()).thenCall(() => (this.isLoading = false));
@@ -357,7 +357,7 @@ class TestEnvironment {
     tick();
   }
 
-  emitSyncProgress(projectId: string): void {
+  setQueuedCount(projectId: string): void {
     const projectDoc = this.realtimeService.get<SFProjectDoc>(SFProjectDoc.COLLECTION, projectId);
     projectDoc.submitJson0Op(op => op.set<number>(p => p.sync.queuedCount, 1), false);
     this.fixture.detectChanges();

--- a/src/SIL.XForge.Scripture/Models/ProgressState.cs
+++ b/src/SIL.XForge.Scripture/Models/ProgressState.cs
@@ -2,7 +2,9 @@ namespace SIL.XForge.Scripture.Models
 {
     public class ProgressState
     {
-        public string ProgressString { get; set; } = string.Empty;
+        public static ProgressState Completed = new ProgressState { ProgressValue = 100.0 };
+        public static ProgressState NotStarted = new ProgressState { ProgressValue = 0.0 };
+        public string? ProgressString { get; set; }
         public double ProgressValue { get; set; }
     }
 }

--- a/src/SIL.XForge.Scripture/Models/ProgressState.cs
+++ b/src/SIL.XForge.Scripture/Models/ProgressState.cs
@@ -2,7 +2,7 @@ namespace SIL.XForge.Scripture.Models
 {
     public class ProgressState
     {
-        public string ProgressString { get; set; }
+        public string ProgressString { get; set; } = string.Empty;
         public double ProgressValue { get; set; }
     }
 }

--- a/src/SIL.XForge.Scripture/Models/ProgressState.cs
+++ b/src/SIL.XForge.Scripture/Models/ProgressState.cs
@@ -2,8 +2,8 @@ namespace SIL.XForge.Scripture.Models
 {
     public class ProgressState
     {
-        public static ProgressState Completed = new ProgressState { ProgressValue = 100.0 };
-        public static ProgressState NotStarted = new ProgressState { ProgressValue = 0.0 };
+        public static readonly ProgressState Completed = new ProgressState { ProgressValue = 1.0 };
+        public static readonly ProgressState NotStarted = new ProgressState { ProgressValue = 0.0 };
         public string? ProgressString { get; set; }
         public double ProgressValue { get; set; }
     }

--- a/src/SIL.XForge.Scripture/Models/Sync.cs
+++ b/src/SIL.XForge.Scripture/Models/Sync.cs
@@ -5,7 +5,6 @@ namespace SIL.XForge.Scripture.Models
     public class Sync
     {
         public int QueuedCount { get; set; }
-        public double? PercentCompleted { get; set; }
         public bool? LastSyncSuccessful { get; set; }
         public DateTime? DateLastSuccessfulSync { get; set; }
 

--- a/src/SIL.XForge.Scripture/Services/INotifier.cs
+++ b/src/SIL.XForge.Scripture/Services/INotifier.cs
@@ -5,7 +5,7 @@ namespace SIL.XForge.Scripture.Services
 {
     public interface INotifier
     {
-        Task NotifySyncProgress(string sfProjectId, ProgressState? progressState);
+        Task NotifySyncProgress(string sfProjectId, ProgressState progressState);
         Task SubscribeToProject(string projectId);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/INotifier.cs
+++ b/src/SIL.XForge.Scripture/Services/INotifier.cs
@@ -5,6 +5,7 @@ namespace SIL.XForge.Scripture.Services
 {
     public interface INotifier
     {
-        Task NotifySyncProgress(string sfProjectId, ProgressState progressState);
+        Task NotifySyncProgress(string sfProjectId, ProgressState? progressState);
+        Task SubscribeToProject(string projectId);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/INotifier.cs
+++ b/src/SIL.XForge.Scripture/Services/INotifier.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using SIL.XForge.Scripture.Models;
+
+namespace SIL.XForge.Scripture.Services
+{
+    public interface INotifier
+    {
+        Task NotifySyncProgress(string sfProjectId, ProgressState progressState);
+    }
+}

--- a/src/SIL.XForge.Scripture/Services/NotificationHub.cs
+++ b/src/SIL.XForge.Scripture/Services/NotificationHub.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using SIL.XForge.Scripture.Models;
+
+namespace SIL.XForge.Scripture.Services
+{
+    public class NotificationHub : Hub<INotifier>, INotifier
+    {
+        public async Task NotifySyncProgress(string projectId, ProgressState progressState) =>
+            await Clients.All.NotifySyncProgress(projectId, progressState);
+    }
+}

--- a/src/SIL.XForge.Scripture/Services/NotificationHub.cs
+++ b/src/SIL.XForge.Scripture/Services/NotificationHub.cs
@@ -6,7 +6,10 @@ namespace SIL.XForge.Scripture.Services
 {
     public class NotificationHub : Hub<INotifier>, INotifier
     {
-        public async Task NotifySyncProgress(string projectId, ProgressState progressState) =>
-            await Clients.All.NotifySyncProgress(projectId, progressState);
+        public async Task NotifySyncProgress(string projectId, ProgressState? progressState) =>
+            await Clients.Group(projectId).NotifySyncProgress(projectId, progressState);
+
+        public async Task SubscribeToProject(string projectId) =>
+            await Groups.AddToGroupAsync(Context.ConnectionId, projectId);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/NotificationHub.cs
+++ b/src/SIL.XForge.Scripture/Services/NotificationHub.cs
@@ -6,7 +6,7 @@ namespace SIL.XForge.Scripture.Services
 {
     public class NotificationHub : Hub<INotifier>, INotifier
     {
-        public async Task NotifySyncProgress(string projectId, ProgressState? progressState) =>
+        public async Task NotifySyncProgress(string projectId, ProgressState progressState) =>
             await Clients.Group(projectId).NotifySyncProgress(projectId, progressState);
 
         public async Task SubscribeToProject(string projectId) =>

--- a/src/SIL.XForge.Scripture/Services/NotificationHub.cs
+++ b/src/SIL.XForge.Scripture/Services/NotificationHub.cs
@@ -6,9 +6,24 @@ namespace SIL.XForge.Scripture.Services
 {
     public class NotificationHub : Hub<INotifier>, INotifier
     {
+        /// <summary>
+        /// Notifies subscribers to a project of sync progress.
+        /// </summary>
+        /// <param name="projectId">The Scripture Forge project identifier.</param>
+        /// <param name="progressState">
+        /// The progress state, including a string value (Paratext only - not used in SF), or percentage value.
+        /// </param>
+        /// <returns>The asynchronous task.</returns>
         public async Task NotifySyncProgress(string projectId, ProgressState progressState) =>
             await Clients.Group(projectId).NotifySyncProgress(projectId, progressState);
 
+        /// <summary>
+        /// Subscribe to notifications for a project.
+        ///
+        /// This is called from the frontend via <c>project-notification.service.ts</c>.
+        /// </summary>
+        /// <param name="projectId">The Scripture Forge project identifier.</param>
+        /// <returns>The asynchronous task.</returns>
         public async Task SubscribeToProject(string projectId) =>
             await Groups.AddToGroupAsync(Context.ConnectionId, projectId);
     }

--- a/src/SIL.XForge.Scripture/Services/NotificationHubExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/NotificationHubExtensions.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using SIL.XForge.Scripture.Models;
+
+namespace SIL.XForge.Scripture.Services
+{
+    public static class NotificationHubExtensions
+    {
+        public static Task NotifySyncProgress(
+            this IHubContext<NotificationHub, INotifier> hubContext,
+            string projectId,
+            ProgressState? progressState
+        ) => hubContext.Clients.Groups(projectId).NotifySyncProgress(projectId, progressState);
+    }
+}

--- a/src/SIL.XForge.Scripture/Services/NotificationHubExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/NotificationHubExtensions.cs
@@ -9,7 +9,7 @@ namespace SIL.XForge.Scripture.Services
         public static Task NotifySyncProgress(
             this IHubContext<NotificationHub, INotifier> hubContext,
             string projectId,
-            ProgressState? progressState
+            ProgressState progressState
         ) => hubContext.Clients.Groups(projectId).NotifySyncProgress(projectId, progressState);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2474,7 +2474,7 @@ namespace SIL.XForge.Scripture.Services
         }
 
         // Make sure there are no asynchronous methods called after this until the progress is completed.
-        private void StartProgressReporting(IProgress<ProgressState> progress)
+        private void StartProgressReporting(IProgress<ProgressState>? progress)
         {
             if (progress == null)
                 return;

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -225,9 +225,9 @@ namespace SIL.XForge.Scripture.Services
                 );
             }
             EnsureProjectReposExists(userSecret, ptProject, source);
-            StartProgressReporting(progress);
-            if (!(ptProject is ParatextResource))
+            if (ptProject is not ParatextResource)
             {
+                StartProgressReporting(progress);
                 SharedProject sharedProj = CreateSharedProject(
                     userSecret,
                     paratextId,

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -613,7 +613,7 @@ namespace SIL.XForge.Scripture.Services
 
             await _notesMapper.InitAsync(_userSecret, _projectSecret, paratextUsers, _projectDoc.Data, token);
 
-            await _hubContext.Clients.All.NotifySyncProgress(projectSFId, new ProgressState { ProgressValue = 0.0 });
+            await _hubContext.NotifySyncProgress(projectSFId, new ProgressState { ProgressValue = 0.0 });
             return true;
         }
 
@@ -1372,7 +1372,7 @@ namespace SIL.XForge.Scripture.Services
                         op.Set(pd => pd.TranslateConfig.Source.IsRightToLeft, sourceSettings.IsRightToLeft);
                 }
             });
-            await _hubContext.Clients.All.NotifySyncProgress(_projectDoc.Id, null);
+            await _hubContext.NotifySyncProgress(_projectDoc.Id, null);
 
             if (_syncMetrics != null)
             {
@@ -1574,7 +1574,7 @@ namespace SIL.XForge.Scripture.Services
             }
             else if (sender is SyncProgress progress)
             {
-                await _hubContext.Clients.All.NotifySyncProgress(
+                await _hubContext.NotifySyncProgress(
                     _projectDoc.Id,
                     new ProgressState { ProgressValue = progress.ProgressValue }
                 );

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -613,7 +613,7 @@ namespace SIL.XForge.Scripture.Services
 
             await _notesMapper.InitAsync(_userSecret, _projectSecret, paratextUsers, _projectDoc.Data, token);
 
-            await _hubContext.NotifySyncProgress(projectSFId, new ProgressState { ProgressValue = 0.0 });
+            await _hubContext.NotifySyncProgress(projectSFId, ProgressState.NotStarted);
             return true;
         }
 
@@ -1372,7 +1372,7 @@ namespace SIL.XForge.Scripture.Services
                         op.Set(pd => pd.TranslateConfig.Source.IsRightToLeft, sourceSettings.IsRightToLeft);
                 }
             });
-            await _hubContext.NotifySyncProgress(_projectDoc.Id, null);
+            await _hubContext.NotifySyncProgress(_projectDoc.Id, ProgressState.Completed);
 
             if (_syncMetrics != null)
             {

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 using SIL.ObjectModel;
 using SIL.Scripture;
@@ -68,6 +69,7 @@ namespace SIL.XForge.Scripture.Services
         private readonly IDeltaUsxMapper _deltaUsxMapper;
         private readonly IParatextNotesMapper _notesMapper;
         private readonly ILogger<ParatextSyncRunner> _logger;
+        private readonly IHubContext<NotificationHub, INotifier> _hubContext;
 
         private IConnection _conn;
         private UserSecret _userSecret;
@@ -86,6 +88,7 @@ namespace SIL.XForge.Scripture.Services
             IRealtimeService realtimeService,
             IDeltaUsxMapper deltaUsxMapper,
             IParatextNotesMapper notesMapper,
+            IHubContext<NotificationHub, INotifier> hubContext,
             ILogger<ParatextSyncRunner> logger
         )
         {
@@ -99,6 +102,7 @@ namespace SIL.XForge.Scripture.Services
             _logger = logger;
             _deltaUsxMapper = deltaUsxMapper;
             _notesMapper = notesMapper;
+            _hubContext = hubContext;
         }
 
         private bool TranslationSuggestionsEnabled => _projectDoc.Data.TranslateConfig.TranslationSuggestionsEnabled;
@@ -577,7 +581,6 @@ namespace SIL.XForge.Scripture.Services
 
             _conn = await _realtimeService.ConnectAsync();
             _conn.BeginTransaction();
-            _conn.ExcludePropertyFromTransaction<SFProject>(op => op.Sync.PercentCompleted);
             _conn.ExcludePropertyFromTransaction<SFProject>(op => op.Sync.QueuedCount);
             _conn.ExcludePropertyFromTransaction<SFProject>(op => op.Sync.DataInSync);
             _projectDoc = await _conn.FetchAsync<SFProject>(projectSFId);
@@ -610,7 +613,7 @@ namespace SIL.XForge.Scripture.Services
 
             await _notesMapper.InitAsync(_userSecret, _projectSecret, paratextUsers, _projectDoc.Data, token);
 
-            await _projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.Sync.PercentCompleted, 0));
+            await _hubContext.Clients.All.NotifySyncProgress(projectSFId, new ProgressState { ProgressValue = 0.0 });
             return true;
         }
 
@@ -1287,10 +1290,9 @@ namespace SIL.XForge.Scripture.Services
                 }
             }
 
-            // NOTE: This is executed outside of the transaction because it modifies "Sync.PercentCompleted"
+            // NOTE: This is executed outside of the transaction because it modifies "Sync.QueuedCount"
             await _projectDoc.SubmitJson0OpAsync(op =>
             {
-                op.Unset(pd => pd.Sync.PercentCompleted);
                 op.Set(pd => pd.Sync.LastSyncSuccessful, successful);
 
                 // Get the latest shared revision of the local hg repo. On a failed synchronize attempt, the data
@@ -1370,6 +1372,7 @@ namespace SIL.XForge.Scripture.Services
                         op.Set(pd => pd.TranslateConfig.Source.IsRightToLeft, sourceSettings.IsRightToLeft);
                 }
             });
+            await _hubContext.Clients.All.NotifySyncProgress(_projectDoc.Id, null);
 
             if (_syncMetrics != null)
             {
@@ -1571,13 +1574,10 @@ namespace SIL.XForge.Scripture.Services
             }
             else if (sender is SyncProgress progress)
             {
-                double percentCompleted = progress.ProgressValue;
-                if (percentCompleted >= 0)
-                {
-                    await _projectDoc.SubmitJson0OpAsync(
-                        op => op.Set(pd => pd.Sync.PercentCompleted, percentCompleted)
-                    );
-                }
+                await _hubContext.Clients.All.NotifySyncProgress(
+                    _projectDoc.Id,
+                    new ProgressState { ProgressValue = progress.ProgressValue }
+                );
             }
         }
 

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -160,6 +160,7 @@ namespace SIL.XForge.Scripture.Services
                 }
 
                 ReportRepoRevs();
+                await NotifySyncProgress(SyncPhase.Phase1, 50.0);
 
                 if (_paratextService.IsResource(targetParatextId))
                 {
@@ -187,8 +188,17 @@ namespace SIL.XForge.Scripture.Services
                 var questionDocsByBook = new Dictionary<int, IReadOnlyList<IDocument<Question>>>();
                 ParatextSettings settings = _paratextService.GetParatextSettings(_userSecret, targetParatextId);
                 // update target Paratext books and notes
+                double i = 0.0;
                 foreach (TextInfo text in _projectDoc.Data.Texts)
                 {
+                    i++;
+
+                    // A resource does not sync to Paratext, so lets skip phase 2 to make the progress bar look better
+                    await NotifySyncProgress(
+                        _paratextService.IsResource(targetParatextId) ? SyncPhase.Phase3 : SyncPhase.Phase2,
+                        i / _projectDoc.Data.Texts.Count
+                    );
+
                     LogMetric($"Updating Paratext book {text.BookNum}");
                     if (settings == null)
                     {
@@ -249,6 +259,8 @@ namespace SIL.XForge.Scripture.Services
                     progress.ProgressUpdated -= SyncProgress_ProgressUpdated;
                 }
 
+                await NotifySyncProgress(SyncPhase.Phase4, 30.0);
+
                 // Check for cancellation
                 if (token.IsCancellationRequested)
                 {
@@ -292,6 +304,8 @@ namespace SIL.XForge.Scripture.Services
 
                     _syncMetrics.Books.Deleted = targetBooksToDelete.Count;
                 }
+
+                await NotifySyncProgress(SyncPhase.Phase4, 60.0);
 
                 // Check for cancellation
                 if (token.IsCancellationRequested)
@@ -364,6 +378,8 @@ namespace SIL.XForge.Scripture.Services
                     }
                 }
 
+                await NotifySyncProgress(SyncPhase.Phase4, 90.0);
+
                 bool resourceNeedsUpdating =
                     paratextProject is ParatextResource paratextResource
                     && _paratextService.ResourceDocsNeedUpdating(_projectDoc.Data, paratextResource);
@@ -379,6 +395,7 @@ namespace SIL.XForge.Scripture.Services
                         token
                     );
                 }
+                await NotifySyncProgress(SyncPhase.Phase6, 20.0);
 
                 // Check for cancellation
                 if (token.IsCancellationRequested)
@@ -397,6 +414,8 @@ namespace SIL.XForge.Scripture.Services
                 // We will always update permissions, even if this is a resource project
                 LogMetric("Updating permissions");
                 await _projectService.UpdatePermissionsAsync(userId, _projectDoc, token);
+
+                await NotifySyncProgress(SyncPhase.Phase6, 40.0);
 
                 // Check for cancellation
                 if (token.IsCancellationRequested)
@@ -494,8 +513,11 @@ namespace SIL.XForge.Scripture.Services
             Dictionary<string, string> ptUsernamesToSFUserIds = await GetPTUsernameToSFUserIdsAsync(token);
 
             // update source and target real-time docs
+            double i = 0.0;
             foreach (int bookNum in targetBooks)
             {
+                i++;
+                await NotifySyncProgress(SyncPhase.Phase5, i / targetBooks.Count);
                 LogMetric($"Updating text info for book {bookNum}");
                 bool hasSource = sourceBooks.Contains(bookNum);
                 int textIndex = _projectDoc.Data.Texts.FindIndex(t => t.BookNum == bookNum);
@@ -565,6 +587,7 @@ namespace SIL.XForge.Scripture.Services
             CancellationToken token
         )
         {
+            await _hubContext.NotifySyncProgress(projectSFId, ProgressState.NotStarted);
             _logger.LogInformation($"Initializing sync for project {projectSFId} with sync metrics id {syncMetricsId}");
             if (!(await _syncMetricsRepository.TryGetAsync(syncMetricsId)).TryResult(out _syncMetrics))
             {
@@ -590,6 +613,8 @@ namespace SIL.XForge.Scripture.Services
                 return false;
             }
 
+            await NotifySyncProgress(SyncPhase.Phase1, 10.0);
+
             if (!(await _projectSecrets.TryGetAsync(projectSFId)).TryResult(out _projectSecret))
             {
                 Log($"Could not find project secret.", projectSFId, userId);
@@ -613,7 +638,7 @@ namespace SIL.XForge.Scripture.Services
 
             await _notesMapper.InitAsync(_userSecret, _projectSecret, paratextUsers, _projectDoc.Data, token);
 
-            await _hubContext.NotifySyncProgress(projectSFId, ProgressState.NotStarted);
+            await NotifySyncProgress(SyncPhase.Phase1, 20.0);
             return true;
         }
 
@@ -1205,6 +1230,7 @@ namespace SIL.XForge.Scripture.Services
             CancellationToken token
         )
         {
+            await NotifySyncProgress(SyncPhase.Phase6, 60.0);
             if (token.IsCancellationRequested)
             {
                 Log($"CompleteSync: There was a cancellation request.");
@@ -1372,7 +1398,7 @@ namespace SIL.XForge.Scripture.Services
                         op.Set(pd => pd.TranslateConfig.Source.IsRightToLeft, sourceSettings.IsRightToLeft);
                 }
             });
-            await _hubContext.NotifySyncProgress(_projectDoc.Id, ProgressState.Completed);
+            await NotifySyncProgress(SyncPhase.Phase6, 80.0);
 
             if (_syncMetrics != null)
             {
@@ -1498,6 +1524,7 @@ namespace SIL.XForge.Scripture.Services
                 }
             }
 
+            await NotifySyncProgress(SyncPhase.Phase6, 100.0);
             Log($"CompleteSync: Finished. Sync was {(successful ? "successful" : "unsuccessful")}.");
         }
 
@@ -1574,11 +1601,34 @@ namespace SIL.XForge.Scripture.Services
             }
             else if (sender is SyncProgress progress)
             {
+                await NotifySyncProgress(SyncPhase.Phase3, progress.ProgressValue);
+            }
+        }
+
+        private async Task NotifySyncProgress(SyncPhase syncPhase, double progress)
+        {
+            if (_projectDoc is not null)
+            {
                 await _hubContext.NotifySyncProgress(
                     _projectDoc.Id,
-                    new ProgressState { ProgressValue = progress.ProgressValue }
+                    new ProgressState
+                    {
+                        // The fraction is based on the number of phases
+                        ProgressValue =
+                            1.0 / 6.0 * (double)syncPhase + (progress > 1.0 ? progress / 100.0 : progress) * 1.0 / 6.0,
+                    }
                 );
             }
+        }
+
+        private enum SyncPhase
+        {
+            Phase1 = 0, // Initial methods
+            Phase2 = 1, // Update Paratext books and notes
+            Phase3 = 2, // Paratext Sync
+            Phase4 = 3, // Deleting texts and granting resource access
+            Phase5 = 4, // Updating texts from Paratext books
+            Phase6 = 5, // Final methods
         }
 
         private class ChapterEqualityComparer : IEqualityComparer<Chapter>

--- a/src/SIL.XForge.Scripture/Services/SyncProgress.cs
+++ b/src/SIL.XForge.Scripture/Services/SyncProgress.cs
@@ -5,7 +5,7 @@ namespace SIL.XForge.Scripture.Services
 {
     public class SyncProgress : IProgress<ProgressState>
     {
-        public event EventHandler ProgressUpdated;
+        public event EventHandler? ProgressUpdated;
         private string _progressString = "";
         private double _progressValue = 0;
 
@@ -20,7 +20,7 @@ namespace SIL.XForge.Scripture.Services
                 _progressString = progressState.ProgressString;
             if (progressState.ProgressValue > _progressValue)
                 _progressValue = progressState.ProgressValue;
-            OnProgressUpdated(new EventArgs());
+            OnProgressUpdated(EventArgs.Empty);
         }
 
         protected void OnProgressUpdated(EventArgs e)

--- a/src/SIL.XForge.Scripture/Services/SyncService.cs
+++ b/src/SIL.XForge.Scripture/Services/SyncService.cs
@@ -326,7 +326,7 @@ namespace SIL.XForge.Scripture.Services
                     $"For SF project id {projectDoc.Id} before setting QueuedCount to 0 as part of cancelling."
                 );
                 // Mark sync as cancelled
-                await _hubContext.NotifySyncProgress(projectDoc.Id, null);
+                await _hubContext.NotifySyncProgress(projectDoc.Id, ProgressState.Completed);
                 await projectDoc.SubmitJson0OpAsync(op =>
                 {
                     op.Set(pd => pd.Sync.QueuedCount, 0);

--- a/src/SIL.XForge.Scripture/Services/SyncService.cs
+++ b/src/SIL.XForge.Scripture/Services/SyncService.cs
@@ -326,7 +326,7 @@ namespace SIL.XForge.Scripture.Services
                     $"For SF project id {projectDoc.Id} before setting QueuedCount to 0 as part of cancelling."
                 );
                 // Mark sync as cancelled
-                await _hubContext.Clients.All.NotifySyncProgress(projectDoc.Id, null);
+                await _hubContext.NotifySyncProgress(projectDoc.Id, null);
                 await projectDoc.SubmitJson0OpAsync(op =>
                 {
                     op.Set(pd => pd.Sync.QueuedCount, 0);

--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement;
 using SIL.XForge.Configuration;
+using SIL.XForge.Scripture.Services;
 
 namespace SIL.XForge.Scripture
 {
@@ -132,6 +133,8 @@ namespace SIL.XForge.Scripture
             services.AddConfiguration(Configuration);
 
             services.AddFeatureManagement();
+
+            services.AddSignalR();
 
             string? nodeOptions = Configuration.GetValue<string>("node-options");
             services.AddSFRealtimeServer(LoggerFactory, Configuration, nodeOptions);
@@ -254,6 +257,7 @@ namespace SIL.XForge.Scripture
             {
                 endpoints.MapControllers();
                 endpoints.MapRazorPages();
+                endpoints.MapHub<NotificationHub>(pattern: "/project-notifications");
             });
 
             // Map JSON-RPC controllers after MVC controllers, so that MVC controllers take precedence.

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -1417,13 +1418,6 @@ namespace SIL.XForge.Scripture.Services
                 .Received(1)
                 .ExcludePropertyFromTransaction(
                     Arg.Is<Expression<Func<SFProject, object>>>(
-                        ex => string.Join('.', new ObjectPath(ex).Items) == "Sync.PercentCompleted"
-                    )
-                );
-            env.Connection
-                .Received(1)
-                .ExcludePropertyFromTransaction(
-                    Arg.Is<Expression<Func<SFProject, object>>>(
                         ex => string.Join('.', new ObjectPath(ex).Items) == "Sync.QueuedCount"
                     )
                 );
@@ -1434,7 +1428,7 @@ namespace SIL.XForge.Scripture.Services
                         ex => string.Join('.', new ObjectPath(ex).Items) == "Sync.DataInSync"
                     )
                 );
-            env.Connection.Received(3).ExcludePropertyFromTransaction(Arg.Any<Expression<Func<SFProject, object>>>());
+            env.Connection.Received(2).ExcludePropertyFromTransaction(Arg.Any<Expression<Func<SFProject, object>>>());
         }
 
         [Test]
@@ -2363,6 +2357,7 @@ namespace SIL.XForge.Scripture.Services
                 SubstituteRealtimeService.ConnectAsync().Returns(Task.FromResult(Connection));
                 DeltaUsxMapper = Substitute.For<IDeltaUsxMapper>();
                 NotesMapper = Substitute.For<IParatextNotesMapper>();
+                var hubContext = Substitute.For<IHubContext<NotificationHub, INotifier>>();
                 MockLogger = new MockLogger<ParatextSyncRunner>();
 
                 Runner = new ParatextSyncRunner(
@@ -2375,6 +2370,7 @@ namespace SIL.XForge.Scripture.Services
                     substituteRealtimeService ? SubstituteRealtimeService : RealtimeService,
                     DeltaUsxMapper,
                     NotesMapper,
+                    hubContext,
                     MockLogger
                 );
             }

--- a/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Hangfire;
 using Hangfire.Common;
 using Hangfire.States;
+using Microsoft.AspNetCore.SignalR;
 using NSubstitute;
 using NUnit.Framework;
 using SIL.XForge.DataAccess;
@@ -516,6 +517,7 @@ namespace SIL.XForge.Scripture.Services
             public TestEnvironment()
             {
                 BackgroundJobClient = Substitute.For<IBackgroundJobClient>();
+                var hubContext = Substitute.For<IHubContext<NotificationHub, INotifier>>();
                 ProjectSecrets = new MemoryRepository<SFProjectSecret>(
                     new[]
                     {
@@ -571,6 +573,7 @@ namespace SIL.XForge.Scripture.Services
 
                 Service = new SyncService(
                     BackgroundJobClient,
+                    hubContext,
                     ProjectSecrets,
                     SyncMetrics,
                     RealtimeService,


### PR DESCRIPTION
[SignalR](https://dotnet.microsoft.com/en-us/apps/aspnet/signalr) is included with ASP.NET 6.0, and is a cross-platform method of providing push notifications to clients. It is flexible, and can be scaled using Redis if SF was to grow beyond one server.

This PR
 * Changes the SF backend from updating `Sync.percentCompleted` with Paratext sync percentage updates to using a SignalR hub
 * Adds a project notification service utilizing SignalR to the frontend
 * Updates the Sync Progress component to use the new service (commit c8e17f5e181d09589f1d34c7115f656818c29adb)
 * Added more sync reporting of the different sync phases (commit 0d2c22cd8dc573803060f61cd352c2d08e4b9d4a)
 * Only shows indeterminate sync progress at the start of the sync (commit 258f4e9c190a66d528a9f21df1f80c8c123ace3d)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1654)
<!-- Reviewable:end -->
