### PR TITLE
SF-1912 Remove .NET Core 3.1 build files in Vagrantfile

### DIFF
--- a/deploy/vagrant_xenial_gui/Vagrantfile
+++ b/deploy/vagrant_xenial_gui/Vagrantfile
@@ -43,6 +43,10 @@ Vagrant.configure("2") do |config|
     git checkout -- src/SIL.XForge.Scripture/ClientApp/package{,-lock}.json || true
     git pull --ff-only --recurse-submodules
 
+    # Clean up from dotnet 3.1, built in the basebox, so dotnet 6.0 can build.
+    cd ~/src/web-xforge
+    find test src -name obj -print0 | xargs -0 rm -vrf
+
     cd ~/src/web-xforge/deploy
     tryharderto ansible-playbook playbook_focal.yml --limit localhost
 


### PR DESCRIPTION
The base image has left over intermediate files from .NET Core 3.1, which can cause the following error on build:

`NETSDK1005: Assets file '/home/vagrant/src/web-xforge/src/Help/UpdateHelp/obj/project.assets.json' doesn't have a target for 'net6.0'. Ensure that restore has run and that you have included 'net6.0' in the TargetFrameworks for your project.`

This PR removes the old obj directories so that the build for .NET 6.0 will be successful.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1744)
<!-- Reviewable:end -->
