### PR TITLE
SF-2007 Enable Lao localization in production

### DIFF
--- a/src/SIL.XForge.Scripture/locales.json
+++ b/src/SIL.XForge.Scripture/locales.json
@@ -74,7 +74,8 @@
   {
     "localName": "ພາສາລາວ",
     "englishName": "Lao",
-    "tags": ["lo", "lo-LA"]
+    "tags": ["lo", "lo-LA"],
+    "production": true
   },
   {
     "localName": "ꤊꤢ꤬ꤛꤢ꤭ꤜꤟꤤ꤬ (W. Kayah Li)",


### PR DESCRIPTION
Fairly little has been translated into Lao, but most of the most important strings for checkers are translated, so I think it makes sense to make it available.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1838)
<!-- Reviewable:end -->
