### PR TITLE
Fix date format tests for Chromium 110

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -92,10 +92,12 @@ describe('I18nService', () => {
   it('should localize dates', () => {
     const date = new Date('November 25, 1991 17:28');
     const service = getI18nService();
-    expect(service.formatDate(date)).toEqual('Nov 25, 1991, 5:28 PM');
+    // As of Chromium 110 the space between the minutes and AM/PM has been changed to U+202F (NARROW NO-BREAK SPACE)
+    // Test for any white space character for maximum compatibility
+    expect(service.formatDate(date)).toMatch(/Nov 25, 1991, 5:28\sPM/);
 
     service.setLocale('en-GB', mockedAuthService);
-    expect(service.formatDate(date)).toEqual('25 Nov 1991, 5:28 pm');
+    expect(service.formatDate(date)).toMatch(/25 Nov 1991, 5:28\spm/);
 
     // As of Chromium 98 for zh-CN it's changed from using characters to indicate AM/PM, to using a 24 hour clock. It's
     // unclear whether the cause is Chromium itself or a localization library. The tests should pass with either version

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/owner/owner.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/owner/owner.component.spec.ts
@@ -59,7 +59,9 @@ describe('OwnerComponent', () => {
     expect(env.fixture.debugElement.query(By.css('.layout .date-time'))).toBeNull();
     env.fixture.componentInstance.checkingOwner.dateTime = '2019-04-25T12:30:00';
     env.fixture.detectChanges();
-    expect(env.dateTime).toBe('Apr 25, 2019, 12:30 PM');
+    // As of Chromium 110 the space between the minutes and AM/PM is now a NARROW NO-BREAK SPACE (U+202F). Test for any
+    // single whitespace character to maximize compatibility.
+    expect(env.dateTime).toMatch(/Apr 25, 2019, 12:30\sPM/);
   });
 
   it('layout set correctly', () => {


### PR DESCRIPTION
Chromium now uses a NARROW NO-BREAK SPACE between the minutes and the am/pm designation

It would probably behoove us to merge this sooner rather than later, because it's likely that our builds are going to start failing at any moment when GitHub Actions starts using Chromium 110 for the builds (which may be now already).

(For what it's worth, I don't actually know that it's Chromium itself; it could be a localization package that Chromium depends on that got upgraded on the system, but I think Chromium tends to ship such functionality internally rather than depend on system libraries)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1714)
<!-- Reviewable:end -->
