### PR TITLE
Update dependencies to .NET 6.0.13

### DIFF
--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -20,8 +20,8 @@
   <ItemGroup>
     <PackageReference Include="DotNetZip" Version="1.16.0" />
     <PackageReference Include="IdentityModel.AspNetCore" Version="4.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.12" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.13" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.13" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="2.5.1" />
     <!-- When using a new major or minor version of ParatextData, update where dependencies.yml copies the
          InternetSettings.xml file. Also update server config scriptureforge.org_v2.yml. -->

--- a/src/SIL.XForge/SIL.XForge.csproj
+++ b/src/SIL.XForge/SIL.XForge.csproj
@@ -14,11 +14,11 @@
     <PackageReference Include="Hangfire.Mongo" Version="1.9.1" />
     <PackageReference Include="IdentityModel" Version="6.0.0" />
     <PackageReference Include="Jering.Javascript.NodeJS" Version="6.3.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.12" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="6.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="6.0.13" />
     <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
     <PackageReference Include="MailKit" Version="3.4.3" />
-    <PackageReference Include="idunno.Authentication.Basic" Version="2.2.3" />
+    <PackageReference Include="idunno.Authentication.Basic" Version="2.3.0" />
     <PackageReference Include="AbrarJahin.DiffMatchPatch" Version="0.1.0" />
     <PackageReference Include="SIL.Core" Version="10.1.0" />
   </ItemGroup>


### PR DESCRIPTION
This Pull Request updates:
 * idunno.Authentication.Basic to 2.3.0
 * Microsoft.AspNetCore.Mvc.NewtonsoftJson to 6.0.13
 * Microsoft.Extensions.Http.Polly to 6.0.13
 * Microsoft.AspNetCore.Authentication.JwtBearer to 6.0.13
 * Microsoft.AspNetCore.SpaServices.Extensions to 6.0.13
 
.NET 6.0.13 fixes a DoS vulnerability [CVE-2023-21538](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-21538).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1660)
<!-- Reviewable:end -->
