### PR TITLE
Add GitHub action to check labels

### DIFF
--- a/.github/actions/check-testing-status-labels/action.yml
+++ b/.github/actions/check-testing-status-labels/action.yml
@@ -1,0 +1,5 @@
+name: "Check testing status labels"
+description: 'Checks that a "testing complete" or "testing not required" label has been applied'
+runs:
+  using: "node16"
+  main: "index.js"

--- a/.github/actions/check-testing-status-labels/index.js
+++ b/.github/actions/check-testing-status-labels/index.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+
+const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, { encoding: 'utf8' }));
+
+const prLabels = event.pull_request.labels;
+
+// Check for labels by node_id rather than name so they can be renamed later if needed
+const satisfactoryLabels = [
+  'LA_kwDOCvNrCM8AAAABAYQhlQ', // testing complete
+  'LA_kwDOCvNrCM8AAAABGHKoGw' // testing not required
+];
+
+const satisfied = prLabels.some(label => satisfactoryLabels.includes(label.node_id));
+
+console.log(`Pull request labels set to ${JSON.stringify(prLabels.map(label => label.name))}`);
+
+console.log(`Testing status is ${satisfied ? 'satisfied' : 'unsatisfied'}`);
+
+process.exit(satisfied ? 0 : 1);

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,0 +1,15 @@
+name: Check labels
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
+
+jobs:
+  check-testing-status-labels:
+    name: check testing status labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Check testing status labels
+        uses: ./.github/actions/check-testing-status-labels


### PR DESCRIPTION
This action should pass/fail depending whether the "testing complete" or "testing not required labels are present.

Notes: GitHub workflows do not by default block a PR from being merged when they fail. That setting is separate, so don't be surprised when you don't see it affect meragability.

You can test this action by changing the labels.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1730)
<!-- Reviewable:end -->
