### PR TITLE
SF-1991 Record Scripture Forge Version on Sync

### DIFF
--- a/src/SIL.XForge.Scripture/Migrator.cs
+++ b/src/SIL.XForge.Scripture/Migrator.cs
@@ -9,7 +9,7 @@ public static class Migrator
 {
     public static void RunMigrations(string environment)
     {
-        string version = FileVersionInfo.GetVersionInfo(Assembly.GetEntryAssembly().Location).ProductVersion;
+        string version = Product.Version;
         string projectPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
         string migratorPath = Path.Combine(

--- a/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
@@ -16,6 +16,7 @@ public class SyncMetrics : IIdentifiable
     public string Id { get; set; }
     public string ErrorDetails { get; set; }
     public string RequiresId { get; set; }
+    public string ProductVersion { get; set; }
     public string ProjectRef { get; set; }
     public SyncStatus Status { get; set; }
     public string UserRef { get; set; }

--- a/src/SIL.XForge.Scripture/Services/JwtRestClient.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtRestClient.cs
@@ -11,8 +11,6 @@ public class JwtRestClient : RESTClient, ISFRestClient
     {
         this.JwtToken = jwtToken;
         ReflectionHelperLite.SetField(this, "authentication", null);
-        string location = System.Reflection.Assembly.GetEntryAssembly().Location;
-        string version = System.Diagnostics.FileVersionInfo.GetVersionInfo(location).ProductVersion ?? "1.0";
-        OverrideApplicationAgent = applicationName.Replace(" ", "") + "/" + version;
+        OverrideApplicationAgent = applicationName.Replace(" ", "") + "/" + Product.Version;
     }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -729,6 +729,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
             return false;
         }
 
+        _syncMetrics.ProductVersion = Product.Version;
         _syncMetrics.DateStarted = DateTime.UtcNow;
         _syncMetrics.Status = SyncStatus.Running;
         if (!await _syncMetricsRepository.ReplaceAsync(_syncMetrics, true))

--- a/src/SIL.XForge.Scripture/ViewComponents/FooterViewComponent.cs
+++ b/src/SIL.XForge.Scripture/ViewComponents/FooterViewComponent.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
@@ -29,9 +28,7 @@ public class FooterViewComponent : ViewComponent
 
     public IViewComponentResult Invoke()
     {
-        var appSettings = new RazorPageSettings();
-        var location = Assembly.GetEntryAssembly().Location;
-        appSettings.ProductVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(location).ProductVersion;
+        var appSettings = new RazorPageSettings { ProductVersion = Product.Version };
 
         var bugsnagConfig = new Dictionary<string, object>
         {

--- a/src/SIL.XForge/ExceptionLogging/ExceptionHandlerServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/ExceptionLogging/ExceptionHandlerServiceCollectionExtensions.cs
@@ -15,10 +15,6 @@ public static class ExceptionHandlerServiceCollectionExtensions
         return services
             .AddBugsnag()
             .Configure<Bugsnag.Configuration>(configuration.GetSection("Bugsnag"))
-            .Configure<Bugsnag.Configuration>(config =>
-            {
-                string location = System.Reflection.Assembly.GetEntryAssembly().Location;
-                config.AppVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(location).ProductVersion;
-            });
+            .Configure<Bugsnag.Configuration>(config => config.AppVersion = Product.Version);
     }
 }

--- a/src/SIL.XForge/Realtime/RealtimeService.cs
+++ b/src/SIL.XForge/Realtime/RealtimeService.cs
@@ -239,9 +239,7 @@ public class RealtimeService : DisposableBase, IRealtimeService
             ReleaseStage = this._configuration.GetValue<string>("Bugsnag:ReleaseStage"),
             this._realtimeOptions.Value.MigrationsDisabled,
             SiteId = this._siteOptions.Value.Id,
-            Version = System.Diagnostics.FileVersionInfo
-                .GetVersionInfo(@System.Reflection.Assembly.GetEntryAssembly().Location)
-                .ProductVersion
+            Product.Version,
         };
     }
 }

--- a/src/SIL.XForge/Utils/Product.cs
+++ b/src/SIL.XForge/Utils/Product.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics;
+using System.Reflection;
+
+namespace SIL.XForge;
+
+public static class Product
+{
+    static Product()
+    {
+        // Setup the product version
+        string? version = null;
+        string? location = Assembly.GetEntryAssembly()?.Location;
+        if (!string.IsNullOrWhiteSpace(location))
+        {
+            version = FileVersionInfo.GetVersionInfo(location).ProductVersion;
+        }
+
+        Version = version ?? "1.0";
+    }
+
+    /// <summary>
+    /// Gets the program version.
+    /// </summary>
+    public static string Version { get; }
+}


### PR DESCRIPTION
This Pull Request:
 * Adds a new `ProductVersion` property to the `SyncMetrics` class, which is set when the sync starts running
 * Centralizes retrieval of the product version in C# to a new `Product.Version` property

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1920)
<!-- Reviewable:end -->
