### PR TITLE
SF-1883 Consider combined verse segments when opening note dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -52,7 +52,7 @@ export function combineVerseRefStrs(startStr?: string, endStr?: string): VerseRe
  * @return The segment ref of the first segment in the verse, or undefined if the segment does not belong to a verse.
  */
 export function getBaseVerse(segmentRef: string): string | undefined {
-  const matchArray: RegExpExecArray | null = VERSE_REGEX.exec(segmentRef);
+  const matchArray: RegExpExecArray | null = VERSE_FROM_SEGMENT_REF_REGEX.exec(segmentRef);
   return matchArray == null ? undefined : matchArray[0];
 }
 
@@ -65,7 +65,7 @@ export function getVerseRefFromSegmentRef(bookNum: number, segmentRef: string): 
   return new VerseRef(bookNum, parts[1], parts[2]);
 }
 
-export function verseSlug(verse: VerseRef) {
+export function verseSlug(verse: VerseRef): string {
   return 'verse_' + verse.chapterNum + '_' + (verse.verse == null ? verse.verseNum : verse.verse);
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2673,6 +2673,21 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('shows the correct combined verse ref for a new note', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.updateParams({ projectId: 'project01', bookId: 'LUK' });
+      env.wait();
+
+      const segmentRef = 'verse_1_2-3';
+      env.setSelectionAndInsertNote(segmentRef);
+      const verseRef = new VerseRef('LUK', 1, '2-3');
+      verify(mockedMatDialog.open(NoteDialogComponent, anything())).once();
+      const [, config] = capture(mockedMatDialog.open).last();
+      expect((config!.data! as NoteDialogData).verseRef!.equals(verseRef)).toBeTrue();
+      env.dispose();
+    }));
+
     it('does not allow selecting section headings', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();


### PR DESCRIPTION
The getBaseVerse function is used in a few places in SF, but it did not take into account the format of segments for a combined verse (i.e. verse_1_5-6) which is a valid segment ref. This changes it to consider that format as the base verse, so when we open a dialog, we give the correct verse reference.

![image](https://user-images.githubusercontent.com/17931130/225397052-98e2400e-28b1-413d-9ff1-abdce0b938e3.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1748)
<!-- Reviewable:end -->
