### PR TITLE
SF-1917 Add reviewer label on note content

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -31,7 +31,8 @@ import { TextDoc, TextDocId } from '../../../core/models/text-doc';
 import { canInsertNote, formatFontSizeToRems } from '../../../shared/utils';
 import { environment } from '../../../../environments/environment';
 
-const COMMENTER_LABEL_REGEX = /<p>\[.+\s-\s.+\]<\/p>\s*<p>(.+)<\/p>/s;
+// Regular expression to match the comment label i.e. [Commenter User - Scripture Forge]
+const COMMENTER_LABEL_REGEX = /^<p>\[[^\]]+\s-\s[^\]]+\]<\/p>\s*<p>(.+)<\/p>/s;
 
 export interface NoteDialogData {
   threadId?: string;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -427,7 +427,8 @@ export class NoteDialogComponent implements OnInit {
   }
 
   private stripSFUserLabel(content: string): string {
-    const matchArray: RegExpExecArray | null = COMMENTER_LABEL_REGEX.exec(content);
+    // trim whitespace since the content gets an extra new line character after being exported to PT
+    const matchArray: RegExpExecArray | null = COMMENTER_LABEL_REGEX.exec(content.trim());
     return matchArray == null ? content : matchArray[1];
   }
 


### PR DESCRIPTION
This change adds the user label to the notes left by non-paratext users. Initially I tried to do this on the back-end, but there were some round-tripping issues that were becoming more complex. Instead, I decided to add the label on the front-end, and make the label invisible in the note dialog.

![SF User Label](https://user-images.githubusercontent.com/17931130/228667060-a50b90dc-2ec2-4f25-8973-97b7a6cb60fa.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1774)
<!-- Reviewable:end -->
