### PR TITLE
SF-1932 - Store updated avatar URL in Auth0 user metadata

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -30,6 +30,9 @@ import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { DialogService } from 'xforge-common/dialog.service';
+import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
+import { User } from 'realtime-server/lib/esm/common/models/user';
+import { UserDoc } from 'xforge-common/models/user-doc';
 import { QuestionDoc } from '../../core/models/question-doc';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SF_TYPE_REGISTRY } from '../../core/models/sf-type-registry';
@@ -590,6 +593,19 @@ class TestEnvironment {
       },
       viewContainerRef
     };
+    this.realtimeService.addSnapshot<User>(UserDoc.COLLECTION, {
+      id: 'user01',
+      data: {
+        name: 'User 01',
+        email: 'user1@example.com',
+        role: SystemRole.User,
+        isDisplayNameConfirmed: true,
+        avatarUrl: '',
+        authId: 'auth01',
+        displayName: 'name',
+        sites: {}
+      }
+    });
 
     this.dialogRef = TestBed.inject(MatDialog).open(QuestionDialogComponent, config);
     this.afterCloseCallback = jasmine.createSpy('afterClose callback');
@@ -614,6 +630,9 @@ class TestEnvironment {
       createStorageFileData(QuestionDoc.COLLECTION, 'question01', '/path/to/audio.mp3', getAudioBlob())
     );
     when(mockedPwaService.onlineStatus$).thenReturn(of(true));
+    when(mockedUserService.getCurrentUser()).thenCall(() =>
+      this.realtimeService.subscribe(UserDoc.COLLECTION, 'user01')
+    );
     this.fixture.detectChanges();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
@@ -23,6 +23,9 @@ import { ChildViewContainerComponent, configureTestingModule, TestTranslocoModul
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
 import { CheckingAnswerExport } from 'realtime-server/lib/esm/scriptureforge/models/checking-config';
+import { User } from 'realtime-server/lib/esm/common/models/user';
+import { UserDoc } from 'xforge-common/models/user-doc';
+import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { CheckingModule } from '../checking/checking.module';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { SF_TYPE_REGISTRY } from '../core/models/sf-type-registry';
@@ -464,12 +467,28 @@ class TestEnvironment {
       id: TestEnvironment.PROJECT01,
       data: TestEnvironment.testProject
     });
+    this.realtimeService.addSnapshot<User>(UserDoc.COLLECTION, {
+      id: 'user01',
+      data: {
+        name: 'User 01',
+        email: 'user1@example.com',
+        role: SystemRole.User,
+        isDisplayNameConfirmed: true,
+        avatarUrl: '',
+        authId: 'auth01',
+        displayName: 'name',
+        sites: {}
+      }
+    });
 
     when(mockedProjectService.getProfile(anything())).thenCall(id =>
       this.realtimeService.subscribe(SFProjectProfileDoc.COLLECTION, id)
     );
     when(mockedProjectService.getText(anything())).thenCall(id =>
       this.realtimeService.subscribe(TextDoc.COLLECTION, id.toString())
+    );
+    when(mockedUserService.getCurrentUser()).thenCall(() =>
+      this.realtimeService.subscribe(UserDoc.COLLECTION, 'user01')
     );
 
     const dialogRef = TestBed.inject(MatDialog).open(TextChooserDialogComponent, { data: config });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/translate-metrics-session.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/translate-metrics-session.spec.ts
@@ -12,6 +12,8 @@ import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { UserService } from 'xforge-common/user.service';
 import { DialogService } from 'xforge-common/dialog.service';
+import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
+import { User } from 'realtime-server/lib/esm/common/models/user';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SF_TYPE_REGISTRY } from '../../core/models/sf-type-registry';
 import { TextDoc, TextDocId } from '../../core/models/text-doc';
@@ -431,6 +433,19 @@ class TestEnvironment {
   constructor() {
     this.addTextDoc(new TextDocId('project02', 40, 1, 'target'));
     this.addTextDoc(new TextDocId('project01', 40, 1, 'target'));
+    this.realtimeService.addSnapshot<User>(UserDoc.COLLECTION, {
+      id: 'user01',
+      data: {
+        name: 'User 01',
+        email: 'user1@example.com',
+        role: SystemRole.User,
+        isDisplayNameConfirmed: true,
+        avatarUrl: '',
+        authId: 'auth01',
+        displayName: 'name',
+        sites: {}
+      }
+    });
 
     when(mockedSFProjectService.getText(anything())).thenCall(id =>
       this.realtimeService.subscribe(TextDoc.COLLECTION, id.toString())
@@ -439,7 +454,9 @@ class TestEnvironment {
     when(mockedSFProjectService.getProfile(anything())).thenResolve({} as SFProjectProfileDoc);
     when(mockedPwaService.isOnline).thenReturn(true);
     when(mockedPwaService.onlineStatus$).thenReturn(of(true));
-    when(mockedUserService.getCurrentUser()).thenResolve({ data: { displayName: 'name' } } as UserDoc);
+    when(mockedUserService.getCurrentUser()).thenCall(() =>
+      this.realtimeService.subscribe(UserDoc.COLLECTION, 'user01')
+    );
 
     this.sourceFixture = TestBed.createComponent(TextComponent);
     this.source = this.sourceFixture.componentInstance;

--- a/src/SIL.XForge/Services/AuthService.cs
+++ b/src/SIL.XForge/Services/AuthService.cs
@@ -48,7 +48,7 @@ public class AuthService : DisposableBase, IAuthService
 
     public Task UpdateAvatar(string authId, string url)
     {
-        var content = new JObject(new JProperty("picture", url));
+        var content = new JObject(new JProperty("user_metadata", new JObject(new JProperty("picture", url))));
         return CallApiAsync(new HttpMethod("PATCH"), $"users/{authId}", content);
     }
 

--- a/src/SIL.XForge/Services/UserService.cs
+++ b/src/SIL.XForge/Services/UserService.cs
@@ -69,9 +69,12 @@ public class UserService : IUserService
             );
             await userDoc.SubmitJson0OpAsync(op =>
             {
+                string picture =
+                    userProfile["user_metadata"] == null ? null : (string)userProfile["user_metadata"]["picture"];
+                string avatarUrl = string.IsNullOrWhiteSpace(picture) ? (string)userProfile["picture"] : picture;
                 op.Set(u => u.Name, name);
                 op.Set(u => u.Email, (string)userProfile["email"]);
-                op.Set(u => u.AvatarUrl, (string)userProfile["picture"]);
+                op.Set(u => u.AvatarUrl, avatarUrl);
                 op.Set(u => u.Role, (string)userProfile["app_metadata"]["xf_role"]);
                 if (ptIdentity != null)
                 {

--- a/src/SIL.XForge/Services/UserService.cs
+++ b/src/SIL.XForge/Services/UserService.cs
@@ -69,8 +69,7 @@ public class UserService : IUserService
             );
             await userDoc.SubmitJson0OpAsync(op =>
             {
-                string picture =
-                    userProfile["user_metadata"] == null ? null : (string)userProfile["user_metadata"]["picture"];
+                string picture = (string)userProfile["user_metadata"]?["picture"];
                 string avatarUrl = string.IsNullOrWhiteSpace(picture) ? (string)userProfile["picture"] : picture;
                 op.Set(u => u.Name, name);
                 op.Set(u => u.Email, (string)userProfile["email"]);

--- a/test/SIL.XForge.Tests/Services/UserServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/UserServiceTests.cs
@@ -102,6 +102,34 @@ public class UserServiceTests
     }
 
     [Test]
+    public async Task PushAuthUserProfile_Metadata_AvatarSet()
+    {
+        var env = new TestEnvironment();
+
+        JObject userProfile = TestEnvironment.CreateUserProfile("user03", "auth03", env.IssuedAt);
+        string primaryAvatar = "https://example.com/avatar.png";
+        string customAvatar = "https://example.com/avatar-custom.png";
+        userProfile["picture"] = primaryAvatar;
+        userProfile["user_metadata"] = new JObject(new JProperty("picture", customAvatar));
+        await env.Service.UpdateUserFromProfileAsync("user03", userProfile.ToString());
+        User user3 = env.GetUser("user03");
+        Assert.That(user3.AvatarUrl, Is.EqualTo(customAvatar));
+    }
+
+    [Test]
+    public async Task PushAuthUserProfile_Metadata_AvatarNotSet()
+    {
+        var env = new TestEnvironment();
+
+        JObject userProfile = TestEnvironment.CreateUserProfile("user03", "auth03", env.IssuedAt);
+        string primaryAvatar = "https://example.com/avatar.png";
+        userProfile["picture"] = primaryAvatar;
+        await env.Service.UpdateUserFromProfileAsync("user03", userProfile.ToString());
+        User user3 = env.GetUser("user03");
+        Assert.That(user3.AvatarUrl, Is.EqualTo(primaryAvatar));
+    }
+
+    [Test]
     public async Task LinkParatextAccountAsync()
     {
         var env = new TestEnvironment();


### PR DESCRIPTION
- Save any update to the Avatar URL (picture) in the user metadata in Auth0
- On receiving the user profile from Auth0, use the picture value from metadata if available
- Update presence information when the user doc changes
- Added return types
- Added a user doc to various tests that use the text component

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1772)
<!-- Reviewable:end -->
