### PR TITLE
SF-1313 The sync status now updates if another user starts a sync

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
@@ -142,6 +142,13 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
       this.projectDoc = await this.projectService.get(projectId);
       this.checkSyncStatus();
       this.loadingFinished();
+
+      // Check to see if a sync has started when the project document changes
+      this.subscribe(this.projectDoc.remoteChanges$, () => {
+        if (!this.syncActive) {
+          this.checkSyncStatus();
+        }
+      });
     });
   }
 


### PR DESCRIPTION
Previously, if a user stated a sync, and another user was on the sync page, the sync component would not automatically update with the sync progress.

This Pull Request updates the sync component so that the project document is monitored, and on any changes, the sync properties are checked for changes, and the sync UI updated. This also fixes SF-1202.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1655)
<!-- Reviewable:end -->
