### PR TITLE
SF-2083 Update Project WritingSystem.Tag on Sync

### DIFF
--- a/src/SIL.XForge.Scripture/Models/ParatextSettings.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextSettings.cs
@@ -17,4 +17,5 @@ public class ParatextSettings
 
     /// <summary> The tag icon used by default for note threads created in SF. </summary>
     public IEnumerable<NoteTag> NoteTags { get; set; }
+    public string? LanguageTag { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -981,7 +981,8 @@ public class ParatextService : DisposableBase, IParatextService
             Editable = scrText.Settings.Editable,
             DefaultFontSize = scrText.Settings.DefaultFontSize,
             DefaultFont = scrText.Settings.DefaultFont,
-            NoteTags = noteTags
+            NoteTags = noteTags,
+            LanguageTag = scrText.Settings.LanguageID?.Id,
         };
     }
 

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1459,6 +1459,8 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 op.Set(pd => pd.DefaultFontSize, settings.DefaultFontSize);
                 if (settings.NoteTags != null)
                     op.Set(pd => pd.NoteTags, settings.NoteTags, _noteTagListEqualityComparer);
+                if (settings.LanguageTag != null)
+                    op.Set(pd => pd.WritingSystem.Tag, settings.LanguageTag);
             }
             // The source can be null if there was an error getting a resource from the DBL
             if (TranslationSuggestionsEnabled && _projectDoc.Data.TranslateConfig.Source != null)
@@ -1468,7 +1470,11 @@ public class ParatextSyncRunner : IParatextSyncRunner
                     _projectDoc.Data.TranslateConfig.Source.ParatextId
                 );
                 if (sourceSettings != null)
+                {
                     op.Set(pd => pd.TranslateConfig.Source.IsRightToLeft, sourceSettings.IsRightToLeft);
+                    if (sourceSettings.LanguageTag != null)
+                        op.Set(pd => pd.TranslateConfig.Source.WritingSystem.Tag, sourceSettings.LanguageTag);
+                }
             }
         });
         await NotifySyncProgress(SyncPhase.Phase7, 80.0);

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -26,6 +26,7 @@ using Paratext.Data.Repository;
 using Paratext.Data.Users;
 using PtxUtils;
 using SIL.Scripture;
+using SIL.WritingSystems;
 using SIL.XForge.Configuration;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
@@ -4436,6 +4437,9 @@ public class ParatextServiceTests
             ProjectCommentManager = CommentManager.Get(ProjectScrText);
             MockScrTextCollection.FindById(Arg.Any<string>(), ptProjectId).Returns(ProjectScrText);
             SetupCommentTags(ProjectScrText, null);
+            // Ensure that the SLDR is initialized for LanguageID.Code to be retrieved correctly
+            if (!Sldr.IsInitialized)
+                Sldr.Initialize(true);
             return ptProjectId;
         }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -765,12 +765,16 @@ public class ParatextSyncRunnerTests
             .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
         int fontSize = 10;
         string font = ProjectSettings.defaultFontName;
+        string sourceWritingSystemTag = "en";
         SFProject project = env.GetProject();
         Assert.That(project.DefaultFontSize, Is.EqualTo(fontSize));
         Assert.That(project.DefaultFont, Is.EqualTo(font));
+        Assert.IsNull(project.WritingSystem.Tag);
+        Assert.That(project.TranslateConfig.Source.WritingSystem.Tag, Is.EqualTo(sourceWritingSystemTag));
         int newFontSize = 16;
         string newFont = "Doulos SIL";
         string customIcon = "customIcon01";
+        string newWritingSystemTag = "en-US";
         List<NoteTag> noteTags = new List<NoteTag>
         {
             new NoteTag
@@ -787,7 +791,8 @@ public class ParatextSyncRunnerTests
                 {
                     DefaultFontSize = newFontSize,
                     DefaultFont = newFont,
-                    NoteTags = noteTags
+                    NoteTags = noteTags,
+                    LanguageTag = newWritingSystemTag,
                 }
             );
 
@@ -797,6 +802,8 @@ public class ParatextSyncRunnerTests
         Assert.That(project.DefaultFontSize, Is.EqualTo(newFontSize));
         Assert.That(project.DefaultFont, Is.EqualTo(newFont));
         Assert.That(project.NoteTags.Select(t => t.Icon), Is.EquivalentTo(new[] { customIcon }));
+        Assert.That(project.WritingSystem.Tag, Is.EqualTo(newWritingSystemTag));
+        Assert.That(project.TranslateConfig.Source.WritingSystem.Tag, Is.EqualTo(newWritingSystemTag));
     }
 
     [Test]


### PR DESCRIPTION
This PR updates the WritingSystem.Tag on sync, loading this from the ScrText Project Settings.

This will update the writing system tag when the language code is changed on the Registry, or if WritingSystem.Tag is blank due to a previous bug.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1904)
<!-- Reviewable:end -->
