### PR TITLE
Configure ESLint to ignore unused variables that start with underscore

### DIFF
--- a/src/RealtimeServer/.eslintrc.json
+++ b/src/RealtimeServer/.eslintrc.json
@@ -38,7 +38,8 @@
         "@typescript-eslint/no-unused-vars": [
           "error",
           {
-            "argsIgnorePattern": "_"
+            "argsIgnorePattern": "^_",
+            "varsIgnorePattern": "^_"
           }
         ],
         "brace-style": ["error", "1tbs"],

--- a/src/SIL.XForge.Scripture/ClientApp/.eslintrc.json
+++ b/src/SIL.XForge.Scripture/ClientApp/.eslintrc.json
@@ -53,7 +53,8 @@
         "@typescript-eslint/no-unused-vars": [
           "error",
           {
-            "argsIgnorePattern": "_"
+            "argsIgnorePattern": "^_",
+            "varsIgnorePattern": "^_"
           }
         ],
         "brace-style": ["error", "1tbs"],

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -327,7 +327,6 @@ describe('SettingsComponent', () => {
 
         env.setBasedOnValue('paratextId01');
         expect(env.inputElement(env.translationSuggestionsCheckbox).checked).toBe(true);
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const [_, secondArg] = capture(mockedSFProjectService.onlineUpdateSettings).last();
         expect(secondArg).toEqual({ sourceParatextId: 'paratextId01', translationSuggestionsEnabled: true });
       }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -523,7 +523,6 @@ export class TextViewModel {
         const style = op.attributes == null || op.attributes.para == null ? null : (op.attributes.para.style as string);
         if (style == null || canParaContainVerseText(style)) {
           // paragraph
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           for (const _ch of op.insert) {
             if (curSegment != null) {
               paraSegments.push(curSegment);


### PR DESCRIPTION
ESLint has been complaining when we do things like:
``` ts
const [_, secondArg] = something.methodThatReturnsArrayOfTwoItems();
```

By convention an underscore leading a variable name indicates that it is used as a placeholder.

Docs for no-unused-vars: https://eslint.org/docs/latest/rules/no-unused-vars

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1758)
<!-- Reviewable:end -->
