### PR TITLE
SF-1919 - Hide option to "Show changes" when viewing a note if there are no changes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
@@ -6,11 +6,18 @@
   <mat-dialog-content class="content-padding" [ngClass]="{ rtl: isRtl, ltr: !isRtl }">
     <div class="text-row">
       <div class="text">
-        <div *ngIf="!isNewNote" class="note-text" [innerHTML]="noteContextText"></div>
+        <div *ngIf="!isNewNote" class="note-text" [innerHTML]="getNoteContextText()"></div>
         <div *ngIf="isNewNote" class="note-text" [innerHTML]="segmentText"></div>
         <div *ngIf="showSegmentText" class="segment-text" [innerHTML]="segmentText"></div>
       </div>
-      <button *ngIf="!isNewNote" mat-icon-button [matMenuTriggerFor]="menu"><mat-icon>more_vert</mat-icon></button>
+      <button
+        *ngIf="!isNewNote && isSegmentDifferentFromContext"
+        id="text-menu-button"
+        mat-icon-button
+        [matMenuTriggerFor]="menu"
+      >
+        <mat-icon>more_vert</mat-icon>
+      </button>
       <mat-menu #menu="matMenu">
         <button mat-menu-item (click)="toggleSegmentText()">
           <mat-icon>compare</mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -81,12 +81,24 @@ describe('NoteDialogComponent', () => {
   it('show selected text and toggle visibility of related segment', fakeAsync(() => {
     env = new TestEnvironment({ noteThread: TestEnvironment.getNoteThread() });
 
+    expect(env.textMenuButton).toBeTruthy();
+    expect(env.component.isSegmentDifferentFromContext).toBeTrue();
     expect(env.noteText.nativeElement.textContent).toEqual('before selection selected text after selection');
     expect(env.segmentText).toBeNull();
     env.toggleSegmentButton();
     expect(env.segmentText.nativeElement.textContent).toEqual(
       `target: chapter 1, verse 7.\ntarget: chapter 1, verse 7 - 2nd paragraph.`
     );
+  }));
+
+  it('only show note context if different from segment text', fakeAsync(() => {
+    const noteThread = TestEnvironment.getNoteThread();
+    noteThread.originalContextBefore = 'target: chapter 1, ';
+    noteThread.originalSelectedText = 'verse 7.\ntarget: chapter 1, verse 7 ';
+    noteThread.originalContextAfter = '- 2nd paragraph.';
+    env = new TestEnvironment({ noteThread });
+    expect(env.textMenuButton).toBeFalsy();
+    expect(env.component.isSegmentDifferentFromContext).toBeFalse();
   }));
 
   it('should not show deleted notes', fakeAsync(() => {
@@ -862,6 +874,10 @@ class TestEnvironment {
 
   get saveButton(): DebugElement {
     return this.overlayContainerElement.query(By.css('button.save-button'));
+  }
+
+  get textMenuButton(): DebugElement {
+    return this.overlayContainerElement.query(By.css('#text-menu-button'));
   }
 
   private get overlayContainerElement(): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -120,6 +120,10 @@ export class NoteDialogComponent implements OnInit {
     return this.projectProfileDoc.data.isRightToLeft ?? false;
   }
 
+  get isSegmentDifferentFromContext(): boolean {
+    return this.getNoteContextText(true) !== this.segmentText;
+  }
+
   get notesToDisplay(): Note[] {
     if (this.threadDoc?.data == null) {
       return [];
@@ -133,19 +137,6 @@ export class NoteDialogComponent implements OnInit {
   get verseRefDisplay(): string {
     const verseRef: VerseRef | undefined = this.verseRef;
     return verseRef == null ? '' : this.i18n.localizeReference(verseRef);
-  }
-
-  get noteContextText(): string {
-    if (this.threadDoc?.data == null) {
-      return '';
-    }
-    return (
-      this.threadDoc.data.originalContextBefore +
-      '<b>' +
-      this.threadDoc.data.originalSelectedText +
-      '</b>' +
-      this.threadDoc.data.originalContextAfter
-    );
   }
 
   get segmentText(): string {
@@ -179,6 +170,19 @@ export class NoteDialogComponent implements OnInit {
       return '';
     }
     return this.parseNote(note.content);
+  }
+
+  getNoteContextText(plainText: boolean = false): string {
+    if (this.threadDoc?.data == null) {
+      return '';
+    }
+    return (
+      this.threadDoc.data.originalContextBefore +
+      (plainText ? '' : '<b>') +
+      this.threadDoc.data.originalSelectedText +
+      (plainText ? '' : '</b>') +
+      this.threadDoc.data.originalContextAfter
+    );
   }
 
   private get projectId(): string {


### PR DESCRIPTION
- Added a string check for segment and context text

**Before**
![image](https://user-images.githubusercontent.com/17464863/225508239-a793d94b-0481-49f0-a7e6-1b536fd9ec41.png)

**After**
![image](https://user-images.githubusercontent.com/17464863/225508346-faf9566a-4ffd-401a-9b70-35efd89e5d5c.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1753)
<!-- Reviewable:end -->
