### PR TITLE
SF-1911 Data Validation in ShareDB and MongoDB

### DIFF
--- a/scripts/db_tools/package-lock.json
+++ b/scripts/db_tools/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@sillsdev/scripture": "^1.4.0",
+        "ajv": "^8.12.0",
+        "ajv-bsontype": "^1.0.7",
         "axios": "^0.27.2",
         "mongodb": "^4.6.0",
         "ot-json0": "^1.1.0",
@@ -22,6 +24,7 @@
         "yargs": "^17.5.1"
       },
       "devDependencies": {
+        "@types/ajv-bsontype": "^1.0.1",
         "@types/mongodb": "^3.6.20",
         "@types/node": "^16.11.36",
         "@types/ws": "^8.5.3",
@@ -85,6 +88,15 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
+    },
+    "node_modules/@types/ajv-bsontype": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ajv-bsontype/-/ajv-bsontype-1.0.1.tgz",
+      "integrity": "sha512-PwVrE2XYceWxmLeTGay4ahQYWHm92PJkTjMPdT8pCmewmIIbhphVe7EAZRxOVMKSAUyWsjynj2cbDe7K1LSggg==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "*"
+      }
     },
     "node_modules/@types/bson": {
       "version": "4.2.0",
@@ -169,6 +181,31 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-bsontype": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/ajv-bsontype/-/ajv-bsontype-1.0.7.tgz",
+      "integrity": "sha512-9dnPihZV22Eqwn55V5VstmE641GDcFwG18BrBhsXTNrf52ASON8sAjomWd/KosAh4w+N7mKU8LB10TBp/cMQVQ=="
+    },
+    "node_modules/ajv/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -505,6 +542,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -615,6 +657,14 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -841,6 +891,14 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -1004,6 +1062,15 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "@types/ajv-bsontype": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ajv-bsontype/-/ajv-bsontype-1.0.1.tgz",
+      "integrity": "sha512-PwVrE2XYceWxmLeTGay4ahQYWHm92PJkTjMPdT8pCmewmIIbhphVe7EAZRxOVMKSAUyWsjynj2cbDe7K1LSggg==",
+      "dev": true,
+      "requires": {
+        "ajv": "*"
+      }
+    },
     "@types/bson": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.2.0.tgz",
@@ -1077,6 +1144,29 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
+    },
+    "ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        }
+      }
+    },
+    "ajv-bsontype": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/ajv-bsontype/-/ajv-bsontype-1.0.7.tgz",
+      "integrity": "sha512-9dnPihZV22Eqwn55V5VstmE641GDcFwG18BrBhsXTNrf52ASON8sAjomWd/KosAh4w+N7mKU8LB10TBp/cMQVQ=="
     },
     "ansi-regex": {
       "version": "5.0.1",
@@ -1292,6 +1382,11 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
+    "json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -1388,6 +1483,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "rich-text": {
       "version": "4.1.0",
@@ -1549,6 +1649,14 @@
       "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true,
       "peer": true
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/scripts/db_tools/package.json
+++ b/scripts/db_tools/package.json
@@ -10,6 +10,8 @@
   "types": "lib/cjs/common/index.d.ts",
   "dependencies": {
     "@sillsdev/scripture": "^1.4.0",
+    "ajv": "^8.12.0",
+    "ajv-bsontype": "^1.0.7",
     "axios": "^0.27.2",
     "mongodb": "^4.6.0",
     "ot-json0": "^1.1.0",
@@ -22,6 +24,7 @@
     "yargs": "^17.5.1"
   },
   "devDependencies": {
+    "@types/ajv-bsontype": "^1.0.1",
     "@types/mongodb": "^3.6.20",
     "@types/node": "^16.11.36",
     "@types/ws": "^8.5.3",

--- a/scripts/db_tools/validate-data.ts
+++ b/scripts/db_tools/validate-data.ts
@@ -105,7 +105,7 @@ class ValidateData {
           for (let document of documents) {
             console.log(`${colored(colors.red, `${collection.name} document failed validation:`)} ${document._id}`);
             if (this.showValidationErrors) {
-              const isValid: Boolean = validate(document);
+              const isValid: boolean = validate(document);
               if (isValid) {
                 console.log(colored(colors.red, 'Could not generate validation errors - please validate manually.'));
               } else {

--- a/scripts/db_tools/validate-data.ts
+++ b/scripts/db_tools/validate-data.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env -S bash -c '"$(dirname "$0")"/node_modules/.bin/ts-node "$(dirname "$0")/$(basename "$0")" "$@"'
+// The above causes the local ts-node to be used even if run from another directory. Setup: npm ci
+//
+// Validate Data
+//
+// Validates the dta in MongoDB based on the validation schemas installed
+//
+// This script needs ts-node and must be run from the containing directory. Setup: npm ci
+// Usage info: ./validate-data.ts --help
+// Examples:
+//   Validate the local database: ./validate-data.ts
+//   Validate the live database: ./validate-data.ts --server live
+//   Show only the ids of documents that are invalid: ./validate-data.ts --no-errors
+
+import Ajv from 'ajv';
+import ajvBsonType from 'ajv-bsontype';
+import { MongoClient, Db, CollectionInfo } from 'mongodb';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { colored, colors, ConnectionSettings, databaseConfigs, useColor } from './utils';
+
+type ProgArgs = {
+  color: boolean;
+  server: string;
+  errors: boolean;
+};
+
+class ValidateData {
+  server: string | undefined;
+  connectionConfig: ConnectionSettings | undefined;
+  showValidationErrors: boolean = false;
+
+  constructor() {
+    this.processArguments();
+  }
+
+  processArguments(): void {
+    const args: ProgArgs = yargs(hideBin(process.argv))
+      .option('color', {
+        type: 'boolean',
+        default: true,
+        description: 'Colourize output (turn off with --no-color)'
+      })
+      .option('server', {
+        type: 'string',
+        choices: ['dev', 'qa', 'live'],
+        default: 'dev',
+        requiresArg: true,
+        description: 'The server to connect to'
+      })
+      .option('errors', {
+        type: 'boolean',
+        default: true,
+        description: 'Display validation errors (turn off with --no-errors)'
+      })
+      .version('0.1.0')
+      .strict()
+      .parseSync();
+
+    const shouldUseColor: boolean = args.color;
+    useColor(shouldUseColor);
+    this.server = args.server;
+    this.connectionConfig = databaseConfigs.get(this.server);
+    this.showValidationErrors = args.errors;
+  }
+
+  async main() {
+    if (this.connectionConfig == null) {
+      throw new Error('null connection config');
+    }
+    process.stdout.write(`Connecting to ${this.server}...`);
+    const client: MongoClient = await MongoClient.connect(this.connectionConfig.dbLocation);
+    console.log(colored(colors.lightGreen, 'connected!'));
+    try {
+      // Setup Ajv
+      const ajv = new Ajv({ strict: false, allErrors: true, logger: false });
+      ajvBsonType(ajv);
+
+      // Connect to the database
+      const db: Db = client.db();
+      const collections = (await db.listCollections().toArray()) as CollectionInfo[];
+
+      // Validate each collection we can validate
+      for (const collection of collections) {
+        if (collection?.options?.validator !== undefined) {
+          process.stdout.write(`Validating Collection: ${collection.name}...`);
+
+          // Retrieve all invalid documents from the collection
+          const documents = await db
+            .collection(collection.name)
+            .find({ $nor: [collection.options.validator] })
+            .toArray();
+
+          if (documents.length === 0) {
+            console.log(colored(colors.lightGreen, 'passed!'));
+            continue;
+          } else {
+            console.log(`${colored(colors.red, 'failed:')} ${documents.length} invalid documents`);
+          }
+
+          // Compile the schema
+          const validate = ajv.compile(collection.options.validator.$jsonSchema);
+
+          // Show failed document
+          for (let document of documents) {
+            console.log(`${colored(colors.red, `${collection.name} document failed validation:`)} ${document._id}`);
+            if (this.showValidationErrors) {
+              const isValid = validate(document);
+              if (isValid) {
+                console.log(colored(colors.red, 'Could not generate validation errors - please validate manually.'));
+              } else {
+                console.log(validate.errors);
+              }
+            }
+          }
+        }
+      }
+    } finally {
+      client.close();
+    }
+  }
+}
+
+const program = new ValidateData();
+program.main();

--- a/scripts/db_tools/validate-data.ts
+++ b/scripts/db_tools/validate-data.ts
@@ -3,7 +3,7 @@
 //
 // Validate Data
 //
-// Validates the dta in MongoDB based on the validation schemas installed
+// Validates the data in MongoDB based on the validation schemas installed
 //
 // This script needs ts-node and must be run from the containing directory. Setup: npm ci
 // Usage info: ./validate-data.ts --help
@@ -14,7 +14,7 @@
 
 import Ajv from 'ajv';
 import ajvBsonType from 'ajv-bsontype';
-import { MongoClient, Db, CollectionInfo } from 'mongodb';
+import { CollectionInfo, Db, Document, MongoClient } from 'mongodb';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { colored, colors, ConnectionSettings, databaseConfigs, useColor } from './utils';
@@ -86,10 +86,10 @@ class ValidateData {
           process.stdout.write(`Validating Collection: ${collection.name}...`);
 
           // Retrieve all invalid documents from the collection
-          const documents = await db
+          const documents = (await db
             .collection(collection.name)
             .find({ $nor: [collection.options.validator] })
-            .toArray();
+            .toArray()) as Document[];
 
           if (documents.length === 0) {
             console.log(colored(colors.lightGreen, 'passed!'));
@@ -105,7 +105,7 @@ class ValidateData {
           for (let document of documents) {
             console.log(`${colored(colors.red, `${collection.name} document failed validation:`)} ${document._id}`);
             if (this.showValidationErrors) {
-              const isValid = validate(document);
+              const isValid: Boolean = validate(document);
               if (isValid) {
                 console.log(colored(colors.red, 'Could not generate validation errors - please validate manually.'));
               } else {

--- a/src/RealtimeServer/.eslintrc.json
+++ b/src/RealtimeServer/.eslintrc.json
@@ -34,6 +34,7 @@
           }
         ],
         "@typescript-eslint/naming-convention": ["error", { "selector": "enumMember", "format": ["PascalCase"] }],
+        "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/no-unused-vars": [
           "error",

--- a/src/RealtimeServer/common/index.ts
+++ b/src/RealtimeServer/common/index.ts
@@ -144,6 +144,7 @@ export = {
       return;
     }
     const connection = server.connect(userId);
+    connection.on('error', err => console.log(err));
     const index = connectionIndex++;
     connections.set(index, connection);
     callback(undefined, index);

--- a/src/RealtimeServer/common/index.ts
+++ b/src/RealtimeServer/common/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { MongoClient } from 'mongodb';
 import * as OTJson0 from 'ot-json0';
 import * as RichText from 'rich-text';
@@ -35,6 +34,7 @@ interface RealtimeServerOptions {
   bugsnagApiKey: string;
   releaseStage: string;
   migrationsDisabled: boolean;
+  dataValidationDisabled: boolean;
   siteId: string;
   version: string;
 }
@@ -69,11 +69,13 @@ async function startServer(options: RealtimeServerOptions): Promise<void> {
     server = new RealtimeServerType(
       options.siteId,
       options.migrationsDisabled,
+      options.dataValidationDisabled,
       new DBType(callback => callback(null, client)),
       new SchemaVersionRepository(db),
       new MongoMilestoneDB(options.connectionString)
     );
     await server.createIndexes(db);
+    await server.addValidationSchema(db);
 
     streamListener = new WebSocketStreamListener(
       options.audience,

--- a/src/RealtimeServer/common/models/validation-schema.ts
+++ b/src/RealtimeServer/common/models/validation-schema.ts
@@ -1,10 +1,15 @@
 export interface ValidationSchema {
+  // Whether or not the schema allows additional properties
   additionalProperties?: boolean;
   bsonType?: string | string[];
   enum?: string[];
   items?: ValidationSchema;
   pattern?: string;
-  properties?: { [key: string]: ValidationSchema };
-  patternProperties?: { [key: string]: ValidationSchema };
+  properties?: SchemaProperties;
+  patternProperties?: SchemaProperties;
   required?: string[];
+}
+
+export interface SchemaProperties {
+  [key: string]: ValidationSchema;
 }

--- a/src/RealtimeServer/common/models/validation-schema.ts
+++ b/src/RealtimeServer/common/models/validation-schema.ts
@@ -1,0 +1,10 @@
+export interface ValidationSchema {
+  additionalProperties?: boolean;
+  bsonType?: string | string[];
+  enum?: string[];
+  items?: ValidationSchema;
+  pattern?: string;
+  properties?: { [key: string]: ValidationSchema };
+  patternProperties?: { [key: string]: ValidationSchema };
+  required?: string[];
+}

--- a/src/RealtimeServer/common/realtime-server.spec.ts
+++ b/src/RealtimeServer/common/realtime-server.spec.ts
@@ -520,6 +520,19 @@ describe('RealtimeServer', () => {
     ]);
   });
 
+  it('connection from the backend server does not validate data', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = env.server.connect('user01');
+    await submitOp(userConn, USERS_COLLECTION, 'user01', [
+      {
+        p: ['this_property_does_not_exist'],
+        oi: 'invalid data'
+      }
+    ]);
+  });
+
   it('validation schemas are loaded for every doc service', async () => {
     const env = new TestEnvironment();
     await env.server.addValidationSchema(env.mongo);

--- a/src/RealtimeServer/common/realtime-server.spec.ts
+++ b/src/RealtimeServer/common/realtime-server.spec.ts
@@ -1,3 +1,4 @@
+import { Db } from 'mongodb';
 import ShareDB from 'sharedb';
 import ShareDBMingo from 'sharedb-mingo-memory';
 import { Doc, Op } from 'sharedb/lib/client';
@@ -20,7 +21,7 @@ const PROJECTS_COLLECTION = 'projects';
 
 describe('RealtimeServer', () => {
   it('migrates docs when schema version does not exist', async () => {
-    const env = new TestEnvironment();
+    const env = new TestEnvironment(false, true);
     await env.createData();
     when(env.mockedUserService.schemaVersion).thenReturn(1);
     const mockedMigration = mock<Migration>();
@@ -38,7 +39,7 @@ describe('RealtimeServer', () => {
   });
 
   it('migrates docs when schema version exists', async () => {
-    const env = new TestEnvironment();
+    const env = new TestEnvironment(false, true);
     await env.createData();
     when(env.mockedProjectService.schemaVersion).thenReturn(2);
     const mockedMigration = mock<Migration>();
@@ -88,7 +89,7 @@ describe('RealtimeServer', () => {
   });
 
   it('migrates op', async () => {
-    const env = new TestEnvironment();
+    const env = new TestEnvironment(false, true);
     await env.createData();
     const userConn = clientConnect(env.server, 'user01');
     const userDoc = await fetchDoc(userConn, USERS_COLLECTION, 'user01');
@@ -141,6 +142,398 @@ describe('RealtimeServer', () => {
     const project = await env.server.getProject('project02');
     expect(project?.name).toEqual('Project 02');
   });
+
+  it('data validation allows key value pairs', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await submitOp(userConn, PROJECTS_COLLECTION, 'project01', [
+      {
+        p: ['userPermissions', 'abc123'],
+        oi: 'admin'
+      }
+    ]);
+  });
+
+  it('data validation stops invalid key value pairs', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await expect(
+      submitOp(userConn, PROJECTS_COLLECTION, 'project01', [
+        {
+          p: ['userPermissions', 'USER01'],
+          oi: 'admin'
+        }
+      ])
+    ).rejects.toThrow('Invalid path for operation');
+  });
+
+  it('data validation stops invalid ops', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await expect(
+      submitOp(userConn, USERS_COLLECTION, 'user01', [
+        {
+          p: ['this_property_does_not_exist'],
+          oi: 'invalid data'
+        }
+      ])
+    ).rejects.toThrow('Invalid path for operation');
+  });
+
+  it('data validation stops ops that have invalid paths', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await expect(
+      submitOp(userConn, USERS_COLLECTION, 'user01', [
+        {
+          p: [0],
+          oi: 'invalid data'
+        }
+      ])
+    ).rejects.toThrow('Invalid path for operation');
+  });
+
+  it('data validation allows valid boolean values', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await submitOp(userConn, USERS_COLLECTION, 'user01', [
+      {
+        p: ['isDisplayNameConfirmed'],
+        oi: true
+      }
+    ]);
+  });
+
+  it('data validation blocks invalid boolean values', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await expect(
+      submitOp(userConn, USERS_COLLECTION, 'user01', [
+        {
+          p: ['isDisplayNameConfirmed'],
+          oi: 'true'
+        }
+      ])
+    ).rejects.toThrow('Invalid operation data');
+  });
+
+  it('data validation allows valid null values', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await submitOp(userConn, USERS_COLLECTION, 'user01', [
+      {
+        p: ['_type'],
+        oi: null
+      }
+    ]);
+  });
+
+  it('data validation allows valid number values', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await submitOp(userConn, USERS_COLLECTION, 'user01', [
+      {
+        p: ['_v'],
+        oi: 1
+      }
+    ]);
+  });
+
+  it('data validation blocks invalid number values', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await expect(
+      submitOp(userConn, USERS_COLLECTION, 'user01', [
+        {
+          p: ['_v'],
+          oi: '1'
+        }
+      ])
+    ).rejects.toThrow('Invalid operation data');
+  });
+
+  it('data validation allows string values', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await submitOp(userConn, USERS_COLLECTION, 'user01', [
+      {
+        p: ['displayName'],
+        oi: 'string value'
+      }
+    ]);
+  });
+
+  it('data validation blocks invalid string values', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await expect(
+      submitOp(userConn, USERS_COLLECTION, 'user01', [
+        {
+          p: ['displayName'],
+          oi: 1
+        }
+      ])
+    ).rejects.toThrow('Invalid operation data');
+  });
+
+  it('data validation allows string values matching a pattern', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await submitOp(userConn, USERS_COLLECTION, 'user01', [
+      {
+        p: ['_id'],
+        oi: 'abc123'
+      }
+    ]);
+  });
+
+  it('data validation blocks string values not matching a pattern', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await expect(
+      submitOp(userConn, USERS_COLLECTION, 'user01', [
+        {
+          p: ['_id'],
+          oi: 'INVALID_ID'
+        }
+      ])
+    ).rejects.toThrow('Invalid operation data');
+  });
+
+  it('data validation allows string values matching an enum', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await submitOp(userConn, PROJECTS_COLLECTION, 'project01', [
+      {
+        p: ['enumExample'],
+        oi: 'first'
+      }
+    ]);
+  });
+
+  it('data validation blocks string values not matching an enum', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await expect(
+      submitOp(userConn, PROJECTS_COLLECTION, 'project01', [
+        {
+          p: ['enumExample'],
+          oi: 'third'
+        }
+      ])
+    ).rejects.toThrow('Invalid operation data');
+  });
+
+  it('data validation allows adding of items to arrays', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await submitOp(userConn, USERS_COLLECTION, 'user01', [
+      {
+        p: ['sites', 'sf', 'projects', 0],
+        li: 'project02'
+      }
+    ]);
+  });
+
+  it('data validation blocks adding of items with invalid values to arrays', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await expect(
+      submitOp(userConn, USERS_COLLECTION, 'user01', [
+        {
+          p: ['sites', 'sf', 'projects', 0],
+          li: 1
+        }
+      ])
+    ).rejects.toThrow('Invalid operation data');
+  });
+
+  it('data validation allows replacing arrays', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await submitOp(userConn, USERS_COLLECTION, 'user01', [
+      {
+        p: ['sites', 'sf', 'projects'],
+        oi: ['project02', 'project02']
+      }
+    ]);
+  });
+
+  it('data validation allows adding of objects', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await submitOp(userConn, PROJECTS_COLLECTION, 'project01', [
+      {
+        p: ['objectExample'],
+        oi: {
+          aNumber: 1,
+          aBool: true
+        }
+      }
+    ]);
+  });
+
+  it('data validation blocks adding of objects with invalid values', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await expect(
+      submitOp(userConn, PROJECTS_COLLECTION, 'project01', [
+        {
+          p: ['objectExample'],
+          oi: {
+            aNumber: 1,
+            aBool: 'invalid_value'
+          }
+        }
+      ])
+    ).rejects.toThrow('Invalid operation data');
+  });
+
+  it('data validation blocks adding of objects with invalid properties', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await expect(
+      submitOp(userConn, PROJECTS_COLLECTION, 'project01', [
+        {
+          p: ['objectExample'],
+          oi: {
+            aNumber: 1,
+            invalidProperty: 'invalid_value'
+          }
+        }
+      ])
+    ).rejects.toThrow('Invalid operation data');
+  });
+
+  it('data validation blocks adding of objects with invalid properties to key value pairs', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await submitOp(userConn, PROJECTS_COLLECTION, 'project01', [
+      {
+        p: ['kvpExample'],
+        oi: { test01: { aNumber: 1 } }
+      }
+    ]);
+
+    // SUT
+    await expect(
+      submitOp(userConn, PROJECTS_COLLECTION, 'project01', [
+        {
+          p: ['kvpExample', 'test01'],
+          oi: {
+            aNumber: 1,
+            invalidProperty: 'invalid_value'
+          }
+        }
+      ])
+    ).rejects.toThrow('Invalid operation data');
+  });
+
+  it('data validation allows number operations', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await submitOp(userConn, PROJECTS_COLLECTION, 'project01', [
+      {
+        p: ['numberExample'],
+        oi: 1
+      }
+    ]);
+
+    // SUT
+    await submitOp(userConn, PROJECTS_COLLECTION, 'project01', [
+      {
+        p: ['numberExample'],
+        na: 1
+      }
+    ]);
+  });
+
+  it('data validation allows operations on property with no data validation configured', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await submitOp(userConn, PROJECTS_COLLECTION, 'project01', [
+      {
+        p: ['noDataValidationExample'],
+        oi: 'test data'
+      }
+    ]);
+  });
+
+  it('disabling data validation does not stop invalid ops', async () => {
+    const env = new TestEnvironment(false, true);
+    await env.createData();
+
+    const userConn = clientConnect(env.server, 'user01');
+    await submitOp(userConn, USERS_COLLECTION, 'user01', [
+      {
+        p: ['this_property_does_not_exist'],
+        oi: 'invalid data'
+      }
+    ]);
+  });
+
+  it('validation schemas are loaded for every doc service', async () => {
+    const env = new TestEnvironment();
+    await env.server.addValidationSchema(env.mongo);
+    verify(env.mockedProjectService.addValidationSchema(env.mongo)).once();
+    verify(env.mockedUserService.addValidationSchema(env.mongo)).once();
+  });
+
+  it('indexes are created for every doc service', async () => {
+    const env = new TestEnvironment();
+    await env.server.createIndexes(env.mongo);
+    verify(env.mockedSchemaVersionRepository.createIndex()).once();
+    verify(env.mockedProjectService.createIndexes(env.mongo)).once();
+    verify(env.mockedUserService.createIndexes(env.mongo)).once();
+  });
 });
 
 class TestEnvironment {
@@ -148,19 +541,82 @@ class TestEnvironment {
   readonly mockedProjectService = mock(ProjectService);
   readonly db: ShareDBMingo;
   readonly mockedSchemaVersionRepository = mock(SchemaVersionRepository);
+  readonly mongo = mock(Db);
   readonly server: RealtimeServer;
 
-  constructor(migrationsDisabled = false) {
+  constructor(migrationsDisabled = false, dataValidationDisabled = false) {
     const ShareDBMingoType = MetadataDB(ShareDBMingo.extendMemoryDB(ShareDB.MemoryDB));
     this.db = new ShareDBMingoType();
     when(this.mockedSchemaVersionRepository.getAll()).thenResolve([
       { _id: PROJECTS_COLLECTION, collection: PROJECTS_COLLECTION, version: 1 }
     ]);
     when(this.mockedUserService.collection).thenReturn(USERS_COLLECTION);
+    const userService = new UserService();
+    when(this.mockedUserService.validationSchema).thenReturn(userService.validationSchema);
+
+    // Add some extra values to the project schema for testing uncommon validation cases
+    when(this.mockedProjectService.validationSchema).thenReturn({
+      bsonType: ProjectService.validationSchema.bsonType,
+      required: ProjectService.validationSchema.required,
+      properties: {
+        ...ProjectService.validationSchema.properties,
+        enumExample: {
+          bsonType: 'string',
+          enum: ['first', 'second']
+        },
+        noDataValidationExample: {},
+        numberExample: {
+          bsonType: 'number'
+        },
+        objectExample: {
+          bsonType: 'object',
+          properties: {
+            aNumber: {
+              bsonType: 'int'
+            },
+            aBool: {
+              bsonType: 'bool'
+            },
+            childArray: {
+              bsonType: 'array',
+              items: {
+                bsonType: 'object',
+                properties: {
+                  aNumber: {
+                    bsonType: 'int'
+                  },
+                  aString: {
+                    bsonType: 'string'
+                  }
+                }
+              },
+              additionalProperties: false
+            }
+          },
+          additionalProperties: false
+        },
+        kvpExample: {
+          bsonType: 'object',
+          patternProperties: {
+            '^[0-9a-z]+$': {
+              bsonType: 'object',
+              properties: {
+                aNumber: {
+                  bsonType: 'int'
+                }
+              },
+              additionalProperties: false
+            }
+          },
+          additionalProperties: false
+        }
+      }
+    });
     when(this.mockedProjectService.collection).thenReturn(PROJECTS_COLLECTION);
     this.server = new RealtimeServer(
       'TEST',
       migrationsDisabled,
+      dataValidationDisabled,
       [instance(this.mockedUserService), instance(this.mockedProjectService)],
       PROJECTS_COLLECTION,
       this.db,
@@ -172,7 +628,18 @@ class TestEnvironment {
 
   async createData(): Promise<void> {
     const conn = this.server.connect();
-    await createDoc<User>(conn, USERS_COLLECTION, 'user01', createTestUser({}));
+    await createDoc<User>(
+      conn,
+      USERS_COLLECTION,
+      'user01',
+      createTestUser({
+        sites: {
+          sf: {
+            projects: []
+          }
+        }
+      })
+    );
 
     await createDoc<Project>(conn, PROJECTS_COLLECTION, 'project01', {
       name: 'Project 01',

--- a/src/RealtimeServer/common/realtime-server.ts
+++ b/src/RealtimeServer/common/realtime-server.ts
@@ -184,8 +184,14 @@ export class RealtimeServer extends ShareDB {
       }
 
       // Perform data validation, if enabled. It will be disabled during migration.
+      // Also, do not validate if the connection is from the backend server - we can trust it
       const validationSchema: ValidationSchema | undefined = this.docServices.get(context.collection)?.validationSchema;
-      if (!this.dataValidationDisabled && validationSchema != null && context.op.op != null) {
+      if (
+        !this.dataValidationDisabled &&
+        validationSchema != null &&
+        context.op.op != null &&
+        !context.agent.connectSession.isServer
+      ) {
         let ops;
         if (Array.isArray(context.op.op)) {
           ops = context.op.op;

--- a/src/RealtimeServer/common/realtime-server.ts
+++ b/src/RealtimeServer/common/realtime-server.ts
@@ -6,7 +6,7 @@ import shareDBAccess from 'sharedb-access';
 import { Connection, Doc, Op, RawOp } from 'sharedb/lib/client';
 import { ConnectSession } from './connect-session';
 import { Project } from './models/project';
-import { ValidationSchema } from './models/validation-schema';
+import { SchemaProperties, ValidationSchema } from './models/validation-schema';
 import { SchemaVersionRepository } from './schema-version-repository';
 import { DocService } from './services/doc-service';
 import { createFetchQuery, docFetch } from './utils/sharedb-utils';
@@ -200,15 +200,15 @@ export class RealtimeServer extends ShareDB {
         }
         // Iterate over every operation
         for (const op of ops) {
-          // Skip blank operations
+          // Skip operations with a null path as they will not be applied
           if (op.p == null) {
             continue;
           }
-          let properties = validationSchema.properties;
+          let properties: SchemaProperties | undefined = validationSchema.properties;
           let patternProperties = false;
           // For each property name in the path array
           for (let i = 0; i < op.p.length; i++) {
-            const propertyName = op.p[i];
+            const propertyName: string | number | symbol = op.p[i];
             let propertySchema: ValidationSchema | undefined;
             // If we have a valid property in our schema matching the current path
             if (typeof propertyName === 'string' && properties != undefined) {

--- a/src/RealtimeServer/common/services/doc-service.ts
+++ b/src/RealtimeServer/common/services/doc-service.ts
@@ -13,6 +13,37 @@ export abstract class DocService<T = any> {
   protected server?: RealtimeServer;
   private readonly migrations = new Map<number, MigrationConstructor>();
 
+  // This is a base schema that covers the minimum required properties for a ShareDB collection
+  // NOTE: Schemas that use this must implement the property "_id"
+  static readonly validationSchema: ValidationSchema = {
+    bsonType: 'object',
+    required: ['_id', '_type', '_v', '_m', '_o'],
+    properties: {
+      _type: {
+        bsonType: ['null', 'string']
+      },
+      _v: {
+        bsonType: 'int'
+      },
+      _m: {
+        bsonType: 'object',
+        required: ['ctime', 'mtime'],
+        properties: {
+          ctime: {
+            bsonType: 'number'
+          },
+          mtime: {
+            bsonType: 'number'
+          }
+        },
+        additionalProperties: false
+      },
+      _o: {
+        bsonType: 'objectId'
+      }
+    }
+  };
+
   constructor(migrations: MigrationConstructor[]) {
     let maxVersion = 0;
     for (const migration of migrations) {

--- a/src/RealtimeServer/common/services/project-data-service.spec.ts
+++ b/src/RealtimeServer/common/services/project-data-service.spec.ts
@@ -7,6 +7,7 @@ import { Project } from '../models/project';
 import { ProjectData } from '../models/project-data';
 import { Operation, ProjectRights } from '../models/project-rights';
 import { User, USERS_COLLECTION } from '../models/user';
+import { ValidationSchema } from '../models/validation-schema';
 import { RealtimeServer } from '../realtime-server';
 import { SchemaVersionRepository } from '../schema-version-repository';
 import { ANY_INDEX, ObjPathTemplate } from '../utils/obj-path';
@@ -322,6 +323,65 @@ class TestDataService extends ProjectDataService<TestData> {
 
   protected readonly indexPaths = [];
   protected readonly immutableProps: ObjPathTemplate[] = [this.pathTemplate(d => d.immutable!)];
+  readonly validationSchema: ValidationSchema = {
+    bsonType: ProjectDataService.validationSchema.bsonType,
+    required: ProjectDataService.validationSchema.required,
+    properties: {
+      ...ProjectDataService.validationSchema.properties,
+      _id: {
+        bsonType: 'string',
+        pattern: '^[0-9a-f]+:[0-9A-Z]+:[0-9]+:target$'
+      },
+      num: {
+        bsonType: 'int'
+      },
+      immutable: {
+        bsonType: 'string'
+      },
+      children: {
+        bsonType: 'array',
+        items: {
+          bsonType: 'object',
+          required: ['id', 'children', 'ownerRef'],
+          properties: {
+            id: {
+              bsonType: 'string'
+            },
+            num: {
+              bsonType: 'int'
+            },
+            children: {
+              bsonType: 'array',
+              items: {
+                bsonType: 'object',
+                required: ['id', 'ownerRef'],
+                properties: {
+                  id: {
+                    bsonType: 'string'
+                  },
+                  num: {
+                    bsonType: 'int'
+                  },
+                  deleted: {
+                    bsonType: 'bool'
+                  },
+                  ownerRef: {
+                    bsonType: 'string'
+                  }
+                },
+                additionalProperties: false
+              }
+            },
+            ownerRef: {
+              bsonType: 'string'
+            }
+          },
+          additionalProperties: false
+        }
+      }
+    },
+    additionalProperties: false
+  };
 
   protected readonly projectRights = new ProjectRights({
     admin: [

--- a/src/RealtimeServer/common/services/project-data-service.spec.ts
+++ b/src/RealtimeServer/common/services/project-data-service.spec.ts
@@ -414,6 +414,7 @@ class TestEnvironment {
     this.server = new RealtimeServer(
       'TEST',
       false,
+      false,
       [this.service, instance(this.mockedProjectService), instance(this.mockedUserService)],
       PROJECTS_COLLECTION,
       this.db,

--- a/src/RealtimeServer/common/services/project-data-service.ts
+++ b/src/RealtimeServer/common/services/project-data-service.ts
@@ -5,6 +5,7 @@ import { OwnedData } from '../models/owned-data';
 import { Project } from '../models/project';
 import { ProjectData } from '../models/project-data';
 import { Operation, ProjectRights } from '../models/project-rights';
+import { ValidationSchema } from '../models/validation-schema';
 import { RealtimeServer } from '../realtime-server';
 import { ObjPathTemplate } from '../utils/obj-path';
 import { JsonDocService } from './json-doc-service';
@@ -32,6 +33,23 @@ export abstract class ProjectDataService<T extends ProjectData> extends JsonDocS
    */
   protected readonly listenForUpdates: boolean = false;
   private readonly domains: ProjectDomainConfig[];
+
+  // NOTE: Schemas that use this must implement the property "_id"
+  readonly validationSchema: ValidationSchema = {
+    bsonType: ProjectDataService.validationSchema.bsonType,
+    required: ProjectDataService.validationSchema.required,
+    properties: {
+      ...ProjectDataService.validationSchema.properties,
+      projectRef: {
+        bsonType: 'string',
+        pattern: '^[0-9a-f]+$'
+      },
+      ownerRef: {
+        bsonType: 'string',
+        pattern: '^[0-9a-f]*$'
+      }
+    }
+  };
 
   constructor(migrations: MigrationConstructor[]) {
     super(migrations);

--- a/src/RealtimeServer/common/services/project-data-service.ts
+++ b/src/RealtimeServer/common/services/project-data-service.ts
@@ -35,11 +35,11 @@ export abstract class ProjectDataService<T extends ProjectData> extends JsonDocS
   private readonly domains: ProjectDomainConfig[];
 
   // NOTE: Schemas that use this must implement the property "_id"
-  readonly validationSchema: ValidationSchema = {
-    bsonType: ProjectDataService.validationSchema.bsonType,
-    required: ProjectDataService.validationSchema.required,
+  static readonly validationSchema: ValidationSchema = {
+    bsonType: JsonDocService.validationSchema.bsonType,
+    required: JsonDocService.validationSchema.required,
     properties: {
-      ...ProjectDataService.validationSchema.properties,
+      ...JsonDocService.validationSchema.properties,
       projectRef: {
         bsonType: 'string',
         pattern: '^[0-9a-f]+$'

--- a/src/RealtimeServer/common/services/project-data-service.ts
+++ b/src/RealtimeServer/common/services/project-data-service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import ShareDB from 'sharedb';
 import { ConnectSession } from '../connect-session';
 import { MigrationConstructor } from '../migration';

--- a/src/RealtimeServer/common/services/project-service.spec.ts
+++ b/src/RealtimeServer/common/services/project-service.spec.ts
@@ -106,6 +106,7 @@ class TestEnvironment {
     this.server = new RealtimeServer(
       'TEST',
       false,
+      false,
       [this.service],
       PROJECTS_COLLECTION,
       this.db,

--- a/src/RealtimeServer/common/services/project-service.ts
+++ b/src/RealtimeServer/common/services/project-service.ts
@@ -13,9 +13,10 @@ export abstract class ProjectService<T extends Project = Project> extends JsonDo
 
   // This is static to aide with testing, and allow SFProjectService to utilize it
   static readonly validationSchema: ValidationSchema = {
-    bsonType: 'object',
-    required: ['_id', '_type', '_v', '_m', '_o'],
+    bsonType: JsonDocService.validationSchema.bsonType,
+    required: JsonDocService.validationSchema.required,
     properties: {
+      ...JsonDocService.validationSchema.properties,
       _id: {
         bsonType: 'string',
         pattern: '^[0-9a-f]+$'
@@ -46,28 +47,6 @@ export abstract class ProjectService<T extends Project = Project> extends JsonDo
       },
       syncDisabled: {
         bsonType: 'bool'
-      },
-      _type: {
-        bsonType: ['null', 'string']
-      },
-      _v: {
-        bsonType: 'int'
-      },
-      _m: {
-        bsonType: 'object',
-        required: ['ctime', 'mtime'],
-        properties: {
-          ctime: {
-            bsonType: 'number'
-          },
-          mtime: {
-            bsonType: 'number'
-          }
-        },
-        additionalProperties: false
-      },
-      _o: {
-        bsonType: 'objectId'
       }
     },
     additionalProperties: false

--- a/src/RealtimeServer/common/services/project-service.ts
+++ b/src/RealtimeServer/common/services/project-service.ts
@@ -1,3 +1,4 @@
+import { ValidationSchema } from '../models/validation-schema';
 import { ConnectSession } from '../connect-session';
 import { Project } from '../models/project';
 import { SystemRole } from '../models/system-role';
@@ -9,6 +10,68 @@ import { JsonDocService } from './json-doc-service';
 export abstract class ProjectService<T extends Project = Project> extends JsonDocService<T> {
   protected abstract get projectAdminRole(): string;
   protected readonly immutableProps = [this.pathTemplate(p => p.name), this.pathTemplate(p => p.userRoles)];
+
+  // This is static to aide with testing, and allow SFProjectService to utilize it
+  static readonly validationSchema: ValidationSchema = {
+    bsonType: 'object',
+    required: ['_id', '_type', '_v', '_m', '_o'],
+    properties: {
+      _id: {
+        bsonType: 'string',
+        pattern: '^[0-9a-f]+$'
+      },
+      name: {
+        bsonType: 'string'
+      },
+      userRoles: {
+        bsonType: 'object',
+        patternProperties: {
+          '^[0-9a-f]+$': {
+            bsonType: 'string'
+          }
+        },
+        additionalProperties: false
+      },
+      userPermissions: {
+        bsonType: 'object',
+        patternProperties: {
+          '^[0-9a-f]+$': {
+            bsonType: 'array',
+            items: {
+              bsonType: 'string'
+            }
+          }
+        },
+        additionalProperties: false
+      },
+      syncDisabled: {
+        bsonType: 'bool'
+      },
+      _type: {
+        bsonType: ['null', 'string']
+      },
+      _v: {
+        bsonType: 'int'
+      },
+      _m: {
+        bsonType: 'object',
+        required: ['ctime', 'mtime'],
+        properties: {
+          ctime: {
+            bsonType: 'number'
+          },
+          mtime: {
+            bsonType: 'number'
+          }
+        },
+        additionalProperties: false
+      },
+      _o: {
+        bsonType: 'objectId'
+      }
+    },
+    additionalProperties: false
+  };
 
   protected allowRead(_docId: string, doc: T, session: ConnectSession): boolean {
     if (session.isServer || session.role === SystemRole.SystemAdmin || Object.keys(doc).length === 0) {

--- a/src/RealtimeServer/common/services/user-service.ts
+++ b/src/RealtimeServer/common/services/user-service.ts
@@ -34,9 +34,10 @@ export class UserService extends JsonDocService<User> {
   ];
 
   readonly validationSchema: ValidationSchema = {
-    bsonType: 'object',
-    required: ['_id', '_type', '_v', '_m', '_o'],
+    bsonType: JsonDocService.validationSchema.bsonType,
+    required: JsonDocService.validationSchema.required,
     properties: {
+      ...JsonDocService.validationSchema.properties,
       _id: {
         bsonType: 'string',
         pattern: '^[0-9a-f]+$'
@@ -87,28 +88,6 @@ export class UserService extends JsonDocService<User> {
       },
       avatarUrl: {
         bsonType: 'string'
-      },
-      _type: {
-        bsonType: ['null', 'string']
-      },
-      _v: {
-        bsonType: 'int'
-      },
-      _m: {
-        bsonType: 'object',
-        required: ['ctime', 'mtime'],
-        properties: {
-          ctime: {
-            bsonType: 'number'
-          },
-          mtime: {
-            bsonType: 'number'
-          }
-        },
-        additionalProperties: false
-      },
-      _o: {
-        bsonType: 'objectId'
       }
     },
     additionalProperties: false

--- a/src/RealtimeServer/common/services/user-service.ts
+++ b/src/RealtimeServer/common/services/user-service.ts
@@ -2,6 +2,7 @@ import ShareDB from 'sharedb';
 import { ConnectSession } from '../connect-session';
 import { SystemRole } from '../models/system-role';
 import { User, USER_INDEX_PATHS, USER_PROFILES_COLLECTION, USERS_COLLECTION } from '../models/user';
+import { ValidationSchema } from '../models/validation-schema';
 import { RealtimeServer } from '../realtime-server';
 import { ANY_KEY, ObjPathTemplate } from '../utils/obj-path';
 import { JsonDocService } from './json-doc-service';
@@ -31,6 +32,87 @@ export class UserService extends JsonDocService<User> {
     this.pathTemplate(u => u.sites[ANY_KEY], false),
     this.pathTemplate(u => u.sites[ANY_KEY].projects)
   ];
+
+  readonly validationSchema: ValidationSchema = {
+    bsonType: 'object',
+    required: ['_id', '_type', '_v', '_m', '_o'],
+    properties: {
+      _id: {
+        bsonType: 'string',
+        pattern: '^[0-9a-f]+$'
+      },
+      name: {
+        bsonType: 'string'
+      },
+      email: {
+        bsonType: 'string'
+      },
+      paratextId: {
+        bsonType: 'string'
+      },
+      role: {
+        bsonType: 'string'
+      },
+      isDisplayNameConfirmed: {
+        bsonType: 'bool'
+      },
+      interfaceLanguage: {
+        bsonType: 'string'
+      },
+      authId: {
+        bsonType: 'string'
+      },
+      sites: {
+        bsonType: 'object',
+        properties: {
+          sf: {
+            bsonType: 'object',
+            required: ['projects'],
+            properties: {
+              currentProjectId: {
+                bsonType: 'string'
+              },
+              projects: {
+                bsonType: 'array',
+                items: {
+                  bsonType: 'string'
+                }
+              }
+            }
+          }
+        }
+      },
+      displayName: {
+        bsonType: 'string'
+      },
+      avatarUrl: {
+        bsonType: 'string'
+      },
+      _type: {
+        bsonType: ['null', 'string']
+      },
+      _v: {
+        bsonType: 'int'
+      },
+      _m: {
+        bsonType: 'object',
+        required: ['ctime', 'mtime'],
+        properties: {
+          ctime: {
+            bsonType: 'number'
+          },
+          mtime: {
+            bsonType: 'number'
+          }
+        },
+        additionalProperties: false
+      },
+      _o: {
+        bsonType: 'objectId'
+      }
+    },
+    additionalProperties: false
+  };
 
   constructor() {
     super(USER_MIGRATIONS);

--- a/src/RealtimeServer/package-lock.json
+++ b/src/RealtimeServer/package-lock.json
@@ -11,6 +11,9 @@
       "dependencies": {
         "@bugsnag/js": "^7.21.0",
         "@sillsdev/scripture": "^1.4.0",
+        "@types/ajv-bsontype": "^1.0.1",
+        "ajv": "^8.12.0",
+        "ajv-bsontype": "^1.0.7",
         "express": "^4.18.1",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^2.1.2",
@@ -750,6 +753,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -767,6 +786,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.7",
@@ -1300,6 +1325,14 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@types/ajv-bsontype": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ajv-bsontype/-/ajv-bsontype-1.0.1.tgz",
+      "integrity": "sha512-PwVrE2XYceWxmLeTGay4ahQYWHm92PJkTjMPdT8pCmewmIIbhphVe7EAZRxOVMKSAUyWsjynj2cbDe7K1LSggg==",
+      "dependencies": {
+        "ajv": "*"
       }
     },
     "node_modules/@types/babel__core": {
@@ -1909,20 +1942,24 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-bsontype": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/ajv-bsontype/-/ajv-bsontype-1.0.7.tgz",
+      "integrity": "sha512-9dnPihZV22Eqwn55V5VstmE641GDcFwG18BrBhsXTNrf52ASON8sAjomWd/KosAh4w+N7mKU8LB10TBp/cMQVQ=="
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -3104,6 +3141,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3180,6 +3233,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/eslint/node_modules/locate-path": {
       "version": "6.0.0",
@@ -3459,8 +3518,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.2.0",
@@ -5054,10 +5112,9 @@
       "dev": true
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -6057,6 +6114,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -6938,7 +7003,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -7687,6 +7751,18 @@
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -7701,6 +7777,12 @@
           "requires": {
             "argparse": "^2.0.1"
           }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
         }
       }
     },
@@ -8119,6 +8201,14 @@
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@types/ajv-bsontype": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ajv-bsontype/-/ajv-bsontype-1.0.1.tgz",
+      "integrity": "sha512-PwVrE2XYceWxmLeTGay4ahQYWHm92PJkTjMPdT8pCmewmIIbhphVe7EAZRxOVMKSAUyWsjynj2cbDe7K1LSggg==",
+      "requires": {
+        "ajv": "*"
       }
     },
     "@types/babel__core": {
@@ -8577,16 +8667,20 @@
       "requires": {}
     },
     "ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
       }
+    },
+    "ajv-bsontype": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/ajv-bsontype/-/ajv-bsontype-1.0.7.tgz",
+      "integrity": "sha512-9dnPihZV22Eqwn55V5VstmE641GDcFwG18BrBhsXTNrf52ASON8sAjomWd/KosAh4w+N7mKU8LB10TBp/cMQVQ=="
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -9292,6 +9386,18 @@
         "text-table": "^0.2.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -9347,6 +9453,12 @@
           "requires": {
             "argparse": "^2.0.1"
           }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
         },
         "locate-path": {
           "version": "6.0.0",
@@ -9724,8 +9836,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -10896,10 +11007,9 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -11650,6 +11760,11 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -12301,7 +12416,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/src/RealtimeServer/package.json
+++ b/src/RealtimeServer/package.json
@@ -23,6 +23,9 @@
   "dependencies": {
     "@bugsnag/js": "^7.21.0",
     "@sillsdev/scripture": "^1.4.0",
+    "@types/ajv-bsontype": "^1.0.1",
+    "ajv": "^8.12.0",
+    "ajv-bsontype": "^1.0.7",
     "express": "^4.18.1",
     "jsonwebtoken": "^9.0.0",
     "jwks-rsa": "^2.1.2",

--- a/src/RealtimeServer/scriptureforge/migrator.ts
+++ b/src/RealtimeServer/scriptureforge/migrator.ts
@@ -57,10 +57,12 @@ async function runMigrations() {
     server = new SFRealtimeServer(
       siteId,
       false,
+      true,
       new DBType(callback => callback(null, client)),
       new SchemaVersionRepository(db)
     );
     await server.createIndexes(db);
+    await server.addValidationSchema(db);
     await server.migrateIfNecessary();
   } finally {
     server?.close();

--- a/src/RealtimeServer/scriptureforge/realtime-server.ts
+++ b/src/RealtimeServer/scriptureforge/realtime-server.ts
@@ -32,11 +32,21 @@ export default class SFRealtimeServer extends RealtimeServer {
   constructor(
     siteId: string,
     migrationsDisabled: boolean,
+    dataValidationDisabled: boolean,
     db: ShareDB.DB,
     schemaVersions: SchemaVersionRepository,
     milestoneDb?: ShareDB.MilestoneDB
   ) {
-    super(siteId, migrationsDisabled, SF_DOC_SERVICES, SF_PROJECTS_COLLECTION, db, schemaVersions, milestoneDb);
+    super(
+      siteId,
+      migrationsDisabled,
+      dataValidationDisabled,
+      SF_DOC_SERVICES,
+      SF_PROJECTS_COLLECTION,
+      db,
+      schemaVersions,
+      milestoneDb
+    );
     this.use('query', (context: ShareDB.middleware.QueryContext, next: (err?: any) => void): void => {
       if (context.collection === NOTE_THREAD_COLLECTION) {
         if (context.agent.connectSession.isServer) {

--- a/src/RealtimeServer/scriptureforge/services/note-thread-migrations.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-migrations.spec.ts
@@ -70,6 +70,7 @@ class TestEnvironment {
     this.server = new RealtimeServer(
       'TEST',
       false,
+      true,
       [new NoteThreadService()],
       NOTE_THREAD_COLLECTION,
       this.db,

--- a/src/RealtimeServer/scriptureforge/services/note-thread-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-service.spec.ts
@@ -314,6 +314,7 @@ class TestEnvironment {
     this.server = new RealtimeServer(
       'TEST',
       false,
+      false,
       [this.service],
       SF_PROJECTS_COLLECTION,
       this.db,

--- a/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
@@ -23,7 +23,7 @@ export class NoteThreadService extends SFProjectDataService<NoteThread> {
       ...SFProjectDataService.validationSchema.properties,
       _id: {
         bsonType: 'string',
-        pattern: '^[0-9a-f]+$'
+        pattern: '^[0-9a-f]+:[0-9a-f]+$'
       },
       dataId: {
         bsonType: 'string'

--- a/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
@@ -27,6 +27,9 @@ export class NoteThreadService extends SFProjectDataService<NoteThread> {
       dataId: {
         bsonType: 'string'
       },
+      threadId: {
+        bsonType: 'string'
+      },
       verseRef: {
         bsonType: 'object',
         required: ['bookNum', 'chapterNum', 'verseNum'],
@@ -97,6 +100,12 @@ export class NoteThreadService extends SFProjectDataService<NoteThread> {
             },
             dateCreated: {
               bsonType: 'string'
+            },
+            editable: {
+              bsonType: 'bool'
+            },
+            versionNumber: {
+              bsonType: 'int'
             },
             ownerRef: {
               bsonType: 'string',

--- a/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
@@ -1,6 +1,7 @@
 import { Connection, Doc } from 'sharedb/lib/client';
 import { createFetchQuery, docSubmitJson0Op } from '../../common/utils/sharedb-utils';
 import { OwnedData } from '../../common/models/owned-data';
+import { ValidationSchema } from '../../common/models/validation-schema';
 import { ProjectDomainConfig } from '../../common/services/project-data-service';
 import { ANY_INDEX } from '../../common/utils/obj-path';
 import { NoteThread, NOTE_THREAD_COLLECTION, NOTE_THREAD_INDEX_PATHS } from '../models/note-thread';
@@ -15,6 +16,160 @@ export class NoteThreadService extends SFProjectDataService<NoteThread> {
 
   protected readonly indexPaths = NOTE_THREAD_INDEX_PATHS;
   protected readonly listenForUpdates = true;
+  readonly validationSchema: ValidationSchema = {
+    bsonType: 'object',
+    required: ['_id', '_type', '_v', '_m', '_o'],
+    properties: {
+      _id: {
+        bsonType: 'string',
+        pattern: '^[0-9a-f]+:.+$' // Allow Latin, Greek, and Hebrew characters
+      },
+      dataId: {
+        bsonType: 'string'
+      },
+      verseRef: {
+        bsonType: 'object',
+        required: ['bookNum', 'chapterNum', 'verseNum'],
+        properties: {
+          bookNum: {
+            bsonType: 'int'
+          },
+          chapterNum: {
+            bsonType: 'int'
+          },
+          verseNum: {
+            bsonType: 'int'
+          },
+          verse: {
+            bsonType: 'string'
+          }
+        },
+        additionalProperties: false
+      },
+      notes: {
+        bsonType: 'array',
+        items: {
+          bsonType: 'object',
+          required: ['threadId', 'type', 'status', 'dataId', 'deleted', 'dateModified', 'dateCreated'],
+          properties: {
+            threadId: {
+              bsonType: 'string'
+            },
+            type: {
+              bsonType: 'string'
+            },
+            conflictType: {
+              bsonType: 'string'
+            },
+            status: {
+              enum: ['', 'todo', 'done', 'deleted']
+            },
+            tagId: {
+              bsonType: 'int'
+            },
+            reattached: {
+              bsonType: 'string'
+            },
+            assignment: {
+              bsonType: 'string'
+            },
+            content: {
+              bsonType: 'string'
+            },
+            acceptedChangeXml: {
+              bsonType: 'string'
+            },
+            dataId: {
+              bsonType: 'string',
+              pattern: '^.+$'
+            },
+            deleted: {
+              bsonType: 'bool'
+            },
+            syncUserRef: {
+              bsonType: 'string'
+            },
+            text: {
+              bsonType: 'string'
+            },
+            dateModified: {
+              bsonType: 'string'
+            },
+            dateCreated: {
+              bsonType: 'string'
+            },
+            ownerRef: {
+              bsonType: 'string',
+              pattern: '^.*$'
+            }
+          },
+          additionalProperties: false
+        }
+      },
+      originalSelectedText: {
+        bsonType: 'string'
+      },
+      originalContextBefore: {
+        bsonType: 'string'
+      },
+      originalContextAfter: {
+        bsonType: 'string'
+      },
+      position: {
+        bsonType: 'object',
+        required: ['start', 'length'],
+        properties: {
+          start: {
+            bsonType: 'int'
+          },
+          length: {
+            bsonType: 'int'
+          }
+        },
+        additionalProperties: false
+      },
+      status: {
+        enum: ['', 'todo', 'done', 'deleted']
+      },
+      publishedToSF: {
+        bsonType: 'bool'
+      },
+      assignment: {
+        bsonType: 'string'
+      },
+      projectRef: {
+        bsonType: 'string',
+        pattern: '^[0-9a-f]+$'
+      },
+      ownerRef: {
+        bsonType: 'string',
+        pattern: '^[0-9a-f]*$'
+      },
+      _type: {
+        bsonType: ['null', 'string']
+      },
+      _v: {
+        bsonType: 'int'
+      },
+      _m: {
+        bsonType: 'object',
+        required: ['ctime', 'mtime'],
+        properties: {
+          ctime: {
+            bsonType: 'number'
+          },
+          mtime: {
+            bsonType: 'number'
+          }
+        },
+        additionalProperties: false
+      },
+      _o: {
+        bsonType: 'objectId'
+      }
+    },
+    additionalProperties: false
+  };
 
   constructor() {
     super(NOTE_THREAD_MIGRATIONS);

--- a/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
@@ -22,7 +22,7 @@ export class NoteThreadService extends SFProjectDataService<NoteThread> {
     properties: {
       _id: {
         bsonType: 'string',
-        pattern: '^[0-9a-f]+:.+$' // Allow Latin, Greek, and Hebrew characters
+        pattern: '^[0-9a-f]+$'
       },
       dataId: {
         bsonType: 'string'
@@ -90,9 +90,6 @@ export class NoteThreadService extends SFProjectDataService<NoteThread> {
               bsonType: 'bool'
             },
             syncUserRef: {
-              bsonType: 'string'
-            },
-            text: {
               bsonType: 'string'
             },
             dateModified: {

--- a/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
@@ -17,9 +17,10 @@ export class NoteThreadService extends SFProjectDataService<NoteThread> {
   protected readonly indexPaths = NOTE_THREAD_INDEX_PATHS;
   protected readonly listenForUpdates = true;
   readonly validationSchema: ValidationSchema = {
-    bsonType: 'object',
-    required: ['_id', '_type', '_v', '_m', '_o'],
+    bsonType: SFProjectDataService.validationSchema.bsonType,
+    required: SFProjectDataService.validationSchema.required,
     properties: {
+      ...SFProjectDataService.validationSchema.properties,
       _id: {
         bsonType: 'string',
         pattern: '^[0-9a-f]+$'
@@ -142,36 +143,6 @@ export class NoteThreadService extends SFProjectDataService<NoteThread> {
       },
       assignment: {
         bsonType: 'string'
-      },
-      projectRef: {
-        bsonType: 'string',
-        pattern: '^[0-9a-f]+$'
-      },
-      ownerRef: {
-        bsonType: 'string',
-        pattern: '^[0-9a-f]*$'
-      },
-      _type: {
-        bsonType: ['null', 'string']
-      },
-      _v: {
-        bsonType: 'int'
-      },
-      _m: {
-        bsonType: 'object',
-        required: ['ctime', 'mtime'],
-        properties: {
-          ctime: {
-            bsonType: 'number'
-          },
-          mtime: {
-            bsonType: 'number'
-          }
-        },
-        additionalProperties: false
-      },
-      _o: {
-        bsonType: 'objectId'
       }
     },
     additionalProperties: false

--- a/src/RealtimeServer/scriptureforge/services/question-migrations.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/question-migrations.spec.ts
@@ -52,6 +52,7 @@ class TestEnvironment {
     this.server = new RealtimeServer(
       'TEST',
       false,
+      true,
       [new QuestionService()],
       QUESTIONS_COLLECTION,
       this.db,

--- a/src/RealtimeServer/scriptureforge/services/question-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/question-service.spec.ts
@@ -76,6 +76,7 @@ class TestEnvironment {
     this.server = new RealtimeServer(
       'TEST',
       false,
+      false,
       [this.service],
       SF_PROJECTS_COLLECTION,
       this.db,

--- a/src/RealtimeServer/scriptureforge/services/question-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/question-service.ts
@@ -21,9 +21,10 @@ export class QuestionService extends SFProjectDataService<Question> {
   protected readonly indexPaths = QUESTION_INDEX_PATHS;
   protected readonly listenForUpdates = true;
   readonly validationSchema: ValidationSchema = {
-    bsonType: 'object',
-    required: ['_id', '_type', '_v', '_m', '_o'],
+    bsonType: SFProjectDataService.validationSchema.bsonType,
+    required: SFProjectDataService.validationSchema.required,
     properties: {
+      ...SFProjectDataService.validationSchema.properties,
       _id: {
         bsonType: 'string',
         pattern: '^[0-9a-f]+:[0-9a-f]+$'
@@ -185,36 +186,6 @@ export class QuestionService extends SFProjectDataService<Question> {
       },
       transceleratorQuestionId: {
         bsonType: 'string'
-      },
-      projectRef: {
-        bsonType: 'string',
-        pattern: '^[0-9a-f]+$'
-      },
-      ownerRef: {
-        bsonType: 'string',
-        pattern: '^[0-9a-f]*$'
-      },
-      _type: {
-        bsonType: ['null', 'string']
-      },
-      _v: {
-        bsonType: 'int'
-      },
-      _m: {
-        bsonType: 'object',
-        required: ['ctime', 'mtime'],
-        properties: {
-          ctime: {
-            bsonType: 'number'
-          },
-          mtime: {
-            bsonType: 'number'
-          }
-        },
-        additionalProperties: false
-      },
-      _o: {
-        bsonType: 'objectId'
       }
     },
     additionalProperties: false

--- a/src/RealtimeServer/scriptureforge/services/question-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/question-service.ts
@@ -99,7 +99,7 @@ export class QuestionService extends SFProjectDataService<Question> {
                     bsonType: 'string'
                   },
                   text: {
-                    bsonType: 'string'
+                    bsonType: ['null', 'string']
                   },
                   dateModified: {
                     bsonType: 'string'
@@ -123,7 +123,7 @@ export class QuestionService extends SFProjectDataService<Question> {
                 properties: {
                   ownerRef: {
                     bsonType: 'string',
-                    pattern: '^[0-9a-f]$'
+                    pattern: '^[0-9a-f]+$'
                   }
                 },
                 additionalProperties: false
@@ -131,6 +131,18 @@ export class QuestionService extends SFProjectDataService<Question> {
             },
             status: {
               enum: ['', 'resolved', 'export']
+            },
+            scriptureText: {
+              bsonType: 'string'
+            },
+            selectionStartClipped: {
+              bsonType: 'bool'
+            },
+            selectionEndClipped: {
+              bsonType: 'bool'
+            },
+            audioUrl: {
+              bsonType: 'string'
             },
             dataId: {
               bsonType: 'string',
@@ -143,7 +155,7 @@ export class QuestionService extends SFProjectDataService<Question> {
               bsonType: 'string'
             },
             text: {
-              bsonType: 'string'
+              bsonType: ['null', 'string']
             },
             dateModified: {
               bsonType: 'string'

--- a/src/RealtimeServer/scriptureforge/services/question-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/question-service.ts
@@ -1,5 +1,6 @@
 import { Doc } from 'sharedb/lib/client';
 import { OwnedData } from '../../common/models/owned-data';
+import { ValidationSchema } from '../../common/models/validation-schema';
 import { ProjectDomainConfig } from '../../common/services/project-data-service';
 import { ANY_INDEX } from '../../common/utils/obj-path';
 import { createFetchQuery, docSubmitJson0Op } from '../../common/utils/sharedb-utils';
@@ -19,6 +20,193 @@ export class QuestionService extends SFProjectDataService<Question> {
 
   protected readonly indexPaths = QUESTION_INDEX_PATHS;
   protected readonly listenForUpdates = true;
+  readonly validationSchema: ValidationSchema = {
+    bsonType: 'object',
+    required: ['_id', '_type', '_v', '_m', '_o'],
+    properties: {
+      _id: {
+        bsonType: 'string',
+        pattern: '^[0-9a-f]+:[0-9a-f]+$'
+      },
+      dataId: {
+        bsonType: 'string',
+        pattern: '^[0-9a-f]+$'
+      },
+      verseRef: {
+        bsonType: 'object',
+        required: ['bookNum', 'chapterNum', 'verseNum'],
+        properties: {
+          bookNum: {
+            bsonType: 'int'
+          },
+          chapterNum: {
+            bsonType: 'int'
+          },
+          verseNum: {
+            bsonType: 'int'
+          },
+          verse: {
+            bsonType: 'string'
+          }
+        },
+        additionalProperties: false
+      },
+      text: {
+        bsonType: 'string'
+      },
+      audioUrl: {
+        bsonType: 'string'
+      },
+      answers: {
+        bsonType: 'array',
+        items: {
+          bsonType: 'object',
+          required: ['dataId', 'deleted', 'dateModified', 'dateCreated'],
+          properties: {
+            verseRef: {
+              bsonType: 'object',
+              required: ['bookNum', 'chapterNum', 'verseNum'],
+              properties: {
+                bookNum: {
+                  bsonType: 'int'
+                },
+                chapterNum: {
+                  bsonType: 'int'
+                },
+                verseNum: {
+                  bsonType: 'int'
+                },
+                verse: {
+                  bsonType: 'string'
+                }
+              },
+              additionalProperties: false
+            },
+            comments: {
+              bsonType: 'array',
+              items: {
+                bsonType: 'object',
+                required: ['dataId', 'deleted', 'dateModified', 'dateCreated'],
+                properties: {
+                  dataId: {
+                    bsonType: 'string',
+                    pattern: '^[0-9a-f]+$'
+                  },
+                  deleted: {
+                    bsonType: 'bool'
+                  },
+                  syncUserRef: {
+                    bsonType: 'string'
+                  },
+                  text: {
+                    bsonType: 'string'
+                  },
+                  dateModified: {
+                    bsonType: 'string'
+                  },
+                  dateCreated: {
+                    bsonType: 'string'
+                  },
+                  ownerRef: {
+                    bsonType: 'string',
+                    pattern: '^[0-9a-f]*$'
+                  }
+                },
+                additionalProperties: false
+              }
+            },
+            likes: {
+              bsonType: 'array',
+              items: {
+                bsonType: 'object',
+                required: ['ownerRef'],
+                properties: {
+                  ownerRef: {
+                    bsonType: 'string',
+                    pattern: '^[0-9a-f]$'
+                  }
+                },
+                additionalProperties: false
+              }
+            },
+            status: {
+              enum: ['', 'resolved', 'export']
+            },
+            dataId: {
+              bsonType: 'string',
+              pattern: '^[0-9a-f]+$'
+            },
+            deleted: {
+              bsonType: 'bool'
+            },
+            syncUserRef: {
+              bsonType: 'string'
+            },
+            text: {
+              bsonType: 'string'
+            },
+            dateModified: {
+              bsonType: 'string'
+            },
+            dateCreated: {
+              bsonType: 'string'
+            },
+            ownerRef: {
+              bsonType: 'string',
+              pattern: '^[0-9a-f]*$'
+            }
+          },
+          additionalProperties: false
+        }
+      },
+      isArchived: {
+        bsonType: 'bool'
+      },
+      dateArchived: {
+        bsonType: 'string'
+      },
+      dateModified: {
+        bsonType: 'string'
+      },
+      dateCreated: {
+        bsonType: 'string'
+      },
+      transceleratorQuestionId: {
+        bsonType: 'string'
+      },
+      projectRef: {
+        bsonType: 'string',
+        pattern: '^[0-9a-f]+$'
+      },
+      ownerRef: {
+        bsonType: 'string',
+        pattern: '^[0-9a-f]*$'
+      },
+      _type: {
+        bsonType: ['null', 'string']
+      },
+      _v: {
+        bsonType: 'int'
+      },
+      _m: {
+        bsonType: 'object',
+        required: ['ctime', 'mtime'],
+        properties: {
+          ctime: {
+            bsonType: 'number'
+          },
+          mtime: {
+            bsonType: 'number'
+          }
+        },
+        additionalProperties: false
+      },
+      _o: {
+        bsonType: 'objectId'
+      }
+    },
+    additionalProperties: false
+  };
 
   constructor() {
     super(QUESTION_MIGRATIONS);

--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.spec.ts
@@ -241,6 +241,7 @@ class TestEnvironment {
     this.server = new RealtimeServer(
       'TEST',
       false,
+      true,
       [new SFProjectService(SF_PROJECT_MIGRATIONS.filter(m => m.VERSION <= endVersion))],
       SF_PROJECTS_COLLECTION,
       this.db,

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.spec.ts
@@ -73,6 +73,7 @@ class TestEnvironment {
     this.server = new RealtimeServer(
       'TEST',
       false,
+      false,
       [this.service],
       SF_PROJECTS_COLLECTION,
       this.db,

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -108,6 +108,38 @@ export class SFProjectService extends ProjectService<SFProject> {
           },
           defaultNoteTagId: {
             bsonType: 'int'
+          },
+          preTranslate: {
+            bsonType: 'bool'
+          },
+          projectType: {
+            enum: [
+              'Standard',
+              'BackTranslation',
+              'Daughter',
+              'TransliterationManual',
+              'TransliterationWithEncoder',
+              'StudyBible',
+              'ConsultantNotes',
+              'StudyBibleAdditions',
+              'Auxiliary',
+              'Xml',
+              'SourceLanguage',
+              'Dictionary',
+              'EnhancedResource'
+            ]
+          },
+          baseProject: {
+            bsonType: 'object',
+            properties: {
+              paratextId: {
+                bsonType: 'string'
+              },
+              shortName: {
+                bsonType: 'string'
+              }
+            },
+            additionalProperties: false
           }
         },
         additionalProperties: false

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -207,6 +207,9 @@ export class SFProjectService extends ProjectService<SFProject> {
                   lastVerse: {
                     bsonType: 'int'
                   },
+                  hasAudio: {
+                    bsonType: 'bool'
+                  },
                   isValid: {
                     bsonType: 'bool'
                   },

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -11,9 +11,10 @@ import {
 } from '../models/sf-project';
 import { SFProjectRole } from '../models/sf-project-role';
 import { SFProjectDomain, SF_PROJECT_RIGHTS } from '../models/sf-project-rights';
-import { Operation } from '../../common/models/project-rights';
 import { ConnectSession } from '../../common/connect-session';
+import { Operation } from '../../common/models/project-rights';
 import { SystemRole } from '../../common/models/system-role';
+import { ValidationSchema } from '../../common/models/validation-schema';
 
 const SF_PROJECT_PROFILE_FIELDS: ShareDB.ProjectionFields = {
   name: true,
@@ -42,6 +43,244 @@ export class SFProjectService extends ProjectService<SFProject> {
 
   protected readonly indexPaths = SF_PROJECT_INDEX_PATHS;
   protected readonly projectAdminRole = SFProjectRole.ParatextAdministrator;
+  readonly validationSchema: ValidationSchema = {
+    bsonType: ProjectService.validationSchema.bsonType,
+    required: ProjectService.validationSchema.required,
+    properties: {
+      ...ProjectService.validationSchema.properties,
+      paratextId: {
+        bsonType: 'string'
+      },
+      shortName: {
+        bsonType: 'string'
+      },
+      writingSystem: {
+        bsonType: 'object',
+        properties: {
+          tag: {
+            bsonType: 'string'
+          }
+        },
+        additionalProperties: false
+      },
+      isRightToLeft: {
+        bsonType: 'bool'
+      },
+      translateConfig: {
+        bsonType: 'object',
+        properties: {
+          translationSuggestionsEnabled: {
+            bsonType: 'bool'
+          },
+          source: {
+            bsonType: 'object',
+            properties: {
+              paratextId: {
+                bsonType: 'string'
+              },
+              projectRef: {
+                bsonType: 'string',
+                pattern: '^[0-9a-f]+$'
+              },
+              name: {
+                bsonType: 'string'
+              },
+              shortName: {
+                bsonType: 'string'
+              },
+              writingSystem: {
+                bsonType: 'object',
+                properties: {
+                  tag: {
+                    bsonType: 'string'
+                  }
+                },
+                additionalProperties: false
+              },
+              isRightToLeft: {
+                bsonType: 'bool'
+              }
+            },
+            additionalProperties: false
+          },
+          shareEnabled: {
+            bsonType: 'bool'
+          },
+          defaultNoteTagId: {
+            bsonType: 'int'
+          }
+        },
+        additionalProperties: false
+      },
+      checkingConfig: {
+        bsonType: 'object',
+        properties: {
+          checkingEnabled: {
+            bsonType: 'bool'
+          },
+          usersSeeEachOthersResponses: {
+            bsonType: 'bool'
+          },
+          shareEnabled: {
+            bsonType: 'bool'
+          },
+          answerExportMethod: {
+            enum: ['', 'all', 'marked_for_export', 'none']
+          },
+          noteTagId: {
+            bsonType: 'int'
+          }
+        },
+        additionalProperties: false
+      },
+      resourceConfig: {
+        bsonType: 'object',
+        properties: {
+          createdTimestamp: {
+            bsonType: 'string'
+          },
+          manifestChecksum: {
+            bsonType: 'string'
+          },
+          permissionsChecksum: {
+            bsonType: 'string'
+          },
+          revision: {
+            bsonType: 'int'
+          }
+        },
+        additionalProperties: false
+      },
+      texts: {
+        bsonType: 'array',
+        items: {
+          bsonType: 'object',
+          required: ['bookNum', 'hasSource'],
+          properties: {
+            bookNum: {
+              bsonType: 'int'
+            },
+            hasSource: {
+              bsonType: 'bool'
+            },
+            chapters: {
+              bsonType: 'array',
+              items: {
+                bsonType: 'object',
+                required: ['number', 'lastVerse', 'isValid'],
+                properties: {
+                  number: {
+                    bsonType: 'int'
+                  },
+                  lastVerse: {
+                    bsonType: 'int'
+                  },
+                  isValid: {
+                    bsonType: 'bool'
+                  },
+                  permissions: {
+                    bsonType: 'object',
+                    patternProperties: {
+                      '^[0-9a-f]+$': {
+                        bsonType: 'string'
+                      }
+                    },
+                    additionalProperties: false
+                  }
+                },
+                additionalProperties: false
+              }
+            },
+            permissions: {
+              bsonType: 'object',
+              patternProperties: {
+                '^[0-9a-f]+$': {
+                  bsonType: 'string'
+                }
+              },
+              additionalProperties: false
+            }
+          },
+          additionalProperties: false
+        }
+      },
+      noteTags: {
+        bsonType: 'array',
+        items: {
+          bsonType: 'object',
+          required: ['tagId', 'name', 'icon', 'creatorResolve'],
+          properties: {
+            tagId: {
+              bsonType: 'int'
+            },
+            name: {
+              bsonType: 'string'
+            },
+            icon: {
+              bsonType: 'string'
+            },
+            creatorResolve: {
+              bsonType: 'bool'
+            }
+          },
+          additionalProperties: false
+        }
+      },
+      sync: {
+        bsonType: 'object',
+        properties: {
+          queuedCount: {
+            bsonType: 'int'
+          },
+          lastSyncSuccessful: {
+            bsonType: 'bool'
+          },
+          dateLastSuccessfulSync: {
+            bsonType: 'string'
+          },
+          syncedToRepositoryVersion: {
+            bsonType: 'string'
+          },
+          dataInSync: {
+            bsonType: 'bool'
+          }
+        },
+        additionalProperties: false
+      },
+      editable: {
+        bsonType: 'bool'
+      },
+      defaultFontSize: {
+        bsonType: 'int'
+      },
+      defaultFont: {
+        bsonType: 'string'
+      },
+      maxGeneratedUsersPerShareKey: {
+        bsonType: 'int'
+      },
+      paratextUsers: {
+        bsonType: 'array',
+        items: {
+          bsonType: 'object',
+          required: ['username', 'opaqueUserId'],
+          properties: {
+            username: {
+              bsonType: 'string'
+            },
+            opaqueUserId: {
+              bsonType: 'string'
+            },
+            sfUserId: {
+              bsonType: 'string'
+            }
+          },
+          additionalProperties: false
+        }
+      }
+    },
+    additionalProperties: false
+  };
 
   constructor(sfProjectMigrations: MigrationConstructor[]) {
     super(sfProjectMigrations);

--- a/src/RealtimeServer/scriptureforge/services/sf-project-user-config-migrations.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-user-config-migrations.spec.ts
@@ -36,6 +36,7 @@ class TestEnvironment {
     this.server = new RealtimeServer(
       'TEST',
       false,
+      true,
       [new SFProjectUserConfigService()],
       SF_PROJECT_USER_CONFIGS_COLLECTION,
       this.db,

--- a/src/RealtimeServer/scriptureforge/services/sf-project-user-config-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-user-config-service.ts
@@ -17,9 +17,10 @@ export class SFProjectUserConfigService extends SFProjectDataService<SFProjectUs
 
   protected readonly indexPaths = SF_PROJECT_USER_CONFIG_INDEX_PATHS;
   readonly validationSchema: ValidationSchema = {
-    bsonType: 'object',
-    required: ['_id', '_type', '_v', '_m', '_o'],
+    bsonType: SFProjectDataService.validationSchema.bsonType,
+    required: SFProjectDataService.validationSchema.required,
     properties: {
+      ...SFProjectDataService.validationSchema.properties,
       _id: {
         bsonType: 'string',
         pattern: '^[0-9a-f]+:[0-9a-f]+$'
@@ -77,36 +78,6 @@ export class SFProjectUserConfigService extends SFProjectDataService<SFProjectUs
         items: {
           bsonType: 'string'
         }
-      },
-      projectRef: {
-        bsonType: 'string',
-        pattern: '^[0-9a-f]+$'
-      },
-      ownerRef: {
-        bsonType: 'string',
-        pattern: '^[0-9a-f]*$'
-      },
-      _type: {
-        bsonType: ['null', 'string']
-      },
-      _v: {
-        bsonType: 'int'
-      },
-      _m: {
-        bsonType: 'object',
-        required: ['ctime', 'mtime'],
-        properties: {
-          ctime: {
-            bsonType: 'number'
-          },
-          mtime: {
-            bsonType: 'number'
-          }
-        },
-        additionalProperties: false
-      },
-      _o: {
-        bsonType: 'objectId'
       }
     },
     additionalProperties: false

--- a/src/RealtimeServer/scriptureforge/services/sf-project-user-config-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-user-config-service.ts
@@ -1,3 +1,4 @@
+import { ValidationSchema } from '../../common/models/validation-schema';
 import { ProjectDomainConfig } from '../../common/services/project-data-service';
 import { SFProjectDomain } from '../models/sf-project-rights';
 import {
@@ -15,6 +16,101 @@ export class SFProjectUserConfigService extends SFProjectDataService<SFProjectUs
   readonly collection = SF_PROJECT_USER_CONFIGS_COLLECTION;
 
   protected readonly indexPaths = SF_PROJECT_USER_CONFIG_INDEX_PATHS;
+  readonly validationSchema: ValidationSchema = {
+    bsonType: 'object',
+    required: ['_id', '_type', '_v', '_m', '_o'],
+    properties: {
+      _id: {
+        bsonType: 'string',
+        pattern: '^[0-9a-f]+:[0-9a-f]+$'
+      },
+      selectedTask: {
+        bsonType: 'string'
+      },
+      selectedQuestionRef: {
+        bsonType: 'string'
+      },
+      selectedBookNum: {
+        bsonType: 'int'
+      },
+      selectedChapterNum: {
+        bsonType: 'int'
+      },
+      isTargetTextRight: {
+        bsonType: 'bool'
+      },
+      confidenceThreshold: {
+        bsonType: 'number'
+      },
+      translationSuggestionsEnabled: {
+        bsonType: 'bool'
+      },
+      numSuggestions: {
+        bsonType: 'int'
+      },
+      selectedSegment: {
+        bsonType: 'string'
+      },
+      selectedSegmentChecksum: {
+        bsonType: 'int'
+      },
+      noteRefsRead: {
+        bsonType: 'array',
+        items: {
+          bsonType: 'string'
+        }
+      },
+      questionRefsRead: {
+        bsonType: 'array',
+        items: {
+          bsonType: 'string'
+        }
+      },
+      answerRefsRead: {
+        bsonType: 'array',
+        items: {
+          bsonType: 'string'
+        }
+      },
+      commentRefsRead: {
+        bsonType: 'array',
+        items: {
+          bsonType: 'string'
+        }
+      },
+      projectRef: {
+        bsonType: 'string',
+        pattern: '^[0-9a-f]+$'
+      },
+      ownerRef: {
+        bsonType: 'string',
+        pattern: '^[0-9a-f]*$'
+      },
+      _type: {
+        bsonType: ['null', 'string']
+      },
+      _v: {
+        bsonType: 'int'
+      },
+      _m: {
+        bsonType: 'object',
+        required: ['ctime', 'mtime'],
+        properties: {
+          ctime: {
+            bsonType: 'number'
+          },
+          mtime: {
+            bsonType: 'number'
+          }
+        },
+        additionalProperties: false
+      },
+      _o: {
+        bsonType: 'objectId'
+      }
+    },
+    additionalProperties: false
+  };
 
   constructor() {
     super(SF_PROJECT_USER_CONFIG_MIGRATIONS);

--- a/src/RealtimeServer/scriptureforge/services/text-audio-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/text-audio-service.spec.ts
@@ -76,6 +76,7 @@ class TestEnvironment {
     this.server = new RealtimeServer(
       'TEST',
       false,
+      false,
       [this.service],
       SF_PROJECTS_COLLECTION,
       this.db,

--- a/src/RealtimeServer/scriptureforge/services/text-audio-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/text-audio-service.ts
@@ -1,3 +1,4 @@
+import { ValidationSchema } from '../../common/models/validation-schema';
 import { ProjectDomainConfig } from '../../common/services/project-data-service';
 import { SFProjectDomain } from '../models/sf-project-rights';
 import { TextAudio, TEXT_AUDIO_COLLECTION, TEXT_AUDIO_INDEX_PATHS } from '../models/text-audio';
@@ -11,6 +12,46 @@ export class TextAudioService extends SFProjectDataService<TextAudio> {
   readonly collection = TEXT_AUDIO_COLLECTION;
 
   protected readonly indexPaths = TEXT_AUDIO_INDEX_PATHS;
+  readonly validationSchema: ValidationSchema = {
+    bsonType: SFProjectDataService.validationSchema.bsonType,
+    required: SFProjectDataService.validationSchema.required,
+    properties: {
+      ...SFProjectDataService.validationSchema.properties,
+      _id: {
+        bsonType: 'string',
+        pattern: '^[0-9a-f]+:[0-9A-Z]+:[0-9]+:target$'
+      },
+      dataId: {
+        bsonType: 'string'
+      },
+      mimeType: {
+        bsonType: 'string'
+      },
+      audioUrl: {
+        bsonType: 'string'
+      },
+      timings: {
+        bsonType: 'array',
+        items: {
+          bsonType: 'object',
+          required: ['textRef', 'from', 'to'],
+          properties: {
+            textRef: {
+              bsonType: 'string'
+            },
+            from: {
+              bsonType: 'number'
+            },
+            to: {
+              bsonType: 'number'
+            }
+          },
+          additionalProperties: false
+        }
+      }
+    },
+    additionalProperties: false
+  };
 
   constructor() {
     super(TEXT_AUDIO_MIGRATIONS);

--- a/src/RealtimeServer/scriptureforge/services/text-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/text-service.spec.ts
@@ -65,6 +65,7 @@ class TestEnvironment {
     this.server = new RealtimeServer(
       'TEST',
       false,
+      false,
       [this.service],
       SF_PROJECTS_COLLECTION,
       this.db,

--- a/src/RealtimeServer/scriptureforge/services/text-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/text-service.ts
@@ -1,6 +1,7 @@
 import { ConnectSession } from '../../common/connect-session';
 import { Project } from '../../common/models/project';
 import { Operation } from '../../common/models/project-rights';
+import { ValidationSchema } from '../../common/models/validation-schema';
 import { DocService } from '../../common/services/doc-service';
 import { SFProjectDomain, SF_PROJECT_RIGHTS } from '../models/sf-project-rights';
 import { TextData, TEXTS_COLLECTION, TEXT_INDEX_PATHS } from '../models/text-data';
@@ -13,6 +14,45 @@ export class TextService extends DocService<TextData> {
   readonly collection = TEXTS_COLLECTION;
 
   protected readonly indexPaths = TEXT_INDEX_PATHS;
+  readonly validationSchema: ValidationSchema = {
+    bsonType: 'object',
+    required: ['_id', '_type', '_v', '_m', '_o'],
+    properties: {
+      _id: {
+        bsonType: 'string',
+        pattern: '^[0-9a-f]+:[0-9A-Z]+:[0-9]+:target$'
+      },
+      ops: {
+        bsonType: 'array',
+        items: {
+          bsonType: 'object'
+        }
+      },
+      _type: {
+        bsonType: ['null', 'string']
+      },
+      _v: {
+        bsonType: 'int'
+      },
+      _m: {
+        bsonType: 'object',
+        required: ['ctime', 'mtime'],
+        properties: {
+          ctime: {
+            bsonType: 'number'
+          },
+          mtime: {
+            bsonType: 'number'
+          }
+        },
+        additionalProperties: false
+      },
+      _o: {
+        bsonType: 'objectId'
+      }
+    },
+    additionalProperties: false
+  };
 
   constructor() {
     super(TEXT_MIGRATIONS);

--- a/src/RealtimeServer/scriptureforge/services/text-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/text-service.ts
@@ -15,9 +15,10 @@ export class TextService extends DocService<TextData> {
 
   protected readonly indexPaths = TEXT_INDEX_PATHS;
   readonly validationSchema: ValidationSchema = {
-    bsonType: 'object',
-    required: ['_id', '_type', '_v', '_m', '_o'],
+    bsonType: DocService.validationSchema.bsonType,
+    required: DocService.validationSchema.required,
     properties: {
+      ...DocService.validationSchema.properties,
       _id: {
         bsonType: 'string',
         pattern: '^[0-9a-f]+:[0-9A-Z]+:[0-9]+:target$'
@@ -27,28 +28,6 @@ export class TextService extends DocService<TextData> {
         items: {
           bsonType: 'object'
         }
-      },
-      _type: {
-        bsonType: ['null', 'string']
-      },
-      _v: {
-        bsonType: 'int'
-      },
-      _m: {
-        bsonType: 'object',
-        required: ['ctime', 'mtime'],
-        properties: {
-          ctime: {
-            bsonType: 'number'
-          },
-          mtime: {
-            bsonType: 'number'
-          }
-        },
-        additionalProperties: false
-      },
-      _o: {
-        bsonType: 'objectId'
       }
     },
     additionalProperties: false

--- a/src/RealtimeServer/typings/sharedb/lib/client.d.ts
+++ b/src/RealtimeServer/typings/sharedb/lib/client.d.ts
@@ -20,7 +20,7 @@ export {
   Path
 } from './common';
 
-export class Connection {
+export class Connection extends EventEmitter {
   state: 'connecting' | 'connected' | 'disconnected' | 'closed' | 'stopped';
   constructor(ws: WebSocket | WS);
   get(collectionName: string, documentID: string): Doc;

--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -134,6 +134,9 @@
       "dependencies": {
         "@bugsnag/js": "^7.21.0",
         "@sillsdev/scripture": "^1.4.0",
+        "@types/ajv-bsontype": "^1.0.1",
+        "ajv": "^8.12.0",
+        "ajv-bsontype": "^1.0.7",
         "express": "^4.18.1",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^2.1.2",
@@ -2029,7 +2032,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3480,8 +3482,7 @@
     "../../RealtimeServer/node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "../../RealtimeServer/node_modules/fast-diff": {
       "version": "1.2.0",
@@ -3504,7 +3505,6 @@
     },
     "../../RealtimeServer/node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT"
     },
     "../../RealtimeServer/node_modules/fast-levenshtein": {
@@ -5013,8 +5013,7 @@
     "../../RealtimeServer/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "../../RealtimeServer/node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -6775,7 +6774,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -65809,6 +65807,7 @@
       "requires": {
         "@bugsnag/js": "^7.21.0",
         "@sillsdev/scripture": "^1.4.0",
+        "@types/ajv-bsontype": "^1.0.1",
         "@types/jest": "^29.2.4",
         "@types/jsonwebtoken": "^9.0.0",
         "@types/lodash-es": "^4.17.7",
@@ -65816,6 +65815,8 @@
         "@types/ws": "^8.5.3",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",
+        "ajv": "^8.12.0",
+        "ajv-bsontype": "^1.0.7",
         "eslint": "^8.28.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-deprecation": "^1.3.3",
@@ -67249,7 +67250,6 @@
           "version": "6.12.6",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -68230,8 +68230,7 @@
         "fast-deep-equal": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-          "dev": true
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "fast-diff": {
           "version": "1.2.0"
@@ -68248,8 +68247,7 @@
           }
         },
         "fast-json-stable-stringify": {
-          "version": "2.1.0",
-          "dev": true
+          "version": "2.1.0"
         },
         "fast-levenshtein": {
           "version": "2.0.6",
@@ -69282,8 +69280,7 @@
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "json-stable-stringify-without-jsonify": {
           "version": "1.0.1",
@@ -70447,7 +70444,6 @@
           "version": "4.4.1",
           "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
           "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-          "dev": true,
           "requires": {
             "punycode": "^2.1.0"
           }

--- a/src/SIL.XForge/Configuration/RealtimeOptions.cs
+++ b/src/SIL.XForge/Configuration/RealtimeOptions.cs
@@ -10,8 +10,8 @@ public class RealtimeOptions
 {
     public string AppModuleName { get; set; }
     public int Port { get; set; }
-    public bool MigrationsDisabled { get; set; } = false;
-    public bool DataValidationDisabled { get; set; } { get; set; }
+    public bool MigrationsDisabled { get; set; }
+    public bool DataValidationDisabled { get; set; }
     public bool DocumentCacheDisabled { get; set; }
     public bool UseExistingRealtimeServer { get; set; }
     public DocConfig UserDoc { get; set; } = new DocConfig("users", typeof(User));

--- a/src/SIL.XForge/Configuration/RealtimeOptions.cs
+++ b/src/SIL.XForge/Configuration/RealtimeOptions.cs
@@ -10,7 +10,8 @@ public class RealtimeOptions
 {
     public string AppModuleName { get; set; }
     public int Port { get; set; }
-    public bool MigrationsDisabled { get; set; }
+    public bool MigrationsDisabled { get; set; } = false;
+    public bool DataValidationDisabled { get; set; } { get; set; }
     public bool DocumentCacheDisabled { get; set; }
     public bool UseExistingRealtimeServer { get; set; }
     public DocConfig UserDoc { get; set; } = new DocConfig("users", typeof(User));

--- a/src/SIL.XForge/Realtime/RealtimeService.cs
+++ b/src/SIL.XForge/Realtime/RealtimeService.cs
@@ -248,6 +248,7 @@ public class RealtimeService : DisposableBase, IRealtimeService
             BugsnagApiKey = this._configuration.GetValue<string>("Bugsnag:ApiKey"),
             ReleaseStage = this._configuration.GetValue<string>("Bugsnag:ReleaseStage"),
             this._realtimeOptions.Value.MigrationsDisabled,
+            this._realtimeOptions.Value.DataValidationDisabled,
             SiteId = this._siteOptions.Value.Id,
             Product.Version,
         };


### PR DESCRIPTION
This PR adds support for the following new features and changes:

 * Schema validation in MongoDB, which logs warnings when does not match the validation schema
 * Op validation in the RealtimeServer of connections from the client, utilizing the MongoDB validation schemas
   * Server connections do not validate data
 * Disables the `@typescript-eslint/no-explicit-any` ESLint rule for the RealtimeServer
 * Catches errors from ShareDB from the web socket connection, and logs them to the console
 * A tool to verify schema validation errors
 * Type checking of op data

**Running Locally**
This PR adds an additional package dependency to the RealtimeServer. After checking out this branch, you will need to:
1. Run `npm i` in the directory `src/RealtimeServer`
2. Run `npm i` in the directory `src/SIL.XForge.Scripture/ClientApp`

**Deployment Instructions**

It is suggested that this feature is disabled on production, until a reasonable length of time has passed of day-to-day use and testing on developer's workstations and QA.

Before deploying on production, disable the feature by running the following command in the production app directory:
```
dotnet user-secrets set "Realtime:DataValidationDisabled" true
```

This command will disable data verification of ops, but will still create the validation schemas in the Mongo database for use with data checking.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1746)
<!-- Reviewable:end -->
