### PR TITLE
Simplify styling of notice component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
@@ -5,24 +5,23 @@ div {
   align-items: center;
   padding: 16px;
   border-radius: 4px;
-  --notice-background: #{$purpleLight};
-  --notice-color: #fff;
-  --notice-border: #{$purpleLight};
+  &.normal {
+    --notice-color: #{$purpleLight};
+  }
   &.error {
-    --notice-background: var(--mdc-theme-error);
-    --notice-border: var(--mdc-theme-error);
+    --notice-color: var(--mdc-theme-error);
   }
   &.warning {
-    --notice-background: #{$orange};
-    --notice-border: #{$orange};
+    --notice-color: #{$orange};
   }
   &.outline {
-    --notice-background: #fff;
-    --notice-color: var(--notice-border);
+    border: 1px solid var(--notice-color);
+    color: var(--notice-color);
   }
-  border: 1px solid var(--notice-border);
-  color: var(--notice-color);
-  background-color: var(--notice-background);
+  &:not(.outline) {
+    background-color: var(--notice-color);
+    color: #fff;
+  }
   mat-icon {
     flex: 0 0 24px;
     margin-inline-end: 16px;


### PR DESCRIPTION
"Simplify" may be a misnomer here, but this seems to me to make more sense. Also, the background is now no longer set to white.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1762)
<!-- Reviewable:end -->
