### PR TITLE
SF-1779 Only update resource access for Paratext users on sync

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -313,8 +313,10 @@ namespace SIL.XForge.Scripture.Services
                     {
                         // NOTE: The following additions/removals not included in the transaction
 
-                        // Add new users who are in the target project, but not the source project
-                        List<string> usersToAdd = _projectDoc.Data.UserRoles.Keys
+                        // Add new PT users who are in the target project, but not the source project
+                        List<string> usersToAdd = _projectDoc.Data.UserRoles
+                            .Where(u => SFProjectRole.IsParatextRole(u.Value))
+                            .Select(u => u.Key)
                             .Except(sourceProject.Data.UserRoles.Keys)
                             .ToList();
                         foreach (string uid in usersToAdd)
@@ -332,8 +334,12 @@ namespace SIL.XForge.Scripture.Services
                             }
                         }
 
-                        // Remove users who are in the target project, and no longer have access
-                        List<string> usersToCheck = _projectDoc.Data.UserRoles.Keys.Except(usersToAdd).ToList();
+                        // Remove PT users who are in the target project, and no longer have access to the resource
+                        List<string> usersToCheck = _projectDoc.Data.UserRoles
+                            .Where(u => SFProjectRole.IsParatextRole(u.Value))
+                            .Select(u => u.Key)
+                            .Except(usersToAdd)
+                            .ToList();
                         foreach (string uid in usersToCheck)
                         {
                             string permission = await _paratextService.GetResourcePermissionAsync(


### PR DESCRIPTION
When a project with a resource is synced, users with access to the target project, but not access to the source project in SF, are granted access to the resource. Currently for all users, whether they have Paratext access or not, an attempt is made to grant each user meeting that criteria access to the source project, by checking whether or not they have access to the resource.

As resources can only be accessed by Paratext users, this fix updates the check for users without access to the resource to only check users with Paratext access.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1668)
<!-- Reviewable:end -->
