### PR TITLE
Fix for note dialog tests breaking for some runs

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -637,33 +637,35 @@ class TestEnvironment {
   static reattached: string = ['MAT 1:4', 'reattached text', '17', 'before selection ', ' after selection'].join(
     REATTACH_SEPARATOR
   );
-  static defaultNoteThread: NoteThread = {
-    originalContextBefore: '',
-    originalContextAfter: '',
-    originalSelectedText: '',
-    dataId: 'thread01',
-    ownerRef: 'user01',
-    position: { start: 0, length: 0 },
-    projectRef: TestEnvironment.PROJECT01,
-    verseRef: { bookNum: 40, chapterNum: 1, verseNum: 1 },
-    status: NoteStatus.Todo,
-    assignment: AssignedUsers.TeamUser,
-    notes: [
-      {
-        dataId: 'note01',
-        type: NoteType.Normal,
-        conflictType: NoteConflictType.DefaultValue,
-        threadId: 'thread01',
-        content: 'thread01',
-        deleted: false,
-        ownerRef: 'user01',
-        status: NoteStatus.Todo,
-        tagId: 1,
-        dateCreated: '',
-        dateModified: ''
-      }
-    ]
-  };
+  static get defaultNoteThread(): NoteThread {
+    return {
+      originalContextBefore: '',
+      originalContextAfter: '',
+      originalSelectedText: '',
+      dataId: 'thread01',
+      ownerRef: 'user01',
+      position: { start: 0, length: 0 },
+      projectRef: TestEnvironment.PROJECT01,
+      verseRef: { bookNum: 40, chapterNum: 1, verseNum: 1 },
+      status: NoteStatus.Todo,
+      assignment: AssignedUsers.TeamUser,
+      notes: [
+        {
+          dataId: 'note01',
+          type: NoteType.Normal,
+          conflictType: NoteConflictType.DefaultValue,
+          threadId: 'thread01',
+          content: 'thread01',
+          deleted: false,
+          ownerRef: 'user01',
+          status: NoteStatus.Todo,
+          tagId: 1,
+          dateCreated: '',
+          dateModified: ''
+        }
+      ]
+    };
+  }
   static getNoteThread(reattachedContent?: string, isInitialSFNote?: boolean): NoteThread {
     const type: NoteType = NoteType.Normal;
     const conflictType: NoteConflictType = NoteConflictType.DefaultValue;


### PR DESCRIPTION
This PR removes defaultNoteThread's mutability, so that tests which use this static property (which was a variable) can depend on its consistency.

The tests which this PR fixes are:
 * "NoteDialogComponent deletes the thread if the last note is deleted" at note-dialog.component.spec.ts:499:39
 * "NoteDialogComponent deletes the thread if the deleted note is the only active note" at note-dialog.component.spec.ts:525:39

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1782)
<!-- Reviewable:end -->
