### PR TITLE
SF-2175 Recover from build status 'Faulted'

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -106,6 +106,14 @@
       </section>
 
       <ng-template #jobExists>
+        <ng-container *ngIf="isDraftFaulted(draftJob)">
+          <section>
+            <h3><mat-icon color="warn">warning</mat-icon>Last generation attempt failed</h3>
+            <p>Click <em>"Generate draft"</em> below to try again.</p>
+          </section>
+          <mat-divider inset></mat-divider>
+        </ng-container>
+
         <section *ngIf="isDraftComplete(draftJob) || !isDraftInProgress(draftJob)" class="view-or-create-options">
           <ng-container *ngIf="isDraftComplete(draftJob)">
             <div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
@@ -6,6 +6,8 @@ app-working-animated-indicator {
 h3 {
   font-size: 20px;
   font-weight: 500;
+  display: flex;
+  gap: 10px;
 }
 
 em {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -235,7 +235,7 @@ describe('DraftGenerationComponent', () => {
       expect(mockDraftGenerationService.startBuildOrGetActiveBuild).toHaveBeenCalledWith('testProjectId');
     });
 
-    it('should attempt "cancel dialog" close for queued build', () => {
+    it('should not attempt "cancel dialog" close for queued build', () => {
       let env = new TestEnvironment(() => {
         mockDraftGenerationService.startBuildOrGetActiveBuild.and.returnValue(
           of({ ...buildDto, state: BuildStates.Queued })
@@ -243,11 +243,11 @@ describe('DraftGenerationComponent', () => {
       });
 
       const mockDialogRef: MatDialogRef<any> = mock(MatDialogRef);
-      when(mockDialogRef.getState()).thenReturn(MatDialogState.OPEN);
       env.component.cancelDialogRef = instance(mockDialogRef);
 
       env.component.generateDraft();
-      verify(mockDialogRef.close()).once();
+      verify(mockDialogRef.getState()).never();
+      verify(mockDialogRef.close()).never();
     });
 
     it('should not attempt "cancel dialog" close for pending build', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -235,12 +235,44 @@ describe('DraftGenerationComponent', () => {
       expect(mockDraftGenerationService.startBuildOrGetActiveBuild).toHaveBeenCalledWith('testProjectId');
     });
 
-    it('should not attempt "cancel dialog" close for queued build', () => {
+    it('should attempt "cancel dialog" close for queued build', () => {
       let env = new TestEnvironment(() => {
-        mockDraftGenerationService.startBuildOrGetActiveBuild.and.returnValue(of(buildDto));
+        mockDraftGenerationService.startBuildOrGetActiveBuild.and.returnValue(
+          of({ ...buildDto, state: BuildStates.Queued })
+        );
       });
 
-      const mockDialogRef = mock(MatDialogRef);
+      const mockDialogRef: MatDialogRef<any> = mock(MatDialogRef);
+      when(mockDialogRef.getState()).thenReturn(MatDialogState.OPEN);
+      env.component.cancelDialogRef = instance(mockDialogRef);
+
+      env.component.generateDraft();
+      verify(mockDialogRef.close()).once();
+    });
+
+    it('should not attempt "cancel dialog" close for pending build', () => {
+      let env = new TestEnvironment(() => {
+        mockDraftGenerationService.startBuildOrGetActiveBuild.and.returnValue(
+          of({ ...buildDto, state: BuildStates.Pending })
+        );
+      });
+
+      const mockDialogRef: MatDialogRef<any> = mock(MatDialogRef);
+      env.component.cancelDialogRef = instance(mockDialogRef);
+
+      env.component.generateDraft();
+      verify(mockDialogRef.getState()).never();
+      verify(mockDialogRef.close()).never();
+    });
+
+    it('should not attempt "cancel dialog" close for active build', () => {
+      let env = new TestEnvironment(() => {
+        mockDraftGenerationService.startBuildOrGetActiveBuild.and.returnValue(
+          of({ ...buildDto, state: BuildStates.Active })
+        );
+      });
+
+      const mockDialogRef: MatDialogRef<any> = mock(MatDialogRef);
       env.component.cancelDialogRef = instance(mockDialogRef);
 
       env.component.generateDraft();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -4,12 +4,12 @@ import { isEmpty } from 'lodash-es';
 import { ProjectType } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { Observable, of, Subscription } from 'rxjs';
 import { map, switchMap, tap } from 'rxjs/operators';
-import { BuildDto } from 'src/app/machine-api/build-dto';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
+import { BuildDto } from '../../machine-api/build-dto';
 import { BuildStates } from '../../machine-api/build-states';
 import { NllbLanguageService } from '../nllb-language.service';
 import { activeBuildStates } from './draft-generation';
@@ -152,7 +152,7 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
     this.cancelBuild();
   }
 
-  startBuild(): void {
+  private startBuild(): void {
     this.jobSubscription?.unsubscribe();
     this.jobSubscription = this.subscribe(
       this.draftGenerationService.startBuildOrGetActiveBuild(this.activatedProject.projectId!).pipe(
@@ -169,7 +169,7 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
     );
   }
 
-  pollBuild(): void {
+  private pollBuild(): void {
     this.jobSubscription?.unsubscribe();
     this.jobSubscription = this.subscribe(
       this.activatedProject.projectId$.pipe(
@@ -191,7 +191,7 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
     );
   }
 
-  cancelBuild(): void {
+  private cancelBuild(): void {
     this.draftGenerationService.cancelBuild(this.activatedProject.projectId!).subscribe(() => {
       // If build is canceled, update job immediately instead of waiting for next poll cycle
       this.pollBuild();
@@ -248,7 +248,6 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
   }
 
   canCancel(job?: BuildDto): boolean {
-    // Cannot cancel 'Queued' build, as it is not yet uploaded to the server (cancel will result in 404)
-    return !job || [BuildStates.Active, BuildStates.Pending].includes(job?.state as BuildStates);
+    return !job || this.isDraftInProgress(job);
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.spec.ts
@@ -89,6 +89,16 @@ describe('DraftGenerationService', () => {
         done();
       });
     });
+
+    it('should return faulted build', done => {
+      const faultedBuild = { ...buildDto, state: BuildStates.Faulted };
+      httpClient.get = jasmine.createSpy().and.returnValue(of({ data: faultedBuild }));
+      service.getBuildProgress(projectId).subscribe(result => {
+        expect(result).toEqual(faultedBuild);
+        expect(httpClient.get).toHaveBeenCalledWith(`translation/builds/id:${projectId}?pretranslate=true`);
+        done();
+      });
+    });
   });
 
   describe('startBuild', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@angular/core';
 import { VerseRef } from '@sillsdev/scripture';
-import { Observable, of, throwError, timer } from 'rxjs';
+import { Observable, of, throwError, timer, EMPTY } from 'rxjs';
 import { catchError, distinct, map, shareReplay, switchMap, takeWhile } from 'rxjs/operators';
 import { BuildStates } from 'src/app/machine-api/build-states';
 import { HttpClient } from 'src/app/machine-api/http-client';
@@ -104,14 +104,19 @@ export class DraftGenerationService {
 
   /**
    * Cancels any pretranslation builds for the specified project.
-   * Build can be canceled if its state is `Active` or `Pending`.
-   * A `Queued` build is uploading to serval and cannot yet be canceled (attempt will result in 404).
    * @param projectId The SF project id for the target translation.
    */
   cancelBuild(projectId: string): Observable<void> {
-    return this.httpClient
-      .post<void>(`translation/pretranslations/cancel`, JSON.stringify(projectId))
-      .pipe(map(res => res.data));
+    return this.httpClient.post<void>(`translation/pretranslations/cancel`, JSON.stringify(projectId)).pipe(
+      map(res => res.data),
+      catchError(err => {
+        // Handle gracefully if no build is currently running
+        if (err.status === 404) {
+          return EMPTY;
+        }
+        return throwError(err);
+      })
+    );
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.ts
@@ -26,7 +26,7 @@ export const DRAFT_GENERATION_SERVICE_OPTIONS = new InjectionToken<DraftGenerati
   {
     providedIn: 'root',
     factory: () => ({
-      pollRate: 1000 * 60 * 5 // Default to 5 minutes
+      pollRate: 1000 * 10 // Default to 10 seconds
     })
   }
 );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.ts
@@ -26,7 +26,7 @@ export const DRAFT_GENERATION_SERVICE_OPTIONS = new InjectionToken<DraftGenerati
   {
     providedIn: 'root',
     factory: () => ({
-      pollRate: 1000 * 10 // Default to 10 seconds
+      pollRate: 10_000 // Default to 10 seconds
     })
   }
 );


### PR DESCRIPTION
- A build job state of `Faulted` will now result in a warning shown to user with a prompt to start a new build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1996)
<!-- Reviewable:end -->
