### PR TITLE
SF-2098 Suggestions Settings to Material

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
@@ -2,10 +2,9 @@
   <h1 mat-dialog-title>{{ t("translation_suggestions_settings") }}</h1>
   <mat-dialog-content class="content-padding" fxLayout="column" fxLayoutGap="25px">
     <div class="offline-text" *ngIf="!pwaService.isOnline">{{ t("settings_not_available_offline") }}</div>
-    <mdc-form-field [formGroup]="suggestionsSwitchFormGroup" class="suggestions-switch">
-      <mdc-switch id="suggestions-enabled-switch" *ngIf="open" formControlName="suggestionsEnabledSwitch"></mdc-switch>
-      <label>{{ t("translation_suggestions") }}</label>
-    </mdc-form-field>
+    <mat-slide-toggle #suggestionsToggle id="suggestions-enabled-switch">{{
+      t("translation_suggestions")
+    }}</mat-slide-toggle>
     <mdc-select
       id="num-suggestions-select"
       [disabled]="settingsDisabled"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
@@ -5,25 +5,25 @@
     <mat-slide-toggle #suggestionsToggle id="suggestions-enabled-switch">{{
       t("translation_suggestions")
     }}</mat-slide-toggle>
-    <mdc-select
-      id="num-suggestions-select"
-      [disabled]="settingsDisabled"
-      [(ngModel)]="numSuggestions"
-      placeholder="{{ t('number_of_suggestions') }}"
-    >
-      <mdc-menu>
-        <mdc-list>
-          <mdc-list-item *ngFor="let value of ['1', '2', '3', '4', '5']" [value]="value">
-            {{ value }}
-          </mdc-list-item>
-        </mdc-list>
-      </mdc-menu>
-    </mdc-select>
-    <mdc-form-field class="suggestions-confidence-field">
-      <label mdcSubtitle2>{{ t("suggestion_confidence") }}</label>
+    <mat-form-field appearance="outline">
+      <mat-label>{{ t("number_of_suggestions") }}</mat-label>
+      <mat-select
+        id="num-suggestions-select"
+        [disabled]="settingsDisabled"
+        [(ngModel)]="numSuggestions"
+        disableOptionCentering
+      >
+        <mat-option *ngFor="let value of ['1', '2', '3', '4', '5']" [value]="value">
+          {{ value }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+    <div class="suggestions-confidence-field">
+      <span class="minor-header">{{ t("suggestion_confidence") }}</span>
       <div class="slider-labels" fxLayout="row" fxLayoutAlign="space-between">
-        <span mdcCaption>{{ t("more") }}</span> <span mdcCaption>{{ confidenceThreshold }}%</span>
-        <span mdcCaption>{{ t("better") }}</span>
+        <span>{{ t("more") }}</span>
+        <span>{{ confidenceThreshold }}%</span>
+        <span>{{ t("better") }}</span>
       </div>
       <mat-slider
         #confidenceThresholdSlider
@@ -33,7 +33,7 @@
         [(ngModel)]="confidenceThreshold"
         (input)="confidenceThreshold = $event.value ?? 0"
       ></mat-slider>
-    </mdc-form-field>
+    </div>
   </mat-dialog-content>
   <mat-dialog-actions fxLayoutAlign="end">
     <button mat-button mat-dialog-close>{{ t("close") }}</button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
@@ -7,7 +7,6 @@
     <mat-slide-toggle
       id="suggestions-enabled-switch"
       [formControl]="suggestionsEnabledSwitch"
-      [disabled]="!pwaService.isOnline"
       (change)="setTranslationSettingsEnabled($event.checked)"
     >
       {{ t("translation_suggestions") }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
@@ -1,10 +1,17 @@
 <ng-container *transloco="let t; read: 'suggestions_settings_dialog'">
   <h1 mat-dialog-title>{{ t("translation_suggestions_settings") }}</h1>
+  <div class="offline-text" *ngIf="!pwaService.isOnline">
+    {{ t("settings_not_available_offline") }}
+  </div>
   <mat-dialog-content>
-    <div class="offline-text" *ngIf="!pwaService.isOnline">{{ t("settings_not_available_offline") }}</div>
-    <mat-slide-toggle #suggestionsToggle id="suggestions-enabled-switch">{{
-      t("translation_suggestions")
-    }}</mat-slide-toggle>
+    <mat-slide-toggle
+      id="suggestions-enabled-switch"
+      [formControl]="suggestionsEnabledSwitch"
+      [disabled]="!pwaService.isOnline"
+      (change)="setTranslationSettingsEnabled($event.checked)"
+    >
+      {{ t("translation_suggestions") }}
+    </mat-slide-toggle>
     <mat-form-field appearance="outline">
       <mat-label>{{ t("number_of_suggestions") }}</mat-label>
       <mat-select

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
@@ -13,12 +13,7 @@
     </mat-slide-toggle>
     <mat-form-field appearance="outline">
       <mat-label>{{ t("number_of_suggestions") }}</mat-label>
-      <mat-select
-        id="num-suggestions-select"
-        [disabled]="settingsDisabled"
-        [(ngModel)]="numSuggestions"
-        disableOptionCentering
-      >
+      <mat-select id="num-suggestions-select" [disabled]="settingsDisabled" [(ngModel)]="numSuggestions">
         <mat-option *ngFor="let value of ['1', '2', '3', '4', '5']" [value]="value">
           {{ value }}
         </mat-option>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; read: 'suggestions_settings_dialog'">
   <h1 mat-dialog-title>{{ t("translation_suggestions_settings") }}</h1>
-  <mat-dialog-content class="content-padding" fxLayout="column" fxLayoutGap="25px">
+  <mat-dialog-content>
     <div class="offline-text" *ngIf="!pwaService.isOnline">{{ t("settings_not_available_offline") }}</div>
     <mat-slide-toggle #suggestionsToggle id="suggestions-enabled-switch">{{
       t("translation_suggestions")
@@ -20,7 +20,7 @@
     </mat-form-field>
     <div class="suggestions-confidence-field">
       <span class="minor-header">{{ t("suggestion_confidence") }}</span>
-      <div class="slider-labels" fxLayout="row" fxLayoutAlign="space-between">
+      <div class="slider-labels">
         <span>{{ t("more") }}</span>
         <span>{{ confidenceThreshold }}%</span>
         <span>{{ t("better") }}</span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
@@ -33,7 +33,7 @@
         <span>{{ t("better") }}</span>
       </div>
       <mat-slider
-        #confidenceThresholdSlider
+        id="confidence-threshold-slider"
         [disabled]="settingsDisabled"
         [min]="0"
         [max]="100"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
@@ -21,6 +21,18 @@ mat-dialog-content.content-padding {
   }
 }
 
-mdc-list-item {
-  height: 2.5em;
+mat-option {
+  height: 2.5em !important;
+}
+
+.minor-header {
+  font-size: 0.875rem;
+  line-height: 1.375rem;
+  font-weight: 500;
+}
+
+span {
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+  font-weight: 400;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
@@ -2,10 +2,6 @@
   margin-top: 15px;
 }
 
-.suggestions-switch {
-  column-gap: 12px;
-}
-
 mat-dialog-content.content-padding {
   padding-top: 15px;
   overflow: visible; // prevent mdc-select menu from causing scroll bar

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
@@ -1,10 +1,19 @@
 .slider-labels {
   margin-top: 15px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
 }
 
-mat-dialog-content.content-padding {
-  padding-top: 15px;
+mat-dialog-content {
+  padding-block: 20px;
   overflow: visible; // prevent mat-select menu from causing scroll bar
+  display: flex;
+  flex-direction: column;
+}
+
+#suggestions-enabled-switch {
+  margin-block-end: 30px;
 }
 
 .suggestions-confidence-field {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
@@ -4,11 +4,7 @@
 
 mat-dialog-content.content-padding {
   padding-top: 15px;
-  overflow: visible; // prevent mdc-select menu from causing scroll bar
-}
-
-#num-suggestions-select ::ng-deep .mdc-select__anchor {
-  width: 100%;
+  overflow: visible; // prevent mat-select menu from causing scroll bar
 }
 
 .suggestions-confidence-field {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
@@ -57,7 +57,7 @@ describe('SuggestionsSettingsDialogComponent', () => {
     env.openDialog();
     expect(env.component!.translationSuggestionsUserEnabled).toBe(true);
 
-    env.clickSwitch(env.matSuggestionsEnabledSwitch);
+    env.clickSwitch(env.suggestionsEnabledSwitch);
     expect(env.component!.translationSuggestionsUserEnabled).toBe(false);
     const userConfigDoc = env.getProjectUserConfigDoc();
     expect(userConfigDoc.data!.translationSuggestionsEnabled).toBe(false);
@@ -88,14 +88,14 @@ describe('SuggestionsSettingsDialogComponent', () => {
     env.openDialog();
 
     expect(env.offlineText).toBeNull();
-    expect(env.suggestionsEnabledSwitch.disabled).toBe(false);
+    expect(env.suggestionsEnabledCheckbox.disabled).toBe(false);
     expect(env.confidenceThresholdSlider.disabled).toBe(false);
     expect(env.numSuggestionsSelect.disabled).toBe(false);
 
     env.isOnline = false;
 
     expect(env.offlineText).not.toBeNull();
-    expect(env.suggestionsEnabledSwitch.disabled).toBe(true);
+    expect(env.suggestionsEnabledCheckbox.disabled).toBe(true);
     expect(env.confidenceThresholdSlider.disabled).toBe(true);
     expect(env.numSuggestionsSelect.disabled).toBe(true);
     env.closeDialog();
@@ -106,8 +106,8 @@ describe('SuggestionsSettingsDialogComponent', () => {
     env.isOnline = false;
     env.openDialog();
 
-    expect(env.suggestionsEnabledSwitch.disabled).toBe(true);
-    expect(env.suggestionsEnabledSwitch.checked).toBe(true);
+    expect(env.suggestionsEnabledCheckbox.disabled).toBe(true);
+    expect(env.suggestionsEnabledCheckbox.checked).toBe(true);
     env.closeDialog();
   }));
 });
@@ -147,12 +147,12 @@ class TestEnvironment {
     return this.fixture.debugElement.query(By.css('#confidence-threshold-slider')).componentInstance;
   }
 
-  get matSuggestionsEnabledSwitch(): HTMLElement {
+  get suggestionsEnabledSwitch(): HTMLElement {
     return this.overlayContainerElement.querySelector('#suggestions-enabled-switch') as HTMLElement;
   }
 
-  get suggestionsEnabledSwitch(): HTMLInputElement {
-    return this.matSuggestionsEnabledSwitch.querySelector('input[type="checkbox"]') as HTMLInputElement;
+  get suggestionsEnabledCheckbox(): HTMLInputElement {
+    return this.suggestionsEnabledSwitch.querySelector('input[type="checkbox"]') as HTMLInputElement;
   }
 
   get numSuggestionsSelect(): MatSelect {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
@@ -1,8 +1,8 @@
-import { MdcSelect } from '@angular-mdc/web';
 import { CommonModule } from '@angular/common';
 import { DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
+import { MatSelect } from '@angular/material/select';
 import { MatSlider } from '@angular/material/slider';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -57,7 +57,7 @@ describe('SuggestionsSettingsDialogComponent', () => {
     env.openDialog();
     expect(env.component!.translationSuggestionsUserEnabled).toBe(true);
 
-    env.clickSwitch(env.mdcSuggestionsEnabledSwitch);
+    env.clickSwitch(env.matSuggestionsEnabledSwitch);
     expect(env.component!.translationSuggestionsUserEnabled).toBe(false);
     const userConfigDoc = env.getProjectUserConfigDoc();
     expect(userConfigDoc.data!.translationSuggestionsEnabled).toBe(false);
@@ -69,7 +69,7 @@ describe('SuggestionsSettingsDialogComponent', () => {
     env.openDialog();
     expect(env.component!.numSuggestions).toEqual('1');
 
-    env.changeSelectValue(env.mdcNumSuggestionsSelect, 2);
+    env.changeSelectValue(env.numSuggestionsSelect, 2);
     expect(env.component!.numSuggestions).toEqual('2');
     const userConfigDoc = env.getProjectUserConfigDoc();
     expect(userConfigDoc.data!.numSuggestions).toEqual(2);
@@ -90,14 +90,14 @@ describe('SuggestionsSettingsDialogComponent', () => {
     expect(env.offlineText).toBeNull();
     expect(env.suggestionsEnabledSwitch.disabled).toBe(false);
     expect(env.confidenceThresholdSlider.disabled).toBe(false);
-    expect(env.mdcNumSuggestionsSelect.disabled).toBe(false);
+    expect(env.numSuggestionsSelect.disabled).toBe(false);
 
     env.isOnline = false;
 
     expect(env.offlineText).not.toBeNull();
     expect(env.suggestionsEnabledSwitch.disabled).toBe(true);
     expect(env.confidenceThresholdSlider.disabled).toBe(true);
-    expect(env.mdcNumSuggestionsSelect.disabled).toBe(true);
+    expect(env.numSuggestionsSelect.disabled).toBe(true);
     env.closeDialog();
   }));
 
@@ -147,15 +147,15 @@ class TestEnvironment {
     return this.component!.confidenceThresholdSlider!;
   }
 
-  get mdcSuggestionsEnabledSwitch(): HTMLElement {
+  get matSuggestionsEnabledSwitch(): HTMLElement {
     return this.overlayContainerElement.querySelector('#suggestions-enabled-switch') as HTMLElement;
   }
 
   get suggestionsEnabledSwitch(): HTMLInputElement {
-    return this.mdcSuggestionsEnabledSwitch.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    return this.matSuggestionsEnabledSwitch.querySelector('input[type="checkbox"]') as HTMLInputElement;
   }
 
-  get mdcNumSuggestionsSelect(): MdcSelect {
+  get numSuggestionsSelect(): MatSelect {
     return this.fixture.debugElement.query(By.css('#num-suggestions-select')).componentInstance;
   }
 
@@ -230,8 +230,8 @@ class TestEnvironment {
     tick();
   }
 
-  changeSelectValue(mdcSelect: MdcSelect, option: number): void {
-    mdcSelect.setSelectionByValue(option.toString());
+  changeSelectValue(matSelect: MatSelect, option: number): void {
+    matSelect.value = option;
     this.fixture.detectChanges();
     tick();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
@@ -144,7 +144,7 @@ class TestEnvironment {
   }
 
   get confidenceThresholdSlider(): MatSlider {
-    return this.component!.confidenceThresholdSlider!;
+    return this.fixture.debugElement.query(By.css('#confidence-threshold-slider')).componentInstance;
   }
 
   get matSuggestionsEnabledSwitch(): HTMLElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.ts
@@ -18,7 +18,7 @@ export interface SuggestionsSettingsDialogData {
   styleUrls: ['./suggestions-settings-dialog.component.scss']
 })
 export class SuggestionsSettingsDialogComponent extends SubscriptionDisposable {
-  suggestionsEnabledSwitch = new UntypedFormControl();
+  suggestionsEnabledSwitch = new UntypedFormControl({ disabled: !this.pwaService.isOnline });
 
   private readonly projectUserConfigDoc: SFProjectUserConfigDoc;
   private confidenceThreshold$ = new BehaviorSubject<number>(20);
@@ -33,6 +33,13 @@ export class SuggestionsSettingsDialogComponent extends SubscriptionDisposable {
     }
 
     this.suggestionsEnabledSwitch.setValue(this.translationSuggestionsUserEnabled);
+    pwaService.onlineStatus$.subscribe(() => {
+      if (pwaService.isOnline) {
+        this.suggestionsEnabledSwitch.enable();
+      } else {
+        this.suggestionsEnabledSwitch.disable();
+      }
+    });
 
     this.subscribe(
       this.confidenceThreshold$.pipe(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.ts
@@ -1,7 +1,6 @@
-import { Component, Inject, ViewChild } from '@angular/core';
+import { Component, Inject } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { MatSlider } from '@angular/material/slider';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { BehaviorSubject } from 'rxjs';
 import { debounceTime, map, skip } from 'rxjs/operators';
 import { PwaService } from 'xforge-common/pwa.service';
@@ -19,28 +18,14 @@ export interface SuggestionsSettingsDialogData {
   styleUrls: ['./suggestions-settings-dialog.component.scss']
 })
 export class SuggestionsSettingsDialogComponent extends SubscriptionDisposable {
-  @ViewChild('confidenceThresholdSlider') confidenceThresholdSlider?: MatSlider;
-
   suggestionsEnabledSwitch = new UntypedFormControl();
 
   private readonly projectUserConfigDoc: SFProjectUserConfigDoc;
   private confidenceThreshold$ = new BehaviorSubject<number>(20);
 
-  constructor(
-    dialogRef: MatDialogRef<SuggestionsSettingsDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) data: SuggestionsSettingsDialogData,
-    readonly pwaService: PwaService
-  ) {
+  constructor(@Inject(MAT_DIALOG_DATA) data: SuggestionsSettingsDialogData, readonly pwaService: PwaService) {
     super();
     this.projectUserConfigDoc = data.projectUserConfigDoc;
-
-    dialogRef.afterOpened().subscribe(() => {
-      if (this.confidenceThresholdSlider != null) {
-        this.confidenceThresholdSlider.disabled = false; // cannot set value when slider is disabled
-        this.confidenceThresholdSlider.value = this.projectUserConfigDoc.data!.confidenceThreshold * 100;
-        this.confidenceThresholdSlider.disabled = this.settingsDisabled;
-      }
-    });
 
     if (this.projectUserConfigDoc.data != null) {
       const percent = Math.round(this.projectUserConfigDoc.data.confidenceThreshold * 100);

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -76,6 +76,7 @@ $material-app-theme: mat.define-light-theme(
 @include mat.radio-theme($material-app-theme);
 @include mat.select-theme($material-app-theme);
 @include mat.slider-theme($material-app-theme);
+@include mat.slide-toggle-theme($material-app-theme);
 @include mat.table-theme($material-app-theme);
 @include mat.toolbar-theme($material-app-theme);
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -41,6 +41,7 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatSelectModule } from '@angular/material/select';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatSliderModule } from '@angular/material/slider';
 import { MatTableModule } from '@angular/material/table';
 import { MatTabsModule } from '@angular/material/tabs';
@@ -79,6 +80,7 @@ const modules = [
   MatRadioModule,
   MatSelectModule,
   MatSliderModule,
+  MatSlideToggleModule,
   MatTableModule,
   MatTabsModule,
   MatToolbarModule,


### PR DESCRIPTION
I looked into rewriting the Suggestions Settings component, since the current patterns there (which I followed) are outdated. But I opted against this, since I believe it's been refactored in [the Biblical Terms task](https://github.com/sillsdev/web-xforge/pull/1731).
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1915)
<!-- Reviewable:end -->
