### PR TITLE
Update I18nStoryModule to work with I18nService

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.stories.ts
@@ -92,3 +92,7 @@ SelectChapter.play = async ({ canvasElement }) => {
   const chapter2 = await within(menu).findByText('2');
   userEvent.click(chapter2);
 };
+
+export const Arabic = Template.bind({});
+Arabic.args = { ...defaultArgs };
+Arabic.parameters = { locale: 'ar' };

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n-story.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n-story.module.ts
@@ -1,41 +1,19 @@
 import { DecoratorFunction } from '@storybook/types';
 import { HttpClientModule } from '@angular/common/http';
-import { ApplicationRef, APP_INITIALIZER, NgModule } from '@angular/core';
-import {
-  TranslocoConfig,
-  TranslocoModule,
-  TranslocoService,
-  TRANSLOCO_CONFIG,
-  TRANSLOCO_LOADER
-} from '@ngneat/transloco';
-import { delay, distinctUntilChanged, tap } from 'rxjs/operators';
+import { APP_INITIALIZER, NgModule } from '@angular/core';
+import { TranslocoConfig, TranslocoModule, TRANSLOCO_CONFIG, TRANSLOCO_LOADER } from '@ngneat/transloco';
 import { I18nService, IGNORE_COOKIE_LOCALE, TranslationLoader } from './i18n.service';
 
-let translocoService: TranslocoService | undefined;
+let i18nService: I18nService | undefined;
 let selectedLocale: string | undefined;
 
 const translocoConfig: TranslocoConfig = { ...I18nService.translocoConfig, prodMode: false };
 
-function getLocaleDir(locale: string): 'ltr' | 'rtl' {
-  return I18nService.locales.find(l => l.tags.some(tag => tag === locale))?.direction ?? 'ltr';
-}
-
-function localizationInit(transloco: TranslocoService, applicationRef: ApplicationRef): () => void {
+function localizationInit(transloco: I18nService): () => void {
   return () => {
-    translocoService = transloco;
+    i18nService = transloco;
 
-    transloco.langChanges$
-      .pipe(
-        distinctUntilChanged(),
-        delay(100), // hideous but necessary
-        tap(() => {
-          document.body.setAttribute('dir', getLocaleDir(transloco.getActiveLang()));
-          applicationRef.tick();
-        })
-      )
-      .subscribe();
-
-    if (selectedLocale != null) translocoService.setActiveLang(selectedLocale);
+    if (selectedLocale != null) i18nService.trySetLocale(selectedLocale);
   };
 }
 
@@ -43,7 +21,7 @@ export const I18nStoryDecorator: DecoratorFunction = (Story, context) => {
   // In some cases the locale has been known to be the empty string, so make sure not to set it to that.
   const locale = context.parameters.locale || context.globals.locale || I18nService.defaultLocale.canonicalTag;
   selectedLocale = locale;
-  if (translocoService != null) translocoService.setActiveLang(locale);
+  if (i18nService != null) i18nService.trySetLocale(locale);
   return Story();
 };
 
@@ -51,7 +29,7 @@ export const I18nStoryDecorator: DecoratorFunction = (Story, context) => {
   imports: [HttpClientModule],
   exports: [TranslocoModule],
   providers: [
-    { provide: APP_INITIALIZER, useFactory: localizationInit, deps: [TranslocoService, ApplicationRef], multi: true },
+    { provide: APP_INITIALIZER, useFactory: localizationInit, deps: [I18nService], multi: true },
     { provide: TRANSLOCO_CONFIG, useValue: translocoConfig },
     { provide: TRANSLOCO_LOADER, useClass: TranslationLoader },
     { provide: IGNORE_COOKIE_LOCALE, useValue: true }


### PR DESCRIPTION
Previously we only set the locale via `TranslocoService`, so `I18nService` was unaware of what locale was set.

Now we set it via `I18nService`, so everything works about as it does in the application.

This actually simplifies things signficantly.

And now we can write stories that rely on `I18nService` and they'll work correctly. I've added an example for `BookChapterChooserComponent` that previously wouldn't have worked correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1896)
<!-- Reviewable:end -->
