### PR TITLE
SF-1960 Set display name when a user signs up with a phone number

### DIFF
--- a/src/SIL.XForge/Services/AuthService.cs
+++ b/src/SIL.XForge/Services/AuthService.cs
@@ -79,6 +79,20 @@ public class AuthService : DisposableBase, IAuthService
         return CallApiAsync(new HttpMethod("PATCH"), $"users/{authId}", content);
     }
 
+    /// <summary>
+    /// Used for SMS authentication as the user has their name and nickname set to their phone number which may get
+    /// exposed in future user requests. This method sets both values to "Anonymous" and is intended to be run once.
+    /// </summary>
+    public async Task<string> UpdateUserToAnonymous(string authId)
+    {
+        var content = new JObject(
+            new JProperty("name", "Anonymous"),
+            new JProperty("nickname", "Anonymous"),
+            new JProperty("picture", "https://cdn.auth0.com/avatars/a.png")
+        );
+        return await CallApiAsync(new HttpMethod("PATCH"), $"users/{authId}", content);
+    }
+
     private async Task<string> CallApiAsync(HttpMethod method, string url, JToken content = null)
     {
         bool refreshed = false;

--- a/src/SIL.XForge/Services/IAuthService.cs
+++ b/src/SIL.XForge/Services/IAuthService.cs
@@ -11,4 +11,5 @@ public interface IAuthService
     Task LinkAccounts(string primaryAuthId, string secondaryAuthId);
     Task UpdateAvatar(string authId, string url);
     Task UpdateInterfaceLanguage(string authId, string language);
+    Task<string> UpdateUserToAnonymous(string authId);
 }

--- a/src/SIL.XForge/Services/UserService.cs
+++ b/src/SIL.XForge/Services/UserService.cs
@@ -55,9 +55,16 @@ public class UserService : IUserService
         bool displayNameSetAtSignup = identities
             .OfType<JObject>()
             .Any(i => (string)i["connection"] == "Transparent-Authentication");
+        bool hasSMSConnection = identities.OfType<JObject>().Any(i => (string)i["connection"] == "sms");
         Regex emailRegex = new Regex(EMAIL_PATTERN);
         await using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
         {
+            // New SMS connection users have their name and nickname to the phone number which we need to change
+            // to anonymous. Users will be asked to set their display name once they start adding content.
+            if (hasSMSConnection && (string)userProfile["name"] == (string)userProfile["phone_number"])
+            {
+                userProfile = JObject.Parse(await _authService.UpdateUserToAnonymous((string)userProfile["user_id"]));
+            }
             string name = (string)userProfile["name"];
             IDocument<User> userDoc = await conn.FetchOrCreateAsync<User>(
                 curUserId,


### PR DESCRIPTION
- Update name, nickname, avatar on Auth0 profile if set to phone_number

*Notes*
* Decided to go with Anonymous rather than trying to generate a random name which may just cause other confusion
* Decided not to use any kind of gravatar type image which either needed an email address or storage for a randomly generated image in order for it to work in both the Auth0 profile and be accessible by our Angular Avatar component.
* As soon as a user updates their display name it will also update their avatar to something relevant
* When signing up for the first time on localhost auth0 tenant (sil-appbuilder) you get a oauth prompt which displays the phone number. At this point the name hasn't been updated. This prompt only appears on this tenant and is not displayed on QA/Live
* The implemented approach will resolve any user currently in this state the next time the log in to SF

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1852)
<!-- Reviewable:end -->
