### PR TITLE
SF-2149 Make like color lighter

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_variables.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_variables.scss
@@ -12,7 +12,7 @@ $orange: #ff7300;
 /* App specific */
 $sf_grey: $greyDark;
 $sf_header: $sf_grey;
-$likes: $blueMedium;
+$likes: #578cff;
 $questions: $purpleLight;
 $answers: $greenLight;
 $comments: $orange;


### PR DESCRIPTION
![](https://github.com/sillsdev/web-xforge/assets/6140710/8d758ecf-d37d-48ed-8824-118e73f58ace)
![](https://github.com/sillsdev/web-xforge/assets/6140710/83a20e9c-b5a4-42fb-8801-8c2f7b8dc994)
![](https://github.com/sillsdev/web-xforge/assets/6140710/a4f511ca-c827-4118-b103-ff850a483bd3)

It's easy to see the difference between the old dark blue and black when they're side by side here, but when you aren't seeing them side by side, the dark blue isn't conveying the message very well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1969)
<!-- Reviewable:end -->
