### PR TITLE
Remove obsolete CheckUserNeedsMigrating endpoint

### DIFF
--- a/src/SIL.XForge/Controllers/UsersRpcController.cs
+++ b/src/SIL.XForge/Controllers/UsersRpcController.cs
@@ -165,7 +165,4 @@ public class UsersRpcController : RpcControllerBase
             throw;
         }
     }
-
-    [Obsolete("Only here for clients still running a front end that still calls it")]
-    public IRpcMethodResult CheckUserNeedsMigrating(string userId) => Ok(false);
 }


### PR DESCRIPTION
This endpoint was left here because it used to be automatically called the moment the app loaded, and if you remove an endpoint from the back end, and users are still using a older client, they'll get errors due to trying to call a non-existent endpoint. It's now been almost a year since it was used, so cleaning it up now makes sense.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1766)
<!-- Reviewable:end -->
