### PR TITLE
SF-1464 Fix wrapping in user list

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.scss
@@ -42,13 +42,15 @@ mdc-text-field {
   width: 65px !important;
 }
 
-.mat-column-name {
+.mat-column-name,
+.mat-column-role {
   padding-right: 0.5em;
   word-break: break-word;
 }
 
-.mat-column-projects {
-  word-break: break-word;
+// Allow the questions permission label to wrap on whitespace to prevent layout issues
+.mat-column-questions_permission .mat-checkbox ::ng-deep label {
+  white-space: initial;
 }
 
 .current-user-label {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -57,7 +57,7 @@ export class TranslationLoader implements TranslocoLoader {
   }
 }
 
-function pad(number: number) {
+function pad(number: number): string {
   return number.toString().padStart(2, '0');
 }
 
@@ -124,7 +124,7 @@ export class I18nService {
     return this.currentLocale;
   }
 
-  get localeCode() {
+  get localeCode(): string {
     return this.currentLocale.canonicalTag;
   }
 
@@ -144,13 +144,13 @@ export class I18nService {
     return this.currentLocale.direction === 'ltr' ? 'left' : 'right';
   }
 
-  get locales() {
+  get locales(): Locale[] {
     return I18nService.locales.filter(
       locale => locale.production || this.featureFlags.showNonPublishedLocalizations.enabled
     );
   }
 
-  setLocale(tag: string, authService: AuthService) {
+  setLocale(tag: string, authService: AuthService): void {
     const locale = I18nService.getLocale(tag);
     if (locale == null) {
       throw new Error(`Cannot set locale to non-existent locale ${tag}`);
@@ -202,14 +202,14 @@ export class I18nService {
     this.document.body.setAttribute('dir', this.direction);
   }
 
-  localizeBook(book: number | string) {
+  localizeBook(book: number | string): string {
     if (typeof book === 'number') {
       book = Canon.bookNumberToId(book);
     }
     return this.transloco.translate(`canon.book_names.${book}`);
   }
 
-  localizeReference(verse: VerseRef) {
+  localizeReference(verse: VerseRef): string {
     // Add RTL mark before colon and hyphen characters, if in a RTL script.
     // See https://software.sil.org/arabicfonts/support/faq/ for description of this solution, under the section
     // "How do I get correct display for “Chapter:Verse” references using a regular “Roman” colon?"
@@ -220,7 +220,11 @@ export class I18nService {
   }
 
   localizeRole(role: string): string {
-    return this.transloco.translate(`roles.${role}`);
+    // The pt_consultant role has a long name with slashes in it and no spaces. This can lead to layout issues because
+    // there aren't spaces to break the line. Insert a zero-width space after each slash.
+    // According to https://unicode.org/reports/tr14/#ZW, regarding ZERO WIDTH SPACE:
+    // "This character is used to enable additional (invisible) break opportunities wherever SPACE cannot be used."
+    return this.transloco.translate(`roles.${role}`).split('/').join('/\u200B');
   }
 
   localizeRoleDescription(role: string): string {
@@ -231,7 +235,7 @@ export class I18nService {
     return this.transloco.selectTranslate<string>(key, params);
   }
 
-  translateAndInsertTags(key: I18nKey, params: object = {}) {
+  translateAndInsertTags(key: I18nKey, params: object = {}): string {
     return this.transloco.translate(key, {
       ...params,
       boldStart: '<strong>',
@@ -244,7 +248,7 @@ export class I18nService {
     });
   }
 
-  formatDate(date: Date) {
+  formatDate(date: Date): string {
     // fall back to en in the event the language code isn't valid
     const format = I18nService.dateFormats[this.localeCode] || {};
     return typeof format === 'function'


### PR DESCRIPTION
Previously the role and permissions checkbox label would not wrap, leaving all the wrapping to the name, which caused it to wrap a ton if it had to wrap.

Here's how it looks now (in French, where the issue was originally reported):

![](https://user-images.githubusercontent.com/6140710/228323898-b171e7cf-c5a7-450c-b09c-b8bc8275c275.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1770)
<!-- Reviewable:end -->
