### PR TITLE
SF-1958 Show the commenter selected verse on bottom sheet

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2618,7 +2618,7 @@ describe('EditorComponent', () => {
     it('shows current selected verse on bottom sheet', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
-      env.setReviewerUser();
+      env.setCommenterUser();
       env.updateParams({ projectId: 'project01', bookId: 'LUK' });
       env.wait();
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -367,9 +367,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   get currentSegmentReference(): string {
-    const segmentRef: string | undefined = this.target?.currentSegmentOrDefault;
-    if (segmentRef == null || this.bookNum == null) return '';
-    const verseRef: VerseRef | undefined = getVerseRefFromSegmentRef(this.bookNum, segmentRef);
+    const verseRef: VerseRef | undefined = this.commenterSelectedVerseRef;
     if (verseRef == null) {
       return '';
     }
@@ -897,15 +895,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   async saveNote(params: SaveNoteParameters): Promise<void> {
-    if (this.projectId == null) {
-      return;
-    }
-    const segmentRef: string | undefined = this.target?.currentSegmentOrDefault;
-    if (segmentRef == null || this.bookNum == null) {
-      return;
-    }
-    const verseRef: VerseRef | undefined = getVerseRefFromSegmentRef(this.bookNum, segmentRef);
-    if (verseRef == null) {
+    if (this.projectId == null || this.bookNum == null) {
       return;
     }
     const currentDate: string = new Date().toJSON();
@@ -928,6 +918,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       deleted: false
     };
     if (params.threadId == null) {
+      const verseRef: VerseRef | undefined = this.commenterSelectedVerseRef;
+      if (verseRef == null) return;
       // Create a new thread
       const noteThread: NoteThread = {
         dataId: threadId,


### PR DESCRIPTION
* use the commenter selected verse when saving a note thread

The currentOrDefault verse for a text isn't the same as the commenter selected verse which will always be set when a user opens a note dialog or bottom sheet to add a new comment. This change abandons the use of currentOrDefault verse.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1792)
<!-- Reviewable:end -->
