### PR TITLE
SF-2004 Make appAutofocus directive work with non-MDC components

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/autofocus.directive.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/autofocus.directive.ts
@@ -1,22 +1,24 @@
-import { MdcTextarea, MdcTextField } from '@angular-mdc/web/textfield';
-import { AfterViewInit, Directive, Host, Optional, Self } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef } from '@angular/core';
 
 /**
- * Auto focuses MdcTextField and MdcTextarea. HTML autofocus attribute does not work for dynamically generated content.
+ * Auto focuses text inputs and textarea. HTML autofocus attribute does not work for dynamically generated content.
  */
 @Directive({
   selector: '[appAutofocus]'
 })
 export class AutofocusDirective implements AfterViewInit {
-  private component: { focus: () => void };
+  constructor(private readonly elementRef: ElementRef<HTMLElement>) {}
 
-  // Angular allows injecting the component or element but doesn't have a good way to handle components of variable type
-  // See https://github.com/angular/angular/issues/8277#issuecomment-323678013 for this workaround
-  constructor(@Host() @Self() @Optional() textField: MdcTextField, @Host() @Self() @Optional() textArea: MdcTextarea) {
-    this.component = (textField || textArea)!;
-  }
+  ngAfterViewInit(): void {
+    const hostElement: HTMLElement = this.elementRef.nativeElement;
 
-  ngAfterViewInit() {
-    setTimeout(() => this.component.focus(), 0);
+    const input =
+      hostElement instanceof HTMLInputElement || hostElement instanceof HTMLTextAreaElement
+        ? hostElement
+        : hostElement.querySelector('input, textarea');
+
+    if (input instanceof HTMLElement) {
+      setTimeout(() => input.focus());
+    }
   }
 }


### PR DESCRIPTION
While experimenting with what it would take to convert the `CheckingCommentFormComponent` to Material recently, I ran into the problem that the `appAutofocus` directive did not work with the Material inputs. For MDC we would use the directive in the template by writing something like:
``` html
<mdc-text-field appAutofocus></mdc-text-field>
```
And then the MdcTextField component would be injected into `appAutofocus`. However, Material does inputs with a directive on an element, so as far as I'm aware we can't inject a component, only an element:
``` html
<input matInput type="text">
```
Hence, I've updated the directive to request an element rather than a component, and it continues to work with MDC, and should work with Material as well. I think it should generally work with any other component library, or any input we make that doesn't use a component library.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1834)
<!-- Reviewable:end -->
