### PR TITLE
SF-2065 Update the selected verse when user opens a note dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2830,7 +2830,7 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('verse keeps selection when opening a note dialog', fakeAsync(() => {
+    it('updates verse selection when opening a note dialog', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
       env.wait();
@@ -2841,6 +2841,11 @@ describe('EditorComponent', () => {
       const verse1Elem: HTMLElement = env.getSegmentElement(segmentRef)!;
       expect(verse1Elem.classList).toContain('commenter-selection');
       expect(window.getComputedStyle(env.insertNoteFab.nativeElement)['visibility']).toBe('visible');
+
+      // simulate clicking the note icon on verse 3
+      const segmentRef3 = 'verse_1_3';
+      const thread2Position: number = env.getNoteThreadEditorPosition('thread02');
+      env.targetEditor.setSelection(thread2Position, 'user');
       const noteElem: HTMLElement = env.getNoteThreadIconElement('verse_1_3', 'thread02')!;
       noteElem.click();
       env.wait();
@@ -2849,9 +2854,6 @@ describe('EditorComponent', () => {
       instance(mockedMatDialog).closeAll();
       env.wait();
       expect(window.getComputedStyle(env.insertNoteFab.nativeElement)['visibility']).toBe('visible');
-      const segmentRef3 = 'verse_1_3';
-      env.clickSegmentRef(segmentRef3);
-      env.wait();
       const verse3Elem: HTMLElement = env.getSegmentElement(segmentRef3)!;
       expect(verse3Elem.classList).toContain('commenter-selection');
       expect(verse1Elem.classList).not.toContain('commenter-selection');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -684,10 +684,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
             op.set(puc => puc.selectedSegment, this.target!.segmentRef);
             op.set(puc => puc.selectedSegmentChecksum!, this.target!.segmentChecksum);
           });
-          if (this.bookNum != null && this.hasEditRight) {
-            const verseRef = getVerseRefFromSegmentRef(this.bookNum, this.target.segmentRef);
-            this.toggleVerseRefElement(verseRef);
-          }
+        }
+        if (this.bookNum != null && this.hasEditRight) {
+          const verseRef: VerseRef | undefined = getVerseRefFromSegmentRef(this.bookNum, this.target.segmentRef);
+          this.toggleVerseRefElement(verseRef);
         }
         await this.translateSegment();
       } finally {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -774,6 +774,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         this.toggleNoteThreadVerseRefs$.next();
         this.shouldNoteThreadsRespondToEdits = true;
         if (this.target?.editor != null) {
+          this.positionInsertNoteFab();
           this.subscribeScroll(this.target.editor);
         }
         break;
@@ -1086,6 +1087,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
     if (this.isInsertNoteFabEnabled) {
       this.setNoteFabVisibility('visible');
+      this.positionInsertNoteFab();
     }
   }
 
@@ -1640,7 +1642,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   private positionInsertNoteFab(): void {
-    if (this.insertNoteFab == null || this.target?.editor == null || !this.isInsertNoteFabEnabled) return;
+    if (this.insertNoteFab == null || this.target?.editor == null) return;
     const selection: RangeStatic | null | undefined = this.target.editor.getSelection();
     if (selection != null) {
       this.insertNoteFab.nativeElement.style.top = `${this.target.selectionBoundsTop}px`;
@@ -1665,18 +1667,20 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     if (segmentElement == null) {
       return;
     }
-    if (this.canShowInsertNoteFab) {
-      let allowToggleVerseSelection: boolean = true;
-      if (this.commenterSelectedVerseRef != null && verseRef.equals(this.commenterSelectedVerseRef)) {
-        allowToggleVerseSelection = !this.hasEditRight;
-      }
-      if (allowToggleVerseSelection) {
-        this.showAddCommentButton = this.target.toggleVerseSelection(verseRef);
-        this.positionInsertNoteFab();
-      }
-    } else {
-      this.showAddCommentButton = false;
+
+    // always keep the selection current even if the note dialog was opened
+    let allowToggleVerseSelection: boolean = true;
+    if (this.commenterSelectedVerseRef != null && verseRef.equals(this.commenterSelectedVerseRef)) {
+      allowToggleVerseSelection = !this.hasEditRight;
     }
+    if (allowToggleVerseSelection) {
+      this.showAddCommentButton = this.target.toggleVerseSelection(verseRef);
+      this.positionInsertNoteFab();
+    }
+    if (!this.isInsertNoteFabEnabled) {
+      this.setNoteFabVisibility('hidden');
+    }
+
     if (this.commenterSelectedVerseRef != null) {
       if (verseRef.equals(this.commenterSelectedVerseRef)) {
         if (!this.hasEditRight) {
@@ -1687,9 +1691,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       // un-select previously selected verses since a note can apply to only one verse.
       this.target.toggleVerseSelection(this.commenterSelectedVerseRef);
     }
-    if (this.dialogService.openDialogCount < 1 && !this.addingMobileNote) {
-      this.commenterSelectedVerseRef = verseRef;
-    }
+    this.commenterSelectedVerseRef = verseRef;
   }
 
   /** Determine the number of embeds that are within an anchoring.


### PR DESCRIPTION
When the editor is editable, there is different logic that determines when a user has selected a verse. This is because users can use the keyboard to jump to the next verse, so we cannot rely on click events. This was causing problems because the selection would change when a user clicks on a note icon to open the dialog, but we introduced logic to prevent the current commenter selection from being updated when the note dialog is open.
This change removes that faulty logic so the commenter selection is always up to date. This also adds extra logic to position the note FAB at text load and when the note dialog closes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1901)
<!-- Reviewable:end -->
