### PR TITLE
SF-2173 Restrict note updating in Scripture Forge

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/note.ts
+++ b/src/RealtimeServer/scriptureforge/models/note.ts
@@ -13,4 +13,6 @@ export interface Note extends Comment {
   assignment?: string;
   content?: string;
   acceptedChangeXml?: string;
+  editable?: boolean;
+  versionNumber?: number;
 }

--- a/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
@@ -25,6 +25,8 @@ export class NoteThreadService extends SFProjectDataService<NoteThread> {
       this.pathTemplate(t => t.originalSelectedText),
       this.pathTemplate(t => t.notes[ANY_INDEX].dataId),
       this.pathTemplate(t => t.notes[ANY_INDEX].ownerRef),
+      this.pathTemplate(t => t.notes[ANY_INDEX].editable),
+      this.pathTemplate(t => t.notes[ANY_INDEX].versionNumber),
       this.pathTemplate(t => t.notes[ANY_INDEX].dateCreated)
     ];
     this.immutableProps.push(...immutableProps);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -973,7 +973,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       conflictType: NoteConflictType.DefaultValue,
       type: NoteType.Normal,
       status: NoteStatus.Todo,
-      deleted: false
+      deleted: false,
+      editable: true,
+      versionNumber: 1
     };
     if (params.threadDataId == null) {
       if (params.verseRef == null) return;
@@ -1000,10 +1002,14 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       );
       const noteIndex: number = threadDoc.data!.notes.findIndex(n => n.dataId === params.dataId);
       if (noteIndex >= 0) {
-        await threadDoc!.submitJson0Op(op => {
-          op.set(t => t.notes[noteIndex].content, params.content);
-          op.set(t => t.notes[noteIndex].dateModified, currentDate);
-        });
+        if (threadDoc.data?.notes[noteIndex].editable === true) {
+          await threadDoc!.submitJson0Op(op => {
+            op.set(t => t.notes[noteIndex].content, params.content);
+            op.set(t => t.notes[noteIndex].dateModified, currentDate);
+          });
+        } else {
+          this.dialogService.message(this.i18n.translate('editor.cannot_edit_note_paratext'));
+        }
       } else {
         note.threadId = threadDoc.data!.threadId;
         await threadDoc.submitJson0Op(op => op.add(t => t.notes, note));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -390,7 +390,7 @@ describe('NoteDialogComponent', () => {
   }));
 
   it('allows user to edit the last note in the thread', fakeAsync(() => {
-    env = new TestEnvironment({ noteThread: TestEnvironment.getNoteThread() });
+    env = new TestEnvironment({ noteThread: TestEnvironment.getNoteThread(undefined, undefined, true) });
     // note03 is marked as deleted
     expect(env.notes.length).toEqual(4);
     const noteThread: NoteThreadDoc = env.getNoteThreadDoc('dataid01');
@@ -409,8 +409,18 @@ describe('NoteDialogComponent', () => {
     expect(env.dialogResult).toEqual({ noteContent: content, noteDataId: 'note05' });
   }));
 
-  it('allows user to delete the last note in the thread', fakeAsync(() => {
+  it('does not allow user to edit the last note in the thread if it is not editable', fakeAsync(() => {
     env = new TestEnvironment({ noteThread: TestEnvironment.getNoteThread() });
+    // note03 is marked as deleted
+    expect(env.notes.length).toEqual(4);
+    const noteThread: NoteThreadDoc = env.getNoteThreadDoc('dataid01');
+    expect(noteThread.data!.notes[4].content).toEqual('note05');
+    const noteNumbers = [1, 2, 3, 4];
+    noteNumbers.forEach(n => expect(env.noteHasEditActions(n)).toBe(false));
+  }));
+
+  it('allows user to delete the last note in the thread', fakeAsync(() => {
+    env = new TestEnvironment({ noteThread: TestEnvironment.getNoteThread(undefined, undefined, true) });
     // note03 is marked as deleted
     expect(env.notes.length).toEqual(4);
     const noteThread: NoteThreadDoc = env.getNoteThreadDoc('dataid01');
@@ -425,8 +435,15 @@ describe('NoteDialogComponent', () => {
     expect(noteThread.data!.notes[4].deleted).toBe(true);
   }));
 
-  it('does not delete the note if a user cancels', fakeAsync(() => {
+  it('does not allow deleting a note that is not editable', fakeAsync(() => {
     env = new TestEnvironment({ noteThread: TestEnvironment.getNoteThread() });
+    expect(env.notes.length).toEqual(4);
+    const noteNumbers = [1, 2, 3, 4];
+    noteNumbers.forEach(n => expect(env.noteHasEditActions(n)).toBe(false));
+  }));
+
+  it('does not delete the note if a user cancels', fakeAsync(() => {
+    env = new TestEnvironment({ noteThread: TestEnvironment.getNoteThread(undefined, undefined, true) });
     expect(env.notes.length).toEqual(4);
     when(mockedDialogService.confirm(anything(), anything())).thenResolve(false);
     expect(env.noteHasEditActions(4)).toBe(true);
@@ -575,6 +592,7 @@ class TestEnvironment {
           threadId: 'thread01',
           content: 'thread01',
           deleted: false,
+          editable: true,
           ownerRef: 'user01',
           status: NoteStatus.Todo,
           tagId: 1,
@@ -584,7 +602,7 @@ class TestEnvironment {
       ]
     };
   }
-  static getNoteThread(reattachedContent?: string, isInitialSFNote?: boolean): NoteThread {
+  static getNoteThread(reattachedContent?: string, isInitialSFNote?: boolean, editable?: boolean): NoteThread {
     const type: NoteType = NoteType.Normal;
     const conflictType: NoteConflictType = NoteConflictType.DefaultValue;
     const tagId: number | undefined = isInitialSFNote === true ? undefined : 1;
@@ -609,6 +627,7 @@ class TestEnvironment {
           threadId: 'thread01',
           content: 'note',
           deleted: false,
+          editable,
           ownerRef: 'user01',
           status: NoteStatus.Todo,
           tagId,
@@ -623,6 +642,7 @@ class TestEnvironment {
           threadId: 'thread01',
           content: 'note02',
           deleted: false,
+          editable,
           ownerRef: 'user01',
           status: NoteStatus.Resolved,
           tagId,
@@ -637,6 +657,7 @@ class TestEnvironment {
           threadId: 'thread01',
           content: 'note03',
           deleted: true,
+          editable,
           ownerRef: 'user01',
           status: NoteStatus.Todo,
           tagId,
@@ -650,6 +671,7 @@ class TestEnvironment {
           threadId: 'thread01',
           content: 'note04',
           deleted: false,
+          editable,
           ownerRef: 'user01',
           status: NoteStatus.Unspecified,
           dateCreated: '',
@@ -662,6 +684,7 @@ class TestEnvironment {
           threadId: 'thread01',
           content: 'note05',
           deleted: false,
+          editable,
           ownerRef: 'user01',
           status: NoteStatus.Done,
           tagId,
@@ -678,6 +701,7 @@ class TestEnvironment {
         threadId: 'thread01',
         content: reattachedContent,
         deleted: false,
+        editable,
         ownerRef: 'user01',
         status: reattachedContent === '' ? NoteStatus.Unspecified : NoteStatus.Todo,
         tagId: reattachedContent === '' ? undefined : 1,
@@ -692,6 +716,7 @@ class TestEnvironment {
         threadId: 'thread01',
         content: 'reattached02',
         deleted: false,
+        editable,
         ownerRef: 'user01',
         status: NoteStatus.Unspecified,
         tagId: 1,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -284,6 +284,7 @@ export class NoteDialogComponent implements OnInit {
     return (
       this.isAddNotesEnabled &&
       note.dataId === this.lastNoteId &&
+      note.editable === true &&
       this.noteIdBeingEdited == null &&
       SF_PROJECT_RIGHTS.hasRight(
         this.projectProfileDoc.data,

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -95,6 +95,7 @@
     "anonymous": "Anonymous",
     "cancel": "Cancel",
     "cannot_edit_chapter_formatting_invalid": "This chapter cannot be edited because the formatting is invalid. Please fix the formatting in Paratext.",
+    "cannot_edit_note_paratext": "You cannot edit this note as it has been edited in Paratext.",
     "configure_translation_suggestions": "Configure translation suggestions",
     "more_notes": "--- {{ count }} more note(s) ---",
     "navigate_to_a_valid_text": "Navigate to a valid text to insert a note",

--- a/src/SIL.XForge.Scripture/Models/FeatureFlags.cs
+++ b/src/SIL.XForge.Scripture/Models/FeatureFlags.cs
@@ -8,4 +8,5 @@ public static class FeatureFlags
     public const string Serval = "Serval";
     public const string UseEchoForPreTranslation = "UseEchoForPreTranslation";
     public const string MachineInProcess = "MachineInProcess";
+    public const string WriteNotesToParatext = "WriteNotesToParatext";
 }

--- a/src/SIL.XForge.Scripture/Models/Note.cs
+++ b/src/SIL.XForge.Scripture/Models/Note.cs
@@ -35,8 +35,47 @@ public class Note : Comment
     /// </summary>
     public string AcceptedChangeXml { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the note is editable in Scripture Forge.
+    /// </summary>
+    /// <value>
+    /// <list type="table">
+    /// <item>
+    ///     <term>
+    ///         <c>true</c>
+    ///     </term>
+    ///     <description>
+    ///         When the note has been created or edited in Scripture Forge.
+    ///     </description>
+    /// </item>
+    /// <item>
+    ///     <term>
+    ///         <c>false</c>
+    ///     </term>
+    ///     <description>
+    ///         When the note has been created or edited in Paratext.
+    ///     </description>
+    /// </item>
+    /// <item>
+    ///     <term>
+    ///         <c>null</c>
+    ///     </term>
+    ///     <description>
+    ///         When the note's state is unknown (assume <c>false</c>).
+    ///     </description>
+    /// </item>
+    /// </list>
+    /// </value>
+    public bool? Editable { get; set; }
+
+    /// <summary>
+    /// Gets or sets the note's version number.
+    /// </summary>
+    /// <remarks>This corresponds the comment version number in the Comment XML file.</remarks>
+    public int? VersionNumber { get; set; }
+
     /// <summary>The default value for ConflictType in Paratext is "unknownConflictType", which is present
     /// in Note XML files when the note is not a conflict note. However, this is not one of the values of
     /// the NoteConflictType enum.</summary>
-    public readonly static string NoConflictType = "unknownConflictType";
+    public const string NoConflictType = "unknownConflictType";
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -1151,7 +1151,16 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 if (index >= 0)
                 {
                     if (threadDoc.Data.Notes[index].Content != updated.Content)
+                    {
                         op.Set(td => td.Notes[index].Content, updated.Content);
+
+                        // As the note content has been updated by PT, disable editing
+                        if (threadDoc.Data.Notes[index].Editable == true)
+                        {
+                            op.Set(td => td.Notes[index].Editable, false);
+                        }
+                    }
+
                     if (threadDoc.Data.Notes[index].Status != updated.Status)
                         op.Set(td => td.Notes[index].Status, updated.Status);
                     if (threadDoc.Data.Notes[index].Type != updated.Type)
@@ -1164,6 +1173,8 @@ public class ParatextSyncRunner : IParatextSyncRunner
                         op.Set(td => td.Notes[index].Assignment, updated.Assignment);
                     if (threadDoc.Data.Notes[index].AcceptedChangeXml != updated.AcceptedChangeXml)
                         op.Set(td => td.Notes[index].AcceptedChangeXml, updated.AcceptedChangeXml);
+                    if (threadDoc.Data.Notes[index].VersionNumber != updated.VersionNumber)
+                        op.Set(td => td.Notes[index].VersionNumber, updated.VersionNumber);
                     _syncMetrics.Notes.Updated++;
                 }
                 else

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -13,6 +13,7 @@ using System.Xml.Linq;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement;
 using Newtonsoft.Json.Linq;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -2134,10 +2135,10 @@ public class ParatextServiceTests
     }
 
     [Test]
-    [Ignore("Not ready to push SF comments to PT")]
     public async Task UpdateParatextComments_AddsComment()
     {
         var env = new TestEnvironment();
+        env.MockFeatureManager.IsEnabledAsync(FeatureFlags.WriteNotesToParatext).Returns(Task.FromResult(true));
         var associatedPtUser = new SFParatextUser(env.Username01);
         string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
@@ -2150,11 +2151,23 @@ public class ParatextServiceTests
         string thread3 = "thread3";
         var thread1Notes = new[]
         {
-            new ThreadNoteComponents { ownerRef = env.User01, tagsAdded = new[] { "1" } }
+            new ThreadNoteComponents
+            {
+                ownerRef = env.User01,
+                tagsAdded = new[] { "1" },
+                editable = true,
+                versionNumber = 1,
+            }
         };
         var thread2Notes = new[]
         {
-            new ThreadNoteComponents { ownerRef = env.User05, tagsAdded = new[] { "1" } }
+            new ThreadNoteComponents
+            {
+                ownerRef = env.User05,
+                tagsAdded = new[] { "1" },
+                editable = true,
+                versionNumber = 1,
+            }
         };
         env.AddNoteThreadData(
             new[]
@@ -2260,10 +2273,10 @@ public class ParatextServiceTests
     }
 
     [Test]
-    [Ignore("Not ready to push SF comments to PT")]
     public async Task UpdateParatextComments_AddsCommentTagIdNotSet()
     {
         var env = new TestEnvironment();
+        env.MockFeatureManager.IsEnabledAsync(FeatureFlags.WriteNotesToParatext).Returns(Task.FromResult(true));
         var associatedPtUser = new SFParatextUser(env.Username01);
         string paratextId = env.SetupProject(env.Project01, associatedPtUser);
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
@@ -2278,7 +2291,8 @@ public class ParatextServiceTests
                     threadNum = 1,
                     noteCount = 1,
                     isNew = true,
-                    notes = new[] { new ThreadNoteComponents { } }
+                    notes = new[] { new ThreadNoteComponents { } },
+                    editable = true,
                 }
             }
         );
@@ -2304,10 +2318,10 @@ public class ParatextServiceTests
     }
 
     [Test]
-    [Ignore("Not ready to push SF comments to PT")]
     public async Task UpdateParatextComments_EditsComment()
     {
         var env = new TestEnvironment();
+        env.MockFeatureManager.IsEnabledAsync(FeatureFlags.WriteNotesToParatext).Returns(Task.FromResult(true));
         var associatedPtUser = new SFParatextUser(env.Username01);
         string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
@@ -2328,7 +2342,8 @@ public class ParatextServiceTests
                     noteCount = 2,
                     username = env.Username01,
                     notes = threadNoteComponents,
-                    isEdited = true
+                    isEdited = true,
+                    editable = true,
                 }
             }
         );
@@ -2347,7 +2362,6 @@ public class ParatextServiceTests
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         IDocument<NoteThread> noteThreadDoc = await TestEnvironment.GetNoteThreadDocAsync(conn, dataId);
-        // Edit a comment
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
         {
             new ParatextUserProfile
@@ -2388,6 +2402,196 @@ public class ParatextServiceTests
         Assert.That(comment.CommentToString(), Is.EqualTo(expected2));
         Assert.That(ptProjectUsers.Count, Is.EqualTo(1));
         Assert.That(syncMetricInfo, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 2)));
+
+        // PT username is not written to server logs
+        env.MockLogger.AssertNoEvent((LogEvent logEvent) => logEvent.Message.Contains(env.Username01));
+    }
+
+    [Test]
+    public async Task UpdateParatextComments_DoesNotEditNonEditableComment()
+    {
+        var env = new TestEnvironment();
+        env.MockFeatureManager.IsEnabledAsync(FeatureFlags.WriteNotesToParatext).Returns(Task.FromResult(true));
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        const string threadId = "thread1";
+        const string dataId = "dataId1";
+        var threadNoteComponents = new[]
+        {
+            new ThreadNoteComponents { ownerRef = env.User01, tagsAdded = new[] { "2" } },
+            new ThreadNoteComponents { ownerRef = env.User05 },
+        };
+        env.AddNoteThreadData(
+            new[]
+            {
+                new ThreadComponents
+                {
+                    threadNum = 1,
+                    noteCount = 2,
+                    username = env.Username01,
+                    notes = threadNoteComponents,
+                    isEdited = true,
+                    editable = false,
+                },
+            }
+        );
+        env.AddParatextComments(
+            new[]
+            {
+                new ThreadComponents
+                {
+                    threadNum = 1,
+                    noteCount = 2,
+                    username = env.Username01,
+                    notes = threadNoteComponents,
+                },
+            }
+        );
+
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        IDocument<NoteThread> noteThreadDoc = await TestEnvironment.GetNoteThreadDocAsync(conn, dataId);
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
+        {
+            new ParatextUserProfile
+            {
+                OpaqueUserId = "syncuser01",
+                Username = env.Username01,
+                SFUserId = env.User01,
+            },
+        }.ToDictionary(u => u.Username);
+        SyncMetricInfo syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
+            userSecret,
+            ptProjectId,
+            40,
+            new[] { noteThreadDoc },
+            env.usernames,
+            ptProjectUsers,
+            env.TagCount
+        );
+
+        // Verify that the Scripture Forge comments were edited
+        Assert.That(noteThreadDoc.Data.Notes.Count, Is.EqualTo(2));
+        const string expectedSF1 = "thread1 note 1: EDITED.";
+        Assert.That(noteThreadDoc.Data.Notes.First().Content, Is.EqualTo(expectedSF1));
+        const string expectedSF2 = "thread1 note 2: EDITED.";
+        Assert.That(noteThreadDoc.Data.Notes.Last().Content, Is.EqualTo(expectedSF2));
+
+        // Verify the Paratext comments have not changed
+        CommentThread thread = env.ProjectCommentManager.FindThread(threadId);
+        Assert.That(thread.Comments.Count, Is.EqualTo(2));
+        Paratext.Data.ProjectComments.Comment comment = thread.Comments.First();
+        const string expected1 =
+            "thread1/User 01/2019-01-01T08:00:00.0000000+00:00-"
+            + "MAT 1:1-"
+            + "thread1 note 1.-"
+            + "Start:15-"
+            + "Tag:2";
+        Assert.That(comment.CommentToString(), Is.EqualTo(expected1));
+
+        comment = thread.Comments[1];
+        const string expected2 =
+            "thread1/User 01/2019-01-02T08:00:00.0000000+00:00-"
+            + "MAT 1:1-"
+            + "<p sf-user-label=\"true\">[User 05 - xForge]</p><p>thread1 note 2.</p>-"
+            + "Start:15-"
+            + "user05";
+        Assert.That(comment.CommentToString(), Is.EqualTo(expected2));
+        Assert.That(ptProjectUsers.Count, Is.EqualTo(1));
+        Assert.That(syncMetricInfo, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
+
+        // PT username is not written to server logs
+        env.MockLogger.AssertNoEvent((LogEvent logEvent) => logEvent.Message.Contains(env.Username01));
+    }
+
+    [Test]
+    public async Task UpdateParatextComments_DoesNotEditCommentWithDifferentVersionNumber()
+    {
+        var env = new TestEnvironment();
+        env.MockFeatureManager.IsEnabledAsync(FeatureFlags.WriteNotesToParatext).Returns(Task.FromResult(true));
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        const string threadId = "thread1";
+        const string dataId = "dataId1";
+        var threadNoteComponents = new[]
+        {
+            new ThreadNoteComponents { ownerRef = env.User01, tagsAdded = new[] { "2" } },
+            new ThreadNoteComponents { ownerRef = env.User05 },
+        };
+        env.AddNoteThreadData(
+            new[]
+            {
+                new ThreadComponents
+                {
+                    threadNum = 1,
+                    noteCount = 2,
+                    username = env.Username01,
+                    notes = threadNoteComponents,
+                    isEdited = true,
+                    editable = true,
+                    versionNumber = 1,
+                },
+            }
+        );
+        env.AddParatextComments(
+            new[]
+            {
+                new ThreadComponents
+                {
+                    threadNum = 1,
+                    noteCount = 2,
+                    username = env.Username01,
+                    notes = threadNoteComponents,
+                    versionNumber = 2,
+                },
+            }
+        );
+
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        IDocument<NoteThread> noteThreadDoc = await TestEnvironment.GetNoteThreadDocAsync(conn, dataId);
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
+        {
+            new ParatextUserProfile
+            {
+                OpaqueUserId = "syncuser01",
+                Username = env.Username01,
+                SFUserId = env.User01,
+            },
+        }.ToDictionary(u => u.Username);
+        SyncMetricInfo syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
+            userSecret,
+            ptProjectId,
+            40,
+            new[] { noteThreadDoc },
+            env.usernames,
+            ptProjectUsers,
+            env.TagCount
+        );
+
+        CommentThread thread = env.ProjectCommentManager.FindThread(threadId);
+        Assert.That(thread.Comments.Count, Is.EqualTo(2));
+        Paratext.Data.ProjectComments.Comment comment = thread.Comments.First();
+        const string expected1 =
+            "thread1/User 01/2019-01-01T08:00:00.0000000+00:00-"
+            + "MAT 1:1-"
+            + "thread1 note 1.-"
+            + "Start:15-"
+            + "Tag:2";
+        Assert.That(comment.CommentToString(), Is.EqualTo(expected1));
+
+        comment = thread.Comments[1];
+        const string expected2 =
+            "thread1/User 01/2019-01-02T08:00:00.0000000+00:00-"
+            + "MAT 1:1-"
+            + "<p sf-user-label=\"true\">[User 05 - xForge]</p><p>thread1 note 2.</p>-"
+            + "Start:15-"
+            + "user05";
+        Assert.That(comment.CommentToString(), Is.EqualTo(expected2));
+        Assert.That(ptProjectUsers.Count, Is.EqualTo(1));
+        Assert.That(syncMetricInfo, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
 
         // PT username is not written to server logs
         env.MockLogger.AssertNoEvent((LogEvent logEvent) => logEvent.Message.Contains(env.Username01));
@@ -2491,10 +2695,10 @@ public class ParatextServiceTests
     }
 
     [Test]
-    [Ignore("Not ready to push SF comments to PT")]
     public async Task UpdateParatextComments_DeleteComment()
     {
         var env = new TestEnvironment();
+        env.MockFeatureManager.IsEnabledAsync(FeatureFlags.WriteNotesToParatext).Returns(Task.FromResult(true));
         var associatedPtUser = new SFParatextUser(env.Username01);
         string paratextId = env.SetupProject(env.Project01, associatedPtUser);
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
@@ -2505,7 +2709,8 @@ public class ParatextServiceTests
         {
             threadNum = 1,
             noteCount = 1,
-            username = env.Username01
+            username = env.Username01,
+            editable = true,
         };
         env.AddParatextComments(new[] { components });
         components.deletedNotes = new[] { true };
@@ -2618,6 +2823,51 @@ public class ParatextServiceTests
     }
 
     [Test]
+    public async Task UpdateParatextComments_DoesNotDeleteNonEditableComment()
+    {
+        var env = new TestEnvironment();
+        env.MockFeatureManager.IsEnabledAsync(FeatureFlags.WriteNotesToParatext).Returns(Task.FromResult(true));
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string paratextId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        const string threadId = "thread1";
+        const string dataId = "dataId1";
+        var components = new ThreadComponents
+        {
+            threadNum = 1,
+            noteCount = 1,
+            username = env.Username01,
+            editable = false,
+        };
+        env.AddParatextComments(new[] { components });
+        components.deletedNotes = new[] { true };
+        env.AddNoteThreadData(new[] { components });
+        CommentThread thread = env.ProjectCommentManager.FindThread(threadId);
+        Assert.NotNull(thread);
+
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        IDocument<NoteThread> noteThreadDoc = await TestEnvironment.GetNoteThreadDocAsync(conn, dataId);
+
+        Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
+        {
+            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 },
+        }.ToDictionary(u => u.Username);
+        var syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
+            userSecret,
+            paratextId,
+            40,
+            new[] { noteThreadDoc },
+            env.usernames,
+            ptProjectUsers,
+            env.TagCount
+        );
+        Assert.That(syncMetricInfo, Is.EqualTo(new SyncMetricInfo(added: 0, updated: 0, deleted: 0)));
+        thread = env.ProjectCommentManager.FindThread(threadId);
+        Assert.NotNull(thread);
+    }
+
+    [Test]
     public async Task UpdateParatextComments_DoesNotDeleteThread()
     {
         var env = new TestEnvironment();
@@ -2676,7 +2926,9 @@ public class ParatextServiceTests
             threadNum = 1,
             noteCount = 1,
             username = env.Username01,
-            isNew = false
+            isNew = false,
+            editable = true,
+            versionNumber = 1,
         };
         env.AddNoteThreadData(new[] { thread });
 
@@ -3338,6 +3590,8 @@ public class ParatextServiceTests
         public bool isConflict;
         public bool appliesToVerse;
         public string reattachedVerseStr;
+        public bool editable;
+        public int versionNumber;
     }
 
     struct ReattachedThreadInfo
@@ -3357,6 +3611,8 @@ public class ParatextServiceTests
         public string assignedPTUser;
         public bool duplicate;
         public string content;
+        public bool? editable;
+        public int? versionNumber;
     }
 
     [Test]
@@ -3985,6 +4241,7 @@ public class ParatextServiceTests
         public readonly SFMemoryRealtimeService RealtimeService;
         public readonly IExceptionHandler MockExceptionHandler;
         public readonly IOptions<SiteOptions> MockSiteOptions;
+        public readonly IFeatureManager MockFeatureManager;
         public readonly IFileSystemService MockFileSystemService;
         public readonly IScrTextCollection MockScrTextCollection;
         public readonly ISharingLogicWrapper MockSharingLogicWrapper;
@@ -4006,6 +4263,7 @@ public class ParatextServiceTests
             MockParatextOptions = Substitute.For<IOptions<ParatextOptions>>();
             MockExceptionHandler = Substitute.For<IExceptionHandler>();
             MockSiteOptions = Substitute.For<IOptions<SiteOptions>>();
+            MockFeatureManager = Substitute.For<IFeatureManager>();
             MockFileSystemService = Substitute.For<IFileSystemService>();
             MockLogger = new MockLogger<ParatextService>();
             MockScrTextCollection = Substitute.For<IScrTextCollection>();
@@ -4078,6 +4336,7 @@ public class ParatextServiceTests
                 RealtimeService,
                 MockExceptionHandler,
                 MockSiteOptions,
+                MockFeatureManager,
                 MockFileSystemService,
                 MockLogger,
                 MockJwtTokenHelper,
@@ -4475,7 +4734,9 @@ public class ParatextServiceTests
                         TagId = noteComponent.tagsAdded == null ? null : int.Parse(noteComponent.tagsAdded[0]),
                         Deleted = comp.deletedNotes != null && comp.deletedNotes[i - 1],
                         Status = noteComponent.status.InternalValue,
-                        Assignment = noteComponent.assignedPTUser
+                        Assignment = noteComponent.assignedPTUser,
+                        Editable = noteComponent.editable ?? comp.editable,
+                        VersionNumber = noteComponent.versionNumber ?? comp.versionNumber,
                     };
                     notes.Add(note);
                     if (noteComponent.duplicate)
@@ -4689,6 +4950,7 @@ public class ParatextServiceTests
                     comment.Type = comp.isConflict ? NoteType.Conflict : NoteType.Normal;
                     comment.ConflictType = NoteConflictType.None;
                     comment.AssignedUser = note.assignedPTUser;
+                    comment.VersionNumber = note.versionNumber ?? comp.versionNumber;
                     ProjectCommentManager.AddComment(comment);
                     if (note.duplicate)
                         ProjectCommentManager.AddComment(comment);

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1813,6 +1813,8 @@ public class ParatextSyncRunnerTests
         Assert.That(thread01.Notes.Count, Is.EqualTo(startingNoteCount + expectedNoteCountChange));
         Assert.That(thread01.Notes[0].Content, Is.EqualTo("thread01 updated."));
         Assert.That(thread01.Notes[0].Assignment, Is.EqualTo(CommentThread.teamUser));
+        Assert.That(thread01.Notes[0].Editable, Is.False);
+        Assert.That(thread01.Notes[0].VersionNumber, Is.EqualTo(2));
         Assert.That(thread01.Notes[1].Deleted, Is.True);
         Assert.That(thread01.Notes[2].Content, Is.EqualTo("thread01 added."));
         string expected = "thread01-syncuser03-thread01 added.-tag:" + expectedNoteTagId;
@@ -3133,7 +3135,7 @@ public class ParatextSyncRunnerTests
                     Assignment = CommentThread.teamUser
                 };
                 noteThreadChange.AddChange(
-                    CreateNote(threadId, "n01", "syncuser01", $"{threadId} updated.", ChangeType.Updated),
+                    CreateNote(threadId, "n01", "syncuser01", $"{threadId} updated.", ChangeType.Updated, null, 2),
                     ChangeType.Updated
                 );
                 noteThreadChange.AddChange(
@@ -3411,9 +3413,11 @@ public class ParatextSyncRunnerTests
                             ThreadId = threadId,
                             OwnerRef = fromCommenter ? "user03" : "user01",
                             SyncUserRef = "syncuser01",
-                            Content = "Paratext note 1.",
+                            Content = "SF note 1.",
                             TagId = tagId,
-                            DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc)
+                            DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc),
+                            Editable = true,
+                            VersionNumber = 1,
                         },
                         new Note
                         {
@@ -3696,7 +3700,8 @@ public class ParatextSyncRunnerTests
             string user,
             string content,
             ChangeType type,
-            int? tagId = null
+            int? tagId = null,
+            int? versionNumber = null
         )
         {
             return new Note
@@ -3709,7 +3714,8 @@ public class ParatextSyncRunnerTests
                 DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc),
                 Deleted = type == ChangeType.Deleted,
                 TagId = tagId,
-                Assignment = CommentThread.teamUser
+                Assignment = CommentThread.teamUser,
+                VersionNumber = versionNumber,
             };
         }
 


### PR DESCRIPTION
**Summary**
This Pull Request restricts note editing and writing to Paratext to only those notes that are created in Scripture Forge.

**New Features and Changed Behavior**
 * A C# Feature Flag to enable Note writing to Paratext
 * Disabled the ability to edit or delete comments created or edited in Paratext by the logged in user

**Testing**
To enable writing Notes to Paratext, enable the feature flag by running the following in `src/SIL.XForge.Scripture/`:
```
dotnet user-secrets set "FeatureManagement:WriteNotesToParatext" true
```
See also the Acceptance test for the corresponding JIRA ticket.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1988)
<!-- Reviewable:end -->
