### PR TITLE
SF-1998 Fix help links

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -37,6 +37,7 @@
         </button>
         <mat-menu #helpMenu="matMenu" class="help-menu">
           <a mat-menu-item target="_blank" [href]="urls.helps">{{ t("help") }}</a>
+          <a mat-menu-item target="_blank" [href]="urls.manual">{{ t("manual") }}</a>
           <a mat-menu-item target="_blank" [href]="urls.communityAnnouncementPage">{{ t("announcements") }}</a>
           <a mat-menu-item target="_blank" [href]="urls.communitySupport">{{ t("community_support") }}</a>
           <a mat-menu-item target="_blank" [href]="issueMailTo" class="report-issue">

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -12,6 +12,7 @@
     "language": "Language",
     "log_out": "Log out",
     "logged_in_as": "Logged in as",
+    "manual": "Manual",
     "offline": "Offline",
     "online": "Online",
     "overview": "Overview",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/external-url.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/external-url.service.spec.ts
@@ -1,0 +1,27 @@
+import { ExternalUrlService } from './external-url.service';
+
+function stubbedI18nService(helpUrlPortion: string): any {
+  return { locale: { helps: helpUrlPortion } };
+}
+
+describe('ExternalUrlService', () => {
+  it('should provide the help URL for English', () => {
+    const service = new ExternalUrlService(stubbedI18nService(''));
+    expect(service.helps).toEqual('https://help.scriptureforge.org');
+  });
+
+  it('should provide the localized help URL', () => {
+    const service = new ExternalUrlService(stubbedI18nService('es'));
+    expect(service.helps).toEqual('https://help.scriptureforge.org/es');
+  });
+
+  it('should provide the manual URL for English', () => {
+    const service = new ExternalUrlService(stubbedI18nService(''));
+    expect(service.manual).toEqual('https://help.scriptureforge.org/manual');
+  });
+
+  it('should provide the localized manual URL', () => {
+    const service = new ExternalUrlService(stubbedI18nService('es'));
+    expect(service.manual).toEqual('https://help.scriptureforge.org/es/manual');
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/external-url.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/external-url.service.ts
@@ -14,14 +14,19 @@ export class ExternalUrlService {
   constructor(private readonly i18n: I18nService) {}
 
   get helps(): string {
-    return environment.helps + '/' + (this.i18n.locale.helps || I18nService.defaultLocale.helps!);
+    const localeUrlPortion = this.i18n.locale.helps || I18nService.defaultLocale.helps!;
+    return localeUrlPortion === '' ? environment.helps : `${environment.helps}/${localeUrlPortion}`;
+  }
+
+  get manual(): string {
+    return this.helps + '/manual';
   }
 
   get transceleratorImportHelpPage(): string {
-    return this.helps + '/index.htm?#t=Tasks%2FAdministrator_tasks%2FImport_questions_from_Transcelerator.htm';
+    return this.helps + '/community-checking#1ed2e353d94847a3861ad3a69d531aac';
   }
 
   get csvImportHelpPage(): string {
-    return this.helps + '/#t=Tasks%2FAdministrator_tasks%2FImport_questions_from_spreadsheet.htm';
+    return this.helps + '/community-checking#42107c9def434bf396442d0004577710';
   }
 }

--- a/src/SIL.XForge.Scripture/locales.json
+++ b/src/SIL.XForge.Scripture/locales.json
@@ -4,14 +4,14 @@
     "englishName": "English (US)",
     "tags": ["en", "en-US"],
     "production": true,
-    "helps": "en"
+    "helps": ""
   },
   {
     "localName": "English (UK)",
     "englishName": "English (UK)",
     "tags": ["en-GB"],
     "production": true,
-    "helps": "en"
+    "helps": ""
   },
   {
     "localName": "简体中文",
@@ -44,7 +44,7 @@
     "englishName": "Portuguese",
     "tags": ["pt-BR"],
     "production": true,
-    "helps": "pt_BR"
+    "helps": "pt-br"
   },
   {
     "localName": "français",


### PR DESCRIPTION
1. Right now the help links in the import questions dialog do not go to the right place anymore. I've updated them to link to the new help site.
2. I added a link to the manual
3. I fixed the locale paths (see comments)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1823)
<!-- Reviewable:end -->
