### PR TITLE
Add Stillness feature flag

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; read: 'app'">
   <mat-progress-bar
-    mode="indeterminate"
+    [mode]="featureFlags.stillness.enabled ? 'determinate' : 'indeterminate'"
     color="accent"
     [class.mat-progress-bar--closed]="isAppLoading !== true"
   ></mat-progress-bar>
@@ -209,7 +209,7 @@
               mat-list-icon
               matBadge="error"
               [matBadgeHidden]="!lastSyncFailed"
-              [class.sync-in-progress]="syncInProgress"
+              [class.sync-in-progress]="syncInProgress && !featureFlags.stillness.enabled"
               id="sync-icon"
               >sync</mat-icon
             >

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
@@ -3,6 +3,7 @@ import { ProgressBarMode } from '@angular/material/progress-bar';
 import { OtJson0Op } from 'ot-json0';
 import { isParatextRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { merge, Observable } from 'rxjs';
+import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { SFProjectDoc } from '../../core/models/sf-project-doc';
 import { ProjectNotificationService } from '../../core/project-notification.service';
@@ -25,7 +26,8 @@ export class SyncProgressComponent extends SubscriptionDisposable {
 
   constructor(
     private readonly projectService: SFProjectService,
-    private readonly projectNotificationService: ProjectNotificationService
+    private readonly projectNotificationService: ProjectNotificationService,
+    private readonly featureFlags: FeatureFlagService
   ) {
     super();
 
@@ -48,6 +50,7 @@ export class SyncProgressComponent extends SubscriptionDisposable {
   }
 
   get mode(): ProgressBarMode {
+    if (this.featureFlags.stillness.enabled) return 'determinate';
     // Show indeterminate only at the beginning, as the sync has not yet started
     return this.syncProgressPercent > 0 ? 'determinate' : 'indeterminate';
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -78,6 +78,11 @@ export class FeatureFlagService {
     'Prevent op acknowledgement (intentionally breaks things)'
   );
 
+  stillness: FeatureFlag = new FeatureFlag(
+    new LocalStorageFlagStore('STILLNESS'),
+    'Stillness (non-distracting progress indicators)'
+  );
+
   get featureFlags(): FeatureFlag[] {
     return Object.values(this).filter(value => value instanceof FeatureFlag);
   }


### PR DESCRIPTION
Indeterminate progress indicators may be helpful when a process is
running and the user can be shown that they need to wait for
something.

When debugging, or when working with unfinished code, the
indeterminate progress indicator may go forever until Continuing the
debugger, or closing the tab.

This patch adds a Stillness feature flag to change indeterminate
progress indication into determinate. There is still a visual
indication, but it is not distracting from studying code in an
adjacent window.

commit-id:747ab149

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1965)
<!-- Reviewable:end -->
