### PR TITLE
Migration fixes and clean ups

### DIFF
--- a/src/RealtimeServer/common/realtime-server.ts
+++ b/src/RealtimeServer/common/realtime-server.ts
@@ -2,7 +2,7 @@
 import { Db } from 'mongodb';
 import ShareDB from 'sharedb';
 import shareDBAccess from 'sharedb-access';
-import { Connection, Doc, RawOp } from 'sharedb/lib/client';
+import { Connection, Doc, Op, RawOp } from 'sharedb/lib/client';
 import { ConnectSession } from './connect-session';
 import { Project } from './models/project';
 import { SchemaVersionRepository } from './schema-version-repository';
@@ -90,12 +90,15 @@ class MigrationAgent extends ShareDB.Agent {
  *
  * @param {number} version The migration version.
  * @param {Doc} doc The doc.
- * @param {*} component The op.
+ * @param {Op[]} ops The ops.
  * @returns {Promise<void>}
  */
-export function submitMigrationOp(version: number, doc: Doc, component: any): Promise<void> {
+export function submitMigrationOp(version: number, doc: Doc, ops: Op[]): Promise<void> {
+  if (ops.length === 0) {
+    return Promise.resolve();
+  }
   return new Promise<void>((resolve, reject) => {
-    const op: RawOp = { op: component, mv: version };
+    const op: RawOp = { op: ops, mv: version };
     doc._submit(op, undefined, err => {
       if (err != null) {
         reject(err);

--- a/src/RealtimeServer/common/realtime-server.ts
+++ b/src/RealtimeServer/common/realtime-server.ts
@@ -243,7 +243,6 @@ export class RealtimeServer extends ShareDB {
         $limit: limit
       });
       while (query.results.length > 0) {
-        console.log(`Migrating ${docService.collection}: ${skip + 1} to ${skip + query.results.length}`);
         let docVersion = curVersion;
         while (docVersion < version) {
           docVersion++;

--- a/src/RealtimeServer/scriptureforge/services/note-thread-migrations.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-migrations.spec.ts
@@ -26,7 +26,7 @@ describe('NoteThreadMigrations', () => {
   });
 
   describe('version 2', () => {
-    it('removes ext user property', async () => {
+    it('removes ext user and tag icon property', async () => {
       const env = new TestEnvironment(1);
       const conn = env.server.connect();
       await createDoc(conn, NOTE_THREAD_COLLECTION, 'project01:thread01', {
@@ -37,6 +37,7 @@ describe('NoteThreadMigrations', () => {
       await env.server.migrateIfNecessary();
       const doc: Doc = await fetchDoc(conn, NOTE_THREAD_COLLECTION, 'project01:thread01');
       expect(doc.data.notes[0].extUserId).toBeUndefined();
+      expect(doc.data.notes[0].tagIcon).toBeUndefined();
     });
   });
 });

--- a/src/RealtimeServer/scriptureforge/services/note-thread-migrations.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-migrations.spec.ts
@@ -31,7 +31,7 @@ describe('NoteThreadMigrations', () => {
       const conn = env.server.connect();
       await createDoc(conn, NOTE_THREAD_COLLECTION, 'project01:thread01', {
         threadId: 'thread01',
-        notes: [{ threadId: 'thread01', extUserId: 'user02' }]
+        notes: [{ threadId: 'thread01', tagIcon: '01flag1', extUserId: 'user02' }]
       });
 
       await env.server.migrateIfNecessary();

--- a/src/RealtimeServer/scriptureforge/services/note-thread-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-migrations.ts
@@ -32,6 +32,10 @@ class NoteThreadMigration2 implements Migration {
       if (extUserId != null) {
         ops.push({ p: ['notes', i, 'extUserId'], od: extUserId });
       }
+      const tagIcon: string | undefined = doc.data.notes[i].tagIcon;
+      if (tagIcon != null) {
+        ops.push({ p: ['notes', i, 'tagIcon'], od: tagIcon });
+      }
     }
 
     if (ops.length > 0) {

--- a/src/RealtimeServer/scriptureforge/services/note-thread-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-migrations.ts
@@ -7,8 +7,9 @@ class NoteThreadMigration1 implements Migration {
 
   async migrateDoc(doc: Doc): Promise<void> {
     const ops: Op[] = [];
-    if (doc.data.tagIcon != null) {
-      ops.push({ p: ['tagIcon'], od: true });
+    const tagIcon: string | undefined = doc.data.tagIcon;
+    if (tagIcon != null) {
+      ops.push({ p: ['tagIcon'], od: tagIcon });
     }
 
     if (ops.length > 0) {

--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
@@ -102,7 +102,7 @@ class SFProjectMigration4 implements Migration {
   static readonly VERSION = 4;
 
   async migrateDoc(doc: Doc): Promise<void> {
-    const ops = [{ p: ['userPermissions'], oi: {} }];
+    const ops: Op[] = [{ p: ['userPermissions'], oi: {} }];
     await submitMigrationOp(SFProjectMigration4.VERSION, doc, ops);
   }
 
@@ -115,7 +115,7 @@ class SFProjectMigration5 implements Migration {
   static readonly VERSION = 5;
 
   async migrateDoc(doc: Doc): Promise<void> {
-    const ops = [];
+    const ops: Op[] = [];
     if (doc.data.translateConfig == null) {
       ops.push({ p: ['translateConfig'], oi: {} });
     }
@@ -133,7 +133,7 @@ class SFProjectMigration6 implements Migration {
   static readonly VERSION = 6;
 
   async migrateDoc(doc: Doc): Promise<void> {
-    const ops = [];
+    const ops: Op[] = [];
     if (doc.data.editable == null) {
       ops.push({ p: ['editable'], oi: true });
     }
@@ -149,7 +149,7 @@ class SFProjectMigration7 implements Migration {
   static readonly VERSION = 7;
 
   async migrateDoc(doc: Doc): Promise<void> {
-    const ops = [];
+    const ops: Op[] = [];
     const tagIcon: string | undefined = doc.data.tagIcon;
     if (tagIcon != null) {
       ops.push({ p: ['tagIcon'], od: tagIcon });
@@ -166,7 +166,7 @@ class SFProjectMigration8 implements Migration {
   static readonly VERSION = 8;
 
   async migrateDoc(doc: Doc): Promise<void> {
-    const ops = [];
+    const ops: Op[] = [];
     const percentCompleted: number | undefined = doc.data.sync?.percentCompleted;
     if (percentCompleted != null) {
       ops.push({ p: ['sync', 'percentCompleted'], od: percentCompleted });

--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
@@ -150,8 +150,9 @@ class SFProjectMigration7 implements Migration {
 
   async migrateDoc(doc: Doc): Promise<void> {
     const ops = [];
-    if (doc.data.tagIcon != null) {
-      ops.push({ p: ['tagIcon'], od: true });
+    const tagIcon: string | undefined = doc.data.tagIcon;
+    if (tagIcon != null) {
+      ops.push({ p: ['tagIcon'], od: tagIcon });
     }
     await submitMigrationOp(SFProjectMigration7.VERSION, doc, ops);
   }
@@ -166,8 +167,9 @@ class SFProjectMigration8 implements Migration {
 
   async migrateDoc(doc: Doc): Promise<void> {
     const ops = [];
-    if (doc.data.sync?.percentCompleted != null) {
-      ops.push({ p: ['sync', 'percentCompleted'], od: true });
+    const percentCompleted: number | undefined = doc.data.sync?.percentCompleted;
+    if (percentCompleted != null) {
+      ops.push({ p: ['sync', 'percentCompleted'], od: percentCompleted });
     }
     if (ops.length > 0) {
       await submitMigrationOp(SFProjectMigration8.VERSION, doc, ops);


### PR DESCRIPTION
This pull request:
 * Updates the note_threads migration to remove the `tagIcon` property.
 * Stops logging migration progress to the console, as it was polluting tests and not displaying on live.
 * Does not submit empty op collections to ShareDB on `submitMigrationOp`.
 * Fixed incorrect `od` ops so that any future developers who copy them will not propagate the incorrect ops.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1722)
<!-- Reviewable:end -->
