### PR TITLE
SF-1935 - Close note bottom sheet when not in use

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
@@ -13,6 +13,8 @@ import { SupportedBrowsersDialogComponent } from 'xforge-common/supported-browse
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { XForgeCommonModule } from 'xforge-common/xforge-common.module';
 import { FeatureFlagsDialogComponent } from 'xforge-common/feature-flags/feature-flags.component';
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { InAppRootOverlayContainer } from 'xforge-common/overlay-container';
 import { environment } from '../environments/environment';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -70,7 +72,12 @@ import { JoinComponent } from './join/join.component';
     TranslocoModule,
     AppRoutingModule
   ],
-  providers: [CookieService, DatePipe, { provide: ErrorHandler, useClass: ExceptionHandlingService }],
+  providers: [
+    CookieService,
+    DatePipe,
+    { provide: ErrorHandler, useClass: ExceptionHandlingService },
+    { provide: OverlayContainer, useClass: InAppRootOverlayContainer }
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -588,6 +588,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     if (this.onTargetDeleteSub != null) {
       this.onTargetDeleteSub.unsubscribe();
     }
+    this.bottomSheet?.dismiss();
   }
 
   async onTargetUpdated(

--- a/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
@@ -153,3 +153,15 @@ button.mdc-icon-button {
 body[dir='rtl'] .mirror-rtl {
   transform: scaleX(-1);
 }
+
+app-root {
+  &:has(.mdc-drawer--open):has(.cdk-overlay-container) {
+    mdc-drawer {
+      z-index: 1002;
+
+      + .mdc-drawer-scrim {
+        z-index: 1001;
+      }
+    }
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/overlay-container.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/overlay-container.spec.ts
@@ -1,0 +1,80 @@
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { Component, DebugElement, TemplateRef, ViewChild } from '@angular/core';
+import { UICommonModule } from 'xforge-common/ui-common.module';
+import { MatBottomSheet } from '@angular/material/bottom-sheet';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { InAppRootOverlayContainer } from './overlay-container';
+
+describe('OverlayContainer', () => {
+  it('should add overlay container as a child of app-root', fakeAsync(() => {
+    const env = new TestEnvironment();
+    expect(env.bottomSheetContainer).toBeFalsy();
+    env.openBottomSheet();
+    expect(env.bottomSheetContainer).toBeTruthy();
+  }));
+});
+
+/**
+ * Host component is generated to contain the <app-root> element. When tests are rendered the initial component
+ * is only rendered as a <div> element whereas this test specifically needs access to the <app-root> element
+ */
+@Component({
+  selector: 'app-host',
+  template: '<app-root #root></app-root>'
+})
+class HostComponent {
+  @ViewChild('root') appRoot?: AppRootComponent;
+
+  open(): void {
+    this.appRoot?.open();
+  }
+}
+@Component({
+  selector: 'app-root',
+  template: '<ng-template #bottomSheet><div class="bottom-sheet-container">Opened</div></ng-template>'
+})
+class AppRootComponent {
+  @ViewChild('bottomSheet') TemplateBottomSheet?: TemplateRef<any>;
+
+  constructor(private bottomSheet: MatBottomSheet) {}
+
+  open(): void {
+    if (this.TemplateBottomSheet == null) {
+      return;
+    }
+    this.bottomSheet.open(this.TemplateBottomSheet);
+  }
+}
+
+class TestEnvironment {
+  readonly component: HostComponent;
+  readonly fixture: ComponentFixture<HostComponent>;
+
+  constructor() {
+    TestBed.configureTestingModule({
+      declarations: [HostComponent, AppRootComponent],
+      imports: [UICommonModule, NoopAnimationsModule],
+      providers: [{ provide: OverlayContainer, useClass: InAppRootOverlayContainer }]
+    });
+
+    this.fixture = TestBed.createComponent(HostComponent);
+    this.component = this.fixture.componentInstance;
+    this.fixture.detectChanges();
+  }
+
+  get bottomSheetContainer(): DebugElement {
+    return this.fixture.debugElement.parent!.query(By.css('app-root .bottom-sheet-container'));
+  }
+
+  openBottomSheet(): void {
+    this.component.open();
+    this.wait();
+  }
+
+  private wait(): void {
+    tick();
+    this.fixture.detectChanges();
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/overlay-container.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/overlay-container.ts
@@ -1,0 +1,31 @@
+import { Inject, Injectable } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { Platform } from '@angular/cdk/platform';
+
+@Injectable({ providedIn: 'root' })
+export class InAppRootOverlayContainer extends OverlayContainer {
+  constructor(@Inject(DOCUMENT) document: any, platform: Platform) {
+    super(document, platform);
+  }
+
+  protected _createContainer(): void {
+    super._createContainer();
+    this.appendToRootComponent();
+  }
+
+  /**
+   * Places the material overlay contents as a child of the <app-root> element
+   * This allows for elements like the menu drawer to open on top of any overlays i.e. bottom sheet
+   */
+  private appendToRootComponent(): void {
+    const rootElement: Element | null = this._document.querySelector('app-root');
+
+    if (this._containerElement == null || rootElement == null) {
+      return;
+    }
+
+    const parent: Element = rootElement || this._document.body;
+    parent.appendChild(this._containerElement);
+  }
+}


### PR DESCRIPTION
- Dismiss an open bottom sheet in the editor on disposal
- Change location for material overlays to be child elements of <app-root>
 - Update z-index for nav drawer and overlay to be higher than other material overlays

**Before**
![image](https://user-images.githubusercontent.com/17464863/229015563-44202c22-90f4-4f98-8485-7bd9bbd46fa3.png)


**After**
![image](https://user-images.githubusercontent.com/17464863/229015463-c1eae096-4565-4bfb-ba12-3f411826606c.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1775)
<!-- Reviewable:end -->
