### PR TITLE
SF-1865 Add default tag for community checking answers

### DIFF
--- a/src/SIL.XForge.Scripture/Models/CheckingConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/CheckingConfig.cs
@@ -7,4 +7,5 @@ public class CheckingConfig
     public bool ShareEnabled { get; set; } = false;
     public string ShareLevel { get; set; } = CheckingShareLevel.Specific;
     public string AnswerExportMethod { get; set; } = CheckingAnswerExport.All;
+    public int? NoteTagId { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/NoteTag.cs
+++ b/src/SIL.XForge.Scripture/Models/NoteTag.cs
@@ -5,6 +5,8 @@ public class NoteTag
     public const string defaultTagIcon = "01flag1";
     public const string sfNoteTagIcon = "06star2";
     public const string sfNoteTagName = "Scripture Forge Note";
+    public const string checkingTagIcon = "07conversation2";
+    public const string checkingTagName = "Scripture Forge Community Checking";
     public const int notSetId = 0;
     public int TagId { get; set; }
     public string Icon { get; set; }

--- a/src/SIL.XForge.Scripture/Services/IParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextNotesMapper.cs
@@ -22,6 +22,7 @@ public interface IParatextNotesMapper
         IEnumerable<IDocument<Question>> questionsDocs,
         Dictionary<string, ParatextUserProfile> ptProjectUsers,
         Dictionary<string, string> userRoles,
-        string answerExportMethod
+        string answerExportMethod,
+        int checkingNoteTagId
     );
 }

--- a/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
+++ b/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
@@ -177,6 +177,8 @@ public static class NotesFormatter
             comment.Date = commentDate;
         comment.ExternalUser = commentElem.Attribute("extUser")?.Value;
         comment.Deleted = commentElem.Attribute("deleted")?.Value == "true";
+        if (commentElem.Element("tagsAdded") != null)
+            comment.TagsAdded = new[] { commentElem.Element("tagsAdded").Value };
         ParseContents(commentElem.Element("content"), comment);
     }
 

--- a/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
@@ -93,7 +93,8 @@ public class ParatextNotesMapper : IParatextNotesMapper
         IEnumerable<IDocument<Question>> questionsDocs,
         Dictionary<string, ParatextUserProfile> ptProjectUsers,
         Dictionary<string, string> userRoles,
-        string answerExportMethod
+        string answerExportMethod,
+        int checkingNoteTagId
     )
     {
         // Usernames of SF community checker users. Paratext users are mapped to null.
@@ -155,7 +156,8 @@ public class ParatextNotesMapper : IParatextNotesMapper
                         threadElem,
                         answer,
                         ptProjectUsers,
-                        answerPrefixContents
+                        answerPrefixContents,
+                        checkingNoteTagId
                     );
                     if (answer.SyncUserRef == null)
                         answerSyncUserIds.Add((j, answerSyncUserId));
@@ -234,7 +236,8 @@ public class ParatextNotesMapper : IParatextNotesMapper
         XElement threadElem,
         Comment comment,
         Dictionary<string, ParatextUserProfile> ptProjectUsers,
-        IReadOnlyList<object> prefixContent = null
+        IReadOnlyList<object> prefixContent = null,
+        int tagId = NoteTag.notSetId
     )
     {
         (string syncUserId, string user, bool canWritePTNoteOnProject) = await GetSyncUserAsync(
@@ -265,6 +268,11 @@ public class ParatextNotesMapper : IParatextNotesMapper
             contentElem.Add(new XElement("p", responseText));
         }
         commentElem.Add(contentElem);
+        if (tagId != NoteTag.notSetId)
+        {
+            var tagsAddedElem = new XElement("tagsAdded", tagId);
+            commentElem.Add(tagsAddedElem);
+        }
 
         var threadId = (string)threadElem.Attribute("id");
         string key = GetCommentKey(threadId, commentElem, ptProjectUsers);

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1968,6 +1968,7 @@ public class ParatextService : DisposableBase, IParatextService
                     existingComment.Contents = comment.Contents;
                     existingComment.VersionNumber += 1;
                     existingComment.Deleted = false;
+                    existingComment.TagsAdded = comment.TagsAdded;
                     syncMetricInfo.Updated++;
                 }
 

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -475,13 +475,17 @@ public class ParatextSyncRunner : IParatextSyncRunner
             if (!_paratextService.IsResource(paratextId))
             {
                 LogMetric("Updating Paratext notes");
+                if (questionDocs.Count > 0)
+                {
+                    await UpdateCheckingNoteTag(paratextId);
+                    await UpdateParatextNotesAsync(text, questionDocs);
+                }
                 IEnumerable<IDocument<NoteThread>> noteThreadDocs = (
                     await FetchNoteThreadDocsAsync(text.BookNum)
                 ).Values;
                 // Only update the note tag if there are SF note threads in the project
                 if (noteThreadDocs.Any(d => d.Data.PublishedToSF == true))
                     await UpdateTranslateNoteTag(paratextId);
-                await UpdateParatextNotesAsync(text, questionDocs);
                 // TODO: Sync Note changes back to Paratext, and record sync metric info
                 // await _paratextService.UpdateParatextCommentsAsync(_userSecret, paratextId, text.BookNum,
                 //     noteThreadDocs, _currentPtSyncUsers);
@@ -813,7 +817,8 @@ public class ParatextSyncRunner : IParatextSyncRunner
             questionDocs,
             _currentPtSyncUsers,
             _projectDoc.Data.UserRoles,
-            _projectDoc.Data.CheckingConfig.AnswerExportMethod
+            _projectDoc.Data.CheckingConfig.AnswerExportMethod,
+            _projectDoc.Data.CheckingConfig.NoteTagId ?? NoteTag.notSetId
         );
         if (notesElem.Elements("thread").Any())
         {
@@ -1197,6 +1202,22 @@ public class ParatextSyncRunner : IParatextSyncRunner
             int noteTagId = _paratextService.UpdateCommentTag(_userSecret, targetParatextId, newNoteTag);
             await _projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.TranslateConfig.DefaultNoteTagId, noteTagId));
         }
+    }
+
+    private async Task<int> UpdateCheckingNoteTag(string targetParatextId)
+    {
+        int noteTagId = _projectDoc.Data.CheckingConfig.NoteTagId ?? NoteTag.notSetId;
+        if (noteTagId != NoteTag.notSetId)
+            return noteTagId;
+        var newNoteTag = new NoteTag
+        {
+            TagId = NoteTag.notSetId,
+            Icon = NoteTag.checkingTagIcon,
+            Name = NoteTag.checkingTagName
+        };
+        noteTagId = _paratextService.UpdateCommentTag(_userSecret, targetParatextId, newNoteTag);
+        await _projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.CheckingConfig.NoteTagId, noteTagId));
+        return noteTagId;
     }
 
     /// <summary>

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
@@ -484,6 +484,16 @@ public class ParatextNotesMapperTests
                                 <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
+                        <thread id=""ANSWER_answer04"">
+                            <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
+                            <comment user=""PT User 3"" extUser=""user04"" date=""2019-01-04T08:00:00.0000000+00:00"">
+                                <content>
+                                    <p><span style=""bold"">Test question?</span></p>
+                                    <p>[User 04 - xForge]</p>
+                                    <p>Test answer 4 is marked for export</p>
+                                </content>
+                            </comment>
+                        </thread>
                     </notes>";
         Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(u => u.Username);
         XElement notesElem = await env.Mapper.GetNotesChangelistAsync(

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
@@ -42,6 +42,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 3.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -51,7 +52,8 @@ public class ParatextNotesMapperTests
             await TestEnvironment.GetQuestionDocsAsync(conn),
             ptProjectUsers,
             TestEnvironment.userRoles,
-            CheckingAnswerExport.All
+            CheckingAnswerExport.All,
+            env.checkingNoteTagId
         );
 
         const string expectedNotesText =
@@ -65,6 +67,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 1.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                             <comment user=""PT User 3"" date=""2019-01-01T09:00:00.0000000+00:00"">
                                 <content>Test comment 1.</content>
@@ -79,6 +82,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 2.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                             <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-02T09:00:00.0000000+00:00"">
                                 <content>
@@ -95,6 +99,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 4 is marked for export</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer05"">
@@ -105,6 +110,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 5 is resolved</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer03"">
@@ -115,6 +121,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 3.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -143,7 +150,8 @@ public class ParatextNotesMapperTests
             await TestEnvironment.GetQuestionDocsAsync(conn),
             ptProjectUsers,
             userRoles,
-            CheckingAnswerExport.All
+            CheckingAnswerExport.All,
+            env.checkingNoteTagId
         );
 
         // User 03 is listed as a community checker because they are not a PT user on the particular project
@@ -158,6 +166,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 1.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                             <comment user=""PT User 1"" extUser=""user03"" date=""2019-01-01T09:00:00.0000000+00:00"">
                                 <content>
@@ -175,6 +184,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 2.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                             <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-02T09:00:00.0000000+00:00"">
                                 <content>
@@ -191,6 +201,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 4 is marked for export</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer05"">
@@ -201,6 +212,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 5 is resolved</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -229,6 +241,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 3.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -238,7 +251,8 @@ public class ParatextNotesMapperTests
             await TestEnvironment.GetQuestionDocsAsync(conn),
             ptProjectUsers,
             TestEnvironment.userRoles,
-            CheckingAnswerExport.All
+            CheckingAnswerExport.All,
+            env.checkingNoteTagId
         );
 
         const string expectedNotesText =
@@ -252,6 +266,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>- xForge audio-only response -</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                             <comment user=""PT User 3"" date=""2019-01-01T09:00:00.0000000+00:00"">
                                 <content>Test comment 1.</content>
@@ -266,6 +281,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 2.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                             <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-02T09:00:00.0000000+00:00"">
                                 <content>
@@ -282,6 +298,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 4 is marked for export</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer05"">
@@ -292,6 +309,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 5 is resolved</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer03"">
@@ -302,6 +320,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 3.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -330,6 +349,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 3.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -339,7 +359,8 @@ public class ParatextNotesMapperTests
             await TestEnvironment.GetQuestionDocsAsync(conn),
             ptProjectUsers,
             TestEnvironment.userRoles,
-            CheckingAnswerExport.All
+            CheckingAnswerExport.All,
+            env.checkingNoteTagId
         );
 
         // User 3 is a PT user but does not have a role on this particular PT project, according to the PT
@@ -358,6 +379,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 1.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                             <comment user=""PT User 1"" extUser=""user03"" date=""2019-01-01T09:00:00.0000000+00:00"">
                                 <content>Test comment 1.</content>
@@ -372,6 +394,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 2.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                             <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-02T09:00:00.0000000+00:00"">
                                 <content>
@@ -388,6 +411,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 4 is marked for export</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer05"">
@@ -398,6 +422,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 5 is resolved</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer03"">
@@ -408,6 +433,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 3.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -436,6 +462,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Old test answer 1.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer02"">
@@ -447,12 +474,14 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 2.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                             <comment user=""PT User 3"" extUser=""user02"" date=""2019-01-02T09:00:00.0000000+00:00"">
                                 <content>
                                     <p>[User 02 - xForge]</p>
                                     <p>Old test comment 2.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -462,7 +491,8 @@ public class ParatextNotesMapperTests
             await TestEnvironment.GetQuestionDocsAsync(conn),
             ptProjectUsers,
             TestEnvironment.userRoles,
-            CheckingAnswerExport.All
+            CheckingAnswerExport.All,
+            env.checkingNoteTagId
         );
 
         const string expectedNotesText =
@@ -476,6 +506,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 1.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                             <comment user=""PT User 3"" date=""2019-01-01T09:00:00.0000000+00:00"">
                                 <content>Test comment 1.</content>
@@ -498,6 +529,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 4 is marked for export</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer05"">
@@ -508,6 +540,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 5 is resolved</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -534,6 +567,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 1.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                             <comment user=""PT User 3"" date=""2019-01-01T09:00:00.0000000+00:00"">
                                 <content>Old test comment 1.</content>
@@ -548,6 +582,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 2.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                             <comment user=""PT User 3"" extUser=""user02"" date=""2019-01-02T09:00:00.0000000+00:00"">
                                 <content>
@@ -567,6 +602,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 3.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -576,7 +612,8 @@ public class ParatextNotesMapperTests
             await TestEnvironment.GetQuestionDocsAsync(conn),
             ptProjectUsers,
             TestEnvironment.userRoles,
-            CheckingAnswerExport.All
+            CheckingAnswerExport.All,
+            env.checkingNoteTagId
         );
 
         const string expectedNotesText =
@@ -596,6 +633,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 4 is marked for export</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer05"">
@@ -606,6 +644,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 5 is resolved</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer02"">
@@ -622,6 +661,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 3.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -644,7 +684,8 @@ public class ParatextNotesMapperTests
             await TestEnvironment.GetQuestionDocsAsync(conn),
             ptProjectUsers,
             TestEnvironment.userRoles,
-            CheckingAnswerExport.All
+            CheckingAnswerExport.All,
+            env.checkingNoteTagId
         );
 
         const string expectedNotesText =
@@ -658,6 +699,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 1.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                             <comment user=""PT User 3"" date=""2019-01-01T09:00:00.0000000+00:00"">
                                 <content>Test comment 1.</content>
@@ -672,6 +714,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 2.</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                             <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-02T09:00:00.0000000+00:00"">
                                 <content>
@@ -688,6 +731,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 4 is marked for export</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer05"">
@@ -698,6 +742,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 5 is resolved</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -720,7 +765,8 @@ public class ParatextNotesMapperTests
             await TestEnvironment.GetQuestionDocsAsync(conn),
             ptProjectUsers,
             TestEnvironment.userRoles,
-            CheckingAnswerExport.None
+            CheckingAnswerExport.None,
+            env.checkingNoteTagId
         );
 
         const string expectedNotesText = @"<notes version=""1.1"" />";
@@ -743,7 +789,8 @@ public class ParatextNotesMapperTests
             await TestEnvironment.GetQuestionDocsAsync(conn),
             ptProjectUsers,
             TestEnvironment.userRoles,
-            CheckingAnswerExport.MarkedForExport
+            CheckingAnswerExport.MarkedForExport,
+            env.checkingNoteTagId
         );
 
         const string expectedNotesText =
@@ -757,6 +804,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 4 is marked for export</p>
                                 </content>
+                                <tagsAdded>3</tagsAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -772,6 +820,7 @@ public class ParatextNotesMapperTests
             { "user03", SFProjectRole.Translator },
             { "user04", SFProjectRole.CommunityChecker }
         };
+        public readonly int checkingNoteTagId = 3;
 
         public TestEnvironment()
         {

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -619,7 +619,7 @@ public class ParatextSyncRunnerTests
         var env = new TestEnvironment();
         Book[] books = { new Book("MAT", 1) };
         env.SetupSFData(true, true, false, true, books);
-        await env.SetupUndefinedNoteTag("project01");
+        await env.SetupUndefinedNoteTag("project01", false);
         SFProject project = env.GetProject();
         Assert.That(project.TranslateConfig.DefaultNoteTagId, Is.Null);
         // introduce a PT note thread
@@ -643,6 +643,36 @@ public class ParatextSyncRunnerTests
         // expect that a new note tag is created
         env.ParatextService.Received().UpdateCommentTag(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<NoteTag>());
         Assert.That(project.TranslateConfig.DefaultNoteTagId, Is.EqualTo(env.translateNoteTagId));
+    }
+
+    [Test]
+    public async Task SyncAsync_CreatesCheckingNoteTag()
+    {
+        var env = new TestEnvironment();
+        Book[] books = { new Book("MAT", 1) };
+        env.SetupSFData(false, true, false, false, books);
+        env.SetupPTData(books);
+
+        SFProject project = env.GetProject("project05");
+        Assert.That(project.CheckingConfig.NoteTagId, Is.Null, "setup");
+        Assert.That(env.ContainsQuestion("project05", "MAT", 1), Is.False, "setup");
+        // project05 does not have checking answers and will not create a tag
+        await env.Runner.RunAsync("project05", "user01", "project05", false, CancellationToken.None);
+        env.ParatextService.DidNotReceive().UpdateCommentTag(Arg.Any<UserSecret>(), "target", Arg.Any<NoteTag>());
+
+        await env.SetupUndefinedNoteTag("project01", true);
+        project = env.GetProject();
+        Assert.That(project.CheckingConfig.NoteTagId, Is.Null, "setup");
+        Assert.That(env.ContainsQuestion("MAT", 1), Is.True, "setup");
+        int noteTagId = 5;
+        env.ParatextService
+            .UpdateCommentTag(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<NoteTag>())
+            .Returns(noteTagId);
+        // project01 has checking answers and will need to create a tag
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+        env.ParatextService.Received(1).UpdateCommentTag(Arg.Any<UserSecret>(), "target", Arg.Any<NoteTag>());
+        project = env.VerifyProjectSync(true);
+        Assert.That(project.CheckingConfig.NoteTagId, Is.EqualTo(noteTagId));
     }
 
     [Test]
@@ -2268,6 +2298,7 @@ public class ParatextSyncRunnerTests
     private class TestEnvironment
     {
         public readonly int translateNoteTagId = 5;
+        public readonly int checkingNoteTagId = 6;
         private readonly MemoryRepository<SFProjectSecret> _projectSecrets;
         private readonly MemoryRepository<SyncMetrics> _syncMetrics;
         private bool _sendReceivedCalled = false;
@@ -2425,6 +2456,9 @@ public class ParatextSyncRunnerTests
 
         public bool ContainsQuestion(string bookId, int chapter) =>
             RealtimeService.GetRepository<Question>().Contains($"project01:question{bookId}{chapter}");
+
+        public bool ContainsQuestion(string projectId, string bookId, int chapter) =>
+            RealtimeService.GetRepository<Question>().Contains($"{projectId}:question{bookId}{chapter}");
 
         public bool ContainsNote(int chapter) =>
             RealtimeService.GetRepository<NoteThread>().Contains($"project01:thread0{chapter}");
@@ -2610,7 +2644,8 @@ public class ParatextSyncRunnerTests
                     CheckingConfig = new CheckingConfig
                     {
                         CheckingEnabled = checkingEnabled,
-                        AnswerExportMethod = CheckingAnswerExport.MarkedForExport
+                        AnswerExportMethod = CheckingAnswerExport.MarkedForExport,
+                        NoteTagId = checkingNoteTagId
                     },
                     Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
                     Sync = new Sync
@@ -2641,7 +2676,7 @@ public class ParatextSyncRunnerTests
                     CheckingConfig = new CheckingConfig
                     {
                         CheckingEnabled = checkingEnabled,
-                        AnswerExportMethod = CheckingAnswerExport.MarkedForExport
+                        AnswerExportMethod = CheckingAnswerExport.MarkedForExport,
                     },
                     WritingSystem = new WritingSystem { Tag = "en" },
                     Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
@@ -2750,6 +2785,7 @@ public class ParatextSyncRunnerTests
                         DataInSync = false
                         // No SyncedToRepositoryVersion
                     },
+                    NoteTags = new List<NoteTag>()
                 },
             };
             RealtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(sfProjects));
@@ -2796,7 +2832,8 @@ public class ParatextSyncRunnerTests
                     Arg.Any<IEnumerable<IDocument<Question>>>(),
                     Arg.Any<Dictionary<string, ParatextUserProfile>>(),
                     Arg.Any<Dictionary<string, string>>(),
-                    CheckingAnswerExport.MarkedForExport
+                    CheckingAnswerExport.MarkedForExport,
+                    Arg.Any<int>()
                 )
                 .Returns(Task.FromResult(notesElem));
         }
@@ -3065,8 +3102,14 @@ public class ParatextSyncRunnerTests
         }
 
         /// <summary> Set the project's default comment tag to the a blank comment tag. </summary>
-        public Task SetupUndefinedNoteTag(string projectId)
+        public Task SetupUndefinedNoteTag(string projectId, bool forChecking)
         {
+            if (forChecking)
+            {
+                return RealtimeService
+                    .GetRepository<SFProject>()
+                    .UpdateAsync(p => p.Id == projectId, u => u.Unset(p => p.CheckingConfig.NoteTagId));
+            }
             return RealtimeService
                 .GetRepository<SFProject>()
                 .UpdateAsync(p => p.Id == projectId, u => u.Unset(p => p.TranslateConfig.DefaultNoteTagId));
@@ -3231,7 +3274,8 @@ public class ParatextSyncRunnerTests
                     Arg.Any<IEnumerable<IDocument<Question>>>(),
                     Arg.Any<Dictionary<string, ParatextUserProfile>>(),
                     Arg.Any<Dictionary<string, string>>(),
-                    CheckingAnswerExport.MarkedForExport
+                    CheckingAnswerExport.MarkedForExport,
+                    Arg.Any<int>()
                 );
 
             // Should not be performing a SR.
@@ -3275,7 +3319,8 @@ public class ParatextSyncRunnerTests
                     Arg.Any<IEnumerable<IDocument<Question>>>(),
                     Arg.Any<Dictionary<string, ParatextUserProfile>>(),
                     Arg.Any<Dictionary<string, string>>(),
-                    CheckingAnswerExport.MarkedForExport
+                    CheckingAnswerExport.MarkedForExport,
+                    Arg.Any<int>()
                 );
 
             // Should be performing a SR.


### PR DESCRIPTION
* add the NoteTagId property on the CheckingConfig class
* create community checking tag if project has answers
* add tagsAdded element when getting note thread changelist

When community checking answers get synchronized with Paratext, any new and existing community checking answers will be exported and giving the default checking tag ID. If the default did not previously exist, then it creates a new one. If the 07conversation2 icon is already in use, that tag ID will be given to the question answers.

![Community Checking Tag](https://user-images.githubusercontent.com/17931130/218546663-7d5d8838-a364-4532-853f-8dbe83a5b8ad.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1701)
<!-- Reviewable:end -->
