### PR TITLE
SF-1889 Attribute new SF notes to reviewer user on sync

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1225,11 +1225,7 @@ public class ParatextService : DisposableBase, IParatextService
                 if (matchedComment != null)
                 {
                     matchedCommentIds.Add(matchedComment.Id);
-                    Paratext.Data.ProjectComments.CommentTag commentIconTag = GetCommentTag(
-                        existingThread,
-                        matchedComment,
-                        commentTags
-                    );
+                    CommentTag commentIconTag = GetCommentTag(existingThread, matchedComment, commentTags);
                     ChangeType changeType = GetCommentChangeType(matchedComment, note, commentIconTag, ptProjectUsers);
                     if (changeType != ChangeType.None)
                     {
@@ -2111,12 +2107,12 @@ public class ParatextService : DisposableBase, IParatextService
         {
             resources = SFInstallableDblResource.GetInstallableDblResources(
                 accessLock.UserSecret,
-                this._paratextOptions.Value,
-                this._restClientFactory,
-                this._fileSystemService,
-                this._jwtTokenHelper,
+                _paratextOptions.Value,
+                _restClientFactory,
+                _fileSystemService,
+                _jwtTokenHelper,
                 _exceptionHandler,
-                this._dblServerUri
+                _dblServerUri
             );
         }
         IReadOnlyDictionary<string, int> resourceRevisions = SFInstallableDblResource.GetInstalledResourceRevisions();
@@ -2222,6 +2218,11 @@ public class ParatextService : DisposableBase, IParatextService
                 }
                 else
                 {
+                    if (!string.IsNullOrEmpty(note.SyncUserRef))
+                        throw new DataNotFoundException(
+                            "Could not find the matching comment for a note containing a sync user."
+                        );
+
                     // new comment added
                     ParatextUserProfile ptProjectUser;
                     UserSecret userSecret = _userSecretRepository.Query().FirstOrDefault(s => s.Id == note.OwnerRef);
@@ -2367,16 +2368,13 @@ public class ParatextService : DisposableBase, IParatextService
     {
         return assignedPTUser switch
         {
-            Paratext.Data.ProjectComments.CommentThread.teamUser
-            or Paratext.Data.ProjectComments.CommentThread.unassignedUser
-            or null
-                => assignedPTUser,
+            CommentThread.teamUser or CommentThread.unassignedUser or null => assignedPTUser,
             _ => FindOrCreateParatextUser(assignedPTUser, ptProjectUsers).OpaqueUserId,
         };
     }
 
     private static CommentTag GetCommentTag(
-        Paratext.Data.ProjectComments.CommentThread thread,
+        CommentThread thread,
         Paratext.Data.ProjectComments.Comment comment,
         CommentTags commentTags
     )


### PR DESCRIPTION
* store note thread doc values in variable at sync time
* throw if a note cannot be found when it should exist
* check the sync user ref on a note before creating a new comment
* some clean up

The primary problem for this issue was that we fetched the note thread docs from the realtime server twice. Once when we export the note thread doc changes to PT, and then a second time when we pull in the up-to-date note threads from PT. When we did this, the SyncUserRef property on the note threads were not up to date on the second set of note thread docs, which caused the sync to incorrectly assume that it needed to delete the existing docs and recreate them with the sync user as the owner. This fixes that problem as well as introduces an exception that is thrown if we have a sync user on a note, but cannot locate the PT equivalent comment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1732)
<!-- Reviewable:end -->
