### PR TITLE
SF-1930 Replace share icon with add user icon

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-button.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-button.component.html
@@ -1,8 +1,8 @@
 <ng-container *transloco="let t; read: 'share'">
   <button *ngIf="iconOnlyButton" (click)="openDialog()" mat-icon-button title="{{ t('share') }}" id="share-btn">
-    <mat-icon>share</mat-icon>
+    <mat-icon class="mirror-rtl">person_add</mat-icon>
   </button>
-  <button *ngIf="!iconOnlyButton" mat-flat-button (click)="openDialog()" color="primary">
-    <mat-icon>share</mat-icon>{{ t("share") }}
+  <button *ngIf="!iconOnlyButton" mat-flat-button (click)="openDialog()" color="primary" class="button-with-text">
+    <mat-icon class="mirror-rtl">person_add</mat-icon> {{ t("share") }}
   </button>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-button.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-button.component.scss
@@ -1,6 +1,5 @@
-button {
-  mat-icon {
-    margin-inline-end: 10px;
-    direction: inherit;
-  }
+.button-with-text ::ng-deep .mat-button-wrapper {
+  display: flex;
+  align-items: center;
+  column-gap: 8px;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-button.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-button.component.ts
@@ -7,7 +7,8 @@ import { ShareDialogComponent, ShareDialogData } from './share-dialog.component'
 
 @Component({
   selector: 'app-share-button',
-  templateUrl: './share-button.component.html'
+  templateUrl: './share-button.component.html',
+  styleUrls: ['./share-button.component.scss']
 })
 export class ShareButtonComponent implements OnInit {
   @Input() defaultRole?: SFProjectRole;


### PR DESCRIPTION
### Rationale
- I think the "add user" icon is a lot easier to understand than the "share" icon that is supposed to evoke the idea of a network. Some users may recognize it but I think it's less helpful in most cases.
- It probably can't be used in every situation that the share icon would be used, since it's possible to share something without adding a user to it.

### Before
![share_button_with_text_before](https://user-images.githubusercontent.com/6140710/227287571-05021644-e0c3-4cc9-b465-01cd27bedf6c.png)
![share_icon_button_before](https://user-images.githubusercontent.com/6140710/227287574-a9a34557-690d-4ca9-9795-133b375792eb.png)
### After
![share_button_with_text_after](https://user-images.githubusercontent.com/6140710/227287746-dd06b717-d418-4d3c-8067-525f9de3045a.png)
![share_icon_button_after](https://user-images.githubusercontent.com/6140710/227287694-b7e3b5d0-ab96-4cca-96fc-1e731194ceb8.png)
In RTL mode:
![share_button_with_text_after_rtl](https://user-images.githubusercontent.com/6140710/227287689-e00e8bef-f03a-4234-a32d-ea2874e71bdf.png)
I don't think flipping the icon is that important, but it's trying to convey "add person", so I think having the "+" come first makes the most sense.

I removed some CSS that wasn't actually being used because it wasn't imported into the component. It got added very recently in #1648.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1763)
<!-- Reviewable:end -->
