### PR TITLE
SF-2087 Show note thread on verses with letters

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/verse-ref-data.ts
+++ b/src/RealtimeServer/scriptureforge/models/verse-ref-data.ts
@@ -13,7 +13,7 @@ export function fromVerseRef(input: VerseRef): VerseRefData {
     bookNum: input.bookNum,
     chapterNum: input.chapterNum,
     verseNum: input.verseNum,
-    verse: input.hasMultiple ? input.verse : undefined
+    verse: input.verse === input.verseNum.toString() ? undefined : input.verse
   };
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
@@ -61,6 +61,8 @@ export function getCombinedVerseTextDoc(id: TextDocId, rtl: boolean = false): Te
   delta.insert(`${id.textType}: chapter ${id.chapterNum}, verse 5,7.`, {
     segment: `verse_${id.chapterNum}_${verse5Str}`
   });
+  delta.insert({ verse: { number: '6a', style: 'v' } });
+  delta.insert(`${id.textType}: chapter ${id.chapterNum}, verse 6a.`, { segment: `verse_${id.chapterNum}_6a` });
   delta.insert('\n', { para: { style: 'p' } });
   return delta;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
@@ -63,6 +63,8 @@ export function getCombinedVerseTextDoc(id: TextDocId, rtl: boolean = false): Te
   });
   delta.insert({ verse: { number: '6a', style: 'v' } });
   delta.insert(`${id.textType}: chapter ${id.chapterNum}, verse 6a.`, { segment: `verse_${id.chapterNum}_6a` });
+  delta.insert({ verse: { number: '6b', style: 'v' } });
+  delta.insert(`${id.textType}: chapter ${id.chapterNum}, verse 6b.`, { segment: `verse_${id.chapterNum}_6b` });
   delta.insert('\n', { para: { style: 'p' } });
   return delta;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -361,8 +361,8 @@ export class TextViewModel {
       if (verseStr != null) {
         // update numbers for the new verse
         const verseParts: string[] = verseStr.split('-');
-        matchStartNum = +verseParts[0];
-        matchLastNum = +verseParts[verseParts.length - 1];
+        matchStartNum = Number.parseInt(verseParts[0]);
+        matchLastNum = Number.parseInt(verseParts[verseParts.length - 1]);
       }
       const matchStartsWithin: boolean = matchStartNum >= startVerseNum && matchStartNum <= lastVerseNum;
       const matchEndsWithin: boolean = matchLastNum >= startVerseNum && matchLastNum <= lastVerseNum;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -31,7 +31,7 @@ import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-
 import { Delta, TextDoc, TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { NoteThreadIcon } from '../../core/models/note-thread-doc';
-import { attributeFromMouseEvent, getBaseVerse, VERSE_REGEX } from '../utils';
+import { attributeFromMouseEvent, getBaseVerse, getVerseStrFromSegmentRef, VERSE_REGEX } from '../utils';
 import { MultiCursorViewer } from '../../translate/editor/multi-viewer/multi-viewer.component';
 import { getAttributesAtPosition, registerScripture } from './quill-scripture';
 import { Segment } from './segment';
@@ -521,6 +521,17 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     return this.viewModel.getVerseSegments(verseRef);
   }
 
+  /**
+   * Get segments compatible for a given verseRef. For verses with letters, only return the segments
+   * that explicitly contain the letter or non-verse segment in the range.
+   * i.e. LUK 1:1a will match segments verse_1_1a, verse_1_1a/p1, s_1 but not verse_1_1 or verse_1_1b.
+   */
+  getCompatibleSegments(verseRef: VerseRef): string[] {
+    const segments: string[] = this.getVerseSegments(verseRef);
+    const defaultValue: string = verseRef.verse;
+    return segments.filter(s => verseRef.verse === (getVerseStrFromSegmentRef(s) ?? defaultValue));
+  }
+
   getSegmentElement(segment: string): Element | null {
     return this.editor == null ? null : this.editor.container.querySelector(`usx-segment[data-segment="${segment}"]`);
   }
@@ -591,8 +602,8 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       return;
     }
 
-    // A single verse can be associated with multiple segments (e.g verse_1_1, verse_1_1/p_1)
-    const verseSegments: string[] = this.viewModel.getVerseSegments(verseRef);
+    // A single verse can be associated with multiple compatible segments (e.g verse_1_1, verse_1_1/p_1)
+    const verseSegments: string[] = this.getCompatibleSegments(verseRef);
     if (verseSegments.length === 0) {
       return;
     }
@@ -677,7 +688,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
 
   toggleVerseSelection(verseRef: VerseRef): boolean {
     if (this.editor == null) return false;
-    const verseSegments: string[] = this.getVerseSegments(verseRef);
+    const verseSegments: string[] = this.getCompatibleSegments(verseRef);
     const verseRange: RangeStatic | undefined = this.getSegmentRange(verseSegments[0]);
     let selectionValue: true | null = true;
     if (verseRange != null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -7,7 +7,7 @@ import { SelectableProject } from '../core/paratext.service';
 
 // Regular expression for getting the verse from a segment ref
 // Some projects will have the right to left marker in the segment attribute which we need to account for
-const VERSE_FROM_SEGMENT_REF_REGEX = /verse_\d+_(\d+[\u200f]?[,-]?\d*[^\/]?)/;
+const VERSE_FROM_SEGMENT_REF_REGEX = /verse_\d+_(\d+[\u200f]?[a-z]?[,-]?\d*[a-z]?[^\/]?)/;
 // Regular expression for the verse segment ref of scripture content
 export const VERSE_REGEX = /verse_[0-9]+_[0-9]+/;
 export const RIGHT_TO_LEFT_MARK = '\u200f';
@@ -67,7 +67,7 @@ export function getVerseRefFromSegmentRef(bookNum: number, segmentRef: string): 
   return new VerseRef(bookNum, parts[1], parts[2]);
 }
 
-/** Returns the verse string from a segment ref. e.g. 6, 6-7, 6,8 */
+/** Returns the verse string from a segment ref. e.g. 6, 6a, 6-7, 6,8 */
 export function getVerseStrFromSegmentRef(segmentRef: string): string | undefined {
   const match: RegExpExecArray | null = VERSE_FROM_SEGMENT_REF_REGEX.exec(segmentRef);
   if (match != null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1536,6 +1536,17 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('shows note on verse with letter', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.updateParams({ projectId: 'project01', bookId: 'LUK' });
+      env.addParatextNoteThread(6, 'LUK 1:6a', '', { start: 0, length: 0 }, ['user01']);
+      env.wait();
+
+      expect(env.getNoteThreadIconElement('verse_1_6a', 'thread06')).not.toBeNull();
+      env.dispose();
+    }));
+
     it('highlights note icons when new content is unread', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setCurrentUser('user02');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1541,9 +1541,11 @@ describe('EditorComponent', () => {
       env.setProjectUserConfig();
       env.updateParams({ projectId: 'project01', bookId: 'LUK' });
       env.addParatextNoteThread(6, 'LUK 1:6a', '', { start: 0, length: 0 }, ['user01']);
+      env.addParatextNoteThread(7, 'LUK 1:6b', '', { start: 0, length: 0 }, ['user01']);
       env.wait();
 
       expect(env.getNoteThreadIconElement('verse_1_6a', 'thread06')).not.toBeNull();
+      expect(env.getNoteThreadIconElement('verse_1_6b', 'thread07')).not.toBeNull();
       env.dispose();
     }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1664,7 +1664,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       !this.showAddCommentUI
     )
       return;
-    const verseSegments: string[] = this.target.getVerseSegments(verseRef);
+    const verseSegments: string[] = this.target.getCompatibleSegments(verseRef);
     const segmentElement: Element | null = this.target.getSegmentElement(verseSegments[0]);
     if (segmentElement == null) {
       return;


### PR DESCRIPTION
Previously, it was assumed that a verse segment would contain only numbers, which we know is not true. This change makes an update so that a verse that contains letters like 6a will correctly be retrieved when getting verse segments that match a particular verseRef. This will ensure that note threads can be embedded on verses with letters.

![image](https://github.com/sillsdev/web-xforge/assets/17931130/716d6a53-f520-46ba-a4fa-4871687db8de)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1911)
<!-- Reviewable:end -->
