### PR TITLE
SF-2158 Support for uploading large audio files

### DIFF
--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
@@ -1,10 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Net.Http.Headers;
 using SIL.XForge.Scripture.Services;
 using SIL.XForge.Services;
 
@@ -18,17 +21,20 @@ namespace SIL.XForge.Scripture.Controllers;
 public class SFProjectsUploadController : ControllerBase
 {
     private readonly IExceptionHandler _exceptionHandler;
+    private readonly IFileSystemService _fileSystemService;
     private readonly IUserAccessor _userAccessor;
     private readonly ISFProjectService _projectService;
 
     public SFProjectsUploadController(
         IUserAccessor userAccessor,
         ISFProjectService projectService,
+        IFileSystemService fileSystemService,
         IExceptionHandler exceptionHandler
     )
     {
         _userAccessor = userAccessor;
         _projectService = projectService;
+        _fileSystemService = fileSystemService;
         _exceptionHandler = exceptionHandler;
         _exceptionHandler.RecordUserIdForException(_userAccessor.UserId);
     }
@@ -36,37 +42,125 @@ public class SFProjectsUploadController : ControllerBase
     /// <summary>
     /// Uploads an audio file.
     /// </summary>
-    /// <param name="projectId">The project identifier.</param>
-    /// <param name="dataId">The data identifier.</param>
-    /// <param name="file">The file contents.</param>
     /// <response code="200">The file was uploaded successfully.</response>
     /// <response code="400">The data or parameters were malformed.</response>
     /// <response code="403">Insufficient permission to upload a file to this project.</response>
     /// <response code="404">The project does not exist.</response>
     [HttpPost("audio")]
-    [RequestSizeLimit(100_000_000)]
-    public async Task<IActionResult> UploadAudioAsync(
-        [FromForm] string projectId,
-        [FromForm] string dataId,
-        [FromForm] IFormFile? file
-    )
+    [RequestSizeLimit(300_000_000)]
+    public async Task<IActionResult> UploadAudioAsync()
     {
+        // Declare the form values
+        string projectId = string.Empty;
+        string dataId = string.Empty;
+        string path = string.Empty;
+
+        // The following code handles via upload via streaming to avoid request and form limits in ASP.NET Core
+        // To increase or decrease the file size limit, modify the RequestSizeLimit attribute for this method
         try
         {
-            // Ensure we have a file
-            if (file is null)
+            // The Content-Type must be a form-data request, and a boundary should be found in it
+            if (
+                !Request.HasFormContentType
+                || !MediaTypeHeaderValue.TryParse(Request.ContentType, out var mediaTypeHeader)
+                || string.IsNullOrEmpty(mediaTypeHeader.Boundary.Value)
+            )
             {
                 return BadRequest();
             }
 
-            await using Stream stream = file.OpenReadStream();
-            Uri uri = await _projectService.SaveAudioAsync(
-                _userAccessor.UserId,
-                projectId,
-                dataId,
-                Path.GetExtension(file.FileName),
-                stream
-            );
+            // Read the multipart data
+            MultipartReader reader = new MultipartReader(mediaTypeHeader.Boundary.Value, Request.Body);
+            MultipartSection section = await reader.ReadNextSectionAsync();
+
+            // Iterate over each multipart section
+            while (section is not null)
+            {
+                bool hasContentDisposition = ContentDispositionHeaderValue.TryParse(
+                    section.ContentDisposition,
+                    out var contentDisposition
+                );
+
+                if (
+                    hasContentDisposition
+                    && contentDisposition.DispositionType.Equals("form-data")
+                    && !string.IsNullOrEmpty(contentDisposition.FileName.Value)
+                )
+                {
+                    // If we have a filename, get the file being uploaded...
+
+                    // Get the filename so we can get the extension
+                    string fileName = contentDisposition.FileName.Value ?? string.Empty;
+
+                    // Strip invalid characters from the file name
+                    fileName = Path.GetInvalidFileNameChars()
+                        .Aggregate(fileName, (current, c) => current.Replace(c.ToString(), string.Empty));
+
+                    // Get the path to the temporary file
+                    path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + Path.GetExtension(fileName));
+
+                    // Write the incoming file data to the temporary file
+                    await using Stream fileStream = _fileSystemService.CreateFile(path);
+                    await section.Body.CopyToAsync(fileStream);
+                }
+                else if (
+                    hasContentDisposition
+                    && contentDisposition.DispositionType.Equals("form-data")
+                    && string.IsNullOrEmpty(contentDisposition.FileName.Value)
+                    && string.IsNullOrEmpty(contentDisposition.FileNameStar.Value)
+                )
+                {
+                    // If we do not have a filename, get the other form data...
+
+                    // Get the media type encoding
+                    bool hasMediaTypeHeader = MediaTypeHeaderValue.TryParse(section.ContentType, out var mediaType);
+                    // Disable the following warning: The UTF-7 encoding is insecure and should not be used.
+#pragma warning disable SYSLIB0001
+                    // As UTF-7 is insecure, substitute UTF-8. If no encoding is specified, default to UTF-8
+                    Encoding encoding =
+                        !hasMediaTypeHeader || Encoding.UTF7.Equals(mediaType.Encoding) || mediaType.Encoding is null
+                            ? Encoding.UTF8
+                            : mediaType.Encoding;
+#pragma warning restore SYSLIB0001
+
+                    using StreamReader streamReader = new StreamReader(
+                        section.Body,
+                        encoding,
+                        detectEncodingFromByteOrderMarks: true,
+                        bufferSize: 1024,
+                        leaveOpen: true
+                    );
+
+                    // The value length limit is enforced by MultipartBodyLengthLimit
+                    string value = await streamReader.ReadToEndAsync();
+                    if (string.Equals(value, "undefined", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    // Collect the required form values
+                    switch (HeaderUtilities.RemoveQuotes(contentDisposition.Name).Value)
+                    {
+                        case "projectId":
+                            projectId = value;
+                            break;
+                        case "dataId":
+                            dataId = value;
+                            break;
+                    }
+                }
+
+                section = await reader.ReadNextSectionAsync();
+            }
+
+            // Throw an error if we do not have the required data
+            if (string.IsNullOrEmpty(projectId) || string.IsNullOrEmpty(dataId) || string.IsNullOrWhiteSpace(path))
+            {
+                return BadRequest();
+            }
+
+            // Convert and save the audio file
+            Uri uri = await _projectService.SaveAudioAsync(_userAccessor.UserId, projectId, dataId, path);
             return Created(uri.PathAndQuery, Path.GetFileName(uri.AbsolutePath));
         }
         catch (ForbiddenException)
@@ -92,6 +186,14 @@ public class SFProjectsUploadController : ControllerBase
                 }
             );
             throw;
+        }
+        finally
+        {
+            // Delete the temporary file, if it still exists
+            if (!string.IsNullOrEmpty(path) && _fileSystemService.FileExists(path))
+            {
+                _fileSystemService.DeleteFile(path);
+            }
         }
     }
 }

--- a/src/SIL.XForge/Services/IAudioService.cs
+++ b/src/SIL.XForge/Services/IAudioService.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using System.Threading.Tasks;
 
 namespace SIL.XForge.Services;
@@ -6,5 +5,5 @@ namespace SIL.XForge.Services;
 public interface IAudioService
 {
     Task ConvertToMp3Async(string inputPath, string outputPath);
-    Task<bool> IsMp3DataAsync(Stream stream);
+    Task<bool> IsMp3FileAsync(string path);
 }

--- a/src/SIL.XForge/Services/IProjectService.cs
+++ b/src/SIL.XForge/Services/IProjectService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Threading.Tasks;
 
 namespace SIL.XForge.Services;
@@ -11,7 +10,7 @@ public interface IProjectService
     Task RemoveUserWithoutPermissionsCheckAsync(string curUserId, string projectId, string projectUserId);
     Task<string> GetProjectRoleAsync(string curUserId, string projectId);
     Task UpdateRoleAsync(string curUserId, string systemRole, string projectId, string projectRole);
-    Task<Uri> SaveAudioAsync(string curUserId, string projectId, string dataId, string extension, Stream inputStream);
+    Task<Uri> SaveAudioAsync(string curUserId, string projectId, string dataId, string path);
     Task DeleteAudioAsync(string curUserId, string projectId, string ownerId, string dataId);
     Task SetSyncDisabledAsync(string curUserId, string systemRole, string projectId, bool isDisabled);
     Task RemoveUserFromAllProjectsAsync(string curUserId, string projectUserId);

--- a/test/SIL.XForge.Tests/Services/AudioServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/AudioServiceTests.cs
@@ -12,103 +12,107 @@ namespace SIL.XForge.Services;
 internal class AudioServiceTests
 {
     [Test]
-    public async Task IsMp3DataAsync_EmptyStream()
+    public async Task IsMp3FileAsync_EmptyStream()
     {
         var env = new TestEnvironment();
+        const string path = "file.mp3";
         await using var stream = new MemoryStream(Array.Empty<byte>());
+        env.FileSystemService.OpenFile(path, FileMode.Open).Returns(stream);
 
         // SUT
-        var result = await env.Service.IsMp3DataAsync(stream);
+        var result = await env.Service.IsMp3FileAsync(path);
         Assert.False(result);
     }
 
     [Test]
-    public async Task IsMp3DataAsync_InvalidData()
+    public async Task IsMp3FileAsync_InvalidData()
     {
         var env = new TestEnvironment();
+        const string path = "file.mp3";
         await using var stream = new MemoryStream(new byte[] { 0x44, 0x2E, 0x56, 0x2E });
+        env.FileSystemService.OpenFile(path, FileMode.Open).Returns(stream);
 
         // SUT
-        var result = await env.Service.IsMp3DataAsync(stream);
+        var result = await env.Service.IsMp3FileAsync(path);
         Assert.False(result);
     }
 
     [Test]
-    public async Task IsMp3DataAsync_StreamTooShort()
+    public async Task IsMp3FileAsync_StreamTooShort()
     {
         var env = new TestEnvironment();
+        const string path = "file.mp3";
         await using var stream = new MemoryStream(new byte[] { 0xFF, 0xFF });
+        env.FileSystemService.OpenFile(path, FileMode.Open).Returns(stream);
 
         // SUT
-        var result = await env.Service.IsMp3DataAsync(stream);
+        var result = await env.Service.IsMp3FileAsync(path);
         Assert.False(result);
     }
 
     [Test]
-    public async Task IsMp3DataAsync_NullStream()
+    public async Task IsMp3FileAsync_NullStream()
     {
         var env = new TestEnvironment();
+        const string path = "file.mp3";
         await using var stream = new MemoryStream(new byte[] { 0x0, 0x0, 0x0, 0x0 });
+        env.FileSystemService.OpenFile(path, FileMode.Open).Returns(stream);
 
         // SUT
-        var result = await env.Service.IsMp3DataAsync(stream);
+        var result = await env.Service.IsMp3FileAsync(path);
         Assert.False(result);
     }
 
     [Test]
-    public async Task IsMp3DataAsync_MP3WithIDv3()
+    public async Task IsMp3FileAsync_MP3WithIDv3()
     {
         var env = new TestEnvironment();
+        const string path = "file.mp3";
         await using var stream = new MemoryStream(new byte[] { 0x49, 0x44, 0x33, 0x03 });
+        env.FileSystemService.OpenFile(path, FileMode.Open).Returns(stream);
 
         // SUT
-        var result = await env.Service.IsMp3DataAsync(stream);
+        var result = await env.Service.IsMp3FileAsync(path);
         Assert.True(result);
     }
 
     [Test]
-    public async Task IsMp3DataAsync_MP3WithFFE()
+    public async Task IsMp3FileAsync_MP3WithFFE()
     {
         var env = new TestEnvironment();
+        const string path = "file.mp3";
         await using var stream = new MemoryStream(new byte[] { 0xFF, 0xEB, 0x10, 0x0 });
+        env.FileSystemService.OpenFile(path, FileMode.Open).Returns(stream);
 
         // SUT
-        var result = await env.Service.IsMp3DataAsync(stream);
+        var result = await env.Service.IsMp3FileAsync(path);
         Assert.True(result);
     }
 
     [Test]
-    public async Task IsMp3DataAsync_MP3WithFFF()
+    public async Task IsMp3FileAsync_MP3WithFFF()
     {
         var env = new TestEnvironment();
+        const string path = "file.mp3";
         await using var stream = new MemoryStream(new byte[] { 0xFF, 0xF3, 0x28, 0xC4 });
+        env.FileSystemService.OpenFile(path, FileMode.Open).Returns(stream);
 
         // SUT
-        var result = await env.Service.IsMp3DataAsync(stream);
+        var result = await env.Service.IsMp3FileAsync(path);
         Assert.True(result);
     }
 
     [Test]
-    public async Task IsMp3DataAsync_MP3WithNullHeader()
+    public async Task IsMp3FileAsync_MP3WithNullHeader()
     {
         var env = new TestEnvironment();
+        const string path = "file.mp3";
         await using var stream = new MemoryStream(new byte[] { 0x0, 0x0, 0x0, 0xFF, 0xF3, 0x28, 0xC4 });
+        env.FileSystemService.OpenFile(path, FileMode.Open).Returns(stream);
 
         // SUT
-        var result = await env.Service.IsMp3DataAsync(stream);
+        var result = await env.Service.IsMp3FileAsync(path);
         Assert.True(result);
-    }
-
-    [Test]
-    public async Task IsMp3DataAsync_ResetsStreamPosition()
-    {
-        var env = new TestEnvironment();
-        await using var stream = new MemoryStream(new byte[] { 0x49, 0x44, 0x33, 0x0 });
-
-        // SUT
-        var result = await env.Service.IsMp3DataAsync(stream);
-        Assert.True(result);
-        Assert.Zero(stream.Position);
     }
 
     private class TestEnvironment
@@ -116,9 +120,11 @@ internal class AudioServiceTests
         public TestEnvironment()
         {
             IOptions<AudioOptions> audioOptions = Substitute.For<IOptions<AudioOptions>>();
-            Service = new AudioService(audioOptions);
+            FileSystemService = Substitute.For<IFileSystemService>();
+            Service = new AudioService(audioOptions, FileSystemService);
         }
 
+        public IFileSystemService FileSystemService { get; }
         public AudioService Service { get; }
     }
 }


### PR DESCRIPTION
This Pull Request:
 * Allows audio file uploads of up to ~300MB (can be changed to any larger value as required)
 * Changes the audio upload endpoint to stream incoming data to a temporary file to allow large file upload support
 * Updated MP3 checking and audio file conversion to use the file path directly

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1973)
<!-- Reviewable:end -->
