### PR TITLE
SF-1844a Add Authorization to the SignalR hub

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/project-notification.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/project-notification.service.ts
@@ -1,14 +1,18 @@
 import { Injectable } from '@angular/core';
-import { HubConnection, HubConnectionBuilder } from '@microsoft/signalr';
+import { HubConnection, HubConnectionBuilder, IHttpConnectionOptions } from '@microsoft/signalr';
+import { AuthService } from 'xforge-common/auth.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ProjectNotificationService {
   private connection: HubConnection;
+  private options: IHttpConnectionOptions = {
+    accessTokenFactory: async () => (await this.authService.getAccessToken()) ?? ''
+  };
 
-  constructor() {
-    this.connection = new HubConnectionBuilder().withUrl('/project-notifications').build();
+  constructor(private authService: AuthService) {
+    this.connection = new HubConnectionBuilder().withUrl('/project-notifications', this.options).build();
   }
 
   setNotifySyncProgressHandler(handler: any): void {

--- a/src/SIL.XForge.Scripture/Services/NotificationHub.cs
+++ b/src/SIL.XForge.Scripture/Services/NotificationHub.cs
@@ -1,9 +1,11 @@
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using SIL.XForge.Scripture.Models;
 
 namespace SIL.XForge.Scripture.Services
 {
+    [Authorize]
     public class NotificationHub : Hub<INotifier>, INotifier
     {
         /// <summary>

--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -257,7 +257,7 @@ namespace SIL.XForge.Scripture
             {
                 endpoints.MapControllers();
                 endpoints.MapRazorPages();
-                endpoints.MapHub<NotificationHub>(pattern: "/project-notifications");
+                endpoints.MapHub<NotificationHub>(pattern: $"/{UrlConstants.ProjectNotifications}");
             });
 
             // Map JSON-RPC controllers after MVC controllers, so that MVC controllers take precedence.

--- a/src/SIL.XForge/Controllers/UrlConstants.cs
+++ b/src/SIL.XForge/Controllers/UrlConstants.cs
@@ -5,5 +5,6 @@ namespace SIL.XForge
         public const string CommandApiNamespace = "command-api";
         public const string Users = "users";
         public const string Projects = "projects";
+        public const string ProjectNotifications = "project-notifications";
     }
 }

--- a/src/SIL.XForge/Services/AuthServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Services/AuthServiceCollectionExtensions.cs
@@ -28,6 +28,21 @@ namespace Microsoft.Extensions.DependencyInjection
                     options.Audience = authOptions.Audience;
                     options.Events = new JwtBearerEvents
                     {
+                        OnMessageReceived = context =>
+                        {
+                            // If the request is for our SignalR hub
+                            string? accessToken = context.Request.Query["access_token"];
+                            if (
+                                !string.IsNullOrEmpty(accessToken)
+                                && context.HttpContext.Request.Path.StartsWithSegments("/project-notifications")
+                            )
+                            {
+                                // Get the token from the query string
+                                context.Token = accessToken;
+                            }
+
+                            return Task.CompletedTask;
+                        },
                         OnTokenValidated = context =>
                         {
                             string scopeClaim = context.Principal.FindFirst(c => c.Type == JwtClaimTypes.Scope)?.Value;

--- a/src/SIL.XForge/Services/AuthServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Services/AuthServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using idunno.Authentication.Basic;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
+using SIL.XForge;
 using SIL.XForge.Configuration;
 using SIL.XForge.Services;
 
@@ -34,7 +35,9 @@ namespace Microsoft.Extensions.DependencyInjection
                             string? accessToken = context.Request.Query["access_token"];
                             if (
                                 !string.IsNullOrEmpty(accessToken)
-                                && context.HttpContext.Request.Path.StartsWithSegments("/project-notifications")
+                                && context.HttpContext.Request.Path.StartsWithSegments(
+                                    $"/{UrlConstants.ProjectNotifications}"
+                                )
                             )
                             {
                                 // Get the token from the query string


### PR DESCRIPTION
During implementation of the SignalR hub, the requirement to authorize connections was accidentally omitted. Due to SignalR's slightly different method of configuration than controllers, this was not picked up prior to merging.

This Pull Request:

 * Enables authorization for the Project Notifications SignalR hub
 * Modifies the Project Notification Service to send the access_token
 * Updates the JwtBearer event handler to read the access_token from the query string if the request is for the Project Notifications SignalR hub (this is how SignalR sends the token)
   * Code is adapted from https://learn.microsoft.com/en-us/aspnet/core/signalr/authn-and-authz?view=aspnetcore-7.0
   * See https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/clients/ts/signalr/src/WebSocketTransport.ts#L75

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1673)
<!-- Reviewable:end -->
