### PR TITLE
SF-2133 Fixed Alignment for Reviewer Questions Panel

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
@@ -45,6 +45,13 @@ app-donut-chart {
   }
 }
 
+#reviewer-questions-list {
+  .mat-list-item {
+    cursor: pointer;
+    margin-inline-start: 16px;
+  }
+}
+
 .no-overflow-ellipsis {
   white-space: nowrap;
   text-overflow: ellipsis;


### PR DESCRIPTION
And changed cursor type to better indicate interactivity.

Another option would be to use ng-deep to override the padding of mat-list-item-content, which is causing the issue. This avoids ng-deep.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1950)
<!-- Reviewable:end -->
