### PR TITLE
SF-2125 Add stream checking for incoming MP3 data

### DIFF
--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
@@ -48,11 +48,17 @@ public class SFProjectsUploadController : ControllerBase
     public async Task<IActionResult> UploadAudioAsync(
         [FromForm] string projectId,
         [FromForm] string dataId,
-        [FromForm] IFormFile file
+        [FromForm] IFormFile? file
     )
     {
         try
         {
+            // Ensure we have a file
+            if (file is null)
+            {
+                return BadRequest();
+            }
+
             await using Stream stream = file.OpenReadStream();
             Uri uri = await _projectService.SaveAudioAsync(
                 _userAccessor.UserId,

--- a/src/SIL.XForge/Services/AudioService.cs
+++ b/src/SIL.XForge/Services/AudioService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using SIL.XForge.Configuration;
@@ -28,6 +29,66 @@ public class AudioService : IAudioService
         await WaitForExitAsync(process);
         if (process.ExitCode != 0)
             throw new InvalidOperationException($"Error: Could not convert {inputPath} to mp3");
+    }
+
+    /// <summary>
+    /// Reads the first three bytes of the stream to see if it is MP3 data
+    /// </summary>
+    /// <param name="stream">The stream.</param>
+    /// <returns><c>true</c> if the stream is and MP3 file; otherwise, <c>false</c>.</returns>
+    /// <remarks>This code is based on the data in magic.mime.</remarks>
+    public async Task<bool> IsMp3DataAsync(Stream stream)
+    {
+        // Reset the stream to the start
+        stream.Seek(0, SeekOrigin.Begin);
+
+        // Declare variables for stream reading
+        byte[] buffer;
+        int bytesRead;
+
+        // Skip null bytes
+        while (true)
+        {
+            buffer = new byte[1];
+            bytesRead = await stream.ReadAsync(buffer.AsMemory(0, 1));
+
+            // End of stream reached without finding a non-null byte
+            if (bytesRead == 0)
+            {
+                // Reset the stream to the start
+                stream.Seek(0, SeekOrigin.Begin);
+                return false;
+            }
+
+            // Found a non-null byte, go back 1 byte and break out of the loop
+            if (buffer[0] != 0x0)
+            {
+                stream.Seek(-1, SeekOrigin.Current);
+                break;
+            }
+        }
+
+        // Read the first 3 non-null bytes of the stream
+        buffer = new byte[3];
+        bytesRead = await stream.ReadAsync(buffer.AsMemory(0, 3));
+
+        // Reset the stream to the start
+        stream.Seek(0, SeekOrigin.Begin);
+
+        // If we read less than 3 bytes, this is not a valid MP3 file
+        if (bytesRead < 3)
+        {
+            return false;
+        }
+
+        // Header is "ID3" - an MP3 file with IDv3 tags
+        if (buffer[0] == 0x49 && buffer[1] == 0x44 && buffer[2] == 0x33)
+        {
+            return true;
+        }
+
+        // Return true if the header is 0xFFE or 0xFFF - an MP3 file without IDv3 tags
+        return buffer[0] == 0xFF && (buffer[1] & 0xE0) == 0xE0;
     }
 
     private static Task WaitForExitAsync(Process process)

--- a/src/SIL.XForge/Services/IAudioService.cs
+++ b/src/SIL.XForge/Services/IAudioService.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Threading.Tasks;
 
 namespace SIL.XForge.Services;
@@ -5,4 +6,5 @@ namespace SIL.XForge.Services;
 public interface IAudioService
 {
     Task ConvertToMp3Async(string inputPath, string outputPath);
+    Task<bool> IsMp3DataAsync(Stream stream);
 }

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -173,7 +173,7 @@ public abstract class ProjectService<TModel, TSecret> : IProjectService
         if (!FileSystemService.DirectoryExists(audioDir))
             FileSystemService.CreateDirectory(audioDir);
         string outputPath = Path.Combine(audioDir, $"{curUserId}_{dataId}.mp3");
-        if (string.Equals(extension, ".mp3", StringComparison.InvariantCultureIgnoreCase))
+        if (await _audioService.IsMp3DataAsync(inputStream))
         {
             await using Stream fileStream = FileSystemService.OpenFile(outputPath, FileMode.Create);
             await inputStream.CopyToAsync(fileStream);

--- a/test/SIL.XForge.Tests/Services/AudioServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/AudioServiceTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NUnit.Framework;
+using SIL.XForge.Configuration;
+
+namespace SIL.XForge.Services;
+
+[TestFixture]
+internal class AudioServiceTests
+{
+    [Test]
+    public async Task IsMp3DataAsync_EmptyStream()
+    {
+        var env = new TestEnvironment();
+        await using var stream = new MemoryStream(Array.Empty<byte>());
+
+        // SUT
+        var result = await env.Service.IsMp3DataAsync(stream);
+        Assert.False(result);
+    }
+
+    [Test]
+    public async Task IsMp3DataAsync_InvalidData()
+    {
+        var env = new TestEnvironment();
+        await using var stream = new MemoryStream(new byte[] { 0x44, 0x2E, 0x56, 0x2E });
+
+        // SUT
+        var result = await env.Service.IsMp3DataAsync(stream);
+        Assert.False(result);
+    }
+
+    [Test]
+    public async Task IsMp3DataAsync_StreamTooShort()
+    {
+        var env = new TestEnvironment();
+        await using var stream = new MemoryStream(new byte[] { 0xFF, 0xFF });
+
+        // SUT
+        var result = await env.Service.IsMp3DataAsync(stream);
+        Assert.False(result);
+    }
+
+    [Test]
+    public async Task IsMp3DataAsync_NullStream()
+    {
+        var env = new TestEnvironment();
+        await using var stream = new MemoryStream(new byte[] { 0x0, 0x0, 0x0, 0x0 });
+
+        // SUT
+        var result = await env.Service.IsMp3DataAsync(stream);
+        Assert.False(result);
+    }
+
+    [Test]
+    public async Task IsMp3DataAsync_MP3WithIDv3()
+    {
+        var env = new TestEnvironment();
+        await using var stream = new MemoryStream(new byte[] { 0x49, 0x44, 0x33, 0x03 });
+
+        // SUT
+        var result = await env.Service.IsMp3DataAsync(stream);
+        Assert.True(result);
+    }
+
+    [Test]
+    public async Task IsMp3DataAsync_MP3WithFFE()
+    {
+        var env = new TestEnvironment();
+        await using var stream = new MemoryStream(new byte[] { 0xFF, 0xEB, 0x10, 0x0 });
+
+        // SUT
+        var result = await env.Service.IsMp3DataAsync(stream);
+        Assert.True(result);
+    }
+
+    [Test]
+    public async Task IsMp3DataAsync_MP3WithFFF()
+    {
+        var env = new TestEnvironment();
+        await using var stream = new MemoryStream(new byte[] { 0xFF, 0xF3, 0x28, 0xC4 });
+
+        // SUT
+        var result = await env.Service.IsMp3DataAsync(stream);
+        Assert.True(result);
+    }
+
+    [Test]
+    public async Task IsMp3DataAsync_MP3WithNullHeader()
+    {
+        var env = new TestEnvironment();
+        await using var stream = new MemoryStream(new byte[] { 0x0, 0x0, 0x0, 0xFF, 0xF3, 0x28, 0xC4 });
+
+        // SUT
+        var result = await env.Service.IsMp3DataAsync(stream);
+        Assert.True(result);
+    }
+
+    [Test]
+    public async Task IsMp3DataAsync_ResetsStreamPosition()
+    {
+        var env = new TestEnvironment();
+        await using var stream = new MemoryStream(new byte[] { 0x49, 0x44, 0x33, 0x0 });
+
+        // SUT
+        var result = await env.Service.IsMp3DataAsync(stream);
+        Assert.True(result);
+        Assert.Zero(stream.Position);
+    }
+
+    private class TestEnvironment
+    {
+        public TestEnvironment()
+        {
+            IOptions<AudioOptions> audioOptions = Substitute.For<IOptions<AudioOptions>>();
+            Service = new AudioService(audioOptions);
+        }
+
+        public AudioService Service { get; }
+    }
+}

--- a/test/SIL.XForge.Tests/Services/ProjectServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/ProjectServiceTests.cs
@@ -46,6 +46,7 @@ public class ProjectServiceTests
         var env = new TestEnvironment();
         const string dataId = "507f1f77bcf86cd799439011";
         string filePath = Path.Combine("site", "audio", Project01, $"{User01}_{dataId}.mp3");
+        env.AudioService.IsMp3DataAsync(Arg.Any<Stream>()).Returns(Task.FromResult(true));
         env.FileSystemService.OpenFile(Arg.Any<string>(), FileMode.Create).Returns(new MemoryStream());
         env.FileSystemService.FileExists(filePath).Returns(true);
 


### PR DESCRIPTION
This PR updates the check to see if an uploaded file is an MP3 to instead of checking for the file extension (which can sometimes be incorrect) to instead check for either presence of ID3 tags, or the MP3 frame header (0xFFE or 0xFFF) at the start of the file (excluding leading null characters).

A check for an null `IFormFile` being uploaded to the UploadAudio endpoint is also added, as uploading a file greater than the limit of 100MB in my tests resulted in this value being null.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1945)
<!-- Reviewable:end -->
