### PR TITLE
SF-2177 Back translation draft UI - Editor integration

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.scss
@@ -144,6 +144,14 @@ app-text {
   }
 }
 
+// Keep the options on the screen
+::ng-deep .mat-select-panel {
+  &.book-select-menu,
+  &.chapter-select-menu {
+    max-height: 65vh !important;
+  }
+}
+
 @keyframes fade-in {
   from {
     opacity: 0;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { DeltaOperation } from 'quill';
-import { isString } from 'src/type-utils';
+import { isString } from '../../../../type-utils';
 import { DraftSegmentMap } from '../draft-generation';
 
 @Injectable({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { DeltaOperation } from 'quill';
+import { isString } from 'src/type-utils';
 import { DraftSegmentMap } from '../draft-generation';
 
 @Injectable({
@@ -27,8 +28,7 @@ export class DraftViewerService {
 
       // Can populate draft if insert is a blank string OR insert is object that has 'blank: true' property.
       // Other objects are not draftable (e.g. 'note-thread-embed').
-      const isInsertBlank =
-        (typeof op.insert === 'string' && op.insert.trim().length === 0) || op.insert.blank === true;
+      const isInsertBlank = (isString(op.insert) && op.insert.trim().length === 0) || op.insert.blank === true;
 
       return isSegmentDraftAvailable && isInsertBlank;
     });
@@ -55,7 +55,7 @@ export class DraftViewerService {
         return op;
       }
 
-      if (typeof op.insert === 'string') {
+      if (isString(op.insert)) {
         if (op.insert.trim().length > 0) {
           // 'insert' is non-blank string; use existing translation
           return op;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -31,6 +31,13 @@
           <div class="toolbar-separator">&nbsp;</div>
           <app-share-button [defaultRole]="defaultShareRole"></app-share-button>
         </ng-container>
+        <ng-container *ngIf="featureFlags.showNmtDrafting.enabled && hasDraft">
+          <div class="toolbar-separator"></div>
+          <button mat-stroked-button title="Preview draft" class="preview-draft-button" (click)="goToDraftPreview()">
+            <mat-icon>edit_note</mat-icon>
+            Preview draft
+          </button>
+        </ng-container>
       </div>
       <ng-container *ngIf="showMultiViewers">
         <div fxFlexAlign="end" class="avatar-padding">
@@ -81,6 +88,7 @@
           class="text-container"
           [style.height]="textHeight"
           [dir]="isTargetRightToLeft ? 'rtl' : 'ltr'"
+          [ngClass]="{ 'has-draft': featureFlags.showNmtDrafting.enabled && hasDraft }"
         >
           <app-text
             #target

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -17,7 +17,6 @@
 }
 
 .language-label {
-  height: 28px;
   line-height: 28px;
 }
 
@@ -41,6 +40,11 @@
   margin: 0 4px;
   height: 36px;
   width: 0;
+}
+
+.preview-draft-button {
+  // Border helps associate button with target editor that shows similar border when it has a draft
+  border: 3px dashed $draft-color;
 }
 
 .ql-suggestions {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -55,7 +55,6 @@ import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/model
 import { fromVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import * as RichText from 'rich-text';
 import { BehaviorSubject, defer, Observable, of, Subject } from 'rxjs';
-import { HttpClient } from 'src/app/machine-api/http-client';
 import { anything, capture, deepEqual, instance, mock, resetCalls, verify, when } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
 import { CONSOLE } from 'xforge-common/browser-globals';
@@ -78,6 +77,7 @@ import { SF_TYPE_REGISTRY } from '../../core/models/sf-type-registry';
 import { Delta, TextDoc, TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
+import { HttpClient } from '../../machine-api/http-client';
 import { RemoteTranslationEngine } from '../../machine-api/remote-translation-engine';
 import { SharedModule } from '../../shared/shared.module';
 import { getCombinedVerseTextDoc, paratextUsersFromRoles } from '../../shared/test-utils';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -26,7 +26,7 @@ import {
   TranslationSuggester
 } from '@sillsdev/machine';
 import { Canon, VerseRef } from '@sillsdev/scripture';
-import isEqual from 'lodash-es/isEqual';
+import { isEqual } from 'lodash-es';
 import Quill, { DeltaStatic, RangeStatic } from 'quill';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { User } from 'realtime-server/lib/esm/common/models/user';
@@ -50,6 +50,8 @@ import { fromVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/vers
 import { DeltaOperation } from 'rich-text';
 import { BehaviorSubject, fromEvent, merge, Subject, Subscription, timer } from 'rxjs';
 import { debounceTime, delayWhen, filter, first, repeat, retryWhen, tap } from 'rxjs/operators';
+import { isString } from 'src/type-utils';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { CONSOLE, ConsoleInterface } from 'xforge-common/browser-globals';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { DialogService } from 'xforge-common/dialog.service';
@@ -89,6 +91,9 @@ import {
   verseRefFromMouseEvent,
   VERSE_REGEX
 } from '../../shared/utils';
+import { DraftSegmentMap } from '../draft-generation/draft-generation';
+import { DraftGenerationService } from '../draft-generation/draft-generation.service';
+import { DraftViewerService } from '../draft-generation/draft-viewer/draft-viewer.service';
 import { MultiCursorViewer } from './multi-viewer/multi-viewer.component';
 import { NoteDialogComponent, NoteDialogData, NoteDialogResult } from './note-dialog/note-dialog.component';
 import {
@@ -138,6 +143,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   textHeight: string = '';
   multiCursorViewers: MultiCursorViewer[] = [];
   insertNoteFabLeft: string = '0px';
+  hasDraft = false;
 
   @ViewChild('targetContainer') targetContainer?: ElementRef;
   @ViewChild('source') source?: TextComponent;
@@ -195,8 +201,11 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     private readonly onlineStatusService: OnlineStatusService,
     private readonly translationEngineService: TranslationEngineService,
     private readonly i18n: I18nService,
-    private readonly featureFlags: FeatureFlagService,
+    public readonly featureFlags: FeatureFlagService,
     private readonly reportingService: ErrorReportingService,
+    private readonly activatedProjectService: ActivatedProjectService,
+    private readonly draftGenerationService: DraftGenerationService,
+    private readonly draftViewerService: DraftViewerService,
     @Inject(CONSOLE) private readonly console: ConsoleInterface,
     private readonly router: Router,
     private bottomSheet: MatBottomSheet
@@ -281,12 +290,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   set chapter(value: number | undefined) {
     if (this._chapter !== value) {
-      this.showSuggestions = false;
-      this.toggleNoteThreadVerses(false);
-      this._chapter = value;
-      this.changeText();
-      this.toggleNoteThreadVerses(true);
-      this.bottomSheet.dismiss();
+      // Update url to reflect current chapter, triggering ActivatedRoute
+      this.router.navigateByUrl(
+        `/projects/${this.projectId}/translate/${Canon.bookNumberToId(this.bookNum!)}/${value}`
+      );
     }
   }
 
@@ -532,6 +539,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         this.loadingStarted();
         const projectId = params['projectId'] as string;
         const bookId = params['bookId'] as string;
+        const chapterNum = params['chapter'] as string | null;
         const bookNum = bookId != null ? Canon.bookIdToNumber(bookId) : 0;
 
         if (this.currentUserDoc === undefined) {
@@ -577,7 +585,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         }
         this.chapters = this.text == null ? [] : this.text.chapters.map(c => c.number);
 
-        this.loadProjectUserConfig();
+        // Set chapter from route if provided
+        this.loadProjectUserConfig(Number(chapterNum) || undefined);
 
         if (this.projectDoc.id !== prevProjectId) {
           this.setupTranslationEngine();
@@ -783,9 +792,14 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         if (this.target?.editor != null) {
           this.positionInsertNoteFab();
           this.subscribeScroll(this.target.editor);
+
+          if (this.featureFlags.showNmtDrafting.enabled) {
+            this.checkForPreTranslations();
+          }
         }
         break;
     }
+
     if ((!this.hasSource || this.sourceLoaded) && this.targetLoaded) {
       this.loadingFinished();
       // Toggle the segment the cursor is focused in - the timeout allows for Quill to get its focus set
@@ -1480,14 +1494,17 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     );
   }
 
-  private loadProjectUserConfig(): void {
-    let chapter = this.chapters.length > 0 ? this.chapters[0] : 1;
+  private loadProjectUserConfig(chapterFromUrl?: number): void {
+    let chapter = chapterFromUrl ?? (this.chapters.length > 0 ? this.chapters[0] : 1);
+
     if (this.projectUserConfigDoc != null && this.projectUserConfigDoc.data != null) {
       const pcnt = Math.round(this.projectUserConfigDoc.data.confidenceThreshold * 100);
       this.translationSuggester.confidenceThreshold = pcnt / 100;
+
       if (this.text != null && this.projectUserConfigDoc.data.selectedBookNum === this.text.bookNum) {
         if (this.projectUserConfigDoc.data.selectedChapterNum != null) {
-          chapter = this.projectUserConfigDoc.data.selectedChapterNum;
+          // Use chapter from url if specified
+          chapter = chapterFromUrl ?? this.projectUserConfigDoc.data.selectedChapterNum;
         }
       }
     }
@@ -1996,5 +2013,45 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   onViewerClicked(viewer: MultiCursorViewer): void {
     this.target!.scrollToViewer(viewer);
+  }
+
+  private checkForPreTranslations(): void {
+    const targetOps: DeltaOperation[] = this.target?.editor?.getContents().ops!;
+    const isChapterComplete: boolean = targetOps.every(op => {
+      // If segment is a verse, check if it has a translation
+      if (VERSE_REGEX.test(op.attributes?.segment)) {
+        // Check if insert is non-blank string
+        if (isString(op.insert)) {
+          return op.insert.trim().length > 0;
+        }
+
+        // Check if insert is object that doesn't have 'blank: true' property (e.g. 'note-thread-embed')
+        return op.insert?.blank !== true;
+      }
+
+      return true;
+    });
+
+    // Set false until service can check actual draft status for chapter
+    this.hasDraft = false;
+
+    // Don't fetch draft if all editor verse segments have existing translations
+    if (isChapterComplete) {
+      return;
+    }
+
+    // If build progress is 'completed', get pretranslations for current chapter
+    this.draftGenerationService
+      .getGeneratedDraft(this.activatedProjectService.projectId!, this.bookNum!, this.chapter!)
+      .subscribe((draft: DraftSegmentMap) => {
+        this.hasDraft = this.draftViewerService.hasDraftOps(draft, targetOps);
+      });
+  }
+
+  goToDraftPreview(): void {
+    const book = Canon.bookNumberToId(this.bookNum!);
+    this.router.navigateByUrl(
+      `/projects/${this.activatedProjectService.projectId}/draft-preview/${book}/${this.chapter}`
+    );
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/type-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/type-utils.ts
@@ -5,6 +5,17 @@ export function isObj(value: unknown): value is object {
   return typeof value === 'object' && value !== null;
 }
 
+/**
+ * Checks if `value` is classified as a string primitive.  This function differs from lodash `isString()`
+ * in that this function will return false for string objects, e.g. `new String('hi')`.
+ *
+ * @param value The value to check.
+ * @return Returns true if value is a string primitive.
+ */
+export function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
 export function hasProp<X, Y extends PropertyKey>(value: X, property: Y): value is X & Record<Y, unknown> {
   return isObj(value) && property in value;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/utils.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/utils.spec.ts
@@ -1,4 +1,4 @@
-import { hasFunctionProp, hasProp, hasStringProp, isObj } from './type-utils';
+import { hasFunctionProp, hasProp, hasStringProp, isObj, isString } from './type-utils';
 
 const miscValues = [undefined, null, NaN, true, false, Infinity, -1, 0, Symbol(), '', '\0', () => {}, BigInt(3)];
 
@@ -8,6 +8,29 @@ describe('type utils', () => {
   it('checks whether a value is an object', () => {
     for (const value of miscValues) expect(isObj(value)).toBeFalse();
     for (const obj of objValues) expect(isObj(obj)).toBeTrue();
+  });
+
+  describe('isString()', () => {
+    it('returns false for string objects', () => {
+      expect(isString(new String())).toBeFalse();
+    });
+    it('returns false for nullish values', () => {
+      expect(isString(undefined)).toBeFalse();
+      expect(isString(null)).toBeFalse();
+    });
+    it('returns false for non-string types', () => {
+      expect(isString(true)).toBeFalse();
+      expect(isString(false)).toBeFalse();
+      expect(isString(0)).toBeFalse();
+      expect(isString(NaN)).toBeFalse();
+      expect(isString(() => {})).toBeFalse();
+      expect(isString({})).toBeFalse();
+      expect(isString([])).toBeFalse();
+    });
+    it('returns true for string primitive values', () => {
+      expect(isString('')).toBeTrue();
+      expect(isString('hello')).toBeTrue();
+    });
   });
 
   it('checks whether a value has a property', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/utils.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/utils.spec.ts
@@ -14,10 +14,12 @@ describe('type utils', () => {
     it('returns false for string objects', () => {
       expect(isString(new String())).toBeFalse();
     });
+
     it('returns false for nullish values', () => {
       expect(isString(undefined)).toBeFalse();
       expect(isString(null)).toBeFalse();
     });
+
     it('returns false for non-string types', () => {
       expect(isString(true)).toBeFalse();
       expect(isString(false)).toBeFalse();
@@ -27,6 +29,7 @@ describe('type utils', () => {
       expect(isString({})).toBeFalse();
       expect(isString([])).toBeFalse();
     });
+
     it('returns true for string primitive values', () => {
       expect(isString('')).toBeTrue();
       expect(isString('hello')).toBeTrue();


### PR DESCRIPTION
This pull request is for the editor component integration for the back translation drafting. It is hidden behind feature flag 'Show NMT drafting'. Once enabled, there will be a 'Generate draft' menu item that will take the user to the draft generation page.

**Draft preview page**
 * User can click the 'Edit' button anytime to navigate to the editor for the current book and chapter.

**Editor page additions**
 * If there are any unapplied pre-translations for the current chapter _(available pre-translations for untranslated segments)_, there will be a 'Preview draft' button that will navigate user to draft preview page for the current book and chapter.
 * In this way, user can work and is 'notified' by the presence of the 'Preview draft' button when draft is available.

**Notes**
 - To experiment with a mock service, add these providers to `TranslateModule`:
```ts
import { HttpClient } from '../machine-api/http-client';  // <-- Use this HttpClient
//...other imports

@NgModule({
  ...
  providers: [
    // These providers are for testing back translation with mock service
    { provide: HttpClient, useClass: MockPreTranslationHttpClient },
    { provide: DRAFT_GENERATION_SERVICE_OPTIONS, useValue: { pollRate: 200 } }
  ]
})
export class TranslateModule {}
```
- You can add test data to `mock-pretranslation-machine-api.ts`.  Currently, there is test data only for the first two chapters of Genesis and Exodus.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1995)
<!-- Reviewable:end -->
