### PR TITLE
SF-2137 Add notes on threads with the correct thread Id

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -96,8 +96,8 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
     return this.realtimeService.subscribe(TextDoc.COLLECTION, textId instanceof TextDocId ? textId.toString() : textId);
   }
 
-  getNoteThread(threadId: string): Promise<NoteThreadDoc> {
-    return this.realtimeService.subscribe(NoteThreadDoc.COLLECTION, threadId);
+  getNoteThread(threadDataId: string): Promise<NoteThreadDoc> {
+    return this.realtimeService.subscribe(NoteThreadDoc.COLLECTION, threadDataId);
   }
 
   queryQuestions(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2734,23 +2734,27 @@ describe('EditorComponent', () => {
     it('allows adding a note to an existing thread', fakeAsync(() => {
       const projectId: string = 'project01';
       const threadDataId: string = 'dataid04';
+      const threadId: string = 'thread04';
       const segmentRef: string = 'verse_1_3';
       const env = new TestEnvironment();
       const content: string = 'content in the thread';
       let noteThread: NoteThreadDoc = env.getNoteThreadDoc(projectId, threadDataId);
       expect(noteThread.data!.notes.length).toEqual(1);
+
       env.setProjectUserConfig();
       env.wait();
       const noteThreadIconElem: HTMLElement = env.getNoteThreadIconElement(segmentRef, threadDataId)!;
       noteThreadIconElem.click();
+      verify(mockedMatDialog.open(NoteDialogComponent, anything())).once();
+      const [, noteDialogData] = capture(mockedMatDialog.open).last();
+      expect((noteDialogData!.data as NoteDialogData).threadDataId).toEqual(threadDataId);
       env.mockNoteDialogRef.close({ noteContent: content });
       env.wait();
       noteThread = env.getNoteThreadDoc(projectId, threadDataId);
       expect(noteThread.data!.notes.length).toEqual(2);
-      expect(noteThread.data!.notes[1].threadId).toEqual(threadDataId);
+      expect(noteThread.data!.notes[1].threadId).toEqual(threadId);
       expect(noteThread.data!.notes[1].content).toEqual(content);
       expect(noteThread.data!.notes[1].tagId).toBe(undefined);
-
       env.dispose();
     }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -956,7 +956,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       return;
     }
     const currentDate: string = new Date().toJSON();
-    const threadId: string = params.threadDataId ?? objectId();
+    const threadId: string = params.threadDataId != null ? '' : objectId();
     // only set the tag id if it is the first note in the thread
     const tagId: number | undefined =
       params.threadDataId == null ? this.projectDoc?.data?.translateConfig.defaultNoteTagId : undefined;
@@ -1004,6 +1004,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
           op.set(t => t.notes[noteIndex].dateModified, currentDate);
         });
       } else {
+        note.threadId = threadDoc.data!.threadId;
         await threadDoc.submitJson0Op(op => op.add(t => t.notes, note));
         await this.updateNoteReadRefs(note.dataId);
       }
@@ -1059,7 +1060,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
     const noteDialogData: NoteDialogData = {
       projectId: this.projectDoc!.id,
-      threadId: threadDataId,
+      threadDataId: threadDataId,
       textDocId: new TextDocId(this.projectDoc!.id, this.bookNum, this.chapter),
       verseRef
     };

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -956,7 +956,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       return;
     }
     const currentDate: string = new Date().toJSON();
-    const threadId: string = params.threadDataId != null ? '' : objectId();
+    // if adding a note to an existing thread, the empty string must be replaced by the existing thread id
+    const newThreadId: string = params.threadDataId != null ? '' : objectId();
     // only set the tag id if it is the first note in the thread
     const tagId: number | undefined =
       params.threadDataId == null ? this.projectDoc?.data?.translateConfig.defaultNoteTagId : undefined;
@@ -964,7 +965,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     const note: Note = {
       dateCreated: currentDate,
       dateModified: currentDate,
-      threadId,
+      threadId: newThreadId,
       dataId: params.dataId ?? objectId(),
       tagId,
       ownerRef: this.userService.currentUserId,
@@ -979,7 +980,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       // Create a new thread
       const noteThread: NoteThread = {
         dataId: objectId(),
-        threadId,
+        threadId: newThreadId,
         verseRef: fromVerseRef(params.verseRef),
         projectRef: this.projectId,
         ownerRef: this.userService.currentUserId,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -723,7 +723,7 @@ class TestEnvironment {
     const configData: NoteDialogData = {
       projectId: TestEnvironment.PROJECT01,
       textDocId,
-      threadId: noteThread?.dataId,
+      threadDataId: noteThread?.dataId,
       verseRef
     };
     TestEnvironment.testProjectProfile.isRightToLeft = isRightToLeftProject;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -23,7 +23,7 @@ import { TextDoc, TextDocId } from '../../../core/models/text-doc';
 import { canInsertNote, formatFontSizeToRems } from '../../../shared/utils';
 
 export interface NoteDialogData {
-  threadId?: string;
+  threadDataId?: string;
   textDocId: TextDocId;
   projectId: string;
   verseRef?: VerseRef;
@@ -65,10 +65,10 @@ export class NoteDialogComponent implements OnInit {
 
   async ngOnInit(): Promise<void> {
     // This can be refactored so the asynchronous calls are done in parallel
-    if (this.threadId == null) {
+    if (this.threadDataId == null) {
       this.textDoc = await this.projectService.getText(this.textDocId);
     } else {
-      this.threadDoc = await this.projectService.getNoteThread(this.projectId + ':' + this.threadId);
+      this.threadDoc = await this.projectService.getNoteThread(this.projectId + ':' + this.threadDataId);
       this.textDoc = await this.projectService.getText(this.textDocId);
     }
 
@@ -113,7 +113,7 @@ export class NoteDialogComponent implements OnInit {
   }
 
   get isNewNote(): boolean {
-    return this.data.threadId == null;
+    return this.data.threadDataId == null;
   }
 
   get isRtl(): boolean {
@@ -196,8 +196,8 @@ export class NoteDialogComponent implements OnInit {
     return this.data.textDocId.toString();
   }
 
-  private get threadId(): string | undefined {
-    return this.data.threadId;
+  private get threadDataId(): string | undefined {
+    return this.data.threadDataId;
   }
 
   private get lastNoteId(): string | undefined {


### PR DESCRIPTION
The problem was that the thread Id for new notes on a thread was mistakenly being set to the thread data Id. The result was the thread Id for new notes was different than the first note in the thread, so when the note was synchronized, the note ended up on a new thread.
This change ensures that the correct thread Id is used for subsequent notes on a thread.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1958)
<!-- Reviewable:end -->
