### PR TITLE
SF-2000 Update audio recorder component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.html
@@ -1,27 +1,22 @@
 <ng-container *transloco="let t; read: 'checking_audio_recorder'">
   <ng-container *ngIf="!hasAudioAttachment">
-    <button *ngIf="!isRecording" mdc-button [unelevated]="true" type="button" (click)="startRecording()" class="record">
-      <mdc-icon>mic</mdc-icon>
+    <button *ngIf="!isRecording" mat-flat-button color="primary" (click)="startRecording()" class="record">
+      <mat-icon>mic</mat-icon>
       {{ t("record") }}
     </button>
-    <button *ngIf="isRecording" mdc-button type="button" (click)="stopRecording()" class="stop-recording">
-      <mdc-icon>stop</mdc-icon>
+    <button *ngIf="isRecording" mat-flat-button color="primary" (click)="stopRecording()" class="stop-recording">
+      <mat-icon>stop</mat-icon>
       {{ t("stop_recording") }}
     </button>
   </ng-container>
   <div *ngIf="hasAudioAttachment" class="has-attachment">
-    <button mdc-button fxHide.xs type="button" (click)="resetRecording()" class="try-again">
-      <mdc-icon>refresh</mdc-icon>
+    <button mat-button fxHide.xs (click)="resetRecording()" class="try-again">
+      <mat-icon>refresh</mat-icon>
       {{ t("try_again") }}
     </button>
-    <button
-      mdc-icon-button
-      fxHide.gt-xs
-      type="button"
-      (click)="resetRecording()"
-      icon="refresh"
-      class="try-again"
-    ></button>
+    <button mat-icon-button fxHide.gt-xs (click)="resetRecording()" class="try-again">
+      <mat-icon>refresh</mat-icon>
+    </button>
     <app-checking-audio-player *ngIf="!!audioUrl" [source]="audioUrl"></app-checking-audio-player>
   </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.spec.ts
@@ -14,12 +14,10 @@ import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { UserService } from 'xforge-common/user.service';
 import { SF_TYPE_REGISTRY } from '../../../core/models/sf-type-registry';
 import { AudioTimePipe, CheckingAudioPlayerComponent } from '../checking-audio-player/checking-audio-player.component';
 import { CheckingAudioRecorderComponent } from './checking-audio-recorder.component';
 
-const mockedUserService = mock(UserService);
 const mockedNoticeService = mock(NoticeService);
 const mockedNavigator = mock(Navigator);
 const mockedPwaService = mock(PwaService);
@@ -31,7 +29,6 @@ describe('CheckingAudioRecorderComponent', () => {
     declarations: [CheckingAudioRecorderComponent, CheckingAudioPlayerComponent, AudioTimePipe],
     imports: [UICommonModule, TestTranslocoModule, TestRealtimeModule.forRoot(SF_TYPE_REGISTRY)],
     providers: [
-      { provide: UserService, useMock: mockedUserService },
       { provide: NoticeService, useMock: mockedNoticeService },
       { provide: NAVIGATOR, useMock: mockedNavigator },
       { provide: PwaService, useMock: mockedPwaService },
@@ -111,9 +108,6 @@ class TestEnvironment {
       id: 'user01',
       data: { name: 'user' }
     });
-    when(mockedUserService.getCurrentUser()).thenCall(() =>
-      this.realtimeService.subscribe(UserDoc.COLLECTION, 'user01')
-    );
     when(mockedNavigator.mediaDevices).thenReturn({
       getUserMedia: (mediaConstraints: MediaStreamConstraints) =>
         this.rejectUserMedia ? Promise.reject() : navigator.mediaDevices.getUserMedia(mediaConstraints)

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.ts
@@ -3,13 +3,12 @@ import { Component, EventEmitter, Inject, OnDestroy, OnInit, Output } from '@ang
 import { translate } from '@ngneat/transloco';
 import RecordRTC from 'recordrtc';
 import { NAVIGATOR } from 'xforge-common/browser-globals';
-import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import {
   BrowserIssue,
   SupportedBrowsersDialogComponent
 } from 'xforge-common/supported-browsers-dialog/supported-browsers-dialog.component';
-import { UserService } from 'xforge-common/user.service';
+import { objectId } from 'xforge-common/utils';
 
 export interface AudioAttachment {
   status?: 'denied' | 'processed' | 'recording' | 'reset' | 'stopped' | 'uploaded';
@@ -29,10 +28,8 @@ export class CheckingAudioRecorderComponent implements OnInit, OnDestroy {
   mediaDevicesUnsupported: boolean = false;
   private stream?: MediaStream;
   private recordRTC?: RecordRTC;
-  private user?: UserDoc;
 
   constructor(
-    private readonly userService: UserService,
     private readonly noticeService: NoticeService,
     @Inject(NAVIGATOR) private readonly navigator: Navigator,
     private readonly dialog: MdcDialog
@@ -46,10 +43,6 @@ export class CheckingAudioRecorderComponent implements OnInit, OnDestroy {
     return this.recordRTC != null && this.recordRTC.state === 'recording';
   }
 
-  get recodingFileName(): string {
-    return this.user == null || this.user.data == null ? '' : this.user.data.displayName + '.webm';
-  }
-
   ngOnDestroy(): void {
     if (this.isRecording) {
       this.stopRecording();
@@ -57,7 +50,6 @@ export class CheckingAudioRecorderComponent implements OnInit, OnDestroy {
   }
 
   async ngOnInit(): Promise<void> {
-    this.user = await this.userService.getCurrentUser();
     this.mediaDevicesUnsupported = this.navigator.mediaDevices?.getUserMedia == null;
   }
 
@@ -72,7 +64,7 @@ export class CheckingAudioRecorderComponent implements OnInit, OnDestroy {
       url: audioVideoWebMURL,
       status: 'processed',
       blob: this.recordRTC.getBlob(),
-      fileName: this.recodingFileName
+      fileName: objectId() + '.webm'
     });
   }
 


### PR DESCRIPTION
- Convert to Material
- Make "Stop Recording" button color primary. Some time ago while watching a user use SF, I noticed that the browser's permission prompt for recording audio had taken his focus away from the dialog, so by the time he'd figured out he needed to give permission and then recorded the audio, he was kind of lost and had trouble finding the "stop recording" button. Making the button color primary isn't going to totally fix that, but when a user is recording, stopping recording is always the expected next action, so it makes sense to make it as prominent as possible.
- I changed the file name of the recorded audio. Previously it was using the users's display name. I can't think of any benefit of doing this (it's not guaranteed to be unique, and it's not shown to users), and I can think of several downsides (there might be characters that cause problems, and there's a slight security concern of having the user's name in the file name). The back end does not use the file name, except to look at the extension and see whether it's specified as MP3, and if not, does a conversion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1829)
<!-- Reviewable:end -->
