### PR TITLE
Save sync metrics logs to DB as they are created

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1668,6 +1668,16 @@ namespace SIL.XForge.Scripture.Services
             LogMetric(message);
         }
 
-        private void LogMetric(string message) => _syncMetrics.Log.Add($"{DateTime.UtcNow} {message}");
+        private void LogMetric(string message)
+        {
+            _syncMetrics.Log.Add($"{DateTime.UtcNow} {message}");
+            _syncMetricsRepository
+                .ReplaceAsync(_syncMetrics, true)
+                .ContinueWith(task =>
+                {
+                    if (!task.Result)
+                        _logger.LogInformation("The sync metrics could not be updated in MongoDB");
+                });
+        }
     }
 }


### PR DESCRIPTION
We've had a number of sync failures recently with very little insight into what went wrong because Jering.Javascript doesn't give a complete stack trace (nowhere in the stack trace does our code appear). The failures usually end with a log of "RunAsync: ParatextData SendReceive finished without throwing." followed by a Jering.Javascript exception.

I'm not certain that this is the right approach, but we clearly need to have more detailed logging of where things are going wrong.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1678)
<!-- Reviewable:end -->
