### PR TITLE
SF-1997 Delete paratext comments only when the corresponding note is marked deleted

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
@@ -101,7 +101,7 @@ export class NoteThreadDoc extends ProjectDataDoc<NoteThread> {
       return '';
     }
 
-    const iconDefinedNotes = this.notesInOrderClone(this.data.notes).filter(n => n.tagId != null);
+    const iconDefinedNotes = this.notesInOrderClone(this.data.notes).filter(n => n.tagId != null && !n.deleted);
     let tagId: number | undefined =
       iconDefinedNotes.length === 0 ? undefined : iconDefinedNotes[iconDefinedNotes.length - 1].tagId;
     if (tagId == null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2975,7 +2975,7 @@ describe('EditorComponent', () => {
       const segmentRef = 'verse_1_3';
       let thread2Elem: HTMLElement | null = env.getNoteThreadIconElement(segmentRef, threadId);
       expect(thread2Elem).not.toBeNull();
-      env.deleteNoteThread('project01', segmentRef, threadId);
+      env.deleteMostRecentNote('project01', segmentRef, threadId);
       thread2Elem = env.getNoteThreadIconElement(segmentRef, threadId);
       expect(thread2Elem).toBeNull();
       env.dispose();
@@ -4062,12 +4062,12 @@ class TestEnvironment {
     this.wait();
   }
 
-  deleteNoteThread(projectId: string, segmentRef: string, threadId: string): void {
+  deleteMostRecentNote(projectId: string, segmentRef: string, threadId: string): void {
     const noteThreadIconElem: HTMLElement = this.getNoteThreadIconElement(segmentRef, threadId)!;
     noteThreadIconElem.click();
     this.wait();
     const noteDoc: NoteThreadDoc = this.getNoteThreadDoc(projectId, threadId);
-    noteDoc.delete();
+    noteDoc.submitJson0Op(op => op.set(d => d.notes[0].deleted, true));
     this.mockNoteDialogRef.close({ deleted: true });
     this.realtimeService.updateAllSubscribeQueries();
     this.wait();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1049,7 +1049,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   private updateReadNotes(threadId: string): void {
-    const noteThread: NoteThreadDoc | undefined = this.noteThreadQuery?.docs.find(d => d.data?.dataId === threadId);
+    const noteThread: NoteThreadDoc | undefined = this.noteThreadQuery?.docs.find(
+      d => d.data?.dataId === threadId && d.data?.notes.filter(n => !n.deleted).length > 0
+    );
     if (noteThread?.data != null && this.projectUserConfigDoc?.data != null) {
       const notesRead: string[] = [];
       for (const note of noteThread.data.notes) {
@@ -1761,7 +1763,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         nt.data != null &&
         nt.data.verseRef.bookNum === this.bookNum &&
         nt.data.verseRef.chapterNum === this.chapter &&
-        nt.data.notes.length > 0 &&
+        nt.data.notes.filter(n => !n.deleted).length > 0 &&
         nt.data.notes[0].type !== NoteType.Conflict
     );
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -405,7 +405,8 @@ describe('NoteDialogComponent', () => {
     verify(mockedDialogService.confirm(anything(), anything())).once();
     expect(env.notes.length).toEqual(3);
     expect(env.noteHasEditActions(3)).toBe(true);
-    expect(noteThread.data!.notes.length).toEqual(4);
+    expect(noteThread.data!.notes.length).toEqual(5);
+    expect(noteThread.data!.notes[4].deleted).toBe(true);
   }));
 
   it('does not delete the note if a user cancels', fakeAsync(() => {
@@ -426,8 +427,8 @@ describe('NoteDialogComponent', () => {
     expect(env.noteHasEditActions(1)).toBe(true);
     env.clickDeleteNote();
     verify(mockedDialogService.confirm(anything(), anything())).once();
-    expect(noteThread.data).toBeUndefined();
     expect(env.dialogResult).toEqual({ deleted: true });
+    expect(noteThread.data!.notes[0].deleted).toBe(true);
   }));
 
   it('deletes the thread if the deleted note is the only active note', fakeAsync(() => {
@@ -452,7 +453,7 @@ describe('NoteDialogComponent', () => {
     expect(env.noteHasEditActions(1)).toBe(true);
     env.clickDeleteNote();
     verify(mockedDialogService.confirm(anything(), anything())).once();
-    expect(threadDoc.data).toBeUndefined();
+    expect(threadDoc.data!.notes[0].deleted).toBe(true);
     expect(env.dialogResult).toEqual({ deleted: true });
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -233,20 +233,13 @@ export class NoteDialogComponent implements OnInit {
     );
     if (!confirmed) return;
 
-    if (this.notesToDisplay.length === 1 && this.notesToDisplay[0].dataId === note.dataId) {
-      // only delete the thread if deleting the only note in the thread
-      await this.threadDoc!.delete();
-      this.dialogRef.close({ deleted: true });
-      return;
-    }
-
     const index: number = this.threadDoc!.data!.notes.findIndex(n => n.dataId === note.dataId);
     if (index >= 0) {
-      await this.threadDoc!.submitJson0Op(op => op.remove(nt => nt.notes, index));
+      await this.threadDoc!.submitJson0Op(op => op.set(nt => nt.notes[index].deleted, true));
     }
 
     if (this.notesToDisplay.length === 0) {
-      this.dialogRef.close();
+      this.dialogRef.close({ deleted: true });
     }
   }
 

--- a/src/SIL.XForge.Scripture/Models/Comment.cs
+++ b/src/SIL.XForge.Scripture/Models/Comment.cs
@@ -21,8 +21,8 @@ public class Comment : IOwnedData
     /// <remarks>
     /// This is used for answers and comments so that they may be deleted correctly from Paratext.
     ///
-    /// For notes, this property is an artifact of the legacy DataAccessServer and should not be set to true
-    /// except for marking a note with the corresponding Paratext comment.
+    /// For notes, this property is an artifact of the legacy DataAccessServer. Marking this as true indicates
+    /// that the corresponding Paratext comment not already marked deleted should be delete if it exists.
     /// </remarks>
     public bool Deleted { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/NoteThreadChange.cs
+++ b/src/SIL.XForge.Scripture/Models/NoteThreadChange.cs
@@ -24,8 +24,6 @@ public class NoteThreadChange
     public string Status { get; set; }
     public string Assignment { get; set; }
 
-    /// <summary> True if the thread has been permanently removed. </summary>
-    public bool ThreadRemoved { get; set; }
     public bool ThreadUpdated { get; set; }
     public List<Note> NotesAdded { get; set; } = new List<Note>();
     public List<Note> NotesUpdated { get; set; } = new List<Note>();
@@ -42,7 +40,6 @@ public class NoteThreadChange
                 || NotesUpdated.Count > 0
                 || NotesDeleted.Count > 0
                 || NoteIdsRemoved.Count > 0
-                || ThreadRemoved
                 || ThreadUpdated
                 || Position != null;
         }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1231,8 +1231,12 @@ public class ParatextService : DisposableBase, IParatextService
             if (existingThread == null)
             {
                 // The thread has been removed
-                threadChange.ThreadRemoved = true;
-                changes.Add(threadChange);
+                threadChange.NoteIdsRemoved = threadDoc.Data.Notes
+                    .Where(n => !n.Deleted)
+                    .Select(n => n.DataId)
+                    .ToList();
+                if (threadChange.NoteIdsRemoved.Count > 0)
+                    changes.Add(threadChange);
                 continue;
             }
             matchedThreadIds.Add(existingThread.Id);
@@ -1256,7 +1260,7 @@ public class ParatextService : DisposableBase, IParatextService
                         );
                     }
                 }
-                else
+                else if (!note.Deleted)
                     threadChange.NoteIdsRemoved.Add(note.DataId);
             }
             if (existingThread.Status.InternalValue != threadDoc.Data.Status)
@@ -2206,15 +2210,11 @@ public class ParatextService : DisposableBase, IParatextService
         List<List<Paratext.Data.ProjectComments.Comment>> changes =
             new List<List<Paratext.Data.ProjectComments.Comment>>();
         IEnumerable<IDocument<NoteThread>> activeThreadDocs = noteThreadDocs.Where(t => t.Data != null);
-        List<string> matchedCommentThreads = new List<string>();
         foreach (IDocument<NoteThread> threadDoc in activeThreadDocs)
         {
             List<Paratext.Data.ProjectComments.Comment> thread = new List<Paratext.Data.ProjectComments.Comment>();
             CommentThread existingThread = commentThreads.SingleOrDefault(ct => ct.Id == threadDoc.Data.DataId);
-            if (existingThread != null)
-                matchedCommentThreads.Add(existingThread.Id);
             List<(int, string)> threadNoteParatextUserRefs = new List<(int, string)>();
-            List<string> matchedCommentIds = new List<string>();
             for (int i = 0; i < threadDoc.Data.Notes.Count; i++)
             {
                 Note note = threadDoc.Data.Notes[i];
@@ -2222,10 +2222,14 @@ public class ParatextService : DisposableBase, IParatextService
                     existingThread == null ? null : GetMatchingCommentFromNote(note, existingThread, ptProjectUsers);
                 if (matchedComment != null)
                 {
-                    matchedCommentIds.Add(matchedComment.Id);
                     var comment = (Paratext.Data.ProjectComments.Comment)matchedComment.Clone();
                     bool commentUpdated = false;
-                    if (note.Content != comment.Contents?.InnerXml)
+                    if (note.Deleted && comment.Deleted != true)
+                    {
+                        comment.Deleted = true;
+                        commentUpdated = true;
+                    }
+                    else if (note.Content != comment.Contents?.InnerXml)
                     {
                         if (comment.Contents == null)
                             comment.AddTextToContent("", false);
@@ -2233,12 +2237,12 @@ public class ParatextService : DisposableBase, IParatextService
                         commentUpdated = true;
                     }
                     if (commentUpdated)
-                    {
                         thread.Add(comment);
-                    }
                 }
                 else
                 {
+                    if (note.Deleted)
+                        continue;
                     if (!string.IsNullOrEmpty(note.SyncUserRef))
                         throw new DataNotFoundException(
                             "Could not find the matching comment for a note containing a sync user."
@@ -2264,42 +2268,16 @@ public class ParatextService : DisposableBase, IParatextService
                     PopulateCommentFromNote(note, comment, sfNoteTagId, isFirstComment);
                     thread.Add(comment);
                     if (note.SyncUserRef == null)
-                    {
                         threadNoteParatextUserRefs.Add((i, ptProjectUser.OpaqueUserId));
-                    }
                 }
             }
 
-            if (existingThread != null)
-            {
-                IEnumerable<Paratext.Data.ProjectComments.Comment> deletedComments = existingThread.Comments.Where(
-                    c => !matchedCommentIds.Contains(c.Id)
-                );
-                foreach (Paratext.Data.ProjectComments.Comment deleted in deletedComments)
-                {
-                    var comment = (Paratext.Data.ProjectComments.Comment)deleted.Clone();
-                    comment.Deleted = true;
-                    thread.Add(comment);
-                }
-            }
             if (thread.Count > 0)
             {
                 changes.Add(thread);
                 // Set the sync user ref on the notes in the SF Mongo DB
                 await UpdateNoteSyncUserAsync(threadDoc, threadNoteParatextUserRefs);
             }
-        }
-        // handle deleted note threads
-        IEnumerable<CommentThread> deletedThreads = commentThreads.Where(t => !matchedCommentThreads.Contains(t.Id));
-        foreach (CommentThread thread in deletedThreads)
-        {
-            var deletedCommentsInThread = new List<Paratext.Data.ProjectComments.Comment>();
-            foreach (Paratext.Data.ProjectComments.Comment comment in thread.Comments)
-            {
-                comment.Deleted = true;
-                deletedCommentsInThread.Add(comment);
-            }
-            changes.Add(deletedCommentsInThread);
         }
         return changes;
     }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1060,24 +1060,10 @@ public class ParatextSyncRunner : IParatextSyncRunner
             else
             {
                 tasks.Add(SubmitChangesOnNoteThreadDocAsync(threadDoc, change, usernamesToUserIds));
-
-                // Record thread metrics and note metrics
-                if (change.ThreadRemoved)
-                {
-                    _syncMetrics.NoteThreads.Deleted++;
-                }
-
                 if (change.ThreadUpdated)
                 {
                     _syncMetrics.NoteThreads.Updated++;
                 }
-
-                _syncMetrics.Notes += new NoteSyncMetricInfo(
-                    added: change.NotesAdded.Count,
-                    deleted: change.NotesDeleted.Count,
-                    updated: change.NotesUpdated.Count,
-                    removed: change.NoteIdsRemoved.Count
-                );
             }
         }
         await Task.WhenAll(tasks);
@@ -1128,12 +1114,6 @@ public class ParatextSyncRunner : IParatextSyncRunner
         IReadOnlyDictionary<string, string> usernamesToUserIds
     )
     {
-        if (change.ThreadRemoved)
-        {
-            await threadDoc.DeleteAsync();
-            return;
-        }
-
         await threadDoc.SubmitJson0OpAsync(op =>
         {
             // Update thread details
@@ -1164,6 +1144,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
                         op.Set(td => td.Notes[index].Assignment, updated.Assignment);
                     if (threadDoc.Data.Notes[index].AcceptedChangeXml != updated.AcceptedChangeXml)
                         op.Set(td => td.Notes[index].AcceptedChangeXml, updated.AcceptedChangeXml);
+                    _syncMetrics.Notes.Updated++;
                 }
                 else
                 {
@@ -1180,6 +1161,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 {
                     // The note can be easily removed by using op.Remove if that is preferred
                     op.Set(td => td.Notes[index].Deleted, true);
+                    _syncMetrics.Notes.Deleted++;
                 }
                 else
                 {
@@ -1200,6 +1182,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
                     usernamesToUserIds.TryGetValue(username, out ownerRef);
                 added.OwnerRef = string.IsNullOrEmpty(ownerRef) ? _userSecret.Id : ownerRef;
                 op.Add(td => td.Notes, added);
+                _syncMetrics.Notes.Added++;
             }
 
             // Permanently removes a note
@@ -1207,7 +1190,10 @@ public class ParatextSyncRunner : IParatextSyncRunner
             {
                 int index = threadDoc.Data.Notes.FindIndex(n => n.DataId == removedId);
                 if (index >= 0)
+                {
                     op.Remove(td => td.Notes, index);
+                    _syncMetrics.Notes.Removed++;
+                }
             }
 
             if (change.Position != null)

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1856,13 +1856,13 @@ public class ParatextSyncRunnerTests
         Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
         Assert.That(
             syncMetrics.Notes,
-            Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
+            Is.EqualTo(new NoteSyncMetricInfo(added: 2, deleted: 0, updated: 0, removed: 0))
         );
         Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
     }
 
     [Test]
-    public async Task SyncAsync_RemovesParatextNoteThreadDoc()
+    public async Task SyncAsync_RemovesNoteFromThreadDoc()
     {
         var env = new TestEnvironment();
         string sfProjectId = "project01";
@@ -1907,13 +1907,13 @@ public class ParatextSyncRunnerTests
         );
         Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
 
-        // Remove the entire thread
-        env.SetupNoteRemovedChange(threadId, null);
+        // Remove note 3
+        env.SetupNoteRemovedChange(threadId, "n03");
 
         // SUT 2
         await env.Runner.RunAsync(sfProjectId, "user01", "project01_alt", false, CancellationToken.None);
 
-        Assert.That(env.ContainsNoteThread(sfProjectId, threadId), Is.False);
+        Assert.That(env.ContainsNoteThread(sfProjectId, threadId), Is.True);
         project = env.GetProject();
         Assert.That(project.Sync.LastSyncSuccessful, Is.True);
 
@@ -1922,9 +1922,9 @@ public class ParatextSyncRunnerTests
         Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
         Assert.That(
             syncMetrics.Notes,
-            Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
+            Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 1))
         );
-        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
+        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
     }
 
     [Test]
@@ -1956,7 +1956,7 @@ public class ParatextSyncRunnerTests
         Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
         Assert.That(
             syncMetrics.Notes,
-            Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
+            Is.EqualTo(new NoteSyncMetricInfo(added: 1, deleted: 0, updated: 0, removed: 0))
         );
         Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 1)));
 
@@ -3076,10 +3076,7 @@ public class ParatextSyncRunnerTests
                 NoteStatus.Resolved.InternalValue,
                 ""
             );
-            if (noteId == null)
-                noteThreadChange.ThreadRemoved = true;
-            else
-                noteThreadChange.NoteIdsRemoved.Add(noteId);
+            noteThreadChange.NoteIdsRemoved.Add(noteId);
             SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
         }
 


### PR DESCRIPTION
Instead of delete paratext notes when a corresponding note in a note thread does not exist, I have updated the logic to only delete paratext notes if the corresponding note in a note thread is marked deleted. This will hopefully significantly reduce the chance of losing Paratext notes.