### PR TITLE
dev: use mongodb 5.0

### DIFF
--- a/deploy/dependencies.yml
+++ b/deploy/dependencies.yml
@@ -11,38 +11,30 @@
       - "vars/os_defaults.yml"
   vars:
     node_version: 16.15.0
-    mongodb_version: 4.0
+    mongodb_version: 5.0
     repo_path: "{{playbook_dir}}/.."
   pre_tasks:
     - name: "Add .NET Core | add key"
-      apt_key:
-        id: BE1229CF
+      get_url:
+        # key id BC528686B50D79E339D3721CEB3E94ADBE1229CF
         url: https://packages.microsoft.com/keys/microsoft.asc
-        keyring: /etc/apt/trusted.gpg.d/microsoft.gpg
+        dest: /etc/apt/trusted.gpg.d/microsoft.asc
       when: base_distribution == 'ubuntu'
     - name: "Add .NET Core | add source"
       apt_repository:
         repo: "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-{{base_distribution_release}}-prod {{base_distribution_release}} main"
         state: present
       when: base_distribution == 'ubuntu'
-    - name: add Mongo apt key
-      apt_key:
-        keyserver: keyserver.ubuntu.com
-        id: 9DA31620334BD75D9DCB49F368818C72E52529D4
+    - name: add mongodb-server-{{mongodb_version}} apt key
+      get_url:
+        url: https://pgp.mongodb.com/server-{{mongodb_version}}.asc
+        dest: /etc/apt/trusted.gpg.d/mongodb-server-{{mongodb_version}}.asc
     - name: add Mongo {{mongodb_version}} repository
       apt_repository:
-        repo: "deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu {{base_distribution_release}}/mongodb-org/{{mongodb_version}} multiverse"
+        repo: "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/mongodb-server-{{mongodb_version}}.asc] https://repo.mongodb.org/apt/ubuntu {{base_distribution_release}}/mongodb-org/{{mongodb_version}} multiverse"
         filename: mongodb-org
         update_cache: yes
-      when: base_distribution == 'ubuntu' and (base_distribution_release == 'xenial' or base_distribution_release == 'bionic')
-    - name: add Mongo {{mongodb_version}} repository (bionic version)
-      # MongoDB only provides mongodb-org package version 4.4, not 4.0, for focal. They do provide a 4.0 tarball. But
-      # the 4.0 bionic package works too and comes with configs and a systemd service.
-      apt_repository:
-        repo: "deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/{{mongodb_version}} multiverse"
-        filename: mongodb-org
-        update_cache: yes
-      when: base_distribution == 'ubuntu' and base_distribution_release == 'focal'
+      when: base_distribution == 'ubuntu'
   tasks:
     - name: install packages
       apt:


### PR DESCRIPTION
The mongodb 4.0 key[1] seems to have expired without an updated key being available. Use mongodb 5.0[2].

The ansible page for apt_key shows[3] how to move away from deprecated apt-key. This patch also changes to use get_url instead of apt_key, following this example. This was also applied to the dotnet key. This change may fix something before it becomes a problem in a future version of Ubuntu.

Note that this change does not do everything needed to successfully _upgrade_ mongodb 4.0 instances to mongodb 5.0.

[1] https://www.mongodb.com/docs/v4.0/tutorial/install-mongodb-on-ubuntu/ 
[2] https://www.mongodb.com/docs/v5.0/tutorial/install-mongodb-on-ubuntu/ 
[3] https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_key_module.html

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1903)
<!-- Reviewable:end -->
