### PR TITLE
SF-1951 Fix position of offline indicator

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.html
@@ -7,6 +7,4 @@
   [borderColor]="borderColor"
   [bgColor]="borderColor"
 ></ngx-avatar>
-<div *ngIf="showOnlineStatus" class="online-status">
-  <mdc-icon *ngIf="(pwaService.onlineStatus$ | async) !== true">cloud_off</mdc-icon>
-</div>
+<mat-icon *ngIf="showOnlineStatus && (pwaService.onlineStatus$ | async) === false">cloud_off</mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.scss
@@ -1,13 +1,10 @@
-.online-status {
-  position: absolute;
-  bottom: 6px;
-  right: 8px;
-  mdc-icon {
-    font-size: 12px;
-    text-shadow: 0 0 2px #000;
-  }
+:host ::ng-deep .avatar-content {
+  border-width: 2px !important;
 }
 
-::ng-deep .avatar-content {
-  border-width: 2px !important;
+mat-icon {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  font-size: 12px;
 }


### PR DESCRIPTION
Before | After
-------|------
![](https://user-images.githubusercontent.com/6140710/232638226-a9ab7ff2-a027-4ae1-8684-d6679dbe6848.png) | ![](https://user-images.githubusercontent.com/6140710/232638081-e36a7a8b-2369-49c3-b42c-32a35b9f5528.png)

I also changed a CSS rule from:
``` scss
::ng-deep .avatar-content { ... }
```
To:
``` scss
:host ::ng-deep .avatar-content { ... }
```
Using `::ng-deep` should generally be avoided because it breaks out of Angular's view encapsulation so the styles apply globally. In this case we want that in order to style a subcomponent. Adding the `:host` selects the current component and applies the rule only to itself and its children, getting rid of any global impact.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1788)
<!-- Reviewable:end -->
