### PR TITLE
SF-2132 Hotfix: Correctly handle note content with mixed styles

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -15,6 +15,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using IdentityModel;
@@ -2404,26 +2405,34 @@ public class ParatextService : DisposableBase, IParatextService
             return content;
         XDocument doc = XDocument.Parse(content);
         XElement contentNode = (XElement)doc.FirstNode;
-        XElement[] elements = contentNode.Elements().ToArray();
-        if (!elements.Any())
+        XNode[] nodes = contentNode.Nodes().ToArray();
+        if (!nodes.Any())
             return contentNode.Value;
 
         int paragraphNodeCount = ((XElement)doc.FirstNode).Elements("p").Count();
         StringBuilder sb = new StringBuilder();
         bool isReviewer = false;
-        for (int i = 0; i < elements.Length; i++)
+        for (int i = 0; i < nodes.Length; i++)
         {
-            XElement elem = elements[i];
+            XNode node = nodes[i];
+            if (node.NodeType == XmlNodeType.Text)
+            {
+                // append text to the content string
+                sb.Append(node);
+                continue;
+            }
+
+            XElement element = (XElement)node;
             // check if the paragraph element contains the user label class
-            if (elem.Attribute("sf-user-label")?.Value == "true")
+            if (element.Attribute("sf-user-label")?.Value == "true")
                 isReviewer = true;
             if (i == 0 && isReviewer)
                 continue;
             // If there is only one paragraph node other than the SF user label then omit the paragraph tags
             if (isReviewer && paragraphNodeCount <= 2)
-                sb.Append(elem.Value);
+                sb.Append(element.Value);
             else
-                sb.Append(elem);
+                sb.Append(node);
         }
         return sb.ToString();
     }


### PR DESCRIPTION
If a Paratext comment has content where the bold or italics style is used, the content does not show correctly in SF. The reason is because we used contentNode.Elements() to get all elements in the content node. However, unformatted text nodes are not elements, so they were excluded. The result is that when a note is created in SF, the content would be missing the unformatted text if the content had mixed styles like bold or italics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1948)
<!-- Reviewable:end -->
