### PR TITLE
Sync Memory Use and Speed Optimizations

### DIFF
--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -49,7 +49,7 @@ namespace SIL.XForge.Scripture.Services
             UserSecret userSecret,
             string paratextId,
             int bookNum,
-            string usx,
+            XDocument usx,
             Dictionary<int, string> chapterAuthors = null
         );
         string GetNotes(UserSecret userSecret, string paratextId, int bookNum);

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -22,7 +22,7 @@ namespace SIL.XForge.Scripture.Services
             SFProject project,
             CancellationToken token
         );
-        ParatextSettings GetParatextSettings(UserSecret userSecret, string paratextId);
+        ParatextSettings? GetParatextSettings(UserSecret userSecret, string paratextId);
 
         Task<IReadOnlyList<ParatextResource>> GetResourcesAsync(string userId);
         bool IsResource(string paratextId);

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using SIL.XForge.Models;
 using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
@@ -43,7 +44,7 @@ namespace SIL.XForge.Scripture.Services
         bool ResourceDocsNeedUpdating(SFProject project, ParatextResource resource);
 
         IReadOnlyList<int> GetBookList(UserSecret userSecret, string paratextId);
-        string GetBookText(UserSecret userSecret, string paratextId, int bookNum);
+        XDocument GetBookText(UserSecret userSecret, string paratextId, int bookNum);
         Task<int> PutBookText(
             UserSecret userSecret,
             string paratextId,

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -44,7 +44,7 @@ namespace SIL.XForge.Scripture.Services
         bool ResourceDocsNeedUpdating(SFProject project, ParatextResource resource);
 
         IReadOnlyList<int> GetBookList(UserSecret userSecret, string paratextId);
-        XDocument GetBookText(UserSecret userSecret, string paratextId, int bookNum);
+        string GetBookText(UserSecret userSecret, string paratextId, int bookNum);
         Task<int> PutBookText(
             UserSecret userSecret,
             string paratextId,

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -53,7 +53,7 @@ namespace SIL.XForge.Scripture.Services
             Dictionary<int, string> chapterAuthors = null
         );
         string GetNotes(UserSecret userSecret, string paratextId, int bookNum);
-        SyncMetricInfo PutNotes(UserSecret userSecret, string paratextId, string notesText);
+        SyncMetricInfo PutNotes(UserSecret userSecret, string paratextId, XElement notesElement);
         Task<SyncMetricInfo> UpdateParatextCommentsAsync(
             UserSecret userSecret,
             string paratextId,

--- a/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
+++ b/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
@@ -178,7 +178,7 @@ namespace SIL.XForge.Scripture.Services
         private static void ParseContents(XElement contentElem, Comment comment)
         {
             string contents;
-            if (contentElem.FirstNode.NodeType == XmlNodeType.Text)
+            if (contentElem.FirstNode?.NodeType == XmlNodeType.Text)
             {
                 contents = ((XText)contentElem.FirstNode).Value;
             }
@@ -198,8 +198,8 @@ namespace SIL.XForge.Scripture.Services
             bldr.Append("<p>");
             foreach (var node in paraElem.Nodes())
             {
-                if (node is XText)
-                    bldr.Append(((XText)node).Value);
+                if (node is XText text)
+                    bldr.Append(text.Value);
                 else
                 {
                     XElement elem = (XElement)node;

--- a/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
+++ b/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
@@ -35,15 +35,14 @@ namespace SIL.XForge.Scripture.Services
         /// <summary>
         /// Parses the XML into a nested list of Comments - each inner list is the data for a thread.
         /// </summary>
-        /// <param name="noteXml"></param>
+        /// <param name="noteXml">The Note XML Element</param>
         /// <param name="ptUser">ParatextUser to use when creating any new Comments.</param>
         /// <returns>Nested list of comments</returns>
         /// <remarks>This code assumes that the XML passes the validation of the notes XML schema.</remarks>
-        public static List<List<Comment>> ParseNotes(string noteXml, ParatextUser ptUser)
+        public static List<List<Comment>> ParseNotes(XElement noteXml, ParatextUser ptUser)
         {
             List<List<Comment>> result = new List<List<Comment>>();
-            XDocument doc = XDocument.Parse(noteXml);
-            foreach (var threadElem in doc.Root.Elements("thread"))
+            foreach (var threadElem in noteXml.Elements("thread"))
             {
                 result.Add(ParseThread(threadElem, ptUser));
             }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -14,7 +14,6 @@ using System.Security.Claims;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using IdentityModel;
@@ -1006,20 +1005,13 @@ namespace SIL.XForge.Scripture.Services
         }
 
         /// <summary> Get PT book text in USX, or throw if can't. </summary>
-        public XDocument GetBookText(UserSecret userSecret, string paratextId, int bookNum)
+        public string GetBookText(UserSecret userSecret, string paratextId, int bookNum)
         {
             using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
             if (scrText == null)
                 throw new DataNotFoundException("Can't get access to cloned project.");
             string usfm = scrText.GetText(bookNum);
-            var doc = new XDocument();
-
-            // Do not be tempted to convert this to async, as the XmlWriter created by XmlWriter.CreateWriter() does not
-            // support it and the XNodeBuilder class used to create the XmlWriter is not publicly accessible.
-            using XmlWriter writer = doc.CreateWriter();
-            UsfmToUsx.ConvertToXmlWriter(scrText, bookNum, usfm, writer, forExport: false);
-            writer.Flush();
-            return doc;
+            return UsfmToUsx.ConvertToXmlString(scrText, bookNum, usfm, false);
         }
 
         /// <summary> Write up-to-date book text from mongo database to Paratext project folder. </summary>

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1213,10 +1213,13 @@ namespace SIL.XForge.Scripture.Services
         }
 
         /// <summary> Write up-to-date notes from the mongo database to the Paratext project folder </summary>
-        public SyncMetricInfo PutNotes(UserSecret userSecret, string paratextId, string notesText)
+        public SyncMetricInfo PutNotes(UserSecret userSecret, string paratextId, XElement notesElement)
         {
             // TODO: should accept some data structure instead of XML
-            var changeList = NotesFormatter.ParseNotes(notesText, new SFParatextUser(GetParatextUsername(userSecret)));
+            var changeList = NotesFormatter.ParseNotes(
+                notesElement,
+                new SFParatextUser(GetParatextUsername(userSecret))
+            );
             return PutCommentThreads(userSecret, paratextId, changeList);
         }
 

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -964,7 +964,7 @@ namespace SIL.XForge.Scripture.Services
 
         /// <summary> Gets basic settings for a Paratext project. </summary>
         /// <returns> The Paratext project settings, or null if the project repository does not exist locally </returns>
-        public ParatextSettings GetParatextSettings(UserSecret userSecret, string paratextId)
+        public ParatextSettings? GetParatextSettings(UserSecret userSecret, string paratextId)
         {
             using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
             if (scrText == null)

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1028,7 +1028,7 @@ namespace SIL.XForge.Scripture.Services
             UserSecret userSecret,
             string paratextId,
             int bookNum,
-            string usx,
+            XDocument usx,
             Dictionary<int, string> chapNumToAuthorSFUserIdMap = null
         )
         {
@@ -1036,14 +1036,14 @@ namespace SIL.XForge.Scripture.Services
             {
                 throw new ArgumentNullException(nameof(userSecret));
             }
-            if (String.IsNullOrWhiteSpace(paratextId))
+            if (string.IsNullOrWhiteSpace(paratextId))
             {
-                throw new ArgumentException(nameof(paratextId));
+                throw new ArgumentNullException(nameof(paratextId));
             }
 
             int booksUpdated = 0;
             StringBuilder log = new StringBuilder(
-                $"ParatextService.PutBookText(userSecret, paratextId {paratextId}, bookNum {bookNum}, usx {usx}, chapterAuthors: {(chapNumToAuthorSFUserIdMap == null ? "null" : ($"count {chapNumToAuthorSFUserIdMap.Count}"))})"
+                $"ParatextService.PutBookText(userSecret, paratextId {paratextId}, bookNum {bookNum}, usx {usx.Root}, chapterAuthors: {(chapNumToAuthorSFUserIdMap == null ? "null" : ($"count {chapNumToAuthorSFUserIdMap.Count}"))})"
             );
             Dictionary<string, ScrText> scrTexts = new Dictionary<string, ScrText>();
             try
@@ -1059,12 +1059,10 @@ namespace SIL.XForge.Scripture.Services
 
                 // We add this here so we can dispose in the finally
                 scrTexts.Add(userSecret.Id, scrText);
-                var doc = new XmlDocument { PreserveWhitespace = true };
-                doc.LoadXml(usx);
-                log.AppendLine($"Imported string as XmlDocument with {doc.ChildNodes.Count} child nodes.");
+                log.AppendLine($"Imported XDocument with {usx.Elements().Count()} elements.");
                 UsxFragmenter.FindFragments(
                     scrText.ScrStylesheet(bookNum),
-                    doc.CreateNavigator(),
+                    usx.CreateNavigator(),
                     XPathExpression.Compile("*[false()]"),
                     out string usfm
                 );

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -15,6 +15,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
+using System.Xml.Linq;
 using System.Xml.XPath;
 using IdentityModel;
 using Microsoft.AspNetCore.Hosting;
@@ -1005,13 +1006,20 @@ namespace SIL.XForge.Scripture.Services
         }
 
         /// <summary> Get PT book text in USX, or throw if can't. </summary>
-        public string GetBookText(UserSecret userSecret, string paratextId, int bookNum)
+        public XDocument GetBookText(UserSecret userSecret, string paratextId, int bookNum)
         {
             using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
             if (scrText == null)
                 throw new DataNotFoundException("Can't get access to cloned project.");
             string usfm = scrText.GetText(bookNum);
-            return UsfmToUsx.ConvertToXmlString(scrText, bookNum, usfm, false);
+            var doc = new XDocument();
+
+            // Do not be tempted to convert this to async, as the XmlWriter created by XmlWriter.CreateWriter() does not
+            // support it and the XNodeBuilder class used to create the XmlWriter is not publicly accessible.
+            using XmlWriter writer = doc.CreateWriter();
+            UsfmToUsx.ConvertToXmlWriter(scrText, bookNum, usfm, writer, forExport: false);
+            writer.Flush();
+            return doc;
         }
 
         /// <summary> Write up-to-date book text from mongo database to Paratext project folder. </summary>

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -703,7 +703,11 @@ namespace SIL.XForge.Scripture.Services
             SortedList<int, IDocument<TextData>> textDocs
         )
         {
-            var oldUsxDoc = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
+            string bookText = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
+
+            // XDocument.Parse ignores whitespace added during USX generation. The unnecessary whitespace can
+            // occasionally cause inaccurate comparisons with XNode.DeepEquals, and so we must remove it.
+            var oldUsxDoc = XDocument.Parse(bookText);
             XDocument newUsxDoc = _deltaUsxMapper.ToUsx(
                 oldUsxDoc,
                 text.Chapters
@@ -842,7 +846,8 @@ namespace SIL.XForge.Scripture.Services
             ISet<int>? chaptersToInclude = null
         )
         {
-            var usxDoc = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
+            string bookText = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
+            var usxDoc = XDocument.Parse(bookText);
             var tasks = new List<Task>();
             Dictionary<int, ChapterDelta> deltas = _deltaUsxMapper
                 .ToChapterDeltas(usxDoc)
@@ -1646,7 +1651,8 @@ namespace SIL.XForge.Scripture.Services
 
         private Dictionary<int, ChapterDelta> GetDeltasByChapter(TextInfo text, string paratextId)
         {
-            XDocument usxDoc = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
+            string bookText = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
+            XDocument usxDoc = XDocument.Parse(bookText);
             Dictionary<int, ChapterDelta> chapterDeltas = _deltaUsxMapper
                 .ToChapterDeltas(usxDoc)
                 .ToDictionary(cd => cd.Number);

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -191,7 +191,12 @@ namespace SIL.XForge.Scripture.Services
                 // Update target Paratext books and notes, if this is not a resource
                 if (!_paratextService.IsResource(targetParatextId))
                 {
-                    await GetAndUpdateParatextBooksAndNotes(SyncPhase.Phase2, targetParatextId, targetTextDocsByBook, questionDocsByBook);
+                    await GetAndUpdateParatextBooksAndNotes(
+                        SyncPhase.Phase2,
+                        targetParatextId,
+                        targetTextDocsByBook,
+                        questionDocsByBook
+                    );
                 }
 
                 // Check for cancellation
@@ -353,7 +358,12 @@ namespace SIL.XForge.Scripture.Services
                 // If a resource needs updating, retrieve the books, as they were not retrieved previously
                 if (resourceNeedsUpdating)
                 {
-                    await GetAndUpdateParatextBooksAndNotes(SyncPhase.Phase5, targetParatextId, targetTextDocsByBook, questionDocsByBook);
+                    await GetAndUpdateParatextBooksAndNotes(
+                        SyncPhase.Phase5,
+                        targetParatextId,
+                        targetTextDocsByBook,
+                        questionDocsByBook
+                    );
                 }
 
                 if (!_paratextService.IsResource(targetParatextId) || resourceNeedsUpdating)

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -187,7 +187,7 @@ namespace SIL.XForge.Scripture.Services
 
                 var targetTextDocsByBook = new Dictionary<int, SortedList<int, IDocument<TextData>>>();
                 var questionDocsByBook = new Dictionary<int, IReadOnlyList<IDocument<Question>>>();
-                ParatextSettings settings = _paratextService.GetParatextSettings(_userSecret, targetParatextId);
+                ParatextSettings? settings = _paratextService.GetParatextSettings(_userSecret, targetParatextId);
                 // update target Paratext books and notes
                 double i = 0.0;
                 foreach (TextInfo text in _projectDoc.Data.Texts)
@@ -1392,7 +1392,7 @@ namespace SIL.XForge.Scripture.Services
                     }
                 }
 
-                ParatextSettings settings = _paratextService.GetParatextSettings(
+                ParatextSettings? settings = _paratextService.GetParatextSettings(
                     _userSecret,
                     _projectDoc.Data.ParatextId
                 );
@@ -1415,7 +1415,7 @@ namespace SIL.XForge.Scripture.Services
                 // The source can be null if there was an error getting a resource from the DBL
                 if (TranslationSuggestionsEnabled && _projectDoc.Data.TranslateConfig.Source != null)
                 {
-                    ParatextSettings sourceSettings = _paratextService.GetParatextSettings(
+                    ParatextSettings? sourceSettings = _paratextService.GetParatextSettings(
                         _userSecret,
                         _projectDoc.Data.TranslateConfig.Source.ParatextId
                     );

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -820,7 +820,7 @@ namespace SIL.XForge.Scripture.Services
                 _syncMetrics.ParatextNotes += _paratextService.PutNotes(
                     _userSecret,
                     _projectDoc.Data.ParatextId,
-                    notesElem.ToString()
+                    notesElem
                 );
             }
         }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -693,8 +693,7 @@ namespace SIL.XForge.Scripture.Services
             SortedList<int, IDocument<TextData>> textDocs
         )
         {
-            string bookText = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
-            var oldUsxDoc = XDocument.Parse(bookText);
+            var oldUsxDoc = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
             XDocument newUsxDoc = _deltaUsxMapper.ToUsx(
                 oldUsxDoc,
                 text.Chapters
@@ -834,8 +833,7 @@ namespace SIL.XForge.Scripture.Services
             ISet<int>? chaptersToInclude = null
         )
         {
-            string bookText = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
-            var usxDoc = XDocument.Parse(bookText);
+            var usxDoc = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
             var tasks = new List<Task>();
             Dictionary<int, ChapterDelta> deltas = _deltaUsxMapper
                 .ToChapterDeltas(usxDoc)
@@ -1639,8 +1637,7 @@ namespace SIL.XForge.Scripture.Services
 
         private Dictionary<int, ChapterDelta> GetDeltasByChapter(TextInfo text, string paratextId)
         {
-            string bookText = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
-            XDocument usxDoc = XDocument.Parse(bookText);
+            XDocument usxDoc = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
             Dictionary<int, ChapterDelta> chapterDeltas = _deltaUsxMapper
                 .ToChapterDeltas(usxDoc)
                 .ToDictionary(cd => cd.Number);

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -569,7 +569,7 @@ namespace SIL.XForge.Scripture.Services
                 Dictionary<int, ChapterDelta> chapterDeltas = GetDeltasByChapter(text, targetParatextId);
 
                 LogMetric("Updating thread docs - updating");
-                await UpdateNoteThreadDocsAsync(text, noteThreadDocs, token, chapterDeltas, ptUsernamesToSFUserIds);
+                await UpdateNoteThreadDocsAsync(text, noteThreadDocs, chapterDeltas, ptUsernamesToSFUserIds);
 
                 // update project metadata
                 LogMetric("Updating project metadata");
@@ -913,7 +913,6 @@ namespace SIL.XForge.Scripture.Services
         private async Task UpdateNoteThreadDocsAsync(
             TextInfo text,
             Dictionary<string, IDocument<NoteThread>> noteThreadDocs,
-            CancellationToken token,
             Dictionary<int, ChapterDelta> chapterDeltas,
             Dictionary<string, string> usernamesToUserIds
         )
@@ -931,12 +930,11 @@ namespace SIL.XForge.Scripture.Services
             foreach (NoteThreadChange change in noteThreadChanges)
             {
                 // Find the thread doc if it exists
-                IDocument<NoteThread> threadDoc;
-                if (!noteThreadDocs.TryGetValue(change.ThreadId, out threadDoc))
+                if (!noteThreadDocs.TryGetValue(change.ThreadId, out IDocument<NoteThread> threadDoc))
                 {
                     // Create a new ParatextNoteThread doc
                     IDocument<NoteThread> doc = GetNoteThreadDoc(change.ThreadId);
-                    async Task createThreadDoc(string threadId, string projectId, NoteThreadChange change)
+                    async Task createThreadDoc(NoteThreadChange change)
                     {
                         VerseRef verseRef = new VerseRef();
                         verseRef.Parse(change.VerseRefStr);
@@ -957,7 +955,7 @@ namespace SIL.XForge.Scripture.Services
                         );
                         await SubmitChangesOnNoteThreadDocAsync(doc, change, usernamesToUserIds);
                     }
-                    tasks.Add(createThreadDoc(change.ThreadId, _projectDoc.Id, change));
+                    tasks.Add(createThreadDoc(change));
                     _syncMetrics.NoteThreads.Added++;
                 }
                 else
@@ -1187,7 +1185,7 @@ namespace SIL.XForge.Scripture.Services
         /// <summary>
         /// Preserve all whitespace in data but remove whitespace at the beginning of lines and remove line endings.
         /// </summary>
-        private XElement ParseText(string text)
+        private static XElement ParseText(string text)
         {
             text = text.Trim().Replace("\r\n", "\n");
             text = Regex.Replace(text, @"\n\s*<", "<", RegexOptions.CultureInvariant);
@@ -1310,7 +1308,7 @@ namespace SIL.XForge.Scripture.Services
             var projectUsers = await _realtimeService
                 .QuerySnapshots<User>()
                 .Where(u => _projectDoc.Data.UserRoles.Keys.Contains(u.Id) && u.ParatextId != null)
-                .Select(u => new { UserId = u.Id, ParatextId = u.ParatextId })
+                .Select(u => new { UserId = u.Id, u.ParatextId })
                 .ToListAsync();
 
             bool dataInSync = true;

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -703,13 +703,12 @@ namespace SIL.XForge.Scripture.Services
 
             if (!XNode.DeepEquals(oldUsxDoc, newUsxDoc))
             {
-                string usx = newUsxDoc.Root.ToString();
                 var chapterAuthors = await GetChapterAuthorsAsync(text, textDocs);
                 _syncMetrics.ParatextBooks.Updated += await _paratextService.PutBookText(
                     _userSecret,
                     paratextId,
                     text.BookNum,
-                    usx,
+                    newUsxDoc,
                     chapterAuthors
                 );
             }

--- a/src/SIL.XForge/Realtime/RealtimeServer.cs
+++ b/src/SIL.XForge/Realtime/RealtimeServer.cs
@@ -20,7 +20,7 @@ namespace SIL.XForge.Realtime
         {
             if (_started)
                 return;
-            InvokeExportAsync<object>("start", options).GetAwaiter().GetResult();
+            InvokeExportAsync("start", options).GetAwaiter().GetResult();
             _started = true;
         }
 
@@ -28,11 +28,11 @@ namespace SIL.XForge.Realtime
         {
             if (!_started)
                 return;
-            InvokeExportAsync<object>("stop").GetAwaiter().GetResult();
+            InvokeExportAsync("stop").GetAwaiter().GetResult();
             _started = false;
         }
 
-        public Task<int> ConnectAsync(string userId = null)
+        public Task<int> ConnectAsync(string? userId = null)
         {
             if (userId != null)
                 return InvokeExportAsync<int>("connect", userId);
@@ -56,17 +56,17 @@ namespace SIL.XForge.Realtime
 
         public Task DeleteDocAsync(int handle, string collection, string id)
         {
-            return InvokeExportAsync<object>("deleteDoc", handle, collection, id);
+            return InvokeExportAsync("deleteDoc", handle, collection, id);
         }
 
         public void Disconnect(int handle)
         {
-            InvokeExportAsync<object>("disconnect", handle).GetAwaiter().GetResult();
+            InvokeExportAsync("disconnect", handle).GetAwaiter().GetResult();
         }
 
         public Task DisconnectAsync(int handle)
         {
-            return InvokeExportAsync<object>("disconnect", handle);
+            return InvokeExportAsync("disconnect", handle);
         }
 
         public Task<T> ApplyOpAsync<T>(string otTypeName, T data, object op)
@@ -74,9 +74,14 @@ namespace SIL.XForge.Realtime
             return InvokeExportAsync<T>("applyOp", otTypeName, data, op);
         }
 
-        private Task<T> InvokeExportAsync<T>(string exportedFunctionName, params object[] args)
+        private Task<T> InvokeExportAsync<T>(string exportedFunctionName, params object?[] args)
         {
             return _nodeJSService.InvokeFromFileAsync<T>(_modulePath, exportedFunctionName, args);
+        }
+
+        private Task InvokeExportAsync(string exportedFunctionName, params object[] args)
+        {
+            return _nodeJSService.InvokeFromFileAsync(_modulePath, exportedFunctionName, args);
         }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/NotesFormatterTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/NotesFormatterTests.cs
@@ -1,0 +1,623 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using NSubstitute;
+using NUnit.Framework;
+using Paratext.Data;
+using Paratext.Data.ProjectComments;
+using Paratext.Data.ProjectFileAccess;
+using Paratext.Data.Users;
+using SIL.Scripture;
+using SIL.XForge.Scripture.Models;
+using Comment = Paratext.Data.ProjectComments.Comment;
+
+namespace SIL.XForge.Scripture.Services
+{
+    [TestFixture]
+    public class NotesFormatterTests
+    {
+        [Test]
+        public void FormatNotes_CommentText()
+        {
+            // Setup the environment
+            var env = new TestEnvironment();
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            env.SetupProject(env.Project01, associatedPtUser);
+
+            // Setup the test data
+            const string xml = "<content>Comment Contents</content>";
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(xml);
+            Comment comment = new Comment(associatedPtUser)
+            {
+                Contents = doc.DocumentElement,
+                DateTime = DateTimeOffset.Now,
+                Thread = "Answer_dataId0123",
+                VerseRefStr = "RUT 1:1",
+            };
+            List<CommentThread> commentThreads = new List<CommentThread>
+            {
+                new CommentThread
+                {
+                    ContextScrTextName = env.ProjectScrText?.Name,
+                    ScrText = env.ProjectScrText,
+                    Comments = new List<Comment> { comment, },
+                },
+            };
+
+            // We use StringBuilder so we can have the environment specific new line
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine("<notes version=\"1.1\">");
+            sb.AppendLine($"  <thread id=\"{comment.Thread}\">");
+            sb.AppendLine($"    <selection verseRef=\"{comment.VerseRefStr}\" startPos=\"0\" selectedText=\"\" />");
+            sb.AppendLine($"    <comment user=\"{env.Username01}\" date=\"{comment.DateTime:o}\">");
+            sb.AppendLine("      <content>Comment Contents</content>");
+            sb.AppendLine("    </comment>");
+            sb.AppendLine("  </thread>");
+            sb.Append("</notes>");
+            string expected = sb.ToString();
+
+            // SUT
+            string actual = NotesFormatter.FormatNotes(commentThreads);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void FormatNotes_ComplexComment()
+        {
+            // Setup the environment
+            var env = new TestEnvironment();
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            env.SetupProject(env.Project01, associatedPtUser);
+
+            // Setup the test data
+            const string xml = "<content><p>Comment Contents</p></content>";
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(xml);
+            Comment comment = new Comment(associatedPtUser)
+            {
+                ContextAfter = "here.",
+                ContextBefore = "Verse",
+                Contents = doc.DocumentElement,
+                DateTime = DateTimeOffset.Now,
+                ExternalUser = "John Doe",
+                SelectedText = "one",
+                StartPosition = 1,
+                Thread = "Answer_dataId0123",
+                Type = NoteType.Conflict,
+                VerseRefStr = "RUT 1:1",
+            };
+            List<CommentThread> commentThreads = new List<CommentThread>
+            {
+                new CommentThread
+                {
+                    ContextScrTextName = env.ProjectScrText?.Name,
+                    ScrText = env.ProjectScrText,
+                    Comments = new List<Comment> { comment, },
+                },
+            };
+
+            // We use StringBuilder so we can have the environment specific new line
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine("<notes version=\"1.1\">");
+            sb.AppendLine($"  <thread id=\"{comment.Thread}\" type=\"conflict\">");
+            sb.Append($"    <selection verseRef=\"{comment.VerseRefStr}\" startPos=\"{comment.StartPosition}\"");
+            sb.Append($" selectedText=\"{comment.SelectedText}\" beforeContext=\"{comment.ContextBefore}\"");
+            sb.AppendLine($" afterContext=\"{comment.ContextAfter}\" />");
+            sb.Append($"    <comment user=\"{env.Username01}\" date=\"{comment.DateTime:o}\"");
+            sb.AppendLine($" extUser=\"{comment.ExternalUser}\">");
+            sb.AppendLine("      <content>");
+            sb.AppendLine("        <p>Comment Contents</p>");
+            sb.AppendLine("      </content>");
+            sb.AppendLine("    </comment>");
+            sb.AppendLine("  </thread>");
+            sb.Append("</notes>");
+            string expected = sb.ToString();
+
+            // SUT
+            string actual = NotesFormatter.FormatNotes(commentThreads);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void FormatNotes_DeletedComment()
+        {
+            // Setup the environment
+            var env = new TestEnvironment();
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            env.SetupProject(env.Project01, associatedPtUser);
+
+            // Setup the test data
+            const string expected = "<notes version=\"1.1\" />";
+            List<CommentThread> commentThreads = new List<CommentThread>
+            {
+                new CommentThread
+                {
+                    ContextScrTextName = env.ProjectScrText?.Name,
+                    ScrText = env.ProjectScrText,
+                    Comments = new List<Comment>
+                    {
+                        new Comment(associatedPtUser)
+                        {
+                            DateTime = DateTimeOffset.Now,
+                            Deleted = true,
+                            Thread = "Answer_dataId0123",
+                            VerseRefStr = "RUT 1:1",
+                        },
+                    },
+                },
+            };
+
+            // SUT
+            string actual = NotesFormatter.FormatNotes(commentThreads);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void FormatNotes_DetailedCommentContents()
+        {
+            // Setup the environment
+            var env = new TestEnvironment();
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            env.SetupProject(env.Project01, associatedPtUser);
+
+            // Setup the test data
+            string xml = "<content><p>Comment Text<bold>Bold Text</bold><italic>Italic Text</italic>";
+            xml += "<language name=\"en_NZ\">Test</language></p></content>";
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(xml);
+            Comment comment = new Comment(associatedPtUser)
+            {
+                Contents = doc.DocumentElement,
+                DateTime = DateTimeOffset.Now,
+                Thread = "Answer_dataId0123",
+                VerseRefStr = "RUT 1:1",
+            };
+            List<CommentThread> commentThreads = new List<CommentThread>
+            {
+                new CommentThread
+                {
+                    ContextScrTextName = env.ProjectScrText?.Name,
+                    ScrText = env.ProjectScrText,
+                    Comments = new List<Comment> { comment, },
+                },
+            };
+
+            // We use StringBuilder so we can have the environment specific new line
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine("<notes version=\"1.1\">");
+            sb.AppendLine($"  <thread id=\"{comment.Thread}\">");
+            sb.AppendLine($"    <selection verseRef=\"{comment.VerseRefStr}\" startPos=\"0\" selectedText=\"\" />");
+            sb.AppendLine($"    <comment user=\"{env.Username01}\" date=\"{comment.DateTime:o}\">");
+            sb.AppendLine("      <content>");
+            sb.Append("        <p>Comment Text<span style=\"bold\">Bold Text</span>");
+            sb.AppendLine("<span style=\"italic\">Italic Text</span><lang name=\"en_NZ\">Test</lang></p>");
+            sb.AppendLine("      </content>");
+            sb.AppendLine("    </comment>");
+            sb.AppendLine("  </thread>");
+            sb.Append("</notes>");
+            string expected = sb.ToString();
+
+            // SUT
+            string actual = NotesFormatter.FormatNotes(commentThreads);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void FormatNotes_EmptyComment()
+        {
+            // Setup the environment
+            var env = new TestEnvironment();
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            env.SetupProject(env.Project01, associatedPtUser);
+
+            // Setup the test data
+            const string thread = "Answer_dataId0123";
+            const string verseRefStr = "RUT 1:1";
+            DateTimeOffset commentDate = DateTimeOffset.Now;
+
+            // We use StringBuilder so we can have the environment specific new line
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine("<notes version=\"1.1\">");
+            sb.AppendLine($"  <thread id=\"{thread}\">");
+            sb.AppendLine($"    <selection verseRef=\"{verseRefStr}\" startPos=\"0\" selectedText=\"\" />");
+            sb.AppendLine($"    <comment user=\"{env.Username01}\" date=\"{commentDate:o}\">");
+            sb.AppendLine("      <content>");
+            sb.AppendLine("        <p></p>");
+            sb.AppendLine("      </content>");
+            sb.AppendLine("    </comment>");
+            sb.AppendLine("  </thread>");
+            sb.Append("</notes>");
+            string expected = sb.ToString();
+            List<CommentThread> commentThreads = new List<CommentThread>
+            {
+                new CommentThread
+                {
+                    ContextScrTextName = env.ProjectScrText?.Name,
+                    ScrText = env.ProjectScrText,
+                    Comments = new List<Comment>
+                    {
+                        new Comment(associatedPtUser)
+                        {
+                            DateTime = commentDate,
+                            Thread = thread,
+                            VerseRefStr = verseRefStr,
+                        },
+                    },
+                },
+            };
+
+            // SUT
+            string actual = NotesFormatter.FormatNotes(commentThreads);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void FormatNotes_MultipleComments()
+        {
+            // Setup the environment
+            var env = new TestEnvironment();
+            var firstPtUser = new SFParatextUser(env.Username01);
+            var secondPtUser = new SFParatextUser(env.Username02);
+            env.SetupProject(env.Project01, firstPtUser);
+
+            // Setup the test data
+            const string thread = "Answer_dataId0123";
+            const string verseRefStr = "RUT 1:1";
+            DateTimeOffset firstCommentDate = DateTimeOffset.Now.AddDays(-1);
+            DateTimeOffset secondCommentDate = DateTimeOffset.Now;
+            const string xml = "<content><p>Comment Contents</p></content>";
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(xml);
+
+            // We use StringBuilder so we can have the environment specific new line
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine("<notes version=\"1.1\">");
+            sb.AppendLine($"  <thread id=\"{thread}\">");
+            sb.AppendLine($"    <selection verseRef=\"{verseRefStr}\" startPos=\"0\" selectedText=\"\" />");
+            sb.AppendLine($"    <comment user=\"{env.Username01}\" date=\"{firstCommentDate:o}\">");
+            sb.AppendLine("      <content>");
+            sb.AppendLine("        <p></p>");
+            sb.AppendLine("      </content>");
+            sb.AppendLine("    </comment>");
+            sb.AppendLine($"    <comment user=\"{env.Username02}\" date=\"{secondCommentDate:o}\">");
+            sb.AppendLine("      <content>");
+            sb.AppendLine("        <p>Comment Contents</p>");
+            sb.AppendLine("      </content>");
+            sb.AppendLine("    </comment>");
+            sb.AppendLine("  </thread>");
+            sb.Append("</notes>");
+            string expected = sb.ToString();
+            List<CommentThread> commentThreads = new List<CommentThread>
+            {
+                new CommentThread
+                {
+                    ContextScrTextName = env.ProjectScrText?.Name,
+                    ScrText = env.ProjectScrText,
+                    Comments = new List<Comment>
+                    {
+                        new Comment(firstPtUser)
+                        {
+                            DateTime = firstCommentDate,
+                            Thread = thread,
+                            VerseRefStr = verseRefStr,
+                        },
+                        new Comment(secondPtUser)
+                        {
+                            DateTime = secondCommentDate,
+                            Thread = thread,
+                            VerseRefStr = verseRefStr,
+                            Contents = doc.DocumentElement,
+                        },
+                    },
+                },
+            };
+
+            // SUT
+            string actual = NotesFormatter.FormatNotes(commentThreads);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void FormatNotes_NoComments()
+        {
+            // Setup the environment
+            var env = new TestEnvironment();
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            env.SetupProject(env.Project01, associatedPtUser);
+
+            // Setup the test data
+            const string expected = "<notes version=\"1.1\" />";
+            List<CommentThread> commentThreads = new List<CommentThread>
+            {
+                new CommentThread { ContextScrTextName = env.ProjectScrText?.Name, ScrText = env.ProjectScrText },
+            };
+
+            // SUT
+            string actual = NotesFormatter.FormatNotes(commentThreads);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void ParseNotes_CommentText()
+        {
+            // Setup the environment
+            var env = new TestEnvironment();
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            env.SetupProject(env.Project01, associatedPtUser);
+
+            // Setup the test data
+            string commentText = "Comment Contents";
+            DateTimeOffset commentDate = DateTimeOffset.Now;
+            string thread = "Answer_dataId0123";
+            string verseRefStr = "RUT 1:2";
+            string xml = $"<notes version=\"1.1\"><thread id=\"{thread}\">";
+            xml += $"<selection verseRef=\"{verseRefStr}\" startPos=\"0\" selectedText=\"\" />";
+            xml += $"<comment user=\"{env.Username01}\" date=\"{commentDate:o}\"><content>{commentText}</content>";
+            xml += "</comment></thread></notes>";
+            XElement noteXml = XElement.Parse(xml);
+
+            // SUT
+            List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
+            Assert.AreEqual(1, actual.Count);
+            Assert.AreEqual(1, actual[0].Count);
+            Assert.AreEqual(commentText, actual[0][0].Contents.InnerXml);
+            Assert.AreEqual(commentDate, actual[0][0].DateTime);
+            Assert.AreEqual(false, actual[0][0].Deleted);
+            Assert.AreEqual(thread, actual[0][0].Thread);
+            Assert.AreEqual(env.Username01, actual[0][0].User);
+            Assert.AreEqual("RUT", actual[0][0].VerseRef.Book);
+            Assert.AreEqual(1, actual[0][0].VerseRef.ChapterNum);
+            Assert.AreEqual(2, actual[0][0].VerseRef.VerseNum);
+        }
+
+        [Test]
+        public void ParseNotes_ComplexComment()
+        {
+            // Setup the environment
+            var env = new TestEnvironment();
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            env.SetupProject(env.Project01, associatedPtUser);
+
+            // Setup the test data
+            DateTimeOffset commentDate = DateTimeOffset.Now;
+            string contents = "<p>Comment Contents</p>";
+            string contextAfter = "here.";
+            string contextBefore = "Verse";
+            string externalUser = "John Doe";
+            string selectedText = "one";
+            int startPosition = 1;
+            string thread = "Answer_dataId0123";
+            string verseRefStr = "RUT 1:2";
+            string xml = $"<notes version=\"1.1\"><thread id=\"{thread}\">";
+            xml += $"<selection verseRef=\"{verseRefStr}\" startPos=\"{startPosition}\"";
+            xml += $" selectedText=\"{selectedText}\" beforeContext=\"{contextBefore}\"";
+            xml += $" afterContext=\"{contextAfter}\" />";
+            xml += $"<comment user=\"{env.Username01}\" date=\"{commentDate:o}\"";
+            xml += $" extUser=\"{externalUser}\">";
+            xml += $"<content>{contents}</content></comment></thread></notes>";
+            XElement noteXml = XElement.Parse(xml);
+
+            // SUT
+            List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
+            Assert.AreEqual(1, actual.Count);
+            Assert.AreEqual(1, actual[0].Count);
+            Assert.AreEqual(contents, actual[0][0].Contents.InnerXml);
+            Assert.AreEqual(false, actual[0][0].Deleted);
+            Assert.AreEqual(contextAfter, actual[0][0].ContextAfter);
+            Assert.AreEqual(contextBefore, actual[0][0].ContextBefore);
+            Assert.AreEqual(externalUser, actual[0][0].ExternalUser);
+            Assert.AreEqual(selectedText, actual[0][0].SelectedText);
+            Assert.AreEqual(startPosition, actual[0][0].StartPosition);
+            Assert.AreEqual(thread, actual[0][0].Thread);
+            Assert.AreEqual(env.Username01, actual[0][0].User);
+            Assert.AreEqual("RUT", actual[0][0].VerseRef.Book);
+            Assert.AreEqual(1, actual[0][0].VerseRef.ChapterNum);
+            Assert.AreEqual(2, actual[0][0].VerseRef.VerseNum);
+        }
+
+        [Test]
+        public void ParseNotes_DeletedComment()
+        {
+            // Setup the environment
+            var env = new TestEnvironment();
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            env.SetupProject(env.Project01, associatedPtUser);
+
+            // Setup the test data
+            string thread = "Answer_dataId0123";
+            string xml = $"<notes version=\"1.1\"><thread id=\"{thread}\">";
+            xml += "<comment deleted=\"true\"></comment></thread></notes>";
+            XElement noteXml = XElement.Parse(xml);
+
+            // SUT
+            List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
+            Assert.AreEqual(1, actual.Count);
+            Assert.AreEqual(1, actual[0].Count);
+            Assert.AreEqual(true, actual[0][0].Deleted);
+            Assert.AreEqual(thread, actual[0][0].Thread);
+        }
+
+        [Test]
+        public void ParseNotes_DetailedCommentContents()
+        {
+            // Setup the environment
+            var env = new TestEnvironment();
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            env.SetupProject(env.Project01, associatedPtUser);
+
+            // Setup the test data
+            DateTimeOffset commentDate = DateTimeOffset.Now;
+            string thread = "Answer_dataId0123";
+            string verseRefStr = "RUT 1:2";
+            string xml = $"<notes version=\"1.1\"><thread id=\"{thread}\">";
+            xml += $"<selection verseRef=\"{verseRefStr}\" startPos=\"0\" selectedText=\"\" />";
+            xml += $"<comment user=\"{env.Username01}\" date=\"{commentDate:o}\"><content>";
+            xml += "<p>Comment Text<span style=\"bold\">Bold Text</span>";
+            xml += "<span style=\"italic\">Italic Text</span><lang name=\"en_NZ\">Test</lang></p>";
+            xml += "</content></comment></thread></notes>";
+            XElement noteXml = XElement.Parse(xml);
+
+            // SUT
+            List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
+            Assert.AreEqual(1, actual.Count);
+            Assert.AreEqual(1, actual[0].Count);
+            string contents = "<p>Comment Text<bold>Bold Text</bold><italic>Italic Text</italic>";
+            contents += "<language name=\"en_NZ\">Test</language></p>";
+            Assert.AreEqual(contents, actual[0][0].Contents.InnerXml);
+            Assert.AreEqual(false, actual[0][0].Deleted);
+            Assert.AreEqual(thread, actual[0][0].Thread);
+            Assert.AreEqual(env.Username01, actual[0][0].User);
+            Assert.AreEqual("RUT", actual[0][0].VerseRef.Book);
+            Assert.AreEqual(1, actual[0][0].VerseRef.ChapterNum);
+            Assert.AreEqual(2, actual[0][0].VerseRef.VerseNum);
+        }
+
+        [Test]
+        public void ParseNotes_EmptyComment()
+        {
+            // Setup the environment
+            var env = new TestEnvironment();
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            env.SetupProject(env.Project01, associatedPtUser);
+
+            // Setup the test data
+            DateTimeOffset commentDate = DateTimeOffset.Now;
+            string thread = "Answer_dataId0123";
+            string verseRefStr = "RUT 1:2";
+            string xml = $"<notes version=\"1.1\"><thread id=\"{thread}\">";
+            xml += $"<selection verseRef=\"{verseRefStr}\" startPos=\"0\" selectedText=\"\" />";
+            xml += $"<comment user=\"{env.Username01}\" date=\"{commentDate:o}\"></comment></thread></notes>";
+            XElement noteXml = XElement.Parse(xml);
+
+            // SUT
+            List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
+            Assert.AreEqual(1, actual.Count);
+            Assert.AreEqual(1, actual[0].Count);
+            Assert.AreEqual(string.Empty, actual[0][0].Contents.InnerXml);
+            Assert.AreEqual(commentDate, actual[0][0].DateTime);
+            Assert.AreEqual(false, actual[0][0].Deleted);
+            Assert.AreEqual(thread, actual[0][0].Thread);
+            Assert.AreEqual(env.Username01, actual[0][0].User);
+            Assert.AreEqual("RUT", actual[0][0].VerseRef.Book);
+            Assert.AreEqual(1, actual[0][0].VerseRef.ChapterNum);
+            Assert.AreEqual(2, actual[0][0].VerseRef.VerseNum);
+        }
+
+        [Test]
+        public void ParseNotes_MultipleComments()
+        {
+            // Setup the environment
+            var env = new TestEnvironment();
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            env.SetupProject(env.Project01, associatedPtUser);
+
+            // Setup the test data
+            DateTimeOffset firstCommentDate = DateTimeOffset.Now.AddDays(-1);
+            DateTimeOffset secondCommentDate = DateTimeOffset.Now;
+            string contents = "<p>Comment Contents</p>";
+            string thread = "Answer_dataId0123";
+            string verseRefStr = "RUT 1:2";
+            string xml = $"<notes version=\"1.1\"><thread id=\"{thread}\">";
+            xml += $"<selection verseRef=\"{verseRefStr}\" startPos=\"0\" selectedText=\"\" />";
+            xml += $"<comment user=\"{env.Username01}\" date=\"{firstCommentDate:o}\"></comment>";
+            xml += $"<comment user=\"{env.Username02}\" date=\"{secondCommentDate:o}\">";
+            xml += $"<content>{contents}</content></comment>";
+            xml += "</thread></notes>";
+            XElement noteXml = XElement.Parse(xml);
+
+            // SUT
+            List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
+            Assert.AreEqual(1, actual.Count);
+            Assert.AreEqual(2, actual[0].Count);
+
+            // First Comment
+            Assert.AreEqual(string.Empty, actual[0][0].Contents.InnerXml);
+            Assert.AreEqual(firstCommentDate, actual[0][0].DateTime);
+            Assert.AreEqual(false, actual[0][0].Deleted);
+            Assert.AreEqual(thread, actual[0][0].Thread);
+            Assert.AreEqual(env.Username01, actual[0][0].User);
+            Assert.AreEqual("RUT", actual[0][0].VerseRef.Book);
+            Assert.AreEqual(1, actual[0][0].VerseRef.ChapterNum);
+            Assert.AreEqual(2, actual[0][0].VerseRef.VerseNum);
+
+            // Second Comment
+            Assert.AreEqual(contents, actual[0][1].Contents.InnerXml);
+            Assert.AreEqual(secondCommentDate, actual[0][1].DateTime);
+            Assert.AreEqual(false, actual[0][1].Deleted);
+            Assert.AreEqual(thread, actual[0][1].Thread);
+            Assert.AreEqual(env.Username02, actual[0][1].User);
+            Assert.AreEqual("RUT", actual[0][1].VerseRef.Book);
+            Assert.AreEqual(1, actual[0][1].VerseRef.ChapterNum);
+            Assert.AreEqual(2, actual[0][1].VerseRef.VerseNum);
+        }
+
+        [Test]
+        public void ParseNotes_NoComments()
+        {
+            // Setup the environment
+            var env = new TestEnvironment();
+            var associatedPtUser = new SFParatextUser(env.Username01);
+            env.SetupProject(env.Project01, associatedPtUser);
+
+            // Setup the test data
+            string xml = "<notes version=\"1.1\"></notes>";
+            XElement noteXml = XElement.Parse(xml);
+
+            // SUT
+            List<List<Comment>> actual = NotesFormatter.ParseNotes(noteXml, associatedPtUser);
+            Assert.AreEqual(0, actual.Count);
+        }
+
+        private class TestEnvironment
+        {
+            public readonly string Project01 = "project01";
+            public readonly string Username01 = "User 01";
+            public readonly string Username02 = "User 02";
+
+            private readonly Dictionary<string, HexId> _ptProjectIds;
+            private readonly string _syncDir = Path.GetTempPath();
+            private readonly string _ruthBookUsfm =
+                "\\id RUT - ProjectNameHere\n" + "\\c 1\n" + "\\v 1 Verse one here.\n" + "\\v 2 Verse 2 here.";
+
+            public TestEnvironment()
+            {
+                _ptProjectIds = new Dictionary<string, HexId> { { Project01, HexId.CreateNew() } };
+            }
+
+            public MockScrText? ProjectScrText { get; private set; }
+
+            public void SetupProject(string baseId, ParatextUser associatedPtUser, bool hasEditPermission = true)
+            {
+                string ptProjectId = _ptProjectIds[baseId].Id;
+                ProjectScrText = GetScrText(associatedPtUser, ptProjectId, hasEditPermission);
+
+                // We set the file manager here so we can track file manager operations after
+                // the ScrText object has been disposed in ParatextService.
+                ProjectFileManager projectFileManager = Substitute.For<ProjectFileManager>(ProjectScrText, null);
+                projectFileManager.IsWritable.Returns(true);
+                ProjectScrText.SetFileManager(projectFileManager);
+            }
+
+            private MockScrText GetScrText(
+                ParatextUser associatedPtUser,
+                string projectId,
+                bool hasEditPermission = true
+            )
+            {
+                string scrTextDir = Path.Combine(_syncDir, projectId, "target");
+                ProjectName projectName = new ProjectName { ProjectPath = scrTextDir, ShortName = "Proj" };
+                var scrText = new MockScrText(associatedPtUser, projectName) { CachedGuid = HexId.FromStr(projectId), };
+                scrText.Permissions.CreateFirstAdminUser();
+                scrText.Data.Add("RUT", _ruthBookUsfm);
+                scrText.Settings.BooksPresentSet = new BookSet("RUT");
+                if (!hasEditPermission)
+                    scrText.Permissions.SetPermission(null, 8, PermissionSet.Manual, false);
+                return scrText;
+            }
+        }
+    }
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/NotesFormatterTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/NotesFormatterTests.cs
@@ -44,7 +44,7 @@ namespace SIL.XForge.Scripture.Services
                 {
                     ContextScrTextName = env.ProjectScrText?.Name,
                     ScrText = env.ProjectScrText,
-                    Comments = new List<Comment> { comment, },
+                    Comments = new List<Comment> { comment },
                 },
             };
 
@@ -96,7 +96,7 @@ namespace SIL.XForge.Scripture.Services
                 {
                     ContextScrTextName = env.ProjectScrText?.Name,
                     ScrText = env.ProjectScrText,
-                    Comments = new List<Comment> { comment, },
+                    Comments = new List<Comment> { comment },
                 },
             };
 
@@ -182,7 +182,7 @@ namespace SIL.XForge.Scripture.Services
                 {
                     ContextScrTextName = env.ProjectScrText?.Name,
                     ScrText = env.ProjectScrText,
-                    Comments = new List<Comment> { comment, },
+                    Comments = new List<Comment> { comment },
                 },
             };
 
@@ -594,9 +594,6 @@ namespace SIL.XForge.Scripture.Services
             {
                 string ptProjectId = _ptProjectIds[baseId].Id;
                 ProjectScrText = GetScrText(associatedPtUser, ptProjectId, hasEditPermission);
-
-                // We set the file manager here so we can track file manager operations after
-                // the ScrText object has been disposed in ParatextService.
                 ProjectFileManager projectFileManager = Substitute.For<ProjectFileManager>(ProjectScrText, null);
                 projectFileManager.IsWritable.Returns(true);
                 ProjectScrText.SetFileManager(projectFileManager);
@@ -610,7 +607,7 @@ namespace SIL.XForge.Scripture.Services
             {
                 string scrTextDir = Path.Combine(_syncDir, projectId, "target");
                 ProjectName projectName = new ProjectName { ProjectPath = scrTextDir, ShortName = "Proj" };
-                var scrText = new MockScrText(associatedPtUser, projectName) { CachedGuid = HexId.FromStr(projectId), };
+                var scrText = new MockScrText(associatedPtUser, projectName) { CachedGuid = HexId.FromStr(projectId) };
                 scrText.Permissions.CreateFirstAdminUser();
                 scrText.Data.Add("RUT", _ruthBookUsfm);
                 scrText.Settings.BooksPresentSet = new BookSet("RUT");

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -439,8 +439,8 @@ namespace SIL.XForge.Scripture.Services
             env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
 
             // SUT
-            XDocument result = env.Service.GetBookText(null, ptProjectId, 8);
-            Assert.IsTrue(XNode.DeepEquals(XDocument.Parse(ruthBookUsx), result));
+            string result = env.Service.GetBookText(null, ptProjectId, 8);
+            Assert.That(result, Is.EqualTo(ruthBookUsx));
         }
 
         [Test]

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -439,8 +439,8 @@ namespace SIL.XForge.Scripture.Services
             env.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
 
             // SUT
-            string result = env.Service.GetBookText(null, ptProjectId, 8);
-            Assert.That(result, Is.EqualTo(ruthBookUsx));
+            XDocument result = env.Service.GetBookText(null, ptProjectId, 8);
+            Assert.IsTrue(XNode.DeepEquals(XDocument.Parse(ruthBookUsx), result));
         }
 
         [Test]

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -650,8 +650,8 @@ namespace SIL.XForge.Scripture.Services
             string threadId = "Answer_0123";
             string content = "Content for comment to update.";
             string verseRef = "RUT 1:1";
-            string updateNotesString = env.GetUpdateNotesString(threadId, env.User01, date, content, verseRef);
-            var syncMetricInfo = env.Service.PutNotes(userSecret, ptProjectId, updateNotesString);
+            XElement updateNotesXml = env.GetUpdateNotesXml(threadId, env.User01, date, content, verseRef);
+            var syncMetricInfo = env.Service.PutNotes(userSecret, ptProjectId, updateNotesXml);
 
             CommentThread thread = env.ProjectCommentManager.FindThread(threadId);
             Assert.That(thread.Comments.Count, Is.EqualTo(1));
@@ -663,8 +663,8 @@ namespace SIL.XForge.Scripture.Services
 
             // Edit a comment
             content = "Edited: Content for comment to update.";
-            updateNotesString = env.GetUpdateNotesString(threadId, env.User01, date, content, verseRef);
-            syncMetricInfo = env.Service.PutNotes(userSecret, ptProjectId, updateNotesString);
+            updateNotesXml = env.GetUpdateNotesXml(threadId, env.User01, date, content, verseRef);
+            syncMetricInfo = env.Service.PutNotes(userSecret, ptProjectId, updateNotesXml);
 
             Assert.That(thread.Comments.Count, Is.EqualTo(1));
             comment = thread.Comments.First();
@@ -672,8 +672,8 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(syncMetricInfo, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 1)));
 
             // Delete a comment
-            updateNotesString = env.GetUpdateNotesString(threadId, env.User01, date, content, verseRef, true);
-            syncMetricInfo = env.Service.PutNotes(userSecret, ptProjectId, updateNotesString);
+            updateNotesXml = env.GetUpdateNotesXml(threadId, env.User01, date, content, verseRef, true);
+            syncMetricInfo = env.Service.PutNotes(userSecret, ptProjectId, updateNotesXml);
 
             Assert.That(thread.Comments.Count, Is.EqualTo(1));
             comment = thread.Comments.First();
@@ -3960,7 +3960,7 @@ namespace SIL.XForge.Scripture.Services
                 return chapterDeltas;
             }
 
-            public string GetUpdateNotesString(
+            public XElement GetUpdateNotesXml(
                 string threadId,
                 string user,
                 DateTime date,
@@ -3992,7 +3992,7 @@ namespace SIL.XForge.Scripture.Services
                 }
                 threadElem.Add(commentElem);
                 notesElem.Add(threadElem);
-                return notesElem.ToString();
+                return notesElem;
             }
 
             public async Task<IEnumerable<IDocument<NoteThread>>> GetNoteThreadDocsAsync(

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -1166,8 +1166,7 @@ namespace SIL.XForge.Scripture.Services
         {
             var env = new TestEnvironment();
             IEnumerable<NoteThreadChange> changes = await env.PrepareChangeOnSingleCommentAsync(
-                (Paratext.Data.ProjectComments.Comment comment) =>
-                {
+                (Paratext.Data.ProjectComments.Comment comment) => {
                     // Not modifying comment.
                 }
             );

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -1166,7 +1166,8 @@ namespace SIL.XForge.Scripture.Services
         {
             var env = new TestEnvironment();
             IEnumerable<NoteThreadChange> changes = await env.PrepareChangeOnSingleCommentAsync(
-                (Paratext.Data.ProjectComments.Comment comment) => {
+                (Paratext.Data.ProjectComments.Comment comment) =>
+                {
                     // Not modifying comment.
                 }
             );
@@ -2149,8 +2150,8 @@ namespace SIL.XForge.Scripture.Services
                 Name = "SF Note Tag",
             };
             env.SetupCommentTags(env.ProjectScrText, noteTag);
-            ParatextSettings settings = env.Service.GetParatextSettings(userSecret, paratextId);
-            Assert.That(settings.NoteTags.Any(t => t.Name == noteTag.Name), Is.True);
+            ParatextSettings? settings = env.Service.GetParatextSettings(userSecret, paratextId);
+            Assert.That(settings?.NoteTags.Any(t => t.Name == noteTag.Name), Is.True);
         }
 
         [Test]
@@ -2166,8 +2167,8 @@ namespace SIL.XForge.Scripture.Services
                 Icon = "sf05",
                 Name = "SF Note Tag"
             };
-            ParatextSettings settings = env.Service.GetParatextSettings(userSecret, paratextId);
-            Assert.That(settings.NoteTags.FirstOrDefault(t => t.Icon == noteTag.Icon), Is.Null);
+            ParatextSettings? settings = env.Service.GetParatextSettings(userSecret, paratextId);
+            Assert.That(settings?.NoteTags.FirstOrDefault(t => t.Icon == noteTag.Icon), Is.Null);
         }
 
         [Test]
@@ -2187,8 +2188,8 @@ namespace SIL.XForge.Scripture.Services
             env.Service.UpdateCommentTag(userSecret, paratextId, noteTag);
             // the new tag is created with a tag id one greater than the last used id
             int tagId = env.TagCount + 1;
-            ParatextSettings settings = env.Service.GetParatextSettings(userSecret, paratextId);
-            Assert.That(settings.NoteTags.First(t => t.Icon == icon).TagId, Is.EqualTo(tagId));
+            ParatextSettings? settings = env.Service.GetParatextSettings(userSecret, paratextId);
+            Assert.That(settings?.NoteTags.First(t => t.Icon == icon).TagId, Is.EqualTo(tagId));
         }
 
         [Test]

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -491,12 +491,7 @@ namespace SIL.XForge.Scripture.Services
                 Substitute.For<IExceptionHandler>()
             );
             var newDocUsx = mapper.ToUsx(oldDocUsx, new List<ChapterDelta> { new ChapterDelta(1, 2, true, data) });
-            int booksUpdated = await env.Service.PutBookText(
-                userSecret,
-                ptProjectId,
-                ruthBookNum,
-                newDocUsx.Root.ToString()
-            );
+            int booksUpdated = await env.Service.PutBookText(userSecret, ptProjectId, ruthBookNum, newDocUsx);
             env.ProjectFileManager.Received(1).WriteFileCreatingBackup(Arg.Any<string>(), Arg.Any<Action<string>>());
             Assert.That(booksUpdated, Is.EqualTo(1));
 
@@ -520,7 +515,12 @@ namespace SIL.XForge.Scripture.Services
                 + "Verse 1 here. <verse number=\"2\" style=\"v\" />Verse 2 here.</usx>";
 
             // SUT
-            int booksUpdated = await env.Service.PutBookText(userSecret, ptProjectId, ruthBookNum, ruthBookUsx);
+            int booksUpdated = await env.Service.PutBookText(
+                userSecret,
+                ptProjectId,
+                ruthBookNum,
+                XDocument.Parse(ruthBookUsx)
+            );
 
             // Make sure only one ScrText was loaded
             env.MockScrTextCollection.Received(1).FindById(env.Username01, ptProjectId);
@@ -557,7 +557,7 @@ namespace SIL.XForge.Scripture.Services
                 userSecret,
                 ptProjectId,
                 ruthBookNum,
-                ruthBookUsx,
+                XDocument.Parse(ruthBookUsx),
                 chapterAuthors
             );
 
@@ -597,7 +597,7 @@ namespace SIL.XForge.Scripture.Services
                 userSecret,
                 ptProjectId,
                 ruthBookNum,
-                ruthBookUsx,
+                XDocument.Parse(ruthBookUsx),
                 chapterAuthors
             );
 

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -270,17 +270,17 @@ namespace SIL.XForge.Scripture.Services
 
             await env.ParatextService
                 .DidNotReceive()
-                .PutBookText(Arg.Any<UserSecret>(), "target", 40, Arg.Any<string>());
+                .PutBookText(Arg.Any<UserSecret>(), "target", 40, Arg.Any<XDocument>());
             await env.ParatextService
                 .DidNotReceive()
-                .PutBookText(Arg.Any<UserSecret>(), "target", 41, Arg.Any<string>());
+                .PutBookText(Arg.Any<UserSecret>(), "target", 41, Arg.Any<XDocument>());
 
             await env.ParatextService
                 .DidNotReceive()
-                .PutBookText(Arg.Any<UserSecret>(), "source", 40, Arg.Any<string>());
+                .PutBookText(Arg.Any<UserSecret>(), "source", 40, Arg.Any<XDocument>());
             await env.ParatextService
                 .DidNotReceive()
-                .PutBookText(Arg.Any<UserSecret>(), "source", 41, Arg.Any<string>());
+                .PutBookText(Arg.Any<UserSecret>(), "source", 41, Arg.Any<XDocument>());
 
             var delta = Delta.New().InsertText("text");
             Assert.That(env.GetText("project01", "MAT", 1).DeepEquals(delta), Is.True);
@@ -318,7 +318,7 @@ namespace SIL.XForge.Scripture.Services
                     Arg.Any<UserSecret>(),
                     "target",
                     40,
-                    Arg.Any<string>(),
+                    Arg.Any<XDocument>(),
                     Arg.Any<Dictionary<int, string>>()
                 );
             await env.ParatextService
@@ -327,7 +327,7 @@ namespace SIL.XForge.Scripture.Services
                     Arg.Any<UserSecret>(),
                     "target",
                     41,
-                    Arg.Any<string>(),
+                    Arg.Any<XDocument>(),
                     Arg.Any<Dictionary<int, string>>()
                 );
 
@@ -337,7 +337,7 @@ namespace SIL.XForge.Scripture.Services
                     Arg.Any<UserSecret>(),
                     "source",
                     40,
-                    Arg.Any<string>(),
+                    Arg.Any<XDocument>(),
                     Arg.Any<Dictionary<int, string>>()
                 );
             await env.ParatextService
@@ -346,7 +346,7 @@ namespace SIL.XForge.Scripture.Services
                     Arg.Any<UserSecret>(),
                     "source",
                     41,
-                    Arg.Any<string>(),
+                    Arg.Any<XDocument>(),
                     Arg.Any<Dictionary<int, string>>()
                 );
 
@@ -385,7 +385,7 @@ namespace SIL.XForge.Scripture.Services
                     Arg.Any<UserSecret>(),
                     "target",
                     40,
-                    Arg.Any<string>(),
+                    Arg.Any<XDocument>(),
                     Arg.Any<Dictionary<int, string>>()
                 );
             await env.ParatextService
@@ -394,7 +394,7 @@ namespace SIL.XForge.Scripture.Services
                     Arg.Any<UserSecret>(),
                     "target",
                     41,
-                    Arg.Any<string>(),
+                    Arg.Any<XDocument>(),
                     Arg.Any<Dictionary<int, string>>()
                 );
 
@@ -404,7 +404,7 @@ namespace SIL.XForge.Scripture.Services
                     Arg.Any<UserSecret>(),
                     "source",
                     40,
-                    Arg.Any<string>(),
+                    Arg.Any<XDocument>(),
                     Arg.Any<Dictionary<int, string>>()
                 );
             await env.ParatextService
@@ -413,7 +413,7 @@ namespace SIL.XForge.Scripture.Services
                     Arg.Any<UserSecret>(),
                     "source",
                     41,
-                    Arg.Any<string>(),
+                    Arg.Any<XDocument>(),
                     Arg.Any<Dictionary<int, string>>()
                 );
 
@@ -2256,7 +2256,7 @@ namespace SIL.XForge.Scripture.Services
                     Arg.Any<UserSecret>(),
                     Arg.Any<string>(),
                     Arg.Any<int>(),
-                    Arg.Any<string>(),
+                    Arg.Any<XDocument>(),
                     Arg.Any<Dictionary<int, string>>()
                 )
                 .Returns(1);
@@ -2269,7 +2269,7 @@ namespace SIL.XForge.Scripture.Services
                     Arg.Any<UserSecret>(),
                     Arg.Any<string>(),
                     Arg.Any<int>(),
-                    Arg.Any<string>(),
+                    Arg.Any<XDocument>(),
                     Arg.Any<Dictionary<int, string>>()
                 );
             ;

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -3485,13 +3485,13 @@ namespace SIL.XForge.Scripture.Services
             {
                 MockGetBookText(paratextId, bookId);
                 int bookNum = Canon.BookIdToNumber(bookId);
-                XDocument newBook = GetBookText(paratextId, bookId, changed ? 2 : 1);
+                string newBookText = GetBookText(paratextId, bookId, changed ? 2 : 1);
                 Func<XDocument, bool> predicate = d =>
                     (string)d?.Root?.Element("book")?.Attribute("code") == bookId
                     && (string)d?.Root?.Element("book") == paratextId;
                 DeltaUsxMapper
                     .ToUsx(Arg.Is<XDocument>(d => predicate(d)), Arg.Any<IEnumerable<ChapterDelta>>())
-                    .Returns(newBook);
+                    .Returns(XDocument.Parse(newBookText));
 
                 for (int c = 1; c <= highestChapter; c++)
                 {
@@ -3521,18 +3521,16 @@ namespace SIL.XForge.Scripture.Services
 
             private void MockGetBookText(string paratextId, string bookId)
             {
-                XDocument oldBookText = GetBookText(paratextId, bookId, 1);
-                XDocument remoteBookText = GetBookText(paratextId, bookId, 3);
+                string oldBookText = GetBookText(paratextId, bookId, 1);
+                string remoteBookText = GetBookText(paratextId, bookId, 3);
                 ParatextService
                     .GetBookText(Arg.Any<UserSecret>(), paratextId, Canon.BookIdToNumber(bookId))
                     .Returns(x => _sendReceivedCalled ? remoteBookText : oldBookText);
             }
 
-            private static XDocument GetBookText(string paratextId, string bookId, int version)
+            private static string GetBookText(string paratextId, string bookId, int version)
             {
-                return XDocument.Parse(
-                    $"<usx version=\"2.5\"><book code=\"{bookId}\" style=\"id\">{paratextId}</book><content version=\"{version}\"/></usx>"
-                );
+                return $"<usx version=\"2.5\"><book code=\"{bookId}\" style=\"id\">{paratextId}</book><content version=\"{version}\"/></usx>";
             }
 
             private void SetupNoteThreadChanges(NoteThreadChange[] noteThreadChanges, string projectId, int bookNum)

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -3485,13 +3485,13 @@ namespace SIL.XForge.Scripture.Services
             {
                 MockGetBookText(paratextId, bookId);
                 int bookNum = Canon.BookIdToNumber(bookId);
-                string newBookText = GetBookText(paratextId, bookId, changed ? 2 : 1);
+                XDocument newBook = GetBookText(paratextId, bookId, changed ? 2 : 1);
                 Func<XDocument, bool> predicate = d =>
                     (string)d?.Root?.Element("book")?.Attribute("code") == bookId
                     && (string)d?.Root?.Element("book") == paratextId;
                 DeltaUsxMapper
                     .ToUsx(Arg.Is<XDocument>(d => predicate(d)), Arg.Any<IEnumerable<ChapterDelta>>())
-                    .Returns(XDocument.Parse(newBookText));
+                    .Returns(newBook);
 
                 for (int c = 1; c <= highestChapter; c++)
                 {
@@ -3521,16 +3521,18 @@ namespace SIL.XForge.Scripture.Services
 
             private void MockGetBookText(string paratextId, string bookId)
             {
-                string oldBookText = GetBookText(paratextId, bookId, 1);
-                string remoteBookText = GetBookText(paratextId, bookId, 3);
+                XDocument oldBookText = GetBookText(paratextId, bookId, 1);
+                XDocument remoteBookText = GetBookText(paratextId, bookId, 3);
                 ParatextService
                     .GetBookText(Arg.Any<UserSecret>(), paratextId, Canon.BookIdToNumber(bookId))
                     .Returns(x => _sendReceivedCalled ? remoteBookText : oldBookText);
             }
 
-            private static string GetBookText(string paratextId, string bookId, int version)
+            private static XDocument GetBookText(string paratextId, string bookId, int version)
             {
-                return $"<usx version=\"2.5\"><book code=\"{bookId}\" style=\"id\">{paratextId}</book><content version=\"{version}\"/></usx>";
+                return XDocument.Parse(
+                    $"<usx version=\"2.5\"><book code=\"{bookId}\" style=\"id\">{paratextId}</book><content version=\"{version}\"/></usx>"
+                );
             }
 
             private void SetupNoteThreadChanges(NoteThreadChange[] noteThreadChanges, string projectId, int bookNum)

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -293,7 +293,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.GetText("project02", "MRK", 1).DeepEquals(delta), Is.True);
             Assert.That(env.GetText("project02", "MRK", 2).DeepEquals(delta), Is.True);
 
-            env.ParatextService.DidNotReceive().PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<string>());
+            env.ParatextService.DidNotReceive().PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<XElement>());
 
             SFProject project = env.VerifyProjectSync(true);
             Assert.That(project.ParatextUsers.Count, Is.EqualTo(2));
@@ -361,7 +361,7 @@ namespace SIL.XForge.Scripture.Services
             Assert.That(env.GetText("project02", "MRK", 1).DeepEquals(delta), Is.True);
             Assert.That(env.GetText("project02", "MRK", 2).DeepEquals(delta), Is.True);
 
-            env.ParatextService.Received(2).PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<string>());
+            env.ParatextService.Received(2).PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<XElement>());
 
             SFProject project = env.GetProject();
             Assert.That(project.ParatextUsers.Count, Is.EqualTo(2));
@@ -417,7 +417,7 @@ namespace SIL.XForge.Scripture.Services
                     Arg.Any<Dictionary<int, string>>()
                 );
 
-            env.ParatextService.DidNotReceive().PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<string>());
+            env.ParatextService.DidNotReceive().PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<XElement>());
 
             var delta = Delta.New().InsertText("text");
             Assert.That(env.GetText("project01", "MAT", 1).DeepEquals(delta), Is.True);
@@ -2231,11 +2231,11 @@ namespace SIL.XForge.Scripture.Services
             env.SetupSFData(true, true, true, false, books);
             env.SetupPTData(books);
             var syncMetricInfo = new SyncMetricInfo(1, 2, 3);
-            env.ParatextService.PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<string>()).Returns(syncMetricInfo);
+            env.ParatextService.PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<XElement>()).Returns(syncMetricInfo);
 
             await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
-            env.ParatextService.Received(2).PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<string>());
+            env.ParatextService.Received(2).PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<XElement>());
 
             env.VerifyProjectSync(true);
 


### PR DESCRIPTION
This pull request improves memory use and speed during syncing by optimizing syncing for projects using Paratext Resources as sources, and optimizing the using of conversion to and from XML for texts and answers.

The changes in this pull request include:
 * **Optimization:** Refactoring `ParatextSyncRunner` so that Paratext Resources will only be updated in MongoDB if they have changed (bebf204f02605b8e2913a9ae07121790dda5ad82)
 * ~~**Optimization:** Optimizing the conversion of USFM to USX from ` String -> XmlWriter -> String -> XmlReader -> XDocument` to now be `String -> XmlWriter -> XDocument` (d023d0034690454ae35b75755031153fdfe3d965)~~ *Removed due to the requirement for `XDocument.Parse` to strip unnecessary whitespace for an accurate USX XDocument comparison.*
 * **Optimization:** Optimizing the conversion of USX to USFM from `XDocument -> String -> XmlDocument > XPathNavigator` to now be `XDocument -> XPathNavigator` (abd589fa6d1afd36308c4a7393dfa47174faaa3c)
 * **Optimization:** Reducing JsonService memory use by: (9f6d745b9640eddaa1ff19238e0d3cd4700ac65a)
   * Implementing an `InvokeExportAsync` method that does not deserialize the output for `void` function calls, utilizing the following codepoints in Jering:
     * https://github.com/JeringTech/Javascript.NodeJS/blob/master/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/OutOfProcessNodeJSService.cs#L132
     * https://github.com/JeringTech/Javascript.NodeJS/blob/master/src/NodeJS/NodeJSServiceImplementations/OutOfProcess/Http/HttpNodeJSService.cs#L138)
   * Implementing a custom `ContractResolver`, as `CamelCasePropertyNamesContractResolver` maintains an in memory cache that is not necessary for SF given the wide range of JSON property names used in ops. (see https://stackoverflow.com/questions/33557737/does-json-net-cache-types-serialization-information)
   * Reusing the `ContractResolver` rather than the `JsonSerializer` (see https://www.newtonsoft.com/json/help/html/Performance.htm)
 * **Optimization:** Optimizing the conversion of Answers to Paratext Notes by working with `XElement` throughout the process, rather than converting two and from text (ecc62dbdeb93ea736983d168b85ea8df123a66b1)
 * **Bug fix:** Fixing a crash found during testing the changes above that occurs when an incoming note from Paratext has a missing <Content> element (9ecaf3c114561f0a8eb7fd6f7035190508dcbfb6)
 * **Coding style improvement:** Correctly defining the nullability for `GetParatextSettings` (bd976e85d35bb0304a32d76de01af99426c0ff71)
 * **Coding style improvement:** Applying Coding Suggestions from Visual Studio to `ParatextSyncRunner` relating to method parameters (de27a704245bffe719bbd006ba209926a97ef09d)
 * **Unit Testing** Created a full set of unit tests for `NotesFormatter` with full coverage, as there were none (9fa4da5da8a3f218fefe0529ff2db34ef07ad306)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1667)
<!-- Reviewable:end -->
