### PR TITLE
SF-1891 Do not select a verse when clicking note thread icon

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2643,6 +2643,36 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('does not select verse when opening a note thread', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.setReviewerUser();
+      env.addParatextNoteThread(
+        6,
+        'MAT 1:1',
+        '',
+        { start: 0, length: 0 },
+        ['user01'],
+        NoteStatus.Todo,
+        undefined,
+        true
+      );
+      env.wait();
+
+      const elem: HTMLElement = env.getNoteThreadIconElement('verse_1_1', 'thread06')!;
+      elem.click();
+      env.mockNoteDialogRef.close();
+      env.wait();
+      const verse1Elem: HTMLElement = env.getSegmentElement('verse_1_1')!;
+      expect(verse1Elem.classList).not.toContain('commenter-selection');
+
+      // select verse 3 after closing the dialog
+      const verse3Elem: HTMLElement = env.getSegmentElement('verse_1_3')!;
+      verse3Elem.click();
+      expect(verse1Elem.classList).not.toContain('commenter-selection');
+      env.dispose();
+    }));
+
     it('does not allow selecting section headings', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1226,28 +1226,33 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       if (segmentElement == null) continue;
 
       this.selectionClickSubs.push(
-        this.subscribe(fromEvent<MouseEvent>(segmentElement, 'click'), event => {
-          if (this.bookNum == null || this.target == null) return;
-          const verseRef: VerseRef | undefined = verseRefFromMouseEvent(event, this.bookNum);
-          if (verseRef == null) return;
-          if (this.canShowInsertNoteFab) {
-            this.showInsertNoteFab = this.target.toggleVerseSelection(verseRef);
-            this.positionInsertNoteFab(segmentElement);
-          } else {
-            this.showInsertNoteFab = false;
-          }
-          if (this.commenterSelectedVerseRef != null) {
-            if (verseRef.equals(this.commenterSelectedVerseRef)) {
-              this.commenterSelectedVerseRef = undefined;
+        this.subscribe(
+          fromEvent<MouseEvent>(segmentElement, 'click').pipe(
+            filter(event => (event.target as HTMLElement).tagName.toLowerCase() !== 'display-note')
+          ),
+          event => {
+            if (this.bookNum == null || this.target == null) return;
+            const verseRef: VerseRef | undefined = verseRefFromMouseEvent(event, this.bookNum);
+            if (verseRef == null) return;
+            if (this.canShowInsertNoteFab) {
+              this.showInsertNoteFab = this.target.toggleVerseSelection(verseRef);
+              this.positionInsertNoteFab(segmentElement);
             } else {
-              // un-select previously selected verses since a note can apply to only one verse.
-              this.target.toggleVerseSelection(this.commenterSelectedVerseRef);
+              this.showInsertNoteFab = false;
+            }
+            if (this.commenterSelectedVerseRef != null) {
+              if (verseRef.equals(this.commenterSelectedVerseRef)) {
+                this.commenterSelectedVerseRef = undefined;
+              } else {
+                // un-select previously selected verses since a note can apply to only one verse.
+                this.target.toggleVerseSelection(this.commenterSelectedVerseRef);
+                this.commenterSelectedVerseRef = verseRef;
+              }
+            } else {
               this.commenterSelectedVerseRef = verseRef;
             }
-          } else {
-            this.commenterSelectedVerseRef = verseRef;
           }
-        })
+        )
       );
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1210,6 +1210,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
               this.target?.formatEmbed(threadId, 'note-thread-embed', { ['highlight']: false });
               this.updateReadNotes(threadId);
             }
+            // stops the event from causing the segment to be selected
             event.stopPropagation();
           })
         )

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1210,6 +1210,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
               this.target?.formatEmbed(threadId, 'note-thread-embed', { ['highlight']: false });
               this.updateReadNotes(threadId);
             }
+            event.stopPropagation();
           })
         )
       );
@@ -1226,33 +1227,28 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       if (segmentElement == null) continue;
 
       this.selectionClickSubs.push(
-        this.subscribe(
-          fromEvent<MouseEvent>(segmentElement, 'click').pipe(
-            filter(event => (event.target as HTMLElement).tagName.toLowerCase() !== 'display-note')
-          ),
-          event => {
-            if (this.bookNum == null || this.target == null) return;
-            const verseRef: VerseRef | undefined = verseRefFromMouseEvent(event, this.bookNum);
-            if (verseRef == null) return;
-            if (this.canShowInsertNoteFab) {
-              this.showInsertNoteFab = this.target.toggleVerseSelection(verseRef);
-              this.positionInsertNoteFab(segmentElement);
+        this.subscribe(fromEvent<MouseEvent>(segmentElement, 'click'), event => {
+          if (this.bookNum == null || this.target == null) return;
+          const verseRef: VerseRef | undefined = verseRefFromMouseEvent(event, this.bookNum);
+          if (verseRef == null) return;
+          if (this.canShowInsertNoteFab) {
+            this.showInsertNoteFab = this.target.toggleVerseSelection(verseRef);
+            this.positionInsertNoteFab(segmentElement);
+          } else {
+            this.showInsertNoteFab = false;
+          }
+          if (this.commenterSelectedVerseRef != null) {
+            if (verseRef.equals(this.commenterSelectedVerseRef)) {
+              this.commenterSelectedVerseRef = undefined;
             } else {
-              this.showInsertNoteFab = false;
-            }
-            if (this.commenterSelectedVerseRef != null) {
-              if (verseRef.equals(this.commenterSelectedVerseRef)) {
-                this.commenterSelectedVerseRef = undefined;
-              } else {
-                // un-select previously selected verses since a note can apply to only one verse.
-                this.target.toggleVerseSelection(this.commenterSelectedVerseRef);
-                this.commenterSelectedVerseRef = verseRef;
-              }
-            } else {
+              // un-select previously selected verses since a note can apply to only one verse.
+              this.target.toggleVerseSelection(this.commenterSelectedVerseRef);
               this.commenterSelectedVerseRef = verseRef;
             }
+          } else {
+            this.commenterSelectedVerseRef = verseRef;
           }
-        )
+        })
       );
     }
   }


### PR DESCRIPTION
Previously if you opened and close a note dialog, the verse would be selected because clicking on the icon actually also selected the verse. However, the UI would not look like the verse was selected.
To fix this issue, we avoid triggering selecting the verse if a user only clicked the note thread icon on the verse.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1733)
<!-- Reviewable:end -->
