### PR TITLE
SF-2081 Create container for audio component over chapter

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -104,6 +104,14 @@
                       <mdc-icon class="mirror-rtl">post_add</mdc-icon> <span>{{ t("add_question") }}</span>
                     </button>
                   </ng-container>
+                  <button
+                    *ngIf="featureFlags.scriptureAudio.enabled"
+                    type="button"
+                    mat-icon-button
+                    (click)="showScriptureAudioPlayer = !showScriptureAudioPlayer"
+                  >
+                    <mat-icon>play_arrow</mat-icon>
+                  </button>
                   <app-font-size (apply)="applyFontChange($event)"></app-font-size>
                   <app-share-button *ngIf="canShare" [defaultRole]="defaultShareRole"></app-share-button>
                 </div>
@@ -118,6 +126,10 @@
               >
                 <as-split-area [size]="100">
                   <div class="panel-content" #scripturePanelContainer>
+                    <div class="scripture-audio-player-wrapper" *ngIf="showScriptureAudioPlayer">
+                      <!-- TODO (scripture audio) replace this with an actually useful component -->
+                      <app-checking-audio-player></app-checking-audio-player>
+                    </div>
                     <app-checking-text
                       #textPanel
                       [id]="textDocId"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -171,3 +171,12 @@
     font-weight: bold;
   }
 }
+
+.scripture-audio-player-wrapper {
+  position: absolute;
+  bottom: 0;
+  background: #e8eae6;
+  width: 100%;
+  z-index: 1;
+  padding: 0.25rem;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -27,6 +27,7 @@ import { UserService } from 'xforge-common/user.service';
 import { objectId } from 'xforge-common/utils';
 import { MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { DialogService } from 'xforge-common/dialog.service';
+import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { QuestionDoc } from '../../core/models/question-doc';
 import { SF_DEFAULT_SHARE_ROLE } from '../../core/models/sf-project-role-info';
@@ -102,6 +103,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
   totalVisibleQuestionsString: string = '0';
   userDoc?: UserDoc;
   visibleQuestions?: QuestionDoc[];
+  showScriptureAudioPlayer: boolean = false;
 
   private _book?: number;
   private _isDrawerPermanent: boolean = true;
@@ -137,6 +139,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
     private readonly router: Router,
     private readonly questionDialogService: QuestionDialogService,
     readonly i18n: I18nService,
+    readonly featureFlags: FeatureFlagService,
     private readonly pwaService: PwaService
   ) {
     super(noticeService);


### PR DESCRIPTION
This is more of scaffolding than a feature.

The positioning of the element works fine. But it's not possible to see the very bottom of the chapter because this component covers it. That wasn't addressed by the original design and we'll need to work through how to address that at a later time.

![](https://github.com/sillsdev/web-xforge/assets/6140710/2922a1e5-f0d4-4d55-b8de-4aa72e68309b)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1899)
<!-- Reviewable:end -->
