### PR TITLE
Exclude Test Projects from Code Coverage Calculations

### DIFF
--- a/test/SIL.XForge.Scripture.Tests/SIL.XForge.Scripture.Tests.csproj
+++ b/test/SIL.XForge.Scripture.Tests/SIL.XForge.Scripture.Tests.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/test/SIL.XForge.Tests/SIL.XForge.Tests.csproj
+++ b/test/SIL.XForge.Tests/SIL.XForge.Tests.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
When writing another PR, I noticed that the code coverage calculations were including the test projects, and so complaining that I was not testing them.

This PR adds an assembly attribute to the test projects that force them to be excluded from the code coverage calculations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1962)
<!-- Reviewable:end -->
