### PR TITLE
SF-2128 Add ProjectType & BaseProject to TranslateConfig

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/translate-config.ts
+++ b/src/RealtimeServer/scriptureforge/models/translate-config.ts
@@ -1,8 +1,29 @@
 import { WritingSystem } from '../../common/models/writing-system';
 
+export enum ProjectType {
+  Standard = 'Standard',
+  BackTranslation = 'BackTranslation',
+  Daughter = 'Daughter',
+  TransliterationManual = 'TransliterationManual',
+  TransliterationWithEncoder = 'TransliterationWithEncoder',
+  StudyBible = 'StudyBible',
+  ConsultantNotes = 'ConsultantNotes',
+  StudyBibleAdditions = 'StudyBibleAdditions',
+  Auxiliary = 'Auxiliary',
+  Xml = 'Xml',
+  SourceLanguage = 'SourceLanguage',
+  Dictionary = 'Dictionary',
+  EnhancedResource = 'EnhancedResource'
+}
+
 export enum TranslateShareLevel {
   Anyone = 'anyone',
   Specific = 'specific'
+}
+
+export interface BaseProject {
+  paratextId: string;
+  shortName: string;
 }
 
 export interface TranslateConfig {
@@ -11,6 +32,8 @@ export interface TranslateConfig {
   shareEnabled: boolean;
   defaultNoteTagId?: number;
   preTranslate: boolean;
+  projectType?: ProjectType;
+  baseProject?: BaseProject;
 }
 
 export interface TranslateSource {

--- a/src/SIL.XForge.Scripture/Models/BaseProject.cs
+++ b/src/SIL.XForge.Scripture/Models/BaseProject.cs
@@ -1,0 +1,24 @@
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// Base Project Information
+/// </summary>
+/// <remarks>This information is retrieved from the ScrText Settings.</remarks>
+public class BaseProject
+{
+    /// <summary>
+    /// Gets or sets the Paratext identifier.
+    /// </summary>
+    /// <value>
+    /// The Paratext identifier.
+    /// </value>
+    public string ParatextId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the short name.
+    /// </summary>
+    /// <value>
+    /// The short name.
+    /// </value>
+    public string ShortName { get; set; } = string.Empty;
+}

--- a/src/SIL.XForge.Scripture/Models/ParatextSettings.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextSettings.cs
@@ -18,4 +18,7 @@ public class ParatextSettings
     /// <summary> The tag icon used by default for note threads created in SF. </summary>
     public IEnumerable<NoteTag> NoteTags { get; set; }
     public string? LanguageTag { get; set; }
+    public string ProjectType { get; set; } = string.Empty;
+    public string BaseProjectShortName { get; set; } = string.Empty;
+    public string? BaseProjectParatextId { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/TranslateConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/TranslateConfig.cs
@@ -3,8 +3,20 @@ namespace SIL.XForge.Scripture.Models;
 public class TranslateConfig
 {
     public bool TranslationSuggestionsEnabled { get; set; }
-    public TranslateSource Source { get; set; }
-    public bool ShareEnabled { get; set; } = false;
+    public TranslateSource? Source { get; set; }
+    public bool ShareEnabled { get; set; }
     public int? DefaultNoteTagId { get; set; }
     public bool PreTranslate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the project type.
+    /// </summary>
+    /// <value>The string value of the project type enumeration.</value>
+    public string? ProjectType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the base project.
+    /// </summary>
+    /// <value>The base project, if specified in the ScrText settings.</value>
+    public BaseProject? BaseProject { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -985,6 +985,9 @@ public class ParatextService : DisposableBase, IParatextService
             DefaultFont = scrText.Settings.DefaultFont,
             NoteTags = noteTags,
             LanguageTag = scrText.Settings.LanguageID?.Id,
+            ProjectType = scrText.Settings.TranslationInfo.Type.ToString(),
+            BaseProjectParatextId = scrText.Settings.TranslationInfo.BaseProjectGuid?.Id,
+            BaseProjectShortName = scrText.Settings.TranslationInfo.BaseProjectName,
         };
     }
 

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1481,6 +1481,34 @@ public class ParatextSyncRunner : IParatextSyncRunner
                     op.Set(pd => pd.NoteTags, settings.NoteTags, _noteTagListEqualityComparer);
                 if (settings.LanguageTag != null)
                     op.Set(pd => pd.WritingSystem.Tag, settings.LanguageTag);
+                op.Set(pd => pd.TranslateConfig.ProjectType, settings.ProjectType);
+                if (!string.IsNullOrEmpty(settings.BaseProjectParatextId))
+                {
+                    // Set the base project
+                    if (_projectDoc.Data.TranslateConfig.BaseProject is null)
+                    {
+                        // Create a new base project record
+                        op.Set(
+                            pd => pd.TranslateConfig.BaseProject,
+                            new BaseProject
+                            {
+                                ParatextId = settings.BaseProjectParatextId,
+                                ShortName = settings.BaseProjectShortName,
+                            }
+                        );
+                    }
+                    else
+                    {
+                        // Update the existing base project record
+                        op.Set(pd => pd.TranslateConfig.BaseProject.ParatextId, settings.BaseProjectParatextId);
+                        op.Set(pd => pd.TranslateConfig.BaseProject.ShortName, settings.BaseProjectShortName);
+                    }
+                }
+                else if (_projectDoc.Data.TranslateConfig.BaseProject is not null)
+                {
+                    // There is no longer a base project, so remove the base project record
+                    op.Unset(pd => pd.TranslateConfig.BaseProject);
+                }
             }
             // The source can be null if there was an error getting a resource from the DBL
             if (TranslationSuggestionsEnabled && _projectDoc.Data.TranslateConfig.Source != null)


### PR DESCRIPTION
This Pull Request adds the following properties to a Project's `TranslateConfig`:
 * `ProjectType` - The project type. This is a string corresponding to the `ProjectType` enum in ParatextData in PascalCase (like the enum's named constants).
 * `BaseProject` (nullable) - details of the project the `sf_project` is based on.
    * `ParatextId` - The base project's Paratext Id
    * `ShortName` - The short name of the base project

This information, which can only be retrieved on sync from the ScrText settings can be used to determine if the Pre-Translation workflow can start.

**Notes**
 - ProjectType has been made nullable and is not populated by a migrator because its value can only be retrieved from the ScrText.
 - I also have included a minor clean up of the C# class TranslateConfig to use nullable types and remove an unnecessary `false` assignment to a bool value (bool defaults to false).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1943)
<!-- Reviewable:end -->
