### PR TITLE
SF-1421 The correct first chapter is now selected if chapter 1 is missing from a book

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1072,6 +1072,23 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('first chapter is missing', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setupProject();
+      env.setProjectUserConfig();
+      env.updateParams({ projectId: 'project01', bookId: 'ROM' });
+      env.wait();
+      expect(env.bookName).toEqual('Romans');
+      expect(env.component.chapter).toBe(2);
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
+      expect(env.component.target!.segmentRef).toEqual('');
+      const selection = env.targetEditor.getSelection();
+      expect(selection).toBeNull();
+      expect(env.component.canEdit).toBe(true);
+      env.dispose();
+    }));
+
     it('ensure direction is RTL when project is to set to RTL', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setupProject({ isRightToLeft: true });
@@ -2682,6 +2699,23 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('first chapter is missing', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setupProject({ translateConfig: defaultTranslateConfig });
+      env.setProjectUserConfig();
+      env.updateParams({ projectId: 'project01', bookId: 'ROM' });
+      env.wait();
+      expect(env.bookName).toEqual('Romans');
+      expect(env.component.chapter).toBe(2);
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
+      expect(env.component.target!.segmentRef).toEqual('');
+      const selection = env.targetEditor.getSelection();
+      expect(selection).toBeNull();
+      expect(env.component.canEdit).toBe(true);
+      env.dispose();
+    }));
+
     it('prevents editing and informs user when text doc is corrupted', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setupProject({ translateConfig: defaultTranslateConfig });
@@ -2878,6 +2912,19 @@ class TestEnvironment {
           }
         ],
         hasSource: true,
+        permissions: this.textInfoPermissions
+      },
+      {
+        bookNum: 45,
+        chapters: [
+          {
+            number: 2,
+            lastVerse: 3,
+            isValid: true,
+            permissions: this.textInfoPermissions
+          }
+        ],
+        hasSource: false,
         permissions: this.textInfoPermissions
       }
     ]

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1258,7 +1258,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   private loadProjectUserConfig() {
-    let chapter = 1;
+    let chapter = this.chapters.length > 0 ? this.chapters[0] : 1;
     if (this.projectUserConfigDoc != null && this.projectUserConfigDoc.data != null) {
       const pcnt = Math.round(this.projectUserConfigDoc.data.confidenceThreshold * 100);
       this.translationSuggester.confidenceThreshold = pcnt / 100;


### PR DESCRIPTION
When chapter one is removed from a book (see SF-1415), the editor will not select the new first chapter of the book. Instead, the chapter dropdown will be blank, and the user needs to manually select the first chapter.

This Pull Request updates the editor so that it will always select the first chapter of a book when that book is navigated to.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1656)
<!-- Reviewable:end -->
