### PR TITLE
SF-2132 Correctly handle note content with mixed styles

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -15,6 +15,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using IdentityModel;
@@ -2409,26 +2410,34 @@ public class ParatextService : DisposableBase, IParatextService
             return content;
         XDocument doc = XDocument.Parse(content);
         XElement contentNode = (XElement)doc.FirstNode;
-        XElement[] elements = contentNode.Elements().ToArray();
-        if (!elements.Any())
+        XNode[] nodes = contentNode.Nodes().ToArray();
+        if (!nodes.Any())
             return contentNode.Value;
 
         int paragraphNodeCount = ((XElement)doc.FirstNode).Elements("p").Count();
         StringBuilder sb = new StringBuilder();
         bool isReviewer = false;
-        for (int i = 0; i < elements.Length; i++)
+        for (int i = 0; i < nodes.Length; i++)
         {
-            XElement elem = elements[i];
+            XNode node = nodes[i];
+            if (node.NodeType == XmlNodeType.Text)
+            {
+                // append text to the content string
+                sb.Append(node);
+                continue;
+            }
+
+            XElement element = (XElement)node;
             // check if the paragraph element contains the user label class
-            if (elem.Attribute("sf-user-label")?.Value == "true")
+            if (element.Attribute("sf-user-label")?.Value == "true")
                 isReviewer = true;
             if (i == 0 && isReviewer)
                 continue;
             // If there is only one paragraph node other than the SF user label then omit the paragraph tags
             if (isReviewer && paragraphNodeCount <= 2)
-                sb.Append(elem.Value);
+                sb.Append(element.Value);
             else
-                sb.Append(elem);
+                sb.Append(node);
         }
         return sb.ToString();
     }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2412,7 +2412,7 @@ public class ParatextService : DisposableBase, IParatextService
         XElement contentNode = (XElement)doc.FirstNode;
         XNode[] nodes = contentNode.Nodes().ToArray();
         if (!nodes.Any())
-            return contentNode.Value;
+            return string.Empty;
 
         int paragraphNodeCount = ((XElement)doc.FirstNode).Elements("p").Count();
         StringBuilder sb = new StringBuilder();
@@ -2424,6 +2424,11 @@ public class ParatextService : DisposableBase, IParatextService
             {
                 // append text to the content string
                 sb.Append(node);
+                continue;
+            }
+            else if (node.NodeType != XmlNodeType.Element)
+            {
+                // we only know to handle strings and elements
                 continue;
             }
 


### PR DESCRIPTION
This change introduces more reliable parsing of Paratext note contents. The problem was that in content with mixed formatting such as bold and italics, the regularly formatted text would be a text node that is not included when calling contentNode.Elements(). To prevent dropping the text, we use contentNode.Nodes() instead which retrieves all nodes in the Paratext note contents. More rigorous testing of the parsing results was also added.