### PR TITLE
SF-2046 Maintain the user's current segment after closing the note di…

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -38,32 +38,10 @@ import { Segment } from './segment';
 import { EditorRange, TextViewModel } from './text-view-model';
 import { NoteDialogData, TextNoteDialogComponent } from './text-note-dialog/text-note-dialog.component';
 
-const EDITORS = new Set<Quill>();
 // When a user is active in the editor a timer starts to mark them as inactive for remote presences
 export const PRESENCE_EDITOR_ACTIVE_TIMEOUT = 3500;
 
-function onNativeSelectionChanged(): void {
-  // workaround for bug where Quill allows a selection inside of an embed
-  const sel = window.document.getSelection();
-  if (sel == null || sel.rangeCount === 0 || !sel.isCollapsed) {
-    return;
-  }
-  const text = sel.getRangeAt(0).commonAncestorContainer.textContent;
-  if (text === '\ufeff') {
-    for (const editor of EDITORS) {
-      if (editor.hasFocus()) {
-        const editorSel = editor.getSelection();
-        if (editorSel != null) {
-          editor.setSelection(editorSel, 'silent');
-        }
-        break;
-      }
-    }
-  }
-}
-
 const USX_FORMATS = registerScripture();
-window.document.addEventListener('selectionchange', onNativeSelectionChanged);
 
 export interface TextUpdatedEvent {
   delta?: DeltaStatic;
@@ -468,9 +446,6 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     if (this.viewModel != null) {
       this.viewModel.unbind();
     }
-    if (this._editor != null) {
-      EDITORS.delete(this._editor);
-    }
     this.dismissPresences();
     if (this.onDeleteSub != null) {
       this.onDeleteSub.unsubscribe();
@@ -489,7 +464,6 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     if (this.id != null) {
       this.bindQuill();
     }
-    EDITORS.add(this._editor);
 
     editor.container.addEventListener('beforeinput', (ev: Event) => this.onBeforeinput(ev));
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2689,8 +2689,9 @@ describe('EditorComponent', () => {
       const projectId: string = 'project01';
       const userId: string = 'user01';
       const env = new TestEnvironment();
-      env.setProjectUserConfig();
+      env.setProjectUserConfig({ selectedBookNum: 40, selectedChapterNum: 1, selectedSegment: 'verse_1_1' });
       env.wait();
+      expect(env.component.target!.segment!.ref).toBe('verse_1_1');
       env.setSelectionAndInsertNote('verse_1_4');
 
       const content: string = 'content in the thread';
@@ -2709,6 +2710,7 @@ describe('EditorComponent', () => {
       expect(noteThread.notes[0].content).toEqual(content);
       expect(noteThread.notes[0].tagId).toEqual(2);
       expect(env.isNoteIconHighlighted(noteThread.dataId)).toBeFalse();
+      expect(env.component.target!.segment!.ref).toBe('verse_1_4');
 
       env.dispose();
     }));
@@ -3776,6 +3778,7 @@ class TestEnvironment {
     if (segmentRef != null) {
       this.clickSegmentRef(segmentRef);
     }
+    this.wait();
     this.insertNoteFab.nativeElement.click();
     tick();
     this.fixture.detectChanges();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2601,11 +2601,13 @@ describe('EditorComponent', () => {
       expect(env.insertNoteFab).toBeTruthy();
       env.insertNoteFab.nativeElement.click();
       env.wait();
+      expect(window.getComputedStyle(env.insertNoteFab.nativeElement)['visibility']).toBe('hidden');
       expect(env.mobileNoteTextArea).toBeTruthy();
       expect(env.component.currentSegmentReference).toEqual('Matthew 1:2');
       verify(mockedMatDialog.open(NoteDialogComponent, anything())).never();
       // Close the bottom sheet
       env.bottomSheetCloseButton!.click();
+      expect(window.getComputedStyle(env.insertNoteFab.nativeElement)['visibility']).toBe('visible');
       env.wait();
 
       env.dispose();
@@ -2831,7 +2833,7 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('deselects a selected verse when opening a note dialog', fakeAsync(() => {
+    it('verse keeps selection when opening a note dialog', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
       env.wait();
@@ -2841,12 +2843,15 @@ describe('EditorComponent', () => {
       env.wait();
       const verse1Elem: HTMLElement = env.getSegmentElement(segmentRef)!;
       expect(verse1Elem.classList).toContain('commenter-selection');
+      expect(window.getComputedStyle(env.insertNoteFab.nativeElement)['visibility']).toBe('visible');
       const noteElem: HTMLElement = env.getNoteThreadIconElement('verse_1_3', 'thread02')!;
       noteElem.click();
       env.wait();
+      expect(window.getComputedStyle(env.insertNoteFab.nativeElement)['visibility']).toBe('hidden');
       verify(mockedMatDialog.open(NoteDialogComponent, anything())).once();
       instance(mockedMatDialog).closeAll();
       env.wait();
+      expect(window.getComputedStyle(env.insertNoteFab.nativeElement)['visibility']).toBe('visible');
       const segmentRef3 = 'verse_1_3';
       env.clickSegmentRef(segmentRef3);
       env.wait();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1480,6 +1480,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     dialogConfig: MatDialogConfig<D>
   ): MatDialogRef<T, R> {
     const selection: RangeStatic | null | undefined = this.target?.editor?.getSelection();
+    const scrollTop: number | undefined = this.target?.editor?.root.scrollTop;
     const dialogRef: MatDialogRef<T, R> = this.dialogService.openMatDialog(component, dialogConfig);
     if (selection == null || !this.canEdit) return dialogRef;
 
@@ -1488,6 +1489,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         const currentSelection: RangeStatic | null | undefined = this.target.editor.getSelection();
         if (currentSelection?.index !== selection.index) {
           this.target.editor.setSelection(selection.index, 0, 'user');
+          if (scrollTop != null) this.target.editor.root.scrollTop = scrollTop;
         }
       }
       subscription.unsubscribe();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1032,6 +1032,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       // at least one must be defined
       return;
     }
+
+    const selectedSegment: string | undefined = this.projectUserConfigDoc?.data?.selectedSegment;
+    const selectedSegmentChecksum: number | undefined = this.projectUserConfigDoc?.data?.selectedSegmentChecksum;
     const noteDialogData: NoteDialogData = {
       projectId: this.projectDoc!.id,
       threadId,
@@ -1054,6 +1057,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     // to prevent introducing erroneous usx-segment elements into the DOM
     this.resetCommenterVerseSelection();
     const result: NoteDialogResult | undefined = await dialogRef.afterClosed().toPromise();
+
     if (result != null) {
       if (result.noteContent != null) {
         await this.saveNote({
@@ -1065,6 +1069,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       }
       this.toggleNoteThreadVerseRefs$.next();
     }
+    // delay setting the selection back to the original segment for the editor to get focus
+    setTimeout(() => this.setSegment(selectedSegment, selectedSegmentChecksum), 10);
   }
 
   private updateReadNotes(threadId: string): void {
@@ -1161,18 +1167,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     if (this.target == null) {
       return;
     }
-    let selectedSegment: string | undefined;
-    let selectedSegmentChecksum: number | undefined;
-    if (
-      this.projectUserConfigDoc != null &&
-      this.projectUserConfigDoc.data != null &&
-      this.projectUserConfigDoc.data.selectedBookNum === this.text.bookNum &&
-      this.projectUserConfigDoc.data.selectedChapterNum === this._chapter &&
-      this.projectUserConfigDoc.data.selectedSegment !== ''
-    ) {
-      selectedSegment = this.projectUserConfigDoc.data.selectedSegment;
-      selectedSegmentChecksum = this.projectUserConfigDoc.data.selectedSegmentChecksum;
-    }
+
     // reset the verse selection before changing text
     this.resetInsertNoteFab(true);
     if (this.source != null) {
@@ -1186,13 +1181,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       this.target.blur();
     }
     this.target.id = targetId;
-    if (selectedSegment != null) {
-      const segmentChanged = this.target.setSegment(selectedSegment, selectedSegmentChecksum, true);
-      if (!segmentChanged && selectedSegmentChecksum == null && this.target.segment != null) {
-        // the segment checksum was unset on the server, so accept the current segment changes
-        this.target.segment.acceptChanges();
-      }
-    }
+    this.setSegment();
     const textDoc = await this.projectService.getText(targetId);
     if (this.onTargetDeleteSub != null) {
       this.onTargetDeleteSub.unsubscribe();
@@ -1209,6 +1198,28 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     this.isTranslating = true;
     this.suggestions = [];
     this.showSuggestions = this.target != null && this.target.isSelectionAtSegmentEnd;
+  }
+
+  private setSegment(selectedSegment?: string, selectedSegmentChecksum?: number): void {
+    if (this.target == null || this.text == null) return;
+    if (
+      selectedSegment == null &&
+      this.projectUserConfigDoc?.data != null &&
+      this.projectUserConfigDoc.data.selectedBookNum === this.text.bookNum &&
+      this.projectUserConfigDoc.data.selectedChapterNum === this._chapter &&
+      this.projectUserConfigDoc.data.selectedSegment !== ''
+    ) {
+      selectedSegment = this.projectUserConfigDoc.data.selectedSegment;
+      selectedSegmentChecksum = this.projectUserConfigDoc.data.selectedSegmentChecksum;
+    }
+
+    if (selectedSegment != null) {
+      const segmentChanged: boolean = this.target.setSegment(selectedSegment, selectedSegmentChecksum, true);
+      if (!segmentChanged && selectedSegmentChecksum == null && this.target.segment != null) {
+        // the segment checksum was unset on the server, so accept the current segment changes
+        this.target.segment.acceptChanges();
+      }
+    }
   }
 
   private async translateSegment(): Promise<void> {


### PR DESCRIPTION
…alog

When a user opens and closes the note dialog, the cursor sometimes jumps to the first segment in the editor. I couldn't figure out why the cursor was jumping, but my best guess is that the first selectable element was being selected when the editor regained focus after the editor is closed.
For this change, I updated the logic so that the current segment is recorded before the dialog opens. When the dialog closes, it will set the current segment to the segment that the users had selected before opening the note dialog.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1871)
<!-- Reviewable:end -->
