### PR TITLE
Revert "Save sync metrics logs to DB as they are created"

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1668,16 +1668,6 @@ namespace SIL.XForge.Scripture.Services
             LogMetric(message);
         }
 
-        private void LogMetric(string message)
-        {
-            _syncMetrics.Log.Add($"{DateTime.UtcNow} {message}");
-            _syncMetricsRepository
-                .ReplaceAsync(_syncMetrics, true)
-                .ContinueWith(task =>
-                {
-                    if (!task.Result)
-                        _logger.LogInformation("The sync metrics could not be updated in MongoDB");
-                });
-        }
+        private void LogMetric(string message) => _syncMetrics.Log.Add($"{DateTime.UtcNow} {message}");
     }
 }


### PR DESCRIPTION
Reverts sillsdev/web-xforge#1678

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1684)
<!-- Reviewable:end -->
