### PR TITLE
SF-1892 Remove displayName from ProjectRoleInfo

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-role-info.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-role-info.ts
@@ -4,17 +4,13 @@ import { isTranslateRole, SFProjectRole } from 'realtime-server/lib/esm/scriptur
 import { ProjectRoleInfo } from 'xforge-common/models/project-role-info';
 
 export const SF_PROJECT_ROLES: ProjectRoleInfo[] = [
-  { role: SFProjectRole.ParatextAdministrator, displayName: 'Administrator', canBeShared: false },
-  { role: SFProjectRole.ParatextTranslator, displayName: 'Translator', canBeShared: false },
-  {
-    role: SFProjectRole.ParatextConsultant,
-    displayName: 'Consultant/Reviewer/Archivist/Typesetter',
-    canBeShared: false
-  },
-  { role: SFProjectRole.ParatextObserver, displayName: 'Observer', canBeShared: false },
-  { role: SFProjectRole.Reviewer, displayName: 'Reviewer', canBeShared: true },
-  { role: SFProjectRole.CommunityChecker, displayName: 'Community Checker', canBeShared: true },
-  { role: SFProjectRole.Observer, displayName: 'View Translation', canBeShared: true }
+  { role: SFProjectRole.ParatextAdministrator, canBeShared: false },
+  { role: SFProjectRole.ParatextTranslator, canBeShared: false },
+  { role: SFProjectRole.ParatextConsultant, canBeShared: false },
+  { role: SFProjectRole.ParatextObserver, canBeShared: false },
+  { role: SFProjectRole.Reviewer, canBeShared: true },
+  { role: SFProjectRole.CommunityChecker, canBeShared: true },
+  { role: SFProjectRole.Observer, canBeShared: true }
 ];
 
 export function canAccessTranslateApp(role?: SFProjectRole): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/project-role-info.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/project-role-info.ts
@@ -1,7 +1,6 @@
-export const NONE_ROLE: ProjectRoleInfo = { role: 'none', displayName: 'None', canBeShared: false };
+export const NONE_ROLE: ProjectRoleInfo = { role: 'none', canBeShared: false };
 
 export interface ProjectRoleInfo {
   role: string;
-  displayName: string;
   canBeShared: boolean;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.html
@@ -34,7 +34,7 @@
               (selectionChange)="updateRole(row, $event.value)"
             >
               <mat-option *ngFor="let projectRole of projectRoles" [value]="projectRole">
-                {{ projectRole.displayName }}
+                {{ i18n.localizeRole(projectRole.role) }}
               </mat-option>
             </mat-select>
           </mat-form-field>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.spec.ts
@@ -84,10 +84,10 @@ describe('SaProjectsComponent', () => {
     const roleSelect = env.roleSelect(0);
     expect(env.selectValue(roleSelect)).toEqual('Administrator');
     env.changeSelectValue(roleSelect, 1);
-    expect(env.selectValue(roleSelect)).toEqual('User');
+    expect(env.selectValue(roleSelect)).toEqual('Translator');
 
-    verify(mockedProjectService.onlineUpdateCurrentUserRole('project01', 'user')).once();
-    expect(env.component.rows[0].projectRole.role).toEqual('user');
+    verify(mockedProjectService.onlineUpdateCurrentUserRole('project01', 'pt_translator')).once();
+    expect(env.component.rows[0].projectRole.role).toEqual('pt_translator');
   }));
 
   it('should add user to project', fakeAsync(() => {
@@ -103,7 +103,7 @@ describe('SaProjectsComponent', () => {
     env.changeSelectValue(roleSelect, 0);
     expect(env.selectValue(roleSelect)).toEqual('Administrator');
 
-    verify(mockedProjectService.onlineAddCurrentUser('project02', 'admin')).once();
+    verify(mockedProjectService.onlineAddCurrentUser('project02', 'pt_administrator')).once();
   }));
 
   it('should remove user from project', fakeAsync(() => {
@@ -199,8 +199,8 @@ class TestEnvironment {
     when(mockedUserService.currentUserId).thenReturn('user01');
     when(mockedProjectService.roles).thenReturn(
       new Map<string, ProjectRoleInfo>([
-        ['admin', { role: 'admin', displayName: 'Administrator', canBeShared: false }],
-        ['user', { role: 'user', displayName: 'User', canBeShared: false }],
+        ['pt_administrator', { role: 'pt_administrator', canBeShared: false }],
+        ['pt_translator', { role: 'pt_translator', canBeShared: false }],
         [NONE_ROLE.role, NONE_ROLE]
       ])
     );
@@ -305,7 +305,7 @@ class TestEnvironment {
         id: 'project01',
         data: {
           name: 'Project 01',
-          userRoles: { user01: 'admin' },
+          userRoles: { user01: 'pt_administrator' },
           userPermissions: {}
         }
       },
@@ -322,7 +322,7 @@ class TestEnvironment {
         id: 'project03',
         data: {
           name: 'Project 03',
-          userRoles: { user01: 'user' },
+          userRoles: { user01: 'pt_translator' },
           userPermissions: {}
         }
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.ts
@@ -3,6 +3,7 @@ import { Project } from 'realtime-server/lib/esm/common/models/project';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { BehaviorSubject } from 'rxjs';
+import { I18nService } from 'xforge-common/i18n.service';
 import { DataLoadingComponent } from '../data-loading-component';
 import { ProjectDoc } from '../models/project-doc';
 import { NONE_ROLE, ProjectRoleInfo } from '../models/project-role-info';
@@ -61,6 +62,7 @@ export class SaProjectsComponent extends DataLoadingComponent implements OnInit 
 
   constructor(
     noticeService: NoticeService,
+    readonly i18n: I18nService,
     private readonly projectService: ProjectService,
     private readonly userService: UserService
   ) {


### PR DESCRIPTION
The display name for a role is now stored in our localization files, and that is the only place we should be getting it from. Having it elsewhere is just a source of potential trouble.

Unfortunately the system administration page was still using the old displayName, so it needed some changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1728)
<!-- Reviewable:end -->
