### PR TITLE
Memory and Speed Optimizations to the Sync Process

### DIFF
--- a/src/RealtimeServer/common/index.ts
+++ b/src/RealtimeServer/common/index.ts
@@ -1,9 +1,10 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { MongoClient } from 'mongodb';
 import * as OTJson0 from 'ot-json0';
 import * as RichText from 'rich-text';
 import ShareDB from 'sharedb';
 import ShareDBMongo from 'sharedb-mongo';
-import { Connection, Doc, OTType, Query } from 'sharedb/lib/client';
+import { Connection, Doc, OTType } from 'sharedb/lib/client';
 import { ExceptionReporter } from './exception-reporter';
 import { MetadataDB } from './metadata-db';
 import { RealtimeServer, RealtimeServerConstructor } from './realtime-server';

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -79,6 +79,8 @@ public interface IParatextService
     bool RestoreRepository(UserSecret userSecret, string paratextId);
     bool LocalProjectDirExists(string paratextId);
     string GetLanguageId(UserSecret userSecret, string paratextId);
+    void FreeCommentManager(UserSecret userSecret, string paratextId);
+    void InitializeCommentManager(UserSecret userSecret, string paratextId);
 
     Task<ParatextProject> SendReceiveAsync(
         UserSecret userSecret,

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1161,8 +1161,8 @@ public class ParatextService : DisposableBase, IParatextService
 
         CommentManager manager = CommentManager.Get(scrText);
 
-        // CommentThread.VerseRef calculates the reallocated location, however in Paratext a note can only be
-        // reallocated within the chapter, so for our query, we only need the first location
+        // CommentThread.VerseRef determines the location of a thread, even if moved. However, in Paratext a note can
+        // only be relocated within the chapter, so for our query, we only need to look at the first note location.
         var threads = manager.FindThreads(commentThread => commentThread.Comments[0].VerseRef.BookNum == bookNum, true);
         return NotesFormatter.FormatNotes(threads);
     }
@@ -1617,7 +1617,7 @@ public class ParatextService : DisposableBase, IParatextService
         ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
         if (scrText is not null)
         {
-            // Initialize the comment manager without a parallel serializer
+            // Initialize the comment manager without a parallel deserializer
             CommentManager commentManager = CommentManager.Get(scrText);
             Memento.AddParallelDeserializer<CommentList>(null);
             commentManager.Load();

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -496,7 +496,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
             }
 
             LogMetric($"Getting Paratext book {text.BookNum}");
-            SortedList<int, IDocument<TextData>> targetTextDocs = FetchTextDocs(text, textDocs);
+            SortedList<int, IDocument<TextData>> targetTextDocs = GetTextDocsForBook(text, textDocs);
             textDocsByBook[text.BookNum] = targetTextDocs;
             if (settings.Editable && !_paratextService.IsResource(paratextId))
             {
@@ -1060,9 +1060,9 @@ public class ParatextSyncRunner : IParatextSyncRunner
     }
 
     /// <summary>
-    /// Fetches all text docs from the database for a book.
+    /// Gets the text docs from <see cref="docs"/> for the book specified in <see cref="text"/>.
     /// </summary>
-    private SortedList<int, IDocument<TextData>> FetchTextDocs(
+    private SortedList<int, IDocument<TextData>> GetTextDocsForBook(
         TextInfo text,
         IReadOnlyCollection<IDocument<TextData>> docs
     )

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -60,6 +60,15 @@ public class ParatextSyncRunner : IParatextSyncRunner
     private static readonly IEqualityComparer<List<Chapter>> _chapterListEqualityComparer =
         SequenceEqualityComparer.Create(new ChapterEqualityComparer());
 
+    /// <summary>
+    /// The regular expression for finding whitespace before XML tags.
+    /// </summary>
+    /// <remarks>This is used by <see cref="ParseText"/>.</remarks>
+    private static readonly Regex WhitespaceBeforeTagsRegex = new Regex(
+        @"\n\s*<",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled
+    );
+
     private readonly IRepository<UserSecret> _userSecrets;
     private readonly IRepository<SFProjectSecret> _projectSecrets;
     private readonly IRepository<SyncMetrics> _syncMetricsRepository;
@@ -1239,7 +1248,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
     private static XElement ParseText(string text)
     {
         text = text.Trim().Replace("\r\n", "\n");
-        text = Regex.Replace(text, @"\n\s*<", "<", RegexOptions.CultureInvariant);
+        text = WhitespaceBeforeTagsRegex.Replace(text, "<");
         return XElement.Parse(text, LoadOptions.PreserveWhitespace);
     }
 

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -456,6 +456,28 @@ public class ParatextSyncRunner : IParatextSyncRunner
         Dictionary<int, IReadOnlyList<IDocument<Question>>> questionDocsByBook
     )
     {
+        // Get the Text Data
+        List<string> textIds = _projectDoc.Data.Texts
+            .SelectMany(t => t.Chapters.Select(c => TextData.GetTextDocId(_projectDoc.Id, t.BookNum, c.Number)))
+            .ToList();
+        IReadOnlyCollection<IDocument<TextData>> textDocs = await _conn.GetAndFetchDocsAsync<TextData>(textIds);
+
+        // Get the Note Threads
+        List<string> noteIds = await _realtimeService
+            .QuerySnapshots<NoteThread>()
+            .Where(pnt => pnt.ProjectRef == _projectDoc.Id)
+            .Select(pnt => pnt.Id)
+            .ToListAsync();
+        IReadOnlyCollection<IDocument<NoteThread>> noteDocs = await _conn.GetAndFetchDocsAsync<NoteThread>(noteIds);
+
+        // Get the Questions
+        List<string> questionIds = await _realtimeService
+            .QuerySnapshots<Question>()
+            .Where(q => q.ProjectRef == _projectDoc.Id)
+            .Select(q => q.Id)
+            .ToListAsync();
+        IReadOnlyCollection<IDocument<Question>> questionDocs = await _conn.GetAndFetchDocsAsync<Question>(questionIds);
+
         ParatextSettings? settings = _paratextService.GetParatextSettings(_userSecret, paratextId);
         double i = 0.0;
         foreach (TextInfo text in _projectDoc.Data.Texts)
@@ -471,7 +493,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
             }
 
             LogMetric($"Getting Paratext book {text.BookNum}");
-            SortedList<int, IDocument<TextData>> targetTextDocs = await FetchTextDocsAsync(text);
+            SortedList<int, IDocument<TextData>> targetTextDocs = FetchTextDocs(text, textDocs);
             textDocsByBook[text.BookNum] = targetTextDocs;
             if (settings.Editable && !_paratextService.IsResource(paratextId))
             {
@@ -479,18 +501,19 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 await UpdateParatextBook(text, paratextId, targetTextDocs);
             }
 
-            IReadOnlyList<IDocument<Question>> questionDocs = await FetchQuestionDocsAsync(text);
-            questionDocsByBook[text.BookNum] = questionDocs;
+            questionDocsByBook[text.BookNum] = questionDocs
+                .Where(q => q.Data.VerseRef.BookNum == text.BookNum)
+                .ToList();
             if (!_paratextService.IsResource(paratextId))
             {
                 LogMetric("Updating Paratext notes");
-                if (questionDocs.Count > 0)
+                if (questionDocsByBook[text.BookNum].Count > 0)
                 {
-                    await UpdateParatextNotesAsync(text, questionDocs);
+                    await UpdateParatextNotesAsync(text, questionDocsByBook[text.BookNum]);
                 }
-                IEnumerable<IDocument<NoteThread>> noteThreadDocs = (
-                    await FetchNoteThreadDocsAsync(text.BookNum)
-                ).Values;
+                IEnumerable<IDocument<NoteThread>> noteThreadDocs = noteDocs.Where(
+                    n => n.Data.VerseRef.BookNum == text.BookNum
+                );
                 // Only update the note tag if there are SF note threads in the project
                 if (noteThreadDocs.Any(d => d.Data.PublishedToSF == true))
                     await UpdateTranslateNoteTag(paratextId);
@@ -1036,26 +1059,23 @@ public class ParatextSyncRunner : IParatextSyncRunner
     /// <summary>
     /// Fetches all text docs from the database for a book.
     /// </summary>
-    internal async Task<SortedList<int, IDocument<TextData>>> FetchTextDocsAsync(TextInfo text)
+    private SortedList<int, IDocument<TextData>> FetchTextDocs(
+        TextInfo text,
+        IReadOnlyCollection<IDocument<TextData>> docs
+    )
     {
-        var textDocs = new SortedList<int, IDocument<TextData>>();
-        var tasks = new List<Task>();
+        var textDocs = new SortedList<int, IDocument<TextData>>(text.Chapters.Count);
         foreach (Chapter chapter in text.Chapters)
         {
-            IDocument<TextData> textDoc = GetTextDoc(text, chapter.Number);
-            textDocs[chapter.Number] = textDoc;
-            tasks.Add(textDoc.FetchAsync());
-        }
-        await Task.WhenAll(tasks);
-
-        // Omit items that are not actually in the database.
-        foreach (KeyValuePair<int, IDocument<TextData>> item in textDocs.ToList())
-        {
-            if (!item.Value.IsLoaded)
+            IDocument<TextData>? textDoc = docs.FirstOrDefault(
+                d => d.Id == TextData.GetTextDocId(_projectDoc.Id, text.BookNum, chapter.Number)
+            );
+            if (textDoc is not null)
             {
-                textDocs.Remove(item.Key);
+                textDocs[chapter.Number] = textDoc;
             }
         }
+
         return textDocs;
     }
 
@@ -1071,44 +1091,19 @@ public class ParatextSyncRunner : IParatextSyncRunner
         _syncMetrics.TextDocs.Deleted += text.Chapters.Count;
     }
 
-    private async Task<IReadOnlyList<IDocument<Question>>> FetchQuestionDocsAsync(TextInfo text)
-    {
-        List<string> questionDocIds = await _realtimeService
-            .QuerySnapshots<Question>()
-            .Where(q => q.ProjectRef == _projectDoc.Id && q.VerseRef.BookNum == text.BookNum)
-            .Select(q => q.Id)
-            .ToListAsync();
-        var questionDocs = new IDocument<Question>[questionDocIds.Count];
-        var tasks = new List<Task>();
-        for (int i = 0; i < questionDocIds.Count; i++)
-        {
-            async Task fetchQuestion(int index) =>
-                questionDocs[index] = await _conn.FetchAsync<Question>(questionDocIds[index]);
-            tasks.Add(fetchQuestion(i));
-        }
-        await Task.WhenAll(tasks);
-        return questionDocs;
-    }
-
     /// <summary>
     /// Fetch the ParatextNoteThread docs from the database and return it in a dictionary with threadId as the key.
     /// </summary>
     private async Task<Dictionary<string, IDocument<NoteThread>>> FetchNoteThreadDocsAsync(int bookNum)
     {
-        List<string> noteThreadDocIds = await _realtimeService
+        List<string> ids = await _realtimeService
             .QuerySnapshots<NoteThread>()
             .Where(pnt => pnt.ProjectRef == _projectDoc.Id && pnt.VerseRef.BookNum == bookNum)
             .Select(pnt => pnt.Id)
             .ToListAsync();
-        IDocument<NoteThread>[] noteThreadDocs = new IDocument<NoteThread>[noteThreadDocIds.Count];
-        var tasks = new List<Task>();
-        for (int i = 0; i < noteThreadDocIds.Count; i++)
-        {
-            async Task fetchNoteThread(int index) =>
-                noteThreadDocs[index] = await _conn.FetchAsync<NoteThread>(noteThreadDocIds[index]);
-            tasks.Add(fetchNoteThread(i));
-        }
-        await Task.WhenAll(tasks);
+        IReadOnlyCollection<IDocument<NoteThread>> noteThreadDocs = await _conn.GetAndFetchDocsAsync<NoteThread>(
+            ids.ToArray()
+        );
         return noteThreadDocs.ToDictionary(ntd => ntd.Data.DataId);
     }
 
@@ -1644,7 +1639,14 @@ public class ParatextSyncRunner : IParatextSyncRunner
         return usernamesToUserIds;
     }
 
-    private IDocument<TextData> GetTextDoc(TextInfo text, int chapter) =>
+    /// <summary>
+    /// Gets a text doc from the database.
+    /// </summary>
+    /// <param name="text">The text info.</param>
+    /// <param name="chapter">The chapter number</param>
+    /// <returns>The TextData IDocument</returns>
+    /// <remarks>This is internal for use in unit tests.</remarks>
+    internal IDocument<TextData> GetTextDoc(TextInfo text, int chapter) =>
         _conn.Get<TextData>(TextData.GetTextDocId(_projectDoc.Id, text.BookNum, chapter));
 
     private async Task DeleteTextDocAsync(TextInfo text, int chapter)

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -145,6 +145,9 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 return;
             }
 
+            // Remove the parallel deserializer
+            _paratextService.InitializeCommentManager(_userSecret, _projectDoc.Data.ParatextId);
+
             string targetParatextId = _projectDoc.Data.ParatextId;
             string? sourceParatextId = _projectDoc.Data.TranslateConfig.Source?.ParatextId;
             string? sourceProjectRef = _projectDoc.Data.TranslateConfig.Source?.ProjectRef;
@@ -1597,6 +1600,9 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 Log("The sync metrics could not be updated in MongoDB");
             }
         }
+
+        // Free the comment manager for this project from memory
+        _paratextService.FreeCommentManager(_userSecret, _projectDoc.Data.ParatextId);
 
         await NotifySyncProgress(SyncPhase.Phase7, 100.0);
         Log($"CompleteSync: Finished. Sync was {(successful ? "successful" : "unsuccessful")}.");

--- a/src/SIL.XForge/Realtime/Document.cs
+++ b/src/SIL.XForge/Realtime/Document.cs
@@ -14,12 +14,16 @@ public class Document<T> : IDocument<T>
     private readonly IConnection _connection;
     private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
 
-    internal Document(IConnection connection, string otTypeName, string collection, string id)
+    internal Document(IConnection connection, string otTypeName, string collection, string id, Snapshot<T>? snapshot)
     {
         _connection = connection;
         OTTypeName = otTypeName;
         Collection = collection;
         Id = id;
+        if (snapshot is not null)
+        {
+            UpdateFromSnapshot(snapshot);
+        }
     }
 
     public string Collection { get; }

--- a/src/SIL.XForge/Realtime/IConnection.cs
+++ b/src/SIL.XForge/Realtime/IConnection.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using SIL.XForge.Models;
@@ -14,6 +15,8 @@ public interface IConnection : IDisposable, IAsyncDisposable
     void ExcludePropertyFromTransaction<T>(Expression<Func<T, object>> field);
     Task<Snapshot<T>> FetchDocAsync<T>(string collection, string id);
     IDocument<T> Get<T>(string id)
+        where T : IIdentifiable;
+    Task<IReadOnlyCollection<IDocument<T>>> GetAndFetchDocsAsync<T>(IReadOnlyCollection<string> ids)
         where T : IIdentifiable;
     void RollbackTransaction();
     Task<Snapshot<T>> SubmitOpAsync<T>(string collection, string id, object op, T currentDoc, int currentVersion);

--- a/src/SIL.XForge/Realtime/IRealtimeServer.cs
+++ b/src/SIL.XForge/Realtime/IRealtimeServer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace SIL.XForge.Realtime;
@@ -11,6 +12,7 @@ public interface IRealtimeServer
     void Disconnect(int handle);
     Task DisconnectAsync(int handle);
     Task<Snapshot<T>> FetchDocAsync<T>(int handle, string collection, string id);
+    Task<Snapshot<T>[]> FetchDocsAsync<T>(int handle, string collection, IReadOnlyCollection<string> ids);
     void Start(object options);
     void Stop();
     Task<Snapshot<T>> SubmitOpAsync<T>(int handle, string collection, string id, object op);

--- a/src/SIL.XForge/Realtime/MemoryConnection.cs
+++ b/src/SIL.XForge/Realtime/MemoryConnection.cs
@@ -110,7 +110,7 @@ public class MemoryConnection : IConnection
             }
         }
 
-        return await Task.FromResult(docs);
+        return docs;
     }
 
     /// <summary>

--- a/src/SIL.XForge/Realtime/MemoryConnection.cs
+++ b/src/SIL.XForge/Realtime/MemoryConnection.cs
@@ -69,7 +69,7 @@ public class MemoryConnection : IConnection
     /// Excludes the field from the transaction.
     /// </summary>
     /// <typeparam name="T">The type.</typeparam>
-    /// <param name="op">The field.</param>
+    /// <param name="field">The field.</param>
     /// <remarks>
     /// The <see cref="MemoryConnection" /> does not support transactions.
     /// </remarks>
@@ -94,6 +94,23 @@ public class MemoryConnection : IConnection
         IDocument<T> doc = new MemoryDocument<T>(repo, docConfig.OTTypeName, docConfig.CollectionName, id);
         _documents[(docConfig.CollectionName, id)] = doc;
         return doc;
+    }
+
+    public async Task<IReadOnlyCollection<IDocument<T>>> GetAndFetchDocsAsync<T>(IReadOnlyCollection<string> ids)
+        where T : IIdentifiable
+    {
+        List<IDocument<T>> docs = new List<IDocument<T>>();
+        foreach (string id in ids)
+        {
+            IDocument<T> doc = Get<T>(id);
+            await doc.FetchAsync();
+            if (doc.IsLoaded)
+            {
+                docs.Add(doc);
+            }
+        }
+
+        return await Task.FromResult(docs);
     }
 
     /// <summary>

--- a/src/SIL.XForge/Realtime/MemoryConnection.cs
+++ b/src/SIL.XForge/Realtime/MemoryConnection.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using SIL.XForge.Configuration;
@@ -100,9 +101,8 @@ public class MemoryConnection : IConnection
         where T : IIdentifiable
     {
         List<IDocument<T>> docs = new List<IDocument<T>>();
-        foreach (string id in ids)
+        foreach (IDocument<T> doc in ids.Select(Get<T>))
         {
-            IDocument<T> doc = Get<T>(id);
             await doc.FetchAsync();
             if (doc.IsLoaded)
             {

--- a/src/SIL.XForge/Realtime/RealtimeServer.cs
+++ b/src/SIL.XForge/Realtime/RealtimeServer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Jering.Javascript.NodeJS;
@@ -44,6 +45,9 @@ public class RealtimeServer : IRealtimeServer
 
     public Task<Snapshot<T>> FetchDocAsync<T>(int handle, string collection, string id) =>
         InvokeExportAsync<Snapshot<T>>("fetchDoc", handle, collection, id);
+
+    public Task<Snapshot<T>[]> FetchDocsAsync<T>(int handle, string collection, IReadOnlyCollection<string> ids) =>
+        InvokeExportAsync<Snapshot<T>[]>("fetchDocs", handle, collection, ids);
 
     public Task<Snapshot<T>> SubmitOpAsync<T>(int handle, string collection, string id, object op) =>
         InvokeExportAsync<Snapshot<T>>("submitOp", handle, collection, id, op);

--- a/src/SIL.XForge/Realtime/Snapshot.cs
+++ b/src/SIL.XForge/Realtime/Snapshot.cs
@@ -1,8 +1,26 @@
 namespace SIL.XForge.Realtime;
 
+/// <summary>
+/// A snapshot of a document of type <typeparamref name="T"/>.
+/// </summary>
+/// <typeparam name="T">The document type.</typeparam>
 public class Snapshot<T>
 {
+    /// <summary>
+    /// The document identifier.
+    /// </summary>
+    /// <remarks>
+    /// This may be used to ensure that a snapshot returned is for a specific document.
+    /// </remarks>
     public string Id { get; set; }
+
+    /// <summary>
+    /// The snapshot version.
+    /// </summary>
     public int Version { get; set; }
+
+    /// <summary>
+    /// The snapshot data.
+    /// </summary>
     public T Data { get; set; }
 }

--- a/src/SIL.XForge/Realtime/Snapshot.cs
+++ b/src/SIL.XForge/Realtime/Snapshot.cs
@@ -2,6 +2,7 @@ namespace SIL.XForge.Realtime;
 
 public class Snapshot<T>
 {
+    public string Id { get; set; }
     public int Version { get; set; }
     public T Data { get; set; }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1534,9 +1534,6 @@ public class ParatextSyncRunnerTests
         var env = new TestEnvironment();
         TextInfo textInfo = env.SetupChapterAuthorsAndGetTextInfo(setChapterPermissions: false);
         await env.Runner.InitAsync("project01", "user01", "project01", CancellationToken.None);
-        List<string> ids = textInfo.Chapters
-            .Select(c => TextData.GetTextDocId("project01", textInfo.BookNum, c.Number))
-            .ToList();
         var textDocs = await env.FetchTextDocsAsync(textInfo);
         textInfo.Chapters.First().Permissions.Add("user05", TextInfoPermission.Write);
         env.RealtimeService.LastModifiedUserId = "user05";

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1435,7 +1435,7 @@ public class ParatextSyncRunnerTests
         var project = Substitute.For<IDocument<SFProject>>();
         project.IsLoaded.Returns(true);
         project.Data.Returns(env.GetProject());
-        env.SubstituteConnection.Get<SFProject>("project01").Returns(project);
+        env.Connection.Get<SFProject>("project01").Returns(project);
 
         // The HTTP call throws this when a cancelled token is passed
         env.ParatextService
@@ -1460,7 +1460,7 @@ public class ParatextSyncRunnerTests
 
         // Check for RollbackTransaction being executed, to ensure
         // that CompleteAsync executes to the end without exception
-        env.SubstituteConnection.Received(1).RollbackTransaction();
+        env.Connection.Received(1).RollbackTransaction();
 
         // Check that the cancellation was logged in the sync metrics
         SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
@@ -1478,30 +1478,28 @@ public class ParatextSyncRunnerTests
 
         // Throw an TaskCanceledException in InitAsync after the exclusions have been called
         // InitAsync calls the IConnection.FetchAsync() extension, which calls IConnection.Get()
-        env.SubstituteConnection.Get<SFProject>("project01").Throws(new TaskCanceledException());
+        env.Connection.Get<SFProject>("project01").Throws(new TaskCanceledException());
 
         // Run the task
         await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
 
         // Only check for ExcludePropertyFromTransaction being executed,
         // as the substitute RealtimeService will not update documents.
-        env.SubstituteConnection
+        env.Connection
             .Received(1)
             .ExcludePropertyFromTransaction(
                 Arg.Is<Expression<Func<SFProject, object>>>(
                     ex => string.Join('.', new ObjectPath(ex).Items) == "Sync.QueuedCount"
                 )
             );
-        env.SubstituteConnection
+        env.Connection
             .Received(1)
             .ExcludePropertyFromTransaction(
                 Arg.Is<Expression<Func<SFProject, object>>>(
                     ex => string.Join('.', new ObjectPath(ex).Items) == "Sync.DataInSync"
                 )
             );
-        env.SubstituteConnection
-            .Received(2)
-            .ExcludePropertyFromTransaction(Arg.Any<Expression<Func<SFProject, object>>>());
+        env.Connection.Received(2).ExcludePropertyFromTransaction(Arg.Any<Expression<Func<SFProject, object>>>());
     }
 
     [Test]
@@ -2344,9 +2342,9 @@ public class ParatextSyncRunnerTests
             ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), "target").Returns("beforeSR");
             ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), "source").Returns("beforeSR", "afterSR");
             RealtimeService = new SFMemoryRealtimeService();
-            SubstituteConnection = Substitute.For<IConnection>();
+            Connection = Substitute.For<IConnection>();
             SubstituteRealtimeService = Substitute.For<IRealtimeService>();
-            SubstituteRealtimeService.ConnectAsync().Returns(Task.FromResult(SubstituteConnection));
+            SubstituteRealtimeService.ConnectAsync().Returns(Task.FromResult(Connection));
             DeltaUsxMapper = Substitute.For<IDeltaUsxMapper>();
             NotesMapper = Substitute.For<IParatextNotesMapper>();
             var hubContext = Substitute.For<IHubContext<NotificationHub, INotifier>>();
@@ -2380,7 +2378,7 @@ public class ParatextSyncRunnerTests
         /// <summary>
         /// Gets the connection to be used with <see cref="SubstituteRealtimeService"/>.
         /// </summary>
-        public IConnection SubstituteConnection { get; }
+        public IConnection Connection { get; }
 
         public SFProject GetProject(string projectSFId = "project01") =>
             RealtimeService.GetRepository<SFProject>().Get(projectSFId);

--- a/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
@@ -254,6 +254,43 @@ public class ConnectionTests
     }
 
     [Test]
+    public async Task GetAndFetchDocAsync_RetrievesDocsWithData()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        string collection = env.RealtimeService.GetDocConfig<Project>().CollectionName;
+        string[] ids = { "id1", "id2" };
+        env.RealtimeService.Server
+            .FetchDocsAsync<Project>(Arg.Any<int>(), collection, ids)
+            .Returns(
+                new Snapshot<Project>[]
+                {
+                    new Snapshot<Project>
+                    {
+                        Data = null,
+                        Id = "id1",
+                        Version = 1,
+                    },
+                    new Snapshot<Project>
+                    {
+                        Data = new TestProject(),
+                        Id = "id2",
+                        Version = 2,
+                    },
+                }
+            );
+
+        // SUT
+        var result = await env.Service.GetAndFetchDocsAsync<Project>(ids);
+
+        // Verify
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual("id2", result.First().Id);
+        Assert.AreEqual(2, result.First().Version);
+        Assert.IsNotNull(result.First().Data);
+    }
+
+    [Test]
     public async Task RollbackTransaction_ClearsQueuedOperationsAndExcludedProperties()
     {
         // Setup


### PR DESCRIPTION
This Pull Request improves memory use and project sync speed for projects with very large numbers of comments, and many books (i.e. complete canons).

The following changes are included:

 * Changed a regular expression used commonly in sync to compiled (reduced memory allocations)
 * Updated the Realtime Server and sync process to retrieve multiple documents at once (lowers socket use and improves sync speed)
 * Updated use of the Paratext `CommentManager` to:
    - Remove the `CommentManager` from the MRU cache when the sync is completed (frees memory after sync completion)
    - Removed the `ParallelDeserializer` for the `CommentList` data type (considerable reduction to sync memory use with the penalty of a slightly slower [in terms of milliseconds] sync)
 * Suppressed the CodeQL warnings for "Unexpected any. Specify a different type" in `index.ts`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1716)
<!-- Reviewable:end -->
