### PR TITLE
SF-1888 Change role names for SF reviewers and observers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
     "caniuse",
     "cdnjs",
     "combobox",
+    "commenters",
     "compodoc",
     "dropdown",
     "ethnologue",

--- a/src/RealtimeServer/scriptureforge/models/sf-project-role.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project-role.ts
@@ -15,8 +15,8 @@ export function isTranslateRole(role: string | undefined): boolean {
     return true;
   }
   switch (role) {
-    case SFProjectRole.Reviewer:
-    case SFProjectRole.Observer:
+    case SFProjectRole.Commenter:
+    case SFProjectRole.Viewer:
       return true;
     default:
       return false;
@@ -28,8 +28,8 @@ export enum SFProjectRole {
   ParatextTranslator = 'pt_translator',
   ParatextConsultant = 'pt_consultant',
   ParatextObserver = 'pt_observer',
-  Reviewer = 'sf_reviewer',
+  Commenter = 'sf_reviewer',
   CommunityChecker = 'sf_community_checker',
-  Observer = 'sf_observer',
+  Viewer = 'sf_observer',
   None = 'none'
 }

--- a/src/RealtimeServer/scriptureforge/services/note-thread-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-service.spec.ts
@@ -301,7 +301,7 @@ class TestEnvironment {
   readonly projectAdminId = 'projectAdmin';
   readonly translator = 'translator';
   readonly checkerId = 'checker';
-  readonly reviewerId = 'reviewer';
+  readonly reviewerId = 'commenter';
   readonly service: NoteThreadService;
   readonly server: RealtimeServer;
   readonly db: ShareDBMingo;
@@ -439,7 +439,7 @@ class TestEnvironment {
         projectAdmin: SFProjectRole.ParatextAdministrator,
         translator: SFProjectRole.ParatextTranslator,
         checker: SFProjectRole.CommunityChecker,
-        reviewer: SFProjectRole.Reviewer
+        commenter: SFProjectRole.Commenter
       },
       userPermissions: {},
       paratextUsers: []

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -151,13 +151,13 @@ describe('AppComponent', () => {
     expect(env.menuLength).toEqual(5);
   }));
 
-  it('hides community checking tool from reviewers', fakeAsync(() => {
+  it('hides community checking tool from commenters', fakeAsync(() => {
     const env = new TestEnvironment();
     env.setCurrentUser('user04');
     env.navigate(['/projects', 'project01']);
     env.init();
 
-    expect(env.component.selectedProjectRole).toEqual(SFProjectRole.Reviewer);
+    expect(env.component.selectedProjectRole).toEqual(SFProjectRole.Commenter);
     expect(env.selectedProjectId).toEqual('project01');
     expect(env.isDrawerVisible).toEqual(true);
     expect(env.component.isTranslateEnabled).toEqual(true);
@@ -617,7 +617,7 @@ class TestEnvironment {
         user01: SFProjectRole.ParatextTranslator,
         user02: SFProjectRole.CommunityChecker,
         user03: SFProjectRole.CommunityChecker,
-        user04: SFProjectRole.Reviewer
+        user04: SFProjectRole.Commenter
       },
       [
         { bookNum: 40, hasSource: true, chapters: [], permissions: {} },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-role-info.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-role-info.ts
@@ -8,9 +8,9 @@ export const SF_PROJECT_ROLES: ProjectRoleInfo[] = [
   { role: SFProjectRole.ParatextTranslator, canBeShared: false },
   { role: SFProjectRole.ParatextConsultant, canBeShared: false },
   { role: SFProjectRole.ParatextObserver, canBeShared: false },
-  { role: SFProjectRole.Reviewer, canBeShared: true },
+  { role: SFProjectRole.Commenter, canBeShared: true },
   { role: SFProjectRole.CommunityChecker, canBeShared: true },
-  { role: SFProjectRole.Observer, canBeShared: true }
+  { role: SFProjectRole.Viewer, canBeShared: true }
 ];
 
 export function canAccessTranslateApp(role?: SFProjectRole): boolean {
@@ -22,4 +22,4 @@ export function canAccessCommunityCheckingApp(role: SFProjectRole): boolean {
 }
 
 export const SF_DEFAULT_SHARE_ROLE: SFProjectRole = SFProjectRole.CommunityChecker;
-export const SF_DEFAULT_TRANSLATE_SHARE_ROLE: SFProjectRole = SFProjectRole.Observer;
+export const SF_DEFAULT_TRANSLATE_SHARE_ROLE: SFProjectRole = SFProjectRole.Viewer;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.spec.ts
@@ -200,12 +200,12 @@ describe('ShareControlComponent', () => {
     env.wait();
     const roles: string[] = env.component.availableRolesInfo.map(info => info.role);
     expect(roles).toContain(SFProjectRole.CommunityChecker);
-    expect(roles).toContain(SFProjectRole.Observer);
-    expect(roles).toContain(SFProjectRole.Reviewer);
-    env.component.roleControl.setValue(SFProjectRole.Observer);
+    expect(roles).toContain(SFProjectRole.Viewer);
+    expect(roles).toContain(SFProjectRole.Commenter);
+    env.component.roleControl.setValue(SFProjectRole.Viewer);
     env.wait();
     verify(mockedProjectService.onlineGetLinkSharingKey('project01', anything(), anything())).twice();
-    env.component.roleControl.setValue(SFProjectRole.Reviewer);
+    env.component.roleControl.setValue(SFProjectRole.Commenter);
     env.wait();
     verify(mockedProjectService.onlineGetLinkSharingKey('project01', anything(), anything())).thrice();
     expect(env.component.isLinkSharingEnabled).toBe(true);
@@ -328,7 +328,7 @@ class TestEnvironment {
         userRoles: {
           user01: SFProjectRole.CommunityChecker,
           user02: SFProjectRole.ParatextAdministrator,
-          user03: SFProjectRole.Observer
+          user03: SFProjectRole.Viewer
         },
         translateConfig: { shareEnabled: true },
         checkingConfig: { checkingEnabled: args.checkingEnabled, shareEnabled: true }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
@@ -119,8 +119,8 @@ export class ShareControlComponent extends SubscriptionDisposable {
 
     const linkSharingSettings = {
       [SFProjectRole.CommunityChecker]: project.checkingConfig.shareEnabled,
-      [SFProjectRole.Observer]: project.translateConfig.shareEnabled,
-      [SFProjectRole.Reviewer]: project.translateConfig.shareEnabled
+      [SFProjectRole.Viewer]: project.translateConfig.shareEnabled,
+      [SFProjectRole.Commenter]: project.translateConfig.shareEnabled
     };
     return linkSharingSettings[this.shareRole] && this.userShareableRoles.includes(this.shareRole);
   }
@@ -140,7 +140,7 @@ export class ShareControlComponent extends SubscriptionDisposable {
           SF_PROJECT_RIGHTS.hasRight(project, this.userService.currentUserId, SFProjectDomain.Questions, Operation.View)
       },
       {
-        role: SFProjectRole.Observer,
+        role: SFProjectRole.Viewer,
         available: true,
         permission:
           project.translateConfig.shareEnabled &&
@@ -148,7 +148,7 @@ export class ShareControlComponent extends SubscriptionDisposable {
           userRole !== SFProjectRole.CommunityChecker
       },
       {
-        role: SFProjectRole.Reviewer,
+        role: SFProjectRole.Commenter,
         available: this.featureFlags.allowAddingNotes.enabled,
         permission: this.isProjectAdmin
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.spec.ts
@@ -35,7 +35,7 @@ const mockedFeatureFlagService = mock(FeatureFlagService);
 enum TestUsers {
   CommunityChecker = 'user01',
   Admin = 'user02',
-  Observer = 'user03'
+  Viewer = 'user03'
 }
 
 describe('ShareDialogComponent', () => {
@@ -82,7 +82,7 @@ describe('ShareDialogComponent', () => {
       })
     );
 
-    env.component.setRole(SFProjectRole.Reviewer);
+    env.component.setRole(SFProjectRole.Commenter);
     env.wait();
     expect(env.shareButton.disabled).toBe(true);
     expect(env.copyLinkButton.disabled).toBe(true);
@@ -143,12 +143,12 @@ describe('ShareDialogComponent', () => {
     });
     const roles: SFProjectRole[] = env.component.availableRoles;
     expect(roles).toContain(SFProjectRole.CommunityChecker);
-    expect(roles).toContain(SFProjectRole.Observer);
-    expect(roles).toContain(SFProjectRole.Reviewer);
-    env.component.setRole(SFProjectRole.Observer);
+    expect(roles).toContain(SFProjectRole.Viewer);
+    expect(roles).toContain(SFProjectRole.Commenter);
+    env.component.setRole(SFProjectRole.Viewer);
     env.wait();
     verify(mockedProjectService.onlineGetLinkSharingKey('project01', anything(), anything())).twice();
-    env.component.setRole(SFProjectRole.Reviewer);
+    env.component.setRole(SFProjectRole.Commenter);
     env.wait();
     verify(mockedProjectService.onlineGetLinkSharingKey('project01', anything(), anything())).thrice();
   }));
@@ -167,19 +167,19 @@ describe('ShareDialogComponent', () => {
     env = new TestEnvironment({ userId: TestUsers.CommunityChecker });
     const roles: SFProjectRole[] = env.component.availableRoles;
     expect(roles).toContain(SFProjectRole.CommunityChecker);
-    expect(roles).not.toContain(SFProjectRole.Observer);
-    expect(roles).not.toContain(SFProjectRole.Reviewer);
+    expect(roles).not.toContain(SFProjectRole.Viewer);
+    expect(roles).not.toContain(SFProjectRole.Commenter);
     expect(env.component.shareRole).toEqual(SFProjectRole.CommunityChecker);
     expect(env.canChangeInvitationRole).toBeFalse();
   }));
 
-  it('observer users can only share the observer role', fakeAsync(() => {
-    env = new TestEnvironment({ userId: TestUsers.Observer, defaultRole: SFProjectRole.Observer });
+  it('viewer users can only share the viewer role', fakeAsync(() => {
+    env = new TestEnvironment({ userId: TestUsers.Viewer, defaultRole: SFProjectRole.Viewer });
     const roles: SFProjectRole[] = env.component.availableRoles;
     expect(roles).not.toContain(SFProjectRole.CommunityChecker);
-    expect(roles).toContain(SFProjectRole.Observer);
-    expect(roles).not.toContain(SFProjectRole.Reviewer);
-    expect(env.component.shareRole).toEqual(SFProjectRole.Observer);
+    expect(roles).toContain(SFProjectRole.Viewer);
+    expect(roles).not.toContain(SFProjectRole.Commenter);
+    expect(env.component.shareRole).toEqual(SFProjectRole.Viewer);
     expect(env.canChangeInvitationRole).toBeFalse();
   }));
 
@@ -187,16 +187,16 @@ describe('ShareDialogComponent', () => {
     env = new TestEnvironment({ userId: TestUsers.Admin, checkingShareEnabled: false, translateShareEnabled: false });
     const roles: SFProjectRole[] = env.component.availableRoles;
     expect(roles).toContain(SFProjectRole.CommunityChecker);
-    expect(roles).toContain(SFProjectRole.Observer);
-    expect(roles).toContain(SFProjectRole.Reviewer);
+    expect(roles).toContain(SFProjectRole.Viewer);
+    expect(roles).toContain(SFProjectRole.Commenter);
   }));
 
   it('admin users can share any role except community checking if it is disabled', fakeAsync(() => {
     env = new TestEnvironment({ userId: TestUsers.Admin, checkingEnabled: false, translateShareEnabled: false });
     const roles: SFProjectRole[] = env.component.availableRoles;
     expect(roles).not.toContain(SFProjectRole.CommunityChecker);
-    expect(roles).toContain(SFProjectRole.Observer);
-    expect(roles).toContain(SFProjectRole.Reviewer);
+    expect(roles).toContain(SFProjectRole.Viewer);
+    expect(roles).toContain(SFProjectRole.Commenter);
   }));
 
   it('admin users can not share with anyone if sharing is disabled', fakeAsync(() => {
@@ -215,14 +215,14 @@ describe('ShareDialogComponent', () => {
     expect(env.component.shareRole).toEqual(SFProjectRole.CommunityChecker);
     expect(env.canChangeLinkUsage).toBeTrue();
 
-    env.component.setRole(SFProjectRole.Observer);
+    env.component.setRole(SFProjectRole.Viewer);
     env.wait();
-    expect(env.component.shareRole).toEqual(SFProjectRole.Observer);
+    expect(env.component.shareRole).toEqual(SFProjectRole.Viewer);
     expect(env.canChangeLinkUsage).toBeTrue();
   }));
 
   it('default role can be set', fakeAsync(() => {
-    env = new TestEnvironment({ defaultRole: SF_DEFAULT_TRANSLATE_SHARE_ROLE, userId: TestUsers.Observer });
+    env = new TestEnvironment({ defaultRole: SF_DEFAULT_TRANSLATE_SHARE_ROLE, userId: TestUsers.Viewer });
     expect(env.component.shareRole).toEqual(SF_DEFAULT_TRANSLATE_SHARE_ROLE);
   }));
 
@@ -259,14 +259,14 @@ describe('ShareDialogComponent', () => {
     env = new TestEnvironment({ userId: TestUsers.Admin });
     let roles: SFProjectRole[] = env.component.availableRoles;
     expect(roles).toContain(SFProjectRole.CommunityChecker);
-    expect(roles).toContain(SFProjectRole.Observer);
+    expect(roles).toContain(SFProjectRole.Viewer);
     expect(env.canChangeLinkUsage).toBeTrue();
 
     env.disableCheckingSharing();
 
     roles = env.component.availableRoles;
     expect(roles).not.toContain(SFProjectRole.CommunityChecker);
-    expect(roles).toContain(SFProjectRole.Observer);
+    expect(roles).toContain(SFProjectRole.Viewer);
     expect(env.canChangeLinkUsage).toBeFalse();
   }));
 
@@ -332,7 +332,7 @@ class TestEnvironment {
         userRoles: {
           user01: SFProjectRole.CommunityChecker,
           user02: SFProjectRole.ParatextAdministrator,
-          user03: SFProjectRole.Observer
+          user03: SFProjectRole.Viewer
         },
         translateConfig: { shareEnabled: translateShareEnabled },
         checkingConfig: { checkingEnabled: checkingEnabled, shareEnabled: checkingShareEnabled }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
@@ -251,7 +251,7 @@ export class ShareDialogComponent extends SubscriptionDisposable {
           SF_PROJECT_RIGHTS.hasRight(project, this.userService.currentUserId, SFProjectDomain.Questions, Operation.View)
       },
       {
-        role: SFProjectRole.Observer,
+        role: SFProjectRole.Viewer,
         available: true,
         permission:
           project.translateConfig.shareEnabled &&
@@ -259,7 +259,7 @@ export class ShareDialogComponent extends SubscriptionDisposable {
           userRole !== SFProjectRole.CommunityChecker
       },
       {
-        role: SFProjectRole.Reviewer,
+        role: SFProjectRole.Commenter,
         available: this.featureFlags.allowAddingNotes.enabled,
         permission: this.isProjectAdmin
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -664,7 +664,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     const textAnchorRange = this.viewModel.getEditorContentRange(embedInsertPos, textAnchor.length);
     const formatLength: number = textAnchorRange.editorLength;
 
-    if (role !== SFProjectRole.Reviewer) {
+    if (role !== SFProjectRole.Commenter) {
       insertFormat['text-anchor'] = 'true';
       this.editor.formatText(embedInsertPos, formatLength, insertFormat, 'api');
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1013,14 +1013,14 @@ describe('EditorComponent', () => {
       verify(env.mockedRemoteTranslationEngine.getWordGraph(anything())).once();
 
       // Change user role on the project and run a sync to force remote updates
-      env.changeUserRole(projectId, userId, SFProjectRole.Observer);
+      env.changeUserRole(projectId, userId, SFProjectRole.Viewer);
       env.setDataInSync(projectId, true, false);
       env.setDataInSync(projectId, false, false);
       env.wait();
       resetCalls(env.mockedRemoteTranslationEngine);
 
       projectDoc = env.getProjectDoc(projectId);
-      expect(projectDoc.data?.userRoles[userId]).toBe(SFProjectRole.Observer);
+      expect(projectDoc.data?.userRoles[userId]).toBe(SFProjectRole.Viewer);
       expect(env.bookName).toEqual('Matthew');
       expect(env.component.canEdit).toBe(false);
 
@@ -2485,7 +2485,7 @@ describe('EditorComponent', () => {
     it('shows only note threads published in Scripture Forge', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
-      env.setReviewerUser();
+      env.setCommenterUser();
       const threadId: string = 'thread06';
       env.addParatextNoteThread(
         threadId,
@@ -2747,10 +2747,10 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('reviewers can click to select verse', fakeAsync(() => {
+    it('commenters can click to select verse', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
-      env.setReviewerUser();
+      env.setCommenterUser();
       env.wait();
 
       const hasSelectionAnchors = env.getSegmentElement('verse_1_1')!.querySelector('display-text-anchor');
@@ -2791,7 +2791,7 @@ describe('EditorComponent', () => {
     it('does not select verse when opening a note thread', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
-      env.setReviewerUser();
+      env.setCommenterUser();
       env.addParatextNoteThread(
         6,
         'MAT 1:1',
@@ -2836,7 +2836,7 @@ describe('EditorComponent', () => {
     it('does not allow selecting section headings', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
-      env.setReviewerUser();
+      env.setCommenterUser();
       env.updateParams({ projectId: 'project01', bookId: 'LUK' });
       env.wait();
 
@@ -2861,10 +2861,10 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('reviewers can create note on selected verse with FAB', fakeAsync(() => {
+    it('commenters can create note on selected verse with FAB', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
-      env.setReviewerUser();
+      env.setCommenterUser();
       env.wait();
 
       const verseSegment: HTMLElement = env.getSegmentElement('verse_1_5')!;
@@ -3147,9 +3147,9 @@ class TestEnvironment {
     user02: SFProjectRole.ParatextConsultant,
     user03: SFProjectRole.ParatextTranslator,
     user04: SFProjectRole.ParatextAdministrator,
-    user05: SFProjectRole.Reviewer,
+    user05: SFProjectRole.Commenter,
     user06: SFProjectRole.ParatextObserver,
-    user07: SFProjectRole.Observer
+    user07: SFProjectRole.Viewer
   };
   private paratextUsersOnProject = paratextUsersFromRoles(this.userRolesOnProject);
   private readonly realtimeService: TestRealtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);
@@ -3529,9 +3529,9 @@ class TestEnvironment {
   }
 
   setParatextReviewerUser(): void {
-    this.setReviewerUser('user02');
+    this.setCommenterUser('user02');
   }
-  setReviewerUser(userId: 'user02' | 'user05' = 'user05'): void {
+  setCommenterUser(userId: 'user02' | 'user05' = 'user05'): void {
     this.setCurrentUser(userId);
     when(mockedSFProjectService.queryNoteThreads('project01')).thenCall((id, _) =>
       this.realtimeService.subscribeQuery(NoteThreadDoc.COLLECTION, {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -501,7 +501,7 @@ class TestEnvironment {
   };
   static userRoles: { [userId: string]: string } = {
     user01: SFProjectRole.ParatextAdministrator,
-    user02: SFProjectRole.Observer
+    user02: SFProjectRole.Viewer
   };
   static testProjectProfile: SFProjectProfile = {
     paratextId: 'pt01',

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -209,8 +209,8 @@
     "pt_observer": "Observer",
     "pt_translator": "Translator",
     "sf_community_checker": "Community Checker",
-    "sf_reviewer": "Reviewer",
-    "sf_observer": "Observer"
+    "sf_reviewer": "Commenter",
+    "sf_observer": "Viewer"
   },
   "role_descriptions": {
     "sf_community_checker": "Answer questions, Comment on answers",

--- a/src/SIL.XForge.Scripture/Models/SFProjectRole.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectRole.cs
@@ -6,9 +6,9 @@ public static class SFProjectRole
     public const string Translator = "pt_translator";
     public const string Consultant = "pt_consultant";
     public const string PTObserver = "pt_observer";
-    public const string Reviewer = "sf_reviewer";
+    public const string Commenter = "sf_reviewer";
     public const string CommunityChecker = "sf_community_checker";
-    public const string SFObserver = "sf_observer";
+    public const string Viewer = "sf_observer";
 
     public static bool IsParatextRole(string role)
     {

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -384,8 +384,8 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
                 SFProjectRole.CommunityChecker,
                 project.CheckingConfig.CheckingEnabled && (isAdmin || project.CheckingConfig.ShareEnabled)
             },
-            { SFProjectRole.SFObserver, project.TranslateConfig.ShareEnabled || isAdmin },
-            { SFProjectRole.Reviewer, project.TranslateConfig.ShareEnabled || isAdmin }
+            { SFProjectRole.Viewer, project.TranslateConfig.ShareEnabled || isAdmin },
+            { SFProjectRole.Commenter, project.TranslateConfig.ShareEnabled || isAdmin }
         }
             .Where(entry => entry.Value)
             .Select(entry => entry.Key)
@@ -473,8 +473,8 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
                 SFProjectRole.CommunityChecker,
                 project.CheckingConfig.CheckingEnabled && (isProjectAdmin || project.CheckingConfig.ShareEnabled)
             },
-            { SFProjectRole.SFObserver, isProjectAdmin || project.TranslateConfig.ShareEnabled },
-            { SFProjectRole.Reviewer, isProjectAdmin || project.TranslateConfig.ShareEnabled }
+            { SFProjectRole.Viewer, isProjectAdmin || project.TranslateConfig.ShareEnabled },
+            { SFProjectRole.Commenter, isProjectAdmin || project.TranslateConfig.ShareEnabled }
         }
             .Where(entry => entry.Value)
             .Select(entry => entry.Key)
@@ -652,8 +652,8 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
                     SFProjectRole.CommunityChecker,
                     project.CheckingConfig.CheckingEnabled && project.CheckingConfig.ShareEnabled
                 },
-                { SFProjectRole.SFObserver, project.TranslateConfig.ShareEnabled },
-                { SFProjectRole.Reviewer, project.TranslateConfig.ShareEnabled },
+                { SFProjectRole.Viewer, project.TranslateConfig.ShareEnabled },
+                { SFProjectRole.Commenter, project.TranslateConfig.ShareEnabled },
             }
                 .Where(entry => entry.Value)
                 .Select(entry => entry.Key)
@@ -1150,19 +1150,19 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         if (role == SFProjectRole.CommunityChecker)
             return true;
 
-        if (role == SFProjectRole.Reviewer)
+        if (role == SFProjectRole.Commenter)
         {
             // This may change if we decide that other users should be able to invite reviewers
             if (IsProjectAdmin(project, userId))
                 return true;
         }
-        else if (role == SFProjectRole.SFObserver)
+        else if (role == SFProjectRole.Viewer)
         {
             if (HasParatextRole(project, userId))
                 return true;
             if (project.UserRoles.TryGetValue(userId, out string projectRole))
             {
-                if (projectRole == SFProjectRole.Reviewer || projectRole == SFProjectRole.SFObserver)
+                if (projectRole == SFProjectRole.Commenter || projectRole == SFProjectRole.Viewer)
                     return true;
             }
         }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -2648,7 +2648,7 @@ public class ParatextSyncRunnerTests
                     {
                         { "user01", SFProjectRole.Administrator },
                         { "user02", SFProjectRole.Translator },
-                        { "user03", SFProjectRole.Reviewer }
+                        { "user03", SFProjectRole.Commenter }
                     },
                     ParatextId = "target",
                     IsRightToLeft = false,

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -100,11 +100,11 @@ public class SFProjectServiceTests
         const string observerEmail = "sf_observer@example.com";
         const string observerKey = "sfobserverkey";
         env.SecurityService.GenerateKey().Returns(observerKey);
-        await env.Service.InviteAsync(User02, Project04, observerEmail, "en", SFProjectRole.SFObserver);
+        await env.Service.InviteAsync(User02, Project04, observerEmail, "en", SFProjectRole.Viewer);
         SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project04);
         Assert.That(
             projectSecret.ShareKeys.Any(
-                s => s.Email == observerEmail && s.Key == observerKey && s.ProjectRole == SFProjectRole.SFObserver
+                s => s.Email == observerEmail && s.Key == observerKey && s.ProjectRole == SFProjectRole.Viewer
             ),
             Is.True
         );
@@ -121,11 +121,11 @@ public class SFProjectServiceTests
         const string reviewerEmail = "reviewer@example.com";
         const string reviewerKey = "reviewerKey";
         env.SecurityService.GenerateKey().Returns(reviewerKey);
-        await env.Service.InviteAsync(User02, Project04, reviewerEmail, "en", SFProjectRole.Reviewer);
+        await env.Service.InviteAsync(User02, Project04, reviewerEmail, "en", SFProjectRole.Commenter);
         projectSecret = env.ProjectSecrets.Get(Project04);
         Assert.That(
             projectSecret.ShareKeys.Any(
-                s => s.Email == reviewerEmail && s.Key == reviewerKey && s.ProjectRole == SFProjectRole.Reviewer
+                s => s.Email == reviewerEmail && s.Key == reviewerKey && s.ProjectRole == SFProjectRole.Commenter
             ),
             Is.True
         );
@@ -146,7 +146,7 @@ public class SFProjectServiceTests
         var env = new TestEnvironment();
         const string email = "bob@example.com";
         const string initialRole = SFProjectRole.CommunityChecker;
-        const string endingRole = SFProjectRole.SFObserver;
+        const string endingRole = SFProjectRole.Viewer;
 
         SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project03);
         Assert.That(
@@ -313,7 +313,7 @@ public class SFProjectServiceTests
                 sk =>
                     sk.Key == "reservedKey"
                     && sk.ShareLinkType == ShareLinkType.Recipient
-                    && sk.ProjectRole == SFProjectRole.SFObserver
+                    && sk.ProjectRole == SFProjectRole.Viewer
             ),
             Is.True,
             "setup"
@@ -323,7 +323,7 @@ public class SFProjectServiceTests
         string shareLink = await env.Service.GetLinkSharingKeyAsync(
             User07,
             Project06,
-            SFProjectRole.SFObserver,
+            SFProjectRole.Viewer,
             ShareLinkType.Recipient
         );
         Assert.That(shareLink, Is.EqualTo("newKey"));
@@ -333,7 +333,7 @@ public class SFProjectServiceTests
                 sk =>
                     sk.Key == "newKey"
                     && sk.ShareLinkType == ShareLinkType.Recipient
-                    && sk.ProjectRole == SFProjectRole.SFObserver
+                    && sk.ProjectRole == SFProjectRole.Viewer
                     && sk.Reserved == null
             ),
             Is.True
@@ -383,7 +383,7 @@ public class SFProjectServiceTests
     public async Task GetLinkSharingKeyAsync_LinkHasExpired_NewShareKeyCreated()
     {
         var env = new TestEnvironment();
-        const string role = SFProjectRole.SFObserver;
+        const string role = SFProjectRole.Viewer;
         SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project06);
 
         Assert.That(
@@ -422,20 +422,15 @@ public class SFProjectServiceTests
         string key = await env.Service.GetLinkSharingKeyAsync(
             User01,
             Project01,
-            SFProjectRole.SFObserver,
+            SFProjectRole.Viewer,
             ShareLinkType.Anyone
         );
         Assert.That(key, Is.Not.Null);
         // An sf observer should have rights to invite another observer
-        key = await env.Service.GetLinkSharingKeyAsync(
-            User06,
-            Project01,
-            SFProjectRole.SFObserver,
-            ShareLinkType.Anyone
-        );
+        key = await env.Service.GetLinkSharingKeyAsync(User06, Project01, SFProjectRole.Viewer, ShareLinkType.Anyone);
         Assert.That(key, Is.Not.Null);
         Assert.ThrowsAsync<ForbiddenException>(
-            () => env.Service.GetLinkSharingKeyAsync(User02, Project01, SFProjectRole.SFObserver, ShareLinkType.Anyone)
+            () => env.Service.GetLinkSharingKeyAsync(User02, Project01, SFProjectRole.Viewer, ShareLinkType.Anyone)
         );
     }
 
@@ -446,12 +441,12 @@ public class SFProjectServiceTests
         string key = await env.Service.GetLinkSharingKeyAsync(
             User01,
             Project01,
-            SFProjectRole.Reviewer,
+            SFProjectRole.Commenter,
             ShareLinkType.Anyone
         );
         Assert.That(key, Is.Not.Null);
         Assert.ThrowsAsync<ForbiddenException>(
-            () => env.Service.GetLinkSharingKeyAsync(User02, Project01, SFProjectRole.Reviewer, ShareLinkType.Anyone)
+            () => env.Service.GetLinkSharingKeyAsync(User02, Project01, SFProjectRole.Commenter, ShareLinkType.Anyone)
         );
     }
 
@@ -1687,7 +1682,7 @@ public class SFProjectServiceTests
                 sk =>
                     sk.Key == "toBeReservedKey"
                     && sk.ShareLinkType == ShareLinkType.Recipient
-                    && sk.ProjectRole == SFProjectRole.Reviewer
+                    && sk.ProjectRole == SFProjectRole.Commenter
                     && sk.ExpirationTime == null
                     && sk.Reserved == null
             ),
@@ -1704,7 +1699,7 @@ public class SFProjectServiceTests
                 sk =>
                     sk.Key == "toBeReservedKey"
                     && sk.ShareLinkType == ShareLinkType.Recipient
-                    && sk.ProjectRole == SFProjectRole.Reviewer
+                    && sk.ProjectRole == SFProjectRole.Commenter
                     && sk.ExpirationTime > DateTime.Now
                     && sk.Reserved == true
             ),
@@ -2725,7 +2720,7 @@ public class SFProjectServiceTests
                                 { User01, SFProjectRole.Administrator },
                                 { User02, SFProjectRole.CommunityChecker },
                                 { User05, SFProjectRole.Translator },
-                                { User06, SFProjectRole.SFObserver }
+                                { User06, SFProjectRole.Viewer }
                             },
                             Texts =
                             {
@@ -3102,7 +3097,7 @@ public class SFProjectServiceTests
                             new ShareKey
                             {
                                 Key = "linksharing04",
-                                ProjectRole = SFProjectRole.SFObserver,
+                                ProjectRole = SFProjectRole.Viewer,
                                 ShareLinkType = ShareLinkType.Anyone
                             },
                         }
@@ -3131,13 +3126,13 @@ public class SFProjectServiceTests
                             {
                                 Key = "expiredKey",
                                 ExpirationTime = currentTime.AddDays(-1),
-                                ProjectRole = SFProjectRole.SFObserver,
+                                ProjectRole = SFProjectRole.Viewer,
                                 ShareLinkType = ShareLinkType.Recipient
                             },
                             new ShareKey
                             {
                                 Key = "usedKey",
-                                ProjectRole = SFProjectRole.SFObserver,
+                                ProjectRole = SFProjectRole.Viewer,
                                 ShareLinkType = ShareLinkType.Recipient,
                                 RecipientUserId = User02
                             },
@@ -3145,14 +3140,14 @@ public class SFProjectServiceTests
                             {
                                 Key = "reservedKey",
                                 ExpirationTime = currentTime.AddDays(1),
-                                ProjectRole = SFProjectRole.SFObserver,
+                                ProjectRole = SFProjectRole.Viewer,
                                 ShareLinkType = ShareLinkType.Recipient,
                                 Reserved = true
                             },
                             new ShareKey
                             {
                                 Key = "toBeReservedKey",
-                                ProjectRole = SFProjectRole.Reviewer,
+                                ProjectRole = SFProjectRole.Commenter,
                                 ShareLinkType = ShareLinkType.Recipient,
                             },
                         }


### PR DESCRIPTION
This change updates the role names from reviewer to commenter, and observer to viewer. This change will clarify the role so that there is less confusion between checking reviewers and translation reviewers. The string in the backend will remain "sf_reviewer" and "sf_observer" since there is no real benefit to changing those strings which would require a migration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1796)
<!-- Reviewable:end -->
