### PR TITLE
SF-2093 Add Developer Web API Documentation

### DIFF
--- a/src/SIL.XForge.Scripture/Controllers/AnonymousController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/AnonymousController.cs
@@ -12,6 +12,9 @@ using SIL.XForge.Services;
 
 namespace SIL.XForge.Scripture.Controllers;
 
+/// <summary>
+/// Provides methods for authentication of anonymous users.
+/// </summary>
 [Route(UrlConstants.Anonymous)]
 [ApiController]
 [AllowAnonymous]
@@ -26,8 +29,14 @@ public class AnonymousController : ControllerBase
         _exceptionHandler = exceptionHandler;
     }
 
+    /// <summary>
+    /// Checks whether or not the share key is valid.
+    /// </summary>
+    /// <param name="content">The share key to check.</param>
+    /// <response code="200">The share key is valid.</response>
+    /// <response code="404">The share key is invalid or not found.</response>
     [HttpPost("checkShareKey")]
-    public async Task<IActionResult> CheckShareKey([FromBody] CheckShareKeyRequest content)
+    public async Task<ActionResult<AnonymousShareKeyResponse>> CheckShareKey([FromBody] CheckShareKeyRequest content)
     {
         try
         {
@@ -50,8 +59,15 @@ public class AnonymousController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Generates an anonymous account.
+    /// </summary>
+    /// <param name="request">The parameters to generate the account.</param>
+    /// <response code="200">The account was generated.</response>
+    /// <response code="204">There was a problem communicating with the authentication server.</response>
+    /// <response code="404">The share key does not exist.</response>
     [HttpPost("generateAccount")]
-    public async Task<IActionResult> GenerateAccount([FromBody] GenerateAccountRequest request)
+    public async Task<ActionResult<bool>> GenerateAccount([FromBody] GenerateAccountRequest request)
     {
         _exceptionHandler.RecordEndpointInfoForException(
             new Dictionary<string, string>

--- a/src/SIL.XForge.Scripture/Controllers/LanguageController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/LanguageController.cs
@@ -5,10 +5,21 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace SIL.XForge.Scripture.Controllers;
 
+/// <summary>
+/// Provides methods to allow users to configure their language and culture settings.
+/// </summary>
 [Route("language-api")]
 [ApiController]
 public class LanguageController : ControllerBase
 {
+    /// <summary>
+    /// Set the user's language to the specified culture, then redirect.
+    /// </summary>
+    /// <param name="culture">The culture to change the culture to.</param>
+    /// <param name="returnUrl">The URL to redirect to upon success.</param>
+    /// <exception cref="ArgumentException">The culture or returnUrl parameters were empty.</exception>
+    /// <response code="200">The culture was updated successfully.</response>
+    /// <response code="400">The culture or returnUrl parameters were empty.</response>
     [HttpPost]
     public IActionResult SetLanguage([FromForm] string culture, [FromForm] string returnUrl)
     {

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -12,6 +12,9 @@ using SIL.XForge.Services;
 
 namespace SIL.XForge.Scripture.Controllers;
 
+/// <summary>
+/// Provides methods for Machine Learning assisted translating.
+/// </summary>
 [Route(MachineApi.Namespace)]
 [ApiController]
 [Authorize]
@@ -34,6 +37,19 @@ public class MachineApiController : ControllerBase
         _exceptionHandler.RecordUserIdForException(_userAccessor.UserId);
     }
 
+    /// <summary>
+    /// Gets a build job.
+    /// </summary>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="buildId">The build identifier.</param>
+    /// <param name="minRevision">The minimum revision.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <remarks>Omitting <paramref name="buildId"/> returns the current build running for the project.</remarks>
+    /// <response code="200">The build is running.</response>
+    /// <response code="204">No build is running.</response>
+    /// <response code="403">You do not have permission to run a build for this project.</response>
+    /// <response code="404">The project does not exist or is not configured on the ML server.</response>
+    /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
     [HttpGet(MachineApi.GetBuild)]
     public async Task<ActionResult<BuildDto?>> GetBuildAsync(
         string sfProjectId,
@@ -82,6 +98,15 @@ public class MachineApiController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Gets a translation engine.
+    /// </summary>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <response code="200">The translation engine is configured for the project.</response>
+    /// <response code="403">You do not have permission to retrieve the translation engine for this project.</response>
+    /// <response code="404">The project does not exist or is not configured on the ML server.</response>
+    /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
     [HttpGet(MachineApi.GetEngine)]
     public async Task<ActionResult<EngineDto>> GetEngineAsync(string sfProjectId, CancellationToken cancellationToken)
     {
@@ -109,6 +134,16 @@ public class MachineApiController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Gets the word graph that represents all possible translations of a segment of text.
+    /// </summary>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="segment">The source segment.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <response code="200">The word graph was successfully generated.</response>
+    /// <response code="403">You do not have permission to retrieve the word graph for this project.</response>
+    /// <response code="404">The project does not exist or is not configured on the ML server.</response>
+    /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
     [HttpPost(MachineApi.GetWordGraph)]
     public async Task<ActionResult<WordGraph>> GetWordGraphAsync(
         string sfProjectId,
@@ -141,6 +176,15 @@ public class MachineApiController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Starts a build job for a translation engine.
+    /// </summary>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <response code="200">The build was successfully started.</response>
+    /// <response code="403">You do not have permission to build this project.</response>
+    /// <response code="404">The project does not exist or is not configured on the ML server.</response>
+    /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
     [HttpPost(MachineApi.StartBuild)]
     public async Task<ActionResult<BuildDto>> StartBuildAsync(
         [FromBody] string sfProjectId,
@@ -171,6 +215,16 @@ public class MachineApiController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Incrementally trains a translation engine with a segment pair.
+    /// </summary>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="segmentPair">The segment pair.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <response code="200">The segment was successfully trained.</response>
+    /// <response code="403">You do not have permission to train a segment for this project.</response>
+    /// <response code="404">The project does not exist or is not configured on the ML server.</response>
+    /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
     [HttpPost(MachineApi.TrainSegment)]
     public async Task<ActionResult> TrainSegmentAsync(
         string sfProjectId,
@@ -203,6 +257,16 @@ public class MachineApiController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Translates a segment of text.
+    /// </summary>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="segment">The source segment.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <response code="200">The translation was successfully generated.</response>
+    /// <response code="403">You do not have permission to translate a segment for this project.</response>
+    /// <response code="404">The project does not exist or is not configured on the ML server.</response>
+    /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
     [HttpPost(MachineApi.Translate)]
     public async Task<ActionResult<TranslationResult>> TranslateAsync(
         string sfProjectId,
@@ -235,6 +299,17 @@ public class MachineApiController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Translates a segment of text into the top N results.
+    /// </summary>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="n">The number of translations.</param>
+    /// <param name="segment">The source segment.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <response code="200">The translation was successfully generated.</response>
+    /// <response code="403">You do not have permission to translate a segment for this project.</response>
+    /// <response code="404">The project does not exist or is not configured on the ML server.</response>
+    /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
     [HttpPost(MachineApi.TranslateN)]
     public async Task<ActionResult<TranslationResult[]>> TranslateNAsync(
         string sfProjectId,

--- a/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
@@ -13,6 +13,9 @@ using SIL.XForge.Utils;
 
 namespace SIL.XForge.Scripture.Controllers;
 
+/// <summary>
+/// Provides methods for retrieving data from Paratext.
+/// </summary>
 [Route("paratext-api")]
 [ApiController]
 [Authorize]
@@ -37,6 +40,11 @@ public class ParatextController : ControllerBase
         _exceptionHandler.RecordUserIdForException(_userAccessor.UserId);
     }
 
+    /// <summary>
+    /// Retrieves the Paratext projects the user has access to.
+    /// </summary>
+    /// <response code="200">The projects were successfully retrieved.</response>
+    /// <response code="204">The user does not have permission to access Paratext.</response>
     [HttpGet("projects")]
     public async Task<ActionResult<IEnumerable<ParatextProject>>> GetAsync()
     {
@@ -56,15 +64,13 @@ public class ParatextController : ControllerBase
     }
 
     /// <summary>
-    /// GET /paratext-api/resources/
+    /// Retrieves the Paratext resources the user has access to.
     /// </summary>
-    /// <returns>
-    /// The resources as projects
-    /// </returns>
-    /// <remarks>
-    /// The UI does not need the extra properties found in the <see cref="ParatextResource" /> class,
-    /// so we just return the base class <see cref="ParatextProject" />.
-    /// </remarks>
+    /// <response code="200">
+    /// The resources were successfully retrieved. A dictionary is returned where the Paratext Id is the key, and the
+    /// values are an array with the short name followed by the name.
+    /// </response>
+    /// <response code="204">The user does not have permission to access Paratext.</response>
     [HttpGet("resources")]
     public async Task<ActionResult<Dictionary<string, string[]>>> ResourcesAsync()
     {
@@ -83,6 +89,11 @@ public class ParatextController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Retrieves the Paratext username for the currently logged in user.
+    /// </summary>
+    /// <response code="200">The logged in user has access to Paratext.</response>
+    /// <response code="204">The user does not have permission to access Paratext.</response>
     [HttpGet("username")]
     public async Task<ActionResult<string>> UsernameAsync()
     {

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
@@ -11,7 +11,7 @@ using SIL.XForge.Services;
 namespace SIL.XForge.Scripture.Controllers;
 
 /// <summary>
-/// This controller contains upload endpoints.
+/// Provides methods for uploading files.
 /// </summary>
 [Authorize]
 [Route(UrlConstants.CommandApiNamespace + "/" + UrlConstants.Projects)]
@@ -33,6 +33,16 @@ public class SFProjectsUploadController : ControllerBase
         _exceptionHandler.RecordUserIdForException(_userAccessor.UserId);
     }
 
+    /// <summary>
+    /// Uploads an audio file.
+    /// </summary>
+    /// <param name="projectId">The project identifier.</param>
+    /// <param name="dataId">The data identifier.</param>
+    /// <param name="file">The file contents.</param>
+    /// <response code="200">The file was uploaded successfully.</response>
+    /// <response code="400">The data or parameters were malformed.</response>
+    /// <response code="403">Insufficient permission to upload a file to this project.</response>
+    /// <response code="404">The project does not exist.</response>
     [HttpPost("audio")]
     [RequestSizeLimit(100_000_000)]
     public async Task<IActionResult> UploadAudioAsync(

--- a/src/SIL.XForge.Scripture/Models/Sync.cs
+++ b/src/SIL.XForge.Scripture/Models/Sync.cs
@@ -20,14 +20,14 @@ public class Sync
     /// More specifically:<br />
     /// True if the the local PT project repository's commit that
     /// is the most recent commit from the last push or pull with the PT SR server (see
-    /// <see cref="HgWrapper.GetLastPublicRevision()"/>), has a commit id that matches
+    /// <see cref="Services.HgWrapper.GetLastPublicRevision"/>), has a commit id that matches
     /// <see cref="SyncedToRepositoryVersion"/>, meaning a sync brought the SF DB up to date by absorbing the
     /// contents of the local PT project hg repository at that commit id.<br />
     /// The SF DB may have been modified since then. And the *remote* PT SR server hg repository may have received
     /// more information since then. And the most recent attempt to sync may or may not have been successful. But
     /// this property can still be true in those situations.
     /// <br />
-    /// False if the local PT repo's <see cref="HgWrapper.GetLastPublicRevision()"/> does not match
+    /// False if the local PT repo's <see cref="Services.HgWrapper.GetLastPublicRevision"/> does not match
     /// <see cref="SyncedToRepositoryVersion"/>. This situation may arise from crashing during sync, with no
     /// successful local PT repo rollback, in which case the local PT repo would have been changed, but we have no
     /// record of successfully importing all local PT repo data into SF DB at the new commit id.

--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="ParatextData" Version="9.3.0.9" />
     <PackageReference Include="Serval.Client" Version="0.5.0" />
     <PackageReference Include="SIL.Machine.WebApi" Version="$(MachineVersion)" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -15,6 +15,8 @@
     <RealtimeServerRoot>..\RealtimeServer\</RealtimeServerRoot>
     <AngularConfig>production</AngularConfig>
     <Nullable>annotations</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SIL.XForge.Scripture/Services/ApiDocumentationExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/ApiDocumentationExtensions.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.OpenApi.Models;
+using SIL.IO;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class ApiDocumentationExtensions
+{
+    public static IServiceCollection AddApiDocumentation(this IServiceCollection services)
+    {
+        // Generate the OpenAPI file at /swagger/v1/swagger.json
+        services.AddSwaggerGen(options =>
+        {
+            // Hide machine-api/v1
+            options.DocumentFilter<ExcludeSilMachineApiFromSwagger>();
+
+            // Hide machine-api/v2
+            options.IgnoreObsoleteActions();
+
+            // Add all other Web API endpoints
+            options.SwaggerDoc(
+                "v1",
+                new OpenApiInfo
+                {
+                    Title = "Scripture Forge API",
+                    Version = "v1",
+                    Description = "This API provides services for the Scripture Forge front end.",
+                    License = new OpenApiLicense
+                    {
+                        Name = "MIT License",
+                        Url = new Uri("https://github.com/sillsdev/web-xforge/blob/master/LICENSE.txt"),
+                    },
+                }
+            );
+
+            // Add the documentation XML file, if it exists
+            string xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+            string xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFilename);
+            if (RobustFile.Exists(xmlPath))
+            {
+                options.IncludeXmlComments(xmlPath, includeControllerXmlComments: true);
+            }
+
+            // Add the security definition to allow a bearer token
+            options.AddSecurityDefinition(
+                "Bearer",
+                new OpenApiSecurityScheme
+                {
+                    Description =
+                        "Enter 'Bearer' [space] and then the token from Scripture Forge into the field below.",
+                    Name = "Authorization",
+                    In = ParameterLocation.Header,
+                    Type = SecuritySchemeType.ApiKey,
+                    Scheme = "Bearer",
+                }
+            );
+
+            // Add the security requirement to implement bearer token support
+            options.AddSecurityRequirement(
+                new OpenApiSecurityRequirement
+                {
+                    {
+                        new OpenApiSecurityScheme
+                        {
+                            Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "Bearer", },
+                        },
+                        Array.Empty<string>()
+                    },
+                }
+            );
+        });
+        return services;
+    }
+
+    private class ExcludeSilMachineApiFromSwagger : IDocumentFilter
+    {
+        public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+        {
+            // Remove the In-Process Machine Controllers from the Swagger documentation paths
+            foreach (string path in swaggerDoc.Paths.Where(p => p.Key.StartsWith("/machine-api/v1")).Select(p => p.Key))
+            {
+                swaggerDoc.Paths.Remove(path);
+            }
+        }
+    }
+}

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -538,6 +538,7 @@ public class ParatextService : DisposableBase, IParatextService
     /// </summary>
     /// <param name="paratextId">The paratext resource identifier.</param>
     /// <param name="sfUserId">The user SF identifier.</param>
+    /// <param name="token">The cancellation token.</param>
     /// <returns>
     /// Read or None.
     /// </returns>
@@ -811,6 +812,7 @@ public class ParatextService : DisposableBase, IParatextService
     /// <param name="ptUsernameMapping">A mapping of user ID to Paratext username.</param>
     /// <param name="book">The book number. Set to zero to check for all books.</param>
     /// <param name="chapter">The chapter number. Set to zero to check for all books.</param>
+    /// <param name="token">The cancellation token.</param>
     /// <returns>
     /// A dictionary of permissions where the key is the user ID and the value is the permission.
     /// </returns>
@@ -2239,8 +2241,9 @@ public class ParatextService : DisposableBase, IParatextService
     /// <summary>
     /// Get Paratext resources that a user has access to.
     /// </summary>
-    /// <param name="userSecret">The user secret.</param>
+    /// <param name="sfUserId">The Scripture Forge user identifier.</param>
     /// <param name="includeInstallableResource">If set to <c>true</c> include the installable resource.</param>
+    /// <param name="token">The cancellation token.</param>
     /// <returns>
     /// The available resources.
     /// </returns>
@@ -2809,7 +2812,7 @@ public class ParatextService : DisposableBase, IParatextService
     /// Writes the chapter to the <see cref="ScrText" />.
     /// </summary>
     /// <param name="scrText">The Scripture Text from Paratext.</param>
-    /// <param name="authorId">The user identifier for the author.</param>
+    /// <param name="userId">The user identifier for the author.</param>
     /// <param name="bookNum">The book number.</param>
     /// <param name="chapterNum">The chapter number. Set to 0 to write the entire book.</param>
     /// <param name="usfm">The USFM to write.</param>

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -46,11 +46,11 @@ namespace SIL.XForge.Scripture.Services;
 /// <code>
 /// Diagram showing a high-level look at the order of data being transmitted:
 /// ┌─────┐  ┌─────┐  ┌───────────┐
-/// │SF DB├─>│Local│  │PT Archives│
-/// │     │  │PT hg├─>│           │
+/// │SF DB├─→│Local│  │PT Archives│
+/// │     │  │PT hg├─→│           │
 /// │     │  │repo │  │           │
-/// │     │  │     │<─┤           │
-/// │     │<─┤     │  │           │
+/// │     │  │     │←─┤           │
+/// │     │←─┤     │  │           │
 /// └─────┘  └─────┘  └───────────┘
 /// </code>
 /// </summary>
@@ -131,9 +131,14 @@ public class ParatextSyncRunner : IParatextSyncRunner
     /// Synchronize content and user permissions in SF DB with Paratext SendReceive servers and PT Registry, for
     /// a project.
     /// </summary>
+    /// <param name="projectSFId">The project's Scripture Forge identifier.</param>
+    /// <param name="userId">The user identifier.</param>
+    /// <param name="syncMetricsId">The sync metrics identifier.</param>
+    /// <param name="trainEngine"><c>true</c> if we are to train the SMT translation engine; otherwise <c>false</c>.</param>
+    /// <param name="token">The cancellation token.</param>
     /// <remarks>
     /// Do not allow multiple sync jobs to run in parallel on the same project by creating a hangfire mutex on the
-    /// <param name="projectSFId"/> parameter, i.e. "{0}".
+    /// <paramref name="projectSFId"/> parameter, i.e. "{0}".
     /// </remarks>
     [Mutex("{0}")]
     public async Task RunAsync(
@@ -469,6 +474,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
     /// <param name="paratextId">The Paratext ID.</param>
     /// <param name="textDocsByBook">The text documents with the book number as key.</param>
     /// <param name="questionDocsByBook">The question documents with the book number as key.</param>
+    /// <param name="noteThreadDocsByBook">The note thread documents with the book number as key.</param>
     /// <returns>The task.</returns>
     /// <exception cref="ArgumentException">The Paratext project repository does not exist.</exception>
     private async Task GetAndUpdateParatextBooksAndNotes(
@@ -559,7 +565,6 @@ public class ParatextSyncRunner : IParatextSyncRunner
     /// <summary>
     /// Updates the resource configuration
     /// </summary>
-    /// <param name="project">The SF project.</param>
     /// <param name="paratextProject">The Paratext project. This should be a resource.</param>
     /// <returns>The asynchronous task.</returns>
     /// <remarks>Only call this if the config requires an update.</remarks>
@@ -1101,7 +1106,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
     }
 
     /// <summary>
-    /// Gets the text docs from <see cref="docs"/> for the book specified in <see cref="text"/>.
+    /// Gets the text docs from <paramref name="docs"/> for the book specified in <paramref name="text"/>.
     /// </summary>
     private SortedList<int, IDocument<TextData>> GetTextDocsForBook(
         TextInfo text,

--- a/src/SIL.XForge.Scripture/Services/SFDblRestClientFactory.cs
+++ b/src/SIL.XForge.Scripture/Services/SFDblRestClientFactory.cs
@@ -20,6 +20,7 @@ public class SFDblRestClientFactory : ISFRestClientFactory
     /// Initializes a new instance of the <see cref="SFDblRestClientFactory"/> class.
     /// </summary>
     /// <param name="jwtTokenHelper">The JWT token helper.</param>
+    /// <param name="siteOptions">The site options.</param>
     public SFDblRestClientFactory(IJwtTokenHelper jwtTokenHelper, IOptions<SiteOptions> siteOptions)
     {
         _jwtTokenHelper = jwtTokenHelper;

--- a/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
+++ b/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
@@ -219,6 +219,7 @@ public class SFInstallableDblResource : InstallableResource
     /// <param name="restClientFactory">The rest client factory.</param>
     /// <param name="fileSystemService">The file system service.</param>
     /// <param name="jwtTokenHelper">The JWT token helper.</param>
+    /// <param name="exceptionHandler">The exception handler.</param>
     /// <param name="baseUrl">The base URL.</param>
     /// <returns>
     ///   <c>true</c> if the user has permission to access the resource; otherwise, <c>false</c>.
@@ -317,6 +318,7 @@ public class SFInstallableDblResource : InstallableResource
     /// <param name="restClientFactory">The rest client factory.</param>
     /// <param name="fileSystemService">The file system service.</param>
     /// <param name="jwtTokenHelper">The JWT token helper.</param>
+    /// <param name="exceptionHandler">The exception handler.</param>
     /// <param name="baseUrl">The base URL.</param>
     /// <param name="id">ID of resource to filter for (optional).</param>
     /// <returns>The Installable Resources.</returns>

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -1046,7 +1046,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
     ///   <c>true</c> if a project translator; otherwise, <c>false</c>.
     /// </returns>
     /// <remarks>
-    /// This only checks the local project, and is based on <see cref="ProjectService.IsProjectAdmin" />.
+    /// This only checks the local project, and is based on <c>ProjectService.IsProjectAdmin</c>.
     /// </remarks>
     private static bool IsProjectTranslator(SFProject project, string userId) =>
         project.UserRoles.TryGetValue(userId, out string role) && role == SFProjectRole.Translator;
@@ -1115,7 +1115,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
     /// <param name="userSecret">The user secret.</param>
     /// <param name="paratextId">The paratext identifier.</param>
     /// <param name="ptProjects">The paratext projects.</param>
-    /// <param name="userIds">The ids and roles of the users who will need to access the source.</param>
+    /// <param name="userRoles">The ids and roles of the users who will need to access the source.</param>
     /// <returns>The <see cref="TranslateSource"/> object for the specified resource.</returns>
     /// <exception cref="DataNotFoundException">The source paratext project does not exist.</exception>
     private async Task<TranslateSource> GetTranslateSourceAsync(

--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -165,7 +165,6 @@ public class Startup
 
         services
             .AddMvc()
-            // TODO: check if JSON.NET is required
             .AddNewtonsoftJson()
             .AddViewLocalization()
             .AddDataAnnotationsLocalization(
@@ -174,6 +173,8 @@ public class Startup
             );
 
         services.AddXFJsonRpc();
+
+        services.AddApiDocumentation();
 
         if (SpaDevServerStartup == SpaDevServerStartup.None)
         {
@@ -199,6 +200,8 @@ public class Startup
         if (IsDevelopmentEnvironment || IsTestingEnvironment)
         {
             app.UseDeveloperExceptionPage();
+            app.UseSwagger();
+            app.UseSwaggerUI();
         }
         else
         {

--- a/test/SIL.XForge.Scripture.Tests/Controllers/AnonymousControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/AnonymousControllerTests.cs
@@ -48,7 +48,7 @@ public class AnonymousControllerTests
     }
 
     [Test]
-    public void GenerateAccount_NotFound()
+    public async Task GenerateAccount_NotFound()
     {
         var env = new TestEnvironment();
         var request = new GenerateAccountRequest()
@@ -62,12 +62,12 @@ public class AnonymousControllerTests
             .Throws(new DataNotFoundException(""));
 
         // SUT
-        var actual = env.Controller.GenerateAccount(request);
+        var actual = await env.Controller.GenerateAccount(request);
         Assert.IsInstanceOf<NotFoundObjectResult>(actual.Result);
     }
 
     [Test]
-    public void GenerateAccount_NotFound_HttpRequestException()
+    public async Task GenerateAccount_NotFound_HttpRequestException()
     {
         var env = new TestEnvironment();
         var request = new GenerateAccountRequest()
@@ -81,12 +81,12 @@ public class AnonymousControllerTests
             .Throws(new HttpRequestException(""));
 
         // SUT
-        var actual = env.Controller.GenerateAccount(request);
+        var actual = await env.Controller.GenerateAccount(request);
         Assert.IsInstanceOf<NoContentResult>(actual.Result);
     }
 
     [Test]
-    public void GenerateAccount_NotFound_SecurityException()
+    public async Task GenerateAccount_NotFound_SecurityException()
     {
         var env = new TestEnvironment();
         var request = new GenerateAccountRequest()
@@ -100,12 +100,12 @@ public class AnonymousControllerTests
             .Throws(new SecurityException());
 
         // SUT
-        var actual = env.Controller.GenerateAccount(request);
+        var actual = await env.Controller.GenerateAccount(request);
         Assert.IsInstanceOf<NoContentResult>(actual.Result);
     }
 
     [Test]
-    public void GenerateAccount_NotFound_TaskCanceledException()
+    public async Task GenerateAccount_NotFound_TaskCanceledException()
     {
         var env = new TestEnvironment();
         var request = new GenerateAccountRequest()
@@ -119,7 +119,7 @@ public class AnonymousControllerTests
             .Throws(new TaskCanceledException());
 
         // SUT
-        var actual = env.Controller.GenerateAccount(request);
+        var actual = await env.Controller.GenerateAccount(request);
         Assert.IsInstanceOf<NoContentResult>(actual.Result);
     }
 


### PR DESCRIPTION
This Pull Request creates developer documentation for the Web APIs exposed by Scripture Forge using OpenAPI and Swagger.

Developer documentation is generated from the XML Documentation comments in the C# code. Enabling the generation of XML documentation also required errors in some of the XML CodeDoc comments to be corrected, as well as the return objects for some API endpoints to be strongly typed.

**Acceptance Test**
As this is a developer only feature, it is suitable for a developer to test this feature by visiting http://localhost:5000/swagger/index.html after building and running.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1916)
<!-- Reviewable:end -->
