### PR TITLE
Fix user menu min width

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -129,6 +129,7 @@ header {
   }
 
   &.user-menu {
+    min-width: 10em;
     .user-info {
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
The recent conversion of the header from MDC to Material caused the user menu to sometimes be so narrow as to look odd.

Before | After
-------|------
![](https://user-images.githubusercontent.com/6140710/236517988-d0243f4f-1e9c-4995-af57-ff7463031e74.png) | ![](https://user-images.githubusercontent.com/6140710/236517985-1d6f69ab-c649-48ef-8b72-6069addc7fc0.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1828)
<!-- Reviewable:end -->
