### PR TITLE
SF-1972 Sync Speed Improvements

### DIFF
--- a/src/SIL.XForge.Scripture/Models/ParatextSyncResults.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextSyncResults.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// The results of what was modified in the Paratext sync, so we can optimize the updating of Scripture Forge.
+/// </summary>
+public class ParatextSyncResults
+{
+    /// <summary>
+    /// Gets the books that this sync modifies
+    /// </summary>
+    /// <value>The book numbers that have been modified in the sync.</value>
+    /// <remarks>This is a HashSet so that there are no duplicates.</remarks>
+    public HashSet<int> Books { get; set; } = new HashSet<int>();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this sync is for a resource
+    /// </summary>
+    /// <value><c>true</c> if this is a resource; otherwise, <c>false</c>.</value>
+    public bool IsResource { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether notes have been updated.
+    /// </summary>
+    /// <value><c>true</c> if the notes have been updated; otherwise, <c>false</c>.</value>
+    public bool NotesChanged { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether permissions have been updated.
+    /// </summary>
+    /// <value><c>true</c> if the permissions have been updated; otherwise, <c>false</c>.</value>
+    public bool PermissionsChanged { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a project level change has taken place.
+    /// This will result in all Scripture Forge data being checked for changes.
+    /// </summary>
+    /// <value><c>true</c> if the project has changed otherwise, <c>false</c>.</value>
+    public bool ProjectChanged { get; set; }
+
+    /// <summary>
+    /// Determines whether a book should be updated in Scripture Forge.
+    /// </summary>
+    /// <param name="bookNum">The book number.</param>
+    /// <returns><c>true</c> if the book should be updated; otherwise, <c>false</c>.</returns>
+    public bool UpdateBook(int bookNum) => ProjectChanged || IsResource || Books.Contains(bookNum);
+
+    /// <summary>
+    /// Gets a value indicating whether the notes should be updated in Scripture Forge.
+    /// </summary>
+    /// <returns><c>true</c> if the notes should be updated; otherwise, <c>false</c>.</returns>
+    public bool UpdateNotes => ProjectChanged || NotesChanged;
+
+    /// <summary>
+    /// Gets a value indicating whether the book and chapter should be updated in Scripture Forge.
+    /// </summary>
+    /// <returns><c>true</c> if the roles should be updated; otherwise, <c>false</c>.</returns>
+    public bool UpdatePermissions => ProjectChanged || IsResource || PermissionsChanged || Books.Count > 0;
+
+    /// <summary>
+    /// Gets a value indicating whether the roles should be updated in Scripture Forge.
+    /// </summary>
+    /// <returns><c>true</c> if the roles should be updated; otherwise, <c>false</c>.</returns>
+    public bool UpdateRoles => ProjectChanged || PermissionsChanged;
+}

--- a/src/SIL.XForge.Scripture/Models/ParatextSyncResults.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextSyncResults.cs
@@ -44,6 +44,10 @@ public class ParatextSyncResults
     /// </summary>
     /// <param name="bookNum">The book number.</param>
     /// <returns><c>true</c> if the book should be updated; otherwise, <c>false</c>.</returns>
+    /// <remarks>
+    /// This will return <c>true</c> for resources, as resource updates are calculated via
+    /// <see cref="Services.ParatextService.ResourceDocsNeedUpdating"/>, and not the Mercurial log.
+    /// </remarks>
     public bool UpdateBook(int bookNum) => ProjectChanged || IsResource || Books.Contains(bookNum);
 
     /// <summary>

--- a/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
@@ -26,6 +26,7 @@ public class SyncMetrics : IIdentifiable
     public SyncMetricInfo NoteThreads { get; set; } = new SyncMetricInfo();
     public SyncMetricInfo ParatextBooks { get; set; } = new SyncMetricInfo();
     public SyncMetricInfo ParatextNotes { get; set; } = new SyncMetricInfo();
+    public ParatextSyncResults ParatextSyncResults { get; set; } = new ParatextSyncResults();
     public SyncMetricInfo Questions { get; set; } = new SyncMetricInfo();
     public bool RepositoryBackupCreated { get; set; }
     public bool RepositoryRestoredFromBackup { get; set; }

--- a/src/SIL.XForge.Scripture/Services/IParatextDataHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextDataHelper.cs
@@ -1,8 +1,11 @@
+using System.Collections.Generic;
 using Paratext.Data;
+using Paratext.Data.Repository;
 
 namespace SIL.XForge.Scripture.Services;
 
 public interface IParatextDataHelper
 {
     void CommitVersionedText(ScrText scrText, string comment);
+    IEnumerable<(ProjectFileType, int[])> GetRevisionChanges(ScrText scrText, string[] revisionIds);
 }

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -83,11 +83,11 @@ public interface IParatextService
     void FreeCommentManager(UserSecret userSecret, string paratextId);
     void InitializeCommentManager(UserSecret userSecret, string paratextId);
 
-    Task<ParatextProject> SendReceiveAsync(
+    Task<(ParatextProject, ParatextSyncResults)> SendReceiveAsync(
         UserSecret userSecret,
         string paratextId,
-        IProgress<ProgressState> progress = null,
+        IProgress<ProgressState>? progress = null,
         CancellationToken token = default,
-        SyncMetrics syncMetrics = null
+        SyncMetrics? syncMetrics = null
     );
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextDataHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextDataHelper.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Paratext.Data;
 using Paratext.Data.Repository;
 
@@ -10,5 +13,36 @@ public class ParatextDataHelper : IParatextDataHelper
     {
         VersionedText vText = VersioningManager.Get(scrText);
         vText.Commit(comment, null, false);
+    }
+
+    /// <summary>
+    /// Gets the changes made in the specified revisions to the ScrText.
+    /// </summary>
+    /// <param name="scrText">The Paratext ScrText</param>
+    /// <param name="revisionIds">The revision identifiers.</param>
+    /// <returns>
+    /// A collection of tuples, where the first value is the file type,
+    /// and the second value is an array of the affected book numbers.
+    /// </returns>
+    public IEnumerable<(ProjectFileType, int[])> GetRevisionChanges(ScrText scrText, string[] revisionIds)
+    {
+        VersionedText versionedText = VersioningManager.Get(scrText);
+        List<HgRevision> revisions = Hg.Default.GetLog(
+            versionedText.Repository,
+            revisionIds.First(),
+            revisionIds.Last()
+        );
+        return revisions
+            .Select(revision => new RevisionChangeInfo(versionedText, revision))
+            .SelectMany(summary => summary.FilesChanged)
+            .Select(
+                c =>
+                    (
+                        c.Key,
+                        c.Key == ProjectFileType.Books
+                            ? c.Value.Where(f => f.File is not null).Select(f => f.File.BookNum).ToArray()
+                            : Array.Empty<int>()
+                    )
+            );
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -30,6 +30,7 @@ using Paratext.Data.RegistryServerAccess;
 using Paratext.Data.Repository;
 using Paratext.Data.Users;
 using PtxUtils;
+using SIL.Extensions;
 using SIL.ObjectModel;
 using SIL.Scripture;
 using SIL.XForge.Configuration;
@@ -181,13 +182,16 @@ public class ParatextService : DisposableBase, IParatextService
     /// project referred to by paratextId. Or if paratextId refers to a DBL Resource, update the local copy of the
     /// resource if needed.
     /// </summary>
-    /// <returns>The project that was synced. This is returned so we can use it for other Paratext logic.</returns>
-    public async Task<ParatextProject> SendReceiveAsync(
+    /// <returns>
+    /// The project that was synced, and the sync results.
+    /// This is returned so we can use it for other Paratext logic.
+    /// </returns>
+    public async Task<(ParatextProject, ParatextSyncResults)> SendReceiveAsync(
         UserSecret userSecret,
         string paratextId,
-        IProgress<ProgressState>? progress,
-        CancellationToken token,
-        SyncMetrics syncMetrics
+        IProgress<ProgressState>? progress = null,
+        CancellationToken token = default,
+        SyncMetrics? syncMetrics = null
     )
     {
         if (userSecret == null || paratextId == null)
@@ -195,8 +199,8 @@ public class ParatextService : DisposableBase, IParatextService
             throw new ArgumentNullException();
         }
 
-        void traceListener(string message) => syncMetrics.Log.Add($"{DateTime.UtcNow:u} Trace: {message}");
-        void alertListener(string message) => syncMetrics.Log.Add($"{DateTime.UtcNow:u} {message}");
+        void traceListener(string message) => syncMetrics?.Log.Add($"{DateTime.UtcNow:u} Trace: {message}");
+        void alertListener(string message) => syncMetrics?.Log.Add($"{DateTime.UtcNow:u} {message}");
         LambdaTraceListener listener = new LambdaTraceListener(traceListener);
         try
         {
@@ -216,6 +220,7 @@ public class ParatextService : DisposableBase, IParatextService
             IEnumerable<ProjectMetadata> projectsMetadata = source.GetProjectsMetaData();
             IEnumerable<string> projectGuids = projectsMetadata.Select(pmd => pmd.ProjectGuid.Id);
             SharedRepository sendReceiveRepository = repositories.FirstOrDefault(r => r.SendReceiveId.Id == paratextId);
+            ParatextSyncResults syncResults = new ParatextSyncResults();
             if (TryGetProject(userSecret, sendReceiveRepository, projectsMetadata, out ParatextProject ptProject))
             {
                 if (!projectGuids.Contains(paratextId))
@@ -239,7 +244,7 @@ public class ParatextService : DisposableBase, IParatextService
                         + $"{paratextId}"
                 );
             }
-            EnsureProjectReposExists(userSecret, ptProject, source);
+            EnsureProjectReposExists(userSecret, ptProject, source, syncResults);
             if (ptProject is not ParatextResource)
             {
                 StartProgressReporting(progress);
@@ -307,12 +312,26 @@ public class ParatextService : DisposableBase, IParatextService
                     );
                 }
 
+                GetSyncResults(results, syncResults, scrText);
+
                 // Update the cached comment manager
                 CommentManager manager = CommentManager.Get(scrText);
                 manager.Load();
             }
+            else
+            {
+                // We have a resource - always flag update all
+                syncResults.IsResource = true;
+            }
 
-            return ptProject;
+            // If we have sync metrics, record the sync results there
+            if (syncMetrics is not null)
+            {
+                syncMetrics.ParatextSyncResults = syncResults;
+            }
+
+            // Return the project and the sync results
+            return (ptProject, syncResults);
         }
         finally
         {
@@ -547,7 +566,100 @@ public class ParatextService : DisposableBase, IParatextService
         return canRead ? TextInfoPermission.Read : TextInfoPermission.None;
     }
 
-    private static string ExplainSRResults(IEnumerable<SendReceiveResult> srResults)
+    /// <summary>
+    /// Parses the SendReceiveResults into a ParatextSyncResults object we can use to identify what to update in SF.
+    /// </summary>
+    /// <param name="srResults">The send/receive results</param>
+    /// <param name="syncResults">The sync results we are to add to.</param>
+    /// <param name="scrText">The Paratext ScrText.</param>
+    /// <remarks>This method is marked internal for unit testing only.</remarks>
+    internal void GetSyncResults(
+        IEnumerable<SendReceiveResult>? srResults,
+        ParatextSyncResults syncResults,
+        ScrText scrText
+    )
+    {
+        // Parse the sync results
+        foreach (SendReceiveResult result in srResults ?? Array.Empty<SendReceiveResult>())
+        {
+            // If we have received any revisions (including merge revisions)
+            string[] revisionIds = result.RevisionsReceived ?? Array.Empty<string>();
+            if (!revisionIds.Any())
+            {
+                continue;
+            }
+
+            foreach (
+                (ProjectFileType fileType, int[] books) in _paratextDataHelper.GetRevisionChanges(scrText, revisionIds)
+            )
+            {
+                switch (fileType)
+                {
+                    case ProjectFileType.BookNames:
+                    case ProjectFileType.Canons:
+                    case ProjectFileType.LanguageSettings:
+                    case ProjectFileType.ProjectUpdate:
+                    case ProjectFileType.PropertiesAndSettings:
+                    case ProjectFileType.Stylesheet:
+                    case ProjectFileType.Versification:
+                    case ProjectFileType.XmlResourceProject:
+                        // Project level change
+                        syncResults.ProjectChanged = true;
+                        break;
+                    case ProjectFileType.Books:
+                        // Add the books that have changed
+                        syncResults.Books.AddRange(books);
+
+                        // If no books were flagged as changed, it may be an error, so force a full sync
+                        if (books.Length == 0)
+                        {
+                            syncResults.ProjectChanged = true;
+                        }
+
+                        break;
+                    case ProjectFileType.Notes:
+                    case ProjectFileType.NoteLanguages:
+                    case ProjectFileType.NoteTags:
+                        // Notes have changed
+                        syncResults.NotesChanged = true;
+                        break;
+                    case ProjectFileType.RolesPermissions:
+                        // Permissions have changed
+                        syncResults.PermissionsChanged = true;
+                        break;
+                    case ProjectFileType.Renderings:
+                    case ProjectFileType.Terms:
+                        // TODO: Biblical Terms Support
+                        break;
+                    case ProjectFileType.Autocorrect:
+                    case ProjectFileType.Denials:
+                    case ProjectFileType.Figures:
+                    case ProjectFileType.Hyphenation:
+                    case ProjectFileType.Interlinear:
+                    case ProjectFileType.Lexicon:
+                    case ProjectFileType.ModuleSpecifications:
+                    case ProjectFileType.NotAProjectFile:
+                    case ProjectFileType.Passages:
+                    case ProjectFileType.PluginData:
+                    case ProjectFileType.Progress:
+                    case ProjectFileType.RubyGlosses:
+                    case ProjectFileType.SavedFilters:
+                    case ProjectFileType.SharedFiles:
+                    case ProjectFileType.SimplifiedMenus:
+                    case ProjectFileType.Spelling:
+                    case ProjectFileType.StatusCheckBoxes:
+                    case ProjectFileType.StudyBibleAdditions:
+                    case ProjectFileType.StudyBibleAdditionBooks:
+                    case ProjectFileType.Unspecified:
+                    default:
+                        // Ignore - does not affect Scripture Forge
+                        break;
+                }
+            }
+        }
+    }
+
+    private static string ExplainSRResults(IEnumerable<SendReceiveResult>? srResults)
     {
         return string.Join(
             ";",
@@ -1864,7 +1976,8 @@ public class ParatextService : DisposableBase, IParatextService
     private void EnsureProjectReposExists(
         UserSecret userSecret,
         ParatextProject target,
-        IInternetSharedRepositorySource repositorySource
+        IInternetSharedRepositorySource repositorySource,
+        ParatextSyncResults syncResults
     )
     {
         string username = GetParatextUsername(userSecret);
@@ -1883,6 +1996,7 @@ public class ParatextService : DisposableBase, IParatextService
                 RepositoryType.Shared
             );
             CloneProjectRepo(repositorySource, target.ParatextId, targetRepo);
+            syncResults.ProjectChanged = true;
         }
     }
 

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -579,8 +579,13 @@ public class ParatextService : DisposableBase, IParatextService
         ScrText scrText
     )
     {
+        if (srResults is null)
+        {
+            return;
+        }
+
         // Parse the sync results
-        foreach (SendReceiveResult result in srResults ?? Array.Empty<SendReceiveResult>())
+        foreach (SendReceiveResult result in srResults)
         {
             // If we have received any revisions (including merge revisions)
             string[] revisionIds = result.RevisionsReceived ?? Array.Empty<string>();

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -150,7 +150,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
         {
             if (!await InitAsync(projectSFId, userId, syncMetricsId, token))
             {
-                await CompleteSync(false, canRollbackParatext, trainEngine, token);
+                await CompleteSync(false, canRollbackParatext, trainEngine, false, token);
                 return;
             }
 
@@ -223,13 +223,14 @@ public class ParatextSyncRunner : IParatextSyncRunner
             // Check for cancellation
             if (token.IsCancellationRequested)
             {
-                await CompleteSync(false, canRollbackParatext, trainEngine, token);
+                await CompleteSync(false, canRollbackParatext, trainEngine, false, token);
                 return;
             }
 
             // Use the new progress bar
             var progress = new SyncProgress();
             ParatextProject paratextProject;
+            ParatextSyncResults syncResults;
             try
             {
                 // Create the handler
@@ -237,7 +238,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
 
                 Log($"RunAsync: Going to do ParatextData SendReceive.");
                 // perform Paratext send/receive
-                paratextProject = await _paratextService.SendReceiveAsync(
+                (paratextProject, syncResults) = await _paratextService.SendReceiveAsync(
                     _userSecret,
                     targetParatextId,
                     progress,
@@ -257,7 +258,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
             // Check for cancellation
             if (token.IsCancellationRequested)
             {
-                await CompleteSync(false, canRollbackParatext, trainEngine, token);
+                await CompleteSync(false, canRollbackParatext, trainEngine, syncResults.UpdateRoles, token);
                 return;
             }
 
@@ -272,7 +273,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
             // Check for cancellation
             if (token.IsCancellationRequested)
             {
-                await CompleteSync(false, canRollbackParatext, trainEngine, token);
+                await CompleteSync(false, canRollbackParatext, trainEngine, syncResults.UpdateRoles, token);
                 return;
             }
 
@@ -303,7 +304,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
             // Check for cancellation
             if (token.IsCancellationRequested)
             {
-                await CompleteSync(false, canRollbackParatext, trainEngine, token);
+                await CompleteSync(false, canRollbackParatext, trainEngine, syncResults.UpdateRoles, token);
                 return;
             }
 
@@ -396,7 +397,8 @@ public class ParatextSyncRunner : IParatextSyncRunner
                     questionDocsByBook,
                     noteThreadDocsByBook,
                     targetBooks,
-                    sourceBooks
+                    sourceBooks,
+                    syncResults
                 );
             }
             LogMetric("Back from UpdateDocsAsync");
@@ -405,7 +407,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
             // Check for cancellation
             if (token.IsCancellationRequested)
             {
-                await CompleteSync(false, canRollbackParatext, trainEngine, token);
+                await CompleteSync(false, canRollbackParatext, trainEngine, syncResults.UpdateRoles, token);
                 return;
             }
 
@@ -416,20 +418,22 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 await UpdateResourceConfig(paratextProject);
             }
 
-            // We will always update permissions, even if this is a resource project
-            LogMetric("Updating permissions");
-            await _projectService.UpdatePermissionsAsync(userId, _projectDoc, token);
+            if (syncResults.UpdatePermissions)
+            {
+                LogMetric("Updating permissions");
+                await _projectService.UpdatePermissionsAsync(userId, _projectDoc, token);
+            }
 
             await NotifySyncProgress(SyncPhase.Phase7, 40.0);
 
             // Check for cancellation
             if (token.IsCancellationRequested)
             {
-                await CompleteSync(false, canRollbackParatext, trainEngine, token);
+                await CompleteSync(false, canRollbackParatext, trainEngine, syncResults.UpdateRoles, token);
                 return;
             }
 
-            await CompleteSync(true, canRollbackParatext, trainEngine, token);
+            await CompleteSync(true, canRollbackParatext, trainEngine, syncResults.UpdateRoles, token);
         }
         catch (Exception e)
         {
@@ -448,7 +452,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 LogMetric(message);
             }
 
-            await CompleteSync(false, canRollbackParatext, trainEngine, token);
+            await CompleteSync(false, canRollbackParatext, trainEngine, false, token);
         }
         finally
         {
@@ -609,7 +613,8 @@ public class ParatextSyncRunner : IParatextSyncRunner
         Dictionary<int, IReadOnlyList<IDocument<Question>>> questionDocsByBook,
         Dictionary<int, IEnumerable<IDocument<NoteThread>>> noteThreadDocsByBook,
         HashSet<int> targetBooks,
-        HashSet<int> sourceBooks
+        HashSet<int> sourceBooks,
+        ParatextSyncResults syncResults
     )
     {
         // update source and target real-time docs
@@ -621,65 +626,85 @@ public class ParatextSyncRunner : IParatextSyncRunner
             LogMetric($"Updating text info for book {bookNum}");
             bool hasSource = sourceBooks.Contains(bookNum);
             int textIndex = _projectDoc.Data.Texts.FindIndex(t => t.BookNum == bookNum);
-            TextInfo text;
-            if (textIndex == -1)
+            if (!syncResults.UpdateBook(bookNum) && textIndex > -1)
             {
-                text = new TextInfo { BookNum = bookNum, HasSource = hasSource };
-                _syncMetrics.Books.Added++;
+                // Update hasSource, as our source may have changed
+                LogMetric("Updating project metadata");
+                await _projectDoc.SubmitJson0OpAsync(op => op.Set(pd => pd.Texts[textIndex].HasSource, hasSource));
             }
             else
             {
-                text = _projectDoc.Data.Texts[textIndex];
-                _syncMetrics.Books.Updated++;
-            }
-
-            // update target text docs
-            if (
-                !targetTextDocsByBook.TryGetValue(text.BookNum, out SortedList<int, IDocument<TextData>> targetTextDocs)
-            )
-            {
-                targetTextDocs = new SortedList<int, IDocument<TextData>>();
-            }
-
-            LogMetric("Updating text docs");
-            List<Chapter> newSetOfChapters = await UpdateTextDocsAsync(text, targetParatextId, targetTextDocs);
-
-            // update question docs
-            if (questionDocsByBook.TryGetValue(text.BookNum, out IReadOnlyList<IDocument<Question>> questionDocs))
-            {
-                LogMetric("Updating question docs");
-                await UpdateQuestionDocsAsync(questionDocs, newSetOfChapters);
-            }
-
-            LogMetric("Updating thread docs - get deltas");
-            Dictionary<int, ChapterDelta> chapterDeltas = GetDeltasByChapter(text, targetParatextId);
-
-            LogMetric("Updating thread docs - updating");
-
-            // update note thread docs
-            if (!noteThreadDocsByBook.TryGetValue(text.BookNum, out IEnumerable<IDocument<NoteThread>> noteThreadDocs))
-            {
-                noteThreadDocs = Array.Empty<IDocument<NoteThread>>();
-            }
-            await UpdateNoteThreadDocsAsync(text, noteThreadDocs.ToDictionary(nt => nt.Data.DataId), chapterDeltas);
-
-            // update project metadata
-            LogMetric("Updating project metadata");
-            await _projectDoc.SubmitJson0OpAsync(op =>
-            {
+                // The book was updated on sync, or it does not exist
+                TextInfo text;
                 if (textIndex == -1)
                 {
-                    // insert text info for new text
-                    text.Chapters = newSetOfChapters;
-                    op.Add(pd => pd.Texts, text);
+                    text = new TextInfo { BookNum = bookNum, HasSource = hasSource };
+                    _syncMetrics.Books.Added++;
                 }
                 else
                 {
-                    // update text info
-                    op.Set(pd => pd.Texts[textIndex].Chapters, newSetOfChapters, _chapterListEqualityComparer);
-                    op.Set(pd => pd.Texts[textIndex].HasSource, hasSource);
+                    text = _projectDoc.Data.Texts[textIndex];
+                    _syncMetrics.Books.Updated++;
                 }
-            });
+
+                // update target text docs
+                if (
+                    !targetTextDocsByBook.TryGetValue(
+                        text.BookNum,
+                        out SortedList<int, IDocument<TextData>> targetTextDocs
+                    )
+                )
+                {
+                    targetTextDocs = new SortedList<int, IDocument<TextData>>();
+                }
+
+                LogMetric("Updating text docs");
+                List<Chapter> newSetOfChapters = await UpdateTextDocsAsync(text, targetParatextId, targetTextDocs);
+
+                // Remove question docs for deleted chapters
+                if (questionDocsByBook.TryGetValue(text.BookNum, out IReadOnlyList<IDocument<Question>> questionDocs))
+                {
+                    LogMetric("Updating question docs");
+                    await UpdateQuestionDocsAsync(questionDocs, newSetOfChapters);
+                }
+
+                // update project metadata
+                LogMetric("Updating project metadata");
+                await _projectDoc.SubmitJson0OpAsync(op =>
+                {
+                    if (textIndex == -1)
+                    {
+                        // insert text info for new text
+                        text.Chapters = newSetOfChapters;
+                        op.Add(pd => pd.Texts, text);
+                    }
+                    else
+                    {
+                        // update text info
+                        op.Set(pd => pd.Texts[textIndex].Chapters, newSetOfChapters, _chapterListEqualityComparer);
+                        op.Set(pd => pd.Texts[textIndex].HasSource, hasSource);
+                    }
+                });
+            }
+
+            // Update note threads
+            if (syncResults.UpdateNotes)
+            {
+                LogMetric("Updating thread docs - get deltas");
+                Dictionary<int, ChapterDelta> chapterDeltas = GetDeltasByChapter(bookNum, targetParatextId);
+
+                LogMetric("Updating thread docs - updating");
+
+                if (!noteThreadDocsByBook.TryGetValue(bookNum, out IEnumerable<IDocument<NoteThread>> noteThreadDocs))
+                {
+                    noteThreadDocs = Array.Empty<IDocument<NoteThread>>();
+                }
+                await UpdateNoteThreadDocsAsync(
+                    bookNum,
+                    noteThreadDocs.ToDictionary(nt => nt.Data.DataId),
+                    chapterDeltas
+                );
+            }
         }
     }
 
@@ -1016,7 +1041,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
     /// Updates ParatextNoteThread docs for a book
     /// </summary>
     private async Task UpdateNoteThreadDocsAsync(
-        TextInfo text,
+        int bookNum,
         Dictionary<string, IDocument<NoteThread>> noteThreadDocs,
         Dictionary<int, ChapterDelta> chapterDeltas
     )
@@ -1024,7 +1049,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
         IEnumerable<NoteThreadChange> noteThreadChanges = _paratextService.GetNoteThreadChanges(
             _userSecret,
             _projectDoc.Data.ParatextId,
-            text.BookNum,
+            bookNum,
             noteThreadDocs.Values,
             chapterDeltas,
             _currentPtSyncUsers
@@ -1305,6 +1330,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
         bool successful,
         bool canRollbackParatext,
         bool trainEngine,
+        bool updateRoles,
         CancellationToken token
     )
     {
@@ -1321,9 +1347,8 @@ public class ParatextSyncRunner : IParatextSyncRunner
         }
 
         LogMetric("Completing sync");
-        bool updateRoles = true;
         IReadOnlyDictionary<string, string> ptUserRoles;
-        if (_paratextService.IsResource(_projectDoc.Data.ParatextId) || token.IsCancellationRequested)
+        if (!updateRoles || _paratextService.IsResource(_projectDoc.Data.ParatextId) || token.IsCancellationRequested)
         {
             // Do not update permissions on sync, if this is a resource project, as then,
             // permission updates will be performed when a target project is synchronized.
@@ -1673,9 +1698,9 @@ public class ParatextSyncRunner : IParatextSyncRunner
     private IDocument<NoteThread> GetNoteThreadDoc(string threadId) =>
         _conn.Get<NoteThread>($"{_projectDoc.Id}:{threadId}");
 
-    private Dictionary<int, ChapterDelta> GetDeltasByChapter(TextInfo text, string paratextId)
+    private Dictionary<int, ChapterDelta> GetDeltasByChapter(int bookNum, string paratextId)
     {
-        string bookText = _paratextService.GetBookText(_userSecret, paratextId, text.BookNum);
+        string bookText = _paratextService.GetBookText(_userSecret, paratextId, bookNum);
         XDocument usxDoc = XDocument.Parse(bookText);
         Dictionary<int, ChapterDelta> chapterDeltas = _deltaUsxMapper
             .ToChapterDeltas(usxDoc)

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -628,7 +628,8 @@ public class ParatextSyncRunner : IParatextSyncRunner
             int textIndex = _projectDoc.Data.Texts.FindIndex(t => t.BookNum == bookNum);
             if (!syncResults.UpdateBook(bookNum) && textIndex > -1)
             {
-                // Update hasSource, as our source may have changed
+                // Update hasSource, as the earlier sync of the source project may have added or removed a book that is
+                // already in the target project and not updated in this sync of the target project.
                 LogMetric("Updating project metadata");
                 await _projectDoc.SubmitJson0OpAsync(op => op.Set(pd => pd.Texts[textIndex].HasSource, hasSource));
             }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -514,7 +514,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
             LogMetric($"Getting Paratext book {text.BookNum}");
             SortedList<int, IDocument<TextData>> targetTextDocs = GetTextDocsForBook(text, textDocs);
             textDocsByBook[text.BookNum] = targetTextDocs;
-            if (settings.Editable && !_paratextService.IsResource(paratextId))
+            if (settings.Editable && !_paratextService.IsResource(paratextId) && Canon.IsCanonical(text.BookNum))
             {
                 LogMetric("Updating Paratext book");
                 await UpdateParatextBook(text, paratextId, targetTextDocs);

--- a/test/SIL.XForge.Scripture.Tests/Models/ParatextSyncResultsTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Models/ParatextSyncResultsTests.cs
@@ -1,0 +1,86 @@
+using NUnit.Framework;
+
+namespace SIL.XForge.Scripture.Models;
+
+[TestFixture]
+public class ParatextSyncResultsTests
+{
+    [Test]
+    public void ParatextSyncResults_BookChanged()
+    {
+        // SUT
+        var syncResults = new ParatextSyncResults();
+        syncResults.Books.Add(1);
+
+        Assert.IsTrue(syncResults.UpdateBook(1));
+        Assert.IsFalse(syncResults.UpdateBook(2));
+        Assert.IsFalse(syncResults.UpdateNotes);
+        Assert.IsTrue(syncResults.UpdatePermissions);
+        Assert.IsFalse(syncResults.UpdateRoles);
+    }
+
+    [Test]
+    public void ParatextSyncResults_IsResource()
+    {
+        // SUT
+        var syncResults = new ParatextSyncResults { IsResource = true };
+
+        Assert.IsTrue(syncResults.UpdateBook(1));
+        Assert.IsTrue(syncResults.UpdateBook(2));
+        Assert.IsFalse(syncResults.UpdateNotes);
+        Assert.IsTrue(syncResults.UpdatePermissions);
+        Assert.IsFalse(syncResults.UpdateRoles);
+    }
+
+    [Test]
+    public void ParatextSyncResults_NoChanges()
+    {
+        // SUT
+        var syncResults = new ParatextSyncResults();
+
+        Assert.IsFalse(syncResults.UpdateBook(1));
+        Assert.IsFalse(syncResults.UpdateBook(2));
+        Assert.IsFalse(syncResults.UpdateNotes);
+        Assert.IsFalse(syncResults.UpdatePermissions);
+        Assert.IsFalse(syncResults.UpdateRoles);
+    }
+
+    [Test]
+    public void ParatextSyncResults_NotesChanged()
+    {
+        // SUT
+        var syncResults = new ParatextSyncResults { NotesChanged = true };
+
+        Assert.IsFalse(syncResults.UpdateBook(1));
+        Assert.IsFalse(syncResults.UpdateBook(2));
+        Assert.IsTrue(syncResults.UpdateNotes);
+        Assert.IsFalse(syncResults.UpdatePermissions);
+        Assert.IsFalse(syncResults.UpdateRoles);
+    }
+
+    [Test]
+    public void ParatextSyncResults_PermissionsChanged()
+    {
+        // SUT
+        var syncResults = new ParatextSyncResults { PermissionsChanged = true };
+
+        Assert.IsFalse(syncResults.UpdateBook(1));
+        Assert.IsFalse(syncResults.UpdateBook(2));
+        Assert.IsFalse(syncResults.UpdateNotes);
+        Assert.IsTrue(syncResults.UpdatePermissions);
+        Assert.IsTrue(syncResults.UpdateRoles);
+    }
+
+    [Test]
+    public void ParatextSyncResults_ProjectChanged()
+    {
+        // SUT
+        var syncResults = new ParatextSyncResults { ProjectChanged = true };
+
+        Assert.IsTrue(syncResults.UpdateBook(1));
+        Assert.IsTrue(syncResults.UpdateBook(2));
+        Assert.IsTrue(syncResults.UpdateNotes);
+        Assert.IsTrue(syncResults.UpdatePermissions);
+        Assert.IsTrue(syncResults.UpdateRoles);
+    }
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -2819,7 +2819,7 @@ public class ParatextServiceTests
         ComparableProjectPermissionManager targetScrTextPermissions = (ComparableProjectPermissionManager)
             env.ProjectScrText.Permissions;
 
-        ParatextProject targetProject = await env.Service.SendReceiveAsync(
+        (ParatextProject targetProject, _) = await env.Service.SendReceiveAsync(
             user01Secret,
             targetProjectId,
             null,
@@ -2827,7 +2827,7 @@ public class ParatextServiceTests
             Substitute.For<SyncMetrics>()
         );
         Assert.IsNotNull(targetProject);
-        ParatextProject sourceProject = await env.Service.SendReceiveAsync(
+        (ParatextProject sourceProject, _) = await env.Service.SendReceiveAsync(
             user01Secret,
             sourceProjectId,
             null,
@@ -2871,7 +2871,7 @@ public class ParatextServiceTests
                 env.MockScrTextCollection.FindById(env.Username01, newSourceProjectId).Returns(newSourceScrText);
             });
 
-        targetProject = await env.Service.SendReceiveAsync(
+        (targetProject, _) = await env.Service.SendReceiveAsync(
             user01Secret,
             targetProjectId,
             null,
@@ -2879,7 +2879,7 @@ public class ParatextServiceTests
             Substitute.For<SyncMetrics>()
         );
         Assert.IsNotNull(targetProject);
-        sourceProject = await env.Service.SendReceiveAsync(
+        (sourceProject, _) = await env.Service.SendReceiveAsync(
             user01Secret,
             newSourceProjectId,
             null,
@@ -2925,7 +2925,7 @@ public class ParatextServiceTests
         env.SetRestClientFactory(user01Secret);
         ScrTextCollection.Initialize("/srv/scriptureforge/projects");
         string resourceId = env.Resource3Id; // See the XML in SetRestClientFactory for this
-        ParatextProject targetProject = await env.Service.SendReceiveAsync(
+        (ParatextProject targetProject, _) = await env.Service.SendReceiveAsync(
             user01Secret,
             ptProjectId,
             null,
@@ -2933,7 +2933,7 @@ public class ParatextServiceTests
             Substitute.For<SyncMetrics>()
         );
         Assert.IsNotNull(targetProject);
-        ParatextProject sourceProject = await env.Service.SendReceiveAsync(
+        (ParatextProject sourceProject, _) = await env.Service.SendReceiveAsync(
             user01Secret,
             resourceId,
             null,
@@ -3761,6 +3761,264 @@ public class ParatextServiceTests
         // SUT
         string languageId = env.Service.GetLanguageId(userSecret, ptProjectId);
         Assert.AreEqual(LanguageId.English.Id, languageId);
+    }
+
+    [Test]
+    public void GetSyncResults_NoResults()
+    {
+        var env = new TestEnvironment();
+
+        SendReceiveResult[] srResults = Array.Empty<SendReceiveResult>();
+        var syncResults = new ParatextSyncResults();
+        var scrText = env.ProjectScrText;
+
+        // SUT
+        env.Service.GetSyncResults(srResults, syncResults, scrText);
+
+        Assert.IsEmpty(syncResults.Books);
+        Assert.IsFalse(syncResults.IsResource);
+        Assert.IsFalse(syncResults.NotesChanged);
+        Assert.IsFalse(syncResults.PermissionsChanged);
+        Assert.IsFalse(syncResults.ProjectChanged);
+    }
+
+    [Test]
+    public void GetSyncResults_EmptyResult()
+    {
+        var env = new TestEnvironment();
+
+        SendReceiveResult[] srResults = { new SendReceiveResult(new SharedProject()) };
+        var syncResults = new ParatextSyncResults();
+        var scrText = env.ProjectScrText;
+
+        // SUT
+        env.Service.GetSyncResults(srResults, syncResults, scrText);
+
+        Assert.IsEmpty(syncResults.Books);
+        Assert.IsFalse(syncResults.IsResource);
+        Assert.IsFalse(syncResults.NotesChanged);
+        Assert.IsFalse(syncResults.PermissionsChanged);
+        Assert.IsFalse(syncResults.ProjectChanged);
+    }
+
+    [Test]
+    public void GetSyncResults_BookChanged()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+
+        string[] revisionIds = { "1" };
+        SendReceiveResult[] srResults =
+        {
+            new SendReceiveResult(new SharedProject()) { RevisionsReceived = revisionIds }
+        };
+        var syncResults = new ParatextSyncResults();
+        var scrText = env.ProjectScrText;
+        env.MockParatextDataHelper
+            .GetRevisionChanges(scrText, revisionIds)
+            .Returns(new[] { (ProjectFileType.Books, new[] { 1 }) });
+
+        // SUT
+        env.Service.GetSyncResults(srResults, syncResults, scrText);
+
+        Assert.AreEqual(1, syncResults.Books.Count);
+        Assert.AreEqual(1, syncResults.Books.First());
+        Assert.IsFalse(syncResults.IsResource);
+        Assert.IsFalse(syncResults.NotesChanged);
+        Assert.IsFalse(syncResults.PermissionsChanged);
+        Assert.IsFalse(syncResults.ProjectChanged);
+    }
+
+    [Test]
+    public void GetSyncResults_IgnoreChanges()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+
+        string[] revisionIds = { "1" };
+        SendReceiveResult[] srResults =
+        {
+            new SendReceiveResult(new SharedProject()) { RevisionsReceived = revisionIds }
+        };
+        var syncResults = new ParatextSyncResults();
+        var scrText = env.ProjectScrText;
+
+        // NOTE: For coverage, we return all of the revisions that would update notes
+        env.MockParatextDataHelper
+            .GetRevisionChanges(scrText, revisionIds)
+            .Returns(
+                new[]
+                {
+                    (ProjectFileType.Renderings, Array.Empty<int>()),
+                    (ProjectFileType.Terms, Array.Empty<int>()),
+                    (ProjectFileType.Autocorrect, Array.Empty<int>()),
+                    (ProjectFileType.Denials, Array.Empty<int>()),
+                    (ProjectFileType.Figures, Array.Empty<int>()),
+                    (ProjectFileType.Hyphenation, Array.Empty<int>()),
+                    (ProjectFileType.Interlinear, Array.Empty<int>()),
+                    (ProjectFileType.Lexicon, Array.Empty<int>()),
+                    (ProjectFileType.ModuleSpecifications, Array.Empty<int>()),
+                    (ProjectFileType.NotAProjectFile, Array.Empty<int>()),
+                    (ProjectFileType.Passages, Array.Empty<int>()),
+                    (ProjectFileType.PluginData, Array.Empty<int>()),
+                    (ProjectFileType.Progress, Array.Empty<int>()),
+                    (ProjectFileType.RubyGlosses, Array.Empty<int>()),
+                    (ProjectFileType.SavedFilters, Array.Empty<int>()),
+                    (ProjectFileType.SharedFiles, Array.Empty<int>()),
+                    (ProjectFileType.SimplifiedMenus, Array.Empty<int>()),
+                    (ProjectFileType.Spelling, Array.Empty<int>()),
+                    (ProjectFileType.StatusCheckBoxes, Array.Empty<int>()),
+                    (ProjectFileType.StudyBibleAdditions, Array.Empty<int>()),
+                    (ProjectFileType.StudyBibleAdditionBooks, Array.Empty<int>()),
+                    (ProjectFileType.Unspecified, Array.Empty<int>()),
+                }
+            );
+
+        // SUT
+        env.Service.GetSyncResults(srResults, syncResults, scrText);
+
+        Assert.IsEmpty(syncResults.Books);
+        Assert.IsFalse(syncResults.IsResource);
+        Assert.IsFalse(syncResults.NotesChanged);
+        Assert.IsFalse(syncResults.PermissionsChanged);
+        Assert.IsFalse(syncResults.ProjectChanged);
+    }
+
+    [Test]
+    public void GetSyncResults_NotesChanged()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+
+        string[] revisionIds = { "1" };
+        SendReceiveResult[] srResults =
+        {
+            new SendReceiveResult(new SharedProject()) { RevisionsReceived = revisionIds }
+        };
+        var syncResults = new ParatextSyncResults();
+        var scrText = env.ProjectScrText;
+
+        // NOTE: For coverage, we return all of the revisions that would update notes
+        env.MockParatextDataHelper
+            .GetRevisionChanges(scrText, revisionIds)
+            .Returns(
+                new[]
+                {
+                    (ProjectFileType.Notes, Array.Empty<int>()),
+                    (ProjectFileType.NoteLanguages, Array.Empty<int>()),
+                    (ProjectFileType.NoteTags, Array.Empty<int>()),
+                }
+            );
+
+        // SUT
+        env.Service.GetSyncResults(srResults, syncResults, scrText);
+
+        Assert.IsEmpty(syncResults.Books);
+        Assert.IsFalse(syncResults.IsResource);
+        Assert.IsTrue(syncResults.NotesChanged);
+        Assert.IsFalse(syncResults.PermissionsChanged);
+        Assert.IsFalse(syncResults.ProjectChanged);
+    }
+
+    [Test]
+    public void GetSyncResults_PermissionsChanged()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+
+        string[] revisionIds = { "1" };
+        SendReceiveResult[] srResults =
+        {
+            new SendReceiveResult(new SharedProject()) { RevisionsReceived = revisionIds }
+        };
+        var syncResults = new ParatextSyncResults();
+        var scrText = env.ProjectScrText;
+        env.MockParatextDataHelper
+            .GetRevisionChanges(scrText, revisionIds)
+            .Returns(new[] { (ProjectFileType.RolesPermissions, Array.Empty<int>()) });
+
+        // SUT
+        env.Service.GetSyncResults(srResults, syncResults, scrText);
+
+        Assert.IsEmpty(syncResults.Books);
+        Assert.IsFalse(syncResults.IsResource);
+        Assert.IsFalse(syncResults.NotesChanged);
+        Assert.IsTrue(syncResults.PermissionsChanged);
+        Assert.IsFalse(syncResults.ProjectChanged);
+    }
+
+    [Test]
+    public void GetSyncResults_ProjectChanged()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+
+        string[] revisionIds = { "1" };
+        SendReceiveResult[] srResults =
+        {
+            new SendReceiveResult(new SharedProject()) { RevisionsReceived = revisionIds }
+        };
+        var syncResults = new ParatextSyncResults();
+        var scrText = env.ProjectScrText;
+
+        // NOTE: For coverage, we return all of the revisions that would update notes
+        env.MockParatextDataHelper
+            .GetRevisionChanges(scrText, revisionIds)
+            .Returns(
+                new[]
+                {
+                    (ProjectFileType.BookNames, Array.Empty<int>()),
+                    (ProjectFileType.Canons, Array.Empty<int>()),
+                    (ProjectFileType.LanguageSettings, Array.Empty<int>()),
+                    (ProjectFileType.ProjectUpdate, Array.Empty<int>()),
+                    (ProjectFileType.PropertiesAndSettings, Array.Empty<int>()),
+                    (ProjectFileType.Stylesheet, Array.Empty<int>()),
+                    (ProjectFileType.Versification, Array.Empty<int>()),
+                    (ProjectFileType.XmlResourceProject, Array.Empty<int>()),
+                }
+            );
+
+        // SUT
+        env.Service.GetSyncResults(srResults, syncResults, scrText);
+
+        Assert.IsEmpty(syncResults.Books);
+        Assert.IsFalse(syncResults.IsResource);
+        Assert.IsFalse(syncResults.NotesChanged);
+        Assert.IsFalse(syncResults.PermissionsChanged);
+        Assert.IsTrue(syncResults.ProjectChanged);
+    }
+
+    [Test]
+    public void GetSyncResults_UnknownBooksChanged()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        env.SetupProject(env.Project01, associatedPtUser);
+
+        string[] revisionIds = { "1" };
+        SendReceiveResult[] srResults =
+        {
+            new SendReceiveResult(new SharedProject()) { RevisionsReceived = revisionIds }
+        };
+        var syncResults = new ParatextSyncResults();
+        var scrText = env.ProjectScrText;
+        env.MockParatextDataHelper
+            .GetRevisionChanges(scrText, revisionIds)
+            .Returns(new[] { (ProjectFileType.Books, Array.Empty<int>()) });
+
+        // SUT
+        env.Service.GetSyncResults(srResults, syncResults, scrText);
+
+        Assert.IsEmpty(syncResults.Books);
+        Assert.IsFalse(syncResults.IsResource);
+        Assert.IsFalse(syncResults.NotesChanged);
+        Assert.IsFalse(syncResults.PermissionsChanged);
+        Assert.IsTrue(syncResults.ProjectChanged);
     }
 
     private class TestEnvironment : IDisposable

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -13,6 +13,7 @@ using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 using Paratext.Data.ProjectComments;
 using Paratext.Data.ProjectSettingsAccess;
+using SIL.Extensions;
 using SIL.Scripture;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
@@ -302,6 +303,65 @@ public class ParatextSyncRunnerTests
     }
 
     [Test]
+    public async Task SyncAsync_HasSourceUpdatedWhenDataNotChanged()
+    {
+        var env = new TestEnvironment();
+        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        env.SetupSFData(true, true, false, false, books);
+        env.SetupPTData(books);
+
+        // Make sure no books are listed as modified
+        env.ParatextSyncResults.Books.Clear();
+
+        // Set hasSource to false
+        SFProject project = env.GetProject();
+        project.Texts[0].HasSource = false;
+        env.RealtimeService.GetRepository<SFProject>().Replace(project);
+
+        // SUT
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        env.MockLogger.AssertEventCount(
+            (LogEvent logEvent) =>
+                logEvent.LogLevel == LogLevel.Information && Regex.IsMatch(logEvent.Message, "Starting"),
+            1
+        );
+
+        await env.ParatextService
+            .DidNotReceive()
+            .PutBookText(Arg.Any<UserSecret>(), "target", 40, Arg.Any<XDocument>());
+        await env.ParatextService
+            .DidNotReceive()
+            .PutBookText(Arg.Any<UserSecret>(), "target", 41, Arg.Any<XDocument>());
+
+        await env.ParatextService
+            .DidNotReceive()
+            .PutBookText(Arg.Any<UserSecret>(), "source", 40, Arg.Any<XDocument>());
+        await env.ParatextService
+            .DidNotReceive()
+            .PutBookText(Arg.Any<UserSecret>(), "source", 41, Arg.Any<XDocument>());
+
+        var delta = Delta.New().InsertText("text");
+        Assert.That(env.GetText("project01", "MAT", 1).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project01", "MAT", 2).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project01", "MRK", 1).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project01", "MRK", 2).DeepEquals(delta), Is.True);
+
+        Assert.That(env.GetText("project02", "MAT", 1).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project02", "MAT", 2).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project02", "MRK", 1).DeepEquals(delta), Is.True);
+        Assert.That(env.GetText("project02", "MRK", 2).DeepEquals(delta), Is.True);
+
+        env.ParatextService.DidNotReceive().PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<XElement>());
+
+        project = env.VerifyProjectSync(true);
+        Assert.That(project.ParatextUsers.Count, Is.EqualTo(2));
+        Assert.IsTrue(project.Texts[0].HasSource);
+        Assert.That(project.UserRoles["user01"], Is.EqualTo(SFProjectRole.Administrator));
+        Assert.That(project.UserRoles["user02"], Is.EqualTo(SFProjectRole.Translator));
+    }
+
+    [Test]
     public async Task SyncAsync_DataChangedTranslateAndCheckingEnabled()
     {
         var env = new TestEnvironment();
@@ -403,6 +463,7 @@ public class ParatextSyncRunnerTests
         env.SetupPTData(new Book("MAT", 3), new Book("MRK", 1));
         Book[] books = new[] { new Book("MRK", 2) };
         env.AddParatextNoteThreadData(books);
+        env.ParatextSyncResults.NotesChanged = true;
         Assert.That(env.ContainsNote(1), Is.True);
 
         await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
@@ -543,6 +604,7 @@ public class ParatextSyncRunnerTests
                 Arg.Any<CancellationToken>()
             )
             .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+        env.ParatextSyncResults.PermissionsChanged = true;
 
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
@@ -1448,16 +1510,7 @@ public class ParatextSyncRunnerTests
 
         // Setup a trap to cancel the task
         env.ParatextService
-            .When(
-                x =>
-                    x.SendReceiveAsync(
-                        Arg.Any<UserSecret>(),
-                        Arg.Any<string>(),
-                        Arg.Any<IProgress<ProgressState>>(),
-                        Arg.Any<CancellationToken>(),
-                        Arg.Any<SyncMetrics>()
-                    )
-            )
+            .When(x => x.GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>()))
             .Do(_ => cancellationTokenSource.Cancel());
 
         // Run the task
@@ -1659,6 +1712,7 @@ public class ParatextSyncRunnerTests
                 Arg.Any<int>()
             )
             .Returns(Task.FromResult(info));
+        env.ParatextSyncResults.NotesChanged = true;
 
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
         await env.ParatextService
@@ -1700,6 +1754,7 @@ public class ParatextSyncRunnerTests
                 Arg.Any<int>()
             )
             .Returns(Task.FromResult(info));
+        env.ParatextSyncResults.NotesChanged = true;
 
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
         await env.ParatextService
@@ -2104,7 +2159,7 @@ public class ParatextSyncRunnerTests
                 Arg.Any<CancellationToken>(),
                 Arg.Any<SyncMetrics>()
             )
-            .Returns(new ParatextResource());
+            .Returns((new ParatextResource(), new ParatextSyncResults { IsResource = true }));
 
         // SUT
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
@@ -2146,7 +2201,7 @@ public class ParatextSyncRunnerTests
                 Arg.Any<CancellationToken>(),
                 Arg.Any<SyncMetrics>()
             )
-            .Returns(new ParatextResource());
+            .Returns((new ParatextResource(), new ParatextSyncResults { IsResource = true }));
 
         // SUT
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
@@ -2301,7 +2356,7 @@ public class ParatextSyncRunnerTests
                 Arg.Any<CancellationToken>(),
                 Arg.Any<SyncMetrics>()
             )
-            .Returns(new ParatextResource());
+            .Returns((new ParatextResource(), new ParatextSyncResults { IsResource = true }));
 
         // Ensure that the source is project02, and has no users with access
         Assert.AreEqual("project02", env.GetProject().TranslateConfig.Source.ProjectRef);
@@ -2427,7 +2482,16 @@ public class ParatextSyncRunnerTests
                     _sendReceivedCalled = true;
                     ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns("afterSR");
                 });
-
+            ParatextSyncResults = new ParatextSyncResults();
+            ParatextService
+                .SendReceiveAsync(
+                    Arg.Any<UserSecret>(),
+                    Arg.Any<string>(),
+                    Arg.Any<IProgress<ProgressState>>(),
+                    Arg.Any<CancellationToken>(),
+                    Arg.Any<SyncMetrics>()
+                )
+                .Returns((null, ParatextSyncResults));
             ParatextService.GetNotes(Arg.Any<UserSecret>(), "target", Arg.Any<int>()).Returns("<notes/>");
             ParatextService.GetParatextUsername(Arg.Is<UserSecret>(u => u.Id == "user01")).Returns("User 1");
             ParatextService
@@ -2477,6 +2541,7 @@ public class ParatextSyncRunnerTests
         public IMachineProjectService MachineProjectService { get; }
         public IParatextNotesMapper NotesMapper { get; }
         public IParatextService ParatextService { get; }
+        public ParatextSyncResults ParatextSyncResults { get; }
         public SFMemoryRealtimeService RealtimeService { get; }
         public IRealtimeService SubstituteRealtimeService { get; }
         public IDeltaUsxMapper DeltaUsxMapper { get; }
@@ -2976,6 +3041,7 @@ public class ParatextSyncRunnerTests
                 if (book.HighestSourceChapter > 0 || book.HighestSourceChapter == book.HighestTargetChapter)
                     AddPTBook(sourceProjectPTId, book.Id, book.HighestSourceChapter, book.MissingSourceChapters);
             }
+            ParatextSyncResults.Books.AddRange(books.Select(b => Canon.BookIdToNumber(b.Id)));
         }
 
         public Task SetUserRole(string userId, string role)
@@ -3026,6 +3092,7 @@ public class ParatextSyncRunnerTests
                         Arg.Any<Dictionary<string, ParatextUserProfile>>()
                     )
                     .Returns(new[] { noteThreadChange });
+                ParatextSyncResults.NotesChanged = true;
                 Dictionary<string, string> userIdsToUsernames = new Dictionary<string, string>
                 {
                     { "user01", "User 1" },
@@ -3148,6 +3215,7 @@ public class ParatextSyncRunnerTests
                     Arg.Any<Dictionary<string, ParatextUserProfile>>()
                 )
                 .Returns(new[] { noteThreadChange });
+            ParatextSyncResults.NotesChanged = true;
         }
 
         /// <summary>Prepare a change report to be provided when thread changes are asked for.</summary>
@@ -3543,6 +3611,7 @@ public class ParatextSyncRunnerTests
                     Arg.Any<Dictionary<string, ParatextUserProfile>>()
                 )
                 .Returns(noteThreadChanges);
+            ParatextSyncResults.NotesChanged = true;
         }
 
         private static Note CreateNote(

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -329,17 +329,7 @@ public class ParatextSyncRunnerTests
 
         await env.ParatextService
             .DidNotReceive()
-            .PutBookText(Arg.Any<UserSecret>(), "target", 40, Arg.Any<XDocument>());
-        await env.ParatextService
-            .DidNotReceive()
-            .PutBookText(Arg.Any<UserSecret>(), "target", 41, Arg.Any<XDocument>());
-
-        await env.ParatextService
-            .DidNotReceive()
-            .PutBookText(Arg.Any<UserSecret>(), "source", 40, Arg.Any<XDocument>());
-        await env.ParatextService
-            .DidNotReceive()
-            .PutBookText(Arg.Any<UserSecret>(), "source", 41, Arg.Any<XDocument>());
+            .PutBookText(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<XDocument>());
 
         var delta = Delta.New().InsertText("text");
         Assert.That(env.GetText("project01", "MAT", 1).DeepEquals(delta), Is.True);

--- a/tools/RepoInfo/Program.cs
+++ b/tools/RepoInfo/Program.cs
@@ -1,0 +1,271 @@
+/*
+ * Paratext Repository Information Tool
+ *
+ * Usage: REPOINFO [CSV] projectpath
+ *
+ * Examples:
+ *  - Display the repository information in the console:
+ *      REPOINFO /var/lib/scriptureforge/sync/59e59e2dce4bb5c863c683c0c4647008dd9767d4
+ *
+ *  - Output the repository information as a CSV file:
+ *      REPOINFO CSV C:\My Paratext 9 Projects\ABC > output.csv
+ *
+ * Notes:
+ *  - The Class column corresponds to how I classify the commit for sync in Scripture Forge
+ *  - The Classifications are:
+ *    BK: Book of the Bible (will affect just that book)
+ *    BT: Biblical Terms
+ *    NA: Does not affect Scripture Forge
+ *    NT: Notes
+ *    PE: Permissions
+ *    PR: Project level (update all SF Books, Notes, Biblical Terms, etc)
+ *  - A blank class means I have not classified it, so will not update Scripture Forge's data
+ */
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Reflection;
+using NetLoc;
+using Paratext.Data.Repository;
+using Paratext.Data.ProjectSettingsAccess;
+using Paratext.Data;
+using SIL.Scripture;
+using SIL.XForge.Scripture.Services;
+
+// Get the project path, and CSV from the command line arguments
+// Allow the arguments to be in any order
+bool csv = false;
+string projectPath = string.Empty;
+if (args.Any())
+{
+    projectPath = args[0];
+    csv = args[0].ToUpperInvariant() == "CSV";
+    if (csv && args.Length > 1)
+    {
+        projectPath = args[1];
+    }
+    else
+    {
+        csv = args.Length > 1 && args[1].ToUpperInvariant() == "CSV";
+    }
+}
+
+// Ensure that a path to the project is specified
+if (string.IsNullOrWhiteSpace(projectPath))
+{
+    Console.WriteLine("You must specify the path to the project.");
+    return;
+}
+
+// Set up Mercurial
+string customHgPath = Environment.GetEnvironmentVariable("HG_PATH") ?? "/usr/local/bin/hg";
+if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+{
+    customHgPath = Path.GetExtension(customHgPath.ToLowerInvariant()) != ".exe" ? customHgPath + ".exe" : customHgPath;
+}
+
+if (!File.Exists(customHgPath))
+{
+    Console.WriteLine($"Error: Could not find hg executable at {customHgPath}. Please install hg 4.7 or greater.");
+    return;
+}
+
+string? assemblyDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+if (string.IsNullOrWhiteSpace(assemblyDirectory))
+{
+    Console.WriteLine("The assembly directory could not be determined.");
+    return;
+}
+
+var hgMerge = Path.Combine(assemblyDirectory, "ParatextMerge.py");
+Hg.Default = new Hg(customHgPath, hgMerge, assemblyDirectory);
+
+// Files which we do not calculate the information for
+var ignoredFiles = new[] { "checkingstatus.xml", "projectprogress.tsv", "unique.id" };
+
+// Initialize so that Paratext.Data can find settings files
+ScrTextCollection.Implementation = new SFScrTextCollection();
+ScrTextCollection.Initialize(projectPath);
+
+// Get the path to the project settings
+string? settingsPath = Path.Combine(projectPath, "Settings.xml");
+if (!File.Exists(settingsPath))
+{
+    settingsPath = Directory.EnumerateFiles(projectPath, "*.ssf").FirstOrDefault();
+    if (settingsPath is null)
+    {
+        Console.WriteLine("The settings for the project could not be found");
+        return;
+    }
+}
+
+// Get the project settings
+using TextReader reader = File.OpenText(settingsPath);
+ProjectSettings settings = new ProjectSettings(reader);
+
+// Initialise the localizer, and hide its output
+var oldOut = Console.Out;
+Console.SetOut(StreamWriter.Null);
+Localizer.Str(string.Empty);
+Console.SetOut(oldOut);
+
+// Get the revisions
+var revisions = Hg.Default.GetLog(projectPath, null, null);
+if (revisions is null)
+{
+    Console.WriteLine("No revisions were found.");
+    return;
+}
+
+// Order revisions from oldest to newest
+revisions.Reverse();
+
+// Setup the columns to display in the table
+//
+// Explanation of pad right values for each column:
+// 1. The highest revision I have seen is < 99999
+// 2. A short commit hash is 12 characters
+// 3. Classification is a 2 letter code (see comments at top of the file)
+// 4. "Properties and Settings" is the longest file type at 23 characters long
+const int col1 = 5;
+const int col2 = 12;
+const int col3 = 2;
+const int col4 = 23;
+int[] cols = { col1, col2, col3, col4 };
+int lastCol = Console.WindowWidth - cols.Sum() - cols.Length;
+bool canDrawDivider = !csv && lastCol > 0;
+if (lastCol < 0)
+{
+    lastCol = int.MaxValue;
+}
+if (csv)
+{
+    Console.WriteLine("Revision,Commit,Type,Class,Filename");
+}
+
+// Display the details of each file of each revision
+foreach (var revision in revisions)
+{
+    bool drawDivider = false;
+    foreach (string affectedFileName in revision.AffectedFileNames)
+    {
+        if (!ignoredFiles.Contains(affectedFileName.ToLowerInvariant()))
+        {
+            FileChange fileChange = new FileChange(affectedFileName, settings, false);
+            string fileChangeType = fileChange.File.FileType.ToLocalizedString();
+
+            // Show an understandable file change type
+            if (string.IsNullOrWhiteSpace(fileChangeType))
+            {
+                if (fileChange.File.BookNum > 0)
+                {
+                    if (fileChange.File.FileTitle.Length > col2 && !csv)
+                    {
+                        fileChangeType = Canon.BookNumberToId(fileChange.File.BookNum);
+                    }
+                    else
+                    {
+                        fileChangeType = fileChange.File.FileTitle;
+                    }
+                }
+                else
+                {
+                    fileChangeType = fileChange.File.FileTitle;
+                }
+            }
+
+            // Get the classification
+            string classification = fileChange.File.FileType switch
+            {
+                ProjectFileType.Books => "BK",
+                ProjectFileType.Terms or ProjectFileType.Renderings => "BT",
+                ProjectFileType.Autocorrect
+                or ProjectFileType.Denials
+                or ProjectFileType.Figures
+                or ProjectFileType.Hyphenation
+                or ProjectFileType.Interlinear
+                or ProjectFileType.Lexicon
+                or ProjectFileType.ModuleSpecifications
+                or ProjectFileType.NotAProjectFile
+                or ProjectFileType.Passages
+                or ProjectFileType.PluginData
+                or ProjectFileType.Progress
+                or ProjectFileType.RubyGlosses
+                or ProjectFileType.SavedFilters
+                or ProjectFileType.SharedFiles
+                or ProjectFileType.SimplifiedMenus
+                or ProjectFileType.Spelling
+                or ProjectFileType.StatusCheckBoxes
+                or ProjectFileType.StudyBibleAdditions
+                or ProjectFileType.StudyBibleAdditionBooks
+                or ProjectFileType.Unspecified
+                    => "NA",
+                ProjectFileType.RolesPermissions => "PE",
+                ProjectFileType.Notes or ProjectFileType.NoteLanguages or ProjectFileType.NoteTags => "NT",
+                ProjectFileType.BookNames
+                or ProjectFileType.Canons
+                or ProjectFileType.LanguageSettings
+                or ProjectFileType.PropertiesAndSettings
+                or ProjectFileType.ProjectUpdate
+                or ProjectFileType.Stylesheet
+                or ProjectFileType.Versification
+                or ProjectFileType.XmlResourceProject
+                    => "PR",
+                _ => string.Empty,
+            };
+
+            WriteLine(revision, affectedFileName, classification, fileChangeType, ref drawDivider);
+        }
+    }
+
+    // Show the details of the merge commit
+    if (!revision.AffectedFileNames.Any())
+    {
+        WriteLine(revision, string.Join(',', revision.ParentRevNumbers), "NA", "Merge Commit", ref drawDivider);
+    }
+
+    if (drawDivider)
+    {
+        for (int i = 0; i < cols.Length; i++)
+        {
+            Console.Write(new string('-', cols[i]));
+            Console.Write('+');
+            if (i == cols.Length - 1)
+            {
+                // Draw a line to the edge of the console
+                Console.WriteLine(new string('-', lastCol));
+            }
+        }
+    }
+}
+
+void WriteLine(HgRevision revision, string fileName, string classification, string fileChangeType, ref bool drawDivider)
+{
+    if (csv)
+    {
+        // Do not let commas in the file name break the CSV file
+        if (fileName.Contains(',', StringComparison.OrdinalIgnoreCase))
+        {
+            fileName = $@"""{fileName}""";
+        }
+        Console.WriteLine(
+            $"{revision.LocalRevisionNumber},{revision.Id[..12]},{classification},{fileChangeType},{fileName}"
+        );
+    }
+    else
+    {
+        // Make sure the filename does not wrap to the next line
+        if (fileName.Length > lastCol)
+        {
+            fileName = $"...{fileName[(fileName.Length - lastCol + 3)..]}";
+        }
+        Console.WriteLine(
+            $"{revision.LocalRevisionNumber, -col1}|{revision.Id[..col2]}|{classification, -col3}|{fileChangeType, -col4}|{fileName}"
+        );
+
+        // Draw a divider at the end of this revision
+        drawDivider = canDrawDivider;
+    }
+}

--- a/tools/RepoInfo/Program.cs
+++ b/tools/RepoInfo/Program.cs
@@ -1,14 +1,14 @@
 /*
  * Paratext Repository Information Tool
  *
- * Usage: REPOINFO [CSV] projectpath
+ * Usage: dotnet run [CSV] projectpath
  *
  * Examples:
  *  - Display the repository information in the console:
- *      REPOINFO /var/lib/scriptureforge/sync/59e59e2dce4bb5c863c683c0c4647008dd9767d4
+ *      dotnet run /var/lib/scriptureforge/sync/59e59e2dce4bb5c863c683c0c4647008dd9767d4/target
  *
  *  - Output the repository information as a CSV file:
- *      REPOINFO CSV C:\My Paratext 9 Projects\ABC > output.csv
+ *      dotnet run CSV C:\My Paratext 9 Projects\ABC > output.csv
  *
  * Notes:
  *  - The Class column corresponds to how I classify the commit for sync in Scripture Forge
@@ -33,6 +33,8 @@ using Paratext.Data.ProjectSettingsAccess;
 using Paratext.Data;
 using SIL.Scripture;
 using SIL.XForge.Scripture.Services;
+
+#nullable enable
 
 // Get the project path, and CSV from the command line arguments
 // Allow the arguments to be in any order

--- a/tools/RepoInfo/RepoInfo.csproj
+++ b/tools/RepoInfo/RepoInfo.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\src\SIL.XForge.Scripture\Services\SFScrTextCollection.cs" Link="SFScrTextCollection.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\src\SIL.XForge.Scripture\changedChapter.py" Link="changedChapter.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\src\SIL.XForge.Scripture\ParatextMerge.py" Link="ParatextMerge.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\src\SIL.XForge.Scripture\revisionStyle.sty" Link="revisionStyle.sty">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\src\SIL.XForge.Scripture\revisionTemplate.tem" Link="revisionTemplate.tem">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ParatextData" Version="9.3.0.9" />
+  </ItemGroup>
+
+</Project>

--- a/tools/RepoInfo/RepoInfo.csproj
+++ b/tools/RepoInfo/RepoInfo.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
     <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
   </PropertyGroup>
 

--- a/tools/RepoInfo/RepoInfo.sln
+++ b/tools/RepoInfo/RepoInfo.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33627.172
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RepoInfo", "RepoInfo.csproj", "{98153D5D-C126-4CB7-9174-7ECFBB4E1A53}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{98153D5D-C126-4CB7-9174-7ECFBB4E1A53}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{98153D5D-C126-4CB7-9174-7ECFBB4E1A53}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98153D5D-C126-4CB7-9174-7ECFBB4E1A53}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{98153D5D-C126-4CB7-9174-7ECFBB4E1A53}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9BDDCD5B-EFE8-4CE2-B5EB-B7D64D15E454}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This Pull Request:
 * Ensures that only the books that can be edited in Scripture Forge are updated in the Paratext repository on sync
 * Parses the Paratext revisions to see what is changed, and only updates Scripture Forge's data in the areas that received changes
 * Adds a RepoInfo tool to explain what has changed in each revision in a Paratext repository

These changes will help improve sync speed for larger projects, with a minimal improvement for small projects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1845)
<!-- Reviewable:end -->
