### PR TITLE
log: record ParatextData messages during SendReceive (#1807)

### DIFF
--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -86,6 +86,7 @@ public interface IParatextService
         UserSecret userSecret,
         string paratextId,
         IProgress<ProgressState> progress = null,
-        CancellationToken token = default
+        CancellationToken token = default,
+        SyncMetrics syncMetrics = null
     );
 }

--- a/src/SIL.XForge.Scripture/Services/LambdaTraceListener.cs
+++ b/src/SIL.XForge.Scripture/Services/LambdaTraceListener.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Text;
+
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>TraceListener that passes messages to a delegate.</summary>
+public class LambdaTraceListener : System.Diagnostics.TraceListener
+{
+    private readonly Action<string> _processor;
+    private readonly StringBuilder _buffer;
+
+    public LambdaTraceListener(Action<string> processor)
+    {
+        _processor = processor;
+        _buffer = new StringBuilder();
+    }
+
+    ///<remarks>Writes are buffered, to be sent upon WriteLine.</remarks>
+    public override void Write(string message) => _buffer.Append(message);
+
+    public override void WriteLine(string message)
+    {
+        string combinedMessage = _buffer + message;
+        _buffer.Clear();
+        _processor(combinedMessage);
+    }
+}

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -232,7 +232,8 @@ public class ParatextSyncRunner : IParatextSyncRunner
                     _userSecret,
                     targetParatextId,
                     progress,
-                    token
+                    token,
+                    _syncMetrics
                 );
                 Log($"RunAsync: ParatextData SendReceive finished without throwing.");
             }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1348,7 +1348,8 @@ public class ParatextSyncRunnerTests
                         Arg.Any<UserSecret>(),
                         Arg.Any<string>(),
                         Arg.Any<IProgress<ProgressState>>(),
-                        Arg.Any<CancellationToken>()
+                        Arg.Any<CancellationToken>(),
+                        Arg.Any<SyncMetrics>()
                     )
             )
             .Do(_ => cancellationTokenSource.Cancel());
@@ -1382,7 +1383,8 @@ public class ParatextSyncRunnerTests
                         Arg.Any<UserSecret>(),
                         Arg.Any<string>(),
                         Arg.Any<IProgress<ProgressState>>(),
-                        Arg.Any<CancellationToken>()
+                        Arg.Any<CancellationToken>(),
+                        Arg.Any<SyncMetrics>()
                     )
             )
             .Do(_ => cancellationTokenSource.Cancel());
@@ -1450,7 +1452,8 @@ public class ParatextSyncRunnerTests
                         Arg.Any<UserSecret>(),
                         Arg.Any<string>(),
                         Arg.Any<IProgress<ProgressState>>(),
-                        Arg.Any<CancellationToken>()
+                        Arg.Any<CancellationToken>(),
+                        Arg.Any<SyncMetrics>()
                     )
             )
             .Do(_ => cancellationTokenSource.Cancel());
@@ -2060,7 +2063,8 @@ public class ParatextSyncRunnerTests
                 Arg.Any<UserSecret>(),
                 Arg.Any<string>(),
                 Arg.Any<IProgress<ProgressState>>(),
-                Arg.Any<CancellationToken>()
+                Arg.Any<CancellationToken>(),
+                Arg.Any<SyncMetrics>()
             )
             .Returns(new ParatextResource());
 
@@ -2101,7 +2105,8 @@ public class ParatextSyncRunnerTests
                 Arg.Any<UserSecret>(),
                 Arg.Any<string>(),
                 Arg.Any<IProgress<ProgressState>>(),
-                Arg.Any<CancellationToken>()
+                Arg.Any<CancellationToken>(),
+                Arg.Any<SyncMetrics>()
             )
             .Returns(new ParatextResource());
 
@@ -2255,7 +2260,8 @@ public class ParatextSyncRunnerTests
                 Arg.Any<UserSecret>(),
                 Arg.Any<string>(),
                 Arg.Any<IProgress<ProgressState>>(),
-                Arg.Any<CancellationToken>()
+                Arg.Any<CancellationToken>(),
+                Arg.Any<SyncMetrics>()
             )
             .Returns(new ParatextResource());
 
@@ -2372,7 +2378,8 @@ public class ParatextSyncRunnerTests
                             Arg.Any<UserSecret>(),
                             "target",
                             Arg.Any<IProgress<ProgressState>>(),
-                            Arg.Any<CancellationToken>()
+                            Arg.Any<CancellationToken>(),
+                            Arg.Any<SyncMetrics>()
                         )
                 )
                 .Do(x =>
@@ -3318,7 +3325,13 @@ public class ParatextSyncRunnerTests
             // Should not be performing a SR.
             await ParatextService
                 .DidNotReceiveWithAnyArgs()
-                .SendReceiveAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<IProgress<ProgressState>>());
+                .SendReceiveAsync(
+                    Arg.Any<UserSecret>(),
+                    Arg.Any<string>(),
+                    Arg.Any<IProgress<ProgressState>>(),
+                    Arg.Any<CancellationToken>(),
+                    Arg.Any<SyncMetrics>()
+                );
 
             // Record of sync is of not success.
             AssertDBSyncMetadata(
@@ -3363,7 +3376,13 @@ public class ParatextSyncRunnerTests
             // Should be performing a SR.
             await ParatextService
                 .Received(1)
-                .SendReceiveAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<IProgress<ProgressState>>());
+                .SendReceiveAsync(
+                    Arg.Any<UserSecret>(),
+                    Arg.Any<string>(),
+                    Arg.Any<IProgress<ProgressState>>(),
+                    Arg.Any<CancellationToken>(),
+                    Arg.Any<SyncMetrics>()
+                );
 
             // Record of sync is of success.
             AssertDBSyncMetadata(


### PR DESCRIPTION
- ParatextData outputs messages using Trace and Alert. Capture these
to SyncMetrics.
- Bump up alert logging to Error level so errors also make their way
thru to the console output.
- May help investigate SF-1968 sync problem.
- SendReceiveAsync is only called in production from
ParatextSyncRunner, and all arguments are specified. Modified to make
all arguments required.

(cherry picked from commit 9fc6800d72f15541978dd9ca1b548517a38f434e)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1810)
<!-- Reviewable:end -->
