### PR TITLE
Update Storybook stories

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comment-form/checking-comment-form.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comment-form/checking-comment-form.stories.ts
@@ -1,34 +1,38 @@
 import { CommonModule } from '@angular/common';
-import { Meta, StoryFn } from '@storybook/angular';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { userEvent, within } from '@storybook/testing-library';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { expect } from '@storybook/jest';
 import { I18nStoryModule } from 'xforge-common/i18n-story.module';
 import { CheckingCommentFormComponent } from './checking-comment-form.component';
 
-export default {
+const meta: Meta<CheckingCommentFormComponent> = {
   title: 'Checking/Comments/Comment Form',
-  component: CheckingCommentFormComponent,
-  argTypes: {
-    text: { control: 'text' }
+  component: CheckingCommentFormComponent
+};
+export default meta;
+
+type Story = StoryObj<CheckingCommentFormComponent>;
+
+const Template: Story = {
+  decorators: [moduleMetadata({ imports: [CommonModule, UICommonModule, I18nStoryModule] })]
+};
+
+export const NewForm: Story = { ...Template };
+
+export const EditForm: Story = {
+  ...Template,
+  args: { text: 'This is a comment' }
+};
+
+export const InvalidForm: Story = {
+  ...Template,
+  args: { text: '' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const saveButton = canvas.getByRole('button', { name: /Save/i });
+    userEvent.click(saveButton);
+    const error = canvas.getByText(/You need to enter your comment before saving/i);
+    expect(error).toBeInTheDocument();
   }
-} as Meta;
-
-const Template: StoryFn = args => ({
-  moduleMetadata: { imports: [CommonModule, UICommonModule, I18nStoryModule] },
-  props: args
-});
-
-export const NewForm = Template.bind({});
-
-export const EditForm = Template.bind({});
-EditForm.args = { text: 'This is a comment' };
-
-export const InvalidForm = Template.bind({});
-InvalidForm.play = async ({ canvasElement }) => {
-  const canvas = within(canvasElement);
-  const saveButton = canvas.getByRole('button', { name: /Save/i });
-  userEvent.click(saveButton);
-  const error = canvas.getByText(/You need to enter your comment before saving/i);
-  expect(error).toBeInTheDocument();
 };

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.stories.ts
@@ -10,7 +10,7 @@ import { BookChapterChooserComponent } from './book-chapter-chooser.component';
 
 const CANON_SIZE = 66; // all books we currently localize
 
-export default {
+const meta: Meta = {
   title: 'Shared/Book & Chapter Chooser',
   component: BookChapterChooserComponent,
   argTypes: {
@@ -19,7 +19,8 @@ export default {
       control: 'select'
     }
   }
-} as Meta<BookChapterChooserComponent>;
+};
+export default meta;
 
 const Template: StoryFn = args => ({
   moduleMetadata: { imports: [CommonModule, UICommonModule, I18nStoryModule] },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.stories.ts
@@ -3,10 +3,11 @@ import { Meta, StoryFn } from '@storybook/angular';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { NoticeComponent } from '../../shared/notice/notice.component';
 
-export default {
+const meta: Meta<NoticeComponent> = {
   title: 'Utility/Notice',
   component: NoticeComponent
-} as Meta;
+};
+export default meta;
 
 const Template: StoryFn = args => ({
   moduleMetadata: { imports: [UICommonModule, CommonModule] },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-button.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-button.stories.ts
@@ -1,34 +1,48 @@
-import { Meta, StoryFn } from '@storybook/angular';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
-import { instance, mock, when } from 'ts-mockito';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nStoryModule } from 'xforge-common/i18n-story.module';
+import { userEvent, within } from '@storybook/testing-library';
 import { of } from 'rxjs';
+import { anything, instance, mock, reset, verify, when } from 'ts-mockito';
 import { ShareButtonComponent } from './share-button.component';
 
 const mockedActivatedRoute = mock(ActivatedRoute);
 when(mockedActivatedRoute.params).thenReturn(of({ projectId: 'project1' }));
 const mockedDialogService = mock(DialogService);
 
-export default {
+const meta: Meta<ShareButtonComponent> = {
   title: 'Utility/ShareButton',
   component: ShareButtonComponent
-} as Meta;
+};
+export default meta;
 
-const Template: StoryFn = args => ({
-  moduleMetadata: {
-    imports: [UICommonModule, CommonModule, I18nStoryModule],
-    providers: [
-      { provide: ActivatedRoute, useValue: instance(mockedActivatedRoute) },
-      { provide: DialogService, useValue: instance(mockedDialogService) }
-    ]
-  },
-  props: args
-});
+type Story = StoryObj<ShareButtonComponent>;
 
-export const IconOnly = Template.bind({});
+const Template: Story = {
+  decorators: [
+    moduleMetadata({
+      imports: [UICommonModule, CommonModule, I18nStoryModule],
+      providers: [
+        { provide: ActivatedRoute, useValue: instance(mockedActivatedRoute) },
+        { provide: DialogService, useValue: instance(mockedDialogService) }
+      ]
+    })
+  ],
+  play: async ({ canvasElement }) => {
+    reset(mockedDialogService);
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button');
+    userEvent.click(button);
+    verify(mockedDialogService.openMatDialog(anything(), anything())).once();
+  }
+};
 
-export const ButtonWithText = Template.bind({});
-ButtonWithText.args = { iconOnlyButton: false };
+export const ButtonWithIcon: Story = { ...Template };
+
+export const ButtonWithText: Story = {
+  ...Template,
+  args: { iconOnlyButton: false }
+};


### PR DESCRIPTION
I've made several changes to the Storybook stories, mainly because I want the early stories we write to be exemplary since they're likely to be the basis for other stories.

- Where possible I replaced `StoryFn` with `StoryObj`, the preferred way of defining stories in Storybook 7 (in some cases `StoryFn` just works better).
- I updated how the metadata for each component is declared so we can avoid writing `as Meta`.
- I added a test to the share button stories.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1800)
<!-- Reviewable:end -->
