### PR TITLE
Fix support for developers with the .NET SDK 7.0.304 installed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -208,3 +208,8 @@ dotnet_diagnostic.CA1825.severity = warning # Avoid unnecessary zero-length arra
 dotnet_diagnostic.CA1829.severity = warning # Use the Count or Length property instead of Enumerable.Count()
 dotnet_diagnostic.CA1834.severity = warning # Use 'StringBuilder.Append(char)' instead of 'StringBuilder.Append(string)'
 dotnet_diagnostic.CA2016.severity = warning # Forward the 'token' parameter to the async method
+
+# Downgrade the following code style diagnostic messages so dotnet format does not fix them automatically.]]
+# NOTE: Consider changing to warning when migrating from .NET 6.
+# The following diagnostic is automatically fixed in .NET SDK 7.0.304 or higher - older versions will cause variance.
+dotnet_diagnostic.IDE0270.severity = suggestion # Null check can be simplified


### PR DESCRIPTION
Although we use .NET 6.0, if a developer upgrades their .NET 7.0 SDK to version 7.0.304, the shared `dotnet format` will be updated to a version that automatically fixes the warning IDE0270, a warning that was not previously turned on in our .editorconfig.

This Pull Request updates our .editorconfig file to treat this warning as an IDE suggestion, meaning it will not be automatically fixed by `dotnet format`.

## Notes on IDE0270 

Documentation for this warning is non-existent on Microsoft's .NET documentation website at this time, but essentially it modifies `if x == null` checks to a null-coalescing operator.

For example, if IDE0270 is set to "warning", and the developer has the .NET 7.0.304 or higher SDK installed, this code block:
```cs
using ScrText scrText = ScrTextCollection.FindById(username, paratextId);
if (scrText == null)
	throw new Exception(
		$"Failed to fetch ScrText for PT project id {paratextId} using PT username {username}"
	);
```
Would be automatically changed to:
```cs
using ScrText scrText = ScrTextCollection.FindById(username, paratextId) ?? throw new Exception(
	$"Failed to fetch ScrText for PT project id {paratextId} using PT username {username}"
);
```

We should only IDE0270 set to "warning" if all developers have the latest .NET 7.0 SDK installed, which is currently not a requirement to build Scripture Forge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1906)
<!-- Reviewable:end -->
