### PR TITLE
Added support for batch migrating ShareDB documents

### DIFF
--- a/src/SIL.XForge/Realtime/RealtimeServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Realtime/RealtimeServiceCollectionExtensions.cs
@@ -28,6 +28,13 @@ public static class RealtimeServiceCollectionExtensions
                 options.NodeAndV8Options = nodeOptions;
             }
         });
+
+        // Disable timeout so the debugger can be paused
+        if (nodeOptions?.Contains("--inspect", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            services.Configure<OutOfProcessNodeJSServiceOptions>(options => options.TimeoutMS = -1);
+        }
+
         services.AddSingleton<IJsonService, RealtimeJsonService>();
 
         services.Configure(configureOptions);


### PR DESCRIPTION
This pull request:
 * Performs migrations on batches of 10,000 documents
 * Sends a log message when each batch is processed
 * Suppresses the CodeQL warning "_Unexpected any. Specify a different type_" in realtime-server.ts
 * Disables the Jering invocation timeout when a debugging parameter (`--inspect` or `--inspect-brk`) is specified for NodeJS
    - The primary purpose of this is to stop debugging pauses or huge collections from causing an invocation timeout
    - This can also be used to give the very long execution time required for some migrations, by specifying `--inspect` in the `node-options` environment variable, which will ensure that the migration process is not interrupted by Jering timing out the request to `Server.Start()`.

**Problem Summary**

When a collection has hundreds of thousands of documents, and a migration is run on the collection, the following crash can occur in the Realtimeserver on startup:

>   FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory

To fix this error, migration of documents now takes place in batches of 10,000 with a mechanism (by specifying `--inspect`) to ensure that the execution of `Server.Start()` takes as long as it needs to running the migrations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1717)
<!-- Reviewable:end -->
