### PR TITLE
Logging hotfix

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1598,7 +1598,7 @@ namespace SIL.XForge.Scripture.Services
             projectSFId ??= _projectDoc?.Id ?? "unknown";
             userId ??= _userSecret?.Id ?? "unknown";
             _logger.LogInformation($"SyncLog ({projectSFId} {userId}): {message}");
-            _syncMetrics.Log.Add($"{DateTime.UtcNow} {message}");
+            _syncMetrics.Log.Add($"{DateTime.UtcNow.ToString("u")} {message}");
         }
 
         private void LogMetric(string message)

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1603,8 +1603,7 @@ namespace SIL.XForge.Scripture.Services
 
         private void LogMetric(string message)
         {
-            _logger.LogInformation($"SyncLog: {DateTime.UtcNow} {message}");
-            _syncMetrics.Log.Add($"{DateTime.UtcNow} {message}");
+            Log(message);
         }
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -369,6 +369,7 @@ namespace SIL.XForge.Scripture.Services
                         token
                     );
                 }
+                LogMetric("Back from UpdateDocsAsync");
 
                 // Check for cancellation
                 if (token.IsCancellationRequested)
@@ -523,13 +524,16 @@ namespace SIL.XForge.Scripture.Services
                 }
 
                 // update note thread docs
-                LogMetric("Updating thread docs");
+                LogMetric("Updating thread docs - fetching");
                 Dictionary<string, IDocument<NoteThread>> noteThreadDocs = await FetchNoteThreadDocsAsync(text.BookNum);
+                LogMetric("Updating thread docs - get deltas");
                 Dictionary<int, ChapterDelta> chapterDeltas = GetDeltasByChapter(text, targetParatextId);
 
+                LogMetric("Updating thread docs - updating");
                 await UpdateNoteThreadDocsAsync(text, noteThreadDocs, token, chapterDeltas, ptUsernamesToSFUserIds);
 
                 // update project metadata
+                LogMetric("Updating project metadata");
                 await _projectDoc.SubmitJson0OpAsync(op =>
                 {
                     if (textIndex == -1)


### PR DESCRIPTION
These cherry-picks are to add additional logging to Live around the area where the Out of memory errors occurred. 

However, Live seems to have recovered from Out of memory troubles from a recent Jering HTTP version change. So I'm not in a rush to send this to Live right away. ?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1689)
<!-- Reviewable:end -->
