### PR TITLE
SF-2088 Add model for Scripture Audio

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/audio-timing.ts
+++ b/src/RealtimeServer/scriptureforge/models/audio-timing.ts
@@ -1,0 +1,5 @@
+export interface AudioTiming {
+  textRef: string;
+  from: number;
+  to: number;
+}

--- a/src/RealtimeServer/scriptureforge/models/sf-project-rights.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project-rights.ts
@@ -12,7 +12,8 @@ export enum SFProjectDomain {
   Likes = 'likes',
   PTNoteThreads = 'pt_note_threads',
   SFNoteThreads = 'sf_note_threads',
-  Notes = 'notes'
+  Notes = 'notes',
+  TextAudio = 'text_audio'
 }
 
 // See https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html
@@ -22,7 +23,8 @@ const rightsByRole: Record<SFProjectRole, { [domain in `${SFProjectDomain}`]?: `
     project_user_configs: ['view_own', 'edit_own'],
     texts: ['view'],
     sf_note_threads: ['view'],
-    notes: ['view']
+    notes: ['view'],
+    text_audio: ['view']
   },
   pt_observer: {
     project_user_configs: ['view_own', 'edit_own'],
@@ -35,13 +37,15 @@ const rightsByRole: Record<SFProjectRole, { [domain in `${SFProjectDomain}`]?: `
     likes: ['view'],
     pt_note_threads: ['view'],
     sf_note_threads: ['view'],
-    notes: ['view']
+    notes: ['view'],
+    text_audio: ['view']
   },
   sf_commenter: {
     project_user_configs: ['view_own', 'edit_own'],
     texts: ['view'],
     sf_note_threads: ['view', 'create', 'delete_own'],
-    notes: ['view', 'create', 'edit_own', 'delete_own']
+    notes: ['view', 'create', 'edit_own', 'delete_own'],
+    text_audio: ['view']
   },
   sf_community_checker: {
     project_user_configs: ['view_own', 'edit_own'],
@@ -50,7 +54,8 @@ const rightsByRole: Record<SFProjectRole, { [domain in `${SFProjectDomain}`]?: `
     answers: ['view', 'create', 'edit_own', 'delete_own'],
     answer_status: ['view'],
     answer_comments: ['view', 'create', 'edit_own', 'delete_own'],
-    likes: ['view', 'create', 'delete_own']
+    likes: ['view', 'create', 'delete_own'],
+    text_audio: ['view']
   },
   pt_consultant: {
     project_user_configs: ['view_own', 'edit_own'],
@@ -63,7 +68,8 @@ const rightsByRole: Record<SFProjectRole, { [domain in `${SFProjectDomain}`]?: `
     likes: ['view'],
     pt_note_threads: ['view', 'create', 'delete_own'],
     sf_note_threads: ['view', 'create', 'delete_own'],
-    notes: ['view', 'create', 'edit_own', 'delete_own']
+    notes: ['view', 'create', 'edit_own', 'delete_own'],
+    text_audio: ['view']
   },
   pt_translator: {
     project_user_configs: ['view_own', 'edit_own'],
@@ -76,7 +82,8 @@ const rightsByRole: Record<SFProjectRole, { [domain in `${SFProjectDomain}`]?: `
     likes: ['view', 'create', 'delete_own'],
     pt_note_threads: ['view', 'create', 'edit', 'delete_own'],
     sf_note_threads: ['view', 'create', 'edit', 'delete_own'],
-    notes: ['view', 'create', 'edit_own', 'delete_own']
+    notes: ['view', 'create', 'edit_own', 'delete_own'],
+    text_audio: ['view']
   },
   pt_administrator: {
     project_user_configs: ['view_own', 'edit_own'],
@@ -89,7 +96,8 @@ const rightsByRole: Record<SFProjectRole, { [domain in `${SFProjectDomain}`]?: `
     likes: ['view', 'create', 'delete_own'],
     pt_note_threads: ['view', 'create', 'edit', 'delete'],
     sf_note_threads: ['view', 'create', 'edit', 'delete'],
-    notes: ['view', 'create', 'edit_own', 'delete']
+    notes: ['view', 'create', 'edit_own', 'delete'],
+    text_audio: ['view', 'edit', 'create']
   },
   none: {}
 };

--- a/src/RealtimeServer/scriptureforge/models/text-audio.ts
+++ b/src/RealtimeServer/scriptureforge/models/text-audio.ts
@@ -1,0 +1,12 @@
+import { ProjectData, PROJECT_DATA_INDEX_PATHS } from '../../common/models/project-data';
+import { AudioTiming } from './audio-timing';
+
+export const TEXT_AUDIO_COLLECTION = 'text_audio';
+export const TEXT_AUDIO_INDEX_PATHS: string[] = PROJECT_DATA_INDEX_PATHS;
+
+export interface TextAudio extends ProjectData {
+  dataId: string;
+  timings: AudioTiming[];
+  mimeType: string;
+  audioUrl: string;
+}

--- a/src/RealtimeServer/scriptureforge/models/text-info.ts
+++ b/src/RealtimeServer/scriptureforge/models/text-info.ts
@@ -3,6 +3,7 @@ export interface Chapter {
   lastVerse: number;
   isValid: boolean;
   permissions: { [userRef: string]: string };
+  hasAudio?: boolean;
 }
 
 /** Documents in the texts collection in the database represent the metadata

--- a/src/RealtimeServer/scriptureforge/realtime-server.ts
+++ b/src/RealtimeServer/scriptureforge/realtime-server.ts
@@ -13,6 +13,7 @@ import { SFProjectService } from './services/sf-project-service';
 import { SFProjectUserConfigService } from './services/sf-project-user-config-service';
 import { TextService } from './services/text-service';
 import { SF_PROJECT_MIGRATIONS } from './services/sf-project-migrations';
+import { TextAudioService } from './services/text-audio-service';
 
 const SF_DOC_SERVICES: DocService[] = [
   new UserService(),
@@ -20,7 +21,8 @@ const SF_DOC_SERVICES: DocService[] = [
   new SFProjectUserConfigService(),
   new TextService(),
   new QuestionService(),
-  new NoteThreadService()
+  new NoteThreadService(),
+  new TextAudioService()
 ];
 
 /**

--- a/src/RealtimeServer/scriptureforge/services/text-audio-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/text-audio-migrations.ts
@@ -1,0 +1,3 @@
+import { MigrationConstructor } from '../../common/migration';
+
+export const TEXT_AUDIO_MIGRATIONS: MigrationConstructor[] = [];

--- a/src/RealtimeServer/scriptureforge/services/text-audio-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/text-audio-service.spec.ts
@@ -1,0 +1,165 @@
+import ShareDB from 'sharedb';
+import ShareDBMingo from 'sharedb-mingo-memory';
+import { instance, mock } from 'ts-mockito';
+import { SystemRole } from '../../common/models/system-role';
+import { User, USERS_COLLECTION } from '../../common/models/user';
+import { RealtimeServer } from '../../common/realtime-server';
+import { SchemaVersionRepository } from '../../common/schema-version-repository';
+import { allowAll, clientConnect, createDoc, fetchDoc, submitJson0Op } from '../../common/utils/test-utils';
+import { CheckingAnswerExport } from '../models/checking-config';
+import { SF_PROJECTS_COLLECTION, SFProject } from '../models/sf-project';
+import { SFProjectRole } from '../models/sf-project-role';
+import { TextAudio, TEXT_AUDIO_COLLECTION } from '../models/text-audio';
+import { getTextDocId } from '../models/text-data';
+import { TextAudioService } from './text-audio-service';
+
+describe('TextAudioService', () => {
+  it('allows member to view text audio timings', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const conn = clientConnect(env.server, 'observer');
+    await expect(fetchDoc(conn, TEXT_AUDIO_COLLECTION, getTextDocId('project01', 40, 1))).resolves.not.toThrow();
+  });
+
+  it('allows administrator to edit text audio timings', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const conn = clientConnect(env.server, 'administrator');
+    await expect(
+      submitJson0Op<TextAudio>(conn, TEXT_AUDIO_COLLECTION, getTextDocId('project01', 40, 1), op =>
+        op.add(n => n.timings, {
+          textRef: '2',
+          from: 1.0,
+          to: 1.5
+        })
+      )
+    ).resolves.not.toThrow();
+  });
+
+  it('does not allow non-member to view text audio timings', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const conn = clientConnect(env.server, 'nonmember');
+    await expect(fetchDoc(conn, TEXT_AUDIO_COLLECTION, getTextDocId('project01', 40, 1))).rejects.toThrow();
+  });
+
+  it('does not allow observer to edit text audio timings', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const conn = clientConnect(env.server, 'observer');
+    await expect(
+      submitJson0Op<TextAudio>(conn, TEXT_AUDIO_COLLECTION, getTextDocId('project01', 40, 1), op =>
+        op.add(n => n.timings, {
+          textRef: '2',
+          from: 1.0,
+          to: 1.5
+        })
+      )
+    ).rejects.toThrow();
+  });
+});
+
+class TestEnvironment {
+  readonly service: TextAudioService;
+  readonly server: RealtimeServer;
+  readonly db: ShareDBMingo;
+  readonly mockedSchemaVersionRepository = mock(SchemaVersionRepository);
+
+  constructor() {
+    this.service = new TextAudioService();
+    const ShareDBMingoType = ShareDBMingo.extendMemoryDB(ShareDB.MemoryDB);
+    this.db = new ShareDBMingoType();
+    this.server = new RealtimeServer(
+      'TEST',
+      false,
+      [this.service],
+      SF_PROJECTS_COLLECTION,
+      this.db,
+      instance(this.mockedSchemaVersionRepository)
+    );
+    allowAll(this.server, USERS_COLLECTION);
+    allowAll(this.server, SF_PROJECTS_COLLECTION);
+  }
+
+  async createData(): Promise<void> {
+    const conn = this.server.connect();
+    await createDoc<User>(conn, USERS_COLLECTION, 'administrator', {
+      name: 'User 01',
+      email: 'user01@example.com',
+      role: SystemRole.User,
+      isDisplayNameConfirmed: true,
+      authId: 'auth01',
+      displayName: 'User 01',
+      avatarUrl: '',
+      sites: {}
+    });
+
+    await createDoc<User>(conn, USERS_COLLECTION, 'observer', {
+      name: 'User 02',
+      email: 'user02@example.com',
+      role: SystemRole.User,
+      isDisplayNameConfirmed: true,
+      authId: 'auth02',
+      displayName: 'User 02',
+      avatarUrl: '',
+      sites: {}
+    });
+
+    await createDoc<User>(conn, USERS_COLLECTION, 'nonmember', {
+      name: 'User 03',
+      email: 'user03@example.com',
+      role: SystemRole.User,
+      isDisplayNameConfirmed: true,
+      authId: 'auth03',
+      displayName: 'User 03',
+      avatarUrl: '',
+      sites: {}
+    });
+
+    await createDoc<SFProject>(conn, SF_PROJECTS_COLLECTION, 'project01', {
+      name: 'Project 01',
+      shortName: 'PT01',
+      paratextId: 'pt01',
+      writingSystem: { tag: 'qaa' },
+      translateConfig: {
+        translationSuggestionsEnabled: false,
+        shareEnabled: true
+      },
+      checkingConfig: {
+        checkingEnabled: false,
+        usersSeeEachOthersResponses: true,
+        shareEnabled: true,
+        answerExportMethod: CheckingAnswerExport.MarkedForExport
+      },
+      texts: [],
+      noteTags: [],
+      sync: { queuedCount: 0 },
+      editable: true,
+      userRoles: {
+        administrator: SFProjectRole.ParatextAdministrator,
+        observer: SFProjectRole.ParatextObserver
+      },
+      paratextUsers: [],
+      userPermissions: {}
+    });
+
+    await createDoc<TextAudio>(conn, TEXT_AUDIO_COLLECTION, getTextDocId('project01', 40, 1), {
+      dataId: 'dataId01',
+      projectRef: 'project01',
+      ownerRef: 'user01',
+      timings: [
+        {
+          textRef: '1',
+          from: 0.0,
+          to: 0.0
+        }
+      ],
+      mimeType: 'audio/mpeg',
+      audioUrl: 'project01/user01_file01.mp3?t=123456789123456789'
+    });
+  }
+}

--- a/src/RealtimeServer/scriptureforge/services/text-audio-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/text-audio-service.ts
@@ -1,0 +1,30 @@
+import { ProjectDomainConfig } from '../../common/services/project-data-service';
+import { SFProjectDomain } from '../models/sf-project-rights';
+import { TextAudio, TEXT_AUDIO_COLLECTION, TEXT_AUDIO_INDEX_PATHS } from '../models/text-audio';
+import { SFProjectDataService } from './sf-project-data-service';
+import { TEXT_AUDIO_MIGRATIONS } from './text-audio-migrations';
+
+/**
+ * This class manages text audio timing docs.
+ */
+export class TextAudioService extends SFProjectDataService<TextAudio> {
+  readonly collection = TEXT_AUDIO_COLLECTION;
+
+  protected readonly indexPaths = TEXT_AUDIO_INDEX_PATHS;
+
+  constructor() {
+    super(TEXT_AUDIO_MIGRATIONS);
+
+    const immutableProps = [this.pathTemplate(t => t.dataId)];
+    this.immutableProps.push(...immutableProps);
+  }
+
+  protected setupDomains(): ProjectDomainConfig[] {
+    return [
+      {
+        projectDomain: SFProjectDomain.TextAudio,
+        pathTemplate: this.pathTemplate()
+      }
+    ];
+  }
+}

--- a/src/SIL.XForge.Scripture/Models/AudioTiming.cs
+++ b/src/SIL.XForge.Scripture/Models/AudioTiming.cs
@@ -1,0 +1,8 @@
+namespace SIL.XForge.Scripture.Models;
+
+public class AudioTiming
+{
+    public string TextRef { get; set; }
+    public double From { get; set; }
+    public double To { get; set; }
+}

--- a/src/SIL.XForge.Scripture/Models/Chapter.cs
+++ b/src/SIL.XForge.Scripture/Models/Chapter.cs
@@ -12,4 +12,5 @@ public class Chapter
     /// be editable in SF.</summary>
     public bool IsValid { get; set; }
     public Dictionary<string, string> Permissions { get; set; } = new Dictionary<string, string>();
+    public bool? HasAudio { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/TextAudio.cs
+++ b/src/SIL.XForge.Scripture/Models/TextAudio.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using SIL.XForge.Models;
+
+namespace SIL.XForge.Scripture.Models;
+
+public class TextAudio : ProjectData
+{
+    public string DataId { get; set; }
+    public List<AudioTiming> Timings { get; set; } = new List<AudioTiming>();
+    public string MimeType { get; set; }
+    public string AudioUrl { get; set; }
+}

--- a/src/SIL.XForge.Scripture/Realtime/SFRealtimeServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Realtime/SFRealtimeServiceCollectionExtensions.cs
@@ -33,7 +33,8 @@ public static class SFRealtimeServiceCollectionExtensions
                         new DocConfig("sf_project_user_configs", typeof(SFProjectUserConfig)),
                         new DocConfig("texts", typeof(TextData), OTType.RichText),
                         new DocConfig("questions", typeof(Question)),
-                        new DocConfig("note_threads", typeof(NoteThread))
+                        new DocConfig("note_threads", typeof(NoteThread)),
+                        new DocConfig("text_audio", typeof(TextAudio)),
                     }
                 );
                 o.UserDataDocs.AddRange(


### PR DESCRIPTION
This Pull Request:
* Adds support for a new `text_audio` to ShareDB to store audio timings and references to the MP3 files
* Adds a `hasAudio` flag to the chapter object (`sf_projects.texts[].chapters[].hasAudio`)
* Adds a migrator to set this flag to `false` for every chapter of every project

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1913)
<!-- Reviewable:end -->
