### PR TITLE
SF-2106 Add UI for scripture audio component

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/text-audio.ts
+++ b/src/RealtimeServer/scriptureforge/models/text-audio.ts
@@ -4,6 +4,10 @@ import { AudioTiming } from './audio-timing';
 export const TEXT_AUDIO_COLLECTION = 'text_audio';
 export const TEXT_AUDIO_INDEX_PATHS: string[] = PROJECT_DATA_INDEX_PATHS;
 
+export function getTextAudioId(projectId: string, bookNum: number, chapterNum: number): string {
+  return `${projectId}:${bookNum}:${chapterNum}:target`;
+}
+
 export interface TextAudio extends ProjectData {
   dataId: string;
   timings: AudioTiming[];

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking.module.ts
@@ -19,6 +19,7 @@ import {
   CheckingAudioPlayerComponent
 } from './checking/checking-audio-player/checking-audio-player.component';
 import { CheckingAudioRecorderComponent } from './checking/checking-audio-recorder/checking-audio-recorder.component';
+import { CheckingScriptureAudioPlayerComponent } from './checking/checking-scripture-audio-player/checking-scripture-audio-player.component';
 import { CheckingQuestionsComponent } from './checking/checking-questions/checking-questions.component';
 import { CheckingTextComponent } from './checking/checking-text/checking-text.component';
 import { CheckingComponent } from './checking/checking.component';
@@ -43,6 +44,7 @@ import { QuestionDialogComponent } from './question-dialog/question-dialog.compo
     CheckingAudioRecorderComponent,
     CheckingAudioRecorderComponent,
     CheckingAudioPlayerComponent,
+    CheckingScriptureAudioPlayerComponent,
     AudioTimePipe,
     CheckingAudioCombinedComponent,
     TextChooserDialogComponent

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.ts
@@ -81,6 +81,11 @@ export class CheckingAudioPlayerComponent extends SubscriptionDisposable impleme
     return isNaN(this._currentTime) || this._currentTime === ARBITRARILY_LARGE_NUMBER ? 0 : this._currentTime;
   }
 
+  set currentTime(time: number) {
+    this.audio.currentTime = time;
+    this._currentTime = this.audio.currentTime;
+  }
+
   get duration(): number {
     return isNaN(this._duration) || this._duration === ARBITRARILY_LARGE_NUMBER ? 0 : this._duration;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.html
@@ -1,0 +1,13 @@
+<div class="scripture-audio-player">
+  <div class="audio-action-buttons">
+    <button mat-icon-button class="previous-ref-button" (click)="previousRef()">
+      <mat-icon>skip_previous</mat-icon>
+    </button>
+    <button mat-icon-button class="play-pause-button" (click)="isPlaying ? pause() : play()">
+      <mat-icon>{{ isPlaying ? "pause" : "play_arrow" }}</mat-icon>
+    </button>
+    <button mat-icon-button class="next-ref-button" (click)="nextRef()"><mat-icon>skip_next</mat-icon></button>
+  </div>
+  <app-checking-audio-player #audioPlayer [source]="source"></app-checking-audio-player>
+  <span class="verse-label">{{ currentVerseLabel }}</span>
+</div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.scss
@@ -1,0 +1,14 @@
+.scripture-audio-player {
+  display: flex;
+  flex-direction: column;
+}
+
+.audio-action-buttons {
+  display: flex;
+  justify-content: center;
+}
+
+.verse-label {
+  padding: 8px;
+  font-weight: bold;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
@@ -1,0 +1,98 @@
+import { Component, DebugElement, NgZone, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { AudioTiming } from 'realtime-server/lib/esm/scriptureforge/models/audio-timing';
+import { of } from 'rxjs';
+import { instance, mock, when } from 'ts-mockito';
+import { PwaService } from 'xforge-common/pwa.service';
+import { TestTranslocoModule } from 'xforge-common/test-utils';
+import { UICommonModule } from 'xforge-common/ui-common.module';
+import { AudioTimePipe, CheckingAudioPlayerComponent } from '../checking-audio-player/checking-audio-player.component';
+import { CheckingScriptureAudioPlayerComponent } from './checking-scripture-audio-player.component';
+
+const audioFile = 'test-audio-player.webm';
+const timingData: AudioTiming[] = [
+  { textRef: 'verse_1_1', from: 0.0, to: 1.0 },
+  { textRef: 'verse_1_2', from: 1.0, to: 2.0 },
+  { textRef: 'verse_1_3', from: 2.0, to: 3.0 }
+];
+
+describe('ScriptureAudioComponent', () => {
+  it('can play and pause audio', async () => {
+    const template =
+      '<app-checking-scripture-audio-player source="' + audioFile + '"></app-checking-scripture-audio-player>';
+    const env = new TestEnvironment(template);
+    await env.waitForPlayer();
+    env.playButton.nativeElement.click();
+    await env.waitForPlayer();
+    env.fixture.detectChanges();
+    expect(env.isPlaying).toBe(true);
+
+    env.playButton.nativeElement.click();
+    await env.waitForPlayer();
+    env.fixture.detectChanges();
+    expect(env.isPlaying).toBe(false);
+  });
+
+  it('can skip to next verse', async () => {
+    const template =
+      '<app-checking-scripture-audio-player source="' + audioFile + '"></app-checking-scripture-audio-player>';
+    const env = new TestEnvironment(template);
+    await env.waitForPlayer();
+
+    env.component.audioPlayer.timing = timingData;
+    await env.waitForPlayer();
+    env.nextRefButton.nativeElement.click();
+    await env.waitForPlayer();
+    expect(env.component.audioPlayer.currentRef).toEqual('verse_1_2');
+    env.previousRefButton.nativeElement.click();
+    await env.waitForPlayer();
+    expect(env.component.audioPlayer.currentRef).toEqual('verse_1_1');
+  });
+});
+
+@Component({ selector: 'app-host', template: '' })
+class HostComponent {
+  @ViewChild(CheckingScriptureAudioPlayerComponent) audioPlayer!: CheckingScriptureAudioPlayerComponent;
+}
+
+class TestEnvironment {
+  readonly mockPwaService = mock(PwaService);
+  fixture: ComponentFixture<HostComponent>;
+  component: HostComponent;
+  ngZone: NgZone;
+
+  constructor(template: string) {
+    TestBed.configureTestingModule({
+      declarations: [HostComponent, CheckingScriptureAudioPlayerComponent, CheckingAudioPlayerComponent, AudioTimePipe],
+      providers: [{ provide: PwaService, useFactory: () => instance(this.mockPwaService) }],
+      imports: [UICommonModule, TestTranslocoModule]
+    });
+    when(this.mockPwaService.onlineStatus$).thenReturn(of(true));
+    TestBed.overrideComponent(HostComponent, { set: { template: template } });
+    this.ngZone = TestBed.inject(NgZone);
+    this.fixture = TestBed.createComponent(HostComponent);
+    this.component = this.fixture.componentInstance;
+  }
+
+  get playButton(): DebugElement {
+    return this.fixture.debugElement.query(By.css('.play-pause-button'));
+  }
+
+  get previousRefButton(): DebugElement {
+    return this.fixture.debugElement.query(By.css('.previous-ref-button'));
+  }
+
+  get nextRefButton(): DebugElement {
+    return this.fixture.debugElement.query(By.css('.next-ref-button'));
+  }
+
+  get isPlaying(): boolean {
+    return this.component.audioPlayer.isPlaying;
+  }
+
+  async waitForPlayer(ms: number = 20): Promise<void> {
+    await new Promise(resolve => this.ngZone.runOutsideAngular(() => setTimeout(resolve, ms)));
+    this.fixture.detectChanges();
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, ViewChild } from '@angular/core';
 import { AudioTiming } from 'realtime-server/lib/esm/scriptureforge/models/audio-timing';
-import { Canon } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/canon';
 import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
 import { TextDocId } from 'src/app/core/models/text-doc';
 import { getVerseStrFromSegmentRef } from 'src/app/shared/utils';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
@@ -1,0 +1,69 @@
+import { Component, Input, ViewChild } from '@angular/core';
+import { AudioTiming } from 'realtime-server/lib/esm/scriptureforge/models/audio-timing';
+import { Canon } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/canon';
+import { VerseRef } from 'realtime-server/lib/esm/scriptureforge/scripture-utils/verse-ref';
+import { TextDocId } from 'src/app/core/models/text-doc';
+import { getVerseStrFromSegmentRef } from 'src/app/shared/utils';
+import { I18nService } from 'xforge-common/i18n.service';
+import { CheckingAudioPlayerComponent } from '../checking-audio-player/checking-audio-player.component';
+
+@Component({
+  selector: 'app-checking-scripture-audio-player',
+  templateUrl: './checking-scripture-audio-player.component.html',
+  styleUrls: ['./checking-scripture-audio-player.component.scss']
+})
+export class CheckingScriptureAudioPlayerComponent {
+  @Input() source?: string;
+  @Input() timing?: AudioTiming[];
+  @Input() textDocId?: TextDocId;
+  @ViewChild('audioPlayer') audioPlayer?: CheckingAudioPlayerComponent;
+
+  constructor(private readonly i18n: I18nService) {}
+
+  get currentRef(): string | undefined {
+    if (this.timing == null) return;
+    const currentTime: number = this.audioPlayer?.currentTime ?? 0;
+    return this.timing.find(t => t.to > currentTime)?.textRef;
+  }
+
+  get currentVerseLabel(): string | undefined {
+    if (this.currentRef == null || this.textDocId == null) return;
+    const verseRef = new VerseRef(
+      this.textDocId.bookNum,
+      this.textDocId.chapterNum,
+      getVerseStrFromSegmentRef(this.currentRef)
+    );
+    return this.i18n.localizeReference(verseRef);
+  }
+
+  get isPlaying(): boolean {
+    return !!this.audioPlayer?.isPlaying;
+  }
+
+  play(): void {
+    this.audioPlayer?.play();
+  }
+
+  pause(): void {
+    this.audioPlayer?.pause();
+  }
+
+  previousRef(): void {
+    if (this.audioPlayer == null || this.timing == null) return;
+    const currentTimingIndex: number = this.timing.findIndex(t => t.textRef === this.currentRef);
+    if (currentTimingIndex < 0) {
+      this.audioPlayer.currentTime = 0;
+    }
+    this.audioPlayer.currentTime = this.timing[currentTimingIndex - 1].from;
+  }
+
+  nextRef(): void {
+    if (this.audioPlayer == null || this.timing == null) return;
+    const currentTimingIndex: number = this.timing.findIndex(t => t.textRef === this.currentRef);
+    if (currentTimingIndex < 0) {
+      // TODO (scripture audio): find a better solution than setting the current time to 0
+      this.audioPlayer.currentTime = 0;
+    }
+    this.audioPlayer.currentTime = this.timing[currentTimingIndex].to;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -145,7 +145,11 @@
                     <!-- TODO (scripture audio) Instead of covering scripture panel, move the audio player below it -->
                     <div class="scripture-audio-player-wrapper" *ngIf="showScriptureAudioPlayer">
                       <!-- TODO (scripture audio) Fetch audio URL from text_audio collection -->
-                      <app-checking-audio-player></app-checking-audio-player>
+                      <app-checking-scripture-audio-player
+                        [source]="chapterAudioSource"
+                        [timing]="chapterTextAudioTiming"
+                        [textDocId]="textDocId"
+                      ></app-checking-scripture-audio-player>
                     </div>
                     <app-checking-text
                       #textPanel

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-type-registry.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-type-registry.ts
@@ -8,6 +8,7 @@ import { QuestionDoc } from './question-doc';
 import { SFProjectDoc } from './sf-project-doc';
 import { SFProjectProfileDoc } from './sf-project-profile-doc';
 import { SFProjectUserConfigDoc } from './sf-project-user-config-doc';
+import { TextAudioDoc } from './text-audio-doc';
 import { TextDoc } from './text-doc';
 
 export const SF_TYPE_REGISTRY = new TypeRegistry(
@@ -19,7 +20,8 @@ export const SF_TYPE_REGISTRY = new TypeRegistry(
     SFProjectUserConfigDoc,
     QuestionDoc,
     TextDoc,
-    NoteThreadDoc
+    NoteThreadDoc,
+    TextAudioDoc
   ],
   [FileType.Audio],
   [EDITED_SEGMENTS]

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/text-audio-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/text-audio-doc.ts
@@ -1,0 +1,11 @@
+import {
+  TextAudio,
+  TEXT_AUDIO_COLLECTION,
+  TEXT_AUDIO_INDEX_PATHS
+} from 'realtime-server/lib/esm/scriptureforge/models/text-audio';
+import { ProjectDataDoc } from 'xforge-common/models/project-data-doc';
+
+export class TextAudioDoc extends ProjectDataDoc<TextAudio> {
+  static readonly COLLECTION = TEXT_AUDIO_COLLECTION;
+  static readonly INDEX_PATHS = TEXT_AUDIO_INDEX_PATHS;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -7,6 +7,7 @@ import { SFProject, SF_PROJECTS_COLLECTION } from 'realtime-server/lib/esm/scrip
 import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { getSFProjectUserConfigDocId } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config';
+import { TextAudio } from 'realtime-server/lib/esm/scriptureforge/models/text-audio';
 import { Subject } from 'rxjs';
 import { CommandService } from 'xforge-common/command.service';
 import { FileService } from 'xforge-common/file.service';
@@ -30,6 +31,7 @@ import { SFProjectUserConfigDoc } from './models/sf-project-user-config-doc';
 import { SFProjectProfileDoc } from './models/sf-project-profile-doc';
 import { TextDoc, TextDocId } from './models/text-doc';
 import { TranslateMetrics } from './models/translate-metrics';
+import { TextAudioDoc } from './models/text-audio-doc';
 
 @Injectable({
   providedIn: 'root'
@@ -167,6 +169,13 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
       [obj<NoteThread>().pathStr(t => t.status)]: NoteStatus.Todo
     };
     return this.realtimeService.subscribeQuery(NoteThreadDoc.COLLECTION, queryParams);
+  }
+
+  queryAudioText(sfProjectId: string): Promise<RealtimeQuery<TextAudioDoc>> {
+    const queryParams: QueryParameters = {
+      [obj<TextAudio>().pathStr(t => t.projectRef)]: sfProjectId
+    };
+    return this.realtimeService.subscribeQuery(TextAudioDoc.COLLECTION, queryParams);
   }
 
   onlineSync(id: string): Promise<void> {


### PR DESCRIPTION
* register text_audio collection for indexedDB
* add query for text audio in checking component
* add scripture audio component

To get this to work, add the audio MRK_003.wav file to the /var/lib/scriptureforge/audio/<projectId> directory. To test the skip feature, you will need to add timing data. I created the timing data using the Add Timing Data on the checking app, and then manually edited the timing data in mongo. I needed to log out and back in to get the up to date timing data.
TODO: highlight the verse when the audio is playing the verse.

![image](https://github.com/sillsdev/web-xforge/assets/17931130/754830e9-ee4c-442d-ab5e-6c2a2f173dff)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1928)
<!-- Reviewable:end -->
