### PR TITLE
SF-1506 Maintain consistent font size for va markers

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -371,9 +371,9 @@ usx-verse {
     margin: 0 0.2em 0 0.3em;
     color: #7c7c7c;
     span[data-style='va'] {
-      font-size: 65%;
+      font-size: 85%;
       color: #5faa5f;
-      top: -0.5em;
+      top: -0.25em;
       position: relative;
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -343,6 +343,12 @@ usx-char {
     color: #5faa5f;
     top: -0.5em;
     position: relative;
+    &:before {
+      content: '(';
+    }
+    &:after {
+      content: ')';
+    }
   }
 }
 
@@ -375,6 +381,12 @@ usx-verse {
       color: #5faa5f;
       top: -0.25em;
       position: relative;
+      &:before {
+        content: '(';
+      }
+      &:after {
+        content: ')';
+      }
     }
   }
 }


### PR DESCRIPTION
The display of the va tag was different sizes depending on whether the marker was next to the base verse embed, or if it was in the middle of a verse. The marker next to a verse embed was smaller. This change bumps up the size of the va text so it is the  same size regardless of where it occurs. The images have been updated now.

Before
![image](https://github.com/sillsdev/web-xforge/assets/17931130/1b8f2dfb-b01a-4cc3-a397-e70b709e77c7)

After
![image](https://github.com/sillsdev/web-xforge/assets/17931130/97b51aa0-3582-4a0c-aef2-7f998cef9caf)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1867)
<!-- Reviewable:end -->
