### PR TITLE
SF-2152 Update to @sillsdev/scripture 1.4.0

### DIFF
--- a/scripts/db_tools/package-lock.json
+++ b/scripts/db_tools/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@sillsdev/scripture": "^1.1.2",
+        "@sillsdev/scripture": "^1.4.0",
         "axios": "^0.27.2",
         "mongodb": "^4.6.0",
         "ot-json0": "^1.1.0",
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@sillsdev/scripture": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@sillsdev/scripture/-/scripture-1.1.2.tgz",
-      "integrity": "sha512-jNGlC94S7KF3WFVqLkRNF0igVJbmFzifVuLspDBMk48qG3iOaxd4Ky/d0cmED2DytYacIvSAdgv8E528O/lIEw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sillsdev/scripture/-/scripture-1.4.0.tgz",
+      "integrity": "sha512-Fwf1+OWfYYS5HmxbBev70dzZHL1a/B/+9c+zxcI76QZaeUEy7hG3BBL/hi1aaWuHC419XX+RaASL6tFng9g7Qg=="
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.0",
@@ -971,9 +971,9 @@
       }
     },
     "@sillsdev/scripture": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@sillsdev/scripture/-/scripture-1.1.2.tgz",
-      "integrity": "sha512-jNGlC94S7KF3WFVqLkRNF0igVJbmFzifVuLspDBMk48qG3iOaxd4Ky/d0cmED2DytYacIvSAdgv8E528O/lIEw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sillsdev/scripture/-/scripture-1.4.0.tgz",
+      "integrity": "sha512-Fwf1+OWfYYS5HmxbBev70dzZHL1a/B/+9c+zxcI76QZaeUEy7hG3BBL/hi1aaWuHC419XX+RaASL6tFng9g7Qg=="
     },
     "@socket.io/component-emitter": {
       "version": "3.1.0",

--- a/scripts/db_tools/package.json
+++ b/scripts/db_tools/package.json
@@ -9,7 +9,7 @@
   "main": "lib/cjs/common/index.js",
   "types": "lib/cjs/common/index.d.ts",
   "dependencies": {
-    "@sillsdev/scripture": "^1.1.2",
+    "@sillsdev/scripture": "^1.4.0",
     "axios": "^0.27.2",
     "mongodb": "^4.6.0",
     "ot-json0": "^1.1.0",

--- a/src/RealtimeServer/package-lock.json
+++ b/src/RealtimeServer/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^7.16.5",
-        "@sillsdev/scripture": "^1.1.2",
+        "@sillsdev/scripture": "^1.4.0",
         "express": "^4.18.1",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^2.1.2",
@@ -1274,9 +1274,9 @@
       }
     },
     "node_modules/@sillsdev/scripture": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@sillsdev/scripture/-/scripture-1.1.2.tgz",
-      "integrity": "sha512-jNGlC94S7KF3WFVqLkRNF0igVJbmFzifVuLspDBMk48qG3iOaxd4Ky/d0cmED2DytYacIvSAdgv8E528O/lIEw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sillsdev/scripture/-/scripture-1.4.0.tgz",
+      "integrity": "sha512-Fwf1+OWfYYS5HmxbBev70dzZHL1a/B/+9c+zxcI76QZaeUEy7hG3BBL/hi1aaWuHC419XX+RaASL6tFng9g7Qg=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
@@ -8093,9 +8093,9 @@
       "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw=="
     },
     "@sillsdev/scripture": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@sillsdev/scripture/-/scripture-1.1.2.tgz",
-      "integrity": "sha512-jNGlC94S7KF3WFVqLkRNF0igVJbmFzifVuLspDBMk48qG3iOaxd4Ky/d0cmED2DytYacIvSAdgv8E528O/lIEw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sillsdev/scripture/-/scripture-1.4.0.tgz",
+      "integrity": "sha512-Fwf1+OWfYYS5HmxbBev70dzZHL1a/B/+9c+zxcI76QZaeUEy7hG3BBL/hi1aaWuHC419XX+RaASL6tFng9g7Qg=="
     },
     "@sinclair/typebox": {
       "version": "0.24.51",

--- a/src/RealtimeServer/package.json
+++ b/src/RealtimeServer/package.json
@@ -22,7 +22,7 @@
   "private": true,
   "dependencies": {
     "@bugsnag/js": "^7.16.5",
-    "@sillsdev/scripture": "^1.1.2",
+    "@sillsdev/scripture": "^1.4.0",
     "express": "^4.18.1",
     "jsonwebtoken": "^9.0.0",
     "jwks-rsa": "^2.1.2",

--- a/src/RealtimeServer/scriptureforge/models/verse-ref-data.ts
+++ b/src/RealtimeServer/scriptureforge/models/verse-ref-data.ts
@@ -1,10 +1,10 @@
-import { VerseRef } from '@sillsdev/scripture';
+import { Canon, VerseRef } from '@sillsdev/scripture';
 
 export function toVerseRef(verseRefData: VerseRefData): VerseRef {
   return new VerseRef(
-    verseRefData.bookNum,
-    verseRefData.chapterNum,
-    verseRefData.verse != null ? verseRefData.verse : verseRefData.verseNum
+    Canon.bookNumberToId(verseRefData.bookNum),
+    verseRefData.chapterNum.toString(),
+    verseRefData.verse != null ? verseRefData.verse : verseRefData.verseNum.toString()
   );
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -29,7 +29,7 @@
         "@ngneat/transloco": "^3.2.0",
         "@ngneat/transloco-locale": "^3.0.1",
         "@sillsdev/machine": "^2.4.1",
-        "@sillsdev/scripture": "^1.1.2",
+        "@sillsdev/scripture": "^1.4.0",
         "angular-file": "^3.6.0",
         "angular-split": "^5.0.0",
         "arraydiff": "^0.1.3",
@@ -133,7 +133,7 @@
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^7.16.5",
-        "@sillsdev/scripture": "^1.1.2",
+        "@sillsdev/scripture": "^1.4.0",
         "express": "^4.18.1",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^2.1.2",
@@ -13546,9 +13546,9 @@
       }
     },
     "node_modules/@sillsdev/scripture": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@sillsdev/scripture/-/scripture-1.1.2.tgz",
-      "integrity": "sha512-jNGlC94S7KF3WFVqLkRNF0igVJbmFzifVuLspDBMk48qG3iOaxd4Ky/d0cmED2DytYacIvSAdgv8E528O/lIEw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sillsdev/scripture/-/scripture-1.4.0.tgz",
+      "integrity": "sha512-Fwf1+OWfYYS5HmxbBev70dzZHL1a/B/+9c+zxcI76QZaeUEy7hG3BBL/hi1aaWuHC419XX+RaASL6tFng9g7Qg=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
@@ -47925,9 +47925,9 @@
       }
     },
     "@sillsdev/scripture": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@sillsdev/scripture/-/scripture-1.1.2.tgz",
-      "integrity": "sha512-jNGlC94S7KF3WFVqLkRNF0igVJbmFzifVuLspDBMk48qG3iOaxd4Ky/d0cmED2DytYacIvSAdgv8E528O/lIEw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sillsdev/scripture/-/scripture-1.4.0.tgz",
+      "integrity": "sha512-Fwf1+OWfYYS5HmxbBev70dzZHL1a/B/+9c+zxcI76QZaeUEy7hG3BBL/hi1aaWuHC419XX+RaASL6tFng9g7Qg=="
     },
     "@sinclair/typebox": {
       "version": "0.24.51",
@@ -65731,7 +65731,7 @@
       "version": "file:../../RealtimeServer",
       "requires": {
         "@bugsnag/js": "^7.16.5",
-        "@sillsdev/scripture": "^1.1.2",
+        "@sillsdev/scripture": "^1.4.0",
         "@types/jest": "^29.2.4",
         "@types/jsonwebtoken": "^9.0.0",
         "@types/lodash-es": "^4.17.7",

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -47,7 +47,7 @@
     "@ngneat/transloco": "^3.2.0",
     "@ngneat/transloco-locale": "^3.0.1",
     "@sillsdev/machine": "^2.4.1",
-    "@sillsdev/scripture": "^1.1.2",
+    "@sillsdev/scripture": "^1.4.0",
     "angular-file": "^3.6.0",
     "angular-split": "^5.0.0",
     "arraydiff": "^0.1.3",

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, ViewChild } from '@angular/core';
 import { AudioTiming } from 'realtime-server/lib/esm/scriptureforge/models/audio-timing';
-import { VerseRef } from '@sillsdev/scripture';
+import { Canon, VerseRef } from '@sillsdev/scripture';
 import { TextDocId } from 'src/app/core/models/text-doc';
 import { getVerseStrFromSegmentRef } from 'src/app/shared/utils';
 import { I18nService } from 'xforge-common/i18n.service';
@@ -28,9 +28,9 @@ export class CheckingScriptureAudioPlayerComponent {
   get currentVerseLabel(): string | undefined {
     if (this.currentRef == null || this.textDocId == null) return;
     const verseRef = new VerseRef(
-      this.textDocId.bookNum,
-      this.textDocId.chapterNum,
-      getVerseStrFromSegmentRef(this.currentRef)
+      Canon.bookNumberToId(this.textDocId.bookNum),
+      this.textDocId.chapterNum.toString(),
+      getVerseStrFromSegmentRef(this.currentRef) ?? ''
     );
     return this.i18n.localizeReference(verseRef);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.spec.ts
@@ -114,8 +114,8 @@ describe('CheckingTextComponent', () => {
   it('highlights combined verse', fakeAsync(() => {
     const env = new TestEnvironment();
     env.component.id = new TextDocId('project01', 41, 1);
-    env.component.questionVerses = [new VerseRef(41, 1, '2-3')];
-    env.component.activeVerse = new VerseRef(41, 1, '2-3');
+    env.component.questionVerses = [new VerseRef('MRK', '1', '2-3')];
+    env.component.activeVerse = new VerseRef('MRK', '1', '2-3');
     env.wait();
     expect(env.segmentHasQuestion(1, 1)).toBe(false);
     expect(env.segmentHasQuestion(1, '2-3')).toBe(true);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -415,7 +415,7 @@ describe('CheckingComponent', () => {
       expect(env.isSegmentHighlighted(1, 1)).toBe(false);
       expect(env.isSegmentHighlighted(1, 5)).toBe(true);
       expect(env.segmentHasQuestion(1, 5)).toBe(true);
-      expect(env.component.questionVerseRefs[0].equals(VerseRef.parse('JHN 1:5'))).toBe(true);
+      expect(env.component.questionVerseRefs[0].equals(new VerseRef('JHN 1:5'))).toBe(true);
     }));
 
     it('unread answers badge is only visible when the setting is ON to see other answers', fakeAsync(() => {
@@ -723,7 +723,7 @@ describe('CheckingComponent', () => {
       const answerAction: AnswerAction = {
         action: 'save',
         text: 'answer 01',
-        verseRef: fromVerseRef(VerseRef.parse('JHN 1:1')),
+        verseRef: fromVerseRef(new VerseRef('JHN 1:1')),
         audio: {
           status: 'processed',
           fileName: 'audioFile.mp3',
@@ -1623,7 +1623,7 @@ describe('CheckingComponent', () => {
       expect(segment.classList.contains('highlight-segment')).toBe(true);
       expect(fromVerseRef(env.component.activeQuestionVerseRef!).verseNum).toEqual(3);
       env.component.questionsPanel!.activeQuestionDoc!.submitJson0Op(op => {
-        op.set(qd => qd.verseRef, fromVerseRef(VerseRef.parse('JHN 1:5')));
+        op.set(qd => qd.verseRef, fromVerseRef(new VerseRef('JHN 1:5')));
       }, false);
       env.waitForSliderUpdate();
       tick();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -745,7 +745,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, O
       questionDoc: undefined,
       textsByBookId: this.textsByBookId,
       projectId: this.projectDoc.id,
-      defaultVerse: new VerseRef(this.book, this.chapter, 1),
+      defaultVerse: new VerseRef(this.book ?? 0, this.chapter ?? 1, 1),
       isRightToLeft: this.projectDoc.data?.isRightToLeft
     };
     const newQuestion = await this.questionDialogService.questionDialog(data);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
@@ -170,7 +170,7 @@ describe('ImportQuestionsDialogComponent', () => {
   it('show scripture chooser dialog', fakeAsync(() => {
     const env = new TestEnvironment();
     env.click(env.importFromTransceleratorButton);
-    when(env.mockedScriptureChooserMatDialogRef.afterClosed()).thenReturn(of(VerseRef.parse('MAT 1:1')));
+    when(env.mockedScriptureChooserMatDialogRef.afterClosed()).thenReturn(of(new VerseRef('MAT 1:1')));
     env.openFromScriptureChooser();
     verify(mockedDialogService.openMatDialog(anything(), anything())).once();
     expect(env.component.fromControl.value).toBe('MAT 1:1');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -423,7 +423,7 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable imple
         const fullReference: string =
           refStartsWithBook || defaultBookId == null ? reference : defaultBookId + ' ' + reference;
         questions.push({
-          verseRef: VerseRef.parse(fullReference),
+          verseRef: new VerseRef(fullReference),
           text: questionText
         });
       } catch {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -185,7 +185,7 @@ describe('QuestionDialogComponent', () => {
   }));
 
   it('should set default verse and text direction when provided', fakeAsync(() => {
-    const verseRef: VerseRef = VerseRef.parse('LUK 1:1');
+    const verseRef: VerseRef = new VerseRef('LUK 1:1');
     env = new TestEnvironment(undefined, verseRef, true);
     flush();
     expect(env.component.scriptureStart.value).toBe('LUK 1:1');
@@ -241,7 +241,7 @@ describe('QuestionDialogComponent', () => {
     env.clickElement(env.scriptureStartInputIcon);
     flush();
     verify(
-      env.dialogServiceSpy.openMatDialog(anything(), objectContaining({ data: { input: VerseRef.parse('MAT 3:4') } }))
+      env.dialogServiceSpy.openMatDialog(anything(), objectContaining({ data: { input: new VerseRef('MAT 3:4') } }))
     ).once();
     flush();
     expect(env.component.scriptureStart.value).toEqual('LUK 1:2');
@@ -289,7 +289,7 @@ describe('QuestionDialogComponent', () => {
     verify(
       env.dialogServiceSpy.openMatDialog(
         anything(),
-        objectContaining({ data: { input: VerseRef.parse('GEN 5:6'), rangeStart: VerseRef.parse('LUK 1:1') } })
+        objectContaining({ data: { input: new VerseRef('GEN 5:6'), rangeStart: new VerseRef('LUK 1:1') } })
       )
     ).once();
     flush();
@@ -307,7 +307,7 @@ describe('QuestionDialogComponent', () => {
     verify(
       env.dialogServiceSpy.openMatDialog(
         anything(),
-        objectContaining({ data: { input: VerseRef.parse('LUK 1:1'), rangeStart: undefined } })
+        objectContaining({ data: { input: new VerseRef('LUK 1:1'), rangeStart: undefined } })
       )
     ).once();
     flush();
@@ -383,7 +383,7 @@ describe('QuestionDialogComponent', () => {
       dataId: 'question01',
       ownerRef: 'user01',
       projectRef: 'project01',
-      verseRef: fromVerseRef(VerseRef.parse('LUK 1:3')),
+      verseRef: fromVerseRef(new VerseRef('LUK 1:3')),
       answers: [],
       isArchived: false,
       dateCreated: '',
@@ -403,7 +403,7 @@ describe('QuestionDialogComponent', () => {
       dataId: 'question01',
       ownerRef: 'user01',
       projectRef: 'project01',
-      verseRef: fromVerseRef(VerseRef.parse('LUK 1:3')),
+      verseRef: fromVerseRef(new VerseRef('LUK 1:3')),
       answers: [],
       isArchived: false,
       dateCreated: '',
@@ -426,7 +426,7 @@ describe('QuestionDialogComponent', () => {
       dataId: 'question01',
       ownerRef: 'user01',
       projectRef: 'project01',
-      verseRef: fromVerseRef(VerseRef.parse('LUK 1:3-4')),
+      verseRef: fromVerseRef(new VerseRef('LUK 1:3-4')),
       answers: [],
       isArchived: false,
       dateCreated: '',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -83,7 +83,7 @@ export class QuestionDialogComponent extends SubscriptionDisposable implements O
 
   get textDocId(): TextDocId | undefined {
     if (this.scriptureStart.value && this.scriptureStart.valid) {
-      const verseData = VerseRef.parse(this.scriptureStart.value);
+      const verseData = new VerseRef(this.scriptureStart.value);
       return new TextDocId(this.data.projectId, verseData.bookNum, verseData.chapterNum);
     }
     return undefined;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.spec.ts
@@ -54,7 +54,7 @@ describe('QuestionDialogService', () => {
     const env = new TestEnvironment();
     const result: QuestionDialogResult = {
       text: 'question added',
-      verseRef: VerseRef.parse('MAT 1:3'),
+      verseRef: new VerseRef('MAT 1:3'),
       audio: {}
     };
     when(env.mockedDialogRef.afterClosed()).thenReturn(of(result));
@@ -75,7 +75,7 @@ describe('QuestionDialogService', () => {
     const env = new TestEnvironment();
     const result: QuestionDialogResult = {
       text: 'This question is added just as user role is changed',
-      verseRef: VerseRef.parse('MAT 1:3'),
+      verseRef: new VerseRef('MAT 1:3'),
       audio: {}
     };
     when(env.mockedDialogRef.afterClosed()).thenReturn(of(result));
@@ -90,7 +90,7 @@ describe('QuestionDialogService', () => {
     const env = new TestEnvironment();
     const result: QuestionDialogResult = {
       text: 'question added',
-      verseRef: VerseRef.parse('MAT 1:3'),
+      verseRef: new VerseRef('MAT 1:3'),
       audio: { fileName: 'someFileName.mp3', blob: new Blob() }
     };
     when(env.mockedDialogRef.afterClosed()).thenReturn(of(result));
@@ -103,7 +103,7 @@ describe('QuestionDialogService', () => {
     const env = new TestEnvironment();
     const result: QuestionDialogResult = {
       text: 'question edited',
-      verseRef: VerseRef.parse('MAT 1:3'),
+      verseRef: new VerseRef('MAT 1:3'),
       audio: {}
     };
     when(env.mockedDialogRef.afterClosed()).thenReturn(of(result));
@@ -117,7 +117,7 @@ describe('QuestionDialogService', () => {
     const env = new TestEnvironment();
     const result: QuestionDialogResult = {
       text: 'question added',
-      verseRef: VerseRef.parse('MAT 1:3'),
+      verseRef: new VerseRef('MAT 1:3'),
       audio: { fileName: 'someFileName.mp3', blob: new Blob() }
     };
     when(env.mockedDialogRef.afterClosed()).thenReturn(of(result));
@@ -142,7 +142,7 @@ describe('QuestionDialogService', () => {
     const env = new TestEnvironment();
     const result: QuestionDialogResult = {
       text: 'question edited',
-      verseRef: VerseRef.parse('MAT 1:3'),
+      verseRef: new VerseRef('MAT 1:3'),
       audio: { status: 'reset' }
     };
     when(env.mockedDialogRef.afterClosed()).thenReturn(of(result));
@@ -216,7 +216,7 @@ class TestEnvironment {
     return {
       dataId: 'q1Id',
       text: 'question to be edited',
-      verseRef: fromVerseRef(VerseRef.parse('MAT 1:3')),
+      verseRef: fromVerseRef(new VerseRef('MAT 1:3')),
       answers: [],
       isArchived: false,
       audioUrl: audioUrl,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.spec.ts
@@ -36,7 +36,7 @@ describe('NoteThreadDoc', () => {
       url: '/assets/icons/TagIcons/flag2.png'
     };
     expect(noteThreadDoc.getIcon(env.noteTags)).toEqual(expectedIcon);
-    const expectedVerseRef = VerseRef.parse('MAT 1:1');
+    const expectedVerseRef = new VerseRef('MAT 1:1');
     expect(noteThreadDoc.currentVerseRef()!.equals(expectedVerseRef)).toBe(true);
   });
 
@@ -133,7 +133,7 @@ describe('NoteThreadDoc', () => {
       url: '/assets/icons/TagIcons/flag3.png'
     };
     expect(noteThreadDoc.getIcon(env.noteTags)).toEqual(expectedIcon);
-    const expectedVerseRef = VerseRef.parse('MAT 1:1');
+    const expectedVerseRef = new VerseRef('MAT 1:1');
     expect(noteThreadDoc.currentVerseRef()!.equals(expectedVerseRef)).toBe(true);
   });
 
@@ -175,7 +175,7 @@ describe('NoteThreadDoc', () => {
 
     const noteThreadDoc: NoteThreadDoc = await env.setupDoc(notes);
     const verseRef: VerseRef = noteThreadDoc.currentVerseRef()!;
-    const expected: VerseRef = VerseRef.parse('MAT 1:2');
+    const expected: VerseRef = new VerseRef('MAT 1:2');
     expect(verseRef.equals(expected)).toBe(true);
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
@@ -76,7 +76,7 @@ export class NoteThreadDoc extends ProjectDataDoc<NoteThread> {
     }
 
     const verseStr: string = lastReattach.reattached.split(REATTACH_SEPARATOR)[0];
-    return VerseRef.parse(verseStr);
+    return new VerseRef(verseStr);
   }
 
   isAssignedToOtherUser(currentUserId: string, paratextProjectUsers: ParatextUserProfile[]): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.spec.ts
@@ -206,13 +206,6 @@ describe('ScriptureChooserDialog', () => {
     expect(env.dialogText).not.toContain(nonexistentVerseOfRomans11);
   }));
 
-  it('identifies OT book', () => {
-    env = new TestEnvironment();
-    expect(env.component.isOT('GEN')).toBe(true);
-    expect(env.component.isOT('LUK')).toBe(false);
-    expect(env.component.isOT('XYZ')).toBe(false);
-  });
-
   it('splits input books by OT and NT', () => {
     env = new TestEnvironment();
     expect(env.component.otBooks.includes('EXO')).toBe(true);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.ts
@@ -58,10 +58,10 @@ export class ScriptureChooserDialogComponent implements OnInit {
   ngOnInit(): void {
     const books = Object.keys(this.data.booksAndChaptersToShow);
     this.otBooks = books
-      .filter(book => this.isOT(book))
+      .filter(book => Canon.isBookOT(book))
       .sort((a, b) => this.data.booksAndChaptersToShow[a].bookNum - this.data.booksAndChaptersToShow[b].bookNum);
     this.ntBooks = books
-      .filter(book => !this.isOT(book))
+      .filter(book => !Canon.isBookOT(book))
       .sort((a, b) => this.data.booksAndChaptersToShow[a].bookNum - this.data.booksAndChaptersToShow[b].bookNum);
 
     if (this.data.rangeStart != null) {
@@ -104,7 +104,7 @@ export class ScriptureChooserDialogComponent implements OnInit {
   onClickChapter(chapter: number): void {
     this.selection.chapter = chapter.toString();
     if (this.data.includeVerseSelection === false) {
-      this.dialogRef.close(new VerseRef(this.selection.book, this.selection.chapter, 0));
+      this.dialogRef.close(new VerseRef(this.selection.book!, this.selection.chapter!, ''));
     } else {
       this.showVerseSelection();
     }
@@ -112,7 +112,7 @@ export class ScriptureChooserDialogComponent implements OnInit {
 
   onClickVerse(verse: number): void {
     this.selection.verse = verse.toString();
-    this.dialogRef.close(new VerseRef(this.selection.book, this.selection.chapter, this.selection.verse));
+    this.dialogRef.close(new VerseRef(this.selection.book!, this.selection.chapter!, this.selection.verse));
   }
 
   onClickBackoutButton(): void {
@@ -141,14 +141,6 @@ export class ScriptureChooserDialogComponent implements OnInit {
 
   showRangeEndSelection(): void {
     this.showing = 'rangeEnd';
-  }
-
-  /** Is the book in the OT?
-   * False if in NT or invalid. */
-  isOT(bookId: string): boolean {
-    const firstBook = 0;
-    const numOTBooks = 39;
-    return Canon.allBookIds.slice(firstBook, numOTBooks).includes(bookId);
   }
 
   /** Returns an array of all chapters for a given book that the dialog was told about.

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -188,7 +188,7 @@ describe('TextComponent', () => {
     tick();
     env.fixture.detectChanges();
 
-    const verseSegments: string[] = env.component.getVerseSegments(VerseRef.parse('LUK 1:1'));
+    const verseSegments: string[] = env.component.getVerseSegments(new VerseRef('LUK 1:1'));
     expect(verseSegments).toEqual(['verse_1_1', 'verse_1_1/q_1', 'verse_1_1/q_2', 'verse_1_1/q_3']);
     const segmentText = env.component.getSegmentText('verse_1_1/q_2');
     expect(segmentText).toEqual('Poetry third line');
@@ -1057,7 +1057,7 @@ describe('TextComponent', () => {
     tick();
     env.fixture.detectChanges();
     // the current text is on chapter 1, so this should result in no matching segments
-    const verseRef: VerseRef = VerseRef.parse('MAT 2:1');
+    const verseRef: VerseRef = new VerseRef('MAT 2:1');
     const segments: string[] = env.component.getVerseSegments(verseRef);
     expect(segments.length).withContext('should be no matching segments when chapter does not match').toBe(0);
   }));
@@ -1068,7 +1068,7 @@ describe('TextComponent', () => {
     tick();
     env.fixture.detectChanges();
     // the current text is in Matthew, so this should result in no matching segments
-    const verseRef: VerseRef = VerseRef.parse('MRK 1:1');
+    const verseRef: VerseRef = new VerseRef('MRK 1:1');
     const segments: string[] = env.component.getVerseSegments(verseRef);
     expect(segments.length).withContext('should be no matching segments when book does not match').toBe(0);
   }));
@@ -1341,7 +1341,7 @@ class TestEnvironment {
 
   /** Where reference is like 'MAT 1:2'. */
   embedThreadAt(reference: string, textAnchor: TextAnchor, role: string = SFProjectRole.ParatextTranslator): void {
-    const verseRef: VerseRef = VerseRef.parse(reference);
+    const verseRef: VerseRef = new VerseRef(reference);
     const uniqueSuffix: string = Math.random().toString();
     const id: string = `embedid${reference}${uniqueSuffix}`;
     const iconSource: string = '--icon-file: url(/assets/icons/TagIcons/01flag1.png)';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -16,7 +16,7 @@ import Quill, { DeltaStatic, RangeStatic, Sources, StringMap } from 'quill';
 import QuillCursors from 'quill-cursors';
 import { AuthType, getAuthType } from 'realtime-server/lib/esm/common/models/user';
 import { TextAnchor } from 'realtime-server/lib/esm/scriptureforge/models/text-anchor';
-import { VerseRef } from '@sillsdev/scripture';
+import { Canon, VerseRef } from '@sillsdev/scripture';
 import { fromEvent, Subject, Subscription, timer } from 'rxjs';
 import { LocalPresence, Presence } from 'sharedb/lib/sharedb';
 import { PwaService } from 'xforge-common/pwa.service';
@@ -1302,7 +1302,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       // If verse segment ref has no exact match, check for segments that fall within a verse reference
       if (VERSE_REGEX.test(segmentRef)) {
         const [_, chapterNum, verseNum] = segmentRef.split('_');
-        const verseRef: VerseRef = new VerseRef(this.id?.bookNum, chapterNum, verseNum);
+        const verseRef: VerseRef = new VerseRef(Canon.bookNumberToId(this.id?.bookNum ?? 0), chapterNum, verseNum);
         const correspondingSegments: string[] = this.getVerseSegments(verseRef);
 
         if (correspondingSegments.length > 0) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -1,7 +1,7 @@
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
-import { VerseRef } from '@sillsdev/scripture';
+import { Canon, VerseRef } from '@sillsdev/scripture';
 import { DeltaOperation } from 'rich-text';
 import { SelectableProject } from '../core/paratext.service';
 
@@ -64,7 +64,7 @@ export function getVerseRefFromSegmentRef(bookNum: number, segmentRef: string): 
     return;
   }
   const parts = baseRef.split('_');
-  return new VerseRef(bookNum, parts[1], parts[2]);
+  return new VerseRef(Canon.bookNumberToId(bookNum), parts[1], parts[2]);
 }
 
 /** Returns the verse string from a segment ref. e.g. 6, 6a, 6-7, 6,8 */
@@ -87,7 +87,7 @@ export function verseRefFromMouseEvent(event: MouseEvent, bookNum: number): Vers
   }
   const segmentParts = clickSegment.split('_', 3);
   const versePart = segmentParts[2].split('/')[0];
-  return new VerseRef(bookNum, segmentParts[1], versePart);
+  return new VerseRef(Canon.bookNumberToId(bookNum), segmentParts[1], versePart);
 }
 
 export function threadIdFromMouseEvent(event: MouseEvent): string | undefined {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2578,7 +2578,7 @@ describe('EditorComponent', () => {
       const content: string = 'content in the thread';
       const userId: string = 'user05';
       const segmentRef: string = 'verse_1_2';
-      const verseRef: VerseRef = new VerseRef('MAT', 1, '2');
+      const verseRef: VerseRef = new VerseRef('MAT', '1', '2');
       const env = new TestEnvironment();
       env.setProjectUserConfig({
         selectedBookNum: verseRef.bookNum,
@@ -2649,7 +2649,7 @@ describe('EditorComponent', () => {
       env.saveMobileNoteButton!.click();
       env.wait();
       const [, noteThread] = capture(mockedSFProjectService.createNoteThread).last();
-      expect(noteThread.verseRef).toEqual(fromVerseRef(VerseRef.parse('LUK 1:1')));
+      expect(noteThread.verseRef).toEqual(fromVerseRef(new VerseRef('LUK 1:1')));
       expect(noteThread.notes[0].content).toEqual(content);
       env.dispose();
     }));
@@ -2941,7 +2941,7 @@ describe('EditorComponent', () => {
 
       const segmentRef = 'verse_1_2-3';
       env.setSelectionAndInsertNote(segmentRef);
-      const verseRef = new VerseRef('LUK', 1, '2-3');
+      const verseRef = new VerseRef('LUK', '1', '2-3');
       verify(mockedMatDialog.open(NoteDialogComponent, anything())).once();
       const [, config] = capture(mockedMatDialog.open).last();
       expect((config!.data! as NoteDialogData).verseRef!.equals(verseRef)).toBeTrue();
@@ -4056,7 +4056,7 @@ class TestEnvironment {
       notes.push(note);
     }
 
-    const verseRef: VerseRef = VerseRef.parse(verseStr);
+    const verseRef: VerseRef = new VerseRef(verseStr);
     this.realtimeService.addSnapshot<NoteThread>(NoteThreadDoc.COLLECTION, {
       id: `project01:${dataId}`,
       data: {
@@ -4080,7 +4080,7 @@ class TestEnvironment {
   reattachNote(projectId: string, threadDataId: string, verseStr: string, position: TextAnchor): void {
     const noteThreadDoc: NoteThreadDoc = this.getNoteThreadDoc(projectId, threadDataId);
     const template: Note = noteThreadDoc.data!.notes[0];
-    const verseRef: VerseRef = VerseRef.parse(verseStr);
+    const verseRef: VerseRef = new VerseRef(verseStr);
     const contextAfter: string = ` ${verseRef.verseNum}.`;
     const reattachParts: string[] = [verseStr, 'verse', position.start.toString(), 'target: chapter 1, ', contextAfter];
     const reattached: string = reattachParts.join(REATTACH_SEPARATOR);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -110,13 +110,13 @@ describe('NoteDialogComponent', () => {
   }));
 
   it('shows segment text for rtl combined verses', fakeAsync(() => {
-    const verseRef: VerseRef = VerseRef.parse('MAT 1:2-3');
+    const verseRef: VerseRef = new VerseRef('MAT 1:2-3');
     env = new TestEnvironment({ verseRef, isRightToLeftProject: true, combinedVerseTextDoc: true });
     expect(env.noteText.nativeElement.textContent).toBe('target: chapter 1, verse 2-3.');
   }));
 
   it('shows segment text for rtl multiple verses', fakeAsync(() => {
-    const verseRef: VerseRef = VerseRef.parse('MAT 1:5,7');
+    const verseRef: VerseRef = new VerseRef('MAT 1:5,7');
     env = new TestEnvironment({ verseRef, isRightToLeftProject: true, combinedVerseTextDoc: true });
     expect(env.noteText.nativeElement.textContent).toBe('target: chapter 1, verse 5,7.');
   }));
@@ -328,7 +328,7 @@ describe('NoteDialogComponent', () => {
   }));
 
   it('show insert note dialog content', fakeAsync(() => {
-    env = new TestEnvironment({ verseRef: VerseRef.parse('MAT 1:1'), noteTagId: 6 });
+    env = new TestEnvironment({ verseRef: new VerseRef('MAT 1:1'), noteTagId: 6 });
     expect(env.noteInputElement).toBeTruthy();
     expect(env.flagIcon).toEqual('/assets/icons/TagIcons/defaultIcon.png');
     expect(env.verseRef).toEqual('Matthew 1:1');
@@ -337,7 +337,7 @@ describe('NoteDialogComponent', () => {
   }));
 
   it('can insert a note', fakeAsync(() => {
-    const verseRef = VerseRef.parse('MAT 1:3');
+    const verseRef = new VerseRef('MAT 1:3');
     env = new TestEnvironment({ verseRef, noteTagId: 2 });
     expect(env.noteInputElement).toBeTruthy();
     expect(env.verseRef).toEqual('Matthew 1:3');
@@ -356,7 +356,7 @@ describe('NoteDialogComponent', () => {
   }));
 
   it('does not save note if textarea is empty', fakeAsync(() => {
-    env = new TestEnvironment({ verseRef: VerseRef.parse('MAT 1:1') });
+    env = new TestEnvironment({ verseRef: new VerseRef('MAT 1:1') });
     expect(env.noteInputElement).toBeTruthy();
     env.submit();
     verify(mockedProjectService.createNoteThread(anything(), anything())).never();
@@ -364,7 +364,7 @@ describe('NoteDialogComponent', () => {
   }));
 
   it('does not show text area for users without write permissions', fakeAsync(() => {
-    const verseRef = VerseRef.parse('MAT 1:3');
+    const verseRef = new VerseRef('MAT 1:3');
     env = new TestEnvironment({ currentUserId: 'user02', verseRef });
     expect(env.noteInputElement).toBeNull();
     expect(env.saveButton).toBeNull();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -312,7 +312,7 @@ export class NoteDialogComponent implements OnInit {
     }
     const reattachedParts: string[] = note.reattached.split(REATTACH_SEPARATOR);
     const verseStr: string = reattachedParts[0];
-    const vref: VerseRef = VerseRef.parse(verseStr);
+    const vref: VerseRef = new VerseRef(verseStr);
     const verseRef: string = this.i18n.localizeReference(vref);
     const reattached: string = translate('note_dialog.reattached');
     return `${verseRef} ${reattached}`;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -137,10 +137,10 @@ describe('I18nService', () => {
   it('should localize references', () => {
     when(mockedTranslocoService.translate<string>('canon.book_names.GEN')).thenReturn('Genesis');
     const service = getI18nService();
-    expect(service.localizeReference(VerseRef.parse('GEN 1:2-3'))).toBe('Genesis 1:2-3');
+    expect(service.localizeReference(new VerseRef('GEN 1:2-3'))).toBe('Genesis 1:2-3');
     service.setLocale('ar', mockedAuthService);
     // Expect right to left mark before : and - characters
-    expect(service.localizeReference(VerseRef.parse('GEN 1:2-3'))).toBe('Genesis 1\u200F:2\u200F-3');
+    expect(service.localizeReference(new VerseRef('GEN 1:2-3'))).toBe('Genesis 1\u200F:2\u200F-3');
   });
 });
 


### PR DESCRIPTION
This PR updates the npm package `@sillsdev/scripture` to the latest version (1.4.0). This update is a requirement for the Biblical Terms feature to be rebased onto master.

This change:

 * Updates Scripture Forge to use the correct constructors for `VerseRef`
 * Replaces use of the `VerseRef.parse` function with the `VerseRef` constructor
 * Replaces the previous Old Testament canon calculation code with `Canon.isBookOT()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1971)
<!-- Reviewable:end -->
