### PR TITLE
SF-2146 Write Comment XML Files with the BOM

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2048,7 +2048,7 @@ public class ParatextService : DisposableBase, IParatextService
         try
         {
             foreach (string user in users)
-                manager.SaveUser(user, false);
+                WriteCommentXml(manager, user);
             _paratextDataHelper.CommitVersionedText(
                 scrText,
                 $"{syncMetricInfo.Added} notes added and "
@@ -2068,6 +2068,17 @@ public class ParatextService : DisposableBase, IParatextService
         }
 
         return syncMetricInfo;
+    }
+
+    private void WriteCommentXml(CommentManager commentManager, string username)
+    {
+        CommentList userComments = new CommentList(
+            commentManager.AllComments.Where(comment => comment.User == username)
+        );
+        string fileName = commentManager.GetUserFileName(username);
+        string path = Path.Combine(commentManager.ScrText.Directory, fileName);
+        using Stream stream = _fileSystemService.CreateFile(path);
+        _fileSystemService.WriteXmlFile(stream, userComments);
     }
 
     private CommentTags? GetCommentTags(UserSecret userSecret, string paratextId)

--- a/src/SIL.XForge/Services/FileSystemService.cs
+++ b/src/SIL.XForge/Services/FileSystemService.cs
@@ -1,5 +1,8 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
+using System.Xml;
+using System.Xml.Serialization;
 
 namespace SIL.XForge.Services;
 
@@ -30,4 +33,22 @@ public class FileSystemService : IFileSystemService
         Directory.EnumerateFiles(path, searchPattern);
 
     public IEnumerable<string> EnumerateDirectories(string path) => Directory.EnumerateDirectories(path);
+
+    public void WriteXmlFile<T>(Stream stream, T data)
+    {
+        XmlSerializerNamespaces xsn = new XmlSerializerNamespaces();
+        xsn.Add(string.Empty, string.Empty);
+        XmlSerializer serializer = new XmlSerializer(typeof(T));
+        XmlWriterSettings settings = new XmlWriterSettings
+        {
+            // Ensure that the BOM is written
+            Encoding = new UTF8Encoding(true),
+            Indent = true,
+            NewLineChars = "\r\n",
+        };
+
+        using XmlWriter xmlWriter = XmlWriter.Create(stream, settings);
+        serializer.Serialize(xmlWriter, data, xsn);
+        xmlWriter.Flush();
+    }
 }

--- a/src/SIL.XForge/Services/IFileSystemService.cs
+++ b/src/SIL.XForge/Services/IFileSystemService.cs
@@ -17,4 +17,5 @@ public interface IFileSystemService
     void MoveFile(string sourceFilePath, string targetFilePath);
     IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*");
     IEnumerable<string> EnumerateDirectories(string path);
+    void WriteXmlFile<T>(Stream stream, T data);
 }

--- a/test/SIL.XForge.Tests/SIL.XForge.Tests.csproj
+++ b/test/SIL.XForge.Tests/SIL.XForge.Tests.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="ParatextData" Version="9.3.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/SIL.XForge.Tests/Services/FileSystemServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/FileSystemServiceTests.cs
@@ -1,0 +1,132 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Paratext.Data.ProjectComments;
+using Paratext.Data.Users;
+
+namespace SIL.XForge.Services;
+
+[TestFixture]
+public class FileSystemServiceTests
+{
+    [Test]
+    public void WriteXmlFile_WritesBom()
+    {
+        var env = new TestEnvironment();
+        using MemoryStream stream = new MemoryStream();
+        CommentList data = new CommentList();
+
+        // SUT
+        env.Service.WriteXmlFile(stream, data);
+
+        // Get the first three bytes
+        stream.Position = 0;
+        byte[] bytes = new byte[3];
+        int count = stream.Read(bytes, 0, 3);
+
+        // Verify the BOM
+        Assert.AreEqual(3, count);
+        Assert.AreEqual(0xEF, bytes[0]);
+        Assert.AreEqual(0xBB, bytes[1]);
+        Assert.AreEqual(0xBF, bytes[2]);
+    }
+
+    [Test]
+    public void WriteXmlFile_WritesAnEmptyCommentList()
+    {
+        var env = new TestEnvironment();
+        using MemoryStream stream = new MemoryStream();
+        CommentList data = new CommentList();
+        string xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n";
+        xml += "<CommentList />";
+
+        // Get the XML as a byte array with BOM
+        Encoding encoding = new UTF8Encoding(true);
+        byte[] expected = encoding.GetPreamble().Concat(encoding.GetBytes(xml)).ToArray();
+
+        // SUT
+        env.Service.WriteXmlFile(stream, data);
+        byte[] actual = stream.ToArray();
+        Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public void WriteXmlFile_WritesComments()
+    {
+        var env = new TestEnvironment();
+        using MemoryStream stream = new MemoryStream();
+
+        // Setup data for the CommentList and XML
+        const string thread = "abc12345";
+        const string user = "Test User";
+        const string verseRefStr = "ROM 1:1";
+        const string language = "en";
+        const string date = "2023-02-01T13:14:15.5034142+12:00";
+        const string selectedText = "Paul";
+        const int startPosition = 5;
+        const string contextBefore = @"\v 1 ";
+        const string contextAfter = ", a servant";
+        const string verse =
+            @"\v 1 Paul, a servant of Jesus Christ, called to be an apostle, separated unto the gospel of God,";
+        const bool hideInTextWindow = false;
+        const string contents = "Plain Text";
+
+        // Setup the Comment List
+        CommentList data = new CommentList
+        {
+            new Comment(new DummyParatextUser(user))
+            {
+                Thread = thread,
+                VerseRefStr = verseRefStr,
+                Language = language,
+                Date = date,
+                SelectedText = selectedText,
+                StartPosition = startPosition,
+                ContextBefore = contextBefore,
+                ContextAfter = contextAfter,
+                Verse = verse,
+                ReplyToUser = string.Empty,
+                HideInTextWindow = false,
+            },
+        };
+        data.First().AddTextToContent(contents, false);
+
+        // Setup the XML data for comparison
+        string xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n";
+        xml += "<CommentList>\r\n";
+        xml += $"  <Comment Thread=\"{thread}\" User=\"{user}\" VerseRef=\"{verseRefStr}\" Language=\"{language}\"";
+        xml += $" Date=\"{date}\">\r\n";
+        xml += $"    <SelectedText>{selectedText}</SelectedText>\r\n";
+        xml += $"    <StartPosition>{startPosition}</StartPosition>\r\n";
+        xml += $"    <ContextBefore>{contextBefore}</ContextBefore>\r\n";
+        xml += $"    <ContextAfter>{contextAfter}</ContextAfter>\r\n";
+        xml += "    <Status></Status>\r\n";
+        xml += "    <Type></Type>\r\n";
+        xml += "    <ConflictType />\r\n";
+        xml += $"    <Verse>{verse}</Verse>\r\n";
+        xml += "    <ReplyToUser />\r\n";
+        xml += $"    <HideInTextWindow>{hideInTextWindow.ToString().ToLowerInvariant()}</HideInTextWindow>\r\n";
+        xml += "    <Contents>\r\n";
+        xml += $"      <p>{contents}</p>\r\n";
+        xml += "    </Contents>\r\n";
+        xml += "  </Comment>\r\n";
+        xml += "</CommentList>";
+
+        // Get the XML as a byte array with BOM
+        Encoding encoding = new UTF8Encoding(true);
+        byte[] expected = encoding.GetPreamble().Concat(encoding.GetBytes(xml)).ToArray();
+
+        // SUT
+        env.Service.WriteXmlFile(stream, data);
+        byte[] actual = stream.ToArray();
+        Assert.AreEqual(expected, actual);
+    }
+
+    private class TestEnvironment
+    {
+        public TestEnvironment() => Service = new FileSystemService();
+
+        public IFileSystemService Service { get; }
+    }
+}


### PR DESCRIPTION
This Pull Request changes the method to write Comment XML files to use a custom XML Serializer rather than ParatextData's `CommentManager SaveUser()` method which uses `Momento.SetXml()`.

A benefit of this method is the fact we can now force the BOM to be written (matching the behavior of ParatextData running on the .NET Framework), and we can also unit test comment writing, to flag in future if either Paratext changes its XML schema for the Comment class or if future versions of .NET change the XML Serialization (as happened with the upgrade to .NET 6.0).

This implementation does not create the .bak file when the new comment XML is written - if this is a blocker we may want to look at our own method of storing this (i.e. versioned .bak files or in a different directory).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1960)
<!-- Reviewable:end -->
