### PR TITLE
Fix share control appearance on mobile

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.scss
@@ -4,7 +4,6 @@
 
 form {
   display: flex;
-  align-items: center;
   width: 100%;
   column-gap: 20px;
   @include media-breakpoint-down(sm) {
@@ -25,8 +24,10 @@ form {
 }
 
 #send-btn {
-  // add margin that is same height as the text field helper text, so the button is centered properly
-  margin-bottom: 19px;
+  align-self: center;
+  @include media-breakpoint-down(sm) {
+    align-self: flex-end;
+  }
 }
 
 .invite-by-link .offline-text {


### PR DESCRIPTION
I broke the layout of the share control on mobile in #1817 (the inputs are not full width like they should be):

![](https://user-images.githubusercontent.com/6140710/236966132-7d76ba0f-187d-47be-b7c7-45d1b1cfc140.png)

To be fair, it was never great to begin with; the button was full width which looks very odd:

![](https://user-images.githubusercontent.com/6140710/236966129-09e37990-6b67-4d4a-8473-87618086fa3a.png)

Here's how it now looks with this change:

![](https://user-images.githubusercontent.com/6140710/236966136-d73ab5c7-8aed-484e-a5af-5a077ed292ba.png)

And on desktop (where it's presumably the most likely to be used, it continues to look like this:

![](https://user-images.githubusercontent.com/6140710/236966135-50d2c146-663d-41ba-b111-683ef5dfc3d7.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1832)
<!-- Reviewable:end -->
