### PR TITLE
SF-2064 Fix verse selected when navigating to a different chapter

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -1065,6 +1065,17 @@ describe('TextComponent', () => {
     });
     verify(mockedDialogService.openMatDialog(TextNoteDialogComponent, anything())).thrice();
   }));
+
+  it('does not match segments when verse ref is from a different chapter', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.id = new TextDocId('project01', 40, 1);
+    tick();
+    env.fixture.detectChanges();
+    // the current text is on chapter 1, so this should result in no matching segments
+    const verseRef: VerseRef = VerseRef.parse('MAT 2:1');
+    const segments: string[] = env.component.getVerseSegments(verseRef);
+    expect(segments.length).withContext('should be no matching segments when chapter does not match').toBe(0);
+  }));
 });
 
 /** Represents both what the TextComponent understand to be the text in a segment, and what the editor

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -518,6 +518,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   }
 
   getVerseSegments(verseRef?: VerseRef): string[] {
+    if (this.id?.chapterNum !== verseRef?.chapterNum) return [];
     return this.viewModel.getVerseSegments(verseRef);
   }
 


### PR DESCRIPTION
The text component would return segments of a chapter when given a verse ref even if the verse ref was for a chapter that was different from the current chapter. The result was that when a user adds a note and navigates to a different verse, the previous selected verse was also selected in the new chapter. This change checks whether the chapters are the same before returning the corresponding segments of a chapter from a verse ref.