### PR TITLE
SF-2039 Convert drawer to Material

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -98,18 +98,21 @@
       </mat-toolbar-row>
     </mat-toolbar>
   </header>
-  <mdc-drawer
-    id="menu-drawer"
-    *ngIf="isProjectSelected"
-    [drawer]="isDrawerPermanent ? 'permanent' : 'modal'"
-    [open]="isExpanded"
-    (closed)="drawerCollapsed()"
+
+  <mat-drawer-container
+    class="top-app-bar-adjust"
+    [class.top-app-bar-adjust-double]="hasUpdate"
+    [dir]="i18n.direction"
+    autosize
   >
-    <mdc-drawer-header>
-      <div
-        [class.top-app-bar-adjust]="isDrawerPermanent"
-        [class.top-app-bar-adjust-double]="hasUpdate && isDrawerPermanent"
-      ></div>
+    <mat-drawer
+      #drawer
+      id="menu-drawer"
+      [mode]="isDrawerPermanent ? 'side' : 'over'"
+      *ngIf="isProjectSelected"
+      [opened]="isExpanded || isDrawerPermanent"
+      (closed)="drawerCollapsed()"
+    >
       <mdc-select
         *ngIf="projectDocs != null"
         dir="auto"
@@ -129,8 +132,6 @@
           </mdc-list>
         </mdc-menu>
       </mdc-select>
-    </mdc-drawer-header>
-    <mdc-drawer-content>
       <mat-nav-list id="tools-menu-list">
         <a
           mat-list-item
@@ -207,6 +208,7 @@
           </ng-container>
         </div>
       </mat-nav-list>
+      <div class="nav-spacer"></div>
       <mat-nav-list id="admin-pages-menu-list" *ngIf="canSeeAdminPages$ | async">
         <mat-divider></mat-divider>
         <div *ngIf="canSync$ | async">
@@ -250,19 +252,13 @@
           </a>
         </div>
       </mat-nav-list>
-    </mdc-drawer-content>
-  </mdc-drawer>
-  <!-- The cdkScrollable attribute is needed so the CDK can listen to scroll events within this container -->
-  <div
-    #appContent
-    cdkScrollable
-    class="app-content top-app-bar-adjust"
-    [class.top-app-bar-adjust-double]="hasUpdate"
-    [dir]="i18n.direction"
-  >
-    <div>
-      <router-outlet></router-outlet>
-      <p *ngIf="showCheckingDisabled" class="checking-unavailable">{{ t("scripture_checking_not_available") }}</p>
+    </mat-drawer>
+    <!-- The cdkScrollable attribute is needed so the CDK can listen to scroll events within this container -->
+    <div #appContent cdkScrollable class="app-content" [dir]="i18n.direction">
+      <div>
+        <router-outlet></router-outlet>
+        <p *ngIf="showCheckingDisabled" class="checking-unavailable">{{ t("scripture_checking_not_available") }}</p>
+      </div>
     </div>
-  </div>
+  </mat-drawer-container>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -26,31 +26,16 @@
     z-index: 8;
   }
 
-  > mdc-drawer {
-    > mdc-drawer-header {
-      padding: 0;
+  .project-select {
+    ::ng-deep .mdc-select__anchor {
+      width: 100%;
+    }
 
-      > .project-select {
-        ::ng-deep .mdc-select__anchor {
-          width: 100%;
-        }
-
-        .mdc-list-item {
-          // Fix overflow in Firefox when a project name uses the Khmer script. As of 2022-11-11, the DBL resource
-          // KHSV05 is one example that will cause overflow, which looks particularly bad in RTL mode because it
-          // overflows to the left in a menu that is layed out in LTR.
-          overflow-wrap: anywhere;
-
-          // Override styles spilling from mdc-drawer to mdc-select (both mdc-drawer and mdc-select can contain
-          // mdc-list-item and it appears the styles applied for the drawer's list items are now styling the select menu).
-          @include typography.typography(subtitle1);
-          margin: 0;
-          border-radius: 0;
-          padding: 0 16px;
-          height: unset;
-          min-height: 48px;
-        }
-      }
+    .mdc-list-item {
+      // Fix overflow in Firefox when a project name uses the Khmer script. As of 2022-11-11, the DBL resource
+      // KHSV05 is one example that will cause overflow, which looks particularly bad in RTL mode because it
+      // overflows to the left in a menu that is layed out in LTR.
+      overflow-wrap: anywhere;
     }
   }
 
@@ -253,12 +238,6 @@ mat-nav-list .mat-list-item {
   background-color: #e7e8e7;
 }
 
-mdc-drawer-content {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-}
-
 #tools-menu-list,
 #admin-pages-menu-list {
   padding-top: 0;
@@ -298,4 +277,23 @@ mdc-drawer-content {
   font-size: small;
   background: #4678d6;
   margin-inline-start: auto;
+}
+
+.mat-drawer-container {
+  width: 100%;
+  background: initial;
+}
+
+.app-content {
+  height: 100%;
+}
+
+.nav-spacer {
+  flex-grow: 1;
+}
+
+.mat-drawer ::ng-deep .mat-drawer-inner-container {
+  display: flex;
+  flex-direction: column;
+  width: 255px;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -109,6 +109,7 @@ $material-theme-accent-error: mat.define-light-theme(
 @include mat.progress-spinner-theme($material-app-theme);
 @include mat.radio-theme($material-app-theme);
 @include mat.select-theme($material-app-theme);
+@include mat.sidenav-theme($material-app-theme);
 @include mat.slide-toggle-theme($material-app-theme);
 @include mat.slider-theme($material-app-theme);
 @include mat.snack-bar-theme($material-app-theme);
@@ -122,7 +123,6 @@ $material-theme-accent-error: mat.define-light-theme(
 // @include mat.button-toggle-theme($material-app-theme);
 // @include mat.chips-theme($material-app-theme);
 // @include mat.grid-list-theme($material-app-theme);
-// @include mat.sidenav-theme($material-app-theme);
 // @include mat.slide-toggle-theme($material-app-theme);
 // @include mat.sort-theme($material-app-theme);
 // @include mat.stepper-theme($material-app-theme);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -50,6 +50,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslocoService } from '@ngneat/transloco';
 import { NgCircleProgressModule } from 'ng-circle-progress';
+import { MatSidenavModule } from '@angular/material/sidenav';
 import { AutofocusDirective } from './autofocus.directive';
 import { BlurOnClickDirective } from './blur-on-click.directive';
 import { DonutChartModule } from './donut-chart/donut-chart.module';
@@ -81,6 +82,7 @@ const modules = [
   MatProgressSpinnerModule,
   MatRadioModule,
   MatSelectModule,
+  MatSidenavModule,
   MatSliderModule,
   MatSlideToggleModule,
   MatSnackBarModule,


### PR DESCRIPTION
The header is now no longer covered by the drawer when it's open. I don't have a strong opinion on whether this is better or not, but it doesn't seem that there's a good way in Material to have it cover the header.

Before | After
-------|------
![](https://github.com/sillsdev/web-xforge/assets/6140710/8851466a-4885-4b2e-a1c5-09e5f525a7cd) | ![](https://github.com/sillsdev/web-xforge/assets/6140710/730b7890-7943-4f8c-854a-9fe15261beb8)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1868)
<!-- Reviewable:end -->
