### PR TITLE
SF-1868 Show mobile keyboard when adding a note

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -893,7 +893,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     const dialogRef = this.dialogService.openMatDialog<NoteDialogComponent, NoteDialogData, boolean>(
       NoteDialogComponent,
       {
-        autoFocus: false,
+        autoFocus: true,
         width: '600px',
         disableClose: true,
         data: noteDialogData
@@ -982,7 +982,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       this.target.editor.scrollingContainer.scrollTop = 0;
     }
     this.textHeight = `calc(100vh - ${top}px)`;
-    if (this.targetFocused) {
+    if (this.targetFocused && this.dialogService.openDialogCount < 1) {
       setTimeout(() => {
         // reset focus, which causes Quill to scroll to the selection
         this.target!.focus();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
@@ -18,6 +18,9 @@ h1 {
 }
 .mat-dialog-content {
   min-height: 300px;
+  @include media-breakpoint-down(sm) {
+    min-height: 200px;
+  }
 }
 .text-row {
   display: flex;


### PR DESCRIPTION
- Enable autofocus for the note dialog
- Reduce height of the note dialog for smaller devices
- Only force focus on the target if there are no dialogs open

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1694)
<!-- Reviewable:end -->
