### PR TITLE
Fix project migration tests to prevent new migrations from being run

### DIFF
--- a/src/RealtimeServer/scriptureforge/realtime-server.ts
+++ b/src/RealtimeServer/scriptureforge/realtime-server.ts
@@ -12,10 +12,11 @@ import { QuestionService } from './services/question-service';
 import { SFProjectService } from './services/sf-project-service';
 import { SFProjectUserConfigService } from './services/sf-project-user-config-service';
 import { TextService } from './services/text-service';
+import { SF_PROJECT_MIGRATIONS } from './services/sf-project-migrations';
 
 const SF_DOC_SERVICES: DocService[] = [
   new UserService(),
-  new SFProjectService(),
+  new SFProjectService(SF_PROJECT_MIGRATIONS),
   new SFProjectUserConfigService(),
   new TextService(),
   new QuestionService(),

--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
@@ -159,20 +159,19 @@ class SFProjectMigration7 implements Migration {
   }
 }
 
+/**
+ * This migration removes the shareLevel property from the translateConfig and checkingConfig objects.
+ * Project admins now select whether whether a share link can be used by only one person or by anyone at the time the
+ * link is created (rather than configuring it on the project).
+ */
 class SFProjectMigration8 implements Migration {
   static readonly VERSION = 8;
 
   async migrateDoc(doc: Doc): Promise<void> {
-    const ops = [];
-    if (doc.data.translateConfig == null) {
-      ops.push({ p: ['translateConfig'], oi: {} });
-    }
-    ops.push({ p: ['translateConfig', 'shareLevel'], od: true });
-
-    if (doc.data.checkingConfig == null) {
-      ops.push({ p: ['checkingConfig'], oi: {} });
-    }
-    ops.push({ p: ['checkingConfig', 'shareLevel'], od: true });
+    const ops = [
+      { p: ['translateConfig', 'shareLevel'], od: true },
+      { p: ['checkingConfig', 'shareLevel'], od: true }
+    ];
     await submitMigrationOp(SFProjectMigration8.VERSION, doc, ops);
   }
 

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.spec.ts
@@ -1,6 +1,7 @@
 import ShareDB from 'sharedb';
 import ShareDBMingo from 'sharedb-mingo-memory';
 import { instance, mock } from 'ts-mockito';
+import { SF_PROJECT_MIGRATIONS } from '../services/sf-project-migrations';
 import { SF_PROJECT_PROFILES_COLLECTION, SF_PROJECTS_COLLECTION, SFProject } from '../models/sf-project';
 import { RealtimeServer } from '../../common/realtime-server';
 import { SchemaVersionRepository } from '../../common/schema-version-repository';
@@ -66,7 +67,7 @@ class TestEnvironment {
   ];
 
   constructor() {
-    this.service = new SFProjectService();
+    this.service = new SFProjectService(SF_PROJECT_MIGRATIONS);
     const ShareDBMingoType = ShareDBMingo.extendMemoryDB(ShareDB.MemoryDB);
     this.db = new ShareDBMingoType();
     this.server = new RealtimeServer(

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -1,4 +1,5 @@
 import ShareDB from 'sharedb';
+import { MigrationConstructor } from '../../common/migration';
 import { ProjectDomainConfig } from '../../common/services/project-data-service';
 import { RealtimeServer } from '../../common/realtime-server';
 import { ProjectService } from '../../common/services/project-service';
@@ -13,7 +14,6 @@ import { SFProjectDomain, SF_PROJECT_RIGHTS } from '../models/sf-project-rights'
 import { Operation } from '../../common/models/project-rights';
 import { ConnectSession } from '../../common/connect-session';
 import { SystemRole } from '../../common/models/system-role';
-import { SF_PROJECT_MIGRATIONS } from './sf-project-migrations';
 
 const SF_PROJECT_PROFILE_FIELDS: ShareDB.ProjectionFields = {
   name: true,
@@ -43,8 +43,8 @@ export class SFProjectService extends ProjectService<SFProject> {
   protected readonly indexPaths = SF_PROJECT_INDEX_PATHS;
   protected readonly projectAdminRole = SFProjectRole.ParatextAdministrator;
 
-  constructor() {
-    super(SF_PROJECT_MIGRATIONS);
+  constructor(sfProjectMigrations: MigrationConstructor[]) {
+    super(sfProjectMigrations);
 
     const immutableProps = [
       this.pathTemplate(p => p.sync),


### PR DESCRIPTION
Every migration test was running all migrations that were available, rather than just one. I updated the tests so you could specify both the version the document is currently at, and the migration version to stop at.

Probably we will want to do this for the other data migration tests as well, but I want to put this out first and decide on the best solution before changing them all.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1707)
<!-- Reviewable:end -->
