### PR TITLE
tool: Update Chromatic workflow to build tip of branch

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Chromatic requires git history
+          ref: ${{ github.event.pull_request.head.sha }} # Chromatic needs the PR branch, not the merge to master
       - name: "Deps: Node"
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Part of the reason Chromatic is so confused is because when we run our builds, by default we check out a merge of the PR branch to the target branch, rather than the tip of the target branch (this is GitHub being smart about making sure any builds will pass after merging, and not just on the PR branch).

However, since Chromatic needs to understand Git history to calculate baselines, [they recommend](https://www.chromatic.com/docs/github-actions#recommended-configuration-for-build-events) using the push event rather than the pull_request event. I didn't like that idea, so I instead opted to just explicitly tell `actions/checkout@v3` to check out the tip of the branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1859)
<!-- Reviewable:end -->
