### PR TITLE
SF-2150 Do not highlight section headings in community checking

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.spec.ts
@@ -51,35 +51,35 @@ describe('CheckingTextComponent', () => {
     const env = new TestEnvironment();
     env.wait();
     expect(env.segmentHasQuestion(1, 1)).toBe(true);
-    expect(env.isSegmentHighlighted(1, 1)).toBe(true);
+    expect(env.isSegmentHighlighted('verse_1_1')).toBe(true);
     // verse 2 is blank
     expect(env.segmentHasQuestion(1, 3)).toBe(true);
-    expect(env.isSegmentHighlighted(1, 3)).toBe(false);
+    expect(env.isSegmentHighlighted('verse_1_3')).toBe(false);
     expect(env.segmentHasQuestion(1, 4)).toBe(false);
-    expect(env.isSegmentHighlighted(1, 4)).toBe(false);
+    expect(env.isSegmentHighlighted('verse_1_4')).toBe(false);
 
     // change 2nd question from v3 to v4
     env.component.questionVerses = [new VerseRef(40, 1, 1), new VerseRef(40, 1, 4)];
 
     env.wait();
     expect(env.segmentHasQuestion(1, 1)).toBe(true);
-    expect(env.isSegmentHighlighted(1, 1)).toBe(true);
+    expect(env.isSegmentHighlighted('verse_1_1')).toBe(true);
     expect(env.segmentHasQuestion(1, 3)).toBe(false);
-    expect(env.isSegmentHighlighted(1, 3)).toBe(false);
+    expect(env.isSegmentHighlighted('verse_1_3')).toBe(false);
     expect(env.segmentHasQuestion(1, 4)).toBe(true);
-    expect(env.isSegmentHighlighted(1, 4)).toBe(false);
+    expect(env.isSegmentHighlighted('verse_1_4')).toBe(false);
   }));
 
   it('should highlight the new verse when the question moves verses and is now active', fakeAsync(() => {
     const env = new TestEnvironment();
     env.wait();
     expect(env.segmentHasQuestion(1, 1)).toBe(true);
-    expect(env.isSegmentHighlighted(1, 1)).toBe(true);
+    expect(env.isSegmentHighlighted('verse_1_1')).toBe(true);
     // verse 2 is blank
     expect(env.segmentHasQuestion(1, 3)).toBe(true);
-    expect(env.isSegmentHighlighted(1, 3)).toBe(false);
+    expect(env.isSegmentHighlighted('verse_1_3')).toBe(false);
     expect(env.segmentHasQuestion(1, 4)).toBe(false);
-    expect(env.isSegmentHighlighted(1, 4)).toBe(false);
+    expect(env.isSegmentHighlighted('verse_1_4')).toBe(false);
 
     // change 2nd question from v3 to v4 and make it active
     const activeVerse = new VerseRef(40, 1, 4);
@@ -88,11 +88,11 @@ describe('CheckingTextComponent', () => {
 
     env.wait();
     expect(env.segmentHasQuestion(1, 1)).toBe(true);
-    expect(env.isSegmentHighlighted(1, 1)).toBe(false);
+    expect(env.isSegmentHighlighted('verse_1_1')).toBe(false);
     expect(env.segmentHasQuestion(1, 3)).toBe(false);
-    expect(env.isSegmentHighlighted(1, 3)).toBe(false);
+    expect(env.isSegmentHighlighted('verse_1_3')).toBe(false);
     expect(env.segmentHasQuestion(1, 4)).toBe(true);
-    expect(env.isSegmentHighlighted(1, 4)).toBe(true);
+    expect(env.isSegmentHighlighted('verse_1_4')).toBe(true);
   }));
 
   it('should show related questions when the text changes ', fakeAsync(() => {
@@ -119,7 +119,9 @@ describe('CheckingTextComponent', () => {
     env.wait();
     expect(env.segmentHasQuestion(1, 1)).toBe(false);
     expect(env.segmentHasQuestion(1, '2-3')).toBe(true);
-    expect(env.isSegmentHighlighted(1, '2-3')).toBe(true);
+    expect(env.isSegmentHighlighted('verse_1_2-3')).toBe(true);
+    expect(env.isSegmentHighlighted('s_2')).toBe(false);
+    expect(env.getSegmentElement('s_2')!.classList).not.toContain('question-segment');
   }));
 
   it('can set text direction explicitly', fakeAsync(() => {
@@ -181,13 +183,19 @@ class TestEnvironment {
     this.fixture.detectChanges();
   }
 
-  isSegmentHighlighted(chapter: number, verse: number | string): boolean {
-    const segment = this.quillEditor.querySelector(`usx-segment[data-segment="verse_${chapter}_${verse}"]`)!;
+  getSegmentElement(segmentRef: string): HTMLElement | null {
+    return this.quillEditor.querySelector(`usx-segment[data-segment="${segmentRef}"]`);
+  }
+
+  isSegmentHighlighted(segmentRef: string): boolean {
+    const segment: HTMLElement | null = this.getSegmentElement(segmentRef)!;
     return segment != null && segment.classList.contains('highlight-segment');
   }
 
   segmentHasQuestion(chapter: number, verse: number | string): boolean {
-    const segment = this.quillEditor.querySelector(`usx-segment[data-segment="verse_${chapter}_${verse}"]`)!;
+    const segment: HTMLElement | null = this.quillEditor.querySelector(
+      `usx-segment[data-segment="verse_${chapter}_${verse}"]`
+    )!;
     return segment != null && segment.classList.contains('question-segment');
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
@@ -31,7 +31,7 @@ export class CheckingTextComponent extends SubscriptionDisposable {
     this._placeholder = value;
   }
 
-  get placeholder() {
+  get placeholder(): string {
     return this._placeholder || translate('text.loading');
   }
 
@@ -93,7 +93,11 @@ export class CheckingTextComponent extends SubscriptionDisposable {
     if (!this.isEditorLoaded || this.questionVerses == null) {
       return;
     }
-    const segments = this.textComponent.toggleFeaturedVerseRefs(value, this.questionVersesInCurrentText, 'question');
+    const segments: string[] = this.textComponent.toggleFeaturedVerseRefs(
+      value,
+      this.questionVersesInCurrentText,
+      'question'
+    );
     if (value) {
       this.subscribeClickEvents(segments);
     } else {
@@ -109,7 +113,8 @@ export class CheckingTextComponent extends SubscriptionDisposable {
       return;
     }
 
-    const refs = this.textComponent.getVerseSegments(this._activeVerse);
+    const refs: string[] =
+      this._activeVerse != null ? this.textComponent.getVerseSegmentsNoHeadings(this._activeVerse) : [];
     this.textComponent.highlight(refs);
   }
 
@@ -124,7 +129,7 @@ export class CheckingTextComponent extends SubscriptionDisposable {
           if (this._id == null) {
             return;
           }
-          const verseRef = verseRefFromMouseEvent(event, this._id.bookNum);
+          const verseRef: VerseRef | undefined = verseRefFromMouseEvent(event, this._id.bookNum);
           if (verseRef != null) {
             this.questionVerseSelected.emit(verseRef);
           }
@@ -133,10 +138,10 @@ export class CheckingTextComponent extends SubscriptionDisposable {
     }
   }
 
-  private scrollToActiveVerse() {
+  private scrollToActiveVerse(): void {
     if (this.activeVerse != null && this.textComponent.editor != null) {
-      const firstSegment = this.textComponent.getVerseSegments(this.activeVerse)[0];
-      const editor = this.textComponent.editor.container.querySelector('.ql-editor');
+      const firstSegment: string = this.textComponent.getVerseSegments(this.activeVerse)[0];
+      const editor: Element | null = this.textComponent.editor.container.querySelector('.ql-editor');
       if (firstSegment != null && editor != null) {
         const element = this.textComponent.getSegmentElement(firstSegment) as HTMLElement;
         if (element != null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
@@ -142,8 +142,8 @@ export class CheckingTextComponent extends SubscriptionDisposable {
     if (this.activeVerse != null && this.textComponent.editor != null) {
       const firstSegment: string = this.textComponent.getVerseSegments(this.activeVerse)[0];
       const editor: Element | null = this.textComponent.editor.container.querySelector('.ql-editor');
-      if (firstSegment != null && editor != null) {
-        const element = this.textComponent.getSegmentElement(firstSegment) as HTMLElement;
+      if (editor != null) {
+        const element: HTMLElement = this.textComponent.getSegmentElement(firstSegment) as HTMLElement;
         if (element != null) {
           editor.scrollTo({ top: element.offsetTop - 20, behavior: 'smooth' });
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -686,7 +686,9 @@ class TestEnvironment {
   }
 
   isSegmentHighlighted(verse: string): boolean {
-    const segment = this.quillEditor.querySelector('usx-segment[data-segment=verse_1_' + verse + ']')!;
+    const segment: HTMLElement | null = this.quillEditor.querySelector(
+      'usx-segment[data-segment=verse_1_' + verse + ']'
+    )!;
     return segment.classList.toString().includes('highlight-segment');
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -532,6 +532,11 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     return segments.filter(s => verseRef.verse === (getVerseStrFromSegmentRef(s) ?? defaultValue));
   }
 
+  getVerseSegmentsNoHeadings(verseRef: VerseRef): string[] {
+    const segments: string[] = this.getVerseSegments(verseRef);
+    return segments.filter(s => VERSE_REGEX.test(s));
+  }
+
   getSegmentElement(segment: string): Element | null {
     return this.editor == null ? null : this.editor.container.querySelector(`usx-segment[data-segment="${segment}"]`);
   }
@@ -552,7 +557,8 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     const verseFeatureCount = new Map<string, number>();
     const chapterFeaturedVerseRefs: VerseRef[] = featureVerseRefs.filter(fvr => fvr.chapterNum === this.id!.chapterNum);
     for (const verseRef of chapterFeaturedVerseRefs) {
-      const featuredVerseSegments: string[] = this.viewModel.getVerseSegments(verseRef);
+      const featuredVerseSegments: string[] =
+        featureName === 'question' ? this.getVerseSegmentsNoHeadings(verseRef) : this.getVerseSegments(verseRef);
       if (featuredVerseSegments.length === 0) {
         continue;
       }


### PR DESCRIPTION
Section headings and other headings do not need to be highlighted when a verse is highlighted in the community checking tool. This change filters out segments that do not belong to a specific verse and only highlights those segments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1981)
<!-- Reviewable:end -->
