### PR TITLE
SF-1934 Fix RTL language marker not recognized in combined verses

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/text-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/text-doc.ts
@@ -7,6 +7,7 @@ import {
   TEXT_INDEX_PATHS
 } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
 import { RealtimeDoc } from 'xforge-common/models/realtime-doc';
+import { RIGHT_TO_LEFT_MARK, VERSE_FROM_SEGMENT_REF_REGEX } from '../../shared/utils';
 
 export const Delta: new (ops?: DeltaOperation[] | { ops: DeltaOperation[] }) => DeltaStatic = Quill.import('delta');
 
@@ -82,7 +83,7 @@ export class TextDoc extends RealtimeDoc<TextData, TextData, RangeStatic> {
     return text;
   }
 
-  getSegmentTextIncludingRelated(ref: string): string {
+  getSegmentTextIncludingRelated(verseStr: string): string {
     if (this.data == null || this.data.ops == null) {
       return '';
     }
@@ -101,10 +102,9 @@ export class TextDoc extends RealtimeDoc<TextData, TextData, RangeStatic> {
         continue;
       }
       // Locate range of ops that match the verse segments
-      if (
-        op.attributes?.segment != null &&
-        (op.attributes.segment === ref || op.attributes.segment.indexOf(ref + '/') === 0)
-      ) {
+      const opSegmentRef: string = op.attributes?.segment ?? '';
+      const match: RegExpMatchArray | null = VERSE_FROM_SEGMENT_REF_REGEX.exec(opSegmentRef);
+      if (match != null && match[1].replace(RIGHT_TO_LEFT_MARK, '') === verseStr) {
         text += textBetweenRelatedSegments + op.insert;
         // Reset text so no double-ups
         textBetweenRelatedSegments = '';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
@@ -4,7 +4,7 @@ import { isParatextRole, SFProjectRole } from 'realtime-server/lib/esm/scripture
 import { TextData } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
 import { CheckingAnswerExport } from 'realtime-server/lib/esm/scriptureforge/models/checking-config';
 import { Delta, TextDocId } from '../core/models/text-doc';
-import { rightLeftMarker } from './utils';
+import { RIGHT_TO_LEFT_MARK } from './utils';
 
 export function getTextDoc(id: TextDocId): TextData {
   const delta = new Delta();
@@ -38,7 +38,7 @@ export function getTextDoc(id: TextDocId): TextData {
 }
 
 export function getCombinedVerseTextDoc(id: TextDocId, rtl: boolean = false): TextData {
-  const verseStr: string = rtl ? `2${rightLeftMarker}-3` : '2-3';
+  const verseStr: string = rtl ? `2${RIGHT_TO_LEFT_MARK}-3` : '2-3';
   const delta = new Delta();
   delta.insert(`Title for chapter ${id.chapterNum}`, { segment: 's_1' });
   delta.insert('\n', { para: { style: 's' } });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
@@ -4,6 +4,7 @@ import { isParatextRole, SFProjectRole } from 'realtime-server/lib/esm/scripture
 import { TextData } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
 import { CheckingAnswerExport } from 'realtime-server/lib/esm/scriptureforge/models/checking-config';
 import { Delta, TextDocId } from '../core/models/text-doc';
+import { rightLeftMarker } from './utils';
 
 export function getTextDoc(id: TextDocId): TextData {
   const delta = new Delta();
@@ -36,7 +37,8 @@ export function getTextDoc(id: TextDocId): TextData {
   return delta;
 }
 
-export function getCombinedVerseTextDoc(id: TextDocId): TextData {
+export function getCombinedVerseTextDoc(id: TextDocId, rtl: boolean = false): TextData {
+  const verseStr: string = rtl ? `2${rightLeftMarker}-3` : '2-3';
   const delta = new Delta();
   delta.insert(`Title for chapter ${id.chapterNum}`, { segment: 's_1' });
   delta.insert('\n', { para: { style: 's' } });
@@ -44,8 +46,10 @@ export function getCombinedVerseTextDoc(id: TextDocId): TextData {
   delta.insert({ blank: true }, { segment: 'p_1' });
   delta.insert({ verse: { number: '1', style: 'v' } });
   delta.insert(`${id.textType}: chapter ${id.chapterNum}, verse 1.`, { segment: `verse_${id.chapterNum}_1` });
-  delta.insert({ verse: { number: '2-3', style: 'v' } });
-  delta.insert(`${id.textType}: chapter ${id.chapterNum}, verse 2-3.`, { segment: `verse_${id.chapterNum}_2-3` });
+  delta.insert({ verse: { number: verseStr, style: 'v' } });
+  delta.insert(`${id.textType}: chapter ${id.chapterNum}, verse 2-3.`, {
+    segment: `verse_${id.chapterNum}_${verseStr}`
+  });
   delta.insert('\n', { para: { style: 'p' } });
   delta.insert('Text in section heading', { segment: 's_2' });
   delta.insert('\n', { para: { style: 's' } });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
@@ -38,7 +38,8 @@ export function getTextDoc(id: TextDocId): TextData {
 }
 
 export function getCombinedVerseTextDoc(id: TextDocId, rtl: boolean = false): TextData {
-  const verseStr: string = rtl ? `2${RIGHT_TO_LEFT_MARK}-3` : '2-3';
+  const verse2Str: string = rtl ? `2${RIGHT_TO_LEFT_MARK}-3` : '2-3';
+  const verse5Str: string = rtl ? `5${RIGHT_TO_LEFT_MARK},7` : '5,7';
   const delta = new Delta();
   delta.insert(`Title for chapter ${id.chapterNum}`, { segment: 's_1' });
   delta.insert('\n', { para: { style: 's' } });
@@ -46,9 +47,9 @@ export function getCombinedVerseTextDoc(id: TextDocId, rtl: boolean = false): Te
   delta.insert({ blank: true }, { segment: 'p_1' });
   delta.insert({ verse: { number: '1', style: 'v' } });
   delta.insert(`${id.textType}: chapter ${id.chapterNum}, verse 1.`, { segment: `verse_${id.chapterNum}_1` });
-  delta.insert({ verse: { number: verseStr, style: 'v' } });
+  delta.insert({ verse: { number: verse2Str, style: 'v' } });
   delta.insert(`${id.textType}: chapter ${id.chapterNum}, verse 2-3.`, {
-    segment: `verse_${id.chapterNum}_${verseStr}`
+    segment: `verse_${id.chapterNum}_${verse2Str}`
   });
   delta.insert('\n', { para: { style: 'p' } });
   delta.insert('Text in section heading', { segment: 's_2' });
@@ -56,6 +57,10 @@ export function getCombinedVerseTextDoc(id: TextDocId, rtl: boolean = false): Te
   delta.insert({ blank: true }, { segment: 'p_2' });
   delta.insert({ verse: { number: '4', style: 'v' } });
   delta.insert(`${id.textType}: chapter ${id.chapterNum}, verse 4.`, { segment: `verse_${id.chapterNum}_4` });
+  delta.insert({ verse: { number: verse5Str, style: 'v' } });
+  delta.insert(`${id.textType}: chapter ${id.chapterNum}, verse 5,7.`, {
+    segment: `verse_${id.chapterNum}_${verse5Str}`
+  });
   delta.insert('\n', { para: { style: 'p' } });
   return delta;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -7,7 +7,7 @@ import { SelectableProject } from '../core/paratext.service';
 
 // Regular expression for getting the verse from a segment ref
 // Some projects will have the right to left marker in the segment attribute which we need to account for
-export const VERSE_FROM_SEGMENT_REF_REGEX = /verse_\d+_(\d+[\u200f]?-?,?\d*[^\/]?)/;
+export const VERSE_FROM_SEGMENT_REF_REGEX = /verse_\d+_(\d+[\u200f]?[,-]?\d*[^\/]?)/;
 // Regular expression for the verse segment ref of scripture content
 export const VERSE_REGEX = /verse_[0-9]+_[0-9]+/;
 export const RIGHT_TO_LEFT_MARK = '\u200f';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -6,10 +6,11 @@ import { DeltaOperation } from 'rich-text';
 import { SelectableProject } from '../core/paratext.service';
 
 // Regular expression for getting the verse from a segment ref
-export const VERSE_FROM_SEGMENT_REF_REGEX = /verse_\d+_(\d+-?\d*)/;
+// Some projects will have the right to left marker in the segment attribute which we need to account for
+export const VERSE_FROM_SEGMENT_REF_REGEX = /verse_\d+_(\d+[\u200f]?-?\d*[^\/]?)/;
 // Regular expression for the verse segment ref of scripture content
 export const VERSE_REGEX = /verse_[0-9]+_[0-9]+/;
-export const rightLeftMarker = '\u200f';
+export const RIGHT_TO_LEFT_MARK = '\u200f';
 
 export function combineVerseRefStrs(startStr?: string, endStr?: string): VerseRef | undefined {
   if (!startStr) {
@@ -66,10 +67,8 @@ export function getVerseRefFromSegmentRef(bookNum: number, segmentRef: string): 
   return new VerseRef(bookNum, parts[1], parts[2]);
 }
 
-export function verseSlug(verse: VerseRef, isRtl: boolean): string {
-  let versePart: string = verse.verse == null ? `${verse.verseNum}` : verse.verse;
-  versePart = isRtl ? versePart.replace('-', `${rightLeftMarker}-`) : versePart;
-  return 'verse_' + verse.chapterNum + '_' + versePart;
+export function verseSlug(verse: VerseRef): string {
+  return 'verse_' + verse.chapterNum + '_' + (verse.verse == null ? verse.verseNum : verse.verse);
 }
 
 export function verseRefFromMouseEvent(event: MouseEvent, bookNum: number): VerseRef | undefined {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -7,7 +7,7 @@ import { SelectableProject } from '../core/paratext.service';
 
 // Regular expression for getting the verse from a segment ref
 // Some projects will have the right to left marker in the segment attribute which we need to account for
-export const VERSE_FROM_SEGMENT_REF_REGEX = /verse_\d+_(\d+[\u200f]?-?\d*[^\/]?)/;
+export const VERSE_FROM_SEGMENT_REF_REGEX = /verse_\d+_(\d+[\u200f]?-?,?\d*[^\/]?)/;
 // Regular expression for the verse segment ref of scripture content
 export const VERSE_REGEX = /verse_[0-9]+_[0-9]+/;
 export const RIGHT_TO_LEFT_MARK = '\u200f';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -9,6 +9,7 @@ import { SelectableProject } from '../core/paratext.service';
 export const VERSE_FROM_SEGMENT_REF_REGEX = /verse_\d+_(\d+-?\d*)/;
 // Regular expression for the verse segment ref of scripture content
 export const VERSE_REGEX = /verse_[0-9]+_[0-9]+/;
+export const rightLeftMarker = '\u200f';
 
 export function combineVerseRefStrs(startStr?: string, endStr?: string): VerseRef | undefined {
   if (!startStr) {
@@ -65,8 +66,10 @@ export function getVerseRefFromSegmentRef(bookNum: number, segmentRef: string): 
   return new VerseRef(bookNum, parts[1], parts[2]);
 }
 
-export function verseSlug(verse: VerseRef): string {
-  return 'verse_' + verse.chapterNum + '_' + (verse.verse == null ? verse.verseNum : verse.verse);
+export function verseSlug(verse: VerseRef, isRtl: boolean): string {
+  let versePart: string = verse.verse == null ? `${verse.verseNum}` : verse.verse;
+  versePart = isRtl ? versePart.replace('-', `${rightLeftMarker}-`) : versePart;
+  return 'verse_' + verse.chapterNum + '_' + versePart;
 }
 
 export function verseRefFromMouseEvent(event: MouseEvent, bookNum: number): VerseRef | undefined {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -49,7 +49,7 @@ import { SFProjectUserConfigDoc } from '../../../core/models/sf-project-user-con
 import { SF_TYPE_REGISTRY } from '../../../core/models/sf-type-registry';
 import { TextDoc, TextDocId } from '../../../core/models/text-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
-import { getTextDoc, paratextUsersFromRoles } from '../../../shared/test-utils';
+import { getCombinedVerseTextDoc, getTextDoc, paratextUsersFromRoles } from '../../../shared/test-utils';
 import { TranslateModule } from '../../translate.module';
 import { NoteDialogComponent, NoteDialogData, NoteDialogResult } from './note-dialog.component';
 
@@ -103,6 +103,12 @@ describe('NoteDialogComponent', () => {
     env = new TestEnvironment({ noteThread });
     expect(env.textMenuButton).toBeFalsy();
     expect(env.component.isSegmentDifferentFromContext).toBeFalse();
+  }));
+
+  it('shows segment text for rtl combined verses', fakeAsync(() => {
+    const verseRef: VerseRef = VerseRef.parse('MAT 1:2-3');
+    env = new TestEnvironment({ verseRef, isRightToLeftProject: true, combinedVerseTextDoc: true });
+    expect(env.noteText.nativeElement.textContent).toBe('target: chapter 1, verse 2-3.');
   }));
 
   it('should not show deleted notes', fakeAsync(() => {
@@ -487,6 +493,7 @@ interface TestEnvironmentConstructorArgs {
   noteThread?: NoteThread;
   verseRef?: VerseRef;
   noteTagId?: number;
+  combinedVerseTextDoc?: boolean;
 }
 
 class TestEnvironment {
@@ -713,7 +720,8 @@ class TestEnvironment {
     currentUserId = 'user01',
     noteThread,
     verseRef,
-    noteTagId
+    noteTagId,
+    combinedVerseTextDoc
   }: TestEnvironmentConstructorArgs = {}) {
     this.fixture = TestBed.createComponent(ChildViewContainerComponent);
     const textDocId = new TextDocId(TestEnvironment.PROJECT01, 40, 1);
@@ -740,7 +748,9 @@ class TestEnvironment {
         id: configData.projectId,
         data: TestEnvironment.testProjectProfile
       });
-      const textData = getTextDoc(textDocId);
+      const textData: TextData = combinedVerseTextDoc
+        ? getCombinedVerseTextDoc(textDocId, isRightToLeftProject)
+        : getTextDoc(textDocId);
       this.realtimeService.addSnapshot<TextData>(TextDoc.COLLECTION, {
         id: textDocId.toString(),
         data: textData,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -111,6 +111,12 @@ describe('NoteDialogComponent', () => {
     expect(env.noteText.nativeElement.textContent).toBe('target: chapter 1, verse 2-3.');
   }));
 
+  it('shows segment text for rtl multiple verses', fakeAsync(() => {
+    const verseRef: VerseRef = VerseRef.parse('MAT 1:5,7');
+    env = new TestEnvironment({ verseRef, isRightToLeftProject: true, combinedVerseTextDoc: true });
+    expect(env.noteText.nativeElement.textContent).toBe('target: chapter 1, verse 5,7.');
+  }));
+
   it('should not show deleted notes', fakeAsync(() => {
     env = new TestEnvironment({ noteThread: TestEnvironment.getNoteThread() });
     expect(env.notes.length).toBe(4);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -20,7 +20,7 @@ import { SFProjectDoc } from '../../../core/models/sf-project-doc';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { TextDoc, TextDocId } from '../../../core/models/text-doc';
-import { canInsertNote, formatFontSizeToRems, verseSlug } from '../../../shared/utils';
+import { canInsertNote, formatFontSizeToRems } from '../../../shared/utils';
 
 export interface NoteDialogData {
   threadId?: string;
@@ -151,8 +151,7 @@ export class NoteDialogComponent implements OnInit {
     if (verseRef == null) {
       return '';
     }
-    const verseSegment: string = verseSlug(verseRef, this.isRtl);
-    return this.textDoc.getSegmentTextIncludingRelated(verseSegment);
+    return this.textDoc.getSegmentTextIncludingRelated(verseRef.verse ?? verseRef.verseNum);
   }
 
   get canInsertNote(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -19,9 +19,8 @@ import { defaultNoteThreadIcon, NoteThreadDoc } from '../../../core/models/note-
 import { SFProjectDoc } from '../../../core/models/sf-project-doc';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
-import { SFProjectUserConfigDoc } from '../../../core/models/sf-project-user-config-doc';
 import { TextDoc, TextDocId } from '../../../core/models/text-doc';
-import { canInsertNote, formatFontSizeToRems } from '../../../shared/utils';
+import { canInsertNote, formatFontSizeToRems, verseSlug } from '../../../shared/utils';
 
 export interface NoteDialogData {
   threadId?: string;
@@ -52,7 +51,6 @@ export class NoteDialogComponent implements OnInit {
   private textDoc?: TextDoc;
   private paratextProjectUsers?: ParatextUserProfile[];
   private noteIdBeingEdited?: string;
-  private projectUserConfigDoc?: SFProjectUserConfigDoc;
   private userRole?: string;
 
   constructor(
@@ -89,9 +87,6 @@ export class NoteDialogComponent implements OnInit {
         );
       }
     }
-
-    this.projectUserConfigDoc = await this.projectService.getUserConfig(this.projectId, this.userService.currentUserId);
-    this.projectUserConfigDoc = await this.projectService.getUserConfig(this.projectId, this.userService.currentUserId);
   }
 
   get canViewAssignedUser(): boolean {
@@ -156,7 +151,8 @@ export class NoteDialogComponent implements OnInit {
     if (verseRef == null) {
       return '';
     }
-    return this.textDoc.getSegmentTextIncludingRelated(`verse_${verseRef.chapter}_${verseRef.verse}`);
+    const verseSegment: string = verseSlug(verseRef, this.isRtl);
+    return this.textDoc.getSegmentTextIncludingRelated(verseSegment);
   }
 
   get canInsertNote(): boolean {


### PR DESCRIPTION
The right-to-left marker exists in the usfm of right-to-left projects on combined verses. This was causing problems because when we looked up text for a specific verse, if the right-to-left marker existed on the op, we would not get a match. This change helps to generate a verse ref that correctly matches what exists on the segment attribute of text ops so we can correctly look up the text strings in a text doc so they can be displayed in the note dialog.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1864)
<!-- Reviewable:end -->
