### PR TITLE
SF-2071 Checking Audio to Material

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-combined/checking-audio-combined.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-combined/checking-audio-combined.component.html
@@ -12,7 +12,7 @@
     <ng-container class="audio-uploader" *ngIf="!isRecorderActive">
       <button
         *ngIf="!source"
-        mdc-button
+        mat-button
         ngfSelect
         type="button"
         [(file)]="uploadAudioFile"
@@ -21,29 +21,30 @@
         class="upload-audio-file"
         [(lastInvalids)]="lastInvalids"
       >
-        <mdc-icon>cloud_upload</mdc-icon>
+        <mat-icon>cloud_upload</mat-icon>
         <span fxShow fxHide.lt-sm>{{ t("upload_audio_file") }}</span> <span fxHide fxShow.xs>{{ t("upload") }}</span>
       </button>
       <button
         *ngIf="source"
-        fxHide.xs
-        mdc-button
+        fxHide.lt-md
+        mat-button
         type="button"
         (click)="resetAudioAttachment()"
         class="remove-audio-file"
       >
-        <mdc-icon>delete</mdc-icon>
+        <mat-icon>delete</mat-icon>
         {{ t("remove_audio_file") }}
       </button>
       <button
         *ngIf="source"
-        mdc-icon-button
-        fxHide.gt-xs
+        mat-icon-button
+        fxHide.gt-sm
         type="button"
         (click)="resetAudioAttachment()"
-        icon="delete"
         class="remove-audio-file"
-      ></button>
+      >
+        <mat-icon>delete</mat-icon>
+      </button>
       <app-checking-audio-player *ngIf="!!source" [source]="source"></app-checking-audio-player>
     </ng-container>
   </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-combined/checking-audio-combined.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-combined/checking-audio-combined.component.scss
@@ -2,8 +2,16 @@
   display: flex;
   align-items: center;
   min-height: 75px;
+  column-gap: 8px;
+
   button {
-    margin-right: 15px;
+    span {
+      margin-inline-start: 4px;
+    }
+    .mat-icon {
+      vertical-align: text-top;
+      font-size: 18px;
+    }
   }
 
   &.recorder-active {
@@ -17,9 +25,5 @@
     app-checking-audio-player {
       flex: 1;
     }
-  }
-
-  .upload-audio-file {
-    margin-left: 10px;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/users.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/users.component.html
@@ -1,11 +1,4 @@
 <ng-container *transloco="let t; read: 'users'">
   <h1>{{ t("users") }}</h1>
-  <!-- (15-03-2019) The Send Message tab is not available in the MVP -->
-  <!-- <mdc-tab-bar #tabBar [fixed]="true">
-    <mdc-tab-scroller>
-      <mdc-tab label="{{ t('collaborators') }}"></mdc-tab>
-      <mdc-tab label="Send Message"></mdc-tab>
-    </mdc-tab-scroller>
-  </mdc-tab-bar> -->
   <app-collaborators></app-collaborators>
 </ng-container>


### PR DESCRIPTION
Only thing I changed functionally was switching between the normal and condensed delete audio file buttons. With MDC, the normal/full text would word-wrap as window width decreased, and with Material it does not. I opted to switch to the delete icon only over researching how to word-wrap. Can change this if desired.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1894)
<!-- Reviewable:end -->
