### PR TITLE
SF-2129 Add Health Endpoint

### DIFF
--- a/src/SIL.XForge.Scripture/Controllers/HealthController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/HealthController.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Serval.Client;
+using SIL.XForge.DataAccess;
+using SIL.XForge.Realtime;
+using SIL.XForge.Scripture.Models;
+
+namespace SIL.XForge.Scripture.Controllers;
+
+/// <summary>
+/// Provides methods for checking on instance health.
+/// </summary>
+/// <remarks>
+/// This can only be accessed from localhost, and is designed for NodePing.
+/// </remarks>
+[Route("health-check")]
+[ApiController]
+public class HealthController : ControllerBase
+{
+    public const int Status531MongoDown = 531;
+    public const int Status532RealtimeServerDown = 532;
+    public const int Status533ServalDown = 533;
+
+    private readonly IExceptionHandler _exceptionHandler;
+    private readonly IRealtimeService _realtimeService;
+    private readonly ITranslationEnginesClient _translationEnginesClient;
+
+    public HealthController(
+        IExceptionHandler exceptionHandler,
+        IRealtimeService realtimeService,
+        ITranslationEnginesClient translationEnginesClient
+    )
+    {
+        _exceptionHandler = exceptionHandler;
+        _realtimeService = realtimeService;
+        _translationEnginesClient = translationEnginesClient;
+    }
+
+    /// <summary>
+    /// Executes the health check.
+    /// </summary>
+    /// <returns>A JSON object containing values corresponding to the health of various systems.</returns>
+    /// <response code="200">All systems are healthy.</response>
+    /// <response code="403">You do not have permission to view the health check.</response>
+    /// <response code="531">Mongo is down.</response>
+    /// <response code="532">The Realtime Server is down.</response>
+    /// <response code="533">Serval is down.</response>
+    [HttpGet]
+    public async Task<ActionResult<HealthCheckResponse>> HealthCheckAsync()
+    {
+        // Restrict this endpoint to local requests
+        if (!IsLocal())
+        {
+            return Forbid();
+        }
+
+        // Create the object to return for the health check
+        var response = new HealthCheckResponse();
+
+        // First, check MongoDB
+        Stopwatch stopWatch;
+        SFProject? project = null;
+        try
+        {
+            stopWatch = Stopwatch.StartNew();
+            project = await _realtimeService.QuerySnapshots<SFProject>().FirstOrDefaultAsync();
+            stopWatch.Stop();
+            response.Mongo.Up = project is not null;
+            response.Mongo.Time = stopWatch.ElapsedMilliseconds;
+            response.Mongo.Status = response.Mongo.Up ? "Success" : "Retrieved project is null";
+        }
+        catch (Exception e)
+        {
+            response.Mongo.Status = e.Message;
+            _exceptionHandler.ReportException(e);
+        }
+
+        // Second, check the realtime server
+        if (project is not null)
+        {
+            try
+            {
+                stopWatch = Stopwatch.StartNew();
+                await using IConnection conn = await _realtimeService.ConnectAsync();
+                IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(project.Id);
+                stopWatch.Stop();
+                response.RealtimeServer.Up = projectDoc.IsLoaded;
+                response.RealtimeServer.Time = stopWatch.ElapsedMilliseconds;
+                response.RealtimeServer.Status = response.RealtimeServer.Up
+                    ? "Success"
+                    : "The project document was not loaded";
+            }
+            catch (Exception e)
+            {
+                response.RealtimeServer.Status = e.Message;
+                _exceptionHandler.ReportException(e);
+            }
+        }
+        else
+        {
+            response.RealtimeServer.Status = "The project was not retrieved from Mongo";
+        }
+
+        // Third, check Serval
+        try
+        {
+            stopWatch = Stopwatch.StartNew();
+            var translationEngines = await _translationEnginesClient.GetAllAsync();
+            stopWatch.Stop();
+            response.Serval.Up = translationEngines.Any();
+            response.Serval.Time = stopWatch.ElapsedMilliseconds;
+            response.Serval.Status = response.Serval.Up ? "Success" : "No translation engines were retrieved";
+        }
+        catch (Exception e)
+        {
+            response.Serval.Status = e.Message;
+            _exceptionHandler.ReportException(e);
+        }
+
+        // Calculate the status code and return the results
+        int statusCode;
+        if (!response.Mongo.Up)
+        {
+            statusCode = Status531MongoDown;
+        }
+        else if (!response.RealtimeServer.Up)
+        {
+            statusCode = Status532RealtimeServerDown;
+        }
+        else if (!response.Serval.Up)
+        {
+            statusCode = Status533ServalDown;
+        }
+        else
+        {
+            return Ok(response);
+        }
+
+        return StatusCode(statusCode, response);
+    }
+
+    /// <summary>
+    /// Returns if a request is from localhost.
+    /// </summary>
+    /// <returns><c>true</c> if the request is local; otherwise, <c>false</c>.</returns>
+    /// <remarks>This check uses similar logic to Hangfire's dashboard.</remarks>
+    private bool IsLocal()
+    {
+        // Get the local and remote IP addresses
+        string remoteIp = HttpContext.Connection.RemoteIpAddress?.ToString();
+        string localIp = HttpContext.Connection.LocalIpAddress?.ToString();
+
+        // Assume not local if remote IP is unknown
+        if (string.IsNullOrEmpty(remoteIp))
+        {
+            return false;
+        }
+
+        // See if localhost
+        return remoteIp is "127.0.0.1" or "::1" || remoteIp == localIp;
+    }
+}

--- a/src/SIL.XForge.Scripture/Models/HealthCheckComponent.cs
+++ b/src/SIL.XForge.Scripture/Models/HealthCheckComponent.cs
@@ -1,0 +1,22 @@
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// The health check status for a component
+/// </summary>
+public class HealthCheckComponent
+{
+    /// <summary>
+    /// Gets or sets a value indicating if the component is up.
+    /// </summary>
+    public bool Up { get; set; }
+
+    /// <summary>
+    /// Gets or sets the response time to the component (in milliseconds).
+    /// </summary>
+    public long Time { get; set; }
+
+    /// <summary>
+    /// Gets or sets the status of the component.
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+}

--- a/src/SIL.XForge.Scripture/Models/HealthCheckResponse.cs
+++ b/src/SIL.XForge.Scripture/Models/HealthCheckResponse.cs
@@ -1,0 +1,22 @@
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// A response to a request for a health check.
+/// </summary>
+public class HealthCheckResponse
+{
+    /// <summary>
+    /// Gets or sets the health check status for Mongo.
+    /// </summary>
+    public HealthCheckComponent Mongo { get; set; } = new HealthCheckComponent();
+
+    /// <summary>
+    /// Gets or sets the health check status for the Realtime Server.
+    /// </summary>
+    public HealthCheckComponent RealtimeServer { get; set; } = new HealthCheckComponent();
+
+    /// <summary>
+    /// Gets or sets the health check status for Serval.
+    /// </summary>
+    public HealthCheckComponent Serval { get; set; } = new HealthCheckComponent();
+}

--- a/test/SIL.XForge.Scripture.Tests/Controllers/HealthCheckControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/HealthCheckControllerTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NUnit.Framework;
+using Serval.Client;
+using SIL.XForge.Realtime;
+using SIL.XForge.Scripture.Models;
+
+namespace SIL.XForge.Scripture.Controllers;
+
+[TestFixture]
+public class HealthCheckControllerTests
+{
+    [Test]
+    public async Task HealthCheck_FailureWithMongo()
+    {
+        var env = new TestEnvironment();
+        env.RealtimeService.QuerySnapshots<SFProject>().Throws(new ArgumentException());
+
+        // SUT
+        var actual = await env.Controller.HealthCheckAsync();
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<ArgumentException>());
+        Assert.IsInstanceOf<ObjectResult>(actual.Result);
+        var objectResult = (ObjectResult)actual.Result!;
+        Assert.AreEqual(HealthController.Status531MongoDown, objectResult.StatusCode);
+        var value = (HealthCheckResponse)objectResult.Value!;
+        Assert.IsFalse(value.Mongo.Up);
+    }
+
+    [Test]
+    public async Task HealthCheck_FailureWithRealtimeServer()
+    {
+        var env = new TestEnvironment();
+        env.RealtimeService.ConnectAsync().Throws(new ArgumentException());
+
+        // SUT
+        var actual = await env.Controller.HealthCheckAsync();
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<ArgumentException>());
+        Assert.IsInstanceOf<ObjectResult>(actual.Result);
+        var objectResult = (ObjectResult)actual.Result!;
+        Assert.AreEqual(HealthController.Status532RealtimeServerDown, objectResult.StatusCode);
+        var value = (HealthCheckResponse)objectResult.Value!;
+        Assert.IsFalse(value.RealtimeServer.Up);
+    }
+
+    [Test]
+    public async Task HealthCheck_FailureWithServal()
+    {
+        var env = new TestEnvironment();
+        env.TranslationEnginesClient.GetAllAsync().Throws(new ArgumentException());
+
+        // SUT
+        var actual = await env.Controller.HealthCheckAsync();
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<ArgumentException>());
+        Assert.IsInstanceOf<ObjectResult>(actual.Result);
+        var objectResult = (ObjectResult)actual.Result!;
+        Assert.AreEqual(HealthController.Status533ServalDown, objectResult.StatusCode);
+        var value = (HealthCheckResponse)objectResult.Value!;
+        Assert.IsFalse(value.Serval.Up);
+    }
+
+    [Test]
+    public async Task HealthCheck_NotLocal()
+    {
+        var env = new TestEnvironment();
+        env.Controller.HttpContext.Connection.RemoteIpAddress = IPAddress.Parse("192.168.0.1");
+
+        // SUT
+        var actual = await env.Controller.HealthCheckAsync();
+
+        Assert.IsInstanceOf<ForbidResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task HealthCheck_SameIp()
+    {
+        var env = new TestEnvironment();
+        var ipAddress = IPAddress.Parse("192.168.0.1");
+        env.Controller.HttpContext.Connection.LocalIpAddress = ipAddress;
+        env.Controller.HttpContext.Connection.RemoteIpAddress = ipAddress;
+
+        // SUT
+        var actual = await env.Controller.HealthCheckAsync();
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task HealthCheck_Success()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        var actual = await env.Controller.HealthCheckAsync();
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+    }
+
+    private class TestEnvironment
+    {
+        private const string Project01 = "project01";
+
+        public TestEnvironment()
+        {
+            // Set up the controller and services
+            ExceptionHandler = Substitute.For<IExceptionHandler>();
+            RealtimeService = Substitute.For<IRealtimeService>();
+            TranslationEnginesClient = Substitute.For<ITranslationEnginesClient>();
+            Controller = new HealthController(ExceptionHandler, RealtimeService, TranslationEnginesClient)
+            {
+                ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext(), },
+            };
+
+            // Most tests will run as if from localhost
+            Controller.HttpContext.Connection.RemoteIpAddress = IPAddress.Loopback;
+
+            // Set up a default project to return from Mongo
+            RealtimeService
+                .QuerySnapshots<SFProject>()
+                .Returns(new List<SFProject> { new SFProject { Id = Project01 } }.AsQueryable());
+
+            // Setup a default connection and document to return from the realtime server
+            var connection = Substitute.For<IConnection>();
+            var document = Substitute.For<IDocument<SFProject>>();
+            document.IsLoaded.Returns(true);
+            connection.Get<SFProject>(Project01).Returns(document);
+            RealtimeService.ConnectAsync().Returns(Task.FromResult(connection));
+
+            // Setup a default translation engine to return from Serval
+            TranslationEnginesClient
+                .GetAllAsync()
+                .Returns(
+                    Task.FromResult<IList<TranslationEngine>>(new List<TranslationEngine> { new TranslationEngine() })
+                );
+        }
+
+        public HealthController Controller { get; }
+        public IExceptionHandler ExceptionHandler { get; }
+        public IRealtimeService RealtimeService { get; }
+        public ITranslationEnginesClient TranslationEnginesClient { get; }
+    }
+}


### PR DESCRIPTION
This Pull Request adds a `/health-check/` endpoint, accessible only from localhost, that can be used with the NodePing Agent. This will enable use to improve monitoring of Scripture Forge.

To test this, use http://localhost:5000/swagger/index.html. No authentication is necessary due to the localhost restriction.

Documentation is available in the document "Health endpoint" in the shared drive.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1946)
<!-- Reviewable:end -->
