### PR TITLE
SF-2002 Create SF user label only for user IDs without a paratext role

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2379,9 +2379,11 @@ public class ParatextService : DisposableBase, IParatextService
     )
     {
         string ownerId = note.OwnerRef;
-        displayNames.TryGetValue(ownerId, out string displayName);
         // if the user is a paratext user, keep the note content as is
-        if (string.IsNullOrEmpty(displayName) || ptProjectUsers.TryGetValue(displayName, out _))
+        if (
+            ptProjectUsers.Values.SingleOrDefault(u => u.SFUserId == ownerId) != null
+            || !displayNames.TryGetValue(ownerId, out string displayName)
+        )
             return note.Content;
 
         var contentElem = new XElement("Contents");
@@ -2611,6 +2613,11 @@ public class ParatextService : DisposableBase, IParatextService
         return new TextAnchor { Start = startPos, Length = posJustPastLastCharacter - startPos };
     }
 
+    /// <summary>
+    /// Finds the Paratext user profile on the project based on the username, if it exists.
+    /// If the Paratext user profile does not exist because the user has not logged into SF, create
+    /// a profile for that user.
+    /// </summary>
     private ParatextUserProfile FindOrCreateParatextUser(
         string paratextUsername,
         Dictionary<string, ParatextUserProfile> ptProjectUsers

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -80,6 +80,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
     private readonly IDeltaUsxMapper _deltaUsxMapper;
     private readonly IParatextNotesMapper _notesMapper;
     private readonly ILogger<ParatextSyncRunner> _logger;
+    private readonly IGuidService _guidService;
     private readonly IHubContext<NotificationHub, INotifier> _hubContext;
 
     private IConnection _conn;
@@ -102,7 +103,8 @@ public class ParatextSyncRunner : IParatextSyncRunner
         IDeltaUsxMapper deltaUsxMapper,
         IParatextNotesMapper notesMapper,
         IHubContext<NotificationHub, INotifier> hubContext,
-        ILogger<ParatextSyncRunner> logger
+        ILogger<ParatextSyncRunner> logger,
+        IGuidService guidService
     )
     {
         _userSecrets = userSecrets;
@@ -116,6 +118,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
         _logger = logger;
         _deltaUsxMapper = deltaUsxMapper;
         _notesMapper = notesMapper;
+        _guidService = guidService;
         _hubContext = hubContext;
     }
 
@@ -729,7 +732,6 @@ public class ParatextSyncRunner : IParatextSyncRunner
             userId,
             _projectDoc.Data.UserRoles.Keys.ToArray()
         );
-        _currentPtSyncUsers = _projectDoc.Data.ParatextUsers.ToDictionary(u => u.Username);
 
         if (!(await _userSecrets.TryGetAsync(userId)).TryResult(out _userSecret))
         {
@@ -737,6 +739,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
             return false;
         }
 
+        _currentPtSyncUsers = await GetCurrentProjectPTUsers(token);
         List<User> paratextUsers = await _realtimeService
             .QuerySnapshots<User>()
             .Where(u => _projectDoc.Data.UserRoles.Keys.Contains(u.Id) && u.ParatextId != null)
@@ -1502,7 +1505,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
             await _projectService.RemoveUserWithoutPermissionsCheckAsync(_userSecret.Id, _projectDoc.Id, userId);
 
         // GetPTUsernameToSFUserIdsAsync will fail if the token is cancelled
-        if (!token.IsCancellationRequested)
+        if (!token.IsCancellationRequested && _currentPtSyncUsers != null)
         {
             Dictionary<string, string> ptUsernamesToSFUserIds = await GetPTUsernameToSFUserIdsAsync(token);
             await _projectDoc.SubmitJson0OpAsync(op =>
@@ -1513,11 +1516,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
                         u => u.Username == activePtSyncUser.Username
                     );
                     if (existingUser == null)
-                    {
-                        if (ptUsernamesToSFUserIds.TryGetValue(activePtSyncUser.Username, out string userId))
-                            activePtSyncUser.SFUserId = userId;
                         op.Add(pd => pd.ParatextUsers, activePtSyncUser);
-                    }
                     else if (
                         existingUser.SFUserId == null
                         && ptUsernamesToSFUserIds.TryGetValue(existingUser.Username, out string userId)
@@ -1659,6 +1658,31 @@ public class ParatextSyncRunner : IParatextSyncRunner
         foreach (KeyValuePair<string, string> kvp in idsToUsernames)
             usernamesToUserIds.Add(kvp.Value, kvp.Key);
         return usernamesToUserIds;
+    }
+
+    private async Task<Dictionary<string, ParatextUserProfile>> GetCurrentProjectPTUsers(CancellationToken token)
+    {
+        IReadOnlyDictionary<string, string> sfUserIdsToUsernames =
+            await _paratextService.GetParatextUsernameMappingAsync(_userSecret, _projectDoc.Data, token);
+        Dictionary<string, ParatextUserProfile> paratextUsers = _projectDoc.Data.ParatextUsers.ToDictionary(
+            p => p.Username
+        );
+        foreach (var (sfUserId, username) in sfUserIdsToUsernames)
+        {
+            if (!paratextUsers.TryGetValue(username, out ParatextUserProfile profile))
+            {
+                ParatextUserProfile userProfile = new ParatextUserProfile
+                {
+                    Username = username,
+                    SFUserId = sfUserId,
+                    OpaqueUserId = _guidService.NewObjectId()
+                };
+                paratextUsers.TryAdd(username, userProfile);
+            }
+            else
+                profile.SFUserId ??= sfUserId;
+        }
+        return paratextUsers;
     }
 
     /// <summary>

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1439,11 +1439,6 @@ public class ParatextSyncRunnerTests
         project.Data.Returns(env.GetProject());
         env.Connection.Get<SFProject>("project01").Returns(project);
 
-        // The HTTP call throws this when a cancelled token is passed
-        // env.ParatextService
-        //     .GetParatextUsernameMappingAsync(Arg.Any<UserSecret>(), Arg.Any<SFProject>(), Arg.Any<CancellationToken>())
-        //     .ThrowsForAnyArgs(new OperationCanceledException());
-
         // Setup a trap to cancel the task
         env.ParatextService
             .When(
@@ -2351,7 +2346,7 @@ public class ParatextSyncRunnerTests
         private readonly MemoryRepository<SFProjectSecret> _projectSecrets;
         private readonly MemoryRepository<SyncMetrics> _syncMetrics;
         private bool _sendReceivedCalled = false;
-        private int _guidStartNum = 3;
+        private readonly int _guidStartNum = 3;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestEnvironment" /> class.

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1440,9 +1440,9 @@ public class ParatextSyncRunnerTests
         env.Connection.Get<SFProject>("project01").Returns(project);
 
         // The HTTP call throws this when a cancelled token is passed
-        env.ParatextService
-            .GetParatextUsernameMappingAsync(Arg.Any<UserSecret>(), Arg.Any<SFProject>(), Arg.Any<CancellationToken>())
-            .ThrowsForAnyArgs(new OperationCanceledException());
+        // env.ParatextService
+        //     .GetParatextUsernameMappingAsync(Arg.Any<UserSecret>(), Arg.Any<SFProject>(), Arg.Any<CancellationToken>())
+        //     .ThrowsForAnyArgs(new OperationCanceledException());
 
         // Setup a trap to cancel the task
         env.ParatextService
@@ -2351,6 +2351,7 @@ public class ParatextSyncRunnerTests
         private readonly MemoryRepository<SFProjectSecret> _projectSecrets;
         private readonly MemoryRepository<SyncMetrics> _syncMetrics;
         private bool _sendReceivedCalled = false;
+        private int _guidStartNum = 3;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestEnvironment" /> class.
@@ -2448,6 +2449,8 @@ public class ParatextSyncRunnerTests
             NotesMapper = Substitute.For<IParatextNotesMapper>();
             var hubContext = Substitute.For<IHubContext<NotificationHub, INotifier>>();
             MockLogger = new MockLogger<ParatextSyncRunner>();
+            GuidService = Substitute.For<IGuidService>();
+            GuidService.NewObjectId().Returns($"syncuser0{_guidStartNum++}");
 
             Runner = new ParatextSyncRunner(
                 userSecrets,
@@ -2461,7 +2464,8 @@ public class ParatextSyncRunnerTests
                 DeltaUsxMapper,
                 NotesMapper,
                 hubContext,
-                MockLogger
+                MockLogger,
+                GuidService
             );
         }
 
@@ -2475,6 +2479,7 @@ public class ParatextSyncRunnerTests
         public IRealtimeService SubstituteRealtimeService { get; }
         public IDeltaUsxMapper DeltaUsxMapper { get; }
         public MockLogger<ParatextSyncRunner> MockLogger { get; }
+        public IGuidService GuidService { get; }
 
         /// <summary>
         /// Gets the connection to be used with <see cref="SubstituteRealtimeService"/>.
@@ -3018,14 +3023,7 @@ public class ParatextSyncRunnerTests
                         Arg.Any<Dictionary<int, ChapterDelta>>(),
                         Arg.Any<Dictionary<string, ParatextUserProfile>>()
                     )
-                    .Returns(x =>
-                    {
-                        ((Dictionary<string, ParatextUserProfile>)x[5]).Add(
-                            "User 3",
-                            new ParatextUserProfile { OpaqueUserId = "syncuser03", Username = "User 3" }
-                        );
-                        return new[] { noteThreadChange };
-                    });
+                    .Returns(new[] { noteThreadChange });
                 Dictionary<string, string> userIdsToUsernames = new Dictionary<string, string>
                 {
                     { "user01", "User 1" },


### PR DESCRIPTION
Using the paratext username to determine if a user is a paratext user on the project is no longer acceptable because Paratext users can update their display name. This change detects if a user is a Paratext user on the project using the SF user id, and if so, then it does not add the SF user label to the note content.
In addition, update the currentPtUsers property in ParatextSyncRunner at the start of the sync so that it is up to date at the start of the sync.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1835)
<!-- Reviewable:end -->
