### PR TITLE
SF-1924 PT comments on SF community checking answers lost after sync

### DIFF
--- a/src/RealtimeServer/common/services/project-data-service.spec.ts
+++ b/src/RealtimeServer/common/services/project-data-service.spec.ts
@@ -253,23 +253,43 @@ describe('ProjectDataService', () => {
     const userConn = clientConnect(env.server, 'user');
     await expect(
       submitJson0Op<TestData>(userConn, TEST_DATA_COLLECTION, 'test02', ops =>
-        ops
-          .add(d => d.children, { id: 'sub04', ownerRef: 'user', children: [] })
-          .insert(d => d.children[1].children, 0, { id: 'sub05', ownerRef: 'user' })
+        ops.insert(d => d.children[0].children, 0, { id: 'sub05', ownerRef: 'user' })
       )
     ).resolves.not.toThrow();
 
     const adminConn = clientConnect(env.server, 'admin');
     await expect(
       submitJson0Op<TestData>(adminConn, TEST_DATA_COLLECTION, 'test02', ops =>
-        ops.set<number>(d => d.children[1].children[0].num!, 1)
+        ops.set<number>(d => d.children[0].children[0].num!, 1)
       )
     ).rejects.toThrow();
     await expect(
       submitJson0Op<TestData>(adminConn, TEST_DATA_COLLECTION, 'test02', ops =>
-        ops.set<boolean>(d => d.children[1].children[0].deleted!, true)
+        ops.set<boolean>(d => d.children[0].children[0].deleted!, true)
       )
     ).resolves.not.toThrow();
+  });
+
+  it('denies updates to the deleted property if delete operations are not permitted', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const userOwnConn = clientConnect(env.server, 'userOwn');
+    await expect(
+      submitJson0Op<TestData>(userOwnConn, TEST_DATA_COLLECTION, 'test03', ops =>
+        ops.insert(d => d.children[0].children, 0, { id: 'sub05', ownerRef: 'userOwn' })
+      )
+    ).resolves.not.toThrow();
+    await expect(
+      submitJson0Op<TestData>(userOwnConn, TEST_DATA_COLLECTION, 'test03', ops =>
+        ops.set<number>(d => d.children[0].children[0].num!, 1)
+      )
+    ).resolves.not.toThrow();
+    await expect(
+      submitJson0Op<TestData>(userOwnConn, TEST_DATA_COLLECTION, 'test03', ops =>
+        ops.set<boolean>(d => d.children[0].children[0].deleted!, true)
+      )
+    ).rejects.toThrow();
   });
 });
 
@@ -349,8 +369,7 @@ class TestDataService extends ProjectDataService<TestData> {
 
       [TestProjectDomain.SubSubData, Operation.ViewOwn],
       [TestProjectDomain.SubSubData, Operation.Create],
-      [TestProjectDomain.SubSubData, Operation.EditOwn],
-      [TestProjectDomain.SubSubData, Operation.DeleteOwn]
+      [TestProjectDomain.SubSubData, Operation.EditOwn]
     ],
     observer: [
       [TestProjectDomain.TestData, Operation.View],

--- a/src/RealtimeServer/common/services/project-data-service.ts
+++ b/src/RealtimeServer/common/services/project-data-service.ts
@@ -149,9 +149,16 @@ export abstract class ProjectDataService<T extends ProjectData> extends JsonDocS
         // property update
         const entityPath = op.p.slice(0, domain.pathTemplate.template.length);
         const oldEntity = this.deepGet(entityPath, oldDoc);
+
+        // Changing the deleted property should be treated as a delete operation
+        let operation: Operation = Operation.Edit;
+        if (op.p[op.p.length - 1] === 'deleted') {
+          operation = Operation.Delete;
+        }
+
         // if the entity doesn't exist in the old doc, then it must be inserted by a previous op that the user has a
         // right to perform, so we don't need to check this edit right
-        if (oldEntity != null && !this.hasRight(project, domain, Operation.Edit, session.userId, oldEntity)) {
+        if (oldEntity != null && !this.hasRight(project, domain, operation, session.userId, oldEntity)) {
           return false;
         }
       } else {

--- a/src/RealtimeServer/common/services/project-data-service.ts
+++ b/src/RealtimeServer/common/services/project-data-service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import ShareDB from 'sharedb';
 import { ConnectSession } from '../connect-session';
 import { MigrationConstructor } from '../migration';

--- a/src/RealtimeServer/scriptureforge/models/comment.ts
+++ b/src/RealtimeServer/scriptureforge/models/comment.ts
@@ -2,6 +2,7 @@ import { OwnedData } from '../../common/models/owned-data';
 
 export interface Comment extends OwnedData {
   dataId: string;
+  deleted: boolean;
   syncUserRef?: string;
   text?: string;
   dateModified: string;

--- a/src/RealtimeServer/scriptureforge/models/note.ts
+++ b/src/RealtimeServer/scriptureforge/models/note.ts
@@ -7,7 +7,6 @@ export interface Note extends Comment {
   threadId: string;
   type: string;
   conflictType: string;
-  deleted: boolean;
   status: NoteStatus;
   tagId?: number;
   reattached?: string;

--- a/src/RealtimeServer/scriptureforge/services/question-migrations.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/question-migrations.spec.ts
@@ -1,0 +1,59 @@
+import ShareDB from 'sharedb';
+import ShareDBMingo from 'sharedb-mingo-memory';
+import { instance, mock, when } from 'ts-mockito';
+import { MetadataDB } from '../../common/metadata-db';
+import { RealtimeServer } from '../../common/realtime-server';
+import { SchemaVersionRepository } from '../../common/schema-version-repository';
+import { createDoc, fetchDoc } from '../../common/utils/test-utils';
+import { QUESTIONS_COLLECTION } from '../models/question';
+import { QuestionService } from './question-service';
+
+describe('QuestionMigrations', () => {
+  describe('version 1', () => {
+    it('migrates docs', async () => {
+      const env = new TestEnvironment(0);
+      const conn = env.server.connect();
+      await createDoc(conn, QUESTIONS_COLLECTION, 'question01', {
+        answers: [{ comments: [{}, { deleted: true }] }, { comments: [{}, {}] }]
+      });
+      await createDoc(conn, QUESTIONS_COLLECTION, 'question02', {
+        answers: []
+      });
+      await env.server.migrateIfNecessary();
+
+      let questionDoc = await fetchDoc(conn, QUESTIONS_COLLECTION, 'question01');
+      expect(questionDoc.data.answers[0].comments[0].deleted).toBe(false);
+      expect(questionDoc.data.answers[0].comments[1].deleted).toBe(true);
+      expect(questionDoc.data.answers[1].comments[0].deleted).toBe(false);
+      expect(questionDoc.data.answers[1].comments[1].deleted).toBe(false);
+      questionDoc = await fetchDoc(conn, QUESTIONS_COLLECTION, 'question02');
+      expect(questionDoc.data.answers.length).toBe(0);
+    });
+  });
+});
+
+class TestEnvironment {
+  readonly db: ShareDBMingo;
+  readonly mockedSchemaVersionRepository = mock(SchemaVersionRepository);
+  readonly server: RealtimeServer;
+
+  /**
+   * @param version The version the document is currently at (so migrations prior to this version will not be run
+   * on the document)
+   */
+  constructor(version: number) {
+    const ShareDBMingoType = MetadataDB(ShareDBMingo.extendMemoryDB(ShareDB.MemoryDB));
+    this.db = new ShareDBMingoType();
+    when(this.mockedSchemaVersionRepository.getAll()).thenResolve([
+      { _id: QUESTIONS_COLLECTION, collection: QUESTIONS_COLLECTION, version }
+    ]);
+    this.server = new RealtimeServer(
+      'TEST',
+      false,
+      [new QuestionService()],
+      QUESTIONS_COLLECTION,
+      this.db,
+      instance(this.mockedSchemaVersionRepository)
+    );
+  }
+}

--- a/src/RealtimeServer/scriptureforge/services/question-migrations.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/question-migrations.spec.ts
@@ -14,7 +14,7 @@ describe('QuestionMigrations', () => {
       const env = new TestEnvironment(0);
       const conn = env.server.connect();
       await createDoc(conn, QUESTIONS_COLLECTION, 'question01', {
-        answers: [{ comments: [{}, { deleted: true }] }, { comments: [{}, {}] }]
+        answers: [{ deleted: true, comments: [{}, { deleted: true }] }, { comments: [{}, {}] }]
       });
       await createDoc(conn, QUESTIONS_COLLECTION, 'question02', {
         answers: []
@@ -22,8 +22,10 @@ describe('QuestionMigrations', () => {
       await env.server.migrateIfNecessary();
 
       let questionDoc = await fetchDoc(conn, QUESTIONS_COLLECTION, 'question01');
+      expect(questionDoc.data.answers[0].deleted).toBe(true);
       expect(questionDoc.data.answers[0].comments[0].deleted).toBe(false);
       expect(questionDoc.data.answers[0].comments[1].deleted).toBe(true);
+      expect(questionDoc.data.answers[1].deleted).toBe(false);
       expect(questionDoc.data.answers[1].comments[0].deleted).toBe(false);
       expect(questionDoc.data.answers[1].comments[1].deleted).toBe(false);
       questionDoc = await fetchDoc(conn, QUESTIONS_COLLECTION, 'question02');

--- a/src/RealtimeServer/scriptureforge/services/question-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/question-migrations.ts
@@ -8,11 +8,11 @@ class QuestionMigration1 implements Migration {
   async migrateDoc(doc: Doc): Promise<void> {
     const ops: Op[] = [];
     for (let i = 0; i < doc.data.answers.length; i++) {
-      if (doc.data.answers[i].deleted === undefined) {
+      if (doc.data.answers[i].deleted == null) {
         ops.push({ p: ['answers', i, 'deleted'], oi: false });
       }
       for (let j = 0; j < doc.data.answers[i].comments.length; j++) {
-        if (doc.data.answers[i].comments[j].deleted === undefined) {
+        if (doc.data.answers[i].comments[j].deleted == null) {
           ops.push({ p: ['answers', i, 'comments', j, 'deleted'], oi: false });
         }
       }

--- a/src/RealtimeServer/scriptureforge/services/question-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/question-migrations.ts
@@ -1,3 +1,31 @@
-import { MigrationConstructor } from '../../common/migration';
+import { Doc, Op, RawOp } from 'sharedb/lib/client';
+import { submitMigrationOp } from '../../common/realtime-server';
+import { Migration, MigrationConstructor } from '../../common/migration';
 
-export const QUESTION_MIGRATIONS: MigrationConstructor[] = [];
+class QuestionMigration1 implements Migration {
+  static readonly VERSION = 1;
+
+  async migrateDoc(doc: Doc): Promise<void> {
+    const ops: Op[] = [];
+    for (let i = 0; i < doc.data.answers.length; i++) {
+      if (doc.data.answers[i].deleted === undefined) {
+        ops.push({ p: ['answers', i, 'deleted'], oi: false });
+      }
+      for (let j = 0; j < doc.data.answers[i].comments.length; j++) {
+        if (doc.data.answers[i].comments[j].deleted === undefined) {
+          ops.push({ p: ['answers', i, 'comments', j, 'deleted'], oi: false });
+        }
+      }
+    }
+
+    if (ops.length > 0) {
+      await submitMigrationOp(QuestionMigration1.VERSION, doc, ops);
+    }
+  }
+
+  migrateOp(_op: RawOp): void {
+    // do nothing
+  }
+}
+
+export const QUESTION_MIGRATIONS: MigrationConstructor[] = [QuestionMigration1];

--- a/src/RealtimeServer/scriptureforge/services/question-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/question-service.spec.ts
@@ -195,6 +195,7 @@ class TestEnvironment {
           text: 'Answer.',
           dateModified: '',
           dateCreated: '',
+          deleted: false,
           likes: [],
           comments: [
             {
@@ -202,7 +203,8 @@ class TestEnvironment {
               ownerRef: 'projectAdmin',
               text: 'Comment.',
               dateModified: '',
-              dateCreated: ''
+              dateCreated: '',
+              deleted: false
             }
           ]
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -673,12 +673,14 @@ class TestEnvironment {
                 likes: [{ ownerRef: this.checkerUser.id }],
                 dateCreated: '',
                 dateModified: '',
+                deleted: false,
                 comments: [
                   {
                     dataId: 'c2Id',
                     ownerRef: this.checkerUser.id,
                     dateCreated: '',
-                    dateModified: ''
+                    dateModified: '',
+                    deleted: false
                   }
                 ]
               }
@@ -707,12 +709,14 @@ class TestEnvironment {
                 likes: [{ ownerRef: this.checkerUser.id }, { ownerRef: this.anotherUserId }],
                 dateCreated: '',
                 dateModified: '',
+                deleted: false,
                 comments: [
                   {
                     dataId: 'c1Id',
                     ownerRef: this.checkerUser.id,
                     dateCreated: '',
-                    dateModified: ''
+                    dateModified: '',
+                    deleted: false
                   }
                 ]
               }
@@ -742,12 +746,14 @@ class TestEnvironment {
                 likes: [{ ownerRef: this.checkerUser.id }],
                 dateCreated: '',
                 dateModified: '',
+                deleted: false,
                 comments: [
                   {
                     dataId: 'c3Id',
                     ownerRef: this.anotherUserId,
                     dateCreated: '',
-                    dateModified: ''
+                    dateModified: '',
+                    deleted: false
                   }
                 ]
               }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -93,9 +93,9 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
     for (const questionDoc of this.allPublishedQuestions) {
       if (questionDoc.data != null) {
         if (canCreateQuestion) {
-          count += questionDoc.data.answers.filter(a => !a.deleted).length;
+          count += questionDoc.getAnswers().length;
         } else {
-          count += questionDoc.data.answers.filter(a => a.ownerRef === currentUserId && !a.deleted).length;
+          count += questionDoc.getAnswers(currentUserId).length;
         }
       }
     }
@@ -109,7 +109,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
     const currentUserId = this.userService.currentUserId;
     for (const questionDoc of this.allPublishedQuestions) {
       if (questionDoc.data != null) {
-        for (const answer of questionDoc.data.answers.filter(answer => !answer.deleted)) {
+        for (const answer of questionDoc.getAnswers()) {
           if (canCreateQuestion) {
             count += answer.likes.length;
           } else {
@@ -128,7 +128,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
     const currentUserId = this.userService.currentUserId;
     for (const questionDoc of this.allPublishedQuestions) {
       if (questionDoc.data != null) {
-        for (const answer of questionDoc.data.answers.filter(a => !a.deleted)) {
+        for (const answer of questionDoc.getAnswers()) {
           if (canCreateQuestion) {
             count += answer.comments.filter(c => !c.deleted).length;
           } else {
@@ -304,7 +304,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
     let count: number = 0;
     for (const q of this.getQuestionDocs(id)) {
       if (q.data != null) {
-        const answerCount = q.data.answers.filter(answer => !answer.deleted).length;
+        const answerCount = q.getAnswers().length;
         count += answerCount;
       }
     }
@@ -387,7 +387,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
       return;
     }
     if (questionDoc != null && questionDoc.data != null) {
-      if (questionDoc.data.answers.filter(answer => !answer.deleted).length > 0) {
+      if (questionDoc.getAnswers().length > 0) {
         const answeredDialogRef = this.dialogService.openMdcDialog(QuestionAnsweredDialogComponent);
         const response = (await answeredDialogRef.afterClosed().toPromise()) as string;
         if (response === 'close') {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking.utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking.utils.ts
@@ -21,7 +21,7 @@ export class CheckingUtils {
     if (question == null) {
       return false;
     }
-    return question.answers.filter(answer => answer.ownerRef === userId).length > 0;
+    return question.answers.filter(answer => answer.ownerRef === userId && !answer.deleted).length > 0;
   }
 
   static hasUserReadQuestion(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -206,10 +206,14 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
 
     if (this.shouldSeeAnswersList) {
       return this._questionDoc.data.answers.filter(
-        answer => answer.ownerRef === this.userService.currentUserId || this._answersToShow.includes(answer.dataId)
+        answer =>
+          (answer.ownerRef === this.userService.currentUserId || this._answersToShow.includes(answer.dataId)) &&
+          !answer.deleted
       );
     } else {
-      return this._questionDoc.data.answers.filter(answer => answer.ownerRef === this.userService.currentUserId);
+      return this._questionDoc.data.answers.filter(
+        answer => answer.ownerRef === this.userService.currentUserId && !answer.deleted
+      );
     }
   }
 
@@ -221,7 +225,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     if (this._questionDoc == null || this._questionDoc.data == null) {
       return [];
     }
-    return this._questionDoc.data.answers;
+    return this._questionDoc.data.answers.filter(answer => !answer.deleted);
   }
 
   get canSeeOtherUserResponses(): boolean {
@@ -236,7 +240,9 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     if (this._questionDoc == null || this._questionDoc.data == null) {
       return 0;
     }
-    return this._questionDoc.data.answers.filter(answer => answer.ownerRef === this.userService.currentUserId).length;
+    return this._questionDoc.data.answers.filter(
+      answer => answer.ownerRef === this.userService.currentUserId && !answer.deleted
+    ).length;
   }
 
   /** Answer belonging to current user, if any. Assumes they don't have more than one answer. */
@@ -244,7 +250,9 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     if (this._questionDoc == null || this._questionDoc.data == null) {
       return null;
     }
-    const answer = this._questionDoc.data.answers.find(ans => ans.ownerRef === this.userService.currentUserId);
+    const answer = this._questionDoc.data.answers.find(
+      ans => ans.ownerRef === this.userService.currentUserId && !ans.deleted
+    );
     return answer !== undefined ? answer : null;
   }
 
@@ -346,7 +354,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
       return;
     }
     const projectId = this._questionDoc.data.projectRef;
-    if (this._questionDoc.data.answers.length > 0) {
+    if (this._questionDoc.data.answers.filter(answer => !answer.deleted).length > 0) {
       const answeredDialogRef = this.dialog.open(QuestionAnsweredDialogComponent);
       const dialogResponse = (await answeredDialogRef.afterClosed().toPromise()) as string;
       if (dialogResponse === 'close') {
@@ -538,7 +546,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     if (this.questionDoc == null || this.questionDoc.data == null) {
       return;
     }
-    this._answersToShow = this.questionDoc.data.answers.map(answer => answer.dataId);
+    this._answersToShow = this.questionDoc.data.answers.filter(answer => !answer.deleted).map(answer => answer.dataId);
     this.refreshAnswersHighlightStatus();
     this.justEditedAnswer = false;
     if (showUnreadClicked) {
@@ -569,7 +577,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
       return;
     }
     this.cacheFileSource(this.questionDoc, this.questionDoc.data.dataId, this.questionDoc.data.audioUrl);
-    for (const answer of this.questionDoc.data.answers) {
+    for (const answer of this.questionDoc.data.answers.filter(answer => !answer.deleted)) {
       this.cacheFileSource(this.questionDoc, answer.dataId, answer.audioUrl);
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -211,9 +211,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
           !answer.deleted
       );
     } else {
-      return this._questionDoc.data.answers.filter(
-        answer => answer.ownerRef === this.userService.currentUserId && !answer.deleted
-      );
+      return this._questionDoc.getAnswers(this.userService.currentUserId);
     }
   }
 
@@ -225,7 +223,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     if (this._questionDoc == null || this._questionDoc.data == null) {
       return [];
     }
-    return this._questionDoc.data.answers.filter(answer => !answer.deleted);
+    return this._questionDoc.getAnswers();
   }
 
   get canSeeOtherUserResponses(): boolean {
@@ -240,9 +238,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     if (this._questionDoc == null || this._questionDoc.data == null) {
       return 0;
     }
-    return this._questionDoc.data.answers.filter(
-      answer => answer.ownerRef === this.userService.currentUserId && !answer.deleted
-    ).length;
+    return this._questionDoc.getAnswers(this.userService.currentUserId).length;
   }
 
   /** Answer belonging to current user, if any. Assumes they don't have more than one answer. */
@@ -251,7 +247,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
       return null;
     }
     const answer = this._questionDoc.data.answers.find(
-      ans => ans.ownerRef === this.userService.currentUserId && !ans.deleted
+      answer => answer.ownerRef === this.userService.currentUserId && !answer.deleted
     );
     return answer !== undefined ? answer : null;
   }
@@ -354,7 +350,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
       return;
     }
     const projectId = this._questionDoc.data.projectRef;
-    if (this._questionDoc.data.answers.filter(answer => !answer.deleted).length > 0) {
+    if (this._questionDoc.getAnswers().length > 0) {
       const answeredDialogRef = this.dialog.open(QuestionAnsweredDialogComponent);
       const dialogResponse = (await answeredDialogRef.afterClosed().toPromise()) as string;
       if (dialogResponse === 'close') {
@@ -546,7 +542,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     if (this.questionDoc == null || this.questionDoc.data == null) {
       return;
     }
-    this._answersToShow = this.questionDoc.data.answers.filter(answer => !answer.deleted).map(answer => answer.dataId);
+    this._answersToShow = this.questionDoc.getAnswers().map(answer => answer.dataId);
     this.refreshAnswersHighlightStatus();
     this.justEditedAnswer = false;
     if (showUnreadClicked) {
@@ -577,7 +573,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
       return;
     }
     this.cacheFileSource(this.questionDoc, this.questionDoc.data.dataId, this.questionDoc.data.audioUrl);
-    for (const answer of this.questionDoc.data.answers.filter(answer => !answer.deleted)) {
+    for (const answer of this.questionDoc.getAnswers()) {
       this.cacheFileSource(this.questionDoc, answer.dataId, answer.audioUrl);
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.ts
@@ -144,7 +144,7 @@ export class CheckingCommentsComponent extends SubscriptionDisposable implements
         if (this.projectUserConfigDoc == null || this.projectUserConfigDoc.data == null || this.answer == null) {
           return;
         }
-        const commentsLength = this.answer.comments.filter(comment => !comment.deleted).length;
+        const commentsLength: number = this.answer.comments.filter(comment => !comment.deleted).length;
         const defaultCommentsToShow =
           commentsLength > this.maxCommentsToShow ? this.maxCommentsToShow - 1 : commentsLength;
         const commentsToShow = this.showAllComments ? commentsLength : defaultCommentsToShow;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.ts
@@ -65,7 +65,7 @@ export class CheckingCommentsComponent extends SubscriptionDisposable implements
   }
 
   get commentCount(): number {
-    return this.answer != null ? this.answer.comments.length : 0;
+    return this.answer != null ? this.answer.comments.filter(c => !c.deleted).length : 0;
   }
 
   get canAddComment(): boolean {
@@ -77,7 +77,12 @@ export class CheckingCommentsComponent extends SubscriptionDisposable implements
   }
 
   getSortedComments(): Comment[] {
-    return this.answer != null ? sortBy(this.answer.comments, c => c.dateCreated) : [];
+    return this.answer != null
+      ? sortBy(
+          this.answer.comments.filter(c => !c.deleted),
+          c => c.dateCreated
+        )
+      : [];
   }
 
   editComment(comment: Comment): void {
@@ -139,11 +144,10 @@ export class CheckingCommentsComponent extends SubscriptionDisposable implements
         if (this.projectUserConfigDoc == null || this.projectUserConfigDoc.data == null || this.answer == null) {
           return;
         }
+        const commentsLength = this.answer.comments.filter(comment => !comment.deleted).length;
         const defaultCommentsToShow =
-          this.answer.comments.length > this.maxCommentsToShow
-            ? this.maxCommentsToShow - 1
-            : this.answer.comments.length;
-        const commentsToShow = this.showAllComments ? this.answer.comments.length : defaultCommentsToShow;
+          commentsLength > this.maxCommentsToShow ? this.maxCommentsToShow - 1 : commentsLength;
+        const commentsToShow = this.showAllComments ? commentsLength : defaultCommentsToShow;
         const commentIdsToMarkRead: string[] = [];
         let commentNumber = 1;
         // Older comments are displayed above newer comments, so iterate over comments starting with the oldest

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -182,9 +182,9 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
     }
 
     if (this.project.checkingConfig.usersSeeEachOthersResponses || !this.canAddAnswer || this.isProjectAdmin) {
-      return questionDoc.data.answers.filter(a => !a.deleted);
+      return questionDoc.getAnswers();
     } else {
-      return questionDoc.data.answers.filter(a => a.ownerRef === this.userService.currentUserId && !a.deleted);
+      return questionDoc.getAnswers(this.userService.currentUserId);
     }
   }
 
@@ -254,7 +254,7 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
             if (!this.hasUserReadAnswer(answer)) {
               op.add(puc => puc.answerRefsRead, answer.dataId);
             }
-            const comments = sortBy(
+            const comments: Comment[] = sortBy(
               answer.comments.filter(c => !c.deleted),
               c => c.dateCreated
             );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -182,9 +182,9 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
     }
 
     if (this.project.checkingConfig.usersSeeEachOthersResponses || !this.canAddAnswer || this.isProjectAdmin) {
-      return questionDoc.data.answers;
+      return questionDoc.data.answers.filter(a => !a.deleted);
     } else {
-      return questionDoc.data.answers.filter(answer => answer.ownerRef === this.userService.currentUserId);
+      return questionDoc.data.answers.filter(a => a.ownerRef === this.userService.currentUserId && !a.deleted);
     }
   }
 
@@ -204,7 +204,7 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
       }
     }
     for (const answer of this.getAnswers(questionDoc)) {
-      for (const comment of answer.comments) {
+      for (const comment of answer.comments.filter(c => !c.deleted)) {
         if (!this.hasUserReadComment(comment)) {
           unread++;
         }
@@ -254,7 +254,10 @@ export class CheckingQuestionsComponent extends SubscriptionDisposable {
             if (!this.hasUserReadAnswer(answer)) {
               op.add(puc => puc.answerRefsRead, answer.dataId);
             }
-            const comments = sortBy(answer.comments, c => c.dateCreated);
+            const comments = sortBy(
+              answer.comments.filter(c => !c.deleted),
+              c => c.dateCreated
+            );
             let readLimit = 3;
             if (comments.length > 3) {
               readLimit = 2;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1985,7 +1985,7 @@ class TestEnvironment {
     return this.getFirstNumberFromElementText('#show-unread-answers-button');
   }
 
-  activateQuestion(dataId: string) {
+  activateQuestion(dataId: string): void {
     const questionDoc = this.getQuestionDoc(dataId);
     this.ngZone.run(() => this.component.questionsPanel!.activateQuestion(questionDoc));
     tick();
@@ -2078,7 +2078,8 @@ class TestEnvironment {
       ownerRef: ADMIN_USER.id,
       text: text,
       dateCreated: date,
-      dateModified: date
+      dateModified: date,
+      deleted: false
     };
     questionDoc.submitJson0Op(op => op.insert(q => q.answers[0].comments, 0, comment), false);
     return commentId;
@@ -2267,7 +2268,7 @@ class TestEnvironment {
   }
 
   /** Delete user's answer via the checking-answers.component. */
-  deleteAnswerOwnedBy(userId: string = CHECKER_USER.id) {
+  deleteAnswerOwnedBy(userId: string = CHECKER_USER.id): void {
     const usersAnswer = this.component.answersPanel!.questionDoc!.data!.answers.filter(
       answer => answer.ownerRef === userId
     )[0];
@@ -2278,7 +2279,7 @@ class TestEnvironment {
   }
 
   /** Delete answer by id behind the scenes */
-  deleteAnswer(answerIdToDelete: string) {
+  deleteAnswer(answerIdToDelete: string): void {
     const questionDoc = this.component.answersPanel!.questionDoc!;
     const answers = questionDoc.data!.answers;
     const answerIndex = answers.findIndex(existingAnswer => existingAnswer.dataId === answerIdToDelete);
@@ -2289,12 +2290,12 @@ class TestEnvironment {
     flush();
   }
 
-  setQuestionFilter(filter: QuestionFilter) {
+  setQuestionFilter(filter: QuestionFilter): void {
     this.component.setQuestionFilter(filter);
     this.waitForQuestionTimersToComplete();
   }
 
-  simulateNewRemoteAnswer(dataId: string = 'newAnswer1', text: string = 'new answer from another user') {
+  simulateNewRemoteAnswer(dataId: string = 'newAnswer1', text: string = 'new answer from another user'): void {
     // Another user on another computer adds a new answer.
     const date = new Date();
     date.setDate(date.getDate() - 1);
@@ -2311,6 +2312,7 @@ class TestEnvironment {
           likes: [],
           dateCreated: dateCreated,
           dateModified: dateCreated,
+          deleted: false,
           audioUrl: '/audio.mp3',
           comments: []
         }),
@@ -2364,7 +2366,7 @@ class TestEnvironment {
     flush();
   }
 
-  private setRouteSnapshot(bookId: string) {
+  private setRouteSnapshot(bookId: string): void {
     const snapshot = new ActivatedRouteSnapshot();
     snapshot.params = { bookId: bookId };
     when(mockedActivatedRoute.snapshot).thenReturn(snapshot);
@@ -2527,6 +2529,7 @@ class TestEnvironment {
       likes: [],
       dateCreated: dateCreated,
       dateModified: dateCreated,
+      deleted: false,
       audioUrl: '/audio.mp3',
       comments: []
     });
@@ -2538,7 +2541,8 @@ class TestEnvironment {
         ownerRef: ADMIN_USER.id,
         text: 'Comment ' + commentNumber + ' on question 7',
         dateCreated: dateCreated,
-        dateModified: dateCreated
+        dateModified: dateCreated,
+        deleted: false
       });
     }
     johnQuestions[6].data!.answers.push({
@@ -2548,6 +2552,7 @@ class TestEnvironment {
       likes: [],
       dateCreated: dateCreated,
       dateModified: dateCreated,
+      deleted: false,
       comments: a7Comments
     });
 
@@ -2558,7 +2563,8 @@ class TestEnvironment {
         ownerRef: CHECKER_USER.id,
         text: 'Comment ' + commentNumber + ' on question 8',
         dateCreated: dateCreated,
-        dateModified: dateCreated
+        dateModified: dateCreated,
+        deleted: false
       });
     }
     johnQuestions[7].data!.answers.push({
@@ -2568,6 +2574,7 @@ class TestEnvironment {
       likes: [],
       dateCreated: dateCreated,
       dateModified: dateCreated,
+      deleted: false,
       comments: a8Comments,
       status: AnswerStatus.Exportable
     });
@@ -2580,6 +2587,7 @@ class TestEnvironment {
       likes: [],
       dateCreated: dateCreated,
       dateModified: dateCreated,
+      deleted: false,
       audioUrl: '/audio.mp3',
       comments: [],
       status: AnswerStatus.Exportable
@@ -2593,6 +2601,7 @@ class TestEnvironment {
       likes: [],
       dateCreated: dateCreated,
       dateModified: dateCreated,
+      deleted: false,
       audioUrl: '/audio.mp3',
       comments: [],
       status: AnswerStatus.Resolved
@@ -2606,6 +2615,7 @@ class TestEnvironment {
       likes: [],
       dateCreated: dateCreated,
       dateModified: dateCreated,
+      deleted: false,
       comments: []
     });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -2284,7 +2284,7 @@ class TestEnvironment {
     const answers = questionDoc.data!.answers;
     const answerIndex = answers.findIndex(existingAnswer => existingAnswer.dataId === answerIdToDelete);
 
-    questionDoc.submitJson0Op(op => op.remove(q => q.answers, answerIndex));
+    questionDoc.submitJson0Op(op => op.set(q => q.answers[answerIndex].deleted, true));
 
     this.fixture.detectChanges();
     flush();
@@ -2340,7 +2340,7 @@ class TestEnvironment {
 
   simulateRemoteDeleteAnswer(questionId: string, answerIndex: number): void {
     const questionDoc = this.getQuestionDoc(questionId);
-    questionDoc.submitJson0Op(op => op.remove(q => q.answers, answerIndex), false);
+    questionDoc.submitJson0Op(op => op.set(q => q.answers[answerIndex].deleted, true), false);
     this.fixture.detectChanges();
     flush();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -859,9 +859,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
     if (this.questionFilterSelected === QuestionFilter.None) matchingQuestions = this.questionDocs.slice();
     else {
       const filterFunction = this.questionFilterFunctions[this.questionFilterSelected];
-      matchingQuestions = this.questionDocs.filter(q =>
-        q.data == null ? false : filterFunction(q.data.answers.filter(answer => !answer.deleted))
-      );
+      matchingQuestions = this.questionDocs.filter(q => (q.data == null ? false : filterFunction(q.getAnswers())));
     }
     this.visibleQuestions = matchingQuestions;
     if (this.totalQuestions() === this.totalVisibleQuestions()) {
@@ -893,11 +891,11 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
     }
     const answerIndex = this.getAnswerIndex(answer);
     if (answerIndex >= 0) {
-      const commentLength = activeQuestionDoc.data!.answers[answerIndex].comments.length;
+      const commentsLength: number = activeQuestionDoc.data!.answers[answerIndex].comments.length;
       activeQuestionDoc
         .submitJson0Op(op => {
           op.set(q => q.answers[answerIndex].deleted, true);
-          for (let commentIndex = 0; commentIndex < commentLength; commentIndex++) {
+          for (let commentIndex = 0; commentIndex < commentsLength; commentIndex++) {
             op.set(q => q.answers[answerIndex].comments[commentIndex].deleted, true);
           }
         })

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
@@ -712,7 +712,8 @@ class TestEnvironment {
         } as Question,
         submitJson0Op: (_: any) => {
           this.editedTransceleratorQuestionIds.push(doc.id);
-        }
+        },
+        getAnswers: () => [] as Answer[]
       } as QuestionDoc);
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -458,7 +458,7 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable imple
         ' ' +
         change.sfVersionOfQuestion!.data!.text,
       after: this.referenceForDisplay(change.question) + ' ' + change.question.text,
-      answerCount: change.sfVersionOfQuestion?.getAnswers?.().length || 0,
+      answerCount: change.sfVersionOfQuestion?.getAnswers().length || 0,
       checked: true
     }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -458,7 +458,7 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable imple
         ' ' +
         change.sfVersionOfQuestion!.data!.text,
       after: this.referenceForDisplay(change.question) + ' ' + change.question.text,
-      answerCount: change.sfVersionOfQuestion?.data?.answers.length || 0,
+      answerCount: change.sfVersionOfQuestion?.getAnswers?.().length || 0,
       checked: true
     }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/question-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/question-doc.ts
@@ -21,6 +21,20 @@ export class QuestionDoc extends ProjectDataDoc<Question> {
     return this.data != null && fileType === FileType.Audio && !this.data.isArchived && this.data.dataId === dataId;
   }
 
+  /**
+   * Gets the answers for this question that have not been deleted.
+   *
+   * @param {string} ownerRef If set, this filters by the owner of the answer.
+   * @returns The answers as an array.
+   */
+  getAnswers(ownerRef: string | undefined = undefined): Answer[] {
+    return (
+      (ownerRef == null
+        ? this.data?.answers.filter(a => !a.deleted)
+        : this.data?.answers.filter(a => !a.deleted && a.ownerRef === ownerRef)) ?? []
+    );
+  }
+
   async updateFileCache(): Promise<void> {
     if (this.realtimeService.fileService == null || this.data == null) {
       return;
@@ -39,7 +53,7 @@ export class QuestionDoc extends ProjectDataDoc<Question> {
       return;
     }
 
-    for (const answer of this.data.answers.filter(answer => !answer.deleted)) {
+    for (const answer of this.getAnswers()) {
       await this.realtimeService.fileService.findOrUpdateCache(
         FileType.Audio,
         this.collection,

--- a/src/SIL.XForge.Scripture/Models/Answer.cs
+++ b/src/SIL.XForge.Scripture/Models/Answer.cs
@@ -4,9 +4,9 @@ namespace SIL.XForge.Scripture.Models;
 
 public class Answer : Comment
 {
-    public VerseRefData VerseRef { get; set; }
-    public string ScriptureText { get; set; }
-    public string AudioUrl { get; set; }
+    public VerseRefData? VerseRef { get; set; }
+    public string? ScriptureText { get; set; }
+    public string? AudioUrl { get; set; }
     public List<Like> Likes { get; set; } = new List<Like>();
     public List<Comment> Comments { get; set; } = new List<Comment>();
     public string Status { get; set; } = AnswerStatus.None;

--- a/src/SIL.XForge.Scripture/Models/Comment.cs
+++ b/src/SIL.XForge.Scripture/Models/Comment.cs
@@ -5,15 +5,24 @@ namespace SIL.XForge.Scripture.Models;
 
 public class Comment : IOwnedData
 {
-    public string DataId { get; set; }
-    public string OwnerRef { get; set; }
+    public string DataId { get; set; } = string.Empty;
+    public string OwnerRef { get; set; } = string.Empty;
 
     /// <summary>
     /// The OpaqueUserId of a ParatextUserProfile. It is used to correlate comments between PT and SF. It may refer
     /// to a SF user who synchronized the comment.
     /// </summary>
-    public string SyncUserRef { get; set; }
-    public string Text { get; set; }
+    public string? SyncUserRef { get; set; }
+    public string? Text { get; set; }
     public DateTime DateModified { get; set; }
     public DateTime DateCreated { get; set; }
+
+    /// <summary>Indicates whether a comment, note, or answer is marked deleted. </summary>
+    /// <remarks>
+    /// This is used for answers and comments so that they may be deleted correctly from Paratext.
+    ///
+    /// For notes, this property is an artifact of the legacy DataAccessServer and should not be set to true
+    /// except for marking a note with the corresponding Paratext comment.
+    /// </remarks>
+    public bool Deleted { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/Note.cs
+++ b/src/SIL.XForge.Scripture/Models/Note.cs
@@ -13,13 +13,6 @@ public class Note : Comment
     /// may read "unknownConflictType".
     /// </summary>
     public string ConflictType { get; set; }
-
-    /// <summary> Indicates whether a note is marked deleted. </summary>
-    /// <remarks>
-    /// This property is an artifact of the legacy DataAccessServer and should not be set to true
-    /// except for marking a note with the corresponding Paratext comment.
-    /// </remarks>
-    public bool Deleted { get; set; }
     public string Status { get; set; }
     public int? TagId { get; set; }
     public string Reattached { get; set; }

--- a/src/SIL.XForge.Scripture/Services/IParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextNotesMapper.cs
@@ -10,13 +10,7 @@ namespace SIL.XForge.Scripture.Services;
 
 public interface IParatextNotesMapper
 {
-    Task InitAsync(
-        UserSecret currentUserSecret,
-        SFProjectSecret projectSecret,
-        List<User> ptUsers,
-        SFProject project,
-        CancellationToken token
-    );
+    Task InitAsync(UserSecret currentUserSecret, List<User> ptUsers, SFProject project, CancellationToken token);
     Task<XElement> GetNotesChangelistAsync(
         XElement oldNotesElem,
         IEnumerable<IDocument<Question>> questionsDocs,

--- a/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
+++ b/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
@@ -74,6 +74,14 @@ public static class NotesFormatter
             commentElem.Add(new XAttribute("extUser", comment.ExternalUser));
         if (comment.Deleted)
             commentElem.Add(new XAttribute("deleted", "true"));
+        if (comment.TagsAdded is not null)
+        {
+            foreach (string tagAdded in comment.TagsAdded)
+            {
+                commentElem.Add(new XElement("tagAdded", tagAdded));
+            }
+        }
+
         commentElem.Add(FormatContent(comment.Contents));
         return commentElem;
     }
@@ -98,7 +106,7 @@ public static class NotesFormatter
     private static XElement FormatParagraph(XmlNode paraNode)
     {
         XElement paraElem = new XElement("p");
-        if (paraNode.ChildNodes.Count == 1 && paraNode.FirstChild.NodeType == XmlNodeType.Text)
+        if (paraNode.ChildNodes.Count == 1 && paraNode.FirstChild?.NodeType == XmlNodeType.Text)
             paraElem.Value = paraNode.InnerText;
         else
         {
@@ -177,8 +185,8 @@ public static class NotesFormatter
             comment.Date = commentDate;
         comment.ExternalUser = commentElem.Attribute("extUser")?.Value;
         comment.Deleted = commentElem.Attribute("deleted")?.Value == "true";
-        if (commentElem.Element("tagsAdded") != null)
-            comment.TagsAdded = new[] { commentElem.Element("tagsAdded").Value };
+        if (commentElem.Elements("tagAdded").Any())
+            comment.TagsAdded = commentElem.Elements("tagAdded").Select(t => t.Value).ToArray();
         ParseContents(commentElem.Element("content"), comment);
     }
 

--- a/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
@@ -202,7 +202,7 @@ public class ParatextNotesMapper : IParatextNotesMapper
         return notesElem;
     }
 
-    /// <summar>
+    /// <summary>
     /// Get the Paratext Comment elements from a project that are associated with Community Checking answers.
     /// </summary>
     private Dictionary<string, XElement> GetOldCommentElements(
@@ -271,7 +271,7 @@ public class ParatextNotesMapper : IParatextNotesMapper
         commentElem.Add(contentElem);
         if (tagId != NoteTag.notSetId)
         {
-            var tagsAddedElem = new XElement("tagsAdded", tagId);
+            var tagsAddedElem = new XElement("tagAdded", tagId);
             commentElem.Add(tagsAddedElem);
         }
 
@@ -339,9 +339,9 @@ public class ParatextNotesMapper : IParatextNotesMapper
     }
 
     private static bool IsCommentNewOrChanged(
-        Dictionary<string, XElement> oldCommentElems,
+        IReadOnlyDictionary<string, XElement> oldCommentElems,
         string key,
-        XElement commentElem,
+        XContainer commentElem,
         bool expectNoteTagSet
     )
     {
@@ -350,7 +350,7 @@ public class ParatextNotesMapper : IParatextNotesMapper
             || !XNode.DeepEquals(oldCommentElem.Element("content"), commentElem.Element("content"))
         )
             return true;
-        return expectNoteTagSet && oldCommentElem.Element("tagsAdded") == null;
+        return expectNoteTagSet && !oldCommentElem.Elements("tagAdded").Any();
     }
 
     private ParatextUserProfile FindOrCreateParatextUser(

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -733,7 +733,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
         // Report on authentication success before other attempts.
         await PreflightAuthenticationReportAsync();
 
-        await _notesMapper.InitAsync(_userSecret, _projectSecret, paratextUsers, _projectDoc.Data, token);
+        await _notesMapper.InitAsync(_userSecret, paratextUsers, _projectDoc.Data, token);
 
         await NotifySyncProgress(SyncPhase.Phase1, 20.0);
         return true;

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
@@ -679,7 +679,7 @@ public class ParatextNotesMapperTests
     }
 
     [Test]
-    public async Task GetNotesChangelistAsync_DoesDeleteParatextNotes()
+    public async Task GetNotesChangelistAsync_DoesNotDeleteParatextNotes()
     {
         var env = new TestEnvironment();
         env.SetParatextProjectRoles(true);
@@ -721,7 +721,7 @@ public class ParatextNotesMapperTests
                                     <p>Test comment 2.</p>
                                 </content>
                             </comment>
-                            <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-02T11:00:00.0000000+00:00"">
+                            <comment user=""PT User 1"" date=""2019-01-02T11:00:00.0000000+00:00"">
                                 <content>
                                     <p>A Paratext Only Comment.</p>
                                 </content>

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
@@ -51,9 +51,9 @@ public class ParatextNotesMapperTests
             XElement.Parse(oldNotesText),
             await TestEnvironment.GetQuestionDocsAsync(conn),
             ptProjectUsers,
-            TestEnvironment.userRoles,
+            TestEnvironment.UserRoles,
             CheckingAnswerExport.All,
-            env.checkingNoteTagId
+            TestEnvironment.CheckingNoteTagId
         );
 
         const string expectedNotesText =
@@ -143,7 +143,7 @@ public class ParatextNotesMapperTests
         const string oldNotesText = @"<notes version=""1.1""></notes>";
         Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(u => u.Username);
 
-        Dictionary<string, string> userRoles = TestEnvironment.userRoles;
+        Dictionary<string, string> userRoles = TestEnvironment.UserRoles;
         userRoles["user03"] = SFProjectRole.CommunityChecker;
         XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
             XElement.Parse(oldNotesText),
@@ -151,7 +151,7 @@ public class ParatextNotesMapperTests
             ptProjectUsers,
             userRoles,
             CheckingAnswerExport.All,
-            env.checkingNoteTagId
+            TestEnvironment.CheckingNoteTagId
         );
 
         // User 03 is listed as a community checker because they are not a PT user on the particular project
@@ -250,9 +250,9 @@ public class ParatextNotesMapperTests
             XElement.Parse(oldNotesText),
             await TestEnvironment.GetQuestionDocsAsync(conn),
             ptProjectUsers,
-            TestEnvironment.userRoles,
+            TestEnvironment.UserRoles,
             CheckingAnswerExport.All,
-            env.checkingNoteTagId
+            TestEnvironment.CheckingNoteTagId
         );
 
         const string expectedNotesText =
@@ -358,9 +358,9 @@ public class ParatextNotesMapperTests
             XElement.Parse(oldNotesText),
             await TestEnvironment.GetQuestionDocsAsync(conn),
             ptProjectUsers,
-            TestEnvironment.userRoles,
+            TestEnvironment.UserRoles,
             CheckingAnswerExport.All,
-            env.checkingNoteTagId
+            TestEnvironment.CheckingNoteTagId
         );
 
         // User 3 is a PT user but does not have a role on this particular PT project, according to the PT
@@ -448,7 +448,7 @@ public class ParatextNotesMapperTests
         var env = new TestEnvironment();
         env.SetParatextProjectRoles(true);
         await env.InitMapperAsync(true, true);
-        env.AddData("syncuser01", "syncuser03", null, "syncuser03");
+        env.AddData("syncUser01", "syncUser03", null, "syncUser03");
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         const string oldNotesText =
@@ -500,9 +500,9 @@ public class ParatextNotesMapperTests
             XElement.Parse(oldNotesText),
             await TestEnvironment.GetQuestionDocsAsync(conn),
             ptProjectUsers,
-            TestEnvironment.userRoles,
+            TestEnvironment.UserRoles,
             CheckingAnswerExport.All,
-            env.checkingNoteTagId
+            TestEnvironment.CheckingNoteTagId
         );
 
         const string expectedNotesText =
@@ -563,7 +563,7 @@ public class ParatextNotesMapperTests
         var env = new TestEnvironment();
         env.SetParatextProjectRoles(true);
         await env.InitMapperAsync(true, true);
-        env.AddData("syncuser01", "syncuser03", "syncuser03", "syncuser03");
+        env.AddData("syncUser01", "syncUser01", "syncUser03", "syncUser01");
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         const string oldNotesText =
@@ -585,7 +585,7 @@ public class ParatextNotesMapperTests
                         </thread>
                         <thread id=""ANSWER_answer02"">
                             <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
-                            <comment user=""PT User 3"" extUser=""user04"" date=""2019-01-02T08:00:00.0000000+00:00"">
+                            <comment user=""PT User 1"" extUser=""user04"" date=""2019-01-02T08:00:00.0000000+00:00"">
                                 <content>
                                     <p><span style=""bold"">Test question?</span></p>
                                     <p><span style=""italic"">This is some scripture. (MAT 1:2-3)</span></p>
@@ -594,13 +594,13 @@ public class ParatextNotesMapperTests
                                 </content>
                                 <tagAdded>3</tagAdded>
                             </comment>
-                            <comment user=""PT User 3"" extUser=""user02"" date=""2019-01-02T09:00:00.0000000+00:00"">
+                            <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-02T09:00:00.0000000+00:00"">
                                 <content>
                                     <p>[User 02 - xForge]</p>
                                     <p>Test comment 2.</p>
                                 </content>
                             </comment>
-                            <comment user=""PT User 1"" date=""2019-01-02T10:00:00.0000000+00:00"">
+                            <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-02T10:00:00.0000000+00:00"">
                                 <content>Test comment 3.</content>
                             </comment>
                         </thread>
@@ -621,9 +621,9 @@ public class ParatextNotesMapperTests
             XElement.Parse(oldNotesText),
             await TestEnvironment.GetQuestionDocsAsync(conn),
             ptProjectUsers,
-            TestEnvironment.userRoles,
+            TestEnvironment.UserRoles,
             CheckingAnswerExport.All,
-            env.checkingNoteTagId
+            TestEnvironment.CheckingNoteTagId
         );
 
         const string expectedNotesText =
@@ -637,7 +637,7 @@ public class ParatextNotesMapperTests
                         </thread>
                         <thread id=""ANSWER_answer04"">
                             <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
-                            <comment user=""PT User 3"" extUser=""user04"" date=""2019-01-04T08:00:00.0000000+00:00"">
+                            <comment user=""PT User 1"" extUser=""user04"" date=""2019-01-04T08:00:00.0000000+00:00"">
                                 <content>
                                     <p><span style=""bold"">Test question?</span></p>
                                     <p>[User 04 - xForge]</p>
@@ -648,7 +648,7 @@ public class ParatextNotesMapperTests
                         </thread>
                         <thread id=""ANSWER_answer05"">
                             <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
-                            <comment user=""PT User 3"" extUser=""user04"" date=""2019-01-05T08:00:00.0000000+00:00"">
+                            <comment user=""PT User 1"" extUser=""user04"" date=""2019-01-05T08:00:00.0000000+00:00"">
                                 <content>
                                     <p><span style=""bold"">Test question?</span></p>
                                     <p>[User 04 - xForge]</p>
@@ -659,7 +659,7 @@ public class ParatextNotesMapperTests
                         </thread>
                         <thread id=""ANSWER_answer02"">
                             <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
-                            <comment user=""PT User 1"" date=""2019-01-02T10:00:00.0000000+00:00"" deleted=""true"">
+                            <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-02T10:00:00.0000000+00:00"" deleted=""true"">
                                 <content>Test comment 3.</content>
                             </comment>
                         </thread>
@@ -679,6 +679,103 @@ public class ParatextNotesMapperTests
     }
 
     [Test]
+    public async Task GetNotesChangelistAsync_DoesDeleteParatextNotes()
+    {
+        var env = new TestEnvironment();
+        env.SetParatextProjectRoles(true);
+        await env.InitMapperAsync(true, true);
+        env.AddData("syncUser01", "syncUser01", "syncUser03", "syncUser01");
+
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        const string oldNotesText =
+            @"
+                    <notes version=""1.1"">
+                        <thread id=""ANSWER_answer01"">
+                            <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
+                            <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-01T08:00:00.0000000+00:00"">
+                                <content>
+                                    <p><span style=""bold"">Test question?</span></p>
+                                    <p>[User 02 - xForge]</p>
+                                    <p>Test answer 1.</p>
+                                </content>
+                                <tagAdded>3</tagAdded>
+                            </comment>
+                            <comment user=""PT User 3"" date=""2019-01-01T09:00:00.0000000+00:00"">
+                                <content>Test comment 1.</content>
+                            </comment>
+                        </thread>
+                        <thread id=""ANSWER_answer02"">
+                            <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
+                            <comment user=""PT User 1"" extUser=""user04"" date=""2019-01-02T08:00:00.0000000+00:00"">
+                                <content>
+                                    <p><span style=""bold"">Test question?</span></p>
+                                    <p><span style=""italic"">This is some scripture. (MAT 1:2-3)</span></p>
+                                    <p>[User 04 - xForge]</p>
+                                    <p>Test answer 2.</p>
+                                </content>
+                                <tagAdded>3</tagAdded>
+                            </comment>
+                            <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-02T09:00:00.0000000+00:00"">
+                                <content>
+                                    <p>[User 02 - xForge]</p>
+                                    <p>Test comment 2.</p>
+                                </content>
+                            </comment>
+                            <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-02T11:00:00.0000000+00:00"">
+                                <content>
+                                    <p>A Paratext Only Comment.</p>
+                                </content>
+                            </comment>
+                        </thread>
+                        <thread id=""ANSWER_answer04"">
+                            <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
+                            <comment user=""PT User 1"" extUser=""user04"" date=""2019-01-04T08:00:00.0000000+00:00"">
+                                <content>
+                                    <p><span style=""bold"">Test question?</span></p>
+                                    <p>[User 04 - xForge]</p>
+                                    <p>Test answer 4 is marked for export</p>
+                                </content>
+                                <tagAdded>3</tagAdded>
+                            </comment>
+                        </thread>
+                        <thread id=""ANSWER_answer05"">
+                            <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
+                            <comment user=""PT User 1"" extUser=""user04"" date=""2019-01-05T08:00:00.0000000+00:00"">
+                                <content>
+                                    <p><span style=""bold"">Test question?</span></p>
+                                    <p>[User 04 - xForge]</p>
+                                    <p>Test answer 5 is resolved</p>
+                                </content>
+                                <tagAdded>3</tagAdded>
+                            </comment>
+                        </thread>
+                        <thread id=""ANSWER_answer06"">
+                            <selection verseRef=""MAT 1:1"" startPos=""0"" selectedText="""" />
+                            <comment user=""PT User 1"" extUser=""user04"" date=""2019-01-05T08:00:00.0000000+00:00"">
+                                <content>
+                                    <p><span style=""bold"">A Paratext Only Question and Answer</span></p>
+                                    <p>[User 04 - xForge]</p>
+                                    <p>Test answer 6 is only in Paratext</p>
+                                </content>
+                                <tagAdded>3</tagAdded>
+                            </comment>
+                        </thread>
+                    </notes>";
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(u => u.Username);
+        XElement notesElem = await env.Mapper.GetNotesChangelistAsync(
+            XElement.Parse(oldNotesText),
+            await TestEnvironment.GetQuestionDocsAsync(conn),
+            ptProjectUsers,
+            TestEnvironment.UserRoles,
+            CheckingAnswerExport.All,
+            TestEnvironment.CheckingNoteTagId
+        );
+
+        const string expectedNotesText = @"<notes version=""1.1"" />";
+        Assert.That(XNode.DeepEquals(notesElem, XElement.Parse(expectedNotesText)), Is.True);
+    }
+
+    [Test]
     public async Task GetNotesChangelistAsync_ExportAllNotes()
     {
         var env = new TestEnvironment();
@@ -693,9 +790,9 @@ public class ParatextNotesMapperTests
             XElement.Parse(oldNotesText),
             await TestEnvironment.GetQuestionDocsAsync(conn),
             ptProjectUsers,
-            TestEnvironment.userRoles,
+            TestEnvironment.UserRoles,
             CheckingAnswerExport.All,
-            env.checkingNoteTagId
+            TestEnvironment.CheckingNoteTagId
         );
 
         const string expectedNotesText =
@@ -774,9 +871,9 @@ public class ParatextNotesMapperTests
             XElement.Parse(oldNotesText),
             await TestEnvironment.GetQuestionDocsAsync(conn),
             ptProjectUsers,
-            TestEnvironment.userRoles,
+            TestEnvironment.UserRoles,
             CheckingAnswerExport.None,
-            env.checkingNoteTagId
+            TestEnvironment.CheckingNoteTagId
         );
 
         const string expectedNotesText = @"<notes version=""1.1"" />";
@@ -798,9 +895,9 @@ public class ParatextNotesMapperTests
             XElement.Parse(oldNotesText),
             await TestEnvironment.GetQuestionDocsAsync(conn),
             ptProjectUsers,
-            TestEnvironment.userRoles,
+            TestEnvironment.UserRoles,
             CheckingAnswerExport.MarkedForExport,
-            env.checkingNoteTagId
+            TestEnvironment.CheckingNoteTagId
         );
 
         const string expectedNotesText =
@@ -823,14 +920,15 @@ public class ParatextNotesMapperTests
 
     private class TestEnvironment
     {
-        public static readonly Dictionary<string, string> userRoles = new Dictionary<string, string>
+        public static readonly Dictionary<string, string> UserRoles = new Dictionary<string, string>
         {
             { "user01", SFProjectRole.Administrator },
             { "user02", SFProjectRole.CommunityChecker },
             { "user03", SFProjectRole.Translator },
-            { "user04", SFProjectRole.CommunityChecker }
+            { "user04", SFProjectRole.CommunityChecker },
         };
-        public readonly int checkingNoteTagId = 3;
+
+        public const int CheckingNoteTagId = 3;
 
         public TestEnvironment()
         {
@@ -838,7 +936,7 @@ public class ParatextNotesMapperTests
                 new[]
                 {
                     new UserSecret { Id = "user01" },
-                    new UserSecret { Id = "user03" }
+                    new UserSecret { Id = "user03" },
                 }
             );
 
@@ -854,7 +952,7 @@ public class ParatextNotesMapperTests
                 { "user01", "User 01" },
                 { "user02", "User 02" },
                 { "user03", "User 03" },
-                { "user04", "User 04" }
+                { "user04", "User 04" },
             };
             UserService
                 .GetUsernameFromUserId(Arg.Any<string>(), Arg.Any<string>())
@@ -864,26 +962,25 @@ public class ParatextNotesMapperTests
                 new LocalizationOptions { ResourcesPath = "Resources" }
             );
             var factory = new ResourceManagerStringLocalizerFactory(options, NullLoggerFactory.Instance);
-            Localizer = new StringLocalizer<SharedResource>(factory);
+            var localizer = new StringLocalizer<SharedResource>(factory);
             var siteOptions = Substitute.For<IOptions<SiteOptions>>();
             siteOptions.Value.Returns(new SiteOptions { Name = "xForge", });
             Mapper = new ParatextNotesMapper(
                 UserSecrets,
                 ParatextService,
                 UserService,
-                Localizer,
+                localizer,
                 siteOptions,
                 new TestGuidService()
             );
         }
 
         public ParatextNotesMapper Mapper { get; }
-        public MemoryRepository<UserSecret> UserSecrets { get; }
+        private MemoryRepository<UserSecret> UserSecrets { get; }
         public SFMemoryRealtimeService RealtimeService { get; }
-        public IParatextService ParatextService { get; }
-        public IUserService UserService { get; }
-        public IStringLocalizer<SharedResource> Localizer { get; }
-        public IEnumerable<ParatextUserProfile> PtProjectUsers { get; set; }
+        private IParatextService ParatextService { get; }
+        private IUserService UserService { get; }
+        public IEnumerable<ParatextUserProfile> PtProjectUsers { get; private set; } = new List<ParatextUserProfile>();
 
         public async Task InitMapperAsync(bool includeSyncUsers, bool twoPtUsersOnProject)
         {
@@ -891,7 +988,6 @@ public class ParatextNotesMapperTests
             PtProjectUsers = project.ParatextUsers;
             await Mapper.InitAsync(
                 UserSecrets.Get("user01"),
-                ProjectSecret(),
                 ParatextUsersOnProject(twoPtUsersOnProject),
                 project,
                 CancellationToken.None
@@ -899,13 +995,12 @@ public class ParatextNotesMapperTests
         }
 
         public void AddData(
-            string answerSyncUserId1,
-            string answerSyncUserId2,
-            string commentSyncUserId1,
-            string commentSyncUserId2,
+            string? answerSyncUserId1,
+            string? answerSyncUserId2,
+            string? commentSyncUserId1,
+            string? commentSyncUserId2,
             bool useAudioResponses = false
-        )
-        {
+        ) =>
             RealtimeService.AddRepository(
                 "questions",
                 OTType.Json0,
@@ -935,9 +1030,9 @@ public class ParatextNotesMapperTests
                                             OwnerRef = "user03",
                                             SyncUserRef = commentSyncUserId1,
                                             DateCreated = new DateTime(2019, 1, 1, 9, 0, 0, DateTimeKind.Utc),
-                                            Text = "Test comment 1."
-                                        }
-                                    }
+                                            Text = "Test comment 1.",
+                                        },
+                                    },
                                 },
                                 new Answer
                                 {
@@ -956,9 +1051,29 @@ public class ParatextNotesMapperTests
                                             OwnerRef = "user02",
                                             SyncUserRef = commentSyncUserId2,
                                             DateCreated = new DateTime(2019, 1, 2, 9, 0, 0, DateTimeKind.Utc),
-                                            Text = "Test comment 2."
-                                        }
-                                    }
+                                            Text = "Test comment 2.",
+                                        },
+                                        new Comment
+                                        {
+                                            DataId = "comment03",
+                                            OwnerRef = "user02",
+                                            SyncUserRef = commentSyncUserId2,
+                                            DateCreated = new DateTime(2019, 1, 2, 10, 0, 0, DateTimeKind.Utc),
+                                            Text = "Test comment 3.",
+                                            Deleted = true,
+                                        },
+                                    },
+                                },
+                                new Answer
+                                {
+                                    DataId = "answer03",
+                                    OwnerRef = "user02",
+                                    SyncUserRef = answerSyncUserId2,
+                                    DateCreated = new DateTime(2019, 1, 3, 8, 0, 0, DateTimeKind.Utc),
+                                    Text = "Test answer 3 is deleted",
+                                    VerseRef = new VerseRefData(40, 1, "2-3"),
+                                    Status = AnswerStatus.Exportable,
+                                    Deleted = true,
                                 },
                                 new Answer
                                 {
@@ -968,7 +1083,7 @@ public class ParatextNotesMapperTests
                                     DateCreated = new DateTime(2019, 1, 4, 8, 0, 0, DateTimeKind.Utc),
                                     Text = "Test answer 4 is marked for export",
                                     VerseRef = new VerseRefData(40, 1, "2-3"),
-                                    Status = AnswerStatus.Exportable
+                                    Status = AnswerStatus.Exportable,
                                 },
                                 new Answer
                                 {
@@ -978,14 +1093,13 @@ public class ParatextNotesMapperTests
                                     DateCreated = new DateTime(2019, 1, 5, 8, 0, 0, DateTimeKind.Utc),
                                     Text = "Test answer 5 is resolved",
                                     VerseRef = new VerseRefData(40, 1, "2-3"),
-                                    Status = AnswerStatus.Resolved
-                                }
-                            }
-                        }
+                                    Status = AnswerStatus.Resolved,
+                                },
+                            },
+                        },
                     }
                 )
             );
-        }
 
         public static async Task<IEnumerable<IDocument<Question>>> GetQuestionDocsAsync(IConnection conn)
         {
@@ -993,28 +1107,11 @@ public class ParatextNotesMapperTests
             return new[] { questionDoc };
         }
 
-        public static async Task<IEnumerable<IDocument<NoteThread>>> GetNoteThreadDocsAsync(
-            IConnection conn,
-            string[] threadIds
-        )
-        {
-            IDocument<NoteThread>[] noteThreadDocs = new IDocument<NoteThread>[threadIds.Length];
-            var tasks = new List<Task>();
-            for (int i = 0; i < threadIds.Length; i++)
-            {
-                async Task fetchNoteThread(int index) =>
-                    noteThreadDocs[index] = await conn.FetchAsync<NoteThread>("project01:" + threadIds[index]);
-                tasks.Add(fetchNoteThread(i));
-            }
-            await Task.WhenAll(tasks);
-            return noteThreadDocs;
-        }
-
         public void SetParatextProjectRoles(bool twoPtUserOnProject)
         {
             Dictionary<string, string> ptUserRoles = new Dictionary<string, string>
             {
-                ["ptuser01"] = SFProjectRole.Administrator
+                ["ptuser01"] = SFProjectRole.Administrator,
             };
             if (twoPtUserOnProject)
                 ptUserRoles["ptuser03"] = SFProjectRole.Translator;
@@ -1028,25 +1125,23 @@ public class ParatextNotesMapperTests
             var ptProjectUsers = new List<ParatextUserProfile>();
             if (includeSyncUsers)
             {
-                ptProjectUsers.Add(new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = "PT User 1" });
-                ptProjectUsers.Add(new ParatextUserProfile { OpaqueUserId = "syncuser03", Username = "PT User 3" });
+                ptProjectUsers.Add(new ParatextUserProfile { OpaqueUserId = "syncUser01", Username = "PT User 1" });
+                ptProjectUsers.Add(new ParatextUserProfile { OpaqueUserId = "syncUser03", Username = "PT User 3" });
             }
             return new SFProject
             {
                 Id = "project01",
                 ParatextId = "paratextId",
                 ParatextUsers = ptProjectUsers,
-                UserRoles = userRoles
+                UserRoles = UserRoles,
             };
         }
-
-        private static SFProjectSecret ProjectSecret() => new SFProjectSecret { Id = "project01", };
 
         private static List<User> ParatextUsersOnProject(bool twoPtUsersOnProject)
         {
             var ptUsers = new List<User>
             {
-                new User { Id = "user01", ParatextId = "ptuser01" }
+                new User { Id = "user01", ParatextId = "ptuser01" },
             };
             if (twoPtUsersOnProject)
                 ptUsers.Add(new User { Id = "user03", ParatextId = "ptuser03" });

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
@@ -42,7 +42,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 3.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -67,7 +67,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 1.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                             <comment user=""PT User 3"" date=""2019-01-01T09:00:00.0000000+00:00"">
                                 <content>Test comment 1.</content>
@@ -82,7 +82,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 2.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                             <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-02T09:00:00.0000000+00:00"">
                                 <content>
@@ -99,7 +99,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 4 is marked for export</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer05"">
@@ -110,7 +110,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 5 is resolved</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer03"">
@@ -121,7 +121,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 3.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -166,7 +166,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 1.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                             <comment user=""PT User 1"" extUser=""user03"" date=""2019-01-01T09:00:00.0000000+00:00"">
                                 <content>
@@ -184,7 +184,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 2.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                             <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-02T09:00:00.0000000+00:00"">
                                 <content>
@@ -201,7 +201,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 4 is marked for export</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer05"">
@@ -212,7 +212,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 5 is resolved</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -241,7 +241,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 3.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -266,7 +266,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>- xForge audio-only response -</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                             <comment user=""PT User 3"" date=""2019-01-01T09:00:00.0000000+00:00"">
                                 <content>Test comment 1.</content>
@@ -281,7 +281,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 2.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                             <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-02T09:00:00.0000000+00:00"">
                                 <content>
@@ -298,7 +298,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 4 is marked for export</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer05"">
@@ -309,7 +309,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 5 is resolved</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer03"">
@@ -320,7 +320,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 3.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -349,7 +349,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 3.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -379,7 +379,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 1.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                             <comment user=""PT User 1"" extUser=""user03"" date=""2019-01-01T09:00:00.0000000+00:00"">
                                 <content>Test comment 1.</content>
@@ -394,7 +394,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 2.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                             <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-02T09:00:00.0000000+00:00"">
                                 <content>
@@ -411,7 +411,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 4 is marked for export</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer05"">
@@ -422,7 +422,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 5 is resolved</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer03"">
@@ -433,7 +433,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 3.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -462,7 +462,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Old test answer 1.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer02"">
@@ -474,14 +474,14 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 2.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                             <comment user=""PT User 3"" extUser=""user02"" date=""2019-01-02T09:00:00.0000000+00:00"">
                                 <content>
                                     <p>[User 02 - xForge]</p>
                                     <p>Old test comment 2.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer04"">
@@ -516,7 +516,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 1.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                             <comment user=""PT User 3"" date=""2019-01-01T09:00:00.0000000+00:00"">
                                 <content>Test comment 1.</content>
@@ -539,7 +539,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 4 is marked for export</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer05"">
@@ -550,7 +550,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 5 is resolved</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -577,7 +577,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 1.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                             <comment user=""PT User 3"" date=""2019-01-01T09:00:00.0000000+00:00"">
                                 <content>Old test comment 1.</content>
@@ -592,7 +592,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 2.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                             <comment user=""PT User 3"" extUser=""user02"" date=""2019-01-02T09:00:00.0000000+00:00"">
                                 <content>
@@ -612,7 +612,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 3.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -643,7 +643,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 4 is marked for export</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer05"">
@@ -654,7 +654,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 5 is resolved</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer02"">
@@ -671,7 +671,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 3.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -709,7 +709,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 02 - xForge]</p>
                                     <p>Test answer 1.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                             <comment user=""PT User 3"" date=""2019-01-01T09:00:00.0000000+00:00"">
                                 <content>Test comment 1.</content>
@@ -724,7 +724,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 2.</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                             <comment user=""PT User 1"" extUser=""user02"" date=""2019-01-02T09:00:00.0000000+00:00"">
                                 <content>
@@ -741,7 +741,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 4 is marked for export</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                         <thread id=""ANSWER_answer05"">
@@ -752,7 +752,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 5 is resolved</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                     </notes>";
@@ -814,7 +814,7 @@ public class ParatextNotesMapperTests
                                     <p>[User 04 - xForge]</p>
                                     <p>Test answer 4 is marked for export</p>
                                 </content>
-                                <tagsAdded>3</tagsAdded>
+                                <tagAdded>3</tagAdded>
                             </comment>
                         </thread>
                     </notes>";

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1226,7 +1226,6 @@ public class ParatextSyncRunnerTests
                 x =>
                     x.InitAsync(
                         Arg.Any<UserSecret>(),
-                        Arg.Any<SFProjectSecret>(),
                         Arg.Any<List<User>>(),
                         Arg.Any<SFProject>(),
                         Arg.Any<CancellationToken>()
@@ -1301,7 +1300,6 @@ public class ParatextSyncRunnerTests
                 x =>
                     x.InitAsync(
                         Arg.Any<UserSecret>(),
-                        Arg.Any<SFProjectSecret>(),
                         Arg.Any<List<User>>(),
                         Arg.Any<SFProject>(),
                         Arg.Any<CancellationToken>()


### PR DESCRIPTION
**Overview**

Comments made in Paratext to Answers exported to Paratext from Scripture Forge were being lost on sync if a newer comment was made in Scripture Forge. This occurred because there was no accurate tracking of comments being deleted. To address that, this PR adds a deleted flag to Comments and Answers that is set when these are deleted, as opposed to the previous behavior which was the removal of the comment or answer from the question document.

**Changes in this Pull Request**

 - Rename `tagsAdded` XML tag to `tagAdded` to conform to Paratext Comments XML tag name
 - Fixed bug where the comment was incorrectly seen as modified when  no change had occurred
 - Add a `deleted` flag to answers and comments
 - Fixed a bug where comments created in Paratext are deleted when a newer comment is added in Scripture Forge
 - When an answer is deleted in SF that has Paratext comments, those comments will remain as their own notes in Paratext

**Known Issues**

 - Updating or deleting a comment or answer in Paratext will be reverted by Scripture Forge on sync
 - Resolving the note corresponding to the question in Paratext will be reverted by Scripture Forge on sync
 - Answers and comments that have been synced then deleted before this PR is merged will not be deleted from Paratext

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1776)
<!-- Reviewable:end -->
