### PR TITLE
SF-1890 Change add comment button logic to be permission based

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -37,7 +37,7 @@ quill-editor {
     }
 
     .question-segment,
-    usx-segment.reviewer-selection {
+    usx-segment.commenter-selection {
       background-image: linear-gradient(to right, gray 75%, transparent 75%);
       background-position: bottom 0.2em left;
       background-repeat: repeat-x;

--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -379,7 +379,7 @@ usx-verse {
   }
 }
 
-span.reviewer-selection > usx-verse {
+span.commenter-selection > usx-verse {
   span > span > span {
     color: white;
     background-color: $greyDark;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -647,7 +647,7 @@ export function registerScripture(): string[] {
   });
 
   formats.push(NoteThreadHighlightClass);
-  const ReviewerSelectedSegmentClass = new ClassAttributor('reviewer-selection', 'reviewer-selection', {
+  const ReviewerSelectedSegmentClass = new ClassAttributor('commenter-selection', 'commenter-selection', {
     scope: Parchment.Scope.INLINE
   });
   formats.push(ReviewerSelectedSegmentClass);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -694,10 +694,10 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     let selectionValue: true | null = true;
     if (verseRange != null) {
       const formats: StringMap = getAttributesAtPosition(this.editor, verseRange.index);
-      selectionValue = formats['reviewer-selection'] ? null : true;
+      selectionValue = formats['commenter-selection'] ? null : true;
     }
 
-    const format: StringMap = { ['reviewer-selection']: selectionValue };
+    const format: StringMap = { ['commenter-selection']: selectionValue };
     let verseEmbedFormatted: boolean = false;
     for (const segment of verseSegments) {
       // only underline the selection if it is part of the verse text i.e. not a section heading

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -112,7 +112,7 @@
             [markInvalid]="true"
             [isRightToLeft]="isTargetRightToLeft"
             [fontSize]="fontSize"
-            [selectableVerses]="isReviewer"
+            [selectableVerses]="showAddCommentUI"
           ></app-text>
           <app-suggestions
             [mdcElevation]="2"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2611,35 +2611,35 @@ describe('EditorComponent', () => {
       const hasSelectionAnchors = env.getSegmentElement('verse_1_1')!.querySelector('display-text-anchor');
       expect(hasSelectionAnchors).toBeNull();
       const verseElem: HTMLElement = env.getSegmentElement('verse_1_1')!;
-      expect(verseElem.classList).not.toContain('reviewer-selection');
+      expect(verseElem.classList).not.toContain('commenter-selection');
 
       // select verse 1
       verseElem.click();
       env.wait();
-      expect(verseElem.classList).toContain('reviewer-selection');
+      expect(verseElem.classList).toContain('commenter-selection');
       let verse2Elem: HTMLElement = env.getSegmentElement('verse_1_2')!;
 
       // select verse 2, deselect verse one
       verse2Elem.click();
       env.wait();
-      expect(verse2Elem.classList).toContain('reviewer-selection');
-      expect(verseElem.classList).not.toContain('reviewer-selection');
+      expect(verse2Elem.classList).toContain('commenter-selection');
+      expect(verseElem.classList).not.toContain('commenter-selection');
 
       // deselect verse 2
       verse2Elem.click();
       env.wait();
-      expect(verse2Elem.classList).not.toContain('reviewer-selection');
+      expect(verse2Elem.classList).not.toContain('commenter-selection');
 
       // reselect verse 2, check that it is not selected when moving to a new book
       verse2Elem.click();
       env.updateParams({ projectId: 'project01', bookId: 'MRK' });
       env.wait();
       verse2Elem = env.getSegmentElement('verse_1_2')!;
-      expect(verse2Elem.classList).not.toContain('reviewer-selection');
+      expect(verse2Elem.classList).not.toContain('commenter-selection');
       const verse3Elem: HTMLElement = env.getSegmentElement('verse_1_3')!;
       verse3Elem.click();
-      expect(verse3Elem.classList).toContain('reviewer-selection');
-      expect(verse2Elem.classList).not.toContain('reviewer-selection');
+      expect(verse3Elem.classList).toContain('commenter-selection');
+      expect(verse2Elem.classList).not.toContain('commenter-selection');
       env.dispose();
     }));
 
@@ -2651,23 +2651,23 @@ describe('EditorComponent', () => {
       env.wait();
 
       let elem: HTMLElement = env.getSegmentElement('s_1')!;
-      expect(elem.classList).not.toContain('reviewer-selection');
+      expect(elem.classList).not.toContain('commenter-selection');
       elem.click();
       env.wait();
-      expect(elem.classList).not.toContain('reviewer-selection');
+      expect(elem.classList).not.toContain('commenter-selection');
 
       elem = env.getSegmentElement('s_2')!;
-      expect(elem.classList).not.toContain('reviewer-selection');
+      expect(elem.classList).not.toContain('commenter-selection');
       elem.click();
       env.wait();
-      expect(elem.classList).not.toContain('reviewer-selection');
+      expect(elem.classList).not.toContain('commenter-selection');
 
       const verseElem: HTMLElement = env.getSegmentElement('verse_1_2-3')!;
-      expect(verseElem.classList).not.toContain('reviewer-selection');
+      expect(verseElem.classList).not.toContain('commenter-selection');
       verseElem.click();
       env.wait();
-      expect(verseElem.classList).toContain('reviewer-selection');
-      expect(elem.classList).not.toContain('reviewer-selection');
+      expect(verseElem.classList).toContain('commenter-selection');
+      expect(elem.classList).not.toContain('commenter-selection');
       env.dispose();
     }));
 
@@ -2680,15 +2680,15 @@ describe('EditorComponent', () => {
       const verseSegment: HTMLElement = env.getSegmentElement('verse_1_5')!;
       verseSegment.click();
       env.wait();
-      expect(verseSegment.classList).toContain('reviewer-selection');
+      expect(verseSegment.classList).toContain('commenter-selection');
 
       // Change to a PT reviewer to assert they can also use the FAB
       verseSegment.click();
-      expect(verseSegment.classList).not.toContain('reviewer-selection');
+      expect(verseSegment.classList).not.toContain('commenter-selection');
       env.setParatextReviewerUser();
       env.wait();
       verseSegment.click();
-      expect(verseSegment.classList).toContain('reviewer-selection');
+      expect(verseSegment.classList).toContain('commenter-selection');
 
       // Click and open the dialog
       env.insertNoteFab.nativeElement.click();


### PR DESCRIPTION
Previously this checked whether the role was reviewer or consultant, but we should be going by permissions, not by roles.

I also renamed some relevant variables to be about whether the commenting UI should be shown, rather than whether the user had a particular role.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1727)
<!-- Reviewable:end -->
