### PR TITLE
SF-1996 Add note threads when book is newly added on a sync

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -532,8 +532,6 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 if (noteThreadDocs.Any(d => d.Data.PublishedToSF == true))
                     await UpdateTranslateNoteTag(paratextId);
 
-                // Skip over updating Paratext notes for now (2023-05-04)
-                /*
                 int sfNoteTagId = _projectDoc.Data.TranslateConfig.DefaultNoteTagId ?? NoteTag.notSetId;
                 _syncMetrics.ParatextNotes += await _paratextService.UpdateParatextCommentsAsync(
                     _userSecret,
@@ -544,7 +542,6 @@ public class ParatextSyncRunner : IParatextSyncRunner
                     _currentPtSyncUsers,
                     sfNoteTagId
                 );
-                */
             }
         }
     }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -656,15 +656,17 @@ public class ParatextSyncRunner : IParatextSyncRunner
 
             LogMetric("Updating thread docs - updating");
 
-            if (noteThreadDocsByBook.TryGetValue(text.BookNum, out IEnumerable<IDocument<NoteThread>> noteThreadDocs))
+            // update note thread docs
+            if (!noteThreadDocsByBook.TryGetValue(text.BookNum, out IEnumerable<IDocument<NoteThread>> noteThreadDocs))
             {
-                await UpdateNoteThreadDocsAsync(
-                    text,
-                    noteThreadDocs.ToDictionary(nt => nt.Data.DataId),
-                    chapterDeltas,
-                    ptUsernamesToSFUserIds
-                );
+                noteThreadDocs = Array.Empty<IDocument<NoteThread>>();
             }
+            await UpdateNoteThreadDocsAsync(
+                text,
+                noteThreadDocs.ToDictionary(nt => nt.Data.DataId),
+                chapterDeltas,
+                ptUsernamesToSFUserIds
+            );
 
             // update project metadata
             LogMetric("Updating project metadata");

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1825,6 +1825,38 @@ public class ParatextSyncRunnerTests
     }
 
     [Test]
+    public async Task SyncAsync_NewBook_AddParatextNoteThreadDoc()
+    {
+        var env = new TestEnvironment();
+        var book = new Book("MAT", 1);
+        env.SetupSFData(false, true, false, false);
+        env.SetupPTData(book);
+
+        env.SetupNewNoteThreadChange("thread02", "syncuser01");
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        SFProject project = env.GetProject();
+        Assert.That(project.Sync.LastSyncSuccessful, Is.True);
+        env.ParatextService
+            .Received(1)
+            .GetNoteThreadChanges(
+                Arg.Any<UserSecret>(),
+                "target",
+                40,
+                Arg.Any<IEnumerable<IDocument<NoteThread>>>(),
+                Arg.Any<Dictionary<int, ChapterDelta>>(),
+                Arg.Any<Dictionary<string, ParatextUserProfile>>()
+            );
+        NoteThread noteThread = env.GetNoteThread("project01", "thread02");
+        // The note was created on the newly created book
+        Assert.That(noteThread.VerseRef.BookNum, Is.EqualTo(40));
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+        Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
+        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
+    }
+
+    [Test]
     public async Task SyncAsync_AddParatextNoteThreadDoc()
     {
         var env = new TestEnvironment();

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1638,7 +1638,6 @@ public class ParatextSyncRunnerTests
     }
 
     [Test]
-    [Ignore("Not ready to sync comments to PT.")]
     public async Task SyncAsync_UpdatesParatextComments()
     {
         var env = new TestEnvironment();
@@ -1679,7 +1678,6 @@ public class ParatextSyncRunnerTests
     }
 
     [Test]
-    [Ignore("Not ready to sync comments to PT.")]
     public async Task SyncAsync_AddParatextComments()
     {
         var env = new TestEnvironment();


### PR DESCRIPTION
When connecting a project for the first time, or if a book is created, the note thread docs were not being created. This would lead to the comments in Paratext being deleted the next time a user does a sync. This fix ensures that note thread docs are updated regardless of whether a book exists or was just added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1814)
<!-- Reviewable:end -->
