### PR TITLE
dev: vagrant: Add Chromium MP3 Support

### DIFF
--- a/deploy/vagrant/sfdev/Vagrantfile
+++ b/deploy/vagrant/sfdev/Vagrantfile
@@ -94,6 +94,9 @@ Vagrant.configure("2") do |config|
     fs.inotify.max_user_instances=10000000
     END
 
+    # Add MP3 support to Chromium
+    sudo apt install -y chromium-codecs-ffmpeg-extra
+
     # Remove canary
     rm ~/Desktop/warning-not-provisioned.txt
     echo Provisioning finished successfully.


### PR DESCRIPTION
By default the version of Chromium in the Vagrant VM does not support MP3 files. This poses issues when using Chromium to test the audio functionality of Scripture Forge out of the box (an audio unavailable message is displayed instead of the play controls).

To resolve this, this PR adds MP3 support to Chromium when the VM is being configured by Vagrant.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1990)
<!-- Reviewable:end -->
