### PR TITLE
Add files for Trusted Web Activity

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/.well-known/assetlinks.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "org.sil.xforge.scripture",
+      "sha256_cert_fingerprints": [
+        "EF:CF:30:DB:7E:C8:D2:34:F2:34:59:21:9E:51:F7:05:F6:EC:B2:11:DA:B9:B6:74:79:1F:F1:BB:5E:C8:68:C8"
+      ]
+    }
+  }
+]

--- a/src/SIL.XForge.Scripture/ClientApp/src/.well-known/assetlinks.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/.well-known/assetlinks.json
@@ -3,7 +3,7 @@
     "relation": ["delegate_permission/common.handle_all_urls"],
     "target": {
       "namespace": "android_app",
-      "package_name": "org.sil.xforge.scripture",
+      "package_name": "org.sil.scriptureforge",
       "sha256_cert_fingerprints": [
         "EF:CF:30:DB:7E:C8:D2:34:F2:34:59:21:9E:51:F7:05:F6:EC:B2:11:DA:B9:B6:74:79:1F:F1:BB:5E:C8:68:C8"
       ]

--- a/src/SIL.XForge.Scripture/ClientApp/src/index.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/index.html
@@ -10,7 +10,7 @@
       }
       gtag("js", new Date());
     </script>
-
+    <link rel="manifest" href="/manifest.json"/>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet" />
     <meta charset="utf-8" />
@@ -22,6 +22,7 @@
     <link rel="apple-touch-icon" href="assets/icons/sf-192x192.png" />
     <link rel="manifest" href="manifest.json" />
     <meta name="theme-color" content="#343a31" />
+    <meta name="description" content="A free set of tools to do more with your Paratext project, wherever you are.">
   </head>
   <body style="margin: 0" class="mdc-typography">
     <noscript>Please enable JavaScript to run this application.</noscript>

--- a/src/SIL.XForge.Scripture/ClientApp/src/index.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/index.html
@@ -10,7 +10,7 @@
       }
       gtag("js", new Date());
     </script>
-    <link rel="manifest" href="/manifest.json"/>
+    <link rel="manifest" href="/manifest.json" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet" />
     <meta charset="utf-8" />
@@ -22,7 +22,7 @@
     <link rel="apple-touch-icon" href="assets/icons/sf-192x192.png" />
     <link rel="manifest" href="manifest.json" />
     <meta name="theme-color" content="#343a31" />
-    <meta name="description" content="A free set of tools to do more with your Paratext project, wherever you are.">
+    <meta name="description" content="A free set of tools to do more with your Paratext project, wherever you are." />
   </head>
   <body style="margin: 0" class="mdc-typography">
     <noscript>Please enable JavaScript to run this application.</noscript>

--- a/src/SIL.XForge.Scripture/ClientApp/src/manifest.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/manifest.json
@@ -4,6 +4,15 @@
   "theme_color": "#343a31",
   "background_color": "#ffffff",
   "display": "standalone",
+  "description": "A free set of tools to do more with your Paratext project, wherever you are.",
+  "orientation": "portrait-primary",
+  "categories": ["productivity"],
+  "related_applications": [
+    {
+      "platform": "play",
+      "id": "org.sil.xforge.scripture"
+    }
+  ],
   "scope": "/",
   "start_url": "/projects",
   "icons": [

--- a/src/SIL.XForge.Scripture/ClientApp/src/manifest.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/manifest.json
@@ -10,7 +10,7 @@
   "related_applications": [
     {
       "platform": "play",
-      "id": "org.sil.xforge.scripture"
+      "id": "org.sil.scriptureforge"
     }
   ],
   "scope": "/",


### PR DESCRIPTION
@megahirt is interested in helping develop an Android app for Scripture Forge. With the asset links file included in this PR, and the manifest file, we can use Bubblewrap CLI to generate a Trusted Web Activity that will display the web app inside an Android activity, with some UI changed to make it look like an app rather than a browsing window.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1769)
<!-- Reviewable:end -->
