### PR TITLE
SF-1765 Sync notes back to Paratext

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -526,16 +526,16 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 // Only update the note tag if there are SF note threads in the project
                 if (noteThreadDocs.Any(d => d.Data.PublishedToSF == true))
                     await UpdateTranslateNoteTag(paratextId);
-                // TODO: Sync Note changes back to Paratext, and record sync metric info
-                // int sfNoteTagId = _projectDoc.Data.TranslateConfig.DefaultNoteTagId ?? NoteTag.notSetId;
-                // await _paratextService.UpdateParatextCommentsAsync(
-                //     _userSecret,
-                //     paratextId,
-                //     text.BookNum,
-                //     noteThreadDocs,
-                //     _currentPtSyncUsers,
-                //     sfNoteTagId
-                // );
+
+                int sfNoteTagId = _projectDoc.Data.TranslateConfig.DefaultNoteTagId ?? NoteTag.notSetId;
+                _syncMetrics.ParatextNotes += await _paratextService.UpdateParatextCommentsAsync(
+                    _userSecret,
+                    paratextId,
+                    text.BookNum,
+                    noteThreadDocs,
+                    _currentPtSyncUsers,
+                    sfNoteTagId
+                );
             }
         }
     }


### PR DESCRIPTION
This change syncs note thread docs in SF to Paratext before the Paratext send/receive occurs. These will be no changes unless a user intentionally enables the adding notes feature flag on the front-end.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1759)
<!-- Reviewable:end -->
