### PR TITLE
Turn off Chromatic on push to master

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,8 +1,6 @@
 name: "Chromatic"
 
 on:
-  push:
-    branches: [develop, master, sf-qa, sf-live]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
I created the Chromatic workflow by copying one of our existing build workflows, which included building commits after they're merged, which isn't really necessary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1809)
<!-- Reviewable:end -->
