### PR TITLE
SF-2147 Fix notes deleted in PT not deleted in SF

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1206,21 +1206,15 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 _syncMetrics.Notes.Added++;
             }
 
-            // Permanently removes a note
-            List<int> removedIndices = new List<int>();
-            for (int i = 0; i < change.NoteIdsRemoved.Count; i++)
-            {
-                string removedId = change.NoteIdsRemoved[i];
-                int index = threadDoc.Data.Notes.FindIndex(n => n.DataId == removedId);
-                if (index >= 0)
-                {
-                    removedIndices.Add(index);
-                }
-            }
+            List<int> removedIndices = change.NoteIdsRemoved
+                .Select(id => threadDoc.Data.Notes.FindIndex(n => n.DataId == id))
+                .Where(index => index >= 0)
+                .ToList();
             // Go through the indices in reverse order so subsequent removal indices are not affected
-            removedIndices.Sort((a, b) => b - a);
+            removedIndices.Sort((a, b) => b.CompareTo(a));
             foreach (int index in removedIndices)
             {
+                // Permanently removes a note
                 op.Remove(td => td.Notes, index);
                 _syncMetrics.Notes.Removed++;
             }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1207,14 +1207,22 @@ public class ParatextSyncRunner : IParatextSyncRunner
             }
 
             // Permanently removes a note
-            foreach (string removedId in change.NoteIdsRemoved)
+            List<int> removedIndices = new List<int>();
+            for (int i = 0; i < change.NoteIdsRemoved.Count; i++)
             {
+                string removedId = change.NoteIdsRemoved[i];
                 int index = threadDoc.Data.Notes.FindIndex(n => n.DataId == removedId);
                 if (index >= 0)
                 {
-                    op.Remove(td => td.Notes, index);
-                    _syncMetrics.Notes.Removed++;
+                    removedIndices.Add(index);
                 }
+            }
+            // Go through the indices in reverse order so subsequent removal indices are not affected
+            removedIndices.Sort((a, b) => b - a);
+            foreach (int index in removedIndices)
+            {
+                op.Remove(td => td.Notes, index);
+                _syncMetrics.Notes.Removed++;
             }
 
             if (change.Position != null)


### PR DESCRIPTION
When multiple notes were deleted from a thread with 3 or more notes in PT, the result was not consistent in SF because when we removed notes from the notes property of a note thread, the operation depends on a static list. But when we remove multiple notes, the list changes for each note removal, and the result is that the wrong notes might be removed from the thread.
This change removes notes from the end of the list to the start of the list so that subsequent removal ops are correct with each note removed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1993)
<!-- Reviewable:end -->
