### PR TITLE
SF-1955 Fix permission message when text is still loading

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -73,7 +73,7 @@
         <div *ngIf="projectTextNotEditable && hasEditRight" class="project-text-not-editable">
           <mat-icon>info</mat-icon> {{ t("project_text_not_editable") }}
         </div>
-        <div *ngIf="userHasGeneralEditRight && !hasChapterEditPermission" class="no-edit-permission-message">
+        <div *ngIf="showNoEditPermissionMessage" class="no-edit-permission-message">
           <mat-icon>info</mat-icon> {{ t("no_permission_edit_chapter", { userRole: userRoleStr }) }}
         </div>
         <div

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -274,7 +274,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   get hasEditRight(): boolean {
-    return this.userHasGeneralEditRight && this.hasChapterEditPermission;
+    return this.userHasGeneralEditRight && this.hasChapterEditPermission === true;
   }
 
   /**
@@ -290,12 +290,18 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   /**
    * Determines whether the user has permission to edit the currently active chapter.
+   * Returns undefined if the necessary data is not yet available.
    */
-  get hasChapterEditPermission(): boolean {
+  get hasChapterEditPermission(): boolean | undefined {
     const chapter = this.text?.chapters.find(c => c.number === this._chapter);
     // Even though permissions is guaranteed to be there in the model, its not in IndexedDB the first time the project
     // is accessed after migration
-    return chapter?.permissions?.[this.userService.currentUserId] === TextInfoPermission.Write;
+    const permission = chapter?.permissions?.[this.userService.currentUserId];
+    return permission == null ? undefined : permission === TextInfoPermission.Write;
+  }
+
+  get showNoEditPermissionMessage(): boolean {
+    return this.userHasGeneralEditRight && this.hasChapterEditPermission === false;
   }
 
   get userRoleStr(): string {
@@ -516,8 +522,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         if (this.projectDoc == null || this.projectDoc.data == null) {
           return;
         }
-        await this.loadNoteThreadDocs(this.projectDoc.id);
         this.text = this.projectDoc.data.texts.find(t => t.bookNum === bookNum);
+        await this.loadNoteThreadDocs(this.projectDoc.id);
         if (this.sourceProjectDoc?.data != null) {
           this.sourceText = this.sourceProjectDoc.data.texts.find(t => t.bookNum === bookNum);
         }


### PR DESCRIPTION
When a text is still loading this nasty permissions message is shown:

![](https://user-images.githubusercontent.com/6140710/232643610-016645e0-9006-4079-a66d-abb6f31267a4.png)

(The "This book does not exist" message should be fixed at some point, but I'm not digging into it now because it's more complicated and isn't in an area I've actively worked on)