### PR TITLE
SF-1973 Flag all chapters of extra-Biblical books as invalid

### DIFF
--- a/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
@@ -144,6 +144,7 @@ public class DeltaUsxMapper : IDeltaUsxMapper
         var chapterDelta = new Delta();
         var nextIds = new Dictionary<string, int>();
         var state = new ParseState();
+        bool bookIsValid = true;
         foreach (XNode node in usxDoc.Element("usx").Nodes())
         {
             switch (node)
@@ -152,6 +153,8 @@ public class DeltaUsxMapper : IDeltaUsxMapper
                     switch (elem.Name.LocalName)
                     {
                         case "book":
+                            // Check for book validity. The list of valid books are in the XSD
+                            bookIsValid = elem.GetSchemaInfo()?.Validity == XmlSchemaValidity.Valid;
                             break;
 
                         case "para":
@@ -200,7 +203,9 @@ public class DeltaUsxMapper : IDeltaUsxMapper
                                 ChapterEnded(chapterDeltas, chapterDelta, state);
                                 nextIds.Clear();
                                 chapterDelta = new Delta();
-                                state.CurChapterIsValid = true;
+
+                                // The book must be valid for the chapter to be valid
+                                state.CurChapterIsValid = bookIsValid;
                             }
                             state.CurRef = null;
                             state.LastVerse = 0;

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -3214,6 +3214,46 @@ public class DeltaUsxMapperTests
         Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
     }
 
+    [Test]
+    public void ToDelta_SecondChapterInInvalidBook()
+    {
+        XDocument usxDoc = Usx(
+            "TDX",
+            Chapter("1"),
+            Para("q", Verse("1"), "This verse is valid, but in an invalid book"),
+            Chapter("2"),
+            Para("q", Verse("1"), "This verse is also valid, but in an invalid book")
+        );
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        var expected = new[]
+        {
+            Delta
+                .New()
+                .InsertChapter("1")
+                .InsertBlank("q_1")
+                .InsertVerse("1")
+                .InsertText("This verse is valid, but in an invalid book", "verse_1_1")
+                .InsertPara("q"),
+            Delta
+                .New()
+                .InsertChapter("2")
+                .InsertBlank("q_1")
+                .InsertVerse("1")
+                .InsertText("This verse is also valid, but in an invalid book", "verse_2_1")
+                .InsertPara("q"),
+        };
+
+        Assert.That(chapterDeltas.Count, Is.EqualTo(2));
+        Assert.That(chapterDeltas[0].IsValid, Is.False);
+        Assert.That(chapterDeltas[1].IsValid, Is.False);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected[0]));
+        Assert.IsTrue(chapterDeltas[1].Delta.DeepEquals(expected[1]));
+    }
+
+    [Test]
     public void ToDelta_LineBreakWithinVerse()
     {
         XDocument usxDoc = Usx(


### PR DESCRIPTION
Extra-biblical books (like Introduction, Indexes, Extra Material) should not be editable in Scripture Forge. However, if one of these books has more than one chapter, and those subsequent chapters (2, 3, etc) are valid, they will be marked as valid and editable in Scripture Forge.

This Pull Request fixes this, by ensuring that if a book is defined as invalid (by not being in the valid books list in `usx-sf.xsd`), all subsequent chapters will be invalid too.

In addition, this PR enables the test `ToDelta_LineBreakWithinVerse`, which was noticed have accidentally had its Test attribute omitted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1798)
<!-- Reviewable:end -->
