### PR TITLE
SF-2148 Migrators can use an existing NodeJS process

### DIFF
--- a/src/Migrations/ServalMigration/Program.cs
+++ b/src/Migrations/ServalMigration/Program.cs
@@ -55,18 +55,6 @@ public class Program
         Directory.SetCurrentDirectory(sfAppDir);
         IWebHostBuilder builder = CreateWebHostBuilder(args);
         IWebHost webHost = builder.Build();
-        try
-        {
-            await webHost.StartAsync();
-        }
-        catch (HttpRequestException)
-        {
-            Log(
-                "There was an error starting the program before getting to the migration"
-                    + " part. Maybe the SF server is running and needs shut down? Rethrowing."
-            );
-            throw;
-        }
 
         // Get the project IDs and admin IDs, if they were set in the environment variables
         string[] sfProjectIdsToMigrate = sfProjectIdsSubset?.Split(' ') ?? Array.Empty<string>();

--- a/src/Migrations/ServalMigration/ServalMigrator.cs
+++ b/src/Migrations/ServalMigration/ServalMigrator.cs
@@ -153,9 +153,19 @@ public class ServalMigrator : DisposableBase
                 if (doWrite)
                 {
                     Program.Log("Adding project to Serval...");
-                    await _machineProjectService.AddProjectAsync(sfUserId, project.Id, cancellationToken);
+                    await _machineProjectService.AddProjectAsync(
+                        sfUserId,
+                        project.Id,
+                        preTranslate: false,
+                        cancellationToken
+                    );
                     Program.Log("Initiating first build...");
-                    await _machineProjectService.BuildProjectAsync(sfUserId, project.Id, cancellationToken);
+                    await _machineProjectService.BuildProjectAsync(
+                        sfUserId,
+                        project.Id,
+                        preTranslate: false,
+                        cancellationToken
+                    );
                 }
                 else
                 {

--- a/src/Migrations/ServalMigration/Startup.cs
+++ b/src/Migrations/ServalMigration/Startup.cs
@@ -77,7 +77,13 @@ public class Startup
         services.AddExceptionReporting(Configuration);
         services.AddConfiguration(Configuration);
         services.AddFeatureManagement(Configuration).AddSessionManager<MigratorFeatureSessionManager>();
-        services.AddSFRealtimeServer(LoggerFactory, Configuration, nodeOptions: null, Program.MigrationsDisabled);
+        services.AddSFRealtimeServer(
+            LoggerFactory,
+            Configuration,
+            nodeOptions: null,
+            Program.MigrationsDisabled,
+            useExistingRealtimeServer: true
+        );
         services.AddSFServices();
         services.AddSFDataAccess(Configuration);
         services.AddSignalR();

--- a/src/SIL.XForge.Scripture/Realtime/SFRealtimeServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Realtime/SFRealtimeServiceCollectionExtensions.cs
@@ -16,7 +16,8 @@ public static class SFRealtimeServiceCollectionExtensions
         ILoggerFactory loggerFactory,
         IConfiguration configuration,
         string? nodeOptions = null,
-        bool migrationsDisabled = false
+        bool migrationsDisabled = false,
+        bool useExistingRealtimeServer = false
     )
     {
         services.AddRealtimeServer(
@@ -26,6 +27,7 @@ public static class SFRealtimeServiceCollectionExtensions
             {
                 o.AppModuleName = "scriptureforge";
                 o.MigrationsDisabled = migrationsDisabled;
+                o.UseExistingRealtimeServer = useExistingRealtimeServer;
                 o.ProjectDoc = new DocConfig("sf_projects", typeof(SFProject));
                 o.ProjectDataDocs.AddRange(
                     new[]
@@ -41,7 +43,8 @@ public static class SFRealtimeServiceCollectionExtensions
                     new[] { new DocConfig("sf_project_user_configs", typeof(SFProjectUserConfig)) }
                 );
             },
-            nodeOptions
+            nodeOptions,
+            useExistingRealtimeServer
         );
         return services;
     }

--- a/src/SIL.XForge/Configuration/RealtimeOptions.cs
+++ b/src/SIL.XForge/Configuration/RealtimeOptions.cs
@@ -12,6 +12,7 @@ public class RealtimeOptions
     public int Port { get; set; }
     public bool MigrationsDisabled { get; set; }
     public bool DocumentCacheDisabled { get; set; }
+    public bool UseExistingRealtimeServer { get; set; }
     public DocConfig UserDoc { get; set; } = new DocConfig("users", typeof(User));
     public DocConfig ProjectDoc { get; set; }
 

--- a/src/SIL.XForge/Realtime/ExistingNodeJSProcess.cs
+++ b/src/SIL.XForge/Realtime/ExistingNodeJSProcess.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Jering.Javascript.NodeJS;
+
+namespace SIL.XForge.Realtime;
+
+public class ExistingNodeJSProcess : INodeJSProcess
+{
+    public void Dispose() => GC.SuppressFinalize(this);
+
+    public void AddOutputReceivedHandler(MessageReceivedEventHandler messageReceivedHandler) =>
+        Task.Run(async () =>
+        {
+            // Delay to fake thread starting
+            await Task.Delay(5000);
+
+            // Code to be executed after the delay
+            messageReceivedHandler.Invoke(
+                "[Jering.Javascript.NodeJS: HttpVersion - HTTP/1.1 Listening on IP - 127.0.0.1 Port - 5002]"
+            );
+        });
+
+    public void AddErrorReceivedHandler(MessageReceivedEventHandler messageReceivedHandler) { }
+
+    public void AddOutputDataReceivedHandler(DataReceivedEventHandler dataReceivedEventHandler) { }
+
+    public void AddErrorDataReceivedHandler(DataReceivedEventHandler dataReceivedEventHandler) { }
+
+    public void SetConnected() => this.Connected = true;
+
+    public void BeginErrorReadLine() { }
+
+    public void BeginOutputReadLine() { }
+
+    public void Kill() { }
+
+    public bool Connected { get; private set; }
+
+    public bool HasExited => false;
+    public string ExitStatus => "Process has not exited";
+    public int SafeID => -1;
+}

--- a/src/SIL.XForge/Realtime/ExistingNodeJSProcessFactory.cs
+++ b/src/SIL.XForge/Realtime/ExistingNodeJSProcessFactory.cs
@@ -1,0 +1,8 @@
+using Jering.Javascript.NodeJS;
+
+namespace SIL.XForge.Realtime;
+
+public class ExistingNodeJSProcessFactory : INodeJSProcessFactory
+{
+    public INodeJSProcess Create(string serverScript) => new ExistingNodeJSProcess();
+}

--- a/src/SIL.XForge/Realtime/RealtimeService.cs
+++ b/src/SIL.XForge/Realtime/RealtimeService.cs
@@ -62,11 +62,20 @@ public class RealtimeService : DisposableBase, IRealtimeService
 
     public void StartServer()
     {
-        object options = CreateOptions();
-        Server.Start(options);
+        if (!_realtimeOptions.Value.UseExistingRealtimeServer)
+        {
+            object options = CreateOptions();
+            Server.Start(options);
+        }
     }
 
-    public void StopServer() => Server.Stop();
+    public void StopServer()
+    {
+        if (!_realtimeOptions.Value.UseExistingRealtimeServer)
+        {
+            Server.Stop();
+        }
+    }
 
     public async Task<IConnection> ConnectAsync(string userId = null)
     {

--- a/src/SIL.XForge/Realtime/RealtimeServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Realtime/RealtimeServiceCollectionExtensions.cs
@@ -16,18 +16,27 @@ public static class RealtimeServiceCollectionExtensions
         ILoggerFactory loggerFactory,
         IConfiguration configuration,
         Action<RealtimeOptions> configureOptions,
-        string? nodeOptions = null
+        string? nodeOptions = null,
+        bool useExistingRealtimeServer = false
     )
     {
         services.AddNodeJS();
         services.Configure<NodeJSProcessOptions>(options =>
         {
+            // Specify the port so NodeJS can be shared with other processes
+            options.Port = 5002;
             options.ProjectPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
             if (!string.IsNullOrWhiteSpace(nodeOptions))
             {
                 options.NodeAndV8Options = nodeOptions;
             }
         });
+
+        // If we are using another NodeJS process, be sure to use our factory implementation
+        if (useExistingRealtimeServer)
+        {
+            services.AddSingleton<INodeJSProcessFactory, ExistingNodeJSProcessFactory>();
+        }
 
         // Disable timeout so the debugger can be paused
         if (nodeOptions?.Contains("--inspect", StringComparison.OrdinalIgnoreCase) == true)


### PR DESCRIPTION
This Pull Request allows a Scripture Forge process, such as a migrator, use an existing NodeJS/Realtime Server process.

This is possible because of the custom `INodeJSProcessFactory` which acts as a stub for the process management features of the Jering.NodeJS. By stubbing these methods out, and specifying the port that NodeJS will use (port 5002), only the main process that started the Realtime Server will have the capability to perform the process management functions which are a part of Jering.NodeJS's tight coupling between the NodeJS process and the .NET process.

The Serval Migrator has been updated to use this new feature, as well as fixing support for the most recent Serval pre-translation changes in Scripture Forge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1963)
<!-- Reviewable:end -->
