### PR TITLE
SF-1980 Fix editor fails to highlight active segment after losing focus

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.html
@@ -20,7 +20,6 @@
   [dir]="$any(textDirection)"
   [lang]="lang"
   [attr.data-browser-engine]="browserEngine"
-  (focusout)="toggleFocus(false)"
   (onBlur)="toggleFocus(false)"
   (onFocus)="toggleFocus(true)"
 >

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -835,9 +835,9 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     return !(newSel == null || sel.index !== newSel.index || sel.length !== newSel.length);
   }
 
-  /**
-   * Both onBlur and focusout are used as sometimes touch devices can trigger one but not the other with Quill
-   */
+  // Triggered for Quill editor component (onFocus) and (onBlur) events.
+  // Don't toggle focus on Quill (focusout) event, as this causes editor to fail to highlight active segment
+  // until an (onBlur) event is triggered.
   toggleFocus(focus: boolean): void {
     this.focused.emit(focus);
   }


### PR DESCRIPTION
This may also fix SF-1819.