### PR TITLE
SF-1897 Deselect the current verse selection when opening note dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -139,7 +139,7 @@
             </div>
           </ng-template>
           <div *ngIf="canInsertNote" #fabButton class="insert-note-fab" [style.left]="insertNoteFabLeft">
-            <button mat-mini-fab title="{{ t('insert_note') }}" (click)="insertNote()">
+            <button mat-mini-fab title="{{ t('add_comment') }}" (click)="insertNote()">
               <mat-icon>add_comment</mat-icon>
             </button>
           </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2725,6 +2725,28 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('can open dialog of the second note on the verse', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.wait();
+      expect(env.getNoteThreadIconElement('verse_1_3', 'thread02')).not.toBeNull();
+      env.mockNoteDialogRef.onClose = () => env.insertNoteThread('user01', 'MAT 1:3', 'threadnew01');
+      env.setSelectionAndInsertNote('verse_1_3');
+      env.mockNoteDialogRef.close(true);
+      verify(mockedMatDialog.open(NoteDialogComponent, anything())).once();
+      env.wait();
+
+      const noteElement: HTMLElement = env.getNoteThreadIconElement('verse_1_3', 'threadnew01')!;
+      noteElement.click();
+      tick();
+      env.fixture.detectChanges();
+      verify(mockedMatDialog.open(NoteDialogComponent, anything())).twice();
+
+      env.setSelectionAndInsertNote('verse_1_3');
+      verify(mockedMatDialog.open(NoteDialogComponent, anything())).thrice();
+      env.dispose();
+    }));
+
     it('reviewers can click to select verse', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2730,13 +2730,13 @@ describe('EditorComponent', () => {
       env.setProjectUserConfig();
       env.wait();
       expect(env.getNoteThreadIconElement('verse_1_3', 'thread02')).not.toBeNull();
-      env.mockNoteDialogRef.onClose = () => env.insertNoteThread('user01', 'MAT 1:3', 'threadnew01');
       env.setSelectionAndInsertNote('verse_1_3');
-      env.mockNoteDialogRef.close(true);
+      const noteDialogResult: NoteDialogResult = { noteContent: 'newly created comment', noteDataId: 'notenew01' };
+      env.mockNoteDialogRef.close(noteDialogResult);
       verify(mockedMatDialog.open(NoteDialogComponent, anything())).once();
       env.wait();
 
-      const noteElement: HTMLElement = env.getNoteThreadIconElement('verse_1_3', 'threadnew01')!;
+      const noteElement: HTMLElement = env.getNoteThreadIconElementAtIndex('verse_1_3', 1)!;
       noteElement.click();
       tick();
       env.fixture.detectChanges();
@@ -3658,6 +3658,13 @@ class TestEnvironment {
     return this.fixture.nativeElement.querySelector(
       `usx-segment[data-segment=${segmentRef}] display-note[data-thread-id=${threadId}]`
     );
+  }
+
+  getNoteThreadIconElementAtIndex(segmentRef: string, index: number): HTMLElement | null {
+    const iconElements: HTMLElement[] | null = this.fixture.nativeElement.querySelectorAll(
+      `usx-segment[data-segment=${segmentRef}] display-note`
+    );
+    return iconElements![index];
   }
 
   /** Editor position of note thread. */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -909,11 +909,12 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       return;
     }
     const currentDate: string = new Date().toJSON();
+    const threadId: string = params.threadId ?? objectId();
     // Configure the note
     const note: Note = {
       dateCreated: currentDate,
       dateModified: currentDate,
-      threadId: params.threadId ?? '',
+      threadId,
       dataId: params.dataId ?? objectId(),
       tagId: this.projectDoc?.data?.translateConfig.defaultNoteTagId,
       ownerRef: this.userService.currentUserId,
@@ -924,8 +925,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       deleted: false
     };
     if (params.threadId == null) {
-      const threadId: string = objectId();
-      note.threadId = threadId;
       // Create a new thread
       const noteThread: NoteThread = {
         dataId: threadId,
@@ -1041,8 +1040,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     this.target?.toggleVerseSelection(verseRef!);
     this.commenterSelectedVerseRef = undefined;
     const result: NoteDialogResult | undefined = await dialogRef.afterClosed().toPromise();
-    if (result?.noteContent != null) {
-      await this.saveNote({ content: result.noteContent, threadId, dataId: result.noteDataId });
+    if (result != null) {
+      if (result.noteContent != null) {
+        await this.saveNote({ content: result.noteContent, threadId, dataId: result.noteDataId });
+      }
       this.toggleNoteThreadVerseRefs$.next();
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1007,7 +1007,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       Array.from(noteThreadVerseRefs.values()),
       'note-thread'
     );
-    this.subscribeClickEvents(segments);
+    // Defer the subscription so that the editor has time to clean up comments on blanks verses
+    Promise.resolve().then(() => this.subscribeClickEvents(segments));
   }
 
   private async showNoteThread(threadId?: string, verseRef?: VerseRef): Promise<void> {


### PR DESCRIPTION
* ensure the updated verse segments resubscribes to click events
* change focused logic to account for bottomsheet
* also fixes SF-1941

SF-1941 prevented users from re-selecting the current verse to add a second comment because the usx segment element was not being subscribed to after the new note thread was created. This change causes toggleNoteThreadVerseRefs to emit, which causes the subscriptions to be re-created.
Then it would be possible to create a second comment. To allow clicking on the second comment to open a dialog, we needed to ensure that the note embed that gets inserted does not create an erroneous usx-segment. So we need to deselect the selected verse which has the commenter-selection class format that caused the inserting of the note embed to go wrong.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1779)
<!-- Reviewable:end -->
