### PR TITLE
SF-2141 Do not show an offline error when pasting a sharing link twice

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.spec.ts
@@ -65,6 +65,20 @@ describe('JoinComponent', () => {
     expect().nothing();
   }));
 
+  it('check sharing link does not show offline error when online', fakeAsync(() => {
+    var env = new TestEnvironment({ isLoggedIn: true, isOnline: true });
+
+    // Set the online status again to trigger updateOfflineJoiningStatus a second time
+    env.onlineStatus = true;
+    tick();
+
+    verify(mockedSFProjectService.onlineJoinWithShareKey(anything())).once();
+    verify(mockedDialogService.message(anything())).never();
+    verify(mockedRouter.navigateByUrl('/projects/project01', anything())).once();
+    verify(mockedRouter.navigateByUrl('/projects', anything())).never();
+    expect().nothing();
+  }));
+
   it('check sharing link forbidden', fakeAsync(() => {
     const callback = (_: TestEnvironment): void => {
       when(mockedSFProjectService.onlineJoinWithShareKey(anything())).thenReject(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
@@ -170,12 +170,9 @@ export class JoinComponent extends DataLoadingComponent {
     if (this.pwaService.isOnline && this.status === 'unavailable') {
       this.name.enable();
       this.status = 'input';
-      return;
-    }
-    if (await this.authService.isLoggedIn) {
+    } else if (!this.pwaService.isOnline && (await this.authService.isLoggedIn)) {
       await this.dialogService.message('join.please_connect_to_use_link');
       this.router.navigateByUrl('/projects', { replaceUrl: true });
-      return;
     } else {
       this.name.disable();
       this.status = 'unavailable';


### PR DESCRIPTION
When pasting a sharing link into an already logged in session, an error stating "Please connect to the internet to join a project using a link." is displayed and the user is redirected to the /projects page, and then the last project open.

This bug occurs because of incorrect logic that checks if the user is offline.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1984)
<!-- Reviewable:end -->
