### PR TITLE
Add translation suggestion story and fix RTL suggestions

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.scss
@@ -49,10 +49,10 @@ mdc-list {
   > mdc-list-item {
     height: 30px;
     padding: 0 8px;
+    column-gap: 5px;
 
     > div {
       font-size: smaller;
-      padding-left: 5px;
     }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.stories.ts
@@ -1,0 +1,35 @@
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { CommonModule } from '@angular/common';
+import { UICommonModule } from 'xforge-common/ui-common.module';
+import { SuggestionsComponent } from './suggestions.component';
+
+const meta: Meta<SuggestionsComponent> = {
+  title: 'Translate/Suggestions',
+  component: SuggestionsComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [CommonModule, UICommonModule],
+      declarations: [SuggestionsComponent]
+    })
+  ]
+};
+export default meta;
+
+type Story = StoryObj<SuggestionsComponent>;
+
+export const Default: Story = {
+  args: {
+    show: true,
+    suggestions: [
+      { words: ['there', 'was', 'dearth', 'in', 'the', 'earth'], confidence: 0.29 },
+      { words: ['there', 'was', 'a', 'famine', 'in', 'the', 'land'], confidence: 0.21 }
+    ]
+  }
+};
+
+export const Loading: Story = {
+  args: {
+    ...Default.args,
+    suggestions: []
+  }
+};


### PR DESCRIPTION
Before | After
-------|------
![](https://user-images.githubusercontent.com/6140710/236380347-43c8592e-f4f1-44dc-85a9-e7811e7feafc.png) | ![](https://user-images.githubusercontent.com/6140710/236380350-b3af2412-d4e1-4fa8-91fc-dcfda4c06013.png)

(In actual practice you can't get to the before state because the suggestions always show LTR, but once that is fixed this would be an issue).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1826)
<!-- Reviewable:end -->
