### PR TITLE
SF-2123 Allow incorrectly or partially deleted users to be removed from projects

### DIFF
--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -1076,7 +1076,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
     /// The role may be the PT role from PT Registry, or a SF role.
     /// The returned Attempt will be Success if they have a non-None role, or otherwise Failure.
     /// </summary>
-    protected async override Task<Attempt<string>> TryGetProjectRoleAsync(SFProject project, string userId)
+    protected override async Task<Attempt<string>> TryGetProjectRoleAsync(SFProject project, string userId)
     {
         Attempt<UserSecret> userSecretAttempt = await _userSecrets.TryGetAsync(userId);
         if (userSecretAttempt.TryResult(out UserSecret userSecret))

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -1063,7 +1063,11 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         IDocument<SFProjectUserConfig> projectUserConfigDoc = await conn.FetchAsync<SFProjectUserConfig>(
             SFProjectUserConfig.GetDocId(projectDoc.Id, userDoc.Id)
         );
-        await projectUserConfigDoc.DeleteAsync();
+        if (projectUserConfigDoc.IsLoaded)
+        {
+            await projectUserConfigDoc.DeleteAsync();
+        }
+
         // Delete any share keys used by this user
         await ProjectSecrets.UpdateAsync(
             projectDoc.Id,

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -100,7 +100,7 @@ public abstract class ProjectService<TModel, TSecret> : IProjectService
             throw new ArgumentNullException();
         }
         IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
-        IDocument<User> userDoc = await GetUserDocAsync(projectUserId, conn);
+        IDocument<User> userDoc = await conn.FetchAsync<User>(projectUserId);
         await RemoveUserFromProjectAsync(conn, projectDoc, userDoc);
     }
 
@@ -303,14 +303,17 @@ public abstract class ProjectService<TModel, TSecret> : IProjectService
             await projectDoc.SubmitJson0OpAsync(op => op.Unset(p => p.UserRoles[userDoc.Id]));
             await projectDoc.SubmitJson0OpAsync(op => op.Unset(p => p.UserPermissions[userDoc.Id]));
         }
-        string siteId = SiteOptions.Value.Id;
-        await userDoc.SubmitJson0OpAsync(op =>
+        if (userDoc.IsLoaded)
         {
-            int index = userDoc.Data.Sites[siteId].Projects.IndexOf(projectDoc.Id);
-            op.Remove(u => u.Sites[siteId].Projects, index);
-            if (userDoc.Data.Sites[siteId].CurrentProjectId == projectDoc.Id)
-                op.Unset(u => u.Sites[siteId].CurrentProjectId);
-        });
+            string siteId = SiteOptions.Value.Id;
+            await userDoc.SubmitJson0OpAsync(op =>
+            {
+                int index = userDoc.Data.Sites[siteId].Projects.IndexOf(projectDoc.Id);
+                op.Remove(u => u.Sites[siteId].Projects, index);
+                if (userDoc.Data.Sites[siteId].CurrentProjectId == projectDoc.Id)
+                    op.Unset(u => u.Sites[siteId].CurrentProjectId);
+            });
+        }
     }
 
     protected bool IsOnProject(TModel project, string userId) => project.UserRoles.ContainsKey(userId);

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -288,7 +288,7 @@ public abstract class ProjectService<TModel, TSecret> : IProjectService
         await userDoc.SubmitJson0OpAsync(op => op.Add(u => u.Sites[siteId].Projects, projectDoc.Id));
     }
 
-    internal protected virtual async Task RemoveUserFromProjectAsync(
+    protected internal virtual async Task RemoveUserFromProjectAsync(
         IConnection conn,
         IDocument<TModel> projectDoc,
         IDocument<User> userDoc

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -1479,6 +1479,27 @@ public class SFProjectServiceTests
     }
 
     [Test]
+    public async Task RemoveUser_RemovesUsersWithMissingProjectUserConfig()
+    {
+        var env = new TestEnvironment();
+        string requestingUser = User07;
+        string userToRemove = User02;
+        string projectId = Project06;
+        string projectUserConfigId = SFProjectUserConfig.GetDocId(projectId, userToRemove);
+        Assert.IsTrue(env.GetProject(projectId).UserRoles.ContainsKey(userToRemove));
+
+        // Delete the project user config
+        int deleted = await env.RealtimeService
+            .GetRepository<SFProjectUserConfig>()
+            .DeleteAllAsync(p => p.Id == projectUserConfigId);
+        Assert.AreEqual(1, deleted);
+
+        // SUT
+        await env.Service.RemoveUserAsync(requestingUser, projectId, userToRemove);
+        Assert.IsFalse(env.GetProject(projectId).UserRoles.ContainsKey(userToRemove));
+    }
+
+    [Test]
     public void UninviteUser_BadProject_Error()
     {
         var env = new TestEnvironment();


### PR DESCRIPTION
The current logic that removes a user from a project crashes if the user has been deleted manually from the database, or if the SFProjectUserConfig is missing.

This Pull Request makes the remove user from project logic more resilient by checking whether the `User` or `SFProjectUserConfig` docs exist before modifying or deleting them.

I also took the opportunity to correct the method signatures of a couple of functions near to the change that my IDE flagged as incorrect.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1949)
<!-- Reviewable:end -->
