### PR TITLE
SF-1870 Parse comment content idempotently

### DIFF
--- a/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
+++ b/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
@@ -98,7 +98,7 @@ public static class NotesFormatter
     private static XElement FormatParagraph(XmlNode paraNode)
     {
         XElement paraElem = new XElement("p");
-        if (paraNode.ChildNodes.Count == 1)
+        if (paraNode.ChildNodes.Count == 1 && paraNode.FirstChild.NodeType == XmlNodeType.Text)
             paraElem.Value = paraNode.InnerText;
         else
         {

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -2350,7 +2350,7 @@ public class ParatextServiceTests
             .ShareChanges(
                 Arg.Is<List<SharedProject>>(
                     list =>
-                        list.Count().Equals(1)
+                        list.Count.Equals(1)
                         && (list[0].SendReceiveId.Id == targetProjectId || list[0].SendReceiveId.Id == sourceProjectId)
                         && (
                             sourceScrTextPermissions.Equals((ComparableProjectPermissionManager)list[0].Permissions)


### PR DESCRIPTION
The version number on community checking notes would increment with each synchronize operation. This was caused by a difference in newLine whitespace around the <p> tags around <bold>community checking question</bold> xml. I could not determine what was removing the newLine whitespace around Paragraph tags.
This change ensures that regardless of those newLine whitespaces so that child nodes in paragraph nodes retain style features.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1698)
<!-- Reviewable:end -->
