### PR TITLE
Increase Hangfire Timeout to 4 hours

### DIFF
--- a/src/SIL.XForge/DataAccess/DataAccessServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/DataAccess/DataAccessServiceCollectionExtensions.cs
@@ -27,7 +27,7 @@ public static class DataAccessServiceCollectionExtensions
                     new MongoStorageOptions
                     {
                         CheckQueuedJobsStrategy = CheckQueuedJobsStrategy.TailNotificationsCollection,
-                        InvisibilityTimeout = TimeSpan.FromMinutes(180),
+                        InvisibilityTimeout = TimeSpan.FromMinutes(240),
                         MigrationOptions = new MongoMigrationOptions
                         {
                             MigrationStrategy = new MigrateMongoMigrationStrategy(),


### PR DESCRIPTION
It was increased to 3 hours in #1853, but apparently not by enough. The job on live has still be restarting itself. I think it must be going just beyond 3 hours.

Long term this shouldn't be an issue, as we are moving to Serval.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1858)
<!-- Reviewable:end -->
