### PR TITLE
SF-1851 Update the source text in the editor when the target text changes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -462,9 +462,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
             const userOnProject: boolean = !!this.currentUser?.sites[environment.siteId].projects.includes(sourceId);
             // Only get the project doc if the user is on the project to avoid an error.
             this.sourceProjectDoc = userOnProject ? await this.projectService.getProfile(sourceId) : undefined;
-            if (this.sourceProjectDoc != null && this.sourceProjectDoc.data != null) {
-              this.sourceText = this.sourceProjectDoc.data.texts.find(t => t.bookNum === bookNum);
-            }
           }
 
           if (this.projectUserConfigChangesSub != null) {
@@ -479,6 +476,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         }
         await this.loadNoteThreadDocs(this.projectDoc.id);
         this.text = this.projectDoc.data.texts.find(t => t.bookNum === bookNum);
+        if (this.sourceProjectDoc?.data != null) {
+          this.sourceText = this.sourceProjectDoc.data.texts.find(t => t.bookNum === bookNum);
+        }
         this.chapters = this.text == null ? [] : this.text.chapters.map(c => c.number);
 
         this.loadProjectUserConfig();


### PR DESCRIPTION
When the source project does not contain all of the books of the target project, the source pane may not always display. This is because the `sourceText` variable of the editor component does not update when the `text` variable updates when the user changes to the next book.

This can occur when a target project is the entire bible, and the source project is the New Testament. In this case, when you connect to the project for the first time or log in after having the cursor last in an Old Testament book, and then click on a New Testament book, the source pane will not display as the `sourceText` variable has not updated to the new source text. This pull request fixes that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1670)
<!-- Reviewable:end -->
