### PR TITLE
SF-2136 Log warnings when SF attempts to push comments to PT

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1363,7 +1363,7 @@ public class ParatextService : DisposableBase, IParatextService
         );
 
         // TODO: Remove these warning logs once the feature is tested and implemented
-        string sfCommentWarning = "SF Comment Warning: ";
+        string sfCommentWarning = "SF Comment Warning:";
         ScrText scrText =
             ScrTextCollection.FindById(username, paratextId)
             ?? throw new DataNotFoundException("Can't get access to cloned project.");
@@ -1384,12 +1384,12 @@ public class ParatextService : DisposableBase, IParatextService
                     );
                 else
                 {
-                    if (existingComment.Contents?.ToString() != comment.Contents?.ToString())
+                    if (existingComment.Contents?.OuterXml != comment.Contents?.OuterXml)
                         _logger.LogWarning(
-                            $"{sfCommentWarning} Comment contents differ\n {existingComment.Contents?.ToString()} \n {comment.Contents?.ToString()}"
+                            $"{sfCommentWarning} Comment contents differ\n{existingComment.Contents?.OuterXml}\n{comment.Contents?.OuterXml}"
                         );
                     _logger.LogWarning(
-                        sfCommentWarning + "Updating sf comment before feature enabled. ID: " + comment.Thread
+                        $"{sfCommentWarning} Updating SF comment before feature enabled. ID: " + comment.Thread
                     );
                 }
             }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -543,7 +543,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 // Only update the note tag if there are SF note threads in the project
                 if (noteThreadDocs.Any(d => d.Data.PublishedToSF == true))
                     await UpdateTranslateNoteTag(paratextId);
-                /*
+
                 int sfNoteTagId = _projectDoc.Data.TranslateConfig.DefaultNoteTagId ?? NoteTag.notSetId;
                 _syncMetrics.ParatextNotes += await _paratextService.UpdateParatextCommentsAsync(
                     _userSecret,
@@ -554,7 +554,6 @@ public class ParatextSyncRunner : IParatextSyncRunner
                     _currentPtSyncUsers,
                     sfNoteTagId
                 );
-                */
             }
         }
     }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -2134,6 +2134,7 @@ public class ParatextServiceTests
     }
 
     [Test]
+    [Ignore("Not ready to push SF comments to PT")]
     public async Task UpdateParatextComments_AddsComment()
     {
         var env = new TestEnvironment();
@@ -2259,6 +2260,7 @@ public class ParatextServiceTests
     }
 
     [Test]
+    [Ignore("Not ready to push SF comments to PT")]
     public async Task UpdateParatextComments_AddsCommentTagIdNotSet()
     {
         var env = new TestEnvironment();
@@ -2302,6 +2304,7 @@ public class ParatextServiceTests
     }
 
     [Test]
+    [Ignore("Not ready to push SF comments to PT")]
     public async Task UpdateParatextComments_EditsComment()
     {
         var env = new TestEnvironment();
@@ -2488,6 +2491,7 @@ public class ParatextServiceTests
     }
 
     [Test]
+    [Ignore("Not ready to push SF comments to PT")]
     public async Task UpdateParatextComments_DeleteComment()
     {
         var env = new TestEnvironment();

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1693,7 +1693,6 @@ public class ParatextSyncRunnerTests
     }
 
     [Test]
-    [Ignore("Not ready to send note changes")]
     public async Task SyncAsync_UpdatesParatextComments()
     {
         var env = new TestEnvironment();
@@ -1735,7 +1734,6 @@ public class ParatextSyncRunnerTests
     }
 
     [Test]
-    [Ignore("Not ready to send note changes")]
     public async Task SyncAsync_AddParatextComments()
     {
         var env = new TestEnvironment();


### PR DESCRIPTION
While the notes feature is behind a feature flag, we do not expect user to be pushing comments to PT. This change introduces warning logs when a project is attempting to push those changes, but prevents those changes from being pushed. We can monitor these logs to see when we have a more robust note roundtripping system. To test this, you can enable the feature flag and create a note in SF and see the warning in the output console when you try to synchronize the project with PT.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1978)
<!-- Reviewable:end -->
