### PR TITLE
SF-2021 Note tags are no longer updated on every sync

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ChapterEqualityComparer.cs
+++ b/src/SIL.XForge.Scripture/Services/ChapterEqualityComparer.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using SIL.XForge.Scripture.Models;
+
+namespace SIL.XForge.Scripture.Services;
+
+public class ChapterEqualityComparer : IEqualityComparer<Chapter>
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// We do not compare permissions, as these are modified in SFProjectService
+    /// </remarks>
+    public bool Equals(Chapter? x, Chapter? y) =>
+        x?.Number == y?.Number && x?.LastVerse == y?.LastVerse && x?.IsValid == y?.IsValid;
+
+    public int GetHashCode(Chapter? obj) => obj is null ? 0 : HashCode.Combine(obj.Number, obj.LastVerse, obj.IsValid);
+}

--- a/src/SIL.XForge.Scripture/Services/DictionaryComparer.cs
+++ b/src/SIL.XForge.Scripture/Services/DictionaryComparer.cs
@@ -6,25 +6,25 @@ namespace SIL.XForge.Scripture.Services;
 
 public class DictionaryComparer<TKey, TValue> : IEqualityComparer<Dictionary<TKey, TValue>>
 {
-    public bool Equals(Dictionary<TKey, TValue> x, Dictionary<TKey, TValue> y)
-    {
-        return (x ?? new Dictionary<TKey, TValue>())
+    public bool Equals(Dictionary<TKey, TValue>? x, Dictionary<TKey, TValue>? y) =>
+        (x ?? new Dictionary<TKey, TValue>())
             .OrderBy(p => p.Key)
             .SequenceEqual((y ?? new Dictionary<TKey, TValue>()).OrderBy(p => p.Key));
-    }
 
-    public int GetHashCode(Dictionary<TKey, TValue> obj)
+    public int GetHashCode(Dictionary<TKey, TValue>? obj)
     {
-        int hash = 0;
-        if (obj != null)
+        HashCode hashCode = new HashCode();
+        if (obj is null)
         {
-            foreach (KeyValuePair<TKey, TValue> element in obj)
-            {
-                hash ^= element.Key.GetHashCode();
-                hash ^= element.Value.GetHashCode();
-            }
+            return hashCode.ToHashCode();
         }
 
-        return hash;
+        foreach (KeyValuePair<TKey, TValue> element in obj.OrderBy(p => p.Key))
+        {
+            hashCode.Add(element.Key);
+            hashCode.Add(element.Value);
+        }
+
+        return hashCode.ToHashCode();
     }
 }

--- a/src/SIL.XForge.Scripture/Services/NoteTagEqualityComparer.cs
+++ b/src/SIL.XForge.Scripture/Services/NoteTagEqualityComparer.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using SIL.XForge.Scripture.Models;
+
+namespace SIL.XForge.Scripture.Services;
+
+public class NoteTagEqualityComparer : IEqualityComparer<NoteTag>
+{
+    public bool Equals(NoteTag? x, NoteTag? y) =>
+        x?.TagId == y?.TagId && x?.Icon == y?.Icon && x?.Name == y?.Name && x?.CreatorResolve == y?.CreatorResolve;
+
+    public int GetHashCode(NoteTag? obj) =>
+        obj is null ? 0 : HashCode.Combine(obj.TagId, obj.Icon, obj.Name, obj.CreatorResolve);
+}

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -59,6 +59,8 @@ public class ParatextSyncRunner : IParatextSyncRunner
     private static readonly double _numberOfPhases = Enum.GetValues(typeof(SyncPhase)).Length;
     private static readonly IEqualityComparer<List<Chapter>> _chapterListEqualityComparer =
         SequenceEqualityComparer.Create(new ChapterEqualityComparer());
+    private static readonly IEqualityComparer<IEnumerable<NoteTag>> _noteTagListEqualityComparer =
+        SequenceEqualityComparer.Create(new NoteTagEqualityComparer());
 
     /// <summary>
     /// The regular expression for finding whitespace before XML tags.
@@ -1468,7 +1470,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 op.Set(pd => pd.DefaultFont, settings.DefaultFont);
                 op.Set(pd => pd.DefaultFontSize, settings.DefaultFontSize);
                 if (settings.NoteTags != null)
-                    op.Set(pd => pd.NoteTags, settings.NoteTags);
+                    op.Set(pd => pd.NoteTags, settings.NoteTags, _noteTagListEqualityComparer);
             }
             // The source can be null if there was an error getting a resource from the DBL
             if (TranslationSuggestionsEnabled && _projectDoc.Data.TranslateConfig.Source != null)
@@ -1732,24 +1734,6 @@ public class ParatextSyncRunner : IParatextSyncRunner
         Phase5 = 4, // Getting the resource texts
         Phase6 = 5, // Updating texts from Paratext books
         Phase7 = 6, // Final methods
-    }
-
-    private class ChapterEqualityComparer : IEqualityComparer<Chapter>
-    {
-        public bool Equals(Chapter x, Chapter y) =>
-            // We do not compare permissions, as these are modified in SFProjectService
-            x.Number == y.Number
-            && x.LastVerse == y.LastVerse
-            && x.IsValid == y.IsValid;
-
-        public int GetHashCode(Chapter obj)
-        {
-            int code = 23;
-            code = code * 31 + obj.Number.GetHashCode();
-            code = code * 31 + obj.LastVerse.GetHashCode();
-            code = code * 31 + obj.IsValid.GetHashCode();
-            return code;
-        }
     }
 
     private void Log(string message, string? projectSFId = null, string? userId = null)

--- a/test/SIL.XForge.Scripture.Tests/Services/ChapterEqualityComparerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ChapterEqualityComparerTests.cs
@@ -1,0 +1,114 @@
+using NUnit.Framework;
+using SIL.XForge.Scripture.Models;
+
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class ChapterEqualityComparerTests
+{
+    [Test]
+    public void Equals_IsFalse()
+    {
+        var x = new Chapter
+        {
+            Number = 1,
+            LastVerse = 2,
+            IsValid = true,
+        };
+        var y = new Chapter
+        {
+            Number = 2,
+            LastVerse = 1,
+            IsValid = true,
+        };
+
+        // SUT
+        var comparer = new ChapterEqualityComparer();
+
+        Assert.IsFalse(comparer.Equals(x, y));
+    }
+
+    [Test]
+    public void Equals_IsTrue()
+    {
+        var x = new Chapter
+        {
+            Number = 1,
+            LastVerse = 2,
+            IsValid = true,
+        };
+        var y = new Chapter
+        {
+            Number = 1,
+            LastVerse = 2,
+            IsValid = true,
+        };
+
+        // SUT
+        var comparer = new ChapterEqualityComparer();
+
+        Assert.IsTrue(comparer.Equals(x, y));
+    }
+
+    [Test]
+    public void Equals_NullIsTrue()
+    {
+        // SUT
+        var comparer = new ChapterEqualityComparer();
+
+        Assert.IsTrue(comparer.Equals(null, null));
+    }
+
+    [Test]
+    public void GetHashCode_IsEqual()
+    {
+        var x = new Chapter
+        {
+            Number = 1,
+            LastVerse = 2,
+            IsValid = true,
+        };
+        var y = new Chapter
+        {
+            Number = 1,
+            LastVerse = 2,
+            IsValid = true,
+        };
+
+        // SUT
+        var comparer = new ChapterEqualityComparer();
+
+        Assert.AreEqual(comparer.GetHashCode(x), comparer.GetHashCode(y));
+    }
+
+    [Test]
+    public void GetHashCode_IsNotEqual()
+    {
+        var x = new Chapter
+        {
+            Number = 1,
+            LastVerse = 2,
+            IsValid = true,
+        };
+        var y = new Chapter
+        {
+            Number = 2,
+            LastVerse = 1,
+            IsValid = true,
+        };
+
+        // SUT
+        var comparer = new ChapterEqualityComparer();
+
+        Assert.AreNotEqual(comparer.GetHashCode(x), comparer.GetHashCode(y));
+    }
+
+    [Test]
+    public void GetHashCode_NullIsEqual()
+    {
+        // SUT
+        var comparer = new ChapterEqualityComparer();
+
+        Assert.AreEqual(comparer.GetHashCode(null), comparer.GetHashCode(null));
+    }
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/DictionaryComparerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DictionaryComparerTests.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class DictionaryComparerTests
+{
+    [Test]
+    public void Equals_IsFalse()
+    {
+        var x = new Dictionary<string, string> { { "one", "value_one" }, { "two", "value_two" } };
+        var y = new Dictionary<string, string> { { "one", "value_three" }, { "two", "value_two" } };
+
+        // SUT
+        var comparer = new DictionaryComparer<string, string>();
+
+        Assert.IsFalse(comparer.Equals(x, y));
+    }
+
+    [Test]
+    public void Equals_IsTrue()
+    {
+        var x = new Dictionary<string, string> { { "one", "value_one" }, { "two", "value_two" } };
+        var y = new Dictionary<string, string> { { "one", "value_one" }, { "two", "value_two" } };
+
+        // SUT
+        var comparer = new DictionaryComparer<string, string>();
+
+        Assert.IsTrue(comparer.Equals(x, y));
+    }
+
+    [Test]
+    public void Equals_NullIsTrue()
+    {
+        // SUT
+        var comparer = new DictionaryComparer<string, string>();
+
+        Assert.IsTrue(comparer.Equals(null, null));
+    }
+
+    [Test]
+    public void GetHashCode_IsEqual()
+    {
+        var x = new Dictionary<string, string> { { "one", "value_one" }, { "two", "value_two" } };
+        var y = new Dictionary<string, string> { { "two", "value_two" }, { "one", "value_one" } };
+
+        // SUT
+        var comparer = new DictionaryComparer<string, string>();
+
+        Assert.AreEqual(comparer.GetHashCode(x), comparer.GetHashCode(y));
+    }
+
+    [Test]
+    public void GetHashCode_IsNotEqual()
+    {
+        var x = new Dictionary<string, string> { { "one", "value_one" }, { "two", "value_two" } };
+        var y = new Dictionary<string, string> { { "one", "value_three" }, { "two", "value_two" } };
+
+        // SUT
+        var comparer = new DictionaryComparer<string, string>();
+
+        Assert.AreNotEqual(comparer.GetHashCode(x), comparer.GetHashCode(y));
+    }
+
+    [Test]
+    public void GetHashCode_NullIsEqual()
+    {
+        // SUT
+        var comparer = new DictionaryComparer<string, string>();
+
+        Assert.AreEqual(comparer.GetHashCode(null), comparer.GetHashCode(null));
+    }
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/NoteTagEqualityComparerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/NoteTagEqualityComparerTests.cs
@@ -1,0 +1,121 @@
+using NUnit.Framework;
+using SIL.XForge.Scripture.Models;
+
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class NoteTagEqualityComparerTests
+{
+    [Test]
+    public void Equals_IsFalse()
+    {
+        var x = new NoteTag
+        {
+            TagId = 0,
+            Icon = "icon",
+            Name = "name",
+            CreatorResolve = true,
+        };
+        var y = new NoteTag
+        {
+            TagId = 1,
+            Icon = "icon",
+            Name = "name",
+            CreatorResolve = true,
+        };
+
+        // SUT
+        var comparer = new NoteTagEqualityComparer();
+
+        Assert.IsFalse(comparer.Equals(x, y));
+    }
+
+    [Test]
+    public void Equals_IsTrue()
+    {
+        var x = new NoteTag
+        {
+            TagId = 0,
+            Icon = "icon",
+            Name = "name",
+            CreatorResolve = true,
+        };
+        var y = new NoteTag
+        {
+            TagId = 0,
+            Icon = "icon",
+            Name = "name",
+            CreatorResolve = true,
+        };
+        // SUT
+        var comparer = new NoteTagEqualityComparer();
+
+        Assert.IsTrue(comparer.Equals(x, y));
+    }
+
+    [Test]
+    public void Equals_NullIsTrue()
+    {
+        // SUT
+        var comparer = new NoteTagEqualityComparer();
+
+        Assert.IsTrue(comparer.Equals(null, null));
+    }
+
+    [Test]
+    public void GetHashCode_IsEqual()
+    {
+        var x = new NoteTag
+        {
+            TagId = 0,
+            Icon = "icon",
+            Name = "name",
+            CreatorResolve = true,
+        };
+        var y = new NoteTag
+        {
+            TagId = 0,
+            Icon = "icon",
+            Name = "name",
+            CreatorResolve = true,
+        };
+
+        // SUT
+        var comparer = new NoteTagEqualityComparer();
+
+        Assert.AreEqual(comparer.GetHashCode(x), comparer.GetHashCode(y));
+    }
+
+    [Test]
+    public void GetHashCode_IsNotEqual()
+    {
+        var x = new NoteTag
+        {
+            TagId = 0,
+            Icon = "icon",
+            Name = "name",
+            CreatorResolve = true,
+        };
+        var y = new NoteTag
+        {
+            TagId = 1,
+            Icon = "icon",
+            Name = "name",
+            CreatorResolve = true,
+        };
+
+        // SUT
+        var comparer = new NoteTagEqualityComparer();
+
+        Assert.AreNotEqual(comparer.GetHashCode(x), comparer.GetHashCode(y));
+    }
+
+    [Test]
+    public void GetHashCode_NullIsEqual()
+    {
+        // SUT
+        var comparer = new NoteTagEqualityComparer();
+
+        Assert.AreEqual(comparer.GetHashCode(null), comparer.GetHashCode(null));
+    }
+}


### PR DESCRIPTION
This PR fixes a bug where the NoteTags were recreated in ShareDB for a Project on every sync.

I also took the opportunity to:
 - Refactor the other equality comparers
 - Create unit tests for the equality comparers
 - Update hash code calculation to use the `HashCode` class which was introduced in .NET Core 2.1, rather than custom hash code generation

This PR comes from noticing unnecessary ops being created while optimizing the sync process.

These ops (which this PR stops the creation of) are:

![image](https://github.com/sillsdev/web-xforge/assets/8665431/b036cf0b-a277-43b5-a433-7a555572e07f)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1847)
<!-- Reviewable:end -->
