### PR TITLE
Add return type warning to eslint

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/.eslintrc.json
+++ b/src/SIL.XForge.Scripture/ClientApp/.eslintrc.json
@@ -35,6 +35,7 @@
         ],
         "@typescript-eslint/consistent-type-definitions": "error",
         "@typescript-eslint/dot-notation": "off",
+        "@typescript-eslint/explicit-function-return-type": "warn",
         "@typescript-eslint/explicit-member-accessibility": [
           "off",
           {

--- a/src/SIL.XForge.Scripture/ClientApp/.eslintrc.json
+++ b/src/SIL.XForge.Scripture/ClientApp/.eslintrc.json
@@ -35,7 +35,12 @@
         ],
         "@typescript-eslint/consistent-type-definitions": "error",
         "@typescript-eslint/dot-notation": "off",
-        "@typescript-eslint/explicit-function-return-type": "warn",
+        "@typescript-eslint/explicit-function-return-type": [
+          "warn",
+          {
+            "allowExpressions": true
+          }
+        ],
         "@typescript-eslint/explicit-member-accessibility": [
           "off",
           {


### PR DESCRIPTION
Show a lint warning if a method doesn't have a return type set.

We decided against making this an error as there are 300 methods that need to be fixed. We decided that we can fix them as we come across them and then change the lint rule to an error in the future.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1677)
<!-- Reviewable:end -->
