### PR TITLE
SF-1937 - Hide user assignment in the notes dialog for commenters

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
@@ -1,7 +1,9 @@
 <ng-container *transloco="let t; read: 'note_dialog'">
   <h1 mat-dialog-title>
     <img [src]="flagIcon" class="note-thread-icon" alt="" /> <span class="verse-reference">{{ verseRefDisplay }}</span>
-    <div id="assignedUser" class="assigned-user">>{{ getAssignedUserString(noteThreadAssignedUserRef) }}</div>
+    <div *ngIf="canViewAssignedUser" id="assignedUser" class="assigned-user">
+      >{{ getAssignedUserString(noteThreadAssignedUserRef) }}
+    </div>
   </h1>
   <mat-dialog-content class="content-padding" [ngClass]="{ rtl: isRtl, ltr: !isRtl }">
     <div class="text-row">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -305,7 +305,7 @@ describe('NoteDialogComponent', () => {
 
   it('hides assigned user for non-paratext users', fakeAsync(() => {
     env = new TestEnvironment({ noteThread: TestEnvironment.getNoteThread(), currentUserId: 'user02' });
-    expect(env.threadAssignedUser.nativeElement.textContent).toContain('Team');
+    expect(env.threadAssignedUser).toBeFalsy();
     expect(env.notes[0].nativeElement.querySelector('.assigned-user').textContent).toContain('Paratext user');
     expect(env.notes[1].nativeElement.querySelector('.assigned-user').textContent).toContain('Team');
   }));


### PR DESCRIPTION
- Hide the assignment in the note header if the current user does not have a Paratext role

**Paratext users see**
![image](https://user-images.githubusercontent.com/17464863/228405980-dee2034f-1758-4d9e-b690-0c9b944be8c0.png)

**Non-Paratext users see**
![image](https://user-images.githubusercontent.com/17464863/228406063-c1e08911-0a48-4813-9cce-6dedf1c19715.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1773)
<!-- Reviewable:end -->
