### PR TITLE
Stop Hangfire jobs deadlocking when a preceding job will not start

### DIFF
--- a/src/SIL.XForge/DataAccess/DataAccessServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/DataAccess/DataAccessServiceCollectionExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.DependencyInjection
                         new MongoStorageOptions
                         {
                             CheckQueuedJobsStrategy = CheckQueuedJobsStrategy.TailNotificationsCollection,
-                            InvisibilityTimeout = TimeSpan.FromMinutes(30),
+                            InvisibilityTimeout = TimeSpan.FromMinutes(120),
                             MigrationOptions = new MongoMigrationOptions
                             {
                                 MigrationStrategy = new MigrateMongoMigrationStrategy(),

--- a/src/SIL.XForge/DataAccess/DataAccessServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/DataAccess/DataAccessServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Extensions.DependencyInjection
                         new MongoStorageOptions
                         {
                             CheckQueuedJobsStrategy = CheckQueuedJobsStrategy.TailNotificationsCollection,
+                            InvisibilityTimeout = TimeSpan.FromMinutes(30),
                             MigrationOptions = new MongoMigrationOptions
                             {
                                 MigrationStrategy = new MigrateMongoMigrationStrategy(),


### PR DESCRIPTION
When Scripture Forge restarts, Hangfire assigns a new server GUID. This replaces the previous server instance, and so any jobs that were scheduled for execution before reboot will be stuck in an aborted state, with the following status on the Job Details screen:

![image](https://user-images.githubusercontent.com/8665431/215651627-bc5f81f4-317c-4ef3-8fe8-5ab88b425a8d.png)

If another job is waiting for that job to finish (it will not start in this state), that job will check every 15 seconds to see if the preceding job has finished (it will not finish), until the maximum document size is reached and Hangfire crashes.

To resolve this, an `InvisibilityTimeout` setting was added to Hangfire, however this is not configured by default for the Mongo storage engine we use. See [Hangfire.Mongo's README.md](https://github.com/Hangfire-Mongo/Hangfire.Mongo#migration):

> NOTE: By default the parameter `InvisibilityTimeout` of the `MongoStorageOptions` is configured with the value null, making the job to stay in status 'processing' in case of an error in the application. To solve this issue, set the value to 30 minutes like in the [SqlServerStorageOptions](https://docs.hangfire.io/en/latest/configuration/using-sql-server.html).

This pull request resolves this deadlock by setting the` InvisibilityTimeout` to 30 minutes, as suggested above.

I was able to successfully replicate this issue by restoring the most recent backup of `sf_jobs` from production to my workstation, and running Scripture Forge first without this fix, then with this fix to confirm that this is indeed the issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1683)
<!-- Reviewable:end -->
