### PR TITLE
Disabled HTTP/2 support for Jering

### DIFF
--- a/src/SIL.XForge/Realtime/RealtimeServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Realtime/RealtimeServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Net;
 using System.Reflection;
 using Jering.Javascript.NodeJS;
 using Microsoft.Extensions.Configuration;
@@ -21,7 +20,6 @@ namespace Microsoft.Extensions.DependencyInjection
         )
         {
             services.AddNodeJS();
-            services.Configure<HttpNodeJSServiceOptions>(options => options.Version = HttpVersion.Version20);
             services.Configure<NodeJSProcessOptions>(options =>
             {
                 options.ProjectPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;


### PR DESCRIPTION
This Pull Request disables HTTP/2 support for Jering, automatically downgrading it to HTTP/1.1

Details are available at: https://github.com/JeringTech/Javascript.NodeJS/#remarks-29

This PR rolls back the change in #1651.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1695)
<!-- Reviewable:end -->
