### PR TITLE
SF-1944 Allow translators to edit note thread position

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/sf-project-rights.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project-rights.ts
@@ -74,8 +74,8 @@ const rightsByRole: Record<SFProjectRole, { [domain in `${SFProjectDomain}`]?: `
     answer_comments: ['view', 'create', 'edit_own', 'delete_own'],
     answer_status: ['view'],
     likes: ['view', 'create', 'delete_own'],
-    pt_note_threads: ['view', 'create', 'delete_own'],
-    sf_note_threads: ['view', 'create', 'delete_own'],
+    pt_note_threads: ['view', 'create', 'edit', 'delete_own'],
+    sf_note_threads: ['view', 'create', 'edit', 'delete_own'],
     notes: ['view', 'create', 'edit_own', 'delete_own']
   },
   pt_administrator: {

--- a/src/RealtimeServer/scriptureforge/services/note-thread-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-service.spec.ts
@@ -114,6 +114,20 @@ describe('NoteThreadService', () => {
     expect(doc).not.toBeNull();
   });
 
+  it('allows translators to edit note thread position', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+    const conn: Connection = clientConnect(env.server, env.translator);
+    const noteThreadId: string = getNoteThreadDocId('project01', 'noteThread01');
+    const doc = await fetchDoc(conn, NOTE_THREAD_COLLECTION, noteThreadId);
+    expect(doc.data.position).toEqual({ start: 0, length: 0 });
+    const position: TextAnchor = { start: 0, length: 7 };
+    await submitJson0Op<NoteThread>(conn, NOTE_THREAD_COLLECTION, noteThreadId, op =>
+      op.set(n => n.position, position)
+    );
+    expect(doc.data.position).toEqual(position);
+  });
+
   it('prohibits reviewer user to read note threads not published in Scripture Forge', async () => {
     const env = new TestEnvironment();
     await env.createData();
@@ -285,6 +299,7 @@ describe('NoteThreadService', () => {
 
 class TestEnvironment {
   readonly projectAdminId = 'projectAdmin';
+  readonly translator = 'translator';
   readonly checkerId = 'checker';
   readonly reviewerId = 'reviewer';
   readonly service: NoteThreadService;
@@ -422,6 +437,7 @@ class TestEnvironment {
       sync: { queuedCount: 0 },
       userRoles: {
         projectAdmin: SFProjectRole.ParatextAdministrator,
+        translator: SFProjectRole.ParatextTranslator,
         checker: SFProjectRole.CommunityChecker,
         reviewer: SFProjectRole.Reviewer
       },


### PR DESCRIPTION
The position of a note thread in a verse is stored on the note thread model. When a translator updates texts that results in changing the position of the note thread position, it is necessary to allow the note thread record to be updated in mongoDB. This change allows translators to update the note thread model.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1777)
<!-- Reviewable:end -->
