### PR TITLE
SF-1905 Disable adding a note on unavailable text

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -434,6 +434,10 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     return undefined;
   }
 
+  get contentShowing(): boolean {
+    return this.id != null && this.viewModel.isLoaded && !this.viewModel.isEmpty;
+  }
+
   /**
    * Is presence enabled and currently available to use
    */
@@ -446,10 +450,6 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
    */
   private get isPresenceEnabled(): boolean {
     return this.enablePresence;
-  }
-
-  private get contentShowing(): boolean {
-    return this.id != null && this.viewModel.isLoaded && !this.viewModel.isEmpty;
   }
 
   ngAfterViewInit(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -27,16 +27,6 @@
             <mat-icon>settings</mat-icon>
           </button>
         </ng-container>
-        <button
-          *ngIf="canInsertNote"
-          mat-icon-button
-          type="button"
-          id="create-note-btn"
-          (click)="insertNote()"
-          title="{{ t('insert_note') }}"
-        >
-          <mat-icon>add_comment</mat-icon>
-        </button>
         <ng-container *ngIf="canShare">
           <div class="toolbar-separator">&nbsp;</div>
           <app-share-button [defaultRole]="defaultShareRole"></app-share-button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -27,6 +27,16 @@
             <mat-icon>settings</mat-icon>
           </button>
         </ng-container>
+        <button
+          *ngIf="canInsertNote"
+          mat-icon-button
+          type="button"
+          id="create-note-btn"
+          (click)="insertNote()"
+          title="{{ t('insert_note') }}"
+        >
+          <mat-icon>add_comment</mat-icon>
+        </button>
         <ng-container *ngIf="canShare">
           <div class="toolbar-separator">&nbsp;</div>
           <app-share-button [defaultRole]="defaultShareRole"></app-share-button>
@@ -117,7 +127,7 @@
               <b>{{ currentSegmentReference }}</b>
               <button mat-flat-button (click)="insertNote()" color="accent">
                 <mat-icon>add_comment</mat-icon>
-                {{ t("insert_note") }}
+                {{ t("add_comment") }}
               </button>
             </div>
           </ng-template>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -117,7 +117,7 @@
               <b>{{ currentSegmentReference }}</b>
               <button mat-flat-button (click)="insertNote()" color="accent">
                 <mat-icon>add_comment</mat-icon>
-                {{ t("add_comment") }}
+                {{ t("insert_note") }}
               </button>
             </div>
           </ng-template>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2584,6 +2584,23 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('cannot insert a note when text is invalid', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.updateParams({ projectId: 'project01', bookId: 'MRK' });
+      env.wait();
+
+      expect(env.bookName).toEqual('Mark');
+      expect(env.component.canEdit).toBeFalse();
+      expect(env.component.isUsfmValid).toBeFalse();
+      expect(env.component.isInsertNoteFabEnabled).toBeTrue();
+      env.insertNoteButton.nativeElement.click();
+      env.wait();
+      verify(mockedNoticeService.show(anything())).once();
+      verify(mockedMatDialog.open(NoteDialogComponent, anything())).never();
+      env.dispose();
+    }));
+
     it('can insert note on verse at cursor position', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2594,7 +2594,7 @@ describe('EditorComponent', () => {
       expect(env.component.canEdit).toBeFalse();
       expect(env.component.isUsfmValid).toBeFalse();
       expect(env.component.isInsertNoteFabEnabled).toBeTrue();
-      env.insertNoteButton.nativeElement.click();
+      env.insertNoteFab.nativeElement.click();
       env.wait();
       verify(mockedNoticeService.show(anything())).once();
       verify(mockedMatDialog.open(NoteDialogComponent, anything())).never();
@@ -2612,14 +2612,14 @@ describe('EditorComponent', () => {
       });
       when(mockedSFProjectService.getText(anything())).thenReturn(promise);
       env.wait();
-      env.insertNoteButton.nativeElement.click();
+      env.insertNoteFab.nativeElement.click();
       env.wait();
       verify(mockedNoticeService.show(anything())).once();
       verify(mockedMatDialog.open(NoteDialogComponent, anything())).never();
       subject.next();
       subject.complete();
       env.wait();
-      env.insertNoteButton.nativeElement.click();
+      env.insertNoteFab.nativeElement.click();
       env.wait();
       verify(mockedNoticeService.show(anything())).once();
       verify(mockedMatDialog.open(NoteDialogComponent, anything())).once();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2601,6 +2601,32 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('cannot insert a note when editor content unavailable', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.onlineStatus = false;
+      const textDoc: TextDoc = env.getTextDoc(new TextDocId('project01', 40, 1));
+      const subject: Subject<void> = new Subject<void>();
+      const promise = new Promise<TextDoc>(resolve => {
+        subject.subscribe(() => resolve(textDoc));
+      });
+      when(mockedSFProjectService.getText(anything())).thenReturn(promise);
+      env.wait();
+      env.insertNoteButton.nativeElement.click();
+      env.wait();
+      verify(mockedNoticeService.show(anything())).once();
+      verify(mockedMatDialog.open(NoteDialogComponent, anything())).never();
+      subject.next();
+      subject.complete();
+      env.wait();
+      env.insertNoteButton.nativeElement.click();
+      env.wait();
+      verify(mockedNoticeService.show(anything())).once();
+      verify(mockedMatDialog.open(NoteDialogComponent, anything())).once();
+      expect().nothing();
+      env.dispose();
+    }));
+
     it('can insert note on verse at cursor position', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2584,23 +2584,6 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('cannot insert a note when text is invalid', fakeAsync(() => {
-      const env = new TestEnvironment();
-      env.setProjectUserConfig();
-      env.updateParams({ projectId: 'project01', bookId: 'MRK' });
-      env.wait();
-
-      expect(env.bookName).toEqual('Mark');
-      expect(env.component.canEdit).toBeFalse();
-      expect(env.component.isUsfmValid).toBeFalse();
-      expect(env.component.isInsertNoteFabEnabled).toBeTrue();
-      env.insertNoteFab.nativeElement.click();
-      env.wait();
-      verify(mockedNoticeService.show(anything())).once();
-      verify(mockedMatDialog.open(NoteDialogComponent, anything())).never();
-      env.dispose();
-    }));
-
     it('cannot insert a note when editor content unavailable', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -823,6 +823,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     if (this.target == null || this.bookNum == null || !this.showAddCommentUI) {
       return;
     }
+    if (!this.isUsfmValid || !this.dataInSync || this.target.areOpsCorrupted) {
+      this.noticeService.show(translate('editor.navigate_to_a_valid_text'));
+      return;
+    }
     let verseRef: VerseRef | undefined = this.commenterSelectedVerseRef;
     if (verseRef == null) {
       const defaultSegmentRef: string | undefined = this.target.firstVerseSegment;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -823,7 +823,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     if (this.target == null || this.bookNum == null || !this.showAddCommentUI) {
       return;
     }
-    if (!this.isUsfmValid || !this.dataInSync || this.target.areOpsCorrupted || !this.target.contentShowing) {
+    if (!this.target.contentShowing) {
       this.noticeService.show(translate('editor.navigate_to_a_valid_text'));
       return;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -823,7 +823,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     if (this.target == null || this.bookNum == null || !this.showAddCommentUI) {
       return;
     }
-    if (!this.isUsfmValid || !this.dataInSync || this.target.areOpsCorrupted) {
+    if (!this.isUsfmValid || !this.dataInSync || this.target.areOpsCorrupted || !this.target.contentShowing) {
       this.noticeService.show(translate('editor.navigate_to_a_valid_text'));
       return;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -110,6 +110,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   textHeight: string = '';
   multiCursorViewers: MultiCursorViewer[] = [];
   insertNoteFabLeft: string = '0px';
+  insertNoteLabel: string = '';
 
   @ViewChild('targetContainer') targetContainer?: ElementRef;
   @ViewChild('source') source?: TextComponent;
@@ -1289,6 +1290,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     this._chapter = chapter;
     this.changeText();
     this.toggleNoteThreadVerses(true);
+    this.insertNoteLabel = translate(this.showAddCommentUI ? 'editor.add_comment' : 'editor.insert_note');
   }
 
   private resetInsertNoteFab(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -110,7 +110,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   textHeight: string = '';
   multiCursorViewers: MultiCursorViewer[] = [];
   insertNoteFabLeft: string = '0px';
-  insertNoteLabel: string = '';
 
   @ViewChild('targetContainer') targetContainer?: ElementRef;
   @ViewChild('source') source?: TextComponent;
@@ -1290,7 +1289,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     this._chapter = chapter;
     this.changeText();
     this.toggleNoteThreadVerses(true);
-    this.insertNoteLabel = translate(this.showAddCommentUI ? 'editor.add_comment' : 'editor.insert_note');
   }
 
   private resetInsertNoteFab(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -84,12 +84,12 @@
     "project_name": "Project Name"
   },
   "editor": {
-    "add_comment": "Add Comment",
     "anonymous": "Anonymous",
     "cannot_edit_chapter_formatting_invalid": "This chapter cannot be edited because the formatting is invalid. Please fix the formatting in Paratext.",
     "configure_translation_suggestions": "Configure translation suggestions",
     "insert_note": "Insert note",
     "more_notes": "--- {{ count }} more note(s) ---",
+    "navigate_to_a_valid_text": "Navigate to a valid text to insert a note",
     "no_permission_edit_chapter": "You don't have permission to edit this chapter, even though you have the {{ userRole }} role. Permissions can only be changed in Paratext.",
     "project_data_out_of_sync": "Your project data is out of sync. Please synchronize your project to edit this text.",
     "project_text_not_editable": "Text in this project is not editable. This setting can be changed in Paratext.",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -84,6 +84,7 @@
     "project_name": "Project Name"
   },
   "editor": {
+    "add_comment": "Add Comment",
     "anonymous": "Anonymous",
     "cannot_edit_chapter_formatting_invalid": "This chapter cannot be edited because the formatting is invalid. Please fix the formatting in Paratext.",
     "configure_translation_suggestions": "Configure translation suggestions",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -88,7 +88,6 @@
     "anonymous": "Anonymous",
     "cannot_edit_chapter_formatting_invalid": "This chapter cannot be edited because the formatting is invalid. Please fix the formatting in Paratext.",
     "configure_translation_suggestions": "Configure translation suggestions",
-    "insert_note": "Insert note",
     "more_notes": "--- {{ count }} more note(s) ---",
     "navigate_to_a_valid_text": "Navigate to a valid text to insert a note",
     "no_permission_edit_chapter": "You don't have permission to edit this chapter, even though you have the {{ userRole }} role. Permissions can only be changed in Paratext.",


### PR DESCRIPTION
On projects where there are texts are unavailable we should not allow a user to add a note. This change makes a snackbar appear when a user clicks the add note button when viewing a texts that is unavailable because a user is offline.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1742)
<!-- Reviewable:end -->
