### PR TITLE
Deploy production as not self-contained

### DIFF
--- a/scripts/build-production
+++ b/scripts/build-production
@@ -30,4 +30,4 @@ EOF
 rm -rf "${BUILD_OUTPUT}"
 dotnet publish "src/${PROJECT}/${PROJECT}.csproj" -c "${CONFIGURATION}" -r "${DEPLOY_RUNTIME}" \
   -o "${BUILD_OUTPUT}/app" /p:Version="${BUILD_NUMBER}" /p:AngularConfig="${ANGULAR_CONFIG}" \
-  --self-contained
+  --self-contained false


### PR DESCRIPTION
Building for production to use the host dotnet, rather than building a
self-contained set of files, may broaden the diagnostics we can gather
regarding memory usage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1682)
<!-- Reviewable:end -->
