### PR TITLE
SF-2053 Backend Support for NMT Pre-Translation

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/translate-config.ts
+++ b/src/RealtimeServer/scriptureforge/models/translate-config.ts
@@ -10,6 +10,7 @@ export interface TranslateConfig {
   source?: TranslateSource;
   shareEnabled: boolean;
   defaultNoteTagId?: number;
+  preTranslate: boolean;
 }
 
 export interface TranslateSource {

--- a/src/RealtimeServer/scriptureforge/services/note-thread-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-service.spec.ts
@@ -424,7 +424,8 @@ class TestEnvironment {
       writingSystem: { tag: 'qaa' },
       translateConfig: {
         translationSuggestionsEnabled: false,
-        shareEnabled: true
+        shareEnabled: true,
+        preTranslate: false
       },
       checkingConfig: {
         checkingEnabled: false,

--- a/src/RealtimeServer/scriptureforge/services/question-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/question-service.spec.ts
@@ -155,7 +155,8 @@ class TestEnvironment {
       writingSystem: { tag: 'qaa' },
       translateConfig: {
         translationSuggestionsEnabled: false,
-        shareEnabled: true
+        shareEnabled: true,
+        preTranslate: false
       },
       checkingConfig: {
         checkingEnabled: false,

--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.spec.ts
@@ -203,6 +203,23 @@ describe('SFProjectMigrations', () => {
       expect(projectDoc.data.checkingConfig.shareLevel).not.toBeDefined();
     });
   });
+
+  describe('version 10', () => {
+    it('adds preTranslate to translate config', async () => {
+      const env = new TestEnvironment(9);
+      const conn = env.server.connect();
+      await createDoc(conn, SF_PROJECTS_COLLECTION, 'project01', {
+        translateConfig: { translationSuggestionsEnabled: false }
+      });
+      let projectDoc = await fetchDoc(conn, SF_PROJECTS_COLLECTION, 'project01');
+      expect(projectDoc.data.translateConfig.preTranslate).not.toBeDefined();
+
+      await env.server.migrateIfNecessary();
+
+      projectDoc = await fetchDoc(conn, SF_PROJECTS_COLLECTION, 'project01');
+      expect(projectDoc.data.translateConfig.preTranslate).toBe(false);
+    });
+  });
 });
 
 class TestEnvironment {

--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
@@ -207,6 +207,22 @@ class SFProjectMigration9 implements Migration {
   }
 }
 
+class SFProjectMigration10 implements Migration {
+  static readonly VERSION = 10;
+
+  async migrateDoc(doc: Doc): Promise<void> {
+    const ops: Op[] = [];
+    if (doc.data.translateConfig != null) {
+      ops.push({ p: ['translateConfig', 'preTranslate'], oi: false });
+    }
+    await submitMigrationOp(SFProjectMigration10.VERSION, doc, ops);
+  }
+
+  migrateOp(_op: RawOp): void {
+    // do nothing
+  }
+}
+
 export const SF_PROJECT_MIGRATIONS: MigrationConstructor[] = [
   SFProjectMigration1,
   SFProjectMigration2,
@@ -216,5 +232,6 @@ export const SF_PROJECT_MIGRATIONS: MigrationConstructor[] = [
   SFProjectMigration6,
   SFProjectMigration7,
   SFProjectMigration8,
-  SFProjectMigration9
+  SFProjectMigration9,
+  SFProjectMigration10
 ];

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.spec.ts
@@ -106,7 +106,8 @@ class TestEnvironment {
       },
       translateConfig: {
         translationSuggestionsEnabled: false,
-        shareEnabled: false
+        shareEnabled: false,
+        preTranslate: false
       },
       writingSystem: {
         tag: 'en'

--- a/src/RealtimeServer/scriptureforge/services/text-audio-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/text-audio-service.spec.ts
@@ -127,7 +127,8 @@ class TestEnvironment {
       writingSystem: { tag: 'qaa' },
       translateConfig: {
         translationSuggestionsEnabled: false,
-        shareEnabled: true
+        shareEnabled: true,
+        preTranslate: false
       },
       checkingConfig: {
         checkingEnabled: false,

--- a/src/RealtimeServer/scriptureforge/services/text-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/text-service.spec.ts
@@ -116,7 +116,8 @@ class TestEnvironment {
       writingSystem: { tag: 'qaa' },
       translateConfig: {
         translationSuggestionsEnabled: false,
-        shareEnabled: true
+        shareEnabled: true,
+        preTranslate: false
       },
       checkingConfig: {
         checkingEnabled: false,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -964,7 +964,8 @@ class TestEnvironment {
         },
         translateConfig: {
           translationSuggestionsEnabled: false,
-          shareEnabled: false
+          shareEnabled: false,
+          preTranslate: false
         },
         checkingConfig: {
           checkingEnabled: true,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -591,7 +591,8 @@ class TestEnvironment {
     },
     translateConfig: {
       translationSuggestionsEnabled: false,
-      shareEnabled: false
+      shareEnabled: false,
+      preTranslate: false
     },
     sync: { queuedCount: 0 },
     editable: true,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.stories.ts
@@ -41,7 +41,8 @@ const defaultArgs = {
     },
     translateConfig: {
       translationSuggestionsEnabled: false,
-      shareEnabled: false
+      shareEnabled: false,
+      preTranslate: false
     },
     checkingConfig: {
       checkingEnabled: true,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1744,6 +1744,7 @@ class TestEnvironment {
     translateConfig: {
       translationSuggestionsEnabled: true,
       shareEnabled: false,
+      preTranslate: false,
       source: {
         paratextId: 'project02',
         projectRef: 'project02',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.spec.ts
@@ -183,7 +183,8 @@ class TestEnvironment {
     writingSystem: { tag: 'en' },
     translateConfig: {
       translationSuggestionsEnabled: false,
-      shareEnabled: false
+      shareEnabled: false,
+      preTranslate: false
     },
     checkingConfig: {
       usersSeeEachOthersResponses: true,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
@@ -385,6 +385,7 @@ class TestEnvironment {
         translateConfig: {
           translationSuggestionsEnabled: settings.translationSuggestionsEnabled,
           shareEnabled: false,
+          preTranslate: false,
           source:
             settings.sourceParatextId == null
               ? undefined

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/build-states.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/build-states.ts
@@ -1,4 +1,5 @@
 export enum BuildStates {
+  Queued = 'QUEUED',
   Pending = 'PENDING',
   Active = 'ACTIVE',
   Completed = 'COMPLETED',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
@@ -225,7 +225,8 @@ class TestEnvironment {
           },
           translateConfig: {
             translationSuggestionsEnabled: false,
-            shareEnabled: false
+            shareEnabled: false,
+            preTranslate: false
           },
           checkingConfig: {
             checkingEnabled: args.checkingEnabled == null ? true : args.checkingEnabled,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -210,7 +210,8 @@ describe('SettingsComponent', () => {
         const env = new TestEnvironment();
         env.setupProject({
           translationSuggestionsEnabled: false,
-          shareEnabled: false
+          shareEnabled: false,
+          preTranslate: false
         });
         tick();
         env.fixture.detectChanges();
@@ -304,7 +305,8 @@ describe('SettingsComponent', () => {
         const env = new TestEnvironment();
         env.setupProject({
           translationSuggestionsEnabled: false,
-          shareEnabled: false
+          shareEnabled: false,
+          preTranslate: false
         });
         env.wait();
         expect(env.translationSuggestionsCheckbox).toBeNull();
@@ -336,6 +338,7 @@ describe('SettingsComponent', () => {
         env.setupProject({
           translationSuggestionsEnabled: false,
           shareEnabled: false,
+          preTranslate: false,
           source: {
             paratextId: 'paratextId01',
             projectRef: 'paratext01',
@@ -677,6 +680,7 @@ class TestEnvironment {
     translateConfig: TranslateConfig = {
       translationSuggestionsEnabled: true,
       shareEnabled: false,
+      preTranslate: false,
       source: {
         paratextId: 'paratextId01',
         projectRef: 'paratext01',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
@@ -120,7 +120,8 @@ export function getSFProject(id: string): SFProjectProfile {
     writingSystem: { tag: 'qaa' },
     translateConfig: {
       translationSuggestionsEnabled: false,
-      shareEnabled: false
+      shareEnabled: false,
+      preTranslate: false
     },
     checkingConfig: {
       checkingEnabled: false,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.spec.ts
@@ -144,6 +144,7 @@ class TestEnvironment {
         translateConfig: {
           translationSuggestionsEnabled: !!args.translationSuggestionsEnabled,
           shareEnabled: false,
+          preTranslate: false,
           source:
             args.sourceProject != null
               ? {
@@ -188,7 +189,8 @@ class TestEnvironment {
           },
           translateConfig: {
             translationSuggestionsEnabled: false,
-            shareEnabled: false
+            shareEnabled: false,
+            preTranslate: false
           },
           checkingConfig: {
             checkingEnabled: false,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
@@ -265,7 +265,8 @@ class TestEnvironment {
         },
         translateConfig: {
           translationSuggestionsEnabled: false,
-          shareEnabled: false
+          shareEnabled: false,
+          preTranslate: false
         },
         checkingConfig: {
           checkingEnabled: false,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
@@ -371,7 +371,8 @@ class TestEnvironment {
     writingSystem: { tag: 'en' },
     translateConfig: {
       translationSuggestionsEnabled: false,
-      shareEnabled: false
+      shareEnabled: false,
+      preTranslate: false
     },
     checkingConfig: {
       usersSeeEachOthersResponses: true,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1048,6 +1048,7 @@ describe('EditorComponent', () => {
         translateConfig: {
           translationSuggestionsEnabled: true,
           shareEnabled: false,
+          preTranslate: false,
           source: {
             paratextId: 'resource01',
             name: 'Resource 1',
@@ -3144,6 +3145,7 @@ describe('EditorComponent', () => {
         translateConfig: {
           translationSuggestionsEnabled: false,
           shareEnabled: false,
+          preTranslate: false,
           source: {
             paratextId: 'resource01',
             name: 'Resource 1',
@@ -3233,7 +3235,9 @@ describe('EditorComponent', () => {
     }));
 
     it('hides translation suggestions settings when suggestions are disabled for the project', fakeAsync(() => {
-      const projectConfig = { translateConfig: { ...defaultTranslateConfig, translationSuggestionsEnabled: false } };
+      const projectConfig = {
+        translateConfig: { ...defaultTranslateConfig, translationSuggestionsEnabled: false, preTranslate: false }
+      };
       const navigationParams: Params = { projectId: 'project01', bookId: 'MRK' };
 
       const env = new TestEnvironment();
@@ -3249,7 +3253,8 @@ describe('EditorComponent', () => {
 
 const defaultTranslateConfig = {
   translationSuggestionsEnabled: false,
-  shareEnabled: false
+  shareEnabled: false,
+  preTranslate: false
 };
 
 class TestEnvironment {
@@ -3305,6 +3310,7 @@ class TestEnvironment {
       translationSuggestionsEnabled: true,
       defaultNoteTagId: 2,
       shareEnabled: false,
+      preTranslate: false,
       source: {
         paratextId: 'source01',
         projectRef: 'project02',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -526,7 +526,8 @@ class TestEnvironment {
     userPermissions: {},
     translateConfig: {
       translationSuggestionsEnabled: false,
-      shareEnabled: false
+      shareEnabled: false,
+      preTranslate: false
     },
     checkingConfig: {
       usersSeeEachOthersResponses: true,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.spec.ts
@@ -186,7 +186,8 @@ class TestEnvironment {
         },
         translateConfig: {
           translationSuggestionsEnabled,
-          shareEnabled: false
+          shareEnabled: false,
+          preTranslate: false
         },
         checkingConfig: {
           checkingEnabled: false,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
@@ -297,7 +297,8 @@ class TestEnvironment {
         },
         translateConfig: {
           translationSuggestionsEnabled,
-          shareEnabled: false
+          shareEnabled: false,
+          preTranslate: false
         },
         checkingConfig: {
           checkingEnabled: false,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
@@ -636,7 +636,8 @@ class TestEnvironment {
       sync: { queuedCount: 0 },
       translateConfig: {
         translationSuggestionsEnabled: false,
-        shareEnabled: false
+        shareEnabled: false,
+        preTranslate: false
       },
       checkingConfig: {
         checkingEnabled: false,

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -169,6 +169,40 @@ public class MachineApiController : ControllerBase
         }
     }
 
+    [HttpGet(MachineApi.GetPreTranslation)]
+    public async Task<ActionResult<PreTranslationDto>> GetPreTranslationAsync(
+        string sfProjectId,
+        int bookNum,
+        int chapterNum,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            PreTranslationDto preTranslation = await _machineApiService.GetPreTranslationAsync(
+                _userAccessor.UserId,
+                sfProjectId,
+                bookNum,
+                chapterNum,
+                cancellationToken
+            );
+            return Ok(preTranslation);
+        }
+        catch (BrokenCircuitException e)
+        {
+            _exceptionHandler.ReportException(e);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
+        }
+        catch (DataNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (ForbiddenException)
+        {
+            return Forbid();
+        }
+    }
+
     /// <summary>
     /// Gets the word graph that represents all possible translations of a segment of text.
     /// </summary>

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -215,6 +215,36 @@ public class MachineApiController : ControllerBase
         }
     }
 
+    [HttpPost(MachineApi.StartPreTranslationBuild)]
+    public async Task<ActionResult<BuildDto>> StartPreTranslationBuildAsync(
+        [FromBody] string sfProjectId,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            BuildDto? build = await _machineApiService.StartPreTranslationBuildAsync(
+                _userAccessor.UserId,
+                sfProjectId,
+                cancellationToken
+            );
+            return build is null ? NoContent() : Ok(build);
+        }
+        catch (BrokenCircuitException e)
+        {
+            _exceptionHandler.ReportException(e);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
+        }
+        catch (DataNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (ForbiddenException)
+        {
+            return Forbid();
+        }
+    }
+
     /// <summary>
     /// Incrementally trains a translation engine with a segment pair.
     /// </summary>

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -38,6 +38,16 @@ public class MachineApiController : ControllerBase
         _exceptionHandler.RecordUserIdForException(_userAccessor.UserId);
     }
 
+    /// <summary>
+    /// Cancels the current pre-translation build.
+    /// </summary>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <response code="200">The build was cancelled successfully.</response>
+    /// <response code="403">You do not have permission to cancel the build.</response>
+    /// <response code="404">The project does not exist or is not configured on the ML server.</response>
+    /// <response code="405">The build cannot be cancelled.</response>
+    /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
     [HttpPost(MachineApi.CancelPreTranslationBuild)]
     public async Task<ActionResult> CancelPreTranslationBuildAsync(
         [FromBody] string sfProjectId,
@@ -78,6 +88,7 @@ public class MachineApiController : ControllerBase
     /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
     /// <param name="buildId">The build identifier.</param>
     /// <param name="minRevision">The minimum revision.</param>
+    /// <param name="preTranslate"><c>true</c> if the build is a pre-translation build.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <remarks>Omitting <paramref name="buildId"/> returns the current build running for the project.</remarks>
     /// <response code="200">The build is running.</response>
@@ -183,6 +194,21 @@ public class MachineApiController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Gets all of the pre-translations for the specified chapter.
+    /// </summary>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="bookNum">The book number.</param>
+    /// <param name="chapterNum">The chapter number.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <remarks>
+    /// If there are no pre-translations (because the build has not started, has not finished, or was cancelled),
+    /// The <c>preTranslations</c> property in the return object will be an empty collection.
+    /// </remarks>
+    /// <response code="200">The pre-translations were successfully queried for.</response>
+    /// <response code="403">You do not have permission to retrieve the pre-translations for this project.</response>
+    /// <response code="404">The project does not exist or is not configured on the ML server.</response>
+    /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
     [HttpGet(MachineApi.GetPreTranslation)]
     public async Task<ActionResult<PreTranslationDto>> GetPreTranslationAsync(
         string sfProjectId,
@@ -295,6 +321,15 @@ public class MachineApiController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Starts a pre-translation build job.
+    /// </summary>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <response code="200">The pre-translation build was successfully started.</response>
+    /// <response code="403">You do not have permission to build this project.</response>
+    /// <response code="404">The project does not exist or is not configured on the ML server.</response>
+    /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
     [HttpPost(MachineApi.StartPreTranslationBuild)]
     public async Task<ActionResult> StartPreTranslationBuildAsync(
         [FromBody] string sfProjectId,

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -96,7 +96,18 @@ public class MachineApiController : ControllerBase
     {
         try
         {
-            BuildDto? build = string.IsNullOrWhiteSpace(buildId)
+            BuildDto? build = null;
+            if (preTranslate && buildId is null)
+            {
+                build = await _machineApiService.GetPreTranslationQueuedStateAsync(
+                    _userAccessor.UserId,
+                    sfProjectId,
+                    cancellationToken
+                );
+            }
+
+            // If a build identifier is not specified, get the current build
+            build ??= string.IsNullOrWhiteSpace(buildId)
                 ? await _machineApiService.GetCurrentBuildAsync(
                     _userAccessor.UserId,
                     sfProjectId,

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -90,6 +90,7 @@ public class MachineApiController : ControllerBase
         string sfProjectId,
         string? buildId,
         [FromQuery] int? minRevision,
+        [FromQuery] bool preTranslate,
         CancellationToken cancellationToken
     )
     {
@@ -100,6 +101,7 @@ public class MachineApiController : ControllerBase
                     _userAccessor.UserId,
                     sfProjectId,
                     minRevision,
+                    preTranslate,
                     cancellationToken
                 )
                 : await _machineApiService.GetBuildAsync(
@@ -107,6 +109,7 @@ public class MachineApiController : ControllerBase
                     sfProjectId,
                     buildId,
                     minRevision,
+                    preTranslate,
                     cancellationToken
                 );
 

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiV2Controller.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiV2Controller.cs
@@ -59,6 +59,7 @@ public class MachineApiV2Controller : ControllerBase
                     _userAccessor.UserId,
                     sfProjectId,
                     minRevision,
+                    preTranslate: false,
                     cancellationToken
                 )
                 : await _machineApiService.GetBuildAsync(
@@ -66,6 +67,7 @@ public class MachineApiV2Controller : ControllerBase
                     sfProjectId,
                     buildId,
                     minRevision,
+                    preTranslate: false,
                     cancellationToken
                 );
 

--- a/src/SIL.XForge.Scripture/Models/MachineApi.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApi.cs
@@ -14,6 +14,7 @@ public static class MachineApi
     public const string TrainSegment = "translation/engines/project:{sfProjectId}/actions/trainSegment";
     public const string Translate = "translation/engines/project:{sfProjectId}/actions/translate";
     public const string TranslateN = "translation/engines/project:{sfProjectId}/actions/translate/{n}";
+    public const string StartPreTranslationBuild = "translation/pretranslations";
 
     public static string GetBuildHref(string sfProjectId, string buildId)
     {

--- a/src/SIL.XForge.Scripture/Models/MachineApi.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApi.cs
@@ -16,6 +16,8 @@ public static class MachineApi
     public const string TranslateN = "translation/engines/project:{sfProjectId}/actions/translate/{n}";
     public const string StartPreTranslationBuild = "translation/pretranslations";
     public const string CancelPreTranslationBuild = "translation/pretranslations/cancel";
+    public const string GetPreTranslation =
+        "translation/engines/project:{sfProjectId}/actions/preTranslate/{bookNum}_{chapterNum}";
 
     public static string GetBuildHref(string sfProjectId, string buildId)
     {

--- a/src/SIL.XForge.Scripture/Models/MachineApi.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApi.cs
@@ -15,6 +15,7 @@ public static class MachineApi
     public const string Translate = "translation/engines/project:{sfProjectId}/actions/translate";
     public const string TranslateN = "translation/engines/project:{sfProjectId}/actions/translate/{n}";
     public const string StartPreTranslationBuild = "translation/pretranslations";
+    public const string CancelPreTranslationBuild = "translation/pretranslations/cancel";
 
     public static string GetBuildHref(string sfProjectId, string buildId)
     {

--- a/src/SIL.XForge.Scripture/Models/PreTranslation.cs
+++ b/src/SIL.XForge.Scripture/Models/PreTranslation.cs
@@ -1,0 +1,7 @@
+namespace SIL.XForge.Scripture.Models;
+
+public class PreTranslation
+{
+    public string Reference { get; set; } = string.Empty;
+    public string Translation { get; set; } = string.Empty;
+}

--- a/src/SIL.XForge.Scripture/Models/PreTranslationDto.cs
+++ b/src/SIL.XForge.Scripture/Models/PreTranslationDto.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace SIL.XForge.Scripture.Models;
+
+public class PreTranslationDto
+{
+    public PreTranslation[] PreTranslations { get; set; } = Array.Empty<PreTranslation>();
+}

--- a/src/SIL.XForge.Scripture/Models/ServalCorpus.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalCorpus.cs
@@ -8,6 +8,14 @@ namespace SIL.XForge.Scripture.Models;
 public class ServalCorpus
 {
     /// <summary>
+    /// Gets or sets a value indicating whether or not this corpus is for pre-translation.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if this corpus is for pre-translation; otherwise, <c>false</c>.
+    /// </value>
+    public bool PreTranslate { get; set; }
+
+    /// <summary>
     /// Gets or sets the source files uploaded to Serval.
     /// </summary>
     /// <value>

--- a/src/SIL.XForge.Scripture/Models/ServalData.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalData.cs
@@ -8,15 +8,23 @@ namespace SIL.XForge.Scripture.Models;
 public class ServalData
 {
     /// <summary>
-    /// Gets or sets the Serval Translation Engine Id for the project.
+    /// Gets or sets the SMT Translation Engine Id for the project.
     /// </summary>
     /// <value>
-    /// The Translation Engine Id.
+    /// The SMT Translation Engine Id.
     /// </value>
     /// <remarks>
     /// The user should not interact with the translation engine directly by ID.
     /// </remarks>
     public string TranslationEngineId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the NMT Translation Engine Id for the project.
+    /// </summary>
+    /// <value>
+    /// The NMT Translation Engine Id.
+    /// </value>
+    public string PreTranslationEngineId { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the corpora uploaded to Serval.

--- a/src/SIL.XForge.Scripture/Models/ServalData.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalData.cs
@@ -38,7 +38,7 @@ public class ServalData
     /// This is used to keep track of whether a build and its corpus is currently uploading to Serval.
     /// If this is longer than 6 hours ago (UTC), there will have been a crash, so an error should be reported.
     /// </remarks>
-    public DateTime? PreTranslationQueued { get; set; }
+    public DateTime? PreTranslationQueuedAt { get; set; }
 
     /// <summary>
     /// Gets or sets the corpora uploaded to Serval.

--- a/src/SIL.XForge.Scripture/Models/ServalData.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalData.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace SIL.XForge.Scripture.Models;
@@ -16,7 +17,7 @@ public class ServalData
     /// <remarks>
     /// The user should not interact with the translation engine directly by ID.
     /// </remarks>
-    public string TranslationEngineId { get; set; } = string.Empty;
+    public string? TranslationEngineId { get; set; }
 
     /// <summary>
     /// Gets or sets the NMT Translation Engine Id for the project.
@@ -24,7 +25,20 @@ public class ServalData
     /// <value>
     /// The NMT Translation Engine Id.
     /// </value>
-    public string PreTranslationEngineId { get; set; } = string.Empty;
+    public string? PreTranslationEngineId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the date and time that the pre-translation build was queued.
+    /// </summary>
+    /// <value>
+    /// The date and time in UTC that the pre-translation build was queued;
+    /// otherwise, null if the build has started on Serval or is not running.
+    /// </value>
+    /// <remarks>
+    /// This is used to keep track of whether a build and its corpus is currently uploading to Serval.
+    /// If this is longer than 6 hours ago (UTC), there will have been a crash, so an error should be reported.
+    /// </remarks>
+    public DateTime? PreTranslationQueued { get; set; }
 
     /// <summary>
     /// Gets or sets the corpora uploaded to Serval.

--- a/src/SIL.XForge.Scripture/Models/TranslateConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/TranslateConfig.cs
@@ -6,4 +6,5 @@ public class TranslateConfig
     public TranslateSource Source { get; set; }
     public bool ShareEnabled { get; set; } = false;
     public int? DefaultNoteTagId { get; set; }
+    public bool PreTranslate { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -32,6 +32,11 @@ public interface IMachineApiService
         int chapterNum,
         CancellationToken cancellationToken
     );
+    Task<BuildDto?> GetPreTranslationQueuedStateAsync(
+        string curUserId,
+        string sfProjectId,
+        CancellationToken cancellationToken
+    );
     Task<WordGraph> GetWordGraphAsync(
         string curUserId,
         string sfProjectId,

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -28,6 +28,11 @@ public interface IMachineApiService
         CancellationToken cancellationToken
     );
     Task<BuildDto> StartBuildAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
+    Task<BuildDto?> StartPreTranslationBuildAsync(
+        string curUserId,
+        string sfProjectId,
+        CancellationToken cancellationToken
+    );
     Task TrainSegmentAsync(
         string curUserId,
         string sfProjectId,

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -14,12 +14,14 @@ public interface IMachineApiService
         string sfProjectId,
         string buildId,
         long? minRevision,
+        bool preTranslate,
         CancellationToken cancellationToken
     );
     Task<BuildDto?> GetCurrentBuildAsync(
         string curUserId,
         string sfProjectId,
         long? minRevision,
+        bool preTranslate,
         CancellationToken cancellationToken
     );
     Task<EngineDto> GetEngineAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -2,6 +2,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Serval.Client;
 using SIL.Machine.WebApi;
+using SIL.XForge.Scripture.Models;
 
 namespace SIL.XForge.Scripture.Services;
 
@@ -22,6 +23,13 @@ public interface IMachineApiService
         CancellationToken cancellationToken
     );
     Task<EngineDto> GetEngineAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
+    Task<PreTranslationDto> GetPreTranslationAsync(
+        string curUserId,
+        string sfProjectId,
+        int bookNum,
+        int chapterNum,
+        CancellationToken cancellationToken
+    );
     Task<WordGraph> GetWordGraphAsync(
         string curUserId,
         string sfProjectId,

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -7,6 +7,7 @@ namespace SIL.XForge.Scripture.Services;
 
 public interface IMachineApiService
 {
+    Task CancelPreTranslationBuildAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
     Task<BuildDto?> GetBuildAsync(
         string curUserId,
         string sfProjectId,
@@ -28,11 +29,7 @@ public interface IMachineApiService
         CancellationToken cancellationToken
     );
     Task<BuildDto> StartBuildAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
-    Task<BuildDto?> StartPreTranslationBuildAsync(
-        string curUserId,
-        string sfProjectId,
-        CancellationToken cancellationToken
-    );
+    Task StartPreTranslationBuildAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
     Task TrainSegmentAsync(
         string curUserId,
         string sfProjectId,

--- a/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
@@ -1,12 +1,28 @@
 using System.Threading;
 using System.Threading.Tasks;
+using Serval.Client;
 
 namespace SIL.XForge.Scripture.Services;
 
 public interface IMachineProjectService
 {
-    Task AddProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
-    Task BuildProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
-    Task RemoveProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
-    Task<bool> SyncProjectCorporaAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
+    Task AddProjectAsync(string curUserId, string sfProjectId, bool preTranslate, CancellationToken cancellationToken);
+    Task<TranslationBuild?> BuildProjectAsync(
+        string curUserId,
+        string sfProjectId,
+        bool preTranslate,
+        CancellationToken cancellationToken
+    );
+    Task RemoveProjectAsync(
+        string curUserId,
+        string sfProjectId,
+        bool preTranslate,
+        CancellationToken cancellationToken
+    );
+    Task<bool> SyncProjectCorporaAsync(
+        string curUserId,
+        string sfProjectId,
+        bool preTranslate,
+        CancellationToken cancellationToken
+    );
 }

--- a/src/SIL.XForge.Scripture/Services/IPreTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/IPreTranslationService.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+using SIL.XForge.Scripture.Models;
+
+namespace SIL.XForge.Scripture.Services;
+
+public interface IPreTranslationService
+{
+    Task<PreTranslation[]> GetPreTranslationsAsync(
+        string curUserId,
+        string sfProjectId,
+        int bookNum,
+        int chapterNum,
+        CancellationToken cancellationToken
+    );
+}

--- a/src/SIL.XForge.Scripture/Services/ISFTextCorpusFactory.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFTextCorpusFactory.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using SIL.Machine.Corpora;
+using SIL.Machine.WebApi.Services;
+
+namespace SIL.XForge.Scripture.Services;
+
+public interface ISFTextCorpusFactory
+{
+    Task<ITextCorpus> CreateAsync(IEnumerable<string> projects, TextCorpusType type, bool preTranslate);
+}

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -124,6 +124,7 @@ public class MachineApiService : IMachineApiService
         string sfProjectId,
         string buildId,
         long? minRevision,
+        bool preTranslate,
         CancellationToken cancellationToken
     )
     {
@@ -141,7 +142,7 @@ public class MachineApiService : IMachineApiService
         else if (await _featureManager.IsEnabledAsync(FeatureFlags.Serval))
         {
             // Execute on Serval, if it is enabled
-            string translationEngineId = await GetTranslationIdAsync(sfProjectId, preTranslate: false);
+            string translationEngineId = await GetTranslationIdAsync(sfProjectId, preTranslate);
             if (string.IsNullOrWhiteSpace(translationEngineId))
             {
                 throw new DataNotFoundException("The translation engine is not configured");
@@ -181,6 +182,7 @@ public class MachineApiService : IMachineApiService
         string curUserId,
         string sfProjectId,
         long? minRevision,
+        bool preTranslate,
         CancellationToken cancellationToken
     )
     {
@@ -199,7 +201,7 @@ public class MachineApiService : IMachineApiService
         else if (await _featureManager.IsEnabledAsync(FeatureFlags.Serval))
         {
             // Otherwise execute on Serval, if it is enabled
-            string translationEngineId = await GetTranslationIdAsync(sfProjectId, preTranslate: false);
+            string translationEngineId = await GetTranslationIdAsync(sfProjectId, preTranslate);
             if (string.IsNullOrWhiteSpace(translationEngineId))
             {
                 throw new DataNotFoundException("The translation engine is not configured");

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -102,7 +102,7 @@ public class MachineApiService : IMachineApiService
         else if (await _featureManager.IsEnabledAsync(FeatureFlags.Serval))
         {
             // Execute on Serval, if it is enabled
-            string translationEngineId = await GetTranslationIdAsync(sfProjectId);
+            string translationEngineId = await GetTranslationIdAsync(sfProjectId, preTranslate: false);
             if (string.IsNullOrWhiteSpace(translationEngineId))
             {
                 throw new DataNotFoundException("The translation engine is not configured");
@@ -160,7 +160,7 @@ public class MachineApiService : IMachineApiService
         else if (await _featureManager.IsEnabledAsync(FeatureFlags.Serval))
         {
             // Otherwise execute on Serval, if it is enabled
-            string translationEngineId = await GetTranslationIdAsync(sfProjectId);
+            string translationEngineId = await GetTranslationIdAsync(sfProjectId, preTranslate: false);
             if (string.IsNullOrWhiteSpace(translationEngineId))
             {
                 throw new DataNotFoundException("The translation engine is not configured");
@@ -209,7 +209,7 @@ public class MachineApiService : IMachineApiService
         // Execute on Serval, if it is enabled
         if (await _featureManager.IsEnabledAsync(FeatureFlags.Serval))
         {
-            string translationEngineId = await GetTranslationIdAsync(sfProjectId);
+            string translationEngineId = await GetTranslationIdAsync(sfProjectId, preTranslate: false);
             if (!string.IsNullOrWhiteSpace(translationEngineId))
             {
                 try
@@ -266,7 +266,7 @@ public class MachineApiService : IMachineApiService
         // Execute on Serval, if it is enabled
         if (await _featureManager.IsEnabledAsync(FeatureFlags.Serval))
         {
-            string translationEngineId = await GetTranslationIdAsync(sfProjectId);
+            string translationEngineId = await GetTranslationIdAsync(sfProjectId, preTranslate: false);
             if (!string.IsNullOrWhiteSpace(translationEngineId))
             {
                 try
@@ -323,13 +323,18 @@ public class MachineApiService : IMachineApiService
         // Execute on Serval, if it is enabled
         if (await _featureManager.IsEnabledAsync(FeatureFlags.Serval))
         {
-            string translationEngineId = await GetTranslationIdAsync(sfProjectId);
+            string translationEngineId = await GetTranslationIdAsync(sfProjectId, preTranslate: false);
             if (!string.IsNullOrWhiteSpace(translationEngineId))
             {
                 try
                 {
                     // We do not need the success boolean result, as we will still rebuild if no files have changed
-                    await _machineProjectService.SyncProjectCorporaAsync(curUserId, sfProjectId, cancellationToken);
+                    await _machineProjectService.SyncProjectCorporaAsync(
+                        curUserId,
+                        sfProjectId,
+                        preTranslate: false,
+                        cancellationToken
+                    );
                     TranslationBuild translationBuild = await _translationEnginesClient.StartBuildAsync(
                         translationEngineId,
                         new TranslationBuildConfig(),
@@ -368,6 +373,46 @@ public class MachineApiService : IMachineApiService
         return UpdateDto(buildDto, sfProjectId);
     }
 
+    public async Task<BuildDto?> StartPreTranslationBuildAsync(
+        string curUserId,
+        string sfProjectId,
+        CancellationToken cancellationToken
+    )
+    {
+        // Ensure that the user has permission
+        await EnsurePermissionAsync(curUserId, sfProjectId);
+
+        // Execute on Serval, if it is enabled
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.Serval))
+        {
+            try
+            {
+                TranslationBuild? translationBuild = await _machineProjectService.BuildProjectAsync(
+                    curUserId,
+                    sfProjectId,
+                    preTranslate: true,
+                    cancellationToken
+                );
+
+                // A null value will be an empty result (204) to the user
+                if (translationBuild is null)
+                {
+                    return null;
+                }
+
+                BuildDto buildDto = CreateDto(translationBuild);
+                return UpdateDto(buildDto, sfProjectId);
+            }
+            catch (Exception e)
+            {
+                await ProcessServalApiExceptionAsync(e);
+            }
+        }
+
+        // We only support Serval for pre-translations
+        throw new DataNotFoundException("The translation engine does not support pre-translations");
+    }
+
     public async Task TrainSegmentAsync(
         string curUserId,
         string sfProjectId,
@@ -381,7 +426,7 @@ public class MachineApiService : IMachineApiService
         // Execute on Serval, if it is enabled
         if (await _featureManager.IsEnabledAsync(FeatureFlags.Serval))
         {
-            string translationEngineId = await GetTranslationIdAsync(sfProjectId);
+            string translationEngineId = await GetTranslationIdAsync(sfProjectId, preTranslate: false);
             if (!string.IsNullOrWhiteSpace(translationEngineId))
             {
                 try
@@ -430,7 +475,7 @@ public class MachineApiService : IMachineApiService
         // Execute on Serval, if it is enabled
         if (await _featureManager.IsEnabledAsync(FeatureFlags.Serval))
         {
-            string translationEngineId = await GetTranslationIdAsync(sfProjectId);
+            string translationEngineId = await GetTranslationIdAsync(sfProjectId, preTranslate: false);
             if (!string.IsNullOrWhiteSpace(translationEngineId))
             {
                 try
@@ -492,7 +537,7 @@ public class MachineApiService : IMachineApiService
         // Execute on Serval, if it is enabled
         if (await _featureManager.IsEnabledAsync(FeatureFlags.Serval))
         {
-            string translationEngineId = await GetTranslationIdAsync(sfProjectId);
+            string translationEngineId = await GetTranslationIdAsync(sfProjectId, preTranslate: false);
             if (!string.IsNullOrWhiteSpace(translationEngineId))
             {
                 try
@@ -778,7 +823,7 @@ public class MachineApiService : IMachineApiService
         return engine ?? throw new DataNotFoundException("The engine does not exist.");
     }
 
-    private async Task<string> GetTranslationIdAsync(string sfProjectId)
+    private async Task<string> GetTranslationIdAsync(string sfProjectId, bool preTranslate)
     {
         // Load the project secret, so we can get the translation engine ID
         if (!(await _projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret))
@@ -787,7 +832,9 @@ public class MachineApiService : IMachineApiService
         }
 
         // Ensure we have a translation engine ID
-        string? translationEngineId = projectSecret.ServalData?.TranslationEngineId;
+        string? translationEngineId = preTranslate
+            ? projectSecret.ServalData?.PreTranslationEngineId
+            : projectSecret.ServalData?.TranslationEngineId;
         return string.IsNullOrWhiteSpace(translationEngineId) ? string.Empty : translationEngineId;
     }
 }

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -211,12 +211,17 @@ public class MachineProjectService : IMachineProjectService
         {
             // If the corpus was updated (or this is a pre-translation engine), start the build
             // We do not need the build ID for tracking as we use GetCurrentBuildAsync for that
+
+            // Get the appropriate translation engine
             string translationEngineId;
             TranslationBuildConfig translationBuildConfig;
             if (preTranslate)
             {
-                // Execute a complete pre-translation
+                // Get the updated project secrets
+                projectSecret = await _projectSecrets.GetAsync(sfProjectId);
                 translationEngineId = projectSecret.ServalData!.PreTranslationEngineId;
+
+                // Execute a complete pre-translation
                 translationBuildConfig = GetTranslationBuildConfig(projectSecret.ServalData);
             }
             else
@@ -586,7 +591,7 @@ public class MachineProjectService : IMachineProjectService
         {
             Pretranslate = servalData.Corpora
                 .Where(s => s.Value.PreTranslate)
-                .Select(c => new PretranslateCorpusConfig { CorpusId = c.Key, TextIds = new List<string>() })
+                .Select(c => new PretranslateCorpusConfig { CorpusId = c.Key })
                 .ToList(),
         };
 

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -233,7 +233,7 @@ public class MachineProjectService : IMachineProjectService
             // Start a build if:
             // - This is an SMT build (i.e. preTranslate is false)
             // - This is an NMT build and no pre-translation build is queued
-            if (!preTranslate || !await PreTranslationBuildQueuedAsync(translationEngineId))
+            if (!preTranslate || !await IsPreTranslationBuildQueuedAsync(translationEngineId))
             {
                 TranslationBuild translationBuild = await _translationEnginesClient.StartBuildAsync(
                     translationEngineId,
@@ -246,7 +246,7 @@ public class MachineProjectService : IMachineProjectService
                 {
                     await _projectSecrets.UpdateAsync(
                         sfProjectId,
-                        u => u.Unset(p => p.ServalData.PreTranslationQueued)
+                        u => u.Unset(p => p.ServalData.PreTranslationQueuedAt)
                     );
                 }
 
@@ -434,7 +434,7 @@ public class MachineProjectService : IMachineProjectService
         }
 
         // See if there is a corpus
-        string? corpusId = projectSecret.ServalData.Corpora
+        string corpusId = projectSecret.ServalData.Corpora
             .FirstOrDefault(c => c.Value.PreTranslate == preTranslate)
             .Key;
 
@@ -686,7 +686,7 @@ public class MachineProjectService : IMachineProjectService
     /// </summary>
     /// <param name="translationEngineId">The translation engine id</param>
     /// <returns><c>true</c> if the pre-translation build is running; otherwise, <c>false</c>.</returns>
-    private async Task<bool> PreTranslationBuildQueuedAsync(string translationEngineId)
+    private async Task<bool> IsPreTranslationBuildQueuedAsync(string translationEngineId)
     {
         bool buildRunning;
         try

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -37,7 +37,7 @@ public class MachineProjectService : IMachineProjectService
     private readonly IParatextService _paratextService;
     private readonly IRepository<SFProjectSecret> _projectSecrets;
     private readonly IRealtimeService _realtimeService;
-    private readonly ITextCorpusFactory _textCorpusFactory;
+    private readonly ISFTextCorpusFactory _textCorpusFactory;
     private readonly ITranslationEnginesClient _translationEnginesClient;
     private readonly IRepository<UserSecret> _userSecrets;
 
@@ -49,7 +49,7 @@ public class MachineProjectService : IMachineProjectService
         IParatextService paratextService,
         IRepository<SFProjectSecret> projectSecrets,
         IRealtimeService realtimeService,
-        ITextCorpusFactory textCorpusFactory,
+        ISFTextCorpusFactory textCorpusFactory,
         ITranslationEnginesClient translationEnginesClient,
         IRepository<UserSecret> userSecrets
     )
@@ -66,7 +66,12 @@ public class MachineProjectService : IMachineProjectService
         _userSecrets = userSecrets;
     }
 
-    public async Task AddProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken)
+    public async Task AddProjectAsync(
+        string curUserId,
+        string sfProjectId,
+        bool preTranslate,
+        CancellationToken cancellationToken
+    )
     {
         // Load the project from the realtime service
         Attempt<SFProject> attempt = await _realtimeService.TryGetSnapshotAsync<SFProject>(sfProjectId);
@@ -84,7 +89,7 @@ public class MachineProjectService : IMachineProjectService
         };
 
         // Only add to the In Process instance if it is enabled
-        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess) && !preTranslate)
         {
             await _engineService.AddProjectAsync(machineProject);
         }
@@ -105,14 +110,19 @@ public class MachineProjectService : IMachineProjectService
         )
         {
             // We do not need the returned project secret
-            await CreateServalProjectAsync(project, cancellationToken);
+            await CreateServalProjectAsync(project, preTranslate, cancellationToken);
         }
     }
 
-    public async Task BuildProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken)
+    public async Task<TranslationBuild?> BuildProjectAsync(
+        string curUserId,
+        string sfProjectId,
+        bool preTranslate,
+        CancellationToken cancellationToken
+    )
     {
         // Build the project with the In Process Machine instance
-        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess) && !preTranslate)
         {
             await _engineService.StartBuildByProjectIdAsync(sfProjectId);
         }
@@ -121,17 +131,20 @@ public class MachineProjectService : IMachineProjectService
         if (!await _featureManager.IsEnabledAsync(FeatureFlags.Serval))
         {
             _logger.LogInformation("Serval feature flag is not enabled");
-            return;
+            return null;
         }
 
         // Load the target project secrets, so we can get the translation engine ID
         if (!(await _projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret))
         {
-            throw new ArgumentException("The project secret cannot be found.");
+            throw new DataNotFoundException("The project secret cannot be found.");
         }
 
-        // Ensure we have a translation engine id
-        if (string.IsNullOrWhiteSpace(projectSecret.ServalData?.TranslationEngineId))
+        // Ensure we have a translation engine id or a pre-translation engine id
+        if (
+            (string.IsNullOrWhiteSpace(projectSecret.ServalData?.PreTranslationEngineId) && preTranslate)
+            || (string.IsNullOrWhiteSpace(projectSecret.ServalData?.TranslationEngineId) && !preTranslate)
+        )
         {
             // We do not have one, likely because the translation is a back translation
             // We can only get the language tags for back translations from the ScrText,
@@ -182,28 +195,62 @@ public class MachineProjectService : IMachineProjectService
                 }
             }
 
+            // If the pre-translate flag is not set, set it now for the front-end UI
+            if (preTranslate && !projectDoc.Data.TranslateConfig.PreTranslate)
+            {
+                await projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.TranslateConfig.PreTranslate, true));
+            }
+
             // Create the Serval project
             // The returned project secret will have the translation engine id
-            projectSecret = await CreateServalProjectAsync(projectDoc.Data, cancellationToken);
+            projectSecret = await CreateServalProjectAsync(projectDoc.Data, preTranslate, cancellationToken);
         }
 
         // Sync the corpus
-        if (await SyncProjectCorporaAsync(curUserId, sfProjectId, cancellationToken))
+        if ((await SyncProjectCorporaAsync(curUserId, sfProjectId, preTranslate, cancellationToken)) || preTranslate)
         {
-            // If the corpus was updated, start the build
+            // If the corpus was updated (or this is a pre-translation engine), start the build
             // We do not need the build ID for tracking as we use GetCurrentBuildAsync for that
-            await _translationEnginesClient.StartBuildAsync(
-                projectSecret.ServalData!.TranslationEngineId,
-                new TranslationBuildConfig(),
-                cancellationToken
-            );
+            string translationEngineId;
+            TranslationBuildConfig translationBuildConfig;
+            if (preTranslate)
+            {
+                // Execute a complete pre-translation
+                translationEngineId = projectSecret.ServalData!.PreTranslationEngineId;
+                translationBuildConfig = GetTranslationBuildConfig(projectSecret.ServalData);
+            }
+            else
+            {
+                translationEngineId = projectSecret.ServalData!.TranslationEngineId;
+                translationBuildConfig = new TranslationBuildConfig();
+            }
+
+            // Start a build if:
+            // - This is an SMT build (i.e. preTranslate is false)
+            // - This is an NMT build and no pre-translation build is queued
+            if (!preTranslate || !await PreTranslationBuildQueuedAsync(translationEngineId))
+            {
+                return await _translationEnginesClient.StartBuildAsync(
+                    translationEngineId,
+                    translationBuildConfig,
+                    cancellationToken
+                );
+            }
         }
+
+        // No build started
+        return null;
     }
 
-    public async Task RemoveProjectAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken)
+    public async Task RemoveProjectAsync(
+        string curUserId,
+        string sfProjectId,
+        bool preTranslate,
+        CancellationToken cancellationToken
+    )
     {
         // Remove the project from the In Process Machine instance
-        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess) && !preTranslate)
         {
             await _engineService.RemoveProjectAsync(sfProjectId);
         }
@@ -218,18 +265,23 @@ public class MachineProjectService : IMachineProjectService
         // Load the target project secrets, so we can get the translation engine ID
         if (!(await _projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret))
         {
-            throw new ArgumentException("The project secret cannot be found.");
+            throw new DataNotFoundException("The project secret cannot be found.");
         }
 
         // Ensure we have a translation engine id
-        if (string.IsNullOrWhiteSpace(projectSecret.ServalData?.TranslationEngineId))
+        string translationEngineId = preTranslate
+            ? projectSecret.ServalData?.PreTranslationEngineId
+            : projectSecret.ServalData?.TranslationEngineId;
+        if (string.IsNullOrWhiteSpace(translationEngineId))
         {
             _logger.LogInformation($"No Translation Engine Id specified for project {sfProjectId}");
             return;
         }
 
         // Remove the corpus files
-        foreach ((string corpusId, _) in projectSecret.ServalData.Corpora)
+        foreach (
+            (string corpusId, _) in projectSecret.ServalData.Corpora.Where(c => c.Value.PreTranslate == preTranslate)
+        )
         {
             foreach (
                 string fileId in projectSecret.ServalData.Corpora[corpusId].SourceFiles
@@ -263,7 +315,6 @@ public class MachineProjectService : IMachineProjectService
             }
 
             // Delete the corpus
-            string translationEngineId = projectSecret.ServalData.TranslationEngineId;
             try
             {
                 await _translationEnginesClient.DeleteCorpusAsync(translationEngineId, corpusId, cancellationToken);
@@ -287,13 +338,23 @@ public class MachineProjectService : IMachineProjectService
                     _logger.LogError(e, message);
                 }
             }
+
+            // Remove our record of the corpus
+            await _projectSecrets.UpdateAsync(sfProjectId, u => u.Unset(p => p.ServalData.Corpora[corpusId]));
         }
 
         // Remove the project from Serval
-        await _translationEnginesClient.DeleteAsync(projectSecret.ServalData.TranslationEngineId, cancellationToken);
+        await _translationEnginesClient.DeleteAsync(translationEngineId, cancellationToken);
 
         // Remove the Serval Data
-        await _projectSecrets.UpdateAsync(sfProjectId, u => u.Unset(p => p.ServalData));
+        if (preTranslate)
+        {
+            await _projectSecrets.UpdateAsync(sfProjectId, u => u.Unset(p => p.ServalData.PreTranslationEngineId));
+        }
+        else
+        {
+            await _projectSecrets.UpdateAsync(sfProjectId, u => u.Unset(p => p.ServalData.TranslationEngineId));
+        }
     }
 
     /// <summary>
@@ -301,10 +362,10 @@ public class MachineProjectService : IMachineProjectService
     /// </summary>
     /// <param name="curUserId">The current user identifier.</param>
     /// <param name="sfProjectId">The project identifier.</param>
+    /// <param name="preTranslate">The project is for pre-translation.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns><c>true</c> if the project corpora and its files were updated; otherwise, <c>false</c>.</returns>
     /// <exception cref="DataNotFoundException">The project does not exist.</exception>
-    /// <exception cref="ArgumentException">One of the arguments was an invalid identifier.</exception>
     /// <remarks>
     /// Notes:
     ///  - If the corpus was updated, then you should start the Build with <see cref="BuildProjectAsync"/>.
@@ -314,6 +375,7 @@ public class MachineProjectService : IMachineProjectService
     public async Task<bool> SyncProjectCorporaAsync(
         string curUserId,
         string sfProjectId,
+        bool preTranslate,
         CancellationToken cancellationToken
     )
     {
@@ -337,23 +399,28 @@ public class MachineProjectService : IMachineProjectService
         // Load the project secrets, so we can get the corpus files
         if (!(await _projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret))
         {
-            throw new ArgumentException("The project secret cannot be found.");
+            throw new DataNotFoundException("The project secret cannot be found.");
         }
 
         // Ensure we have serval data
         if (projectSecret.ServalData is null)
         {
-            throw new ArgumentException("The Serval data cannot be found.");
+            throw new DataNotFoundException("The Serval data cannot be found.");
         }
 
         // Ensure we have a translation engine ID
-        if (string.IsNullOrWhiteSpace(projectSecret.ServalData?.TranslationEngineId))
+        string translationEngineId = preTranslate
+            ? projectSecret.ServalData?.PreTranslationEngineId
+            : projectSecret.ServalData?.TranslationEngineId;
+        if (string.IsNullOrWhiteSpace(translationEngineId))
         {
-            throw new ArgumentException("The translation engine ID cannot be found.");
+            throw new DataNotFoundException("The translation engine ID cannot be found.");
         }
 
         // See if there is a corpus
-        string? corpusId = projectSecret.ServalData.Corpora.Keys.FirstOrDefault();
+        string? corpusId = projectSecret.ServalData.Corpora
+            .FirstOrDefault(c => c.Value.PreTranslate == preTranslate)
+            .Key;
 
         // Get the files we have already synced
         var oldSourceCorpusFiles = new List<ServalCorpusFile>();
@@ -363,10 +430,15 @@ public class MachineProjectService : IMachineProjectService
         }
 
         // Reuse the SFTextCorpusFactory implementation
-        ITextCorpus? textCorpus = await _textCorpusFactory.CreateAsync(new[] { sfProjectId }, TextCorpusType.Source);
+        ITextCorpus? textCorpus = await _textCorpusFactory.CreateAsync(
+            new[] { sfProjectId },
+            TextCorpusType.Source,
+            preTranslate
+        );
         var newSourceCorpusFiles = new List<ServalCorpusFile>();
         corpusUpdated |= await UploadNewCorpusFilesAsync(
             project.Id,
+            includeBlankSegments: false,
             textCorpus,
             oldSourceCorpusFiles,
             newSourceCorpusFiles,
@@ -380,10 +452,11 @@ public class MachineProjectService : IMachineProjectService
             oldTargetCorpusFiles = projectSecret.ServalData.Corpora[corpusId].TargetFiles;
         }
 
-        textCorpus = await _textCorpusFactory.CreateAsync(new[] { sfProjectId }, TextCorpusType.Target);
+        textCorpus = await _textCorpusFactory.CreateAsync(new[] { sfProjectId }, TextCorpusType.Target, preTranslate);
         List<ServalCorpusFile> newTargetCorpusFiles = new List<ServalCorpusFile>();
         corpusUpdated |= await UploadNewCorpusFilesAsync(
             project.Id,
+            preTranslate,
             textCorpus,
             oldTargetCorpusFiles,
             newTargetCorpusFiles,
@@ -410,7 +483,7 @@ public class MachineProjectService : IMachineProjectService
             if (string.IsNullOrEmpty(corpusId))
             {
                 corpus = await _translationEnginesClient.AddCorpusAsync(
-                    projectSecret.ServalData.TranslationEngineId,
+                    translationEngineId,
                     corpusConfig,
                     cancellationToken
                 );
@@ -423,7 +496,7 @@ public class MachineProjectService : IMachineProjectService
                     TargetFiles = corpusConfig.TargetFiles,
                 };
                 corpus = await _translationEnginesClient.UpdateCorpusAsync(
-                    projectSecret.ServalData.TranslationEngineId,
+                    translationEngineId,
                     corpusId,
                     corpusUpdateConfig,
                     cancellationToken
@@ -436,7 +509,12 @@ public class MachineProjectService : IMachineProjectService
                 u =>
                     u.Set(
                         p => p.ServalData.Corpora[corpus.Id],
-                        new ServalCorpus { SourceFiles = newSourceCorpusFiles, TargetFiles = newTargetCorpusFiles }
+                        new ServalCorpus
+                        {
+                            SourceFiles = newSourceCorpusFiles,
+                            TargetFiles = newTargetCorpusFiles,
+                            PreTranslate = preTranslate,
+                        }
                     )
             );
         }
@@ -448,11 +526,16 @@ public class MachineProjectService : IMachineProjectService
     /// Gets the segments from the text with Unix/Linux line endings.
     /// </summary>
     /// <param name="text">The IText</param>
+    /// <param name="includeBlankSegments">
+    /// <c>true</c> if we are to include blank segments (usually for a pre-translation target); otherwise <c>false</c>.
+    /// </param>
     /// <returns>The text file data to be uploaded to Serval.</returns>
-    private static string GetTextFileData(IText text)
+    private static string GetTextFileData(IText text, bool includeBlankSegments)
     {
         var sb = new StringBuilder();
-        foreach (TextSegment segment in text.GetSegments().Where(s => !s.IsEmpty))
+
+        // For pre-translation, we must upload empty lines with segment refs for the correct references to be returned
+        foreach (TextSegment segment in text.GetSegments().Where(s => !s.IsEmpty || includeBlankSegments))
         {
             // We pad the verse number so the string based key comparisons in Machine will be accurate.
             // If the int does not parse successfully, it will be because it is a Biblical Term - which has a Greek or
@@ -493,45 +576,126 @@ public class MachineProjectService : IMachineProjectService
     }
 
     /// <summary>
+    /// Gets the TranslationBuildConfig for the specified ServalData object.
+    /// </summary>
+    /// <param name="servalData">The Serval data.</param>
+    /// <returns>The TranslationBuildConfig for a Pre-Translate build.</returns>
+    /// <remarks>Do not use with SMT builds.</remarks>
+    private static TranslationBuildConfig GetTranslationBuildConfig(ServalData servalData) =>
+        new TranslationBuildConfig
+        {
+            Pretranslate = servalData.Corpora
+                .Where(s => s.Value.PreTranslate)
+                .Select(c => new PretranslateCorpusConfig { CorpusId = c.Key, TextIds = new List<string>() })
+                .ToList(),
+        };
+
+    /// <summary>
     /// Creates a project in Serval.
     /// </summary>
     /// <param name="sfProject">The Scripture Forge project</param>
+    /// <param name="preTranslate">The project is for pre-translation.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The asynchronous task.</returns>
-    /// <exception cref="ArgumentException">The translation engine could not be created.</exception>
+    /// <exception cref="DataNotFoundException">The translation engine could not be created.</exception>
     private async Task<SFProjectSecret> CreateServalProjectAsync(
         SFProject sfProject,
+        bool preTranslate,
         CancellationToken cancellationToken
     )
     {
-        TranslationEngineConfig engineConfig = new TranslationEngineConfig
+        // Get the existing project secret, so we can see how to create the engine and update the Serval data
+        SFProjectSecret projectSecret = await _projectSecrets.GetAsync(sfProject.Id);
+        if (
+            (string.IsNullOrWhiteSpace(projectSecret.ServalData?.PreTranslationEngineId) && preTranslate)
+            || (string.IsNullOrWhiteSpace(projectSecret.ServalData?.TranslationEngineId) && !preTranslate)
+        )
         {
-            Name = sfProject.Id,
-            SourceLanguage = sfProject.TranslateConfig.Source.WritingSystem.Tag,
-            TargetLanguage = sfProject.WritingSystem.Tag,
-            Type = "SmtTransfer",
-        };
-        // Add the project to Serval
-        TranslationEngine translationEngine = await _translationEnginesClient.CreateAsync(
-            engineConfig,
-            cancellationToken
-        );
-        if (string.IsNullOrWhiteSpace(translationEngine.Id))
-        {
-            throw new ArgumentException("Translation Engine ID from Serval is missing.");
+            TranslationEngineConfig engineConfig = new TranslationEngineConfig
+            {
+                Name = sfProject.Id,
+                SourceLanguage = sfProject.TranslateConfig.Source.WritingSystem.Tag,
+                TargetLanguage = sfProject.WritingSystem.Tag,
+                Type = preTranslate ? "Nmt" : "SmtTransfer",
+            };
+            // Add the project to Serval
+            TranslationEngine translationEngine = await _translationEnginesClient.CreateAsync(
+                engineConfig,
+                cancellationToken
+            );
+            if (string.IsNullOrWhiteSpace(translationEngine.Id))
+            {
+                throw new DataNotFoundException("Translation Engine ID from Serval is missing.");
+            }
+
+            if (projectSecret.ServalData is not null && preTranslate)
+            {
+                // Store the Pre-Translation Engine ID
+                projectSecret = await _projectSecrets.UpdateAsync(
+                    sfProject.Id,
+                    u => u.Set(p => p.ServalData.PreTranslationEngineId, translationEngine.Id)
+                );
+            }
+            else if (projectSecret.ServalData is not null)
+            {
+                // Store the Translation Engine ID
+                projectSecret = await _projectSecrets.UpdateAsync(
+                    sfProject.Id,
+                    u => u.Set(p => p.ServalData.TranslationEngineId, translationEngine.Id)
+                );
+            }
+            else if (preTranslate)
+            {
+                // Store the Pre-Translation Engine ID
+                projectSecret = await _projectSecrets.UpdateAsync(
+                    sfProject.Id,
+                    u => u.Set(p => p.ServalData, new ServalData { PreTranslationEngineId = translationEngine.Id })
+                );
+            }
+            else
+            {
+                // Store the Translation Engine ID
+                projectSecret = await _projectSecrets.UpdateAsync(
+                    sfProject.Id,
+                    u => u.Set(p => p.ServalData, new ServalData { TranslationEngineId = translationEngine.Id })
+                );
+            }
         }
 
-        // Store the Translation Engine ID
-        return await _projectSecrets.UpdateAsync(
-            sfProject.Id,
-            u => u.Set(p => p.ServalData, new ServalData { TranslationEngineId = translationEngine.Id })
-        );
+        return projectSecret;
+    }
+
+    /// <summary>
+    /// Determines if a pre-translation build is queued.
+    /// </summary>
+    /// <param name="translationEngineId">The translation engine id</param>
+    /// <returns><c>true</c> if the pre-translation build is running; otherwise, <c>false</c>.</returns>
+    private async Task<bool> PreTranslationBuildQueuedAsync(string translationEngineId)
+    {
+        bool buildRunning;
+        try
+        {
+            TranslationBuild translationBuild = await _translationEnginesClient.GetCurrentBuildAsync(
+                translationEngineId
+            );
+            buildRunning = translationBuild.Pretranslate is not null && translationBuild.Pretranslate.Any();
+        }
+        catch (ServalApiException e) when (e.StatusCode == StatusCodes.Status204NoContent)
+        {
+            // A 204 error means no build is running
+            buildRunning = false;
+        }
+
+        return buildRunning;
     }
 
     /// <summary>
     /// Syncs an <see cref="ITextCorpus"/> to Serval, creating files on Serval as necessary.
     /// </summary>
     /// <param name="projectId">The project identifier.</param>
+    /// <param name="includeBlankSegments">
+    /// <c>true</c> if we are to include blank segments (usually for a pre-translation target); otherwise <c>false</c>.
+    /// </param>
     /// <param name="textCorpus">The text corpus created by <see cref="SFTextCorpusFactory"/>.</param>
     /// <param name="oldCorpusFiles">The existing corpus files (optional).</param>
     /// <param name="newCorpusFiles">The updated list of corpus files.</param>
@@ -542,6 +706,7 @@ public class MachineProjectService : IMachineProjectService
     /// </remarks>
     private async Task<bool> UploadNewCorpusFilesAsync(
         string projectId,
+        bool includeBlankSegments,
         ITextCorpus? textCorpus,
         ICollection<ServalCorpusFile>? oldCorpusFiles,
         ICollection<ServalCorpusFile> newCorpusFiles,
@@ -554,7 +719,7 @@ public class MachineProjectService : IMachineProjectService
         // Sync each text
         foreach (IText text in textCorpus?.Texts ?? Array.Empty<IText>())
         {
-            string textFileData = GetTextFileData(text);
+            string textFileData = GetTextFileData(text, includeBlankSegments);
             if (!string.IsNullOrWhiteSpace(textFileData))
             {
                 // Remove the project id from the start of the text id (if present)

--- a/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
@@ -96,6 +96,7 @@ public static class MachineServiceCollectionExtensions
         });
         services.AddSingleton<IMachineApiService, MachineApiService>();
         services.AddSingleton<IMachineProjectService, MachineProjectService>();
+        services.AddSingleton<IPreTranslationService, PreTranslationService>();
         return services;
     }
 

--- a/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
@@ -40,6 +40,7 @@ public static class MachineServiceCollectionExtensions
                 o.MachineDatabaseName = "xforge_machine";
             })
             .AddTextCorpus<SFTextCorpusFactory>();
+        services.AddSingleton<ISFTextCorpusFactory, SFTextCorpusFactory>();
         services.AddSingleton<IAuthorizationHandler, MachineAuthorizationHandler>();
         services.AddSingleton<IBuildHandler, SFBuildHandler>();
 

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1563,7 +1563,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
             if (TranslationSuggestionsEnabled && trainEngine && hasSourceTextDocs)
             {
                 // Start training Machine engine
-                await _machineProjectService.BuildProjectAsync(_userSecret.Id, _projectDoc.Id, token);
+                await _machineProjectService.BuildProjectAsync(_userSecret.Id, _projectDoc.Id, false, token);
             }
 
             // Backup the repository

--- a/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Serval.Client;
+using SIL.Machine.Corpora;
+using SIL.Scripture;
+using SIL.XForge.DataAccess;
+using SIL.XForge.Scripture.Models;
+using SIL.XForge.Services;
+
+namespace SIL.XForge.Scripture.Services;
+
+public class PreTranslationService : IPreTranslationService
+{
+    private readonly IRepository<SFProjectSecret> _projectSecrets;
+    private readonly ITranslationEnginesClient _translationEnginesClient;
+
+    public PreTranslationService(
+        IRepository<SFProjectSecret> projectSecrets,
+        ITranslationEnginesClient translationEnginesClient
+    )
+    {
+        _projectSecrets = projectSecrets;
+        _translationEnginesClient = translationEnginesClient;
+    }
+
+    public static string GetTextId(int bookNum, int chapterNum) => $"{bookNum}_{chapterNum}";
+
+    public async Task<PreTranslation[]> GetPreTranslationsAsync(
+        string curUserId,
+        string sfProjectId,
+        int bookNum,
+        int chapterNum,
+        CancellationToken cancellationToken
+    )
+    {
+        List<PreTranslation> preTranslations = new List<PreTranslation>();
+
+        // Load the target project secrets, so we can get the translation engine ID and corpus ID
+        if (!(await _projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret))
+        {
+            throw new DataNotFoundException("The project secret cannot be found.");
+        }
+
+        // Ensure we have the parameters to retrieve the pre-translation
+        string translationEngineId = projectSecret.ServalData?.PreTranslationEngineId;
+        string corpusId = projectSecret.ServalData?.Corpora.FirstOrDefault(c => c.Value.PreTranslate).Key;
+        if (string.IsNullOrWhiteSpace(translationEngineId) || string.IsNullOrWhiteSpace(corpusId))
+        {
+            throw new DataNotFoundException("The pre-translation engine is not configured.");
+        }
+
+        // Get the pre-translation data from Serval
+        string textId = GetTextId(bookNum, chapterNum);
+        foreach (
+            Pretranslation preTranslation in await _translationEnginesClient.GetAllPretranslations2Async(
+                translationEngineId,
+                corpusId,
+                textId,
+                cancellationToken
+            )
+        )
+        {
+            // A reference will be in the format "40_1:verse_001_002"
+            string reference = preTranslation.Refs.FirstOrDefault();
+            if (string.IsNullOrWhiteSpace(reference))
+            {
+                continue;
+            }
+
+            // Check for then remove the textId from the reference
+            string[] referenceParts;
+            if (reference.Contains(':'))
+            {
+                referenceParts = reference.Split(':', StringSplitOptions.RemoveEmptyEntries);
+                if (referenceParts.Length != 2)
+                {
+                    continue;
+                }
+
+                // The first part must be the text id
+                if (referenceParts.First() != textId)
+                {
+                    continue;
+                }
+
+                // Remove the reference part
+                reference = referenceParts.Last();
+            }
+
+            // Ensure this is for a verse - we do not support headings and metadata
+            if (!reference.StartsWith("verse_"))
+            {
+                continue;
+            }
+
+            referenceParts = reference.Split('_', StringSplitOptions.RemoveEmptyEntries);
+            if (
+                referenceParts.Length != 3
+                || !int.TryParse(referenceParts[1], out int refChapterNum)
+                || refChapterNum != chapterNum
+            )
+            {
+                continue;
+            }
+
+            // Get the reference in the form MAT 1:2
+            string verse = referenceParts.Last();
+            VerseRef verseRef = new VerseRefData(bookNum, chapterNum, verse).ToVerseRef();
+            reference = verseRef.Text;
+
+            // Build the translation string
+            StringBuilder sb = new StringBuilder();
+            string[] words = preTranslation.Translation.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            for (int i = 0; i < words.Length; i++)
+            {
+                string word = words[i];
+
+                // Add a preceding space if this is not the first word or punctuation
+                if (i > 0 && (word.Length != 1 || !char.IsPunctuation(word.First())))
+                {
+                    sb.Append(' ');
+                }
+
+                sb.Append(word);
+            }
+
+            // Remove the last space and get the translation
+            sb.TrimEnd();
+            string translation = sb.ToString();
+
+            // Add the pre-translation
+            preTranslations.Add(new PreTranslation { Reference = reference, Translation = translation, });
+        }
+
+        return preTranslations.ToArray();
+    }
+}

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -107,7 +107,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Throws(new DataNotFoundException("Entity Deleted"));
 
         // SUT
@@ -115,6 +115,7 @@ public class MachineApiControllerTests
             Project01,
             Build01,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 
@@ -127,7 +128,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -135,6 +136,7 @@ public class MachineApiControllerTests
             Project01,
             Build01,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 
@@ -149,7 +151,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Returns(Task.FromResult<BuildDto>(null));
 
         // SUT
@@ -157,6 +159,7 @@ public class MachineApiControllerTests
             Project01,
             Build01,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 
@@ -169,7 +172,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -177,6 +180,7 @@ public class MachineApiControllerTests
             Project01,
             Build01,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 
@@ -189,7 +193,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -197,6 +201,7 @@ public class MachineApiControllerTests
             Project01,
             Build01,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 
@@ -209,7 +214,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Returns(Task.FromResult(new BuildDto()));
 
         // SUT
@@ -217,6 +222,7 @@ public class MachineApiControllerTests
             Project01,
             Build01,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 
@@ -229,7 +235,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Throws(new DataNotFoundException("Entity Deleted"));
 
         // SUT
@@ -237,6 +243,7 @@ public class MachineApiControllerTests
             Project01,
             buildId: null,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 
@@ -249,7 +256,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -257,6 +264,7 @@ public class MachineApiControllerTests
             Project01,
             buildId: null,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 
@@ -271,7 +279,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Returns(Task.FromResult<BuildDto>(null));
 
         // SUT
@@ -279,6 +287,7 @@ public class MachineApiControllerTests
             Project01,
             buildId: null,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 
@@ -291,7 +300,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -299,6 +308,7 @@ public class MachineApiControllerTests
             Project01,
             buildId: null,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 
@@ -311,7 +321,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -319,6 +329,7 @@ public class MachineApiControllerTests
             Project01,
             buildId: null,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 
@@ -331,7 +342,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Returns(Task.FromResult(new BuildDto()));
 
         // SUT
@@ -339,6 +350,7 @@ public class MachineApiControllerTests
             Project01,
             buildId: null,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
@@ -20,6 +21,84 @@ public class MachineApiControllerTests
     private const string Build01 = "build01";
     private const string Project01 = "project01";
     private const string User01 = "user01";
+
+    [Test]
+    public async Task CancelPreTranslationBuildAsync_MachineApiDown()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+
+        // SUT
+        ActionResult actual = await env.Controller.CancelPreTranslationBuildAsync(Project01, CancellationToken.None);
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+        Assert.IsInstanceOf<ObjectResult>(actual);
+        Assert.AreEqual(StatusCodes.Status503ServiceUnavailable, (actual as ObjectResult)?.StatusCode);
+    }
+
+    [Test]
+    public async Task CancelPreTranslationBuildAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            .Throws(new ForbiddenException());
+
+        // SUT
+        ActionResult actual = await env.Controller.CancelPreTranslationBuildAsync(Project01, CancellationToken.None);
+
+        Assert.IsInstanceOf<ForbidResult>(actual);
+    }
+
+    [Test]
+    public async Task CancelPreTranslationBuildAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            .Throws(new DataNotFoundException(string.Empty));
+
+        // SUT
+        ActionResult actual = await env.Controller.CancelPreTranslationBuildAsync(Project01, CancellationToken.None);
+
+        Assert.IsInstanceOf<NotFoundResult>(actual);
+    }
+
+    [Test]
+    public async Task CancelPreTranslationBuildAsync_NotSupported()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            .Throws(new NotSupportedException());
+
+        // SUT
+        ActionResult actual = await env.Controller.CancelPreTranslationBuildAsync(Project01, CancellationToken.None);
+
+        Assert.IsInstanceOf<IStatusCodeActionResult>(actual);
+        Assert.AreEqual(StatusCodes.Status405MethodNotAllowed, (actual as IStatusCodeActionResult)?.StatusCode);
+    }
+
+    [Test]
+    public async Task CancelPreTranslationBuildAsync_Success()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            .Returns(Task.CompletedTask);
+
+        // SUT
+        ActionResult actual = await env.Controller.CancelPreTranslationBuildAsync(Project01, CancellationToken.None);
+
+        Assert.IsInstanceOf<OkResult>(actual);
+    }
 
     [Test]
     public async Task GetBuildAsync_BuildEnded()
@@ -530,15 +609,12 @@ public class MachineApiControllerTests
         var env = new TestEnvironment();
         env.MachineApiService
             .StartPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
-            .Returns(Task.FromResult(new BuildDto()));
+            .Returns(Task.CompletedTask);
 
         // SUT
-        ActionResult<BuildDto> actual = await env.Controller.StartPreTranslationBuildAsync(
-            Project01,
-            CancellationToken.None
-        );
+        ActionResult actual = await env.Controller.StartPreTranslationBuildAsync(Project01, CancellationToken.None);
 
-        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+        Assert.IsInstanceOf<OkResult>(actual);
     }
 
     [Test]

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -209,6 +209,96 @@ public class MachineApiControllerTests
     }
 
     [Test]
+    public async Task GetBuildAsync_PreTranslationQueued()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetPreTranslationQueuedStateAsync(User01, Project01, CancellationToken.None)
+            .Returns(Task.FromResult(new BuildDto()));
+
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
+            Project01,
+            buildId: null,
+            minRevision: null,
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+        await env.MachineApiService
+            .Received(1)
+            .GetPreTranslationQueuedStateAsync(User01, Project01, CancellationToken.None);
+        await env.MachineApiService
+            .DidNotReceiveWithAnyArgs()
+            .GetCurrentBuildAsync(User01, Project01, null, true, CancellationToken.None);
+        await env.MachineApiService
+            .DidNotReceiveWithAnyArgs()
+            .GetBuildAsync(User01, Project01, Build01, null, true, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task GetBuildAsync_PreTranslationNotQueued()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetCurrentBuildAsync(User01, Project01, null, true, CancellationToken.None)
+            .Returns(Task.FromResult(new BuildDto()));
+
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
+            Project01,
+            buildId: null,
+            minRevision: null,
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+        await env.MachineApiService
+            .Received(1)
+            .GetPreTranslationQueuedStateAsync(User01, Project01, CancellationToken.None);
+        await env.MachineApiService
+            .Received(1)
+            .GetCurrentBuildAsync(User01, Project01, null, true, CancellationToken.None);
+        await env.MachineApiService
+            .DidNotReceiveWithAnyArgs()
+            .GetBuildAsync(User01, Project01, Build01, null, true, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task GetBuildAsync_PreTranslationSpecificBuild()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetBuildAsync(User01, Project01, Build01, null, true, CancellationToken.None)
+            .Returns(Task.FromResult(new BuildDto()));
+
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetBuildAsync(
+            Project01,
+            Build01,
+            minRevision: null,
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+        await env.MachineApiService
+            .DidNotReceiveWithAnyArgs()
+            .GetPreTranslationQueuedStateAsync(User01, Project01, CancellationToken.None);
+        await env.MachineApiService
+            .DidNotReceiveWithAnyArgs()
+            .GetCurrentBuildAsync(User01, Project01, null, true, CancellationToken.None);
+        await env.MachineApiService
+            .Received(1)
+            .GetBuildAsync(User01, Project01, Build01, null, true, CancellationToken.None);
+    }
+
+    [Test]
     public async Task GetBuildAsync_Success()
     {
         // Set up test environment

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -468,6 +468,80 @@ public class MachineApiControllerTests
     }
 
     [Test]
+    public async Task StartPreTranslationBuildAsync_MachineApiDown()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .StartPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+
+        // SUT
+        ActionResult<BuildDto> actual = await env.Controller.StartPreTranslationBuildAsync(
+            Project01,
+            CancellationToken.None
+        );
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+        Assert.IsInstanceOf<ObjectResult>(actual.Result);
+        Assert.AreEqual(StatusCodes.Status503ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
+    }
+
+    [Test]
+    public async Task StartPreTranslationBuildAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .StartPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            .Throws(new ForbiddenException());
+
+        // SUT
+        ActionResult<BuildDto> actual = await env.Controller.StartPreTranslationBuildAsync(
+            Project01,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<ForbidResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task StartPreTranslationBuildAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .StartPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            .Throws(new DataNotFoundException(string.Empty));
+
+        // SUT
+        ActionResult<BuildDto> actual = await env.Controller.StartPreTranslationBuildAsync(
+            Project01,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task StartPreTranslationBuildAsync_Success()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .StartPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            .Returns(Task.FromResult(new BuildDto()));
+
+        // SUT
+        ActionResult<BuildDto> actual = await env.Controller.StartPreTranslationBuildAsync(
+            Project01,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+    }
+
+    [Test]
     public async Task TrainSegmentAsync_MachineApiDown()
     {
         // Set up test environment

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiV2ControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiV2ControllerTests.cs
@@ -28,7 +28,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Throws(new DataNotFoundException("Entity Deleted"));
 
         // SUT
@@ -48,7 +48,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -70,7 +70,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Returns(Task.FromResult<BuildDto>(null));
 
         // SUT
@@ -90,7 +90,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -110,7 +110,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -130,7 +130,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Returns(Task.FromResult(new BuildDto { Engine = new ResourceDto() }));
 
         // SUT
@@ -150,7 +150,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Throws(new DataNotFoundException("Entity Deleted"));
 
         // SUT
@@ -170,7 +170,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -192,7 +192,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Returns(Task.FromResult<BuildDto>(null));
 
         // SUT
@@ -212,7 +212,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -232,7 +232,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -252,7 +252,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Returns(Task.FromResult(new BuildDto { Engine = new ResourceDto() }));
 
         // SUT

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -125,7 +125,7 @@ public class MachineApiServiceTests
         await env.Service.CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None);
 
         await env.TranslationEnginesClient.Received(1).CancelBuildAsync(TranslationEngine01, CancellationToken.None);
-        Assert.IsNull(env.ProjectSecrets.Get(Project01).ServalData!.PreTranslationQueued);
+        Assert.IsNull(env.ProjectSecrets.Get(Project01).ServalData!.PreTranslationQueuedAt);
     }
 
     [Test]
@@ -2224,7 +2224,7 @@ public class MachineApiServiceTests
         public async Task QueuePreTranslationBuildAsync(DateTime? dateTime = null) =>
             await ProjectSecrets.UpdateAsync(
                 Project01,
-                u => u.Set(p => p.ServalData.PreTranslationQueued, dateTime ?? DateTime.UtcNow)
+                u => u.Set(p => p.ServalData.PreTranslationQueuedAt, dateTime ?? DateTime.UtcNow)
             );
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -142,6 +142,7 @@ public class MachineApiServiceTests
             Project01,
             Build01,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 
@@ -162,7 +163,15 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.GetBuildAsync(User01, Project01, Build01, minRevision: 1, CancellationToken.None)
+            () =>
+                env.Service.GetBuildAsync(
+                    User01,
+                    Project01,
+                    Build01,
+                    minRevision: 1,
+                    preTranslate: false,
+                    CancellationToken.None
+                )
         );
     }
 
@@ -179,7 +188,15 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.GetBuildAsync(User01, Project01, Build01, minRevision, CancellationToken.None)
+            () =>
+                env.Service.GetBuildAsync(
+                    User01,
+                    Project01,
+                    Build01,
+                    minRevision,
+                    preTranslate: false,
+                    CancellationToken.None
+                )
         );
     }
 
@@ -199,6 +216,7 @@ public class MachineApiServiceTests
             Project01,
             Build01,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 
@@ -215,7 +233,15 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.GetBuildAsync(User01, Project01, Build01, minRevision: null, CancellationToken.None)
+            () =>
+                env.Service.GetBuildAsync(
+                    User01,
+                    Project01,
+                    Build01,
+                    minRevision: null,
+                    preTranslate: false,
+                    CancellationToken.None
+                )
         );
     }
 
@@ -233,6 +259,7 @@ public class MachineApiServiceTests
                     Project01,
                     Build01,
                     minRevision: null,
+                    preTranslate: false,
                     CancellationToken.None
                 )
         );
@@ -252,6 +279,7 @@ public class MachineApiServiceTests
                     "invalid_project_id",
                     Build01,
                     minRevision: null,
+                    preTranslate: false,
                     CancellationToken.None
                 )
         );
@@ -266,7 +294,15 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.GetBuildAsync(User01, Project03, Build01, minRevision: null, CancellationToken.None)
+            () =>
+                env.Service.GetBuildAsync(
+                    User01,
+                    Project03,
+                    Build01,
+                    minRevision: null,
+                    preTranslate: false,
+                    CancellationToken.None
+                )
         );
     }
 
@@ -302,6 +338,7 @@ public class MachineApiServiceTests
             Project01,
             Build01,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 
@@ -350,6 +387,7 @@ public class MachineApiServiceTests
             Project01,
             Build01,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 
@@ -371,7 +409,14 @@ public class MachineApiServiceTests
         var env = new TestEnvironment();
 
         // SUT
-        _ = await env.Service.GetBuildAsync(User01, Project01, Build01, minRevision: null, CancellationToken.None);
+        _ = await env.Service.GetBuildAsync(
+            User01,
+            Project01,
+            Build01,
+            minRevision: null,
+            preTranslate: false,
+            CancellationToken.None
+        );
 
         await env.Builds.Received(1).GetByLocatorAsync(BuildLocatorType.Id, Build01, CancellationToken.None);
         await env.TranslationEnginesClient
@@ -394,6 +439,7 @@ public class MachineApiServiceTests
             User01,
             Project01,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 
@@ -414,7 +460,14 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.GetCurrentBuildAsync(User01, Project01, minRevision: 1, CancellationToken.None)
+            () =>
+                env.Service.GetCurrentBuildAsync(
+                    User01,
+                    Project01,
+                    minRevision: 1,
+                    preTranslate: false,
+                    CancellationToken.None
+                )
         );
     }
 
@@ -431,7 +484,14 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.GetCurrentBuildAsync(User01, Project01, minRevision, CancellationToken.None)
+            () =>
+                env.Service.GetCurrentBuildAsync(
+                    User01,
+                    Project01,
+                    minRevision,
+                    preTranslate: false,
+                    CancellationToken.None
+                )
         );
     }
 
@@ -450,6 +510,7 @@ public class MachineApiServiceTests
             User01,
             Project01,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 
@@ -466,7 +527,14 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.GetCurrentBuildAsync(User01, Project01, minRevision: null, CancellationToken.None)
+            () =>
+                env.Service.GetCurrentBuildAsync(
+                    User01,
+                    Project01,
+                    minRevision: null,
+                    preTranslate: false,
+                    CancellationToken.None
+                )
         );
     }
 
@@ -483,6 +551,7 @@ public class MachineApiServiceTests
                     "invalid_user_id",
                     Project01,
                     minRevision: null,
+                    preTranslate: false,
                     CancellationToken.None
                 )
         );
@@ -501,6 +570,7 @@ public class MachineApiServiceTests
                     User01,
                     "invalid_project_id",
                     minRevision: null,
+                    preTranslate: false,
                     CancellationToken.None
                 )
         );
@@ -518,7 +588,14 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.GetCurrentBuildAsync(User01, Project01, minRevision: null, CancellationToken.None)
+            () =>
+                env.Service.GetCurrentBuildAsync(
+                    User01,
+                    Project01,
+                    minRevision: null,
+                    preTranslate: false,
+                    CancellationToken.None
+                )
         );
     }
 
@@ -531,7 +608,14 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.GetCurrentBuildAsync(User01, Project03, minRevision: null, CancellationToken.None)
+            () =>
+                env.Service.GetCurrentBuildAsync(
+                    User01,
+                    Project03,
+                    minRevision: null,
+                    preTranslate: false,
+                    CancellationToken.None
+                )
         );
     }
 
@@ -566,6 +650,7 @@ public class MachineApiServiceTests
             User01,
             Project01,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 
@@ -613,6 +698,7 @@ public class MachineApiServiceTests
             User01,
             Project01,
             minRevision: null,
+            preTranslate: false,
             CancellationToken.None
         );
 
@@ -634,7 +720,13 @@ public class MachineApiServiceTests
         var env = new TestEnvironment();
 
         // SUT
-        _ = await env.Service.GetCurrentBuildAsync(User01, Project01, minRevision: null, CancellationToken.None);
+        _ = await env.Service.GetCurrentBuildAsync(
+            User01,
+            Project01,
+            minRevision: null,
+            preTranslate: false,
+            CancellationToken.None
+        );
 
         await env.Builds
             .Received(1)

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
 using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement;
 using NSubstitute;
@@ -45,6 +48,83 @@ public class MachineApiServiceTests
     private const string User01 = "user01";
     private const string Segment = "segment";
     private const string TargetSegment = "targetSegment";
+
+    [Test]
+    public void CancelPreTranslationBuildAsync_NoFeatureFlagEnabled()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.Serval).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void CancelPreTranslationBuildAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.CancelPreTranslationBuildAsync("invalid_user_id", Project01, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void CancelPreTranslationBuildAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.CancelPreTranslationBuildAsync(User01, "invalid_project_id", CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void CancelPreTranslationBuildAsync_NoTranslationEngine()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.CancelPreTranslationBuildAsync(User01, "invalid_project_id", CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void CancelPreTranslationBuildAsync_NotSupported()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.TranslationEnginesClient
+            .CancelBuildAsync(TranslationEngine01, CancellationToken.None)
+            .Throws(ServalApiExceptions.NotSupported);
+
+        // SUT
+        Assert.ThrowsAsync<NotSupportedException>(
+            () => env.Service.CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public async Task CancelPreTranslationBuildAsync_Success()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        await env.Service.CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None);
+
+        await env.TranslationEnginesClient.Received(1).CancelBuildAsync(TranslationEngine01, CancellationToken.None);
+    }
 
     [Test]
     public async Task GetBuildAsync_InProcessNoRevisionNoBuildRunning()
@@ -1220,88 +1300,15 @@ public class MachineApiServiceTests
     }
 
     [Test]
-    public void StartPreTranslationBuildAsync_NoTranslationEngine()
-    {
-        // Set up test environment
-        var env = new TestEnvironment();
-        env.MachineProjectService
-            .BuildProjectAsync(User01, Project01, true, CancellationToken.None)
-            .Throws(new DataNotFoundException("Not Found"));
-
-        // SUT
-        Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.StartPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
-        );
-    }
-
-    [Test]
-    public void StartPreTranslationBuildAsync_Outage()
-    {
-        // Set up test environment
-        var env = new TestEnvironment();
-        env.MachineProjectService
-            .BuildProjectAsync(User01, Project01, true, CancellationToken.None)
-            .Throws(new BrokenCircuitException());
-
-        // SUT
-        Assert.ThrowsAsync<BrokenCircuitException>(
-            () => env.Service.StartPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
-        );
-    }
-
-    [Test]
-    public async Task StartPreTranslationBuildAsync_NoBuild()
-    {
-        // Set up test environment
-        var env = new TestEnvironment();
-        env.MachineProjectService
-            .BuildProjectAsync(User01, Project01, true, CancellationToken.None)
-            .Returns(Task.FromResult<TranslationBuild>(null));
-
-        // SUT
-        BuildDto? actual = await env.Service.StartPreTranslationBuildAsync(User01, Project01, CancellationToken.None);
-        Assert.IsNull(actual);
-    }
-
-    [Test]
     public async Task StartPreTranslationBuildAsync_Success()
     {
         // Set up test environment
         var env = new TestEnvironment();
-        const string buildDtoId = $"{Project01}.{Build01}";
-        const string message = "Training language model";
-        const double percentCompleted = 0.01;
-        const int revision = 2;
-        const JobState state = JobState.Active;
-        env.MachineProjectService
-            .BuildProjectAsync(User01, Project01, true, CancellationToken.None)
-            .Returns(
-                Task.FromResult(
-                    new TranslationBuild
-                    {
-                        Url = "https://example.com",
-                        Id = Build01,
-                        Engine = new ResourceLink { Id = "engineId", Url = "https://example.com" },
-                        Message = message,
-                        PercentCompleted = percentCompleted,
-                        Revision = revision,
-                        State = state,
-                    }
-                )
-            );
 
         // SUT
-        BuildDto actual = await env.Service.StartPreTranslationBuildAsync(User01, Project01, CancellationToken.None);
+        await env.Service.StartPreTranslationBuildAsync(User01, Project01, CancellationToken.None);
 
-        Assert.IsNotNull(actual);
-        Assert.AreEqual(message, actual.Message);
-        Assert.AreEqual(percentCompleted, actual.PercentCompleted);
-        Assert.AreEqual(revision, actual.Revision);
-        Assert.AreEqual(state.ToString().ToUpperInvariant(), actual.State);
-        Assert.AreEqual(buildDtoId, actual.Id);
-        Assert.AreEqual(MachineApi.GetBuildHref(Project01, Build01), actual.Href);
-        Assert.AreEqual(Project01, actual.Engine.Id);
-        Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Engine.Href);
+        env.BackgroundJobClient.Received(1).Create(Arg.Any<Job>(), Arg.Any<IState>());
     }
 
     [Test]
@@ -1911,6 +1918,7 @@ public class MachineApiServiceTests
     {
         public TestEnvironment()
         {
+            BackgroundJobClient = Substitute.For<IBackgroundJobClient>();
             Builds = Substitute.For<IBuildRepository>();
             Engines = Substitute.For<IEngineRepository>();
             Engines
@@ -1941,7 +1949,11 @@ public class MachineApiServiceTests
                     new SFProjectSecret
                     {
                         Id = Project01,
-                        ServalData = new ServalData { TranslationEngineId = TranslationEngine01 },
+                        ServalData = new ServalData
+                        {
+                            TranslationEngineId = TranslationEngine01,
+                            PreTranslationEngineId = TranslationEngine01
+                        },
                     },
                     new SFProjectSecret { Id = Project02 },
                 }
@@ -1972,6 +1984,7 @@ public class MachineApiServiceTests
             TranslationEnginesClient = Substitute.For<ITranslationEnginesClient>();
 
             Service = new MachineApiService(
+                BackgroundJobClient,
                 Builds,
                 Engines,
                 engineOptions,
@@ -1985,6 +1998,7 @@ public class MachineApiServiceTests
             );
         }
 
+        public IBackgroundJobClient BackgroundJobClient { get; }
         public IBuildRepository Builds { get; }
         public IEngineRepository Engines { get; }
         public IEngineService EngineService { get; }

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -184,7 +184,7 @@ public class MachineProjectServiceTests
         await env.DataFilesClient
             .DidNotReceiveWithAnyArgs()
             .UpdateAsync(Arg.Any<string>(), Arg.Any<FileParameter>(), CancellationToken.None);
-        Assert.IsNull(env.ProjectSecrets.Get(Project02).ServalData!.PreTranslationQueued);
+        Assert.IsNull(env.ProjectSecrets.Get(Project02).ServalData!.PreTranslationQueuedAt);
     }
 
     [Test]
@@ -739,7 +739,7 @@ public class MachineProjectServiceTests
                         Id = Project02,
                         ServalData = new ServalData
                         {
-                            PreTranslationQueued = options.PreTranslationBuildIsQueued ? DateTime.UtcNow : null,
+                            PreTranslationQueuedAt = options.PreTranslationBuildIsQueued ? DateTime.UtcNow : null,
                             TranslationEngineId = TranslationEngine02,
                             Corpora = new Dictionary<string, ServalCorpus>
                             {

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -98,7 +98,7 @@ public class ParatextSyncRunnerTests
 
         await env.MachineProjectService
             .DidNotReceive()
-            .BuildProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            .BuildProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         env.VerifyProjectSync(true);
 
         // Verify the sync metrics
@@ -135,7 +135,9 @@ public class ParatextSyncRunnerTests
         Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
         Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
 
-        await env.MachineProjectService.Received().BuildProjectAsync("user01", "project01", CancellationToken.None);
+        await env.MachineProjectService
+            .Received()
+            .BuildProjectAsync("user01", "project01", false, CancellationToken.None);
         env.VerifyProjectSync(true);
 
         // Verify the sync metrics
@@ -172,7 +174,9 @@ public class ParatextSyncRunnerTests
         Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
         Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
 
-        await env.MachineProjectService.Received().BuildProjectAsync("user01", "project01", CancellationToken.None);
+        await env.MachineProjectService
+            .Received()
+            .BuildProjectAsync("user01", "project01", false, CancellationToken.None);
         env.VerifyProjectSync(true);
 
         // Verify the sync metrics
@@ -210,7 +214,7 @@ public class ParatextSyncRunnerTests
 
         await env.MachineProjectService
             .DidNotReceive()
-            .BuildProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            .BuildProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         env.VerifyProjectSync(true);
 
         // Verify the sync metrics
@@ -239,7 +243,7 @@ public class ParatextSyncRunnerTests
 
         await env.MachineProjectService
             .DidNotReceive()
-            .BuildProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            .BuildProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         env.VerifyProjectSync(true);
 
         // Verify the sync metrics

--- a/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
@@ -1,0 +1,160 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using NUnit.Framework;
+using Serval.Client;
+using SIL.XForge.DataAccess;
+using SIL.XForge.Scripture.Models;
+using SIL.XForge.Services;
+
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class PreTranslationServiceTests
+{
+    private const string Project01 = "project01";
+    private const string Project02 = "project02";
+    private const string User01 = "user01";
+    private const string Corpus01 = "corpus01";
+    private const string TranslationEngine01 = "translationEngine01";
+
+    [Test]
+    public void GetPreTranslationsAsync_ThrowsExceptionWhenProjectSecretMissing()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetPreTranslationsAsync(User01, "invalid_project_id", 40, 1, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void GetPreTranslationsAsync_ThrowsExceptionWhenNoPreTranslationConfigured()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetPreTranslationsAsync(User01, Project02, 40, 1, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public async Task GetPreTranslationsAsync_ReturnsEmptyArrayIfNoPreTranslations()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        const int bookNum = 40;
+        const int chapterNum = 1;
+        string textId = PreTranslationService.GetTextId(bookNum, chapterNum);
+        env.TranslationEnginesClient
+            .GetAllPretranslations2Async(TranslationEngine01, Corpus01, textId, CancellationToken.None)
+            .Returns(Task.FromResult<IList<Pretranslation>>(new List<Pretranslation>()));
+
+        // SUT
+        PreTranslation[] actual = await env.Service.GetPreTranslationsAsync(
+            User01,
+            Project01,
+            40,
+            1,
+            CancellationToken.None
+        );
+        Assert.Zero(actual.Length);
+    }
+
+    [Test]
+    public async Task GetPreTranslationsAsync_ReturnsUsablePreTranslations()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        const int bookNum = 40;
+        const int chapterNum = 1;
+        string textId = PreTranslationService.GetTextId(bookNum, chapterNum);
+        env.TranslationEnginesClient
+            .GetAllPretranslations2Async(TranslationEngine01, Corpus01, textId, CancellationToken.None)
+            .Returns(
+                Task.FromResult<IList<Pretranslation>>(
+                    new List<Pretranslation>
+                    {
+                        new Pretranslation { TextId = "40_1", Translation = "Matthew", },
+                        new Pretranslation
+                        {
+                            TextId = "40_1",
+                            Refs = { "40_1:verse_001_001" },
+                            Translation =
+                                "The book of the birth of Jesus Christ , the son of David , the son of Abraham .",
+                        },
+                        new Pretranslation
+                        {
+                            TextId = "40_1",
+                            Refs = { "40_1:verse_001_002" },
+                            Translation =
+                                "Abraham was the father of Isaac , Isaac was the father of James , and James was the father of Jude and his brethren .",
+                        },
+                    }
+                )
+            );
+
+        // SUT
+        PreTranslation[] actual = await env.Service.GetPreTranslationsAsync(
+            User01,
+            Project01,
+            40,
+            1,
+            CancellationToken.None
+        );
+        Assert.AreEqual(2, actual.Length);
+        Assert.AreEqual("MAT 1:1", actual.First().Reference);
+        Assert.AreEqual(
+            "The book of the birth of Jesus Christ, the son of David, the son of Abraham.",
+            actual.First().Translation
+        );
+        Assert.AreEqual("MAT 1:2", actual.Last().Reference);
+        Assert.AreEqual(
+            "Abraham was the father of Isaac, Isaac was the father of James, and James was the father of Jude and his brethren.",
+            actual.Last().Translation
+        );
+    }
+
+    private class TestEnvironment
+    {
+        public TestEnvironment()
+        {
+            var projectSecrets = new MemoryRepository<SFProjectSecret>(
+                new[]
+                {
+                    new SFProjectSecret
+                    {
+                        Id = Project01,
+                        ServalData = new ServalData
+                        {
+                            PreTranslationEngineId = TranslationEngine01,
+                            Corpora = new Dictionary<string, ServalCorpus>
+                            {
+                                {
+                                    "another_corpus",
+                                    new ServalCorpus { PreTranslate = false, }
+                                },
+                                {
+                                    Corpus01,
+                                    new ServalCorpus { PreTranslate = true, }
+                                },
+                            },
+                        },
+                    },
+                    new SFProjectSecret { Id = Project02 },
+                }
+            );
+            TranslationEnginesClient = Substitute.For<ITranslationEnginesClient>();
+            Service = new PreTranslationService(projectSecrets, TranslationEnginesClient);
+        }
+
+        public PreTranslationService Service { get; }
+        public ITranslationEnginesClient TranslationEnginesClient { get; }
+    }
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -2100,8 +2100,12 @@ public class SFProjectServiceTests
         Assert.That(project.TranslateConfig.Source.ParatextId, Is.EqualTo("changedId"));
         Assert.That(project.TranslateConfig.Source.Name, Is.EqualTo("NewSource"));
 
-        await env.MachineProjectService.Received().RemoveProjectAsync(User01, Project01, CancellationToken.None);
-        await env.MachineProjectService.Received().AddProjectAsync(User01, Project01, CancellationToken.None);
+        await env.MachineProjectService
+            .Received()
+            .RemoveProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None);
+        await env.MachineProjectService
+            .Received()
+            .AddProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None);
         await env.SyncService.Received().SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
     }
 
@@ -2122,10 +2126,10 @@ public class SFProjectServiceTests
 
         await env.MachineProjectService
             .DidNotReceive()
-            .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env.MachineProjectService
             .DidNotReceive()
-            .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env.SyncService.Received().SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
     }
 
@@ -2145,8 +2149,10 @@ public class SFProjectServiceTests
 
         await env.MachineProjectService
             .DidNotReceive()
-            .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-        await env.MachineProjectService.Received().AddProjectAsync(User01, Project03, CancellationToken.None);
+            .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await env.MachineProjectService
+            .Received()
+            .AddProjectAsync(User01, Project03, preTranslate: false, CancellationToken.None);
         await env.SyncService.Received().SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
     }
 
@@ -2168,10 +2174,12 @@ public class SFProjectServiceTests
         Assert.That(project.TranslateConfig.TranslationSuggestionsEnabled, Is.False);
         Assert.That(project.TranslateConfig.Source, Is.Null);
 
-        await env.MachineProjectService.Received().RemoveProjectAsync(User01, Project01, CancellationToken.None);
+        await env.MachineProjectService
+            .Received()
+            .RemoveProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None);
         await env.MachineProjectService
             .DidNotReceive()
-            .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env.SyncService.Received().SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
     }
 
@@ -2187,10 +2195,10 @@ public class SFProjectServiceTests
 
         await env.MachineProjectService
             .DidNotReceive()
-            .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env.MachineProjectService
             .DidNotReceive()
-            .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env.SyncService.Received().SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
     }
 
@@ -2206,10 +2214,10 @@ public class SFProjectServiceTests
 
         await env.MachineProjectService
             .DidNotReceive()
-            .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env.MachineProjectService
             .DidNotReceive()
-            .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env.SyncService.DidNotReceive().SyncAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
     }
 
@@ -2226,7 +2234,9 @@ public class SFProjectServiceTests
         Assert.That(env.ContainsProject(Project01), Is.False);
         User user = env.GetUser(User01);
         Assert.That(user.Sites[SiteId].Projects, Does.Not.Contain(Project01));
-        await env.MachineProjectService.Received().RemoveProjectAsync(User01, Project01, CancellationToken.None);
+        await env.MachineProjectService
+            .Received()
+            .RemoveProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None);
         env.FileSystemService.Received().DeleteDirectory(ptProjectDir);
         Assert.That(env.ProjectSecrets.Contains(Project01), Is.False);
 
@@ -2236,7 +2246,9 @@ public class SFProjectServiceTests
         await env.Service.DeleteProjectAsync(User01, SourceOnly);
 
         await env.SyncService.Received().CancelSyncAsync(User01, SourceOnly);
-        await env.MachineProjectService.Received().RemoveProjectAsync(User01, SourceOnly, CancellationToken.None);
+        await env.MachineProjectService
+            .Received()
+            .RemoveProjectAsync(User01, SourceOnly, preTranslate: false, CancellationToken.None);
         env.FileSystemService.Received().DeleteDirectory(ptProjectDir);
         Assert.That(env.ContainsProject(SourceOnly), Is.False);
         Assert.That(env.GetUser(User01).Sites[SiteId].Projects, Does.Not.Contain(SourceOnly));

--- a/test/SIL.XForge.Scripture.Tests/Services/SFScriptureTextTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFScriptureTextTests.cs
@@ -67,7 +67,14 @@ public class SFScriptureTextTests
         var tokenizer = new LatinWordTokenizer();
 
         // SUT
-        var text = new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc);
+        var text = new SFScriptureText(
+            tokenizer,
+            projectId,
+            bookNumber,
+            chapterNumber,
+            includeBlankSegments: false,
+            doc
+        );
 
         Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
         Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
@@ -122,7 +129,14 @@ public class SFScriptureTextTests
         var tokenizer = new LatinWordTokenizer();
 
         // SUT
-        var text = new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc);
+        var text = new SFScriptureText(
+            tokenizer,
+            projectId,
+            bookNumber,
+            chapterNumber,
+            includeBlankSegments: false,
+            doc
+        );
 
         Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
         Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
@@ -151,7 +165,14 @@ public class SFScriptureTextTests
         var tokenizer = new LatinWordTokenizer();
 
         // SUT
-        var text = new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc);
+        var text = new SFScriptureText(
+            tokenizer,
+            projectId,
+            bookNumber,
+            chapterNumber,
+            includeBlankSegments: false,
+            doc
+        );
 
         Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
         Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
@@ -168,7 +189,7 @@ public class SFScriptureTextTests
 
         // SUT
         Assert.Throws<ArgumentNullException>(
-            () => new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc)
+            () => new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, includeBlankSegments: false, doc)
         );
     }
 
@@ -188,7 +209,151 @@ public class SFScriptureTextTests
 
         // SUT
         Assert.Throws<ArgumentException>(
-            () => new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, doc)
+            () => new SFScriptureText(tokenizer, projectId, bookNumber, chapterNumber, includeBlankSegments: false, doc)
         );
+    }
+
+    [Test]
+    public void Create_ExcludeBlankSegmentsIfIncludeBlankSegmentsFalse()
+    {
+        var doc = new BsonDocument
+        {
+            { "_id", "abc123:MAT:1:target" },
+            {
+                "ops",
+                new BsonArray
+                {
+                    new BsonDocument
+                    {
+                        {
+                            "insert",
+                            new BsonDocument
+                            {
+                                {
+                                    "chapter",
+                                    new BsonDocument { { "number", "1" }, { "style", "c" } }
+                                },
+                            }
+                        },
+                    },
+                    new BsonDocument
+                    {
+                        {
+                            "insert",
+                            new BsonDocument
+                            {
+                                {
+                                    "verse",
+                                    new BsonDocument { { "number", "1" }, { "style", "v" } }
+                                },
+                            }
+                        },
+                    },
+                    new BsonDocument
+                    {
+                        {
+                            "insert",
+                            new BsonDocument { { "blank", true } }
+                        },
+                        {
+                            "attributes",
+                            new BsonDocument { { "segment", "verse_1_1" } }
+                        },
+                    },
+                }
+            },
+        };
+        const int numberOps = 3;
+        const int numberSegments = 0;
+        const int bookNumber = 40;
+        const int chapterNumber = 1;
+        const string projectId = "myProject";
+        Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
+        var tokenizer = new LatinWordTokenizer();
+
+        // SUT
+        var text = new SFScriptureText(
+            tokenizer,
+            projectId,
+            bookNumber,
+            chapterNumber,
+            includeBlankSegments: false,
+            doc
+        );
+
+        Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
+    }
+
+    [Test]
+    public void Create_IncludeBlankSegmentsIfIncludeBlankSegmentsTrue()
+    {
+        var doc = new BsonDocument
+        {
+            { "_id", "abc123:MAT:1:target" },
+            {
+                "ops",
+                new BsonArray
+                {
+                    new BsonDocument
+                    {
+                        {
+                            "insert",
+                            new BsonDocument
+                            {
+                                {
+                                    "chapter",
+                                    new BsonDocument { { "number", "1" }, { "style", "c" } }
+                                },
+                            }
+                        },
+                    },
+                    new BsonDocument
+                    {
+                        {
+                            "insert",
+                            new BsonDocument
+                            {
+                                {
+                                    "verse",
+                                    new BsonDocument { { "number", "1" }, { "style", "v" } }
+                                },
+                            }
+                        },
+                    },
+                    new BsonDocument
+                    {
+                        {
+                            "insert",
+                            new BsonDocument { { "blank", true } }
+                        },
+                        {
+                            "attributes",
+                            new BsonDocument { { "segment", "verse_1_1" } }
+                        },
+                    },
+                }
+            },
+        };
+        const int numberOps = 3;
+        const int numberSegments = 1;
+        const int bookNumber = 40;
+        const int chapterNumber = 1;
+        const string projectId = "myProject";
+        Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
+        var tokenizer = new LatinWordTokenizer();
+
+        // SUT
+        var text = new SFScriptureText(
+            tokenizer,
+            projectId,
+            bookNumber,
+            chapterNumber,
+            includeBlankSegments: true,
+            doc
+        );
+
+        Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/ServalApiExceptions.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ServalApiExceptions.cs
@@ -37,6 +37,15 @@ public static class ServalApiExceptions
             null
         );
 
+    public static ServalApiException NotSupported =>
+        new ServalApiException(
+            "The translation engine does not support cancelling builds.",
+            StatusCodes.Status405MethodNotAllowed,
+            null,
+            new Dictionary<string, IEnumerable<string>>(),
+            null
+        );
+
     public static ServalApiException TimeOut =>
         new ServalApiException(
             "The long polling request timed out.",


### PR DESCRIPTION
This PR adds:
 * A pre-translate setting the translate config
 * Pre-Translation corpus syncing and build
 * Retrieval of the Draft Pre-Translation
 * Get Pre-Translation Build endpoint
 * An additional build status of "Queued" for builds that are being uploaded to Serval

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1887)
<!-- Reviewable:end -->
