### PR TITLE
SF-2066 Keep insert note fab hidden for commenters on smaller devices

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2878,6 +2878,34 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('keeps insert note fab hidden for commenters on mobile devices', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      when(mockedMediaObserver.isActive(anything())).thenReturn(true);
+      env.addParatextNoteThread(
+        6,
+        'MAT 1:1',
+        '',
+        { start: 0, length: 0 },
+        ['user01'],
+        NoteStatus.Todo,
+        undefined,
+        true
+      );
+      env.setCommenterUser();
+      env.wait();
+
+      env.clickSegmentRef('verse_1_3');
+      expect(window.getComputedStyle(env.insertNoteFab.nativeElement)['visibility']).toBe('hidden');
+      const noteElem: HTMLElement = env.getNoteThreadIconElement('verse_1_1', 'thread06')!;
+      noteElem.click();
+      env.wait();
+      env.mockNoteDialogRef.close();
+      env.wait();
+      expect(window.getComputedStyle(env.insertNoteFab.nativeElement)['visibility']).toBe('hidden');
+      env.dispose();
+    }));
+
     it('shows the correct combined verse ref for a new note', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -438,16 +438,12 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     return this.pwaService.isOnline && this.multiCursorViewers.length > 0;
   }
 
-  get isInsertNoteFabEnabled(): boolean {
-    return this.isAddNotesEnabled && this.canShowInsertNoteFab;
-  }
-
   set showInsertNoteFab(value: boolean) {
     if (this.insertNoteFab == null || this.TemplateBottomSheet == null) return;
     this.addingMobileNote = false;
     // Mobile users without editing rights will see a bottom sheet instead of a FAB
-    if (this.mediaObserver.isActive('lt-lg') && !this.hasEditRight) {
-      this.insertNoteFab.nativeElement.style.visibility = 'hidden';
+    if (this.isCommenterOnMobileDevice) {
+      this.setNoteFabVisibility('hidden');
       if (value) {
         if (this.bottomSheetRef?.containerInstance == null) {
           this.bottomSheetRef = this.bottomSheet.open(this.TemplateBottomSheet, { hasBackdrop: false });
@@ -456,7 +452,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         this.bottomSheet.dismiss();
       }
     } else {
-      this.insertNoteFab.nativeElement.style.visibility = value ? 'visible' : 'hidden';
+      this.setNoteFabVisibility(value ? 'visible' : 'hidden');
       this.bottomSheet.dismiss();
     }
   }
@@ -496,6 +492,14 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   private get isAddNotesEnabled(): boolean {
     return this.featureFlags.allowAddingNotes.enabled;
+  }
+
+  private get isInsertNoteFabEnabled(): boolean {
+    return this.isAddNotesEnabled && this.canShowInsertNoteFab && !this.isCommenterOnMobileDevice;
+  }
+
+  private get isCommenterOnMobileDevice(): boolean {
+    return !this.hasEditRight && this.mediaObserver.isActive('lt-lg');
   }
 
   private get canShowInsertNoteFab(): boolean {
@@ -1082,7 +1086,11 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   /** Sets the visibility of the insert note FAB. If the FAB does not exist, this is a no-op. */
   private setNoteFabVisibility(visible: 'visible' | 'hidden'): void {
     if (this.insertNoteFab?.nativeElement != null) {
-      this.insertNoteFab.nativeElement.style.visibility = visible;
+      if (this.isInsertNoteFabEnabled) {
+        this.insertNoteFab.nativeElement.style.visibility = visible;
+        return;
+      }
+      this.insertNoteFab.nativeElement.style.visibility = 'hidden';
     }
   }
 


### PR DESCRIPTION
Users with commenting permission will see the add note FAB only on larger devices. On smaller devices, commenters will see the bottom sheet appear when selecting a verse. This change ensures that the add note FAB is never visible for commenters on smaller devices.