### PR TITLE
SF-1988 Support for resources with duplicate short names

### DIFF
--- a/src/SIL.XForge.Scripture/Services/SFScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/SFScrTextCollection.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Paratext.Data;
 using SIL.WritingSystems;
 
@@ -14,6 +15,11 @@ public class SFScrTextCollection : ScrTextCollection
 {
     // Keep track of languages that weren't found in SLDR so we don't call over and over for the same bad code.
     private static readonly List<string> _sldrLookupFailed = new List<string>();
+
+    /// <summary>
+    /// The location where resources reside if there is more than one resource with the same short name.
+    /// </summary>
+    public static string ResourcesByIdDirectory => Path.Combine(SettingsDirectory, "_resourcesById");
 
     protected override string DictionariesDirectoryInternal => null;
 


### PR DESCRIPTION
This Pull Request allows resources to have the same short name. It does this by:
 * Support for loading resources from the `_resourcesById` directory
 * Ensuring that checks for the existing resource file check the DBL Id, so that if a resource is being installed shares a short name with an existing resource, it is installed to the `_resourcesById` directory

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1812)
<!-- Reviewable:end -->
