### PR TITLE
Fixed Kayah Li script on Windows

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -9,6 +9,7 @@ quill-editor {
   > .ql-container {
     @include typography.typography(body1);
     > .ql-editor {
+      font-family: Roboto, 'Noto Sans Kayah Li', sans-serif;
       line-height: 1.6;
       width: 100%;
       word-break: break-word;

--- a/src/SIL.XForge.Scripture/ClientApp/src/index.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/index.html
@@ -12,7 +12,10 @@
     </script>
 
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+Kayah+Li&family=Roboto:wght@300;400;500&display=swap"
+      rel="stylesheet"
+    />
     <meta charset="utf-8" />
     <title>Scripture Forge</title>
     <base href="/" />


### PR DESCRIPTION
This Pull Request fixes Kayah Li script on Windows 10 and 11 by including the "Noto Sans Kayah Li" font.

Support for other scripts is not included, as testing a broad range of DBL resources in non-latin scripts all displayed correctly on Windows 10 and 11.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1816)
<!-- Reviewable:end -->
