### PR TITLE
Add Mongo query to count answers by month

### DIFF
--- a/mongodb/Questions/CountAnswersByMonth.mongodb
+++ b/mongodb/Questions/CountAnswersByMonth.mongodb
@@ -1,0 +1,39 @@
+use('xforge');
+
+// Get the number of answers per month across all projects
+
+const answersByMonth = db.questions.aggregate([
+  {$match: {
+    answers: { $exists: true }
+  }},
+  {$project: {
+    answers: 1
+  }},
+  {$unwind: '$answers'},
+  {$project: {
+    dateString: { $dateToString: { format: '%Y-%m', date: {$dateFromString: { dateString: '$answers.dateCreated' } } } }
+  }},
+  {$group: {
+    _id: '$dateString',
+    count: { $sum: 1 },
+  }},
+  {$sort: { _id: 1 }}
+]).toArray();
+
+const startYear = answersByMonth[0]._id.substring(0, 4) * 1;
+const startMonth = answersByMonth[0]._id.substring(5, 7) * 1;
+
+const endYear = answersByMonth[answersByMonth.length - 1]._id.substring(0, 4) * 1;
+const endMonth = answersByMonth[answersByMonth.length - 1]._id.substring(5, 7) * 1;
+
+for (let i = startYear; i <= endYear; i++) {
+  let start = i === startYear ? startMonth : 1;
+  let end = i === endYear ? endMonth : 12;
+  for (let j = start; j <= end; j++) {
+    const dateString = `${i}-${j < 10 ? '0' + j : j}`;
+    const answer = answersByMonth.find(a => a._id === dateString);
+    console.log(`${dateString}\t${answer ? answer.count : 0}`)
+  }
+}
+
+answersByMonth


### PR DESCRIPTION
I've been using this query successfully for a good while now to count answers by the month they were added.

I wanted it to print out a total for every month regardless of whether any answers were added in that month, but unfortunately that requires a fairly verbose script at the end. It does make it easy to copy the output though and put it into a spreadsheet for plotting, which is what I've been doing with the results.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1801)
<!-- Reviewable:end -->
