### PR TITLE
Upgrade notice component to use ng-content

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.html
@@ -1,4 +1,4 @@
 <div [ngClass]="{ outline }" [class]="type">
   <mat-icon *ngIf="icon">{{ icon }}</mat-icon>
-  <span>{{ notice }}</span>
+  <span><ng-content></ng-content></span>
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
@@ -5,6 +5,7 @@ div {
   align-items: center;
   padding: 16px;
   border-radius: 4px;
+  column-gap: 16px;
   &.normal {
     --notice-color: #{$purpleLight};
   }
@@ -23,9 +24,7 @@ div {
     color: #fff;
   }
   mat-icon {
-    flex: 0 0 24px;
-    margin-inline-end: 16px;
+    flex-shrink: 0;
     align-self: flex-start;
-    direction: inherit;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.spec.ts
@@ -7,28 +7,27 @@ import { NoticeComponent } from './notice.component';
 
 describe('NoticeComponent', () => {
   it('should create', () => {
-    const template = '<app-notice text="app.online"></app-notice>';
+    const template = '<app-notice>This is a notice</app-notice>';
     const env = new TestEnvironment(template);
     expect(env.fixture.componentInstance).toBeTruthy();
-    expect(env.noticeText).toEqual('app.online');
     expect(env.icon).toBeFalsy();
     expect(env.container.classes['normal']).toBeTrue();
   });
 
   it('should show icon', () => {
-    const template = '<app-notice text="app.online" icon="info"></app-notice>';
+    const template = '<app-notice icon="info">This is a notice</app-notice>';
     const env = new TestEnvironment(template);
     expect(env.icon).toBeTruthy();
   });
 
   it('should set error class', () => {
-    const template = '<app-notice text="app.online" type="error"></app-notice>';
+    const template = '<app-notice type="error">This is an error</app-notice>';
     const env = new TestEnvironment(template);
     expect(env.container.classes['error']).toBeTrue();
   });
 
   it('should set warning class', () => {
-    const template = '<app-notice text="app.online" type="warning"></app-notice>';
+    const template = '<app-notice type="warning">This is a warning</app-notice>';
     const env = new TestEnvironment(template);
     expect(env.container.classes['warning']).toBeTrue();
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.ts
@@ -1,6 +1,4 @@
 import { Component, Input } from '@angular/core';
-import { I18nKey } from 'xforge-common/i18n.service';
-import { TranslocoService } from '@ngneat/transloco';
 
 @Component({
   selector: 'app-notice',
@@ -9,15 +7,8 @@ import { TranslocoService } from '@ngneat/transloco';
 })
 export class NoticeComponent {
   @Input() icon?: string;
-  @Input() text?: I18nKey;
   @Input() type: 'normal' | 'warning' | 'error' = 'normal';
   @Input() outline: boolean = false;
 
-  constructor(private readonly transloco: TranslocoService) {}
-  get notice(): string {
-    if (this.text == null) {
-      return '';
-    }
-    return this.transloco.translate(this.text);
-  }
+  constructor() {}
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
@@ -63,20 +63,14 @@
           </mat-selection-list>
         </mat-menu>
       </div>
-      <app-notice
-        *ngIf="isRecipientOnlyLink"
-        icon="info"
-        [outline]="true"
-        text="share_dialog.recipient_only_notice"
-      ></app-notice>
+      <app-notice *ngIf="isRecipientOnlyLink" icon="info" [outline]="true">
+        {{ t("recipient_only_notice") }}
+      </app-notice>
     </ng-container>
   </div>
-  <app-notice
-    *ngIf="showLinkSharingUnavailable"
-    type="error"
-    icon="cloud_off"
-    text="share_dialog.link_sharing_not_available_offline"
-  ></app-notice>
+  <app-notice *ngIf="showLinkSharingUnavailable" type="error" icon="cloud_off">
+    {{ t("link_sharing_not_available_offline") }}
+  </app-notice>
   <div mat-dialog-actions>
     <button
       id="share-btn"


### PR DESCRIPTION
- Changed notice component to use [ng-content](https://angular.io/guide/content-projection)
- Updated the styling to use a column gap instead of a margin

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1768)
<!-- Reviewable:end -->
