### PR TITLE
SF-1878b Highlight note thread only if unread notes exist

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3573,9 +3573,10 @@ class TestEnvironment {
     const note = this.targetTextEditor.querySelector(`usx-segment display-note[data-thread-id=${threadId}]`);
     expect(note).withContext('note thread highlight').not.toBeNull();
     const thread: HTMLElement | null = this.targetTextEditor.querySelector(
-      `usx-segment display-note[data-thread-id=${threadId}].note-thread-highlight`
+      `usx-segment display-note[data-thread-id=${threadId}]`
     );
-    return thread != null;
+    expect(thread).withContext('note thread highlight').not.toBeNull();
+    return thread!.classList.contains('note-thread-highlight');
   }
 
   openNoteDialogAndEdit(segmentRef: string, thread: NoteThread): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1535,8 +1535,9 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('shows highlights note icons when new content is unread', fakeAsync(() => {
+    it('highlights note icons when new content is unread', fakeAsync(() => {
       const env = new TestEnvironment();
+      env.setCurrentUser('user02');
       env.setProjectUserConfig({ noteRefsRead: ['thread01_note0', 'thread02_note0'] });
       env.wait();
 
@@ -1553,7 +1554,7 @@ describe('EditorComponent', () => {
       let iconElement: HTMLElement = env.getNoteThreadIconElement('verse_1_1', 'thread01')!;
       iconElement.click();
       env.wait();
-      puc = env.getProjectUserConfigDoc('user01');
+      puc = env.getProjectUserConfigDoc('user02');
       expect(puc.data!.noteRefsRead).toContain('thread01_note1');
       expect(puc.data!.noteRefsRead).toContain('thread01_note2');
       expect(env.isNoteIconHighlighted('thread01')).toBe(false);
@@ -1562,7 +1563,7 @@ describe('EditorComponent', () => {
       iconElement = env.getNoteThreadIconElement('verse_1_3', 'thread02')!;
       iconElement.click();
       env.wait();
-      puc = env.getProjectUserConfigDoc('user01');
+      puc = env.getProjectUserConfigDoc('user02');
       expect(puc.data!.noteRefsRead).toContain('thread02_note0');
       expect(puc.data!.noteRefsRead.filter(ref => ref === 'thread02_note0').length).toEqual(1);
       expect(env.isNoteIconHighlighted('thread02')).toBe(false);
@@ -2616,8 +2617,14 @@ describe('EditorComponent', () => {
       env.wait();
       env.setSelectionAndInsertNote('verse_1_4');
 
+      // The new note appears in the editor and is marked read
+      const threadId = 'threadnew01';
+      env.mockNoteDialogRef.onClose = () => env.insertNoteThread('user01', 'MAT 1:4', threadId);
       env.mockNoteDialogRef.close(true);
-      env.wait();
+      tick();
+      env.fixture.detectChanges();
+
+      expect(env.isNoteIconHighlighted(threadId)).toBeFalse();
       verify(mockedMatDialog.open(NoteDialogComponent, anything())).once();
       const [, config] = capture(mockedMatDialog.open).last();
       const noteVerseRef: VerseRef = (config as MatDialogConfig).data!.verseRef;
@@ -3491,6 +3498,25 @@ class TestEnvironment {
     );
   }
 
+  insertNoteThread(userId: string, verseStr: string, threadId: string): void {
+    const noteId = 'notenew01';
+    const noteThread: NoteThread = {
+      projectRef: 'project01',
+      verseRef: fromVerseRef(VerseRef.parse(verseStr)),
+      ownerRef: userId,
+      dataId: threadId,
+      originalContextBefore: '',
+      originalContextAfter: '',
+      originalSelectedText: '',
+      status: NoteStatus.Todo,
+      position: { start: 0, length: 0 },
+      notes: [this.getNoteTemplate(threadId, noteId, userId)]
+    };
+    this.realtimeService.create(NoteThreadDoc.COLLECTION, `project01:${threadId}`, noteThread);
+    // this is needed to simulate that this happens immediately before the dialog is closed
+    tick();
+  }
+
   getChapterElement(index: number): Element | null {
     const chapters = this.targetEditor.container.querySelectorAll('usx-chapter');
     if (chapters.hasOwnProperty(index) !== undefined) {
@@ -3544,8 +3570,10 @@ class TestEnvironment {
   }
 
   isNoteIconHighlighted(threadId: string): boolean {
+    const note = this.targetTextEditor.querySelector(`usx-segment display-note[data-thread-id=${threadId}]`);
+    expect(note).withContext('note thread highlight').not.toBeNull();
     const thread: HTMLElement | null = this.targetTextEditor.querySelector(
-      `usx-segment display-note[data-thread-id="${threadId}"].note-thread-highlight`
+      `usx-segment display-note[data-thread-id=${threadId}].note-thread-highlight`
     );
     return thread != null;
   }
@@ -3878,12 +3906,12 @@ class TestEnvironment {
     return noteEmbedCount;
   }
 
-  getNoteTemplate(threadId: string): Note {
+  getNoteTemplate(threadId: string, noteId: string, userId: string): Note {
     const date: string = '2022-08-01T01:00:000Z';
     return {
-      dataId: 'notenew01',
+      dataId: noteId,
       threadId,
-      ownerRef: 'user01',
+      ownerRef: userId,
       status: NoteStatus.Todo,
       content: 'New note thread',
       conflictType: NoteConflictType.DefaultValue,
@@ -3968,6 +3996,7 @@ class TestEnvironment {
 
 class MockNoteDialogRef {
   close$ = new Subject<boolean | void>();
+  onClose: () => void = () => {};
 
   constructor(element: Element) {
     // steal the focus to simulate a dialog stealing the focus
@@ -3975,6 +4004,7 @@ class MockNoteDialogRef {
   }
 
   close(result?: boolean): void {
+    this.onClose();
     this.close$.next(result);
     this.close$.complete();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1649,10 +1649,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     if (thread.data == null || this.projectUserConfigDoc?.data == null) return false;
     // look for any note that has not been read and was authored by another user
     const noteRefsRead: string[] = this.projectUserConfigDoc.data.noteRefsRead;
-    const unreadNoteIndex: number = thread.data.notes.findIndex(
+    return thread.data.notes.some(
       n => n.ownerRef !== this.userService.currentUserId && !noteRefsRead.includes(n.dataId)
     );
-    return unreadNoteIndex > -1;
   }
 
   private syncScroll(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1646,11 +1646,13 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   private hasNewContent(thread: NoteThreadDoc): boolean {
-    const noteId: string | undefined = thread.data?.notes[thread.data?.notes.length - 1].dataId;
-    if (noteId == null || this.projectUserConfigDoc?.data == null) {
-      return false;
-    }
-    return !this.projectUserConfigDoc.data.noteRefsRead.includes(noteId);
+    if (thread.data == null || this.projectUserConfigDoc?.data == null) return false;
+    // look for any note that has not been read and was authored by another user
+    const noteRefsRead: string[] = this.projectUserConfigDoc.data.noteRefsRead;
+    const unreadNoteIndex: number = thread.data.notes.findIndex(
+      n => n.ownerRef !== this.userService.currentUserId && !noteRefsRead.includes(n.dataId)
+    );
+    return unreadNoteIndex > -1;
   }
 
   private syncScroll(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -364,7 +364,7 @@ describe('NoteDialogComponent', () => {
       TestEnvironment.PROJECT01,
       'user01'
     );
-    expect(projectUserConfigDoc.data!.noteRefsRead).toContain(noteThread.notes[0].dataId);
+    expect(projectUserConfigDoc.data!.noteRefsRead).not.toContain(noteThread.notes[0].dataId);
   }));
 
   it('show sf note tag on notes with undefined tag id', fakeAsync(() => {
@@ -417,7 +417,7 @@ describe('NoteDialogComponent', () => {
       TestEnvironment.PROJECT01,
       'user01'
     );
-    expect(projectUserConfigDoc.data!.noteRefsRead).toContain(noteThread.data!.notes[5].dataId);
+    expect(projectUserConfigDoc.data!.noteRefsRead).not.toContain(noteThread.data!.notes[5].dataId);
   }));
 
   it('allows user to edit the last note in the thread', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -392,7 +392,6 @@ export class NoteDialogComponent implements OnInit {
         publishedToSF: true
       };
       await this.projectService.createNoteThread(this.projectId, noteThread);
-      await this.updateNoteReadRefs(this.noteBeingEdited.dataId);
       this.dialogRef.close(true);
       return;
     }
@@ -406,14 +405,8 @@ export class NoteDialogComponent implements OnInit {
       });
     } else {
       await this.threadDoc!.submitJson0Op(op => op.add(t => t.notes, this.noteBeingEdited));
-      await this.updateNoteReadRefs(this.noteBeingEdited.dataId);
     }
     this.dialogRef.close(true);
-  }
-
-  private async updateNoteReadRefs(noteId: string): Promise<void> {
-    if (this.projectUserConfigDoc?.data == null || this.projectUserConfigDoc.data.noteRefsRead.includes(noteId)) return;
-    await this.projectUserConfigDoc.submitJson0Op(op => op.add(puc => puc.noteRefsRead, noteId));
   }
 
   private getNoteTemplate(threadId: string | undefined): Note {


### PR DESCRIPTION
When a note gets inserted, the scripture editor responds to the new note too fast sometimes, and the note appears in the editor before our system has had the chance to mark it read. To prevent this race-condition from happening, we have to explicitly wait for the note ID to be recorded in the projectUserConfigDoc before saving the note.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1719)
<!-- Reviewable:end -->
