### PR TITLE
SF-2003 Fix note anchors not updated after notes loaded

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2978,6 +2978,15 @@ describe('EditorComponent', () => {
       env.deleteNoteThread('project01', segmentRef, threadId);
       thread2Elem = env.getNoteThreadIconElement(segmentRef, threadId);
       expect(thread2Elem).toBeNull();
+
+      // notes respond to edits after note icon removed
+      const note1position: number = env.getNoteThreadEditorPosition('thread01');
+      env.targetEditor.setSelection(note1position + 2, 'user');
+      const noteThreadDoc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'thread01');
+      const originalPos: TextAnchor = { start: 8, length: 9 };
+      expect(noteThreadDoc.data!.position).toEqual(originalPos);
+      env.typeCharacters('t');
+      expect(noteThreadDoc.data!.position).toEqual({ start: originalPos.start, length: originalPos.length + 1 });
       env.dispose();
     }));
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1001,6 +1001,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       Array.from(noteThreadVerseRefs.values()),
       'note-thread'
     );
+    this.shouldNoteThreadsRespondToEdits = true;
     // Defer the subscription so that the editor has time to clean up comments on blanks verses
     Promise.resolve().then(() => this.subscribeClickEvents(segments));
   }


### PR DESCRIPTION
If note threads are refreshed while a user is interacting with note threads, responding to text edits is turned off and never turned back on. This change turns it back on so that text anchors get correctly updated when the text is edited.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1833)
<!-- Reviewable:end -->
