### PR TITLE
SF-1896 Scroll FAB button with the editor

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -300,6 +300,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   get id(): TextDocId | undefined {
     return this._id;
   }
+
   @Input() set id(value: TextDocId | undefined) {
     if (!isEqual(this._id, value)) {
       this._id = value;
@@ -340,6 +341,14 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
         this.clearHighlight();
       }
     }
+  }
+
+  get selectionBoundsTop(): number {
+    return this.highlightMarkerTop;
+  }
+
+  get scrollPosition(): number {
+    return this.editor == null ? 0 : this.editor.root.scrollTop;
   }
 
   get segmentRef(): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -106,7 +106,7 @@ app-text {
 }
 
 .insert-note-fab {
-  position: fixed;
+  position: absolute;
   visibility: hidden;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -164,6 +164,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   private toggleNoteThreadSub?: Subscription;
   private shouldNoteThreadsRespondToEdits: boolean = false;
   private commenterSelectedVerseRef?: VerseRef;
+  private scrollSubscription?: Subscription;
 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
@@ -747,6 +748,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         this.targetLoaded = true;
         this.toggleNoteThreadVerseRefs$.next();
         this.shouldNoteThreadsRespondToEdits = true;
+        if (this.target?.editor != null) {
+          this.subscribeScroll(this.target.editor);
+        }
         break;
     }
     if ((!this.hasSource || this.sourceLoaded) && this.targetLoaded) {
@@ -1373,7 +1377,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
           if (verseRef == null) return;
           if (this.canShowInsertNoteFab) {
             this.showInsertNoteFab = this.target.toggleVerseSelection(verseRef);
-            this.positionInsertNoteFab(segmentElement);
+            this.positionInsertNoteFab();
           } else {
             this.showInsertNoteFab = false;
           }
@@ -1443,7 +1447,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       const targetRect: DOMRect | undefined = this.targetContainer?.nativeElement.getBoundingClientRect();
       if (targetRect != null) {
         const adjustment: number = this.isTargetRightToLeft ? 20 : -60;
-        const leftCoordinate: number = (this.isTargetRightToLeft ? targetRect.left : targetRect.right) + adjustment;
+        const leftCoordinate: number =
+          (this.isTargetRightToLeft ? targetRect.left : targetRect.right - targetRect.left) + adjustment;
         this.insertNoteFabLeft = `${leftCoordinate}px`;
       }
     }, 10);
@@ -1566,11 +1571,12 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
   }
 
-  private positionInsertNoteFab(segmentElement: Element): void {
-    if (this.insertNoteFab == null || this.target == null || !this.isInsertNoteFabEnabled) return;
-    const selection: RangeStatic | null | undefined = this.target.editor?.getSelection();
+  private positionInsertNoteFab(): void {
+    if (this.insertNoteFab == null || this.target?.editor == null || !this.isInsertNoteFabEnabled) return;
+    const selection: RangeStatic | null | undefined = this.target.editor.getSelection();
     if (selection != null) {
-      this.insertNoteFab.nativeElement.style.top = `${segmentElement.getBoundingClientRect().top}px`;
+      this.insertNoteFab.nativeElement.style.top = `${this.target.selectionBoundsTop}px`;
+      this.insertNoteFab.nativeElement.style.marginTop = `-${this.target.scrollPosition}px`;
     } else {
       // hide the insert note FAB when the user clicks outside of the editor
       this.showInsertNoteFab = false;
@@ -1840,6 +1846,26 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       newScrollTop += sourceBottomPosition;
     }
     this.source.editor.scrollingContainer.scrollTop = newScrollTop;
+  }
+
+  private subscribeScroll(editor: Quill): void {
+    this.scrollSubscription?.unsubscribe();
+    this.scrollSubscription = this.subscribe(fromEvent(editor.root, 'scroll'), () => {
+      if (this.insertNoteFab == null || this.target == null || this.targetContainer == null) return;
+      const bounds: DOMRect = this.targetContainer.nativeElement.getBoundingClientRect();
+      const fabHeight = 40;
+      const targetContainerBottom: number = bounds.bottom - bounds.top - fabHeight;
+
+      // bound the FAB to the top of the editor
+      let scrollTop: number = Math.min(this.target.selectionBoundsTop, editor.root.scrollTop);
+      // bound the FAB to the bottom of the editor
+      const minScroll: number = Math.max(this.target.selectionBoundsTop - targetContainerBottom, 0);
+      if (scrollTop < minScroll) {
+        scrollTop = minScroll;
+      }
+
+      this.insertNoteFab.nativeElement.style.marginTop = `-${scrollTop}px`;
+    });
   }
 
   onViewerClicked(viewer: MultiCursorViewer): void {


### PR DESCRIPTION
The change scrolls the add note FAB with the editor as the user scrolls by setting the marginTop of the FAB element to be the inverse of the scroll value. As the user scrolls down, the FAB marginTop decreases, so it appears that the FAB is anchored to the selection in the editor.
When the FAB hits the top of bottom of the page, it will not move further. This prevents the fab from appear outside the editor.