### PR TITLE
Update NPM dependencies flagged as vulnerable

### DIFF
--- a/scripts/db_tools/package-lock.json
+++ b/scripts/db_tools/package-lock.json
@@ -704,9 +704,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
-      "integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.3.tgz",
+      "integrity": "sha512-JMafRntWVO2DCJimKsRTh/wnqVvO4hrfwOqtO7f+uzwsQMuxO6VwImtYxaQ+ieoyshWOTJyV0fA21lccEXRPpQ==",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"
@@ -1453,9 +1453,9 @@
       }
     },
     "socket.io-parser": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
-      "integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.3.tgz",
+      "integrity": "sha512-JMafRntWVO2DCJimKsRTh/wnqVvO4hrfwOqtO7f+uzwsQMuxO6VwImtYxaQ+ieoyshWOTJyV0fA21lccEXRPpQ==",
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"

--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -13468,6 +13468,12 @@
         "lodash.values": "^4.3.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
+      "dev": true
+    },
     "node_modules/@storybook/addon-actions": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-7.0.5.tgz",
@@ -22342,11 +22348,6 @@
         "@types/responselike": "^1.0.0"
       }
     },
-    "node_modules/@types/component-emitter": {
-      "version": "1.2.11",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/connect": {
       "version": "3.4.35",
       "dev": true,
@@ -22366,13 +22367,18 @@
     },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "dev": true
     },
     "node_modules/@types/cors": {
-      "version": "2.8.12",
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
       "dev": true,
-      "license": "MIT"
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/detect-port": {
       "version": "1.3.2",
@@ -24837,8 +24843,9 @@
     },
     "node_modules/base64id": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^4.5.0 || >= 5.9"
       }
@@ -26115,11 +26122,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/component-emitter": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "dev": true,
@@ -26300,8 +26302,9 @@
     },
     "node_modules/cookie": {
       "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -27636,9 +27639,10 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.2.1",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.2.tgz",
+      "integrity": "sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",
@@ -27649,16 +27653,17 @@
         "cors": "~2.8.5",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.0.3",
-        "ws": "~8.2.3"
+        "ws": "~8.11.0"
       },
       "engines": {
         "node": ">=10.0.0"
       }
     },
     "node_modules/engine.io-parser": {
-      "version": "5.0.4",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.7.tgz",
+      "integrity": "sha512-P+jDFbvK6lE3n1OL+q9KuzdOFWkkZ/cMV9gol/SbVfpyqfvrfrFTOFJ6fQm2VC3PZHlU3QPhVwmbsCnauHF2MQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -36271,11 +36276,13 @@
       }
     },
     "node_modules/lint-staged/node_modules/yaml": {
-      "version": "2.1.1",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.0.tgz",
+      "integrity": "sha512-8/1wgzdKc7bc9E6my5wZjmdavHLvO/QOmLG1FBugblEvY4IXrLjlViIOmL24HthU042lWTDRO90Fz1Yp66UnMw==",
       "dev": true,
-      "license": "ISC",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14",
+        "npm": ">= 7"
       }
     },
     "node_modules/listr2": {
@@ -44260,33 +44267,38 @@
       "dev": true
     },
     "node_modules/socket.io": {
-      "version": "4.5.1",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.1.tgz",
+      "integrity": "sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
         "debug": "~4.3.2",
-        "engine.io": "~6.2.0",
-        "socket.io-adapter": "~2.4.0",
-        "socket.io-parser": "~4.0.4"
+        "engine.io": "~6.4.1",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.1"
       },
       "engines": {
         "node": ">=10.0.0"
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.4.0",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+      "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
       "dev": true,
-      "license": "MIT"
+      "dependencies": {
+        "ws": "~8.11.0"
+      }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.0.5",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.3.tgz",
+      "integrity": "sha512-JMafRntWVO2DCJimKsRTh/wnqVvO4hrfwOqtO7f+uzwsQMuxO6VwImtYxaQ+ieoyshWOTJyV0fA21lccEXRPpQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@types/component-emitter": "^1.2.10",
-        "component-emitter": "~1.3.0",
+        "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"
       },
       "engines": {
@@ -47751,26 +47763,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.11.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/webpack-hot-middleware": {
       "version": "2.25.3",
       "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.25.3.tgz",
@@ -48155,9 +48147,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.2.3",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -52773,6 +52766,12 @@
         "lodash.union": "^4.6.0",
         "lodash.values": "^4.3.0"
       }
+    },
+    "@socket.io/component-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
+      "dev": true
     },
     "@storybook/addon-actions": {
       "version": "7.0.5",
@@ -59243,10 +59242,6 @@
         "@types/responselike": "^1.0.0"
       }
     },
-    "@types/component-emitter": {
-      "version": "1.2.11",
-      "dev": true
-    },
     "@types/connect": {
       "version": "3.4.35",
       "dev": true,
@@ -59264,11 +59259,18 @@
     },
     "@types/cookie": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
       "dev": true
     },
     "@types/cors": {
-      "version": "2.8.12",
-      "dev": true
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/detect-port": {
       "version": "1.3.2",
@@ -61067,6 +61069,8 @@
     },
     "base64id": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
       "dev": true
     },
     "basic-auth": {
@@ -61941,10 +61945,6 @@
       "version": "1.0.1",
       "dev": true
     },
-    "component-emitter": {
-      "version": "1.3.0",
-      "dev": true
-    },
     "compressible": {
       "version": "2.0.18",
       "dev": true,
@@ -62080,6 +62080,8 @@
     },
     "cookie": {
       "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "dev": true
     },
     "cookie-signature": {
@@ -63005,7 +63007,9 @@
       }
     },
     "engine.io": {
-      "version": "6.2.1",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.2.tgz",
+      "integrity": "sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==",
       "dev": true,
       "requires": {
         "@types/cookie": "^0.4.1",
@@ -63017,11 +63021,13 @@
         "cors": "~2.8.5",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.0.3",
-        "ws": "~8.2.3"
+        "ws": "~8.11.0"
       }
     },
     "engine.io-parser": {
-      "version": "5.0.4",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.7.tgz",
+      "integrity": "sha512-P+jDFbvK6lE3n1OL+q9KuzdOFWkkZ/cMV9gol/SbVfpyqfvrfrFTOFJ6fQm2VC3PZHlU3QPhVwmbsCnauHF2MQ==",
       "dev": true
     },
     "enhanced-resolve": {
@@ -69029,7 +69035,9 @@
       },
       "dependencies": {
         "yaml": {
-          "version": "2.1.1",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.0.tgz",
+          "integrity": "sha512-8/1wgzdKc7bc9E6my5wZjmdavHLvO/QOmLG1FBugblEvY4IXrLjlViIOmL24HthU042lWTDRO90Fz1Yp66UnMw==",
           "dev": true
         }
       }
@@ -79187,27 +79195,35 @@
       }
     },
     "socket.io": {
-      "version": "4.5.1",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.1.tgz",
+      "integrity": "sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
         "debug": "~4.3.2",
-        "engine.io": "~6.2.0",
-        "socket.io-adapter": "~2.4.0",
-        "socket.io-parser": "~4.0.4"
+        "engine.io": "~6.4.1",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.1"
       }
     },
     "socket.io-adapter": {
-      "version": "2.4.0",
-      "dev": true
-    },
-    "socket.io-parser": {
-      "version": "4.0.5",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+      "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
       "dev": true,
       "requires": {
-        "@types/component-emitter": "^1.2.10",
-        "component-emitter": "~1.3.0",
+        "ws": "~8.11.0"
+      }
+    },
+    "socket.io-parser": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.3.tgz",
+      "integrity": "sha512-JMafRntWVO2DCJimKsRTh/wnqVvO4hrfwOqtO7f+uzwsQMuxO6VwImtYxaQ+ieoyshWOTJyV0fA21lccEXRPpQ==",
+      "dev": true,
+      "requires": {
+        "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"
       }
     },
@@ -81642,10 +81658,6 @@
             "ajv-formats": "^2.1.1",
             "ajv-keywords": "^5.0.0"
           }
-        },
-        "ws": {
-          "version": "8.11.0",
-          "dev": true
         }
       }
     },
@@ -81886,7 +81898,9 @@
       }
     },
     "ws": {
-      "version": "8.2.3",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "dev": true
     },
     "xml": {


### PR DESCRIPTION
This pull request updates the following vulnerable dependencies:

Dependencies of Karma:
 * socket.io-parser (see https://github.com/sillsdev/web-xforge/security/dependabot/83)
 * engine.io (Uncaught Exception vulnerability - https://github.com/advisories/GHSA-q9mw-68c2-j6m5)

Dependency of lint-staged:
 * yaml (Uncaught Exception in yaml - https://github.com/advisories/GHSA-f9xv-q969-pqx4)

Dependency of the ping-rts DB tool:
 * socket.io-parser (see https://github.com/sillsdev/web-xforge/security/dependabot/84)
 
These are only used in testing and development.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1865)
<!-- Reviewable:end -->
