### PR TITLE
Fixed TypeScript Lint Issues

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/typings/quill.d.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/typings/quill.d.ts
@@ -27,7 +27,7 @@ declare module 'quill' {
   }
 
   export interface Selection {
-    getBounds(index: number, length?: number): ClientRect;
+    getBounds(index: number, length?: number): DOMRect;
     update(sources: Sources): void;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.spec.ts
@@ -103,9 +103,10 @@ describe('AuthHttpInterceptor', () => {
       expect(request.headers.get('authorization')).toEqual(`Bearer ${TestEnvironment.accessToken}`);
       return true;
     });
-    request.error(new ErrorEvent('Error', { message: 'An error occurred' }));
+    const mockError = new ProgressEvent('An error occurred');
+    request.error(mockError);
     tick();
-    expect(result!.error.message).toBe('An error occurred');
+    expect(result!.error).toBe(mockError);
     env.httpMock.verify();
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
@@ -594,7 +594,7 @@ class TestEnvironment {
   static encodeAccessToken(token: Auth0AccessToken) {
     // The response from auth0 contains 3 parts separated by a dot
     // jwtDecode does a base64 decode on a JSON string after the first dot
-    return '.' + btoa(JSON.stringify(token));
+    return '.' + window.btoa(JSON.stringify(token));
   }
 
   constructor({

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-utils.ts
@@ -143,7 +143,7 @@ export function getAudioBlob(): Blob {
     'ABgACAAIABgACAAYACgACAAoAAgASAAACABIABgACABIABgACABYAAAIACh4AABIeAAIACgACAAIACgAWAAIABgAWGgAABg4AAB' +
     'oAFhYAAAIAAhoADgAeAAIATgoAAAIAGhYACgACAA4AGgAOABoAGgASABoACgAeEgAKAAAWFgAABACKAFYAHgAGDgAAHgACABYAB' +
     'gACABAQCAMQA1wAhADB2A=';
-  const byteCharacters = atob(base64);
+  const byteCharacters = window.atob(base64);
   const byteNumbers = new Array(byteCharacters.length);
   for (let i = 0; i < byteCharacters.length; i++) {
     byteNumbers[i] = byteCharacters.charCodeAt(i);


### PR DESCRIPTION
This Pull Request fixes the following TypeScript lint issues:

 * *src\SIL.XForge.Scripture\ClientApp\src\typings\quill.d.ts*
   **30:48  warning  'ClientRect' is deprecated.**

 * *src\SIL.XForge.Scripture\ClientApp\src\xforge-common\auth-http-interceptor.spec.ts*
   **106:13  warning  'error' is deprecated. Http requests never emit an `ErrorEvent`. Please specify a `ProgressEvent`.**

 * *src\SIL.XForge.Scripture\ClientApp\src\xforge-common\auth.service.spec.ts*
   **597:18  warning  'btoa' is deprecated. Use `buf.toString('base64')` instead.**

 * *src\SIL.XForge.Scripture\ClientApp\src\xforge-common\test-utils.ts*
   **146:26  warning  'atob' is deprecated. Use `Buffer.from(data, 'base64')` instead.**

The following lint issue is not fixed, as #1648 removes the affected code:

* *src\SIL.XForge.Scripture\ClientApp\src\app\shared\share\share-control.component.ts*
  **183:14  warning  'execCommand' is deprecated.**

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1661)
<!-- Reviewable:end -->
