### PR TITLE
Add noteTagId to CheckingConfig TS model

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/checking-config.ts
+++ b/src/RealtimeServer/scriptureforge/models/checking-config.ts
@@ -15,4 +15,5 @@ export interface CheckingConfig {
   shareEnabled: boolean;
   shareLevel: CheckingShareLevel;
   answerExportMethod: CheckingAnswerExport;
+  noteTagId?: number;
 }


### PR DESCRIPTION
This was added to the C# model in
049f672a10e54ceb3a252999f1805245ff87d97b but was mistakenly omitted from the TS model.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1751)
<!-- Reviewable:end -->
