### PR TITLE
SF-1444 Preserve important whitespace when get text

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -145,19 +145,18 @@
       "args": ["${file}"]
     },
     {
-      "name": "Migration Sync User",
+      "name": "Migration",
       "type": "coreclr",
       "request": "launch",
-      "preLaunchTask": "build-migrator-sync-user-to-pt-user",
-      "program": "${workspaceRoot}/src/Migrations/SyncUserToPTUser/bin/Debug/net6.0/SyncUserToPTUser.dll",
-      "cwd": "${workspaceRoot}/src/Migrations/SyncUserToPTUser",
+      "preLaunchTask": "build-migrator",
+      // This build target can be adjusted to a newer migration being worked on by changing the path in 'program', and in the tasks.json build-migrator 'cwd'.
+      "program": "${workspaceRoot}/src/Migrations/WhitespaceRestoreMigration/bin/Debug/net6.0/WhitespaceRestoreMigration.dll",
       "stopAtEntry": false,
       "console": "integratedTerminal",
-      "args": ["--start-ng-serve=listen"],
+      "args": ["read", "${workspaceRoot}/src/SIL.XForge.Scripture"],
       "env": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        // "SYNC_USER_PROJECT_IDS": "6201831c0e13de5c38e0ed7d",
-        "SYNC_USER_MODE_RUN": "true"
+        // "SF_PROJECT_SET": "544444444444444444444 655555555555555555555",
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
     {
@@ -171,19 +170,5 @@
         "/src": "${workspaceFolder}/src"
       }
     }
-    // {
-    //   "name": "Migration Foo",
-    //   "type": "coreclr",
-    //   "request": "launch",
-    //   "preLaunchTask": "build-migrator-foo",
-    //   "program": "${workspaceRoot}/src/Migrations/Foo/bin/Debug/net6.0/Foo.dll",
-    //   "cwd": "${workspaceRoot}/src/Migrations/Foo",
-    //   "stopAtEntry": false,
-    //   "console": "integratedTerminal",
-    //   "args": ["--start-ng-serve=listen"],
-    //   "env": {
-    //     "ASPNETCORE_ENVIRONMENT": "Development"
-    //   }
-    // },
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -120,13 +120,13 @@
       "problemMatcher": "$msCompile"
     },
     {
-      "label": "build-migrator-sync-user-to-pt-user",
+      "label": "build-migrator",
       "command": "dotnet",
       "args": ["build", "/property:GenerateFullPaths=true"],
       "type": "shell",
       "group": "build",
       "options": {
-        "cwd": "${workspaceRoot}/src/Migrations/SyncUserToPTUser"
+        "cwd": "${workspaceRoot}/src/Migrations/WhitespaceRestoreMigration"
       },
       "problemMatcher": "$msCompile"
     },
@@ -146,16 +146,5 @@
       },
       "problemMatcher": []
     }
-    // {
-    //   "label": "build-migrator-foo",
-    //   "command": "dotnet",
-    //   "args": ["build", "/property:GenerateFullPaths=true"],
-    //   "type": "shell",
-    //   "group": "build",
-    //   "options": {
-    //     "cwd": "${workspaceRoot}/src/Migrations/Foo"
-    //   },
-    //   "problemMatcher": "$msCompile"
-    // },
   ]
 }

--- a/scripts/db_tools/manage-db.ts
+++ b/scripts/db_tools/manage-db.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env -S bash -c '"$(dirname "$0")"/node_modules/.bin/ts-node "$(dirname "$0")/$(basename "$0")" "$@"'
+// The above causes the local ts-node to be used even if run from another directory. Setup: npm i
+//
+// Manage DB
+//
+// This script connects to the database and runs JavaScript code specified on the command line. This is useful for small
+// tasks that don't merit their own script, and without modifying versioned files.
+//
+// For example, remove a doc from a Mongo db collection:
+/*
+  ./manage-db.ts --server dev --eval "
+    const sfUserId = "111111111111111111111111";
+    console.log('Removing user secret doc id', sfUserId);
+    await db.collection('user_secrets').findOneAndDelete({ _id: sfUserId });
+  "
+*/
+// More complex example allowing values to be set from Bash, and using ShareDB / realtime server to change a project's
+// resourceConfig.revision field:
+/*
+  # Setting values ahead of time in Bash.
+  collection="sf_projects"
+  id="111111111111111111111111"
+  field="['resourceConfig', 'revision']"
+  oldValue="8"
+  newValue="-1"
+  # Run script, consuming those values.
+  ./manage-db.ts --server dev --eval "
+    const id = \"${id}\";
+    const collection = \"${collection}\";
+    const field = eval(\"${field}\");
+    const oldValue = \"${oldValue}\";
+    const newValue = \"${newValue}\";
+    const doc = conn.get(collection, id);
+    await utils.fetchDoc(doc);
+    console.log('Orig doc data:', doc.data);
+    await utils.submitDocOp(doc, {
+      p: field,
+      od: oldValue,
+    oi: newValue
+    });
+  "
+*/
+
+import * as RichText from 'rich-text';
+import { Db, MongoClient } from 'mongodb';
+import ShareDB from 'sharedb';
+import { Connection } from 'sharedb/lib/client';
+import WebSocket from 'ws';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import utilsLib from './utils';
+
+type ProgArgs = {
+  server: string;
+  eval: string;
+};
+
+class Program {
+  server: string = 'dev';
+  connectionConfig: utilsLib.ConnectionSettings | undefined;
+  codeToRun: string = 'console.log("Hello.");';
+
+  constructor() {
+    this.processArguments();
+  }
+
+  processArguments() {
+    const args: ProgArgs = yargs(hideBin(process.argv))
+      .option('server', {
+        type: 'string',
+        choices: ['dev', 'qa', 'live'],
+        default: this.server,
+        requiresArg: true,
+        description: 'server to connect to'
+      })
+      .option('eval', {
+        type: 'string',
+        requiresArg: true,
+        description: 'code to run',
+        default: this.codeToRun
+      })
+      .strict()
+      .parseSync();
+
+    this.server = args.server;
+    this.connectionConfig = utilsLib.databaseConfigs.get(this.server);
+    this.codeToRun = args.eval;
+  }
+
+  /** Run the lambda with a connection to the db. */
+  async withDB(activity: (conn: Connection, db: Db) => Promise<void>): Promise<void> {
+    if (this.connectionConfig == null) throw new Error('null connection config');
+    console.log(`Connecting to ${this.server}.`);
+    const ws: WebSocket = utilsLib.createWS(this.connectionConfig);
+    const conn: Connection = new Connection(ws);
+    const client: MongoClient = await MongoClient.connect(this.connectionConfig.dbLocation);
+    try {
+      const db: Db = client.db();
+      await activity(conn, db);
+    } finally {
+      client.close();
+      (conn as any).close();
+    }
+  }
+
+  async main() {
+    ShareDB.types.register(RichText.type);
+    await this.withDB(async (conn: Connection, db: Db) => {
+      const utils: any = utilsLib;
+      const evaluation = eval(`async () => { ${this.codeToRun}}`);
+      await evaluation();
+    });
+  }
+}
+
+const program = new Program();
+program.main();

--- a/scripts/db_tools/trigger-resources-need-sync.ts
+++ b/scripts/db_tools/trigger-resources-need-sync.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env -S bash -c '"$(dirname "$0")"/node_modules/.bin/ts-node "$(dirname "$0")/$(basename "$0")" "$@"'
+// The above causes the local ts-node to be used even if run from another directory. Setup: npm i
+
+import * as RichText from 'rich-text';
+import { Db, MongoClient } from 'mongodb';
+import ShareDB from 'sharedb';
+import { Connection, Doc } from 'sharedb/lib/client';
+import WebSocket from 'ws';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { ConnectionSettings, createWS, databaseConfigs, submitDocOp } from './utils';
+import { SFProject } from '../../src/RealtimeServer/scriptureforge/models/sf-project';
+
+type ProgArgs = {
+  server: string;
+};
+
+class Program {
+  server: string | undefined;
+  connectionConfig: ConnectionSettings | undefined;
+
+  constructor() {
+    this.processArguments();
+  }
+
+  processArguments() {
+    const args: ProgArgs = yargs(hideBin(process.argv))
+      .option('server', {
+        type: 'string',
+        choices: ['dev', 'qa', 'live'],
+        default: 'dev',
+        requiresArg: true,
+        description: 'server to connect to'
+      })
+      .strict()
+      .parseSync();
+
+    this.server = args.server;
+    this.connectionConfig = databaseConfigs.get(this.server);
+  }
+
+  /** Run the lambda with a connection to the db. */
+  async withDB(activity: (conn: Connection, db: Db) => Promise<void>): Promise<void> {
+    if (this.connectionConfig == null) {
+      throw new Error('null connection config');
+    }
+    console.log(`Connecting to ${this.server}.`);
+    const ws: WebSocket = createWS(this.connectionConfig);
+    const conn: Connection = new Connection(ws);
+
+    const client: MongoClient = await MongoClient.connect(this.connectionConfig.dbLocation);
+    try {
+      const db: Db = client.db();
+      await activity(conn, db);
+    } finally {
+      client.close();
+      (conn as any).close();
+    }
+  }
+
+  async main() {
+    ShareDB.types.register(RichText.type);
+    await this.withDB(async (conn: Connection, db: Db) => {
+      // This script marks all resources so they need to be synchronized.
+
+      const SF_PROJECTS_COLLECTION = 'sf_projects';
+      await new Promise<void>((resolve, reject) => {
+        conn.createFetchQuery(
+          SF_PROJECTS_COLLECTION,
+          { resourceConfig: { $exists: true } },
+          {},
+          async (err, results: Doc[]) => {
+            if (err) {
+              console.error('Error fetching documents:', err);
+              return;
+            }
+
+            console.log(`Fetched ${results.length} documents.`);
+            for (const projDoc of results) {
+              const proj: SFProject = projDoc.data;
+              console.log(`${proj.shortName} had resourceConfig.revision ${proj.resourceConfig?.revision}`);
+              if (proj.resourceConfig != null) {
+                await submitDocOp(projDoc, {
+                  p: ['resourceConfig', 'revision'],
+                  od: proj.resourceConfig.revision,
+                  oi: -1
+                });
+              }
+            }
+            resolve();
+          }
+        );
+      });
+    });
+  }
+}
+
+const program = new Program();
+program.main();

--- a/src/Migrations/WhitespaceRestoreMigration/Migrator.cs
+++ b/src/Migrations/WhitespaceRestoreMigration/Migrator.cs
@@ -1,0 +1,750 @@
+using System.Data;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using DiffPlex.DiffBuilder;
+using DiffPlex.DiffBuilder.Model;
+using SIL.ObjectModel;
+using SIL.XForge.DataAccess;
+using SIL.XForge.Models;
+using SIL.XForge.Realtime;
+using SIL.XForge.Realtime.Json0;
+using SIL.XForge.Realtime.RichText;
+using SIL.XForge.Scripture.Models;
+using SIL.XForge.Scripture.Services;
+
+namespace WhitespaceRestoreMigration;
+
+enum DirtyStatus
+{
+    CLEAN,
+    DIRTY,
+    MATCHES_NEW
+}
+
+/// <summary>
+/// See <see cref="Program"/>.
+/// </summary>
+public class Migrator : DisposableBase
+{
+    private readonly IRealtimeService _realtimeService;
+    private readonly IParatextService _paratextService;
+    private readonly IRepository<UserSecret> _userSecretRepo;
+    private readonly IDeltaUsxMapper _deltaUsxMapper;
+    private readonly DataTable _problemStats;
+    private readonly DataTable _projectStats;
+
+    public Migrator(
+        IRealtimeService realtimeService,
+        IParatextService paratextService,
+        IRepository<UserSecret> userSecretRepo,
+        IDeltaUsxMapper deltaUsxMapper
+    )
+    {
+        _realtimeService = realtimeService;
+        _paratextService = paratextService;
+        _userSecretRepo = userSecretRepo;
+        _deltaUsxMapper = deltaUsxMapper;
+
+        // Prepare some data tables to collect information on the migration run.
+
+        _problemStats = new DataTable();
+        _problemStats.Columns.Add("SFProjectId", typeof(string));
+        _problemStats.Columns.Add("Book", typeof(int));
+        _problemStats.Columns.Add("Chapter", typeof(int));
+        _problemStats.Columns.Add("DirtyStatus", typeof(DirtyStatus));
+
+        _projectStats = new DataTable();
+        _projectStats.Columns.Add("SFProjectId", typeof(string));
+        _projectStats.PrimaryKey = new DataColumn[] { _projectStats.Columns["SFProjectId"]! };
+        _projectStats.Columns.Add("NotLoad", typeof(bool));
+        _projectStats.Columns.Add("BusySyncing", typeof(bool));
+        _projectStats.Columns.Add("IsResource", typeof(bool));
+        _projectStats.Columns.Add("NoAdequateUser", typeof(bool));
+        _projectStats.Columns.Add("NullSyncedToRepositoryVersion", typeof(bool));
+        _projectStats.Columns.Add("HasMalformedText", typeof(bool));
+        _projectStats.Columns.Add("Error", typeof(bool));
+        _projectStats.Columns.Add("SyncWasAlreadyDisabled", typeof(bool));
+        _projectStats.Columns.Add("SyncShouldStayDisabled", typeof(bool));
+        _projectStats.Columns.Add("SyncShouldLaterBeReenabled", typeof(bool));
+        _projectStats.Columns.Add("SyncWasReenabled", typeof(bool));
+    }
+
+    public async Task<bool> MigrateAsync(
+        bool writeMode,
+        bool listProjectsMode,
+        ICollection<string> sfProjectIdsToMigrate,
+        IDictionary<string, string> sfUsersToUse
+    )
+    {
+        bool allSuccess = true;
+        // Migration may take a long time. Projects have sync disabled after they are migrated. So migrate recently
+        // used projects last so more active projects don't have to wait as long while their sync is disabled.
+        List<string> sfProjectIds = await _realtimeService
+            .QuerySnapshots<SFProject>()
+            .OrderBy(proj => proj.Sync.DateLastSuccessfulSync)
+            .Select(proj => proj.Id)
+            .ToListAsync();
+
+        // If we are only to migrate some projects, restrict this list to them
+        if (sfProjectIdsToMigrate.Any())
+            sfProjectIds.RemoveAll(pid => !sfProjectIdsToMigrate.Contains(pid));
+
+        string ids = string.Join(" ", sfProjectIds);
+        int count = sfProjectIds.Count;
+        Program.Log($"Working on {count} projects with these SF project ids: {ids}");
+
+        if (listProjectsMode)
+        {
+            Program.Log($"No further processing for list-projects mode.");
+            return true;
+        }
+
+        IConnection conn = await _realtimeService.ConnectAsync();
+        try
+        {
+            int iteration = 0;
+            foreach (string sfProjectId in sfProjectIds)
+            {
+                iteration++;
+                _projectStats.Rows.Add(sfProjectId);
+
+                IDocument<SFProject> sfProjectDoc = await conn.FetchAsync<SFProject>(sfProjectId);
+                if (!sfProjectDoc.IsLoaded)
+                {
+                    Program.Log($"sf proj {sfProjectId}: Skipping project that would not load.");
+                    _projectStats.Rows.Find(sfProjectId)!["NotLoad"] = true;
+                    continue;
+                }
+                SFProject project = sfProjectDoc.Data;
+
+                if (_paratextService.IsResource(project.ParatextId))
+                {
+                    Program.Log($"sf proj {project.Id}: Skipping resource.");
+                    _projectStats.Rows.Find(project.Id)!["IsResource"] = true;
+                    continue;
+                }
+
+                Program.Log($"sf proj {project.Id}: Migrating project {project.Name} ({iteration}/{count})");
+
+                bool syncBeganDisabled = project.SyncDisabled;
+                if (syncBeganDisabled)
+                {
+                    Program.Log($"sf proj {project.Id}: Warning: project sync was already disabled. Continuing.");
+                    _projectStats.Rows.Find(project.Id)!["SyncWasAlreadyDisabled"] = true;
+                }
+                // Disable sync for the project. Even in read-mode since we `hg checkout` a revision in the project
+                // repo dir.
+                await SetSyncDisabledAsync(sfProjectDoc, true);
+
+                // Wait for an existing sync to finish
+                sfProjectDoc = await conn.FetchAsync<SFProject>(sfProjectId);
+                project = sfProjectDoc.Data;
+                // (How to tell a project is syncing, from ParatextSyncRunner.CompleteSync().)
+                bool projectIsSyncing = project.Sync.QueuedCount > 0;
+                if (projectIsSyncing)
+                {
+                    int generousSyncWaitTimeMinutes = 20;
+                    Program.Log(
+                        $"sf proj {project.Id}: Waiting {generousSyncWaitTimeMinutes} minutes for project to finish existing sync."
+                    );
+                    await Task.Delay(TimeSpan.FromMinutes(generousSyncWaitTimeMinutes));
+                    sfProjectDoc = await conn.FetchAsync<SFProject>(sfProjectId);
+                    project = sfProjectDoc.Data;
+                    projectIsSyncing = project.Sync.QueuedCount > 0;
+                    if (projectIsSyncing)
+                    {
+                        Program.Log(
+                            $"sf proj {project.Id}: Project has been syncing for over {generousSyncWaitTimeMinutes} minutes. It is probably not really syncing. Processing."
+                        );
+                        _projectStats.Rows.Find(project.Id)!["BusySyncing"] = true;
+                    }
+                    else
+                    {
+                        Program.Log($"sf proj {project.Id}: Project finished syncing. Processing.");
+                    }
+                }
+
+                IEnumerable<string> projectPtAdminUserIds = project
+                    .UserRoles.Where(ur => ur.Value == SFProjectRole.Administrator)
+                    .Select(ur => ur.Key);
+                // We'll aim to use an admin user, but any pt_foo role will do to read from the PT hg repo.
+                IEnumerable<string> projectPtRoleUsers = projectPtAdminUserIds.Concat(
+                    project.UserRoles.Where(role => SFProjectRole.IsParatextRole(role.Value)).Select(role => role.Key)
+                );
+                if (!projectPtRoleUsers.Any())
+                {
+                    List<string> projectSfUserIds = project.UserRoles.Select(ur => ur.Key).ToList();
+                    string users = projectSfUserIds.Any() ? string.Join(", ", projectSfUserIds) : "None";
+                    Program.Log(
+                        $"sf proj {project.Id}: Error: No users on project had an adequate role. Skipping project. Users include: {users}"
+                    );
+                    _projectStats.Rows.Find(project.Id)!["NoAdequateUser"] = true;
+                    allSuccess = false;
+
+                    if (writeMode)
+                    {
+                        // The SF-1444 fix will soon be applied, and this project should not be synced until it can be
+                        // properly migrated.
+                        _projectStats.Rows.Find(project.Id)!["SyncShouldStayDisabled"] = true;
+                    }
+                    else
+                    {
+                        await SetSyncDisabledUnlessBeganDisabledAsync(sfProjectDoc, syncBeganDisabled, false);
+                    }
+
+                    continue;
+                }
+
+                string sfUserId = "";
+                // Use specific users if requested.
+                bool wasRequested = false;
+                if (sfUsersToUse.ContainsKey(project.Id))
+                {
+                    sfUserId = sfUsersToUse[project.Id];
+                    wasRequested = true;
+                }
+                else
+                {
+                    sfUserId = projectPtRoleUsers.First();
+                }
+
+                Program.Log(
+                    $"sf proj {project.Id}: For SF project, using{(wasRequested ? " requested" : "")} SF user id {sfUserId}."
+                );
+                try
+                {
+                    conn.BeginTransaction();
+                    await ProcessProjectAsync(writeMode, project, sfUserId, conn);
+                    await conn.CommitTransactionAsync();
+                }
+                catch (Exception e)
+                {
+                    _projectStats.Rows.Find(project.Id)!["Error"] = true;
+                    Program.Log(
+                        $"sf proj {project.Id}: Error: Unhandled error while processing project. Rolling back transaction and skipping project. Exception thrown: {e}"
+                    );
+                    conn.RollbackTransaction();
+                    if (writeMode)
+                    {
+                        _projectStats.Rows.Find(project.Id)!["SyncShouldStayDisabled"] = true;
+                    }
+                    else
+                    {
+                        await SetSyncDisabledUnlessBeganDisabledAsync(sfProjectDoc, syncBeganDisabled, false);
+                    }
+                    allSuccess = false;
+                    continue;
+                }
+
+                if (writeMode)
+                {
+                    // Where there were no problems, sync was not already disabled, and we are in write mode and so won't
+                    // re-enable sync in the migrator, mark the project to need sync later re-enabled.
+                    if (!syncBeganDisabled)
+                    {
+                        _projectStats.Rows.Find(project.Id)!["SyncShouldLaterBeReenabled"] = true;
+                    }
+                }
+                else
+                {
+                    // Re-enable sync for project, but only if it was enabled to begin with, and only if we are in
+                    // read-mode.
+                    await SetSyncDisabledUnlessBeganDisabledAsync(sfProjectDoc, syncBeganDisabled, false);
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Program.Log($"Error: Exception thrown: {e}");
+            Program.Log(
+                $"Warning: Migration activity will be printed, but it was not from a successful or complete run."
+            );
+            return false;
+        }
+        finally
+        {
+            ReportStats();
+            conn?.Dispose();
+        }
+
+        return allSuccess;
+    }
+
+    private async Task SetSyncDisabledUnlessBeganDisabledAsync(
+        IDocument<SFProject> sfProjectDoc,
+        bool syncBeganDisabled,
+        bool syncDisabled
+    )
+    {
+        if (syncBeganDisabled)
+        {
+            return;
+        }
+        await SetSyncDisabledAsync(sfProjectDoc, syncDisabled);
+        if (!syncDisabled)
+        {
+            _projectStats.Rows.Find(sfProjectDoc.Id)!["SyncWasReenabled"] = true;
+        }
+    }
+
+    private static async Task SetSyncDisabledAsync(IDocument<SFProject> sfProjectDoc, bool syncDisabled) =>
+        await sfProjectDoc.SubmitJson0OpAsync(opBuilder => opBuilder.Set(proj => proj.SyncDisabled, syncDisabled));
+
+    /// <summary>
+    /// Disposes managed resources.
+    /// </summary>
+    protected override void DisposeManagedResources() { }
+
+    /// <returns>If successful</returns>
+    private async Task ProcessProjectAsync(bool writeMode, SFProject project, string sfUserId, IConnection conn)
+    {
+        UserSecret? userSecret = _userSecretRepo.Query().FirstOrDefault((UserSecret us) => us.Id == sfUserId);
+        if (userSecret == null)
+        {
+            throw new Exception(
+                $"When processing SF project id {project.Id}, could not find user secret for SF user id {sfUserId}."
+            );
+        }
+
+        try
+        {
+            // Manage memory usage somewhat better, by initializing and freeing the comment manager.
+            _paratextService.InitializeCommentManager(userSecret, project.ParatextId);
+
+            // Checkout PT repo at last-sync revision
+            if (project.Sync.SyncedToRepositoryVersion == null)
+            {
+                Program.Log(
+                    $"sf proj {project.Id}: Warning. The SF DB SyncedToRepositoryVersion is null. Maybe this project is being Connected, or has not synced successfully since we started tracking this information. Will be using PT hg repo as it is."
+                );
+                _projectStats.Rows.Find(project.Id)!["NullSyncedToRepositoryVersion"] = true;
+            }
+            else
+            {
+                Program.Log(
+                    $"sf proj {project.Id}: Setting hg repo to last imported hg repo rev of {project.Sync.SyncedToRepositoryVersion}."
+                );
+                _paratextService.SetRepoToRevision(
+                    userSecret,
+                    project.ParatextId,
+                    project.Sync.SyncedToRepositoryVersion
+                );
+            }
+            foreach (TextInfo bookInfo in project.Texts)
+            {
+                await ProcessBookAsync(writeMode, project, userSecret, bookInfo, conn);
+            }
+        }
+        finally
+        {
+            _paratextService.ClearParatextDataCaches(userSecret, project.ParatextId);
+        }
+    }
+
+    /// <returns>If successful</returns>
+    private async Task ProcessBookAsync(
+        bool writeMode,
+        SFProject project,
+        UserSecret userSecret,
+        TextInfo bookInfo,
+        IConnection conn
+    )
+    {
+        string bookText = _paratextService.GetBookText(userSecret, project.ParatextId, bookInfo.BookNum);
+
+        // Parser mechanism from before SF-1444 fix:
+        XDocument oldParser = XDocument.Parse(bookText);
+
+        // Parser mechanism from after SF-1444 fix:
+        string bookUsx = Regex.Replace(bookText, @"^\s*", "", RegexOptions.CultureInvariant);
+        bookUsx = Regex.Replace(bookUsx, @"\r?\n\s*", "", RegexOptions.CultureInvariant);
+        XDocument newParser = XDocument.Parse(bookUsx, LoadOptions.PreserveWhitespace);
+
+        // It might be that using the new parser mechanism will not yield a result that is any different than
+        // the old. If so we don't need to migrate this book.
+        bool oldAndNewAreSame = XNode.DeepEquals(oldParser, newParser);
+        if (oldAndNewAreSame)
+        {
+            Program.Log(
+                $"sf proj {project.Id}: book {bookInfo.BookNum}: Old and new parser outputs match. Not malformed."
+            );
+            return;
+        }
+
+        Program.Log(
+            $"sf proj {project.Id}: book {bookInfo.BookNum}: Old and new parser outputs differ. Malformed text."
+        );
+        _projectStats.Rows.Find(project.Id)!["HasMalformedText"] = true;
+        DisplayXDocumentDiff(oldParser, newParser);
+
+        List<string> allProjectChapterTextDocIds = project
+            .Texts.SelectMany(t => t.Chapters.Select(c => TextData.GetTextDocId(project.Id, t.BookNum, c.Number)))
+            .ToList();
+        IReadOnlyCollection<IDocument<TextData>> textDocsInSFDB = await conn.GetAndFetchDocsAsync<TextData>(
+            allProjectChapterTextDocIds
+        );
+        SortedList<int, IDocument<TextData>> bookChapterTextDocsInSFDB = GetTextDocsForBook(
+            project,
+            bookInfo,
+            textDocsInSFDB
+        );
+        foreach (Chapter chapter in bookInfo.Chapters)
+        {
+            await ProcessChapterAsync(
+                writeMode,
+                project,
+                bookInfo,
+                bookChapterTextDocsInSFDB,
+                chapter,
+                oldParser,
+                newParser
+            );
+        }
+    }
+
+    private async Task ProcessChapterAsync(
+        bool writeMode,
+        SFProject project,
+        TextInfo bookInfo,
+        SortedList<int, IDocument<TextData>> bookChapterTextDocsInSFDB,
+        Chapter chapter,
+        XDocument oldParser,
+        XDocument newParser
+    )
+    {
+        IDocument<TextData> chapterTextDocInSFDB = bookChapterTextDocsInSFDB[chapter.Number];
+        ChapterDelta chapterDeltaInSFDB =
+            new(chapter.Number, chapter.LastVerse, chapter.IsValid, chapterTextDocInSFDB.Data);
+
+        // The chapter text in SF DB came from USX originally, and would have been parsed by the older parsing
+        // method. Has it been untouched since that time?
+        bool sfChapterIsUnchangedFromOlderParserOutput = DoesUsxAlreadyIncorporateChapterDelta(
+            oldParser,
+            chapter.Number,
+            chapterDeltaInSFDB,
+            out _
+        );
+
+        // The chapter text in SF DB could already match how the new parsing method parses the USX. For example,
+        // maybe the migrator was already run on the chapter. Is this so?
+        bool sfChapterAlreadyMatchesNewParser = DoesUsxAlreadyIncorporateChapterDelta(
+            newParser,
+            chapter.Number,
+            chapterDeltaInSFDB,
+            out ChapterDelta chapterDeltaFromNewParseOfUsx
+        );
+
+        if (sfChapterAlreadyMatchesNewParser)
+        {
+            Program.Log(
+                $"sf proj {project.Id}: book {bookInfo.BookNum}: chap {chapter.Number}: Text in SF DB already matches new parser. Skipping."
+            );
+            _problemStats.Rows.Add(project.Id, bookInfo.BookNum, chapter.Number, DirtyStatus.MATCHES_NEW);
+        }
+        else if (sfChapterIsUnchangedFromOlderParserOutput)
+        {
+            Program.Log(
+                $"sf proj {project.Id}: book {bookInfo.BookNum}: chap {chapter.Number}: Text was not modified in SF since import from old parser. {(writeMode ? "Replacing in SF with newly parsed data." : "Not changing, since in read-only mode.")}"
+            );
+            _problemStats.Rows.Add(project.Id, bookInfo.BookNum, chapter.Number, DirtyStatus.CLEAN);
+            Delta patch = chapterTextDocInSFDB.Data.Diff(chapterDeltaFromNewParseOfUsx.Delta);
+            // Program.Log($"sf proj {project.Id}: book {bookInfo.BookNum}: chap {chapter.Number}: patch to fix: {patch}");
+            if (writeMode)
+            {
+                if (patch.Ops.Count > 0)
+                    await chapterTextDocInSFDB.SubmitOpAsync(patch);
+            }
+        }
+        else
+        {
+            // If the chapter text in SF DB has been modified from it's import by an older parsing of the USX,
+            // leave it alone so we don't overwrite any user edits.
+            Program.Log(
+                $"sf proj {project.Id}: book {bookInfo.BookNum}: chap {chapter.Number}: Text was modified in SF since import from old parser. Skipping."
+            );
+            _problemStats.Rows.Add(project.Id, bookInfo.BookNum, chapter.Number, DirtyStatus.DIRTY);
+        }
+    }
+
+    /// <summary>
+    /// Determine if USX already matches a specific chapter delta's content. In other words, does
+    /// chapter <paramref name="chapterNumber"/> in <paramref name="usx"/> already match
+    /// <paramref name="someChapterDelta"/>? Returns the comparison result.
+    /// Also, chapter <paramref name="chapterNumber"/> in <paramref name="usx"/> is returned as
+    /// <paramref name="specifiedChapterDeltaFromUsx"/>.
+    /// </summary>
+    /// Implementation notes:
+    /// ToUsx expects that the chapterdeltas passed to it will have a count that matches the usx chapters. So we can't
+    /// just pass the single chapterdelta that we want to use. Instead, pass a chapterdelta set that has the data
+    /// from the USX, except that a single chapterdelta will be replaced with the chapterdelta we wanted to use.
+    private bool DoesUsxAlreadyIncorporateChapterDelta(
+        XDocument usx,
+        int chapterNumber,
+        ChapterDelta someChapterDelta,
+        out ChapterDelta specifiedChapterDeltaFromUsx
+    )
+    {
+        // Get a set of chapter deltas that correspond to the usx input.
+        Dictionary<int, ChapterDelta> chapterDeltas = _deltaUsxMapper
+            .ToChapterDeltas(usx)
+            .ToDictionary(cd => cd.Number);
+
+        try
+        {
+            // Before we try something new, can we even round-trip the existing data?
+            XDocument usxWithOUTChapterModification = _deltaUsxMapper.ToUsx(usx, chapterDeltas.Values.ToArray());
+        }
+        catch
+        {
+            Program.Log(
+                $"When processing chapter {chapterNumber}, we couldn't roundtrip with DeltaUsxMapper, before checking if the USX already incorporates a different chapter delta. Cannot migrate project. Rethrowing."
+            );
+            throw;
+        }
+
+        // Overwrite one of the chapters with a replacement. But return the original chapter delta that we are
+        // overwriting.
+        specifiedChapterDeltaFromUsx = chapterDeltas[chapterNumber];
+        chapterDeltas[chapterNumber] = someChapterDelta;
+        XDocument usxWithChapterModification = _deltaUsxMapper.ToUsx(usx, chapterDeltas.Values.ToArray());
+        bool usxAlreadyIncorporatesSpecifiedChapterData = XNode.DeepEquals(usx, usxWithChapterModification);
+        return usxAlreadyIncorporatesSpecifiedChapterData;
+    }
+
+    /// <summary>
+    /// Gets the text docs from <see cref="docs"/> for the book specified in <see cref="text"/>.
+    /// </summary>
+    /// cf. ParatextSyncRunner.GetTextDocsForBook.
+    private static SortedList<int, IDocument<TextData>> GetTextDocsForBook(
+        SFProject project,
+        TextInfo text,
+        IReadOnlyCollection<IDocument<TextData>> docs
+    )
+    {
+        var textDocs = new SortedList<int, IDocument<TextData>>(text.Chapters.Count);
+        foreach (Chapter chapter in text.Chapters)
+        {
+            IDocument<TextData>? textDoc = docs.FirstOrDefault(
+                d => d.Id == TextData.GetTextDocId(project.Id, text.BookNum, chapter.Number)
+            );
+            if (textDoc is not null)
+            {
+                textDocs[chapter.Number] = textDoc;
+            }
+        }
+
+        return textDocs;
+    }
+
+    private void ReportStats()
+    {
+        Program.Log(
+            $"Stats: Chapters with malformed text are as follows. Anything not listed was not found to be malformed."
+        );
+        var projectGroups = _problemStats
+            .AsEnumerable()
+            .GroupBy(
+                row =>
+                    new
+                    {
+                        SFProjectId = row.Field<string>("SFProjectId"),
+                        DirtyStatus = row.Field<DirtyStatus>("DirtyStatus")
+                    }
+            )
+            .OrderBy(group => group.Key.SFProjectId);
+
+        foreach (var projectGroup in projectGroups)
+        {
+            string description = string.Empty;
+            switch (projectGroup.Key.DirtyStatus)
+            {
+                case DirtyStatus.CLEAN:
+                    description = "was not user-modified";
+                    break;
+                case DirtyStatus.DIRTY:
+                    description = "was user-modified";
+                    break;
+                case DirtyStatus.MATCHES_NEW:
+                    description = "already matches new parser";
+                    break;
+                default:
+                    break;
+            }
+
+            Program.Log($"Stats: SFProjectId: {projectGroup.Key.SFProjectId}, Chap {description}.");
+
+            var bookGroups = projectGroup.GroupBy(row => row.Field<int>("Book"));
+
+            foreach (var bookGroup in bookGroups)
+            {
+                Program.Log($"Stats: - Book: {bookGroup.Key}");
+
+                var chapterNumbers = bookGroup
+                    .Select(row => row.Field<int>("Chapter"))
+                    .OrderBy(chapterNumber => chapterNumber);
+
+                Program.Log($"Stats: - Chapters: " + string.Join(", ", chapterNumbers));
+            }
+        }
+
+        Program.Log($"Stats: Projects processed: {_projectStats.Rows.Count}");
+        Program.Log($"Stats: Projects stopped at NotLoad: {_projectStats.Select("NotLoad = true").Length}");
+        Program.Log($"Stats: Projects stopped at IsResource: {_projectStats.Select("IsResource = true").Length}");
+        IEnumerable<string?> projectsNoUser = _projectStats
+            .Select("NoAdequateUser = true")
+            .Select((DataRow row) => row["SFProjectID"].ToString());
+        Program.Log($"Stats: Projects stopped at NoAdequateUser: {projectsNoUser.Count()}");
+        Program.Log(
+            $"Stats: Projects with NullSyncedToRepositoryVersion: {_projectStats.Select("NullSyncedToRepositoryVersion = true").Length}"
+        );
+        IEnumerable<string?> projectsWithNeed = _projectStats
+            .Select("HasMalformedText = true")
+            .Select((DataRow row) => row["SFProjectID"].ToString());
+        Program.Log($"Stats: Projects with HasMalformedText: {projectsWithNeed.Count()}");
+        IEnumerable<string?> projectsWithError = _projectStats
+            .Select("Error = true")
+            .Select((DataRow row) => row["SFProjectID"].ToString());
+        Program.Log($"Stats: Projects with Error: {projectsWithError.Count()}");
+        IEnumerable<string?> projectsWithNotLoad = _projectStats
+            .Select("NotLoad = true")
+            .Select((DataRow row) => row["SFProjectID"].ToString());
+        Program.Log($"Stats: Projects with NotLoad: {projectsWithNotLoad.Count()}");
+        IEnumerable<string?> projectsWithBusySyncing = _projectStats
+            .Select("BusySyncing = true")
+            .Select((DataRow row) => row["SFProjectID"].ToString());
+        Program.Log($"Stats: Projects with BusySyncing: {projectsWithBusySyncing.Count()}");
+
+        Dictionary<DirtyStatus, int> chapterCounts = _problemStats
+            .AsEnumerable()
+            .GroupBy(row => row.Field<DirtyStatus>("DirtyStatus"))
+            .ToDictionary(group => group.Key, group => group.Count());
+
+        int cleanChaptersCount = chapterCounts.GetValueOrDefault(DirtyStatus.CLEAN);
+        int dirtyChaptersCount = chapterCounts.GetValueOrDefault(DirtyStatus.DIRTY);
+        int matchesNewChaptersCount = chapterCounts.GetValueOrDefault(DirtyStatus.MATCHES_NEW);
+
+        Program.Log(
+            $"Stats: Total malformed chapters: {cleanChaptersCount} not user-modified, {dirtyChaptersCount} user-modified, {matchesNewChaptersCount} already matches new parser."
+        );
+
+        IEnumerable<string?> projectsUnprocessable = projectsNoUser
+            .Concat(projectsWithError)
+            .Concat(projectsWithNotLoad);
+        Program.Log(
+            $"Stats: The following non-resource projects could not be fully processed ({projectsUnprocessable.Count()}): {string.Join(" ", projectsUnprocessable)}"
+        );
+        Program.Log(
+            $"Stats: The following projects need or needed migrated, based on parser comparison alone (not what was in SF DB) ({projectsWithNeed.Count()}): {string.Join(" ", projectsWithNeed)}"
+        );
+
+        IEnumerable<string?> projectsSyncWasAlreadyDisabled = _projectStats
+            .Select("SyncWasAlreadyDisabled = true")
+            .Select((DataRow row) => row["SFProjectID"].ToString());
+        Program.Log(
+            $"Stats: Projects that had sync already disabled ({projectsSyncWasAlreadyDisabled.Count()}): {string.Join(" ", projectsSyncWasAlreadyDisabled)}"
+        );
+
+        IEnumerable<string?> projectsShouldStayDisabled = _projectStats
+            .Select("SyncShouldStayDisabled = true")
+            .Select((DataRow row) => row["SFProjectID"].ToString());
+        Program.Log(
+            $"Stats: Projects that newly have sync disabled and should be left that way ({projectsShouldStayDisabled.Count()}): {string.Join(" ", projectsShouldStayDisabled)}"
+        );
+
+        IEnumerable<string?> projectsShouldLaterBeReenabled = _projectStats
+            .Select("SyncShouldLaterBeReenabled = true")
+            .Select((DataRow row) => row["SFProjectID"].ToString());
+        Program.Log(
+            $"Stats: Projects that should have sync re-enabled after applying SF-1444 fix ({projectsShouldLaterBeReenabled.Count()}): {string.Join(" ", projectsShouldLaterBeReenabled)}"
+        );
+
+        IEnumerable<string?> projectsSyncWasReenabled = _projectStats
+            .Select("SyncWasReenabled = true")
+            .Select((DataRow row) => row["SFProjectID"].ToString());
+        Program.Log(
+            $"Stats: Projects that had sync re-enabled ({projectsSyncWasReenabled.Count()}): {string.Join(" ", projectsSyncWasReenabled)}"
+        );
+    }
+
+    /// <summary>
+    /// XDocument.ToString() sometimes pretty-prints the output, such as with indentation that is not from actual
+    /// text nodes in the document. Conversely, this method returns a string representation of an XDocument without
+    /// formatting, which can be useful when paying attention to what whitespace is really in the XDocument.
+    /// </summary>
+    public static string XDocumentToStringUnformatted(XDocument inputUsx)
+    {
+        using MemoryStream stream = new();
+        inputUsx.Save(stream, SaveOptions.DisableFormatting);
+        byte[] rawBytes = stream.ToArray();
+        string usx = System.Text.Encoding.UTF8.GetString(rawBytes);
+        // The usx element starts after a BOM and xml declaration.
+        string endOfDeclaration = "?>";
+        int start = usx.IndexOf(endOfDeclaration) + endOfDeclaration.Length;
+        usx = usx[start..];
+        return usx;
+    }
+
+    private static void DisplayXDocumentDiff(XDocument fromOldParser, XDocument fromNewParser)
+    {
+        const char spaceRepresentation = '\u23b5';
+        string oldParserResult = XDocumentToStringUnformatted(fromOldParser)
+            .Replace("<verse", "\n<verse")
+            .Replace(' ', spaceRepresentation);
+
+        string newParserResult = XDocumentToStringUnformatted(fromNewParser)
+            .Replace("<verse", "\n<verse")
+            .Replace(' ', spaceRepresentation);
+
+        string oldWithoutTrailingSpaces = oldParserResult.Replace($"{spaceRepresentation}\n", "\n");
+        string newWithoutTrailingSpaces = newParserResult.Replace($"{spaceRepresentation}\n", "\n");
+
+        bool onlyAdditionOfSingleTrailingSpaces = oldWithoutTrailingSpaces == newWithoutTrailingSpaces;
+
+        if (onlyAdditionOfSingleTrailingSpaces)
+        {
+            Program.Log(
+                $"Note: The new parser output only differs from the old parser output by the addition or removal of single trailing spaces. (A)"
+            );
+            // Don't bother showing diff.
+            return;
+        }
+
+        bool orOnlyInsertionOfSingleSpaceBetweenElements =
+            oldWithoutTrailingSpaces.Replace($">{spaceRepresentation}<", "><")
+            == newWithoutTrailingSpaces.Replace($">{spaceRepresentation}<", "><");
+        if (orOnlyInsertionOfSingleSpaceBetweenElements)
+        {
+            Program.Log(
+                $"Note: The new parser output only differs from the old parser output by the insertion or removal of single spaces between elements, or single trailing spaces. (B)"
+            );
+        }
+        else
+        {
+            Program.Log(
+                $"Note: The new parser output differs from the old parser output by more than just the addition or removal of single trailing spaces or single spaces between elements. (C)"
+            );
+        }
+
+        Program.Log($"Difference between old parser output and new parser output:");
+
+        DiffPaneModel diff = InlineDiffBuilder.Diff(oldParserResult, newParserResult, ignoreWhiteSpace: false);
+
+        foreach (DiffPiece line in diff.Lines)
+        {
+            switch (line.Type)
+            {
+                case DiffPlex.DiffBuilder.Model.ChangeType.Deleted:
+                    Console.WriteLine("-" + line.Text);
+                    break;
+                case DiffPlex.DiffBuilder.Model.ChangeType.Inserted:
+                    Console.WriteLine("+" + line.Text);
+                    break;
+                case DiffPlex.DiffBuilder.Model.ChangeType.Unchanged:
+                    break;
+                default:
+                    Console.WriteLine($"A difference line was of an unexpected type ({line.Type}): {line.Text}");
+                    break;
+            }
+        }
+    }
+}

--- a/src/Migrations/WhitespaceRestoreMigration/Program.cs
+++ b/src/Migrations/WhitespaceRestoreMigration/Program.cs
@@ -1,0 +1,173 @@
+using System.Net;
+using System.Reflection;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using SIL.XForge.Scripture.Services;
+
+namespace WhitespaceRestoreMigration;
+
+/// <summary>
+/// SF-1444 fixes a bug where whitespace is lost when importing PT data into SF. But before the bug was fixed, past data
+/// may have been imported with spaces lost. This migrator is to detect and fix those situations, where possible, by
+/// re-writing the data in SF to retain those spaces.
+///
+/// To use the migrator and apply SF-1444, first run the migrator, which will migrate data and lock all projects. Then
+/// release the SF-1444 fix. Then unlock all migrated projects (and leave projects locked that were unable to be
+/// migrated for whatever reason. They should not sync until migrated so they do not push bad changes back to Paratext
+/// Archives.)
+///
+/// Scripture Forge must be running in order to run this migrator, which uses the existing realtime server. Note that
+/// "read" mode only doesn't write a migration. It does touch the local hg repo, and even temporarily disable sync on
+/// projects.
+///
+/// Usage: cd bin/Debug/net6.0; ASPNETCORE_ENVIRONMENT=Development ./WhitespaceRestoreMigration read
+/// ../../../../../SIL.XForge.Scripture
+///
+/// Usage on server: export SF_APP_DIR=/path/to/sf/app; sudo --user $(stat --format='%G' "${SF_APP_DIR}")
+/// ASPNETCORE_ENVIRONMENT=DevelopmentORStagingORProduction time ./WhitespaceRestoreMigration read "${SF_APP_DIR}" |&
+/// tee ~/output-WhitespaceRestoreMigration-$(date '+%Y%m%d-%H%M%S').txt
+/// </summary>
+public class Program
+{
+    /// <summary>
+    /// Gets a value indicating whether to disable realtime server migrations.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if realtime server migrations are disabled; otherwise, <c>false</c>.
+    /// </value>
+    /// <remarks>
+    /// This exists for the <see cref="Startup" /> class to retrieve this value.
+    /// </remarks>
+    public static bool RealtimeServerMigrationsDisabled { get; private set; }
+
+    /// <summary>
+    /// Defines the entry point of the application.
+    /// </summary>
+    /// <param name="args">Application arguments.</param>
+    public static async Task Main(string[] args)
+    {
+        string usage = "Arg 1 must be 'read', 'write', or 'list-projects'. Arg 2 must be the path to the SF app dir.";
+        if (args.Length < 2)
+            throw new Exception($"Error: Missing required arguments. {usage}");
+        bool writeMode;
+        bool listProjectsMode = false;
+        if (args[0] == "read")
+            writeMode = false;
+        else if (args[0] == "write")
+            writeMode = true;
+        else if (args[0] == "list-projects")
+        {
+            writeMode = false;
+            listProjectsMode = true;
+        }
+        else
+            throw new Exception($"Error: {usage}");
+        string sfAppDir = args[1];
+
+        RealtimeServerMigrationsDisabled = !writeMode;
+        string? aspNetCoreEnv = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        if (aspNetCoreEnv == null)
+            throw new Exception($"Refusing to run unless ASPNETCORE_ENVIRONMENT is specified.");
+        Log($"Operating as ASPNETCORE_ENVIRONMENT {aspNetCoreEnv}.");
+
+        // Space-delimited set of SF project ids, to optionally specify a subset of projects to process.
+        string? sfProjectIdsSubset = Environment.GetEnvironmentVariable("SF_PROJECT_SET");
+        // Space-delimited set of projects and users, to optionally specify that a specific user be used when
+        // processing a given project. Specify each project and user pair as the SF project id, colon, SF user id.
+        string? sfUserRequestValues = Environment.GetEnvironmentVariable("SF_PROJECT_USERS");
+
+        Log($"Running in {(writeMode ? "write mode." : "read mode.")}");
+
+        // Set up the web host.
+        Log("Starting Scripture Forge Server...");
+        Directory.SetCurrentDirectory(sfAppDir);
+        IWebHostBuilder builder = CreateWebHostBuilder(args);
+        IWebHost webHost = builder.Build();
+        try
+        {
+            await webHost.StartAsync();
+        }
+        catch (HttpRequestException)
+        {
+            Log("There was an error starting the program before getting to the migration" + " part. Rethrowing.");
+            throw;
+        }
+
+        // Get the project IDs and user IDs, if they were set in the environment variables
+        string[] sfProjectIdsToMigrate = sfProjectIdsSubset?.Split(' ') ?? Array.Empty<string>();
+        Dictionary<string, string> sfUsersToUse = new Dictionary<string, string>();
+        foreach (string sfUserRequest in sfUserRequestValues?.Split(' ') ?? Array.Empty<string>())
+        {
+            string[] request = sfUserRequest.Split(':');
+            sfUsersToUse.Add(request[0], request[1]);
+        }
+
+        // Migrate projects
+        var migrator = webHost.Services.GetService<Migrator>();
+        bool success = await migrator!.MigrateAsync(writeMode, listProjectsMode, sfProjectIdsToMigrate, sfUsersToUse);
+
+        // Stop the web host.
+        Log("Stopping Scripture Forge Server...");
+        await webHost.StopAsync();
+
+        Log(success ? "Finished Migration." : "Migration Failed.");
+    }
+
+    internal static void Log(string message)
+    {
+        string when = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+        Console.WriteLine($"{when} Migration: {message}");
+    }
+
+    private static IWebHostBuilder CreateWebHostBuilder(string[] args)
+    {
+        IWebHostBuilder builder = WebHost.CreateDefaultBuilder(args);
+
+        // Secrets to connect to PT web API are associated with the SIL.XForge.Scripture assembly
+        var sfAssembly = Assembly.GetAssembly(typeof(ParatextService));
+
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddUserSecrets(sfAssembly)
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .Build();
+
+        // Random, big number.
+        int migratorDotnetPort = 39570;
+
+        return builder
+            .ConfigureAppConfiguration(
+                (context, config) =>
+                {
+                    IWebHostEnvironment env = context.HostingEnvironment;
+                    if (env.IsDevelopment() || env.IsEnvironment("Testing"))
+                    {
+                        config.AddJsonFile("appsettings.user.json", true);
+                    }
+                    else
+                    {
+                        config.AddJsonFile("secrets.json", true, true);
+                    }
+
+                    if (env.IsEnvironment("Testing"))
+                    {
+                        Assembly appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
+                        config.AddUserSecrets(appAssembly, true);
+                    }
+
+                    config.AddEnvironmentVariables();
+                }
+            )
+            .UseConfiguration(configuration)
+            .ConfigureKestrel(
+                options =>
+                    // Listen to a different port than the default. Then it won't have a
+                    // conflict if SF is running. And specific, rather than just available, to
+                    // make sure we really won't be handling user requests.
+                    options.Listen(IPAddress.Loopback, migratorDotnetPort)
+            )
+            .UseStartup<Startup>();
+    }
+}

--- a/src/Migrations/WhitespaceRestoreMigration/Properties/launchSettings.json
+++ b/src/Migrations/WhitespaceRestoreMigration/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "WhitespaceRestoreMigration": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Migrations/WhitespaceRestoreMigration/Startup.cs
+++ b/src/Migrations/WhitespaceRestoreMigration/Startup.cs
@@ -1,0 +1,95 @@
+using System.Globalization;
+using Autofac;
+using Autofac.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using SIL.XForge.Configuration;
+using SIL.XForge.Scripture;
+
+namespace WhitespaceRestoreMigration;
+
+/// <summary>
+/// Configurations and services needed to bootstrap the migration app.
+/// This was copied and modified from `SIL.XForge.Scripture/Startup.cs`.
+/// </summary>
+public class Startup
+{
+    public Startup(IConfiguration configuration, IWebHostEnvironment env, ILoggerFactory loggerFactory)
+    {
+        Configuration = configuration;
+        Configuration["Realtime:DocumentCacheDisabled"] = "true";
+        Environment = env;
+        LoggerFactory = loggerFactory;
+    }
+
+    public IConfiguration Configuration { get; }
+
+    public IWebHostEnvironment Environment { get; }
+
+    public ILoggerFactory LoggerFactory { get; }
+
+    public IContainer? ApplicationContainer { get; private set; }
+
+    /// <summary>
+    /// Configures the services.
+    /// </summary>
+    /// <param name="services">The services.</param>
+    /// <returns>The service provider.</returns>
+    public IServiceProvider ConfigureServices(IServiceCollection services)
+    {
+        var containerBuilder = new ContainerBuilder();
+
+        services.AddExceptionReporting(Configuration);
+        services.AddConfiguration(Configuration);
+        services.AddSFRealtimeServer(
+            LoggerFactory,
+            Configuration,
+            nodeOptions: null,
+            Program.RealtimeServerMigrationsDisabled,
+            useExistingRealtimeServer: true
+        );
+        services.AddSFServices();
+        services.AddSFDataAccess(Configuration);
+        services.Configure<RequestLocalizationOptions>(opts =>
+        {
+            var supportedCultures = new List<CultureInfo>();
+            foreach (var culture in SharedResource.Cultures)
+            {
+                supportedCultures.Add(new CultureInfo(culture.Key));
+            }
+
+            opts.DefaultRequestCulture = new RequestCulture("en");
+            // Formatting numbers, dates, etc.
+            opts.SupportedCultures = supportedCultures;
+            // UI strings that we localized.
+            opts.SupportedUICultures = supportedCultures;
+        });
+        services.AddLocalization(options => options.ResourcesPath = "Resources");
+        services.AddSFMachine(Configuration, Environment);
+
+        services.AddSingleton<Migrator>();
+
+        containerBuilder.Populate(services);
+        ApplicationContainer = containerBuilder.Build();
+        return new AutofacServiceProvider(ApplicationContainer);
+    }
+
+    /// <summary>
+    /// Configures the specified application.
+    /// </summary>
+    /// <param name="app">The application.</param>
+    /// <param name="appLifetime">The application lifetime.</param>
+    public void Configure(IApplicationBuilder app, IHostApplicationLifetime appLifetime)
+    {
+        Program.Log(@"Configuring app");
+        app.UseSFDataAccess();
+        app.UseSFServices();
+        app.UseMachine();
+        appLifetime.ApplicationStopped.Register(() => ApplicationContainer?.Dispose());
+    }
+}

--- a/src/Migrations/WhitespaceRestoreMigration/WhitespaceRestoreMigration.csproj
+++ b/src/Migrations/WhitespaceRestoreMigration/WhitespaceRestoreMigration.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\SIL.XForge.Scripture\SIL.XForge.Scripture.csproj" />
+    <ProjectReference Include="..\..\SIL.XForge\SIL.XForge.csproj" />
+    <PackageReference Include="DiffPlex" Version="1.7.2" />
+
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="process-by-chunk">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/src/Migrations/WhitespaceRestoreMigration/WhitespaceRestoreMigration.sln
+++ b/src/Migrations/WhitespaceRestoreMigration/WhitespaceRestoreMigration.sln
@@ -1,0 +1,42 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33205.214
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WhitespaceRestoreMigration", "WhitespaceRestoreMigration.csproj", "{FCE29858-6EF8-46CF-AB9A-390DA472F53E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIL.XForge", "..\..\SIL.XForge\SIL.XForge.csproj", "{665D56C2-6609-4477-91D0-16590AAEDDFD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIL.XForge.Scripture", "..\..\SIL.XForge.Scripture\SIL.XForge.Scripture.csproj", "{13D18568-D56E-4D4F-86C4-038DF06BBDDA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A3FFEBCE-071C-4FD7-BB5E-878802CA5302}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\..\.editorconfig = ..\..\..\.editorconfig
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FCE29858-6EF8-46CF-AB9A-390DA472F53E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FCE29858-6EF8-46CF-AB9A-390DA472F53E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FCE29858-6EF8-46CF-AB9A-390DA472F53E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FCE29858-6EF8-46CF-AB9A-390DA472F53E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{665D56C2-6609-4477-91D0-16590AAEDDFD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{665D56C2-6609-4477-91D0-16590AAEDDFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{665D56C2-6609-4477-91D0-16590AAEDDFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{665D56C2-6609-4477-91D0-16590AAEDDFD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{13D18568-D56E-4D4F-86C4-038DF06BBDDA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{13D18568-D56E-4D4F-86C4-038DF06BBDDA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{13D18568-D56E-4D4F-86C4-038DF06BBDDA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{13D18568-D56E-4D4F-86C4-038DF06BBDDA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EA40286F-FC4B-496F-B8D1-BC03011F6392}
+	EndGlobalSection
+EndGlobal

--- a/src/Migrations/WhitespaceRestoreMigration/build-production
+++ b/src/Migrations/WhitespaceRestoreMigration/build-production
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Build for running on another computer.
+# Usage: ./build-production
+
+set -u
+
+scriptDir="$(dirname "$0")"
+cd "${scriptDir}"
+# Derive the name of the program from the name of the directory of the script.
+programName="$(basename "$(pwd)")"
+outputProductName="${programName}"
+outputDir="bin/${outputProductName}"
+
+if ! grep 'RuntimeIdentifier' ../../SIL.XForge.Scripture/SIL.XForge.Scripture.csproj >/dev/null; then
+  echo "Adding '<RuntimeIdentifier>linux-x64</RuntimeIdentifier>' to ../../SIL.XForge.Scripture/SIL.XForge.Scripture.csproj ."
+  perl -pi -e 's#</TargetFramework>#</TargetFramework>\n    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>#' ../../SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+fi
+
+dotnet publish --runtime "linux-x64" --self-contained true --output "${outputDir}" || echo "Warning: Non-zero exit code."
+ls -ld "${outputDir}"

--- a/src/Migrations/WhitespaceRestoreMigration/process-by-chunk
+++ b/src/Migrations/WhitespaceRestoreMigration/process-by-chunk
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -ueo pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") "'--chunk-size=5 --command="echo Processing chunk: \${chunk}" --ids="1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20"'
+  exit 1
+}
+
+chunk_size=""
+ids=""
+command=""
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --chunk-size=*)
+      chunk_size="${1#*=}"
+      shift 1
+      ;;
+    --command=*)
+      command="${1#*=}"
+      shift 1
+      ;;
+    --ids=*)
+      ids="${1#*=}"
+      shift 1
+      ;;
+    *)
+      echo "Invalid argument: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Check if required arguments are provided
+if [[ -z "$ids" ]]; then
+  echo "Missing argument: --ids"
+  usage
+fi
+
+if [[ -z "$command" ]]; then
+  echo "Missing argument: --command"
+  usage
+fi
+
+if [[ -z "$chunk_size" ]]; then
+  echo "Missing argument: --chunk-size"
+  usage
+fi
+
+# Split the space-delimited IDs into an array
+id_array=($ids)
+
+total_ids=${#id_array[@]}
+start_index=0
+
+# Process the IDs in chunks of size 'chunk_size'
+while [[ $start_index -lt $total_ids ]]; do
+  end_index=$((start_index + chunk_size - 1))
+  # Ensure the end index doesn't exceed the total number of IDs
+  if [[ $end_index -ge $total_ids ]]; then
+    end_index=$((total_ids - 1))
+  fi
+
+  # Extract the chunk of IDs
+  chunk="${id_array[@]:start_index:end_index-start_index+1}"
+
+  # Execute the command for the chunk
+  eval "$command"
+
+  # Move the start index to the next chunk
+  start_index=$((end_index + 1))
+done

--- a/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
@@ -489,8 +489,8 @@ public class DeltaUsxMapper : IDeltaUsxMapper
 
     /// <summary>
     /// It may be that this method is taking USX, leaving alone all chapters not specified and valid in
-    /// chapterDeltas, and then replacing all chapters in the USX, that are in chapterDeltas and valid, with
-    /// the data from the chapterDeltas.
+    /// chapterDeltas, leaving alone most chapters not already present in oldUsxDoc, and then replacing
+    /// all chapters in the USX, that are in chapterDeltas and valid, with the data from the chapterDeltas.
     /// </summary>
     public XDocument ToUsx(XDocument oldUsxDoc, IEnumerable<ChapterDelta> chapterDeltas)
     {

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1086,6 +1086,8 @@ public class ParatextService : DisposableBase, IParatextService
                 out string usfm
             );
             log.AppendLine($"Created usfm of {usfm}");
+            // Among other things, normalizing the USFM will remove trailing spaces at the end of verses,
+            // which may cause some churn. This is similar to running "Standardize whitespace" in Paratext.
             usfm = UsfmToken.NormalizeUsfm(scrText.ScrStylesheet(bookNum), usfm, false, scrText.RightToLeft, scrText);
             log.AppendLine($"Normalized usfm to {usfm}");
 


### PR DESCRIPTION
Getting book USX from Paratext and then using XDocument.Parse()
produces an XDocument for further processing. Sometimes important
whitespace can be lost when doing this, such as the space between
`<char>In</char> <char>the</char>`.

Manually pre-process the whitespace, and ask XDocument.Parse() to
preserve the whitespace it is given.


Before this change:

![image](https://user-images.githubusercontent.com/7265309/228052491-5f325f9f-d3bf-4572-8c6f-744b91bcdf26.png)

With this change:

![image](https://user-images.githubusercontent.com/7265309/228052553-0b55fb17-80d0-437e-9c05-379e3bcdf8cc.png)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1764)
<!-- Reviewable:end -->
