### PR TITLE
SF-2120 Add ability to disable the document cache

### DIFF
--- a/src/SIL.XForge/Configuration/RealtimeOptions.cs
+++ b/src/SIL.XForge/Configuration/RealtimeOptions.cs
@@ -10,7 +10,8 @@ public class RealtimeOptions
 {
     public string AppModuleName { get; set; }
     public int Port { get; set; }
-    public bool MigrationsDisabled = false;
+    public bool MigrationsDisabled { get; set; }
+    public bool DocumentCacheDisabled { get; set; }
     public DocConfig UserDoc { get; set; } = new DocConfig("users", typeof(User));
     public DocConfig ProjectDoc { get; set; }
 

--- a/src/SIL.XForge/Realtime/RealtimeService.cs
+++ b/src/SIL.XForge/Realtime/RealtimeService.cs
@@ -70,7 +70,8 @@ public class RealtimeService : DisposableBase, IRealtimeService
 
     public async Task<IConnection> ConnectAsync(string userId = null)
     {
-        var conn = new Connection(this);
+        RealtimeOptions options = _realtimeOptions.Value;
+        var conn = new Connection(this, options.DocumentCacheDisabled);
         try
         {
             await conn.StartAsync(userId);


### PR DESCRIPTION
This PR adds the ability to disable the connection's document cache. This is of importance for Migrators, which will load every document in a collection just once, and not need to retrieve them again.

To enable this feature, add the following line to the Migrator's `Startup` class constructor:
```cs
Configuration["Realtime:DocumentCacheDisabled"] = "true";
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1929)
<!-- Reviewable:end -->
