### PR TITLE
SF-2159 Added GetLastCompletedPreTranslationBuild

### DIFF
--- a/src/SIL.XForge.Scripture/Models/MachineApi.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApi.cs
@@ -18,6 +18,8 @@ public static class MachineApi
     public const string CancelPreTranslationBuild = "translation/pretranslations/cancel";
     public const string GetPreTranslation =
         "translation/engines/project:{sfProjectId}/actions/preTranslate/{bookNum}_{chapterNum}";
+    public const string GetLastCompletedPreTranslationBuild =
+        "translation/engines/project:{sfProjectId}/actions/getLastCompletedPreTranslationBuild";
 
     public static string GetBuildHref(string sfProjectId, string buildId)
     {

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -25,6 +25,11 @@ public interface IMachineApiService
         CancellationToken cancellationToken
     );
     Task<EngineDto> GetEngineAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
+    Task<BuildDto?> GetLastCompletedPreTranslationBuildAsync(
+        string curUserId,
+        string sfProjectId,
+        CancellationToken cancellationToken
+    );
     Task<PreTranslationDto> GetPreTranslationAsync(
         string curUserId,
         string sfProjectId,

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -510,6 +510,98 @@ public class MachineApiControllerTests
     }
 
     [Test]
+    public async Task GetLastCompletedPreTranslationBuildAsync_MachineApiDown()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetLastCompletedPreTranslationBuildAsync(
+            Project01,
+            CancellationToken.None
+        );
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+        Assert.IsInstanceOf<ObjectResult>(actual.Result);
+        Assert.AreEqual(StatusCodes.Status503ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
+    }
+
+    [Test]
+    public async Task GetLastCompletedPreTranslationBuildAsync_NoCompletedBuild()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            .Returns(Task.FromResult<BuildDto>(null));
+
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetLastCompletedPreTranslationBuildAsync(
+            Project01,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<NoContentResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetLastCompletedPreTranslationBuildAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            .Throws(new ForbiddenException());
+
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetLastCompletedPreTranslationBuildAsync(
+            Project01,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<ForbidResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetLastCompletedPreTranslationBuildAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            .Throws(new DataNotFoundException(string.Empty));
+
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetLastCompletedPreTranslationBuildAsync(
+            Project01,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetLastCompletedPreTranslationBuildAsync_Success()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            .Returns(Task.FromResult(new BuildDto()));
+
+        // SUT
+        ActionResult<BuildDto?> actual = await env.Controller.GetLastCompletedPreTranslationBuildAsync(
+            Project01,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+    }
+
+    [Test]
     public async Task GetPreTranslationAsync_MachineApiDown()
     {
         // Set up test environment

--- a/test/SIL.XForge.Scripture.Tests/Services/ServalApiExceptions.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ServalApiExceptions.cs
@@ -19,6 +19,15 @@ public static class ServalApiExceptions
             null
         );
 
+    public static ServalApiException InternalServerError =>
+        new ServalApiException(
+            "The HTTP status code of the response was not expected (500).",
+            StatusCodes.Status500InternalServerError,
+            null,
+            new Dictionary<string, IEnumerable<string>>(),
+            null
+        );
+
     public static ServalApiException NoContent =>
         new ServalApiException(
             "There is no build currently running.",


### PR DESCRIPTION
This Pull Request adds another endpoint to the V3 machine-api to allow the translation drafting frontend to discover if there have been any successful pre-translation builds in the past. If such a build exists, this means that the pre-translation draft for a chapter can be retrieved from Serval.

The new endpoint (which can be tested with Swagger) is: `/machine-api/v3/translation/engines/project:{sfProjectId}/actions/getLastCompletedPreTranslationBuild`

I also took the opportunity with this PR to plug a couple of minor gaps in the test coverage I found when calculating the test coverage data for the new API endpoint.

As this is a new API endpoint, regression testing is not needed, but developer acceptance testing that the endpoint serves the functionality requirement for the pre-translation frontend is required.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1975)
<!-- Reviewable:end -->
