### PR TITLE
SF-2228 Allow Pre-Translation build cancellation during upload to Serval

### DIFF
--- a/src/SIL.XForge.Scripture/Models/ServalData.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalData.cs
@@ -28,6 +28,11 @@ public class ServalData
     public string? PreTranslationEngineId { get; set; }
 
     /// <summary>
+    /// Gets or sets the Hangfire Job Id for the Pre-Translation job.
+    /// </summary>
+    public string? PreTranslationJobId { get; set; }
+
+    /// <summary>
     /// Gets or sets the date and time that the pre-translation build was queued.
     /// </summary>
     /// <value>

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -124,19 +124,40 @@ public class MachineApiService : IMachineApiService
             throw new DataNotFoundException("The translation engine is not configured");
         }
 
+        // If we have pre-translation job information
+        if (
+            (await _projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret)
+            && (
+                projectSecret.ServalData?.PreTranslationJobId is not null
+                || projectSecret.ServalData?.PreTranslationQueuedAt is not null
+            )
+        )
+        {
+            // Cancel the Hangfire job
+            if (projectSecret.ServalData?.PreTranslationJobId is not null)
+            {
+                _backgroundJobClient.Delete(projectSecret.ServalData?.PreTranslationJobId);
+            }
+
+            // Clear the pre-translation queued status and job id
+            await _projectSecrets.UpdateAsync(
+                sfProjectId,
+                u =>
+                {
+                    u.Unset(p => p.ServalData.PreTranslationJobId);
+                    u.Unset(p => p.ServalData.PreTranslationQueuedAt);
+                }
+            );
+        }
+
         try
         {
             // Cancel the build on Serval
             await _translationEnginesClient.CancelBuildAsync(translationEngineId, cancellationToken);
-
-            // Clear the pre-translation queued status
-            if (
-                (await _projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret)
-                && projectSecret.ServalData?.PreTranslationQueuedAt is not null
-            )
-            {
-                await _projectSecrets.UpdateAsync(sfProjectId, u => u.Unset(p => p.ServalData.PreTranslationQueuedAt));
-            }
+        }
+        catch (ServalApiException e) when (e.StatusCode == StatusCodes.Status404NotFound)
+        {
+            // We do not mind if a 404 exception comes from Serval - we can assume the job is now cancelled
         }
         catch (Exception e)
         {
@@ -590,14 +611,18 @@ public class MachineApiService : IMachineApiService
         }
 
         // This will take a while, so we run it in the background
-        _backgroundJobClient.Enqueue<MachineProjectService>(
+        string jobId = _backgroundJobClient.Enqueue<MachineProjectService>(
             r => r.BuildProjectAsync(curUserId, sfProjectId, true, CancellationToken.None)
         );
 
-        // Set the pre-translation queued date and time
+        // Set the pre-translation queued date and time, and hang fire job id
         await _projectSecrets.UpdateAsync(
             sfProjectId,
-            u => u.Set(p => p.ServalData.PreTranslationQueuedAt, DateTime.UtcNow)
+            u =>
+            {
+                u.Set(p => p.ServalData.PreTranslationJobId, jobId);
+                u.Set(p => p.ServalData.PreTranslationQueuedAt, DateTime.UtcNow);
+            }
         );
     }
 

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -237,10 +237,17 @@ public class MachineProjectService : IMachineProjectService
                 cancellationToken
             );
 
-            // Clear the pre-translation queued status
+            // Clear the pre-translation queued status and job id
             if (preTranslate)
             {
-                await _projectSecrets.UpdateAsync(sfProjectId, u => u.Unset(p => p.ServalData.PreTranslationQueuedAt));
+                await _projectSecrets.UpdateAsync(
+                    sfProjectId,
+                    u =>
+                    {
+                        u.Unset(p => p.ServalData.PreTranslationJobId);
+                        u.Unset(p => p.ServalData.PreTranslationQueuedAt);
+                    }
+                );
             }
 
             return translationBuild;

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -170,6 +170,7 @@ public class MachineProjectServiceTests
         await env.DataFilesClient
             .DidNotReceiveWithAnyArgs()
             .UpdateAsync(Arg.Any<string>(), Arg.Any<FileParameter>(), CancellationToken.None);
+        Assert.IsNull(env.ProjectSecrets.Get(Project02).ServalData!.PreTranslationJobId);
         Assert.IsNull(env.ProjectSecrets.Get(Project02).ServalData!.PreTranslationQueuedAt);
     }
 
@@ -725,6 +726,7 @@ public class MachineProjectServiceTests
                         Id = Project02,
                         ServalData = new ServalData
                         {
+                            PreTranslationJobId = options.PreTranslationBuildIsQueued ? "jobId" : null,
                             PreTranslationQueuedAt = options.PreTranslationBuildIsQueued ? DateTime.UtcNow : null,
                             TranslationEngineId = TranslationEngine02,
                             Corpora = new Dictionary<string, ServalCorpus>


### PR DESCRIPTION
Currently, while a pre-translation build is being uploaded to Serval, cancelling it before it has finished uploading does nothing.

This Pull Request changes this so that when a pre-translation build is cancelled in this state, the Hangfire job is stopped.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1991)
<!-- Reviewable:end -->
