### PR TITLE
Improve ChildViewContainerComponent reuse

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-confirmation-dialog/import-questions-confirmation-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-confirmation-dialog/import-questions-confirmation-dialog.component.spec.ts
@@ -1,9 +1,9 @@
 import { MdcDialog, MdcDialogRef } from '@angular-mdc/web/dialog';
 import { CommonModule } from '@angular/common';
-import { Component, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { ChildViewContainerComponent, configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import {
   EditedQuestion,
@@ -68,31 +68,10 @@ describe('ImportQuestionsConfirmationDialogComponent', () => {
   }));
 });
 
-@Directive({
-  // es lint complains that a directive should be used as an attribute
-  // eslint-disable-next-line @angular-eslint/directive-selector
-  selector: 'viewContainerDirective'
-})
-class ViewContainerDirective {
-  constructor(public viewContainerRef: ViewContainerRef) {}
-}
-
-@Component({
-  selector: 'app-view-container',
-  template: '<viewContainerDirective></viewContainerDirective>'
-})
-class ChildViewContainerComponent {
-  @ViewChild(ViewContainerDirective, { static: true }) viewContainer!: ViewContainerDirective;
-
-  get childViewContainer(): ViewContainerRef {
-    return this.viewContainer.viewContainerRef;
-  }
-}
-
 @NgModule({
   imports: [CommonModule, UICommonModule, TestTranslocoModule],
-  declarations: [ViewContainerDirective, ChildViewContainerComponent, ImportQuestionsConfirmationDialogComponent],
-  exports: [ViewContainerDirective, ChildViewContainerComponent, ImportQuestionsConfirmationDialogComponent]
+  declarations: [ImportQuestionsConfirmationDialogComponent],
+  exports: [ImportQuestionsConfirmationDialogComponent]
 })
 class DialogTestModule {}
 
@@ -141,7 +120,7 @@ class TestEnvironment {
     return this.dialogRef.afterClosed().toPromise();
   }
 
-  click(element: HTMLElement) {
+  click(element: HTMLElement): void {
     element.click();
     this.update();
   }
@@ -161,7 +140,7 @@ class TestEnvironment {
     return promiseForResult;
   }
 
-  private update() {
+  private update(): void {
     tick();
     this.fixture.detectChanges();
     flush();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
@@ -1,6 +1,6 @@
 import { MdcDialogRef } from '@angular-mdc/web';
 import { CommonModule } from '@angular/common';
-import { Component, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { UntypedFormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatCheckbox } from '@angular/material/checkbox';
@@ -20,7 +20,7 @@ import { AuthService } from 'xforge-common/auth.service';
 import { CsvService } from 'xforge-common/csv-service.service';
 import { DialogService } from 'xforge-common/dialog.service';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
-import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { ChildViewContainerComponent, configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { TestingRetryingRequestService } from 'xforge-common/testing-retrying-request.service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { QuestionDoc } from '../../core/models/question-doc';
@@ -450,41 +450,10 @@ describe('ImportQuestionsDialogComponent', () => {
   }));
 });
 
-@Directive({
-  // es lint complains that a directive should be used as an attribute
-  // eslint-disable-next-line @angular-eslint/directive-selector
-  selector: 'viewContainerDirective'
-})
-class ViewContainerDirective {
-  constructor(public viewContainerRef: ViewContainerRef) {}
-}
-
-@Component({
-  selector: 'app-view-container',
-  template: '<viewContainerDirective></viewContainerDirective>'
-})
-class ChildViewContainerComponent {
-  @ViewChild(ViewContainerDirective, { static: true }) viewContainer!: ViewContainerDirective;
-
-  get childViewContainer(): ViewContainerRef {
-    return this.viewContainer.viewContainerRef;
-  }
-}
-
 @NgModule({
   imports: [CommonModule, UICommonModule, TestTranslocoModule, NoopAnimationsModule, ngfModule],
-  declarations: [
-    ViewContainerDirective,
-    ChildViewContainerComponent,
-    ScriptureChooserDialogComponent,
-    ImportQuestionsDialogComponent
-  ],
-  exports: [
-    ViewContainerDirective,
-    ChildViewContainerComponent,
-    ScriptureChooserDialogComponent,
-    ImportQuestionsDialogComponent
-  ]
+  declarations: [ScriptureChooserDialogComponent, ImportQuestionsDialogComponent],
+  exports: [ScriptureChooserDialogComponent, ImportQuestionsDialogComponent]
 })
 class DialogTestModule {}
 
@@ -679,13 +648,13 @@ class TestEnvironment {
     this.click(this.overlayContainerElement.querySelector('#from-btn') as HTMLInputElement);
   }
 
-  setOnline(value: boolean) {
+  setOnline(value: boolean): void {
     this.online$.next(value);
     tick();
     this.fixture.detectChanges();
   }
 
-  setControlValue(control: UntypedFormControl, value: string) {
+  setControlValue(control: UntypedFormControl, value: string): void {
     control.setValue(value);
     tick();
     this.fixture.detectChanges();
@@ -716,14 +685,14 @@ class TestEnvironment {
     tick();
   }
 
-  selectFileWithContents(contents: string[][], filename = 'filename.csv') {
+  selectFileWithContents(contents: string[][], filename = 'filename.csv'): void {
     when(mockedCsvService.parse(anything())).thenResolve(contents);
     this.component.fileSelected({ name: filename } as File);
     tick();
     this.fixture.detectChanges();
   }
 
-  click(element: HTMLElement) {
+  click(element: HTMLElement): void {
     element.click();
     tick();
     this.fixture.detectChanges();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -1,7 +1,7 @@
 import { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
-import { Component, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CookieService } from 'ngx-cookie-service';
@@ -20,7 +20,12 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { PwaService } from 'xforge-common/pwa.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
-import { configureTestingModule, getAudioBlob, TestTranslocoModule } from 'xforge-common/test-utils';
+import {
+  ChildViewContainerComponent,
+  configureTestingModule,
+  getAudioBlob,
+  TestTranslocoModule
+} from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -522,31 +527,10 @@ describe('QuestionDialogComponent', () => {
   }));
 });
 
-@Directive({
-  // es lint complains that a directive should be used as an attribute
-  // eslint-disable-next-line @angular-eslint/directive-selector
-  selector: 'viewContainerDirective'
-})
-class ViewContainerDirective {
-  constructor(public viewContainerRef: ViewContainerRef) {}
-}
-
-@Component({
-  selector: 'app-view-container',
-  template: '<viewContainerDirective></viewContainerDirective>'
-})
-class ChildViewContainerComponent {
-  @ViewChild(ViewContainerDirective, { static: true }) viewContainer!: ViewContainerDirective;
-
-  get childViewContainer(): ViewContainerRef {
-    return this.viewContainer.viewContainerRef;
-  }
-}
-
 @NgModule({
   imports: [CommonModule, UICommonModule, CheckingModule, TestTranslocoModule, NoopAnimationsModule],
-  declarations: [ViewContainerDirective, ChildViewContainerComponent, ScriptureChooserDialogComponent],
-  exports: [ViewContainerDirective, ChildViewContainerComponent, ScriptureChooserDialogComponent]
+  declarations: [ScriptureChooserDialogComponent],
+  exports: [ScriptureChooserDialogComponent]
 })
 class DialogTestModule {}
 
@@ -677,7 +661,7 @@ class TestEnvironment {
     return this.overlayContainerElement.querySelector('#question-scripture-end-helper-text') as HTMLElement;
   }
 
-  inputValue(element: HTMLElement, value: string) {
+  inputValue(element: HTMLElement, value: string): void {
     const inputElem = element.querySelector('input, textarea') as HTMLInputElement | HTMLTextAreaElement;
     inputElem.value = value;
     inputElem.dispatchEvent(new Event('input'));
@@ -685,7 +669,7 @@ class TestEnvironment {
     tick();
   }
 
-  clickElement(element: HTMLElement) {
+  clickElement(element: HTMLElement): void {
     element.click();
     this.fixture.detectChanges();
     tick();
@@ -696,7 +680,7 @@ class TestEnvironment {
     return segment.classList.toString().includes('highlight-segment');
   }
 
-  setAudioStatus(status: 'denied' | 'processed' | 'recording' | 'reset' | 'stopped' | 'uploaded') {
+  setAudioStatus(status: 'denied' | 'processed' | 'recording' | 'reset' | 'stopped' | 'uploaded'): void {
     const audio: AudioAttachment = { status: status };
     this.component.processAudio(audio);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.spec.ts
@@ -1,6 +1,6 @@
 import { MatDialog, MatDialogConfig, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { Component, DebugElement, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
+import { DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { fakeAsync, flush } from '@angular/core/testing';
 import { BrowserModule, By } from '@angular/platform-browser';
@@ -12,7 +12,7 @@ import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils
 import { mock } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
 import { BugsnagService } from 'xforge-common/bugsnag.service';
-import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { ChildViewContainerComponent, configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TextsByBookId } from '../core/models/texts-by-book-id';
@@ -417,27 +417,6 @@ describe('ScriptureChooserDialog', () => {
     expect(env.component.selection.chapter).toBeUndefined();
   }));
 
-  @Directive({
-    // es lint complains that a directive should be used as an attribute
-    // eslint-disable-next-line @angular-eslint/directive-selector
-    selector: 'viewContainerDirective'
-  })
-  class ViewContainerDirective {
-    constructor(public viewContainerRef: ViewContainerRef) {}
-  }
-
-  @Component({
-    selector: 'app-view-container',
-    template: '<viewContainerDirective></viewContainerDirective>'
-  })
-  class ChildViewContainerComponent {
-    @ViewChild(ViewContainerDirective, { static: true }) viewContainer!: ViewContainerDirective;
-
-    get childViewContainer(): ViewContainerRef {
-      return this.viewContainer.viewContainerRef;
-    }
-  }
-
   @NgModule({
     imports: [
       BrowserModule,
@@ -448,8 +427,8 @@ describe('ScriptureChooserDialog', () => {
       TestTranslocoModule,
       NoopAnimationsModule
     ],
-    declarations: [ViewContainerDirective, ChildViewContainerComponent, ScriptureChooserDialogComponent],
-    exports: [ViewContainerDirective, ChildViewContainerComponent, ScriptureChooserDialogComponent]
+    declarations: [ScriptureChooserDialogComponent],
+    exports: [ScriptureChooserDialogComponent]
   })
   class TestModule {}
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.spec.ts
@@ -1,11 +1,11 @@
 import { MdcDialog, MdcDialogConfig, MdcDialogRef } from '@angular-mdc/web/dialog';
-import { Component, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, inject, TestBed, tick } from '@angular/core/testing';
 import { CookieService } from 'ngx-cookie-service';
 import { mock } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
 import { BugsnagService } from 'xforge-common/bugsnag.service';
-import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { ChildViewContainerComponent, configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { DeleteProjectDialogComponent } from './delete-project-dialog.component';
 
@@ -23,7 +23,6 @@ describe('DeleteProjectDialogComponent', () => {
 
   let dialog: MdcDialog;
   let viewContainerFixture: ComponentFixture<ChildViewContainerComponent>;
-  let testViewContainerRef: ViewContainerRef;
 
   it('should allow user to delete the project', fakeAsync(() => {
     const env = new TestEnvironment();
@@ -63,7 +62,7 @@ describe('DeleteProjectDialogComponent', () => {
 
     constructor() {
       this.afterCloseCallback = jasmine.createSpy('afterClose callback');
-      const config: MdcDialogConfig = { data: { name: 'project01' }, viewContainerRef: testViewContainerRef };
+      const config: MdcDialogConfig = { data: { name: 'project01' } };
       this.dialogRef = dialog.open(DeleteProjectDialogComponent, config);
       this.dialogRef.afterClosed().subscribe(this.afterCloseCallback);
       this.component = this.dialogRef.componentInstance;
@@ -87,7 +86,7 @@ describe('DeleteProjectDialogComponent', () => {
       return this.overlayContainerElement.querySelector('#project-entry') as HTMLElement;
     }
 
-    inputValue(element: HTMLElement, value: string) {
+    inputValue(element: HTMLElement, value: string): void {
       const inputElem = element.querySelector('input') as HTMLInputElement;
       inputElem.value = value;
       inputElem.dispatchEvent(new Event('input'));
@@ -95,7 +94,7 @@ describe('DeleteProjectDialogComponent', () => {
       tick();
     }
 
-    clickElement(element: HTMLElement) {
+    clickElement(element: HTMLElement): void {
       element.click();
       this.fixture.detectChanges();
       tick();
@@ -108,34 +107,12 @@ describe('DeleteProjectDialogComponent', () => {
 
   beforeEach(() => {
     viewContainerFixture = TestBed.createComponent(ChildViewContainerComponent);
-    testViewContainerRef = viewContainerFixture.componentInstance.childViewContainer;
   });
 });
 
-@Directive({
-  // es lint complains that a directive should be used as an attribute
-  // eslint-disable-next-line @angular-eslint/directive-selector
-  selector: 'viewContainerDirective'
-})
-class ViewContainerDirective {
-  constructor(public viewContainerRef: ViewContainerRef) {}
-}
-
-@Component({
-  selector: 'app-view-container',
-  template: '<viewContainerDirective></viewContainerDirective>'
-})
-class ChildViewContainerComponent {
-  @ViewChild(ViewContainerDirective, { static: true }) viewContainer!: ViewContainerDirective;
-
-  get childViewContainer(): ViewContainerRef {
-    return this.viewContainer.viewContainerRef;
-  }
-}
-
 @NgModule({
   imports: [UICommonModule, TestTranslocoModule],
-  declarations: [ViewContainerDirective, ChildViewContainerComponent, DeleteProjectDialogComponent],
-  exports: [ViewContainerDirective, ChildViewContainerComponent, DeleteProjectDialogComponent]
+  declarations: [DeleteProjectDialogComponent],
+  exports: [DeleteProjectDialogComponent]
 })
 class DialogTestModule {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, DebugElement, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
+import { DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
@@ -10,7 +10,7 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { PwaService } from 'xforge-common/pwa.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
-import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { ChildViewContainerComponent, configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
 import { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
@@ -296,31 +296,8 @@ interface TestEnvironmentArgs {
   translateShareEnabled?: boolean;
 }
 
-@Directive({
-  // es lint complains that a directive should be used as an attribute
-  // eslint-disable-next-line @angular-eslint/directive-selector
-  selector: 'viewContainerDirective'
-})
-class ViewContainerDirective {
-  constructor(public viewContainerRef: ViewContainerRef) {}
-}
-
-@Component({
-  selector: 'app-view-container',
-  template: '<viewContainerDirective></viewContainerDirective>'
-})
-class ChildViewContainerComponent {
-  @ViewChild(ViewContainerDirective, { static: true }) viewContainer!: ViewContainerDirective;
-
-  get childViewContainer(): ViewContainerRef {
-    return this.viewContainer.viewContainerRef;
-  }
-}
-
 @NgModule({
-  imports: [CommonModule, UICommonModule, TestTranslocoModule, NoopAnimationsModule],
-  declarations: [ViewContainerDirective, ChildViewContainerComponent],
-  exports: [ViewContainerDirective, ChildViewContainerComponent]
+  imports: [CommonModule, UICommonModule, TestTranslocoModule, NoopAnimationsModule]
 })
 class DialogTestModule {}
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.spec.ts
@@ -1,6 +1,11 @@
-import { Component, DebugElement, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
+import { DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { configureTestingModule, matDialogCloseDelay, TestTranslocoModule } from 'xforge-common/test-utils';
+import {
+  ChildViewContainerComponent,
+  configureTestingModule,
+  matDialogCloseDelay,
+  TestTranslocoModule
+} from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -39,31 +44,10 @@ describe('TextNoteDialogComponent', () => {
   }));
 });
 
-@Directive({
-  // es lint complains that a directive should be used as an attribute
-  // eslint-disable-next-line @angular-eslint/directive-selector
-  selector: 'viewContainerDirective'
-})
-class ViewContainerDirective {
-  constructor(public viewContainerRef: ViewContainerRef) {}
-}
-
-@Component({
-  selector: 'app-view-container',
-  template: '<viewContainerDirective></viewContainerDirective>'
-})
-class ChildViewContainerComponent {
-  @ViewChild(ViewContainerDirective, { static: true }) viewContainer!: ViewContainerDirective;
-
-  get childViewContainer(): ViewContainerRef {
-    return this.viewContainer.viewContainerRef;
-  }
-}
-
 @NgModule({
   imports: [UICommonModule, TestTranslocoModule],
-  declarations: [ViewContainerDirective, ChildViewContainerComponent, TextNoteDialogComponent],
-  exports: [ViewContainerDirective, ChildViewContainerComponent, TextNoteDialogComponent]
+  declarations: [TextNoteDialogComponent],
+  exports: [TextNoteDialogComponent]
 })
 class DialogTestModule {}
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
@@ -1,9 +1,10 @@
 import { CommonModule } from '@angular/common';
-import { Component, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { CookieService } from 'ngx-cookie-service';
+import { DeltaStatic } from 'quill';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { getTextDocId } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
@@ -18,7 +19,7 @@ import { BugsnagService } from 'xforge-common/bugsnag.service';
 import { PwaService } from 'xforge-common/pwa.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
-import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { ChildViewContainerComponent, configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
 import { CheckingAnswerExport } from 'realtime-server/lib/esm/scriptureforge/models/checking-config';
@@ -338,31 +339,8 @@ describe('TextChooserDialogComponent', () => {
   }));
 });
 
-@Directive({
-  // es lint complains that a directive should be used as an attribute
-  // eslint-disable-next-line @angular-eslint/directive-selector
-  selector: 'viewContainerDirective'
-})
-class ViewContainerDirective {
-  constructor(public viewContainerRef: ViewContainerRef) {}
-}
-
-@Component({
-  selector: 'app-view-container',
-  template: '<viewContainerDirective></viewContainerDirective>'
-})
-class ChildViewContainerComponent {
-  @ViewChild(ViewContainerDirective, { static: true }) viewContainer!: ViewContainerDirective;
-
-  get childViewContainer(): ViewContainerRef {
-    return this.viewContainer.viewContainerRef;
-  }
-}
-
 @NgModule({
-  imports: [CommonModule, UICommonModule, CheckingModule, TestTranslocoModule],
-  exports: [ViewContainerDirective, ChildViewContainerComponent],
-  declarations: [ViewContainerDirective, ChildViewContainerComponent]
+  imports: [CommonModule, UICommonModule, CheckingModule, TestTranslocoModule]
 })
 class DialogTestModule {}
 
@@ -522,54 +500,54 @@ class TestEnvironment {
     return this.select('#cancel-button') as HTMLButtonElement;
   }
 
-  get headingText() {
+  get headingText(): string {
     return this.select('.select-chapter h2').textContent!;
   }
 
-  get selectChapter() {
+  get selectChapter(): HTMLButtonElement {
     return this.select('.select-chapter') as HTMLButtonElement;
   }
 
-  get errorMessage() {
+  get errorMessage(): Element {
     return this.select('.error-message');
   }
 
-  get selectedText() {
+  get selectedText(): string {
     // trim because template adds white space around the text
     return this.select('.selection-preview').textContent!.trim();
   }
 
-  get editor() {
+  get editor(): Element {
     return this.select('quill-editor');
   }
 
-  select(query: string) {
+  select(query: string): Element {
     return this.overlayContainerElement.querySelector(query)!;
   }
 
-  fireSelectionChange() {
+  fireSelectionChange(): void {
     this.selectionChangeHandler();
     tick(100); // event handler debounce time
     this.fixture.detectChanges();
   }
 
-  closeDialog() {
+  closeDialog(): void {
     this.cancelButton.click();
     flush();
   }
 
-  click(button: HTMLButtonElement) {
+  click(button: HTMLButtonElement): void {
     button.click();
     this.fixture.detectChanges();
   }
 
-  elementFromHtml(html: string) {
+  elementFromHtml(html: string): Element {
     const div = document.createElement('div');
     div.innerHTML = html;
     return div.firstChild! as Element;
   }
 
-  static get delta() {
+  static get delta(): DeltaStatic {
     const delta = new Delta();
     delta.insert({ chapter: { number: '1', style: 'c' } });
     delta.insert('heading text', { para: { style: 'p' } });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
-import { Component, DebugElement, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
+import { DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
@@ -33,7 +33,12 @@ import { DialogService } from 'xforge-common/dialog.service';
 import { FeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
-import { configureTestingModule, matDialogCloseDelay, TestTranslocoModule } from 'xforge-common/test-utils';
+import {
+  ChildViewContainerComponent,
+  configureTestingModule,
+  matDialogCloseDelay,
+  TestTranslocoModule
+} from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
 import { CheckingAnswerExport } from 'realtime-server/lib/esm/scriptureforge/models/checking-config';
@@ -517,27 +522,8 @@ describe('NoteDialogComponent', () => {
   }));
 });
 
-@Directive({
-  // es lint complains that a directive should be used as an attribute
-  // eslint-disable-next-line @angular-eslint/directive-selector
-  selector: 'appViewContainerDirective'
-})
-class ViewContainerDirective {
-  constructor(public viewContainerRef: ViewContainerRef) {}
-}
-
-@Component({
-  selector: 'app-view-container',
-  template: '<appViewContainerDirective></appViewContainerDirective>'
-})
-class ChildViewContainerComponent {
-  @ViewChild(ViewContainerDirective, { static: true }) viewContainer!: ViewContainerDirective;
-}
-
 @NgModule({
-  imports: [CommonModule, UICommonModule, TranslateModule, TestTranslocoModule],
-  declarations: [ViewContainerDirective, ChildViewContainerComponent],
-  exports: [ViewContainerDirective, ChildViewContainerComponent]
+  imports: [CommonModule, UICommonModule, TranslateModule, TestTranslocoModule]
 })
 class DialogTestModule {}
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
@@ -1,6 +1,6 @@
 import { MdcSelect } from '@angular-mdc/web';
 import { CommonModule } from '@angular/common';
-import { Component, DebugElement, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
+import { DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { MatSlider } from '@angular/material/slider';
@@ -17,7 +17,12 @@ import { mock, when } from 'ts-mockito';
 import { PwaService } from 'xforge-common/pwa.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
-import { configureTestingModule, matDialogCloseDelay, TestTranslocoModule } from 'xforge-common/test-utils';
+import {
+  ChildViewContainerComponent,
+  configureTestingModule,
+  matDialogCloseDelay,
+  TestTranslocoModule
+} from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { SFProjectUserConfigDoc } from '../../core/models/sf-project-user-config-doc';
 import { SF_TYPE_REGISTRY } from '../../core/models/sf-type-registry';
@@ -107,31 +112,10 @@ describe('SuggestionsSettingsDialogComponent', () => {
   }));
 });
 
-@Directive({
-  // es lint complains that a directive should be used as an attribute
-  // eslint-disable-next-line @angular-eslint/directive-selector
-  selector: 'viewContainerDirective'
-})
-class ViewContainerDirective {
-  constructor(public viewContainerRef: ViewContainerRef) {}
-}
-
-@Component({
-  selector: 'app-view-container',
-  template: '<viewContainerDirective></viewContainerDirective>'
-})
-class ChildViewContainerComponent {
-  @ViewChild(ViewContainerDirective, { static: true }) viewContainer!: ViewContainerDirective;
-
-  get childViewContainer(): ViewContainerRef {
-    return this.viewContainer.viewContainerRef;
-  }
-}
-
 @NgModule({
   imports: [CommonModule, UICommonModule, TestTranslocoModule],
-  declarations: [ViewContainerDirective, ChildViewContainerComponent, SuggestionsSettingsDialogComponent],
-  exports: [ViewContainerDirective, ChildViewContainerComponent, SuggestionsSettingsDialogComponent]
+  declarations: [SuggestionsSettingsDialogComponent],
+  exports: [SuggestionsSettingsDialogComponent]
 })
 class DialogTestModule {}
 
@@ -234,12 +218,12 @@ class TestEnvironment {
     );
   }
 
-  clickSwitch(element: HTMLElement) {
+  clickSwitch(element: HTMLElement): void {
     const inputElem = element.querySelector('input')!;
     this.click(inputElem);
   }
 
-  click(element: HTMLElement) {
+  click(element: HTMLElement): void {
     element.click();
     flush();
     this.fixture.detectChanges();

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error/error.component.spec.ts
@@ -1,8 +1,8 @@
 import { MdcDialog, MdcDialogConfig } from '@angular-mdc/web/dialog';
 import { CommonModule } from '@angular/common';
-import { Component, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
-import { configureTestingModule, TestTranslocoModule } from '../test-utils';
+import { ChildViewContainerComponent, configureTestingModule, TestTranslocoModule } from '../test-utils';
 import { UICommonModule } from '../ui-common.module';
 import { ErrorAlert, ErrorComponent } from './error.component';
 
@@ -41,31 +41,10 @@ describe('ErrorComponent', () => {
   }));
 });
 
-@Directive({
-  // es lint complains that a directive should be used as an attribute
-  // eslint-disable-next-line @angular-eslint/directive-selector
-  selector: 'viewContainerDirective'
-})
-class ViewContainerDirective {
-  constructor(public viewContainerRef: ViewContainerRef) {}
-}
-
-@Component({
-  selector: 'app-view-container',
-  template: '<viewContainerDirective></viewContainerDirective>'
-})
-class ChildViewContainerComponent {
-  @ViewChild(ViewContainerDirective, { static: true }) viewContainer!: ViewContainerDirective;
-
-  get childViewContainer(): ViewContainerRef {
-    return this.viewContainer.viewContainerRef;
-  }
-}
-
 @NgModule({
   imports: [CommonModule, UICommonModule, TestTranslocoModule],
-  declarations: [ViewContainerDirective, ChildViewContainerComponent, ErrorComponent],
-  exports: [ViewContainerDirective, ChildViewContainerComponent, ErrorComponent]
+  declarations: [ErrorComponent],
+  exports: [ErrorComponent]
 })
 class DialogTestModule {}
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-delete-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-delete-dialog.component.spec.ts
@@ -1,11 +1,11 @@
 import { MdcDialog, MdcDialogConfig, MdcDialogRef } from '@angular-mdc/web/dialog';
 import { CommonModule } from '@angular/common';
-import { Component, DebugElement, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
+import { DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { AvatarTestingModule } from '../avatar/avatar-testing.module';
-import { configureTestingModule } from '../test-utils';
+import { ChildViewContainerComponent, configureTestingModule } from '../test-utils';
 import { UICommonModule } from '../ui-common.module';
 import { SaDeleteDialogComponent, SaDeleteUserDialogData } from './sa-delete-dialog.component';
 
@@ -29,31 +29,10 @@ describe('DeleteDialogComponent', () => {
   }));
 });
 
-@Directive({
-  // es lint complains that a directive should be used as an attribute
-  // eslint-disable-next-line @angular-eslint/directive-selector
-  selector: 'viewContainerDirective'
-})
-class ViewContainerDirective {
-  constructor(public viewContainerRef: ViewContainerRef) {}
-}
-
-@Component({
-  selector: 'app-view-container',
-  template: '<viewContainerDirective></viewContainerDirective>'
-})
-class ChildViewContainerComponent {
-  @ViewChild(ViewContainerDirective, { static: true }) viewContainer!: ViewContainerDirective;
-
-  get childViewContainer(): ViewContainerRef {
-    return this.viewContainer.viewContainerRef;
-  }
-}
-
 @NgModule({
   imports: [AvatarTestingModule, CommonModule, UICommonModule],
-  declarations: [ViewContainerDirective, ChildViewContainerComponent, SaDeleteDialogComponent],
-  exports: [ViewContainerDirective, ChildViewContainerComponent, SaDeleteDialogComponent]
+  declarations: [SaDeleteDialogComponent],
+  exports: [SaDeleteDialogComponent]
 })
 class TestModule {}
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-utils.ts
@@ -1,3 +1,4 @@
+import { Component, Directive, NgModule, ViewChild, ViewContainerRef } from '@angular/core';
 import { TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { HAMMER_LOADER } from '@angular/platform-browser';
 import { TranslocoTestingModule } from '@ngneat/transloco';
@@ -14,7 +15,7 @@ import { en } from './i18n.service';
  *
  * @param {() => TestModuleMetadata} createModuleDef A function that creates the test module definition.
  */
-export const configureTestingModule = (createModuleDef: () => TestModuleMetadata) => {
+export const configureTestingModule = (createModuleDef: () => TestModuleMetadata): void => {
   const mocks: any[] = [];
 
   let moduleDef: TestModuleMetadata;
@@ -151,3 +152,31 @@ export function getAudioBlob(): Blob {
   const byteArray = new Uint8Array(byteNumbers);
   return new Blob([byteArray], { type: 'audio/wav' });
 }
+
+@Directive({
+  // es lint complains that a directive should be used as an attribute
+  // eslint-disable-next-line @angular-eslint/directive-selector
+  selector: 'viewContainerDirective'
+})
+export class ViewContainerDirective {
+  constructor(public viewContainerRef: ViewContainerRef) {}
+}
+
+@Component({
+  selector: 'app-view-container',
+  template: '<viewContainerDirective></viewContainerDirective>'
+})
+export class ChildViewContainerComponent {
+  @ViewChild(ViewContainerDirective, { static: true }) viewContainer!: ViewContainerDirective;
+
+  get childViewContainer(): ViewContainerRef {
+    return this.viewContainer.viewContainerRef;
+  }
+}
+
+@NgModule({
+  imports: [],
+  declarations: [ChildViewContainerComponent, ViewContainerDirective],
+  exports: [ViewContainerDirective]
+})
+export class ChildViewContainerModule {}


### PR DESCRIPTION
When writing dialog unit tests for #1731, I noticed that the class `ChildViewContainerComponent` was copy-pasted into each `*-dialog.spec.ts` file.

This PR updates all of these spec.ts files to instead use `ChildViewContainerComponent` declared in `test-utils.ts`.

I also took the opportunity to clean up some of the "Missing return type on function" @typescript-eslint/explicit-function-return-type warnings in the classes I was updating.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1761)
<!-- Reviewable:end -->
