### PR TITLE
SF-1923 Use bottom sheet for commenters to add new notes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -113,12 +113,24 @@
             (showChange)="showSuggestions = $event"
           ></app-suggestions>
           <ng-template #fabBottomSheet>
-            <div class="fab-bottom-sheet">
+            <div class="fab-bottom-sheet" [dir]="direction">
               <b>{{ currentSegmentReference }}</b>
-              <button mat-flat-button (click)="insertNote()" color="accent">
+              <button *ngIf="!addingMobileNote" mat-flat-button (click)="toggleAddingMobileNote()" color="accent">
                 <mat-icon>add_comment</mat-icon>
                 {{ t("add_comment") }}
               </button>
+              <form *ngIf="addingMobileNote">
+                <mat-form-field class="full-width" appearance="outline">
+                  <mat-label>{{ t("your_comment") }}</mat-label>
+                  <textarea #mobileNoteTextarea matInput [formControl]="mobileNoteControl"></textarea>
+                </mat-form-field>
+                <div class="fab-action-buttons">
+                  <button mat-button class="close-button" (click)="toggleAddingMobileNote()">{{ t("cancel") }}</button>
+                  <button mat-flat-button class="save-button" color="primary" (click)="saveMobileNote()">
+                    {{ t("save") }}
+                  </button>
+                </div>
+              </form>
             </div>
           </ng-template>
           <div *ngIf="canInsertNote" #fabButton class="insert-note-fab" [style.left]="insertNoteFabLeft">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -115,7 +115,12 @@
           <ng-template #fabBottomSheet>
             <div class="fab-bottom-sheet" [dir]="direction">
               <b>{{ currentSegmentReference }}</b>
-              <button *ngIf="!addingMobileNote" mat-flat-button (click)="toggleAddingMobileNote()" color="accent">
+              <button
+                *ngIf="!addingMobileNote && !hasEditRight"
+                mat-flat-button
+                (click)="toggleAddingMobileNote()"
+                color="accent"
+              >
                 <mat-icon>add_comment</mat-icon>
                 {{ t("add_comment") }}
               </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -117,4 +117,11 @@ app-text {
     display: block;
     margin-bottom: 10px;
   }
+  mat-form-field {
+    width: 100%;
+  }
+  .fab-action-buttons {
+    display: flex;
+    justify-content: flex-end;
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2590,6 +2590,31 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('shows fab for users with editing rights but uses bottom sheet for adding new notes on mobile viewport', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig({ selectedBookNum: 40, selectedChapterNum: 1, selectedSegment: 'verse_1_1' });
+      env.setCurrentUser('user04');
+      env.wait();
+
+      // Allow check for mobile viewports to return TRUE
+      when(mockedMediaObserver.isActive(anything())).thenReturn(true);
+      let verseSegment: HTMLElement = env.getSegmentElement('verse_1_2')!;
+      verseSegment.click();
+      env.wait();
+      expect(env.insertNoteFabMobile).toBeFalsy();
+      expect(env.insertNoteFab).toBeTruthy();
+      env.insertNoteFab.nativeElement.click();
+      env.wait();
+      expect(env.mobileNoteTextArea).toBeTruthy();
+      verify(mockedMatDialog.open(NoteDialogComponent, anything())).never();
+      // Close the bottom sheet
+      verseSegment = env.getSegmentElement('verse_1_2')!;
+      verseSegment.click();
+      env.wait();
+
+      env.dispose();
+    }));
+
     it('can open insert note dialog on default verse', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2578,7 +2578,7 @@ describe('EditorComponent', () => {
       env.insertNoteFabMobile!.click();
       env.wait();
       env.component.mobileNoteControl.setValue(content);
-      env.saveMobileNote!.click();
+      env.saveMobileNoteButton!.click();
       env.wait();
       const [, noteThread] = capture(mockedSFProjectService.createNoteThread).last();
       expect(noteThread.verseRef).toEqual(fromVerseRef(verseRef));
@@ -3384,7 +3384,7 @@ class TestEnvironment {
     return document.querySelector('.fab-bottom-sheet form textarea');
   }
 
-  get saveMobileNote(): HTMLButtonElement | null {
+  get saveMobileNoteButton(): HTMLButtonElement | null {
     return document.querySelector('.fab-bottom-sheet .save-button');
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -890,7 +890,7 @@ describe('EditorComponent', () => {
       expect(env.component.sourceLabel).toEqual('SRC');
       expect(env.component.targetLabel).toEqual('TRG');
       expect(env.component.target!.segmentRef).toEqual('');
-      var selection = env.targetEditor.getSelection();
+      let selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
       expect(env.component.canEdit).toBe(true);
       expect(env.isSourceAreaHidden).toBe(true);
@@ -2558,6 +2558,37 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('shows insert new note from mobile viewport', fakeAsync(() => {
+      const content: string = 'content in the thread';
+      const userId: string = 'user05';
+      const segmentRef: string = 'verse_1_2';
+      const verseRef: VerseRef = new VerseRef('MAT', 1, '2');
+      const env = new TestEnvironment();
+      env.setProjectUserConfig({
+        selectedBookNum: verseRef.bookNum,
+        selectedChapterNum: verseRef.chapterNum,
+        selectedSegment: 'verse_1_3'
+      });
+      env.setCurrentUser(userId);
+      env.wait();
+
+      // Allow check for mobile viewports to return TRUE
+      when(mockedMediaObserver.isActive(anything())).thenReturn(true);
+      env.clickSegmentRef(segmentRef);
+      env.insertNoteFabMobile!.click();
+      env.wait();
+      env.component.mobileNoteControl.setValue(content);
+      env.saveMobileNote!.click();
+      env.wait();
+      const [, noteThread] = capture(mockedSFProjectService.createNoteThread).last();
+      expect(noteThread.verseRef).toEqual(fromVerseRef(verseRef));
+      expect(noteThread.publishedToSF).toBe(true);
+      expect(noteThread.notes[0].ownerRef).toEqual(userId);
+      expect(noteThread.notes[0].content).toEqual(content);
+
+      env.dispose();
+    }));
+
     it('can open insert note dialog on default verse', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
@@ -3353,6 +3384,10 @@ class TestEnvironment {
     return document.querySelector('.fab-bottom-sheet form textarea');
   }
 
+  get saveMobileNote(): HTMLButtonElement | null {
+    return document.querySelector('.fab-bottom-sheet .save-button');
+  }
+
   get sharingButton(): DebugElement {
     return this.fixture.debugElement.query(By.css('app-share-button'));
   }
@@ -3416,6 +3451,12 @@ class TestEnvironment {
   set onlineStatus(value: boolean) {
     when(mockedPwaService.isOnline).thenReturn(value);
     when(mockedPwaService.onlineStatus$).thenReturn(of(value));
+  }
+
+  clickSegmentRef(segmentRef: string): void {
+    const range = this.component.target!.getSegmentRange(segmentRef);
+    this.targetEditor.setSelection(range!.index, 0, 'user');
+    this.getSegmentElement(segmentRef)!.click();
   }
 
   deleteText(textId: string): void {
@@ -3591,8 +3632,7 @@ class TestEnvironment {
 
   setSelectionAndInsertNote(segmentRef: string | undefined): void {
     if (segmentRef != null) {
-      this.getSegmentElement(segmentRef)!.click();
-      this.component.target!.segmentRef = segmentRef;
+      this.clickSegmentRef(segmentRef);
     }
     this.insertNoteFab.nativeElement.click();
     tick();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -43,7 +43,7 @@ import { Canon } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/ca
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
 import * as RichText from 'rich-text';
 import { BehaviorSubject, defer, Observable, of, Subject } from 'rxjs';
-import { anything, capture, deepEqual, instance, mock, objectContaining, resetCalls, verify, when } from 'ts-mockito';
+import { anything, capture, deepEqual, instance, mock, resetCalls, verify, when } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
 import { CONSOLE } from 'xforge-common/browser-globals';
 import { BugsnagService } from 'xforge-common/bugsnag.service';
@@ -75,7 +75,7 @@ import { getCombinedVerseTextDoc, paratextUsersFromRoles } from '../../shared/te
 import { PRESENCE_EDITOR_ACTIVE_TIMEOUT } from '../../shared/text/text.component';
 import { TrainingProgressComponent } from '../training-progress/training-progress.component';
 import { EditorComponent, UPDATE_SUGGESTIONS_TIMEOUT } from './editor.component';
-import { NoteDialogComponent } from './note-dialog/note-dialog.component';
+import { NoteDialogComponent, NoteDialogResult } from './note-dialog/note-dialog.component';
 import { SuggestionsComponent } from './suggestions.component';
 import { ACTIVE_EDIT_TIMEOUT } from './translate-metrics-session';
 import { NoteDialogData } from './note-dialog/note-dialog.component';
@@ -2546,9 +2546,14 @@ describe('EditorComponent', () => {
       verseSegment.click();
       env.wait();
       expect(env.insertNoteFabMobile).toBeTruthy();
+      expect(env.mobileNoteTextArea).toBeFalsy();
       env.insertNoteFabMobile!.click();
       env.wait();
-      verify(mockedMatDialog.open(NoteDialogComponent, anything())).once();
+      expect(env.mobileNoteTextArea).toBeTruthy();
+      // Close the bottom sheet
+      verseSegment = env.getSegmentElement('verse_1_2')!;
+      verseSegment.click();
+      env.wait();
 
       env.dispose();
     }));
@@ -2614,23 +2619,54 @@ describe('EditorComponent', () => {
     }));
 
     it('can insert note on verse at cursor position', fakeAsync(() => {
+      const projectId: string = 'project01';
+      const userId: string = 'user01';
       const env = new TestEnvironment();
       env.setProjectUserConfig();
       env.wait();
       env.setSelectionAndInsertNote('verse_1_4');
 
-      // The new note appears in the editor and is marked read
-      const threadId = 'threadnew01';
-      env.mockNoteDialogRef.onClose = () => env.insertNoteThread('user01', 'MAT 1:4', threadId);
-      env.mockNoteDialogRef.close(true);
-      tick();
-      env.fixture.detectChanges();
-
+      const content: string = 'content in the thread';
+      env.mockNoteDialogRef.close({ noteContent: content });
+      env.wait();
       expect(env.isNoteIconHighlighted(threadId)).toBeFalse();
       verify(mockedMatDialog.open(NoteDialogComponent, anything())).once();
       const [, config] = capture(mockedMatDialog.open).last();
       const noteVerseRef: VerseRef = (config as MatDialogConfig).data!.verseRef;
       expect(noteVerseRef.toString()).toEqual('MAT 1:4');
+
+      verify(mockedSFProjectService.createNoteThread(projectId, anything())).once();
+      const [, noteThread] = capture(mockedSFProjectService.createNoteThread).last();
+      expect(noteThread.verseRef).toEqual(fromVerseRef(noteVerseRef));
+      expect(noteThread.publishedToSF).toBe(true);
+      expect(noteThread.notes[0].ownerRef).toEqual(userId);
+      expect(noteThread.notes[0].content).toEqual(content);
+      expect(noteThread.notes[0].tagId).toEqual(2);
+      const projectUserConfigDoc: SFProjectUserConfigDoc = env.getProjectUserConfigDoc(userId);
+      expect(projectUserConfigDoc.data!.noteRefsRead).toContain(noteThread.notes[0].dataId);
+
+      env.dispose();
+    }));
+
+    it('allows adding a note to an existing thread', fakeAsync(() => {
+      const projectId: string = 'project01';
+      const threadId: string = 'thread04';
+      const segmentRef: string = 'verse_1_3';
+      const env = new TestEnvironment();
+      const content: string = 'content in the thread';
+      let noteThread: NoteThreadDoc = env.getNoteThreadDoc(projectId, threadId);
+      expect(noteThread.data!.notes.length).toEqual(1);
+      env.setProjectUserConfig();
+      env.wait();
+      const noteThreadIconElem: HTMLElement = env.getNoteThreadIconElement(segmentRef, threadId)!;
+      noteThreadIconElem.click();
+      env.mockNoteDialogRef.close({ noteContent: content });
+      env.wait();
+      noteThread = env.getNoteThreadDoc(projectId, threadId);
+      expect(noteThread.data!.notes.length).toEqual(2);
+      expect(noteThread.data!.notes[1].threadId).toEqual(threadId);
+      expect(noteThread.data!.notes[1].content).toEqual(content);
+
       env.dispose();
     }));
 
@@ -3277,6 +3313,10 @@ class TestEnvironment {
     when(mockedMatDialog.open(GenericDialogComponent, anything())).thenReturn(instance(this.mockedDialogRef));
     when(this.mockedDialogRef.afterClosed()).thenReturn(of());
     when(mockedMediaObserver.isActive(anything())).thenReturn(false);
+    when(mockedSFProjectService.getNoteThread(anything())).thenCall((id: string) => {
+      const [projectId, threadId] = id.split(':');
+      return this.getNoteThreadDoc(projectId, threadId);
+    });
 
     this.router = TestBed.inject(Router);
     this.location = TestBed.inject(Location);
@@ -3301,16 +3341,16 @@ class TestEnvironment {
     return this.fixture.debugElement.query(By.css('#settings-btn'));
   }
 
-  get floatingNoteButton(): DebugElement {
-    return this.fixture.debugElement.query(By.css('.floating-note-button'));
-  }
-
   get insertNoteFab(): DebugElement {
     return this.fixture.debugElement.query(By.css('.insert-note-fab > button'));
   }
 
   get insertNoteFabMobile(): HTMLButtonElement | null {
     return document.querySelector('.fab-bottom-sheet button');
+  }
+
+  get mobileNoteTextArea(): HTMLTextAreaElement | null {
+    return document.querySelector('.fab-bottom-sheet form textarea');
   }
 
   get sharingButton(): DebugElement {
@@ -3500,41 +3540,6 @@ class TestEnvironment {
     );
   }
 
-  insertNoteThread(userId: string, verseStr: string, threadId: string): void {
-    const noteId = 'notenew01';
-    const noteThread: NoteThread = {
-      projectRef: 'project01',
-      verseRef: fromVerseRef(VerseRef.parse(verseStr)),
-      ownerRef: userId,
-      dataId: threadId,
-      originalContextBefore: '',
-      originalContextAfter: '',
-      originalSelectedText: '',
-      status: NoteStatus.Todo,
-      position: { start: 0, length: 0 },
-      notes: [this.getNoteTemplate(threadId, noteId, userId)]
-    };
-    this.realtimeService.create(NoteThreadDoc.COLLECTION, `project01:${threadId}`, noteThread);
-    // this is needed to simulate that this happens immediately before the dialog is closed
-    tick();
-  }
-
-  getChapterElement(index: number): Element | null {
-    const chapters = this.targetEditor.container.querySelectorAll('usx-chapter');
-    if (chapters.hasOwnProperty(index) !== undefined) {
-      return chapters[index];
-    }
-    return null;
-  }
-
-  getParagraphElement(index: number): Element | null {
-    const paragraphs = this.targetEditor.container.querySelectorAll('usx-para');
-    if (paragraphs.hasOwnProperty(index) !== undefined) {
-      return paragraphs[index];
-    }
-    return null;
-  }
-
   getProjectDoc(projectId: string): SFProjectProfileDoc {
     return this.realtimeService.get<SFProjectProfileDoc>(SFProjectProfileDoc.COLLECTION, projectId);
   }
@@ -3545,10 +3550,6 @@ class TestEnvironment {
 
   getTextDoc(textId: TextDocId): TextDoc {
     return this.realtimeService.get<TextDoc>(TextDoc.COLLECTION, textId.toString());
-  }
-
-  getUserDoc(userId: string): UserDoc {
-    return this.realtimeService.get<UserDoc>(UserDoc.COLLECTION, userId);
   }
 
   getNoteThreadDoc(projectId: string, threadId: string): NoteThreadDoc {
@@ -3581,22 +3582,6 @@ class TestEnvironment {
     return thread!.classList.contains('note-thread-highlight');
   }
 
-  openNoteDialogAndEdit(segmentRef: string, thread: NoteThread): void {
-    const iconElement: HTMLElement = this.getNoteThreadIconElement(segmentRef, thread.dataId)!;
-    iconElement.click();
-    this.wait();
-
-    this.mockNoteDialogRef.close(true);
-    this.wait();
-    const noteDialogData: NoteDialogData = {
-      verseRef: undefined,
-      threadId: thread.dataId,
-      projectId: 'project01',
-      textDocId: new TextDocId('project01', 40, 1)
-    };
-    verify(mockedMatDialog.open(NoteDialogComponent, objectContaining({ data: noteDialogData }))).once();
-  }
-
   setDataInSync(projectId: string, isInSync: boolean, source?: any): void {
     const projectDoc: SFProjectProfileDoc = this.getProjectDoc(projectId);
     projectDoc.submitJson0Op(op => op.set(p => p.sync.dataInSync!, isInSync), source);
@@ -3604,16 +3589,10 @@ class TestEnvironment {
     this.fixture.detectChanges();
   }
 
-  selectSegment(segmentRef: string): void {
-    const range: RangeStatic = this.component.target!.getSegmentRange(segmentRef)!;
-    this.targetEditor.setSelection(range.index, 'user');
-    this.wait();
-    this.fixture.detectChanges();
-  }
-
   setSelectionAndInsertNote(segmentRef: string | undefined): void {
     if (segmentRef != null) {
       this.getSegmentElement(segmentRef)!.click();
+      this.component.target!.segmentRef = segmentRef;
     }
     this.insertNoteFab.nativeElement.click();
     tick();
@@ -3909,22 +3888,6 @@ class TestEnvironment {
     return noteEmbedCount;
   }
 
-  getNoteTemplate(threadId: string, noteId: string, userId: string): Note {
-    const date: string = '2022-08-01T01:00:000Z';
-    return {
-      dataId: noteId,
-      threadId,
-      ownerRef: userId,
-      status: NoteStatus.Todo,
-      content: 'New note thread',
-      conflictType: NoteConflictType.DefaultValue,
-      dateCreated: date,
-      dateModified: date,
-      deleted: false,
-      type: NoteType.Normal
-    };
-  }
-
   resolveNote(projectId: string, threadId: string): void {
     const noteDoc: NoteThreadDoc = this.getNoteThreadDoc(projectId, threadId);
     noteDoc.submitJson0Op(op => op.set(n => n.status, NoteStatus.Resolved));
@@ -3938,7 +3901,7 @@ class TestEnvironment {
     this.wait();
     const noteDoc: NoteThreadDoc = this.getNoteThreadDoc(projectId, threadId);
     noteDoc.delete();
-    this.mockNoteDialogRef.close(true);
+    this.mockNoteDialogRef.close({ deleted: true });
     this.realtimeService.updateAllSubscribeQueries();
     this.wait();
   }
@@ -3998,7 +3961,7 @@ class TestEnvironment {
 }
 
 class MockNoteDialogRef {
-  close$ = new Subject<boolean | void>();
+  close$ = new Subject<NoteDialogResult | void>();
   onClose: () => void = () => {};
 
   constructor(element: Element) {
@@ -4006,13 +3969,13 @@ class MockNoteDialogRef {
     element.appendChild(document.createElement('input')).focus();
   }
 
-  close(result?: boolean): void {
+  close(result?: NoteDialogResult): void {
     this.onClose();
     this.close$.next(result);
     this.close$.complete();
   }
 
-  afterClosed(): Observable<boolean | void> {
+  afterClosed(): Observable<NoteDialogResult | void> {
     return this.close$;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -61,6 +61,7 @@ import { GenericDialogComponent, GenericDialogOptions } from 'xforge-common/gene
 import { CheckingAnswerExport } from 'realtime-server/lib/esm/scriptureforge/models/checking-config';
 import { NoteTag, SF_TAG_ICON } from 'realtime-server/lib/esm/scriptureforge/models/note-tag';
 import { MediaObserver } from '@angular/flex-layout';
+import { getNoteThreadDocId } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { NoteThreadDoc } from '../../core/models/note-thread-doc';
 import { SFProjectDoc } from '../../core/models/sf-project-doc';
@@ -2660,7 +2661,6 @@ describe('EditorComponent', () => {
       const content: string = 'content in the thread';
       env.mockNoteDialogRef.close({ noteContent: content });
       env.wait();
-      expect(env.isNoteIconHighlighted(threadId)).toBeFalse();
       verify(mockedMatDialog.open(NoteDialogComponent, anything())).once();
       const [, config] = capture(mockedMatDialog.open).last();
       const noteVerseRef: VerseRef = (config as MatDialogConfig).data!.verseRef;
@@ -2673,8 +2673,7 @@ describe('EditorComponent', () => {
       expect(noteThread.notes[0].ownerRef).toEqual(userId);
       expect(noteThread.notes[0].content).toEqual(content);
       expect(noteThread.notes[0].tagId).toEqual(2);
-      const projectUserConfigDoc: SFProjectUserConfigDoc = env.getProjectUserConfigDoc(userId);
-      expect(projectUserConfigDoc.data!.noteRefsRead).toContain(noteThread.notes[0].dataId);
+      expect(env.isNoteIconHighlighted(noteThread.dataId)).toBeFalse();
 
       env.dispose();
     }));
@@ -3327,6 +3326,16 @@ class TestEnvironment {
         [obj<NoteThread>().pathStr(t => t.status)]: NoteStatus.Todo
       })
     );
+    when(mockedSFProjectService.createNoteThread(anything(), anything())).thenCall(
+      (projectId: string, noteThread: NoteThread) => {
+        this.realtimeService.create(
+          NoteThreadDoc.COLLECTION,
+          getNoteThreadDocId(projectId, noteThread.dataId),
+          noteThread
+        );
+        tick();
+      }
+    );
 
     when(mockedPwaService.isOnline).thenReturn(true);
     when(mockedPwaService.onlineStatus$).thenReturn(of(true));
@@ -3614,10 +3623,8 @@ class TestEnvironment {
   }
 
   isNoteIconHighlighted(threadId: string): boolean {
-    const note = this.targetTextEditor.querySelector(`usx-segment display-note[data-thread-id=${threadId}]`);
-    expect(note).withContext('note thread highlight').not.toBeNull();
     const thread: HTMLElement | null = this.targetTextEditor.querySelector(
-      `usx-segment display-note[data-thread-id=${threadId}]`
+      `usx-segment display-note[data-thread-id='${threadId}']`
     );
     expect(thread).withContext('note thread highlight').not.toBeNull();
     return thread!.classList.contains('note-thread-highlight');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -495,6 +495,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         this.showSuggestions = false;
         this.sourceLoaded = false;
         this.targetLoaded = false;
+        this.bottomSheet.dismiss();
         this.loadingStarted();
         const projectId = params['projectId'] as string;
         const bookId = params['bookId'] as string;
@@ -958,7 +959,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       this.mobileNoteControl.reset();
       // On-screen keyboards appearing can interfere with the resize height logic which then changes the focus
       // Waiting for 100ms was found to be a good amount of time for that to be resolved
-      setTimeout(() => this.mobileNoteTextarea?.nativeElement.focus(), 100);
+      setTimeout(() => this.mobileNoteTextarea?.nativeElement.focus(), 650);
     } else if (this.hasEditRight) {
       this.bottomSheetRef?.dismiss();
       this.insertNoteFab!.nativeElement.style.visibility = 'visible';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -264,6 +264,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       this._chapter = value;
       this.changeText();
       this.toggleNoteThreadVerses(true);
+      this.bottomSheet.dismiss();
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -18,7 +18,7 @@ import { Operation } from 'realtime-server/lib/esm/common/models/project-rights'
 import { User } from 'realtime-server/lib/esm/common/models/user';
 import { Note } from 'realtime-server/lib/esm/scriptureforge/models/note';
 import { ParatextUserProfile } from 'realtime-server/lib/esm/scriptureforge/models/paratext-user-profile';
-import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
+import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { TextAnchor } from 'realtime-server/lib/esm/scriptureforge/models/text-anchor';
 import { TextType } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
@@ -36,21 +36,24 @@ import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { PwaService } from 'xforge-common/pwa.service';
 import { UserService } from 'xforge-common/user.service';
-import { getLinkHTML, issuesEmailTemplate } from 'xforge-common/utils';
+import { getLinkHTML, issuesEmailTemplate, objectId } from 'xforge-common/utils';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { NoteTag } from 'realtime-server/lib/esm/scriptureforge/models/note-tag';
 import { NoteType } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { MatBottomSheet, MatBottomSheetRef } from '@angular/material/bottom-sheet';
+import { UntypedFormControl, Validators } from '@angular/forms';
+import { XFValidators } from 'xforge-common/xfvalidators';
+import { NoteConflictType, NoteStatus, NoteThread } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
+import { fromVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { environment } from '../../../environments/environment';
 import { NoteThreadDoc, NoteThreadIcon } from '../../core/models/note-thread-doc';
 import { SFProjectDoc } from '../../core/models/sf-project-doc';
 import { SF_DEFAULT_TRANSLATE_SHARE_ROLE } from '../../core/models/sf-project-role-info';
 import { SFProjectUserConfigDoc } from '../../core/models/sf-project-user-config-doc';
-import { Delta } from '../../core/models/text-doc';
-import { TextDocId } from '../../core/models/text-doc';
+import { Delta, TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
 import { RemoteTranslationEngine } from '../../machine-api/remote-translation-engine';
@@ -67,11 +70,11 @@ import {
   formatFontSizeToRems,
   getVerseRefFromSegmentRef,
   threadIdFromMouseEvent,
-  verseRefFromMouseEvent,
-  VERSE_REGEX
+  VERSE_REGEX,
+  verseRefFromMouseEvent
 } from '../../shared/utils';
 import { MultiCursorViewer } from './multi-viewer/multi-viewer.component';
-import { NoteDialogComponent, NoteDialogData } from './note-dialog/note-dialog.component';
+import { NoteDialogComponent, NoteDialogData, NoteDialogResult } from './note-dialog/note-dialog.component';
 import {
   SuggestionsSettingsDialogComponent,
   SuggestionsSettingsDialogData
@@ -80,6 +83,12 @@ import { Suggestion } from './suggestions.component';
 import { TranslateMetricsSession } from './translate-metrics-session';
 
 export const UPDATE_SUGGESTIONS_TIMEOUT = 100;
+
+export interface SaveNoteParameters {
+  content: string;
+  dataId?: string;
+  threadId?: string;
+}
 
 const PUNCT_SPACE_REGEX = /^(?:\p{P}|\p{S}|\p{Cc}|\p{Z})+$/u;
 
@@ -102,11 +111,13 @@ const PUNCT_SPACE_REGEX = /^(?:\p{P}|\p{S}|\p{Cc}|\p{Z})+$/u;
   styleUrls: ['./editor.component.scss']
 })
 export class EditorComponent extends DataLoadingComponent implements OnDestroy, AfterViewInit {
+  addingMobileNote: boolean = false;
   suggestions: Suggestion[] = [];
   showSuggestions: boolean = false;
   chapters: number[] = [];
   isProjectAdmin: boolean = false;
   metricsSession?: TranslateMetricsSession;
+  mobileNoteControl: UntypedFormControl = new UntypedFormControl('');
   textHeight: string = '';
   multiCursorViewers: MultiCursorViewer[] = [];
   insertNoteFabLeft: string = '0px';
@@ -116,6 +127,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   @ViewChild('target') target?: TextComponent;
   @ViewChild('fabButton') insertNoteFab?: ElementRef<HTMLElement>;
   @ViewChild('fabBottomSheet') TemplateBottomSheet?: TemplateRef<any>;
+  @ViewChild('mobileNoteTextarea') mobileNoteTextarea?: ElementRef<HTMLTextAreaElement>;
 
   private translationEngine?: RemoteTranslationEngine;
   private isTranslating: boolean = false;
@@ -175,6 +187,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
     this.segmentUpdated$ = new Subject<void>();
     this.subscribe(this.segmentUpdated$.pipe(debounceTime(UPDATE_SUGGESTIONS_TIMEOUT)), () => this.updateSuggestions());
+    this.mobileNoteControl.setValidators([Validators.required, XFValidators.someNonWhitespace]);
   }
 
   get sourceLabel(): string {
@@ -353,6 +366,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     return this.i18n.localizeReference(verseRef);
   }
 
+  get direction(): 'ltr' | 'rtl' {
+    return this.i18n.direction;
+  }
+
   get fontSize(): string | undefined {
     return formatFontSizeToRems(this.projectDoc?.data?.defaultFontSize);
   }
@@ -406,6 +423,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   set showInsertNoteFab(value: boolean) {
     if (this.insertNoteFab == null || this.TemplateBottomSheet == null) return;
+    this.addingMobileNote = false;
     if (this.mediaObserver.isActive('lt-lg')) {
       this.insertNoteFab.nativeElement.style.visibility = 'hidden';
       if (value) {
@@ -849,6 +867,88 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
   }
 
+  async saveMobileNote(): Promise<void> {
+    if (!this.mobileNoteControl.valid || this.projectId == null) {
+      return;
+    }
+
+    await this.saveNote({ content: this.mobileNoteControl.value });
+    this.addingMobileNote = false;
+    this.resetInsertNoteFab();
+  }
+
+  async saveNote(params: SaveNoteParameters): Promise<void> {
+    if (this.projectId == null) {
+      return;
+    }
+    const segmentRef: string | undefined = this.target?.currentSegmentOrDefault;
+    if (segmentRef == null || this.bookNum == null) {
+      return;
+    }
+    const verseRef: VerseRef | undefined = getVerseRefFromSegmentRef(this.bookNum, segmentRef);
+    if (verseRef == null) {
+      return;
+    }
+    const currentDate = new Date().toJSON();
+    // Configure the note
+    const note: Note = {
+      dateCreated: currentDate,
+      dateModified: currentDate,
+      threadId: params.threadId ?? '',
+      dataId: params.dataId ?? objectId(),
+      tagId: this.projectDoc?.data?.translateConfig.defaultNoteTagId,
+      ownerRef: this.userService.currentUserId,
+      content: params.content,
+      conflictType: NoteConflictType.DefaultValue,
+      type: NoteType.Normal,
+      status: NoteStatus.Todo,
+      deleted: false
+    };
+    if (params.threadId == null) {
+      const threadId: string = objectId();
+      note.threadId = threadId;
+      // Create a new thread
+      const noteThread: NoteThread = {
+        dataId: threadId,
+        verseRef: fromVerseRef(verseRef),
+        projectRef: this.projectId,
+        ownerRef: this.userService.currentUserId,
+        notes: [note],
+        position: { start: 0, length: 0 },
+        originalContextBefore: '',
+        originalSelectedText: this.target?.segmentText!,
+        originalContextAfter: '',
+        status: NoteStatus.Todo,
+        publishedToSF: true
+      };
+      await this.projectService.createNoteThread(this.projectId, noteThread);
+      await this.updateNoteReadRefs(note.dataId);
+    } else {
+      // updated the existing note
+      const threadDoc: NoteThreadDoc = await this.projectService.getNoteThread(this.projectId + ':' + params.threadId);
+      const noteIndex: number = threadDoc.data!.notes.findIndex(n => n.dataId === params.dataId);
+      if (noteIndex >= 0) {
+        await threadDoc!.submitJson0Op(op => {
+          op.set(t => t.notes[noteIndex].content, params.content);
+          op.set(t => t.notes[noteIndex].dateModified, currentDate);
+        });
+      } else {
+        await threadDoc.submitJson0Op(op => op.add(t => t.notes, note));
+        await this.updateNoteReadRefs(note.dataId);
+      }
+    }
+    this.toggleNoteThreadVerses(false);
+    this.toggleNoteThreadVerses(true);
+  }
+
+  toggleAddingMobileNote(): void {
+    this.addingMobileNote = !this.addingMobileNote;
+    if (this.addingMobileNote) {
+      this.mobileNoteControl.reset();
+      setTimeout(() => this.mobileNoteTextarea?.nativeElement.focus(), 100);
+    }
+  }
+
   /** Insert or remove note thread embeds into the quill editor. */
   private toggleNoteThreadVerses(toggleOn: boolean): void {
     if (
@@ -899,17 +999,20 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       textDocId: new TextDocId(this.projectDoc!.id, this.bookNum, this.chapter),
       verseRef
     };
-    const dialogRef = this.dialogService.openMatDialog<NoteDialogComponent, NoteDialogData, boolean>(
+    const dialogRef = this.dialogService.openMatDialog<
       NoteDialogComponent,
-      {
-        autoFocus: true,
-        width: '600px',
-        disableClose: true,
-        data: noteDialogData
-      }
-    );
-    const result: boolean | undefined = await dialogRef.afterClosed().toPromise();
-    if (result === true) {
+      NoteDialogData,
+      NoteDialogResult | undefined
+    >(NoteDialogComponent, {
+      autoFocus: true,
+      width: '600px',
+      disableClose: true,
+      data: noteDialogData
+    });
+    const result: NoteDialogResult | undefined = await dialogRef.afterClosed().toPromise();
+    if (result?.noteContent != null) {
+      await this.saveNote({ content: result.noteContent, threadId, dataId: result.noteDataId });
+    } else if (result?.deleted) {
       this.toggleNoteThreadVerses(false);
       this.toggleNoteThreadVerses(true);
     }
@@ -934,6 +1037,11 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         }
       });
     }
+  }
+
+  private async updateNoteReadRefs(noteId: string): Promise<void> {
+    if (this.projectUserConfigDoc?.data == null || this.projectUserConfigDoc.data.noteRefsRead.includes(noteId)) return;
+    await this.projectUserConfigDoc.submitJson0Op(op => op.add(puc => puc.noteRefsRead, noteId));
   }
 
   private setupTranslationEngine(): void {
@@ -1293,6 +1401,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   private resetInsertNoteFab(): void {
+    if (this.addingMobileNote) {
+      return;
+    }
     this.showInsertNoteFab = false;
     if (this.target != null && this.commenterSelectedVerseRef != null) {
       this.target.toggleVerseSelection(this.commenterSelectedVerseRef);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -923,7 +923,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         publishedToSF: true
       };
       await this.projectService.createNoteThread(this.projectId, noteThread);
-      await this.updateNoteReadRefs(note.dataId);
     } else {
       // updated the existing note
       const threadDoc: NoteThreadDoc = await this.projectService.getNoteThread(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -47,6 +47,7 @@ import { UntypedFormControl, Validators } from '@angular/forms';
 import { XFValidators } from 'xforge-common/xfvalidators';
 import { NoteConflictType, NoteStatus, NoteThread } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { fromVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
+import { getNoteThreadDocId } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { environment } from '../../../environments/environment';
 import { NoteThreadDoc, NoteThreadIcon } from '../../core/models/note-thread-doc';
@@ -874,7 +875,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
     await this.saveNote({ content: this.mobileNoteControl.value });
     this.addingMobileNote = false;
-    this.resetInsertNoteFab();
+    this.bottomSheetRef?.dismiss();
   }
 
   async saveNote(params: SaveNoteParameters): Promise<void> {
@@ -889,7 +890,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     if (verseRef == null) {
       return;
     }
-    const currentDate = new Date().toJSON();
+    const currentDate: string = new Date().toJSON();
     // Configure the note
     const note: Note = {
       dateCreated: currentDate,
@@ -925,7 +926,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       await this.updateNoteReadRefs(note.dataId);
     } else {
       // updated the existing note
-      const threadDoc: NoteThreadDoc = await this.projectService.getNoteThread(this.projectId + ':' + params.threadId);
+      const threadDoc: NoteThreadDoc = await this.projectService.getNoteThread(
+        getNoteThreadDocId(this.projectId, params.threadId)
+      );
       const noteIndex: number = threadDoc.data!.notes.findIndex(n => n.dataId === params.dataId);
       if (noteIndex >= 0) {
         await threadDoc!.submitJson0Op(op => {
@@ -945,6 +948,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     this.addingMobileNote = !this.addingMobileNote;
     if (this.addingMobileNote) {
       this.mobileNoteControl.reset();
+      // On-screen keyboards appearing can interfere with the resize height logic which then changes the focus
+      // Waiting for 100ms was found to be a good amount of time for that to be resolved
       setTimeout(() => this.mobileNoteTextarea?.nativeElement.focus(), 100);
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -25,9 +25,8 @@ import { TextData } from 'realtime-server/lib/esm/scriptureforge/models/text-dat
 import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
 import { ParatextUserProfile } from 'realtime-server/lib/esm/scriptureforge/models/paratext-user-profile';
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
-import { fromVerseRef, VerseRefData } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import * as RichText from 'rich-text';
-import { anything, capture, mock, verify, when } from 'ts-mockito';
+import { anything, mock, verify, when } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
 import { DialogService } from 'xforge-common/dialog.service';
 import { FeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
@@ -52,7 +51,7 @@ import { TextDoc, TextDocId } from '../../../core/models/text-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { getTextDoc, paratextUsersFromRoles } from '../../../shared/test-utils';
 import { TranslateModule } from '../../translate.module';
-import { NoteDialogComponent, NoteDialogData } from './note-dialog.component';
+import { NoteDialogComponent, NoteDialogData, NoteDialogResult } from './note-dialog.component';
 
 const mockedAuthService = mock(AuthService);
 const mockedCookieService = mock(CookieService);
@@ -331,20 +330,7 @@ describe('NoteDialogComponent', () => {
     expect(env.component.segmentText).toEqual('target: chapter 1, verse 3.');
     env.submit();
 
-    const verseData: VerseRefData = fromVerseRef(verseRef);
-    verify(mockedProjectService.createNoteThread('project01', anything())).once();
-    const [, noteThread] = capture(mockedProjectService.createNoteThread).last();
-    expect(noteThread.verseRef).toEqual(verseData);
-    expect(noteThread.originalSelectedText).toEqual('target: chapter 1, verse 3.');
-    expect(noteThread.publishedToSF).toBe(true);
-    expect(noteThread.notes[0].ownerRef).toEqual('user01');
-    expect(noteThread.notes[0].content).toEqual('Enter note content');
-    expect(noteThread.notes[0].tagId).toEqual(2);
-    const projectUserConfigDoc: SFProjectUserConfigDoc = env.getProjectUserConfigDoc(
-      TestEnvironment.PROJECT01,
-      'user01'
-    );
-    expect(projectUserConfigDoc.data!.noteRefsRead).not.toContain(noteThread.notes[0].dataId);
+    expect(env.dialogResult).toEqual({ noteContent: 'Enter note content', noteDataId: undefined });
   }));
 
   it('show sf note tag on notes with undefined tag id', fakeAsync(() => {
@@ -380,24 +366,11 @@ describe('NoteDialogComponent', () => {
 
   it('allows adding a note to an existing thread', fakeAsync(() => {
     env = new TestEnvironment({ noteThread: TestEnvironment.getNoteThread() });
-    const noteThread: NoteThreadDoc = env.getNoteThreadDoc('thread01');
-    expect(noteThread.data!.notes.length).toEqual(5);
     expect(env.noteInputElement).toBeTruthy();
-    // note 03 is marked deleted and is not displayed
-    expect(env.component.notesToDisplay.length).toEqual(4);
     const content = 'content in the thread';
-    env.enterNoteContent('content in the thread');
+    env.enterNoteContent(content);
     env.submit();
-    expect(noteThread.data!.notes.length).toEqual(6);
-    expect(noteThread.data!.notes[5].dataId).not.toContain('note0');
-    expect(noteThread.data!.notes[5].threadId).toEqual('thread01');
-    expect(noteThread.data!.notes[5].content).toEqual(content);
-    expect(env.dialogResult).toBe(true);
-    const projectUserConfigDoc: SFProjectUserConfigDoc = env.getProjectUserConfigDoc(
-      TestEnvironment.PROJECT01,
-      'user01'
-    );
-    expect(projectUserConfigDoc.data!.noteRefsRead).not.toContain(noteThread.data!.notes[5].dataId);
+    expect(env.dialogResult).toEqual({ noteContent: content, noteDataId: undefined });
   }));
 
   it('allows user to edit the last note in the thread', fakeAsync(() => {
@@ -417,8 +390,7 @@ describe('NoteDialogComponent', () => {
     const content = 'note 05 edited content';
     env.enterNoteContent(content);
     env.submit();
-    expect(noteThread.data!.notes[4].content).toEqual(content);
-    expect(env.dialogResult).toBe(true);
+    expect(env.dialogResult).toEqual({ noteContent: content, noteDataId: 'note05' });
   }));
 
   it('allows user to delete the last note in the thread', fakeAsync(() => {
@@ -455,7 +427,7 @@ describe('NoteDialogComponent', () => {
     env.clickDeleteNote();
     verify(mockedDialogService.confirm(anything(), anything())).once();
     expect(noteThread.data).toBeUndefined();
-    expect(env.dialogResult).toBe(true);
+    expect(env.dialogResult).toEqual({ deleted: true });
   }));
 
   it('deletes the thread if the deleted note is the only active note', fakeAsync(() => {
@@ -481,7 +453,7 @@ describe('NoteDialogComponent', () => {
     env.clickDeleteNote();
     verify(mockedDialogService.confirm(anything(), anything())).once();
     expect(threadDoc.data).toBeUndefined();
-    expect(env.dialogResult).toBe(true);
+    expect(env.dialogResult).toEqual({ deleted: true });
   }));
 
   it('show notes in correct date order', fakeAsync(() => {
@@ -731,8 +703,8 @@ class TestEnvironment {
   readonly fixture: ComponentFixture<ChildViewContainerComponent>;
   readonly realtimeService: TestRealtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);
   readonly component: NoteDialogComponent;
-  readonly dialogRef: MatDialogRef<NoteDialogComponent, boolean>;
-  dialogResult?: boolean;
+  readonly dialogRef: MatDialogRef<NoteDialogComponent, NoteDialogResult | undefined>;
+  dialogResult?: NoteDialogResult;
 
   constructor({
     includeSnapshots = true,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -349,6 +349,9 @@ export class NoteDialogComponent implements OnInit {
       return;
     }
 
-    this.dialogRef.close({ noteContent: this.currentNoteContent, noteDataId: this.noteIdBeingEdited });
+    this.dialogRef.close({
+      noteContent: this.currentNoteContent,
+      noteDataId: this.noteIdBeingEdited
+    });
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -1,28 +1,21 @@
 import { Component, Inject, OnInit } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { translate } from '@ngneat/transloco';
-import { cloneDeep, sortBy } from 'lodash-es';
-import { fromVerseRef, toVerseRef, VerseRefData } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
+import { sortBy } from 'lodash-es';
+import { toVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { Note, REATTACH_SEPARATOR } from 'realtime-server/lib/esm/scriptureforge/models/note';
 import { NoteTag, SF_TAG_ICON } from 'realtime-server/lib/esm/scriptureforge/models/note-tag';
-import {
-  AssignedUsers,
-  NoteConflictType,
-  NoteStatus,
-  NoteThread,
-  NoteType
-} from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
+import { AssignedUsers, NoteStatus } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
 import { ParatextUserProfile } from 'realtime-server/lib/esm/scriptureforge/models/paratext-user-profile';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
-import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
+import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { UserService } from 'xforge-common/user.service';
-import { objectId } from 'xforge-common/utils';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { isParatextRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
-import { NoteThreadDoc, defaultNoteThreadIcon } from '../../../core/models/note-thread-doc';
+import { defaultNoteThreadIcon, NoteThreadDoc } from '../../../core/models/note-thread-doc';
 import { SFProjectDoc } from '../../../core/models/sf-project-doc';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
@@ -35,6 +28,12 @@ export interface NoteDialogData {
   textDocId: TextDocId;
   projectId: string;
   verseRef?: VerseRef;
+}
+
+export interface NoteDialogResult {
+  deleted?: boolean;
+  noteContent?: string;
+  noteDataId?: string;
 }
 
 // TODO: Implement a diff - there is an accepted solution here that might be a good starting point:
@@ -52,12 +51,12 @@ export class NoteDialogComponent implements OnInit {
   private projectProfileDoc?: SFProjectProfileDoc;
   private textDoc?: TextDoc;
   private paratextProjectUsers?: ParatextUserProfile[];
-  private noteBeingEdited?: Note;
+  private noteIdBeingEdited?: string;
   private projectUserConfigDoc?: SFProjectUserConfigDoc;
   private userRole?: string;
 
   constructor(
-    private readonly dialogRef: MatDialogRef<NoteDialogComponent, boolean>,
+    private readonly dialogRef: MatDialogRef<NoteDialogComponent, NoteDialogResult | undefined>,
     @Inject(MAT_DIALOG_DATA) private readonly data: NoteDialogData,
     private readonly i18n: I18nService,
     private readonly projectService: SFProjectService,
@@ -92,7 +91,7 @@ export class NoteDialogComponent implements OnInit {
     }
 
     this.projectUserConfigDoc = await this.projectService.getUserConfig(this.projectId, this.userService.currentUserId);
-    this.noteBeingEdited = this.getNoteTemplate(this.threadId);
+    this.projectUserConfigDoc = await this.projectService.getUserConfig(this.projectId, this.userService.currentUserId);
   }
 
   get canViewAssignedUser(): boolean {
@@ -138,7 +137,7 @@ export class NoteDialogComponent implements OnInit {
       return [];
     }
     return sortBy(
-      this.threadDoc.data.notes.filter(n => !n.deleted && n.dataId !== this.noteBeingEdited?.dataId),
+      this.threadDoc.data.notes.filter(n => !n.deleted && n.dataId !== this.noteIdBeingEdited),
       n => new Date(n.dateCreated)
     );
   }
@@ -223,7 +222,7 @@ export class NoteDialogComponent implements OnInit {
   }
 
   editNote(note: Note): void {
-    this.noteBeingEdited = cloneDeep(note);
+    this.noteIdBeingEdited = note.dataId;
     this.currentNoteContent = note.content ?? '';
   }
 
@@ -237,7 +236,7 @@ export class NoteDialogComponent implements OnInit {
     if (this.notesToDisplay.length === 1 && this.notesToDisplay[0].dataId === note.dataId) {
       // only delete the thread if deleting the only note in the thread
       await this.threadDoc!.delete();
-      this.dialogRef.close(true);
+      this.dialogRef.close({ deleted: true });
       return;
     }
 
@@ -247,7 +246,7 @@ export class NoteDialogComponent implements OnInit {
     }
 
     if (this.notesToDisplay.length === 0) {
-      this.dialogRef.close(true);
+      this.dialogRef.close();
     }
   }
 
@@ -297,7 +296,7 @@ export class NoteDialogComponent implements OnInit {
     return (
       this.isAddNotesEnabled &&
       note.dataId === this.lastNoteId &&
-      this.noteBeingEdited?.dataId === '' &&
+      this.noteIdBeingEdited == null &&
       SF_PROJECT_RIGHTS.hasRight(
         this.projectProfileDoc.data,
         this.userService.currentUserId,
@@ -316,8 +315,7 @@ export class NoteDialogComponent implements OnInit {
     const selectedText: string = reattachedParts[1];
     const contextBefore: string = reattachedParts[3];
     const contextAfter: string = reattachedParts[4];
-    const reattachedText: string = contextBefore + '<b>' + selectedText + '</b>' + contextAfter;
-    return reattachedText;
+    return contextBefore + '<b>' + selectedText + '</b>' + contextAfter;
   }
 
   reattachedVerse(note: Note): string {
@@ -346,83 +344,11 @@ export class NoteDialogComponent implements OnInit {
   }
 
   async submit(): Promise<void> {
-    if (
-      this.noteBeingEdited == null ||
-      this.currentNoteContent == null ||
-      this.currentNoteContent.trim().length === 0
-    ) {
+    if (this.currentNoteContent == null || this.currentNoteContent.trim().length === 0) {
       this.dialogRef.close();
       return;
     }
-    const verseRef: VerseRef | undefined = this.verseRef;
-    if (verseRef == null) return;
 
-    const currentDate = new Date().toJSON();
-    if (this.noteBeingEdited.dataId === '') {
-      this.noteBeingEdited.dataId = objectId();
-      this.noteBeingEdited.dateCreated = currentDate;
-    }
-    this.noteBeingEdited.dateModified = currentDate;
-    this.noteBeingEdited.content = this.currentNoteContent;
-
-    await this.saveChanges(fromVerseRef(verseRef));
-  }
-
-  private async saveChanges(verseRef: VerseRefData): Promise<void> {
-    if (this.noteBeingEdited == null) {
-      this.dialogRef.close(false);
-      return;
-    }
-    if (this.noteBeingEdited.threadId === '') {
-      // create a new thread
-      const threadId: string = objectId();
-      this.noteBeingEdited.threadId = threadId;
-      this.noteBeingEdited.tagId = this.defaultNoteTagId;
-
-      const noteThread: NoteThread = {
-        dataId: threadId,
-        verseRef: verseRef,
-        projectRef: this.projectId,
-        ownerRef: this.userService.currentUserId,
-        notes: [this.noteBeingEdited],
-        position: { start: 0, length: 0 },
-        originalContextBefore: '',
-        originalSelectedText: this.segmentText,
-        originalContextAfter: '',
-        status: NoteStatus.Todo,
-        publishedToSF: true
-      };
-      await this.projectService.createNoteThread(this.projectId, noteThread);
-      this.dialogRef.close(true);
-      return;
-    }
-
-    // updated the existing note
-    const noteIndex: number = this.threadDoc!.data!.notes.findIndex(n => n.dataId === this.noteBeingEdited!.dataId);
-    if (noteIndex >= 0) {
-      await this.threadDoc!.submitJson0Op(op => {
-        op.set(t => t.notes[noteIndex].content, this.noteBeingEdited!.content);
-        op.set(t => t.notes[noteIndex].dateModified, this.noteBeingEdited!.dateModified);
-      });
-    } else {
-      await this.threadDoc!.submitJson0Op(op => op.add(t => t.notes, this.noteBeingEdited));
-    }
-    this.dialogRef.close(true);
-  }
-
-  private getNoteTemplate(threadId: string | undefined): Note {
-    return {
-      dataId: '',
-      // thread id is the empty string when the note belongs to a new thread
-      threadId: threadId ?? '',
-      ownerRef: this.userService.currentUserId,
-      content: '',
-      dateCreated: '',
-      dateModified: '',
-      conflictType: NoteConflictType.DefaultValue,
-      type: NoteType.Normal,
-      status: NoteStatus.Todo,
-      deleted: false
-    };
+    this.dialogRef.close({ noteContent: this.currentNoteContent, noteDataId: this.noteIdBeingEdited });
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -86,6 +86,7 @@
   "editor": {
     "add_comment": "Add Comment",
     "anonymous": "Anonymous",
+    "cancel": "Cancel",
     "cannot_edit_chapter_formatting_invalid": "This chapter cannot be edited because the formatting is invalid. Please fix the formatting in Paratext.",
     "configure_translation_suggestions": "Configure translation suggestions",
     "more_notes": "--- {{ count }} more note(s) ---",
@@ -93,11 +94,13 @@
     "no_permission_edit_chapter": "You don't have permission to edit this chapter, even though you have the {{ userRole }} role. Permissions can only be changed in Paratext.",
     "project_data_out_of_sync": "Your project data is out of sync. Please synchronize your project to edit this text.",
     "project_text_not_editable": "Text in this project is not editable. This setting can be changed in Paratext.",
+    "save": "Save",
     "swap_source_and_target": "Swap source and target",
     "text_doc_corrupted": "This chapter cannot be edited because the data has become corrupted.",
     "text_has_been_deleted": "The book has been deleted or is no longer accessible.",
     "to_report_issue_email": "To report an issue, email {{ issueEmailLink }}.",
-    "verse_too_long_for_suggestions": "This verse is too long to generate suggestions."
+    "verse_too_long_for_suggestions": "This verse is too long to generate suggestions.",
+    "your_comment": "Your comment"
   },
   "import_questions_confirmation_dialog": {
     "done": "Done",


### PR DESCRIPTION
- Adding notes via the mobile bottom sheet now displays a textarea
- Users can now add notes via the bottom sheet form
- Refactored notes to be added via the editor component rather than the note dialog

![image](https://user-images.githubusercontent.com/17464863/227819467-0c7d1928-5c37-40bf-89d3-ef7c658c03da.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1765)
<!-- Reviewable:end -->
