### PR TITLE
SF-2029 Fixed Code Coverage failing Pull Requests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,3 +12,11 @@ flag_management:
         type: patch
         target: 90%
         informational: true
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
This Pull Request forces the Codecov errors to be informational. This previously worked, but a change to how Codecov loads the configuration caused a reduction in code coverage to give a red cross to a Pull Request or Commit.

When this PR had a commit included that removed tests, the following status displayed for Codecov:

![image](https://github.com/sillsdev/web-xforge/assets/8665431/db6d1732-3710-4b3f-aca6-101c58b27e07)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1854)
<!-- Reviewable:end -->
