### PR TITLE
SF-2086 Delete thread doc if all notes removed in Paratext

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1146,6 +1146,14 @@ public class ParatextSyncRunner : IParatextSyncRunner
     /// </summary>
     private async Task SubmitChangesOnNoteThreadDocAsync(IDocument<NoteThread> threadDoc, NoteThreadChange change)
     {
+        bool hasNotesInThread =
+            change.NotesAdded.Count > 0 || threadDoc.Data.Notes.Any(n => !change.NoteIdsRemoved.Contains(n.DataId));
+        if (!hasNotesInThread)
+        {
+            await threadDoc.DeleteAsync();
+            return;
+        }
+
         await threadDoc.SubmitJson0OpAsync(op =>
         {
             // Update thread details

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1963,7 +1963,7 @@ public class ParatextSyncRunnerTests
         );
         await env.SetThreadNotesAsync(sfProjectId, threadId, beginningNoteSet);
         env.SetupPTData(book);
-        env.SetupNoteRemovedChange(threadId, "n02");
+        env.SetupNoteRemovedChange(threadId, new[] { "n02" });
         NoteThread thread01 = env.GetNoteThread(sfProjectId, threadId);
         Assert.That(
             thread01.Notes.Select(n => n.DataId),
@@ -1989,7 +1989,7 @@ public class ParatextSyncRunnerTests
         Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
 
         // Remove note 3
-        env.SetupNoteRemovedChange(threadId, "n03");
+        env.SetupNoteRemovedChange(threadId, new[] { "n03" });
 
         // SUT 2
         await env.Runner.RunAsync(sfProjectId, "user01", "project01_alt", false, CancellationToken.None);
@@ -2006,6 +2006,20 @@ public class ParatextSyncRunnerTests
             Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 1))
         );
         Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+    }
+
+    [Test]
+    public async Task SyncAsync_NoteThreadDeleted()
+    {
+        var env = new TestEnvironment();
+        var book = new Book("MAT", 1);
+        env.SetupSFData(true, false, false, true, book);
+        env.SetupPTData(book);
+        env.SetupNoteRemovedChange("thread01", new[] { "n01", "n02" });
+
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        Assert.Throws<KeyNotFoundException>(() => env.GetNoteThread("project01", "thread01"));
     }
 
     [Test]
@@ -3159,7 +3173,7 @@ public class ParatextSyncRunnerTests
             SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
         }
 
-        public void SetupNoteRemovedChange(string threadId, string noteId, string verseRef = "MAT 1:1")
+        public void SetupNoteRemovedChange(string threadId, string[] noteIds, string verseRef = "MAT 1:1")
         {
             var noteThreadChange = new NoteThreadChange(
                 threadId,
@@ -3169,8 +3183,10 @@ public class ParatextSyncRunnerTests
                 " context after",
                 NoteStatus.Resolved.InternalValue,
                 ""
-            );
-            noteThreadChange.NoteIdsRemoved.Add(noteId);
+            )
+            {
+                NoteIdsRemoved = new List<string>(noteIds)
+            };
             SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
         }
 


### PR DESCRIPTION
Delete the note thread when the Paratext note has been permanently deleted. This change is to prevent orphaned note thread docs from being present in the mongoDB. However, because of how realtime doc deletion works, the note thread doc never gets completely removed from mongoDB, but will remain as a mostly empty record. See the image below.

![image](https://github.com/sillsdev/web-xforge/assets/17931130/9a8de705-3128-4f26-a893-04c03f9f01cf)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1912)
<!-- Reviewable:end -->
