### PR TITLE
SF-2170 Echo Support for Pre-Translation Drafting

### DIFF
--- a/src/SIL.XForge.Scripture/Models/FeatureFlags.cs
+++ b/src/SIL.XForge.Scripture/Models/FeatureFlags.cs
@@ -6,5 +6,6 @@ namespace SIL.XForge.Scripture.Models;
 public static class FeatureFlags
 {
     public const string Serval = "Serval";
+    public const string UseEchoForPreTranslation = "UseEchoForPreTranslation";
     public const string MachineInProcess = "MachineInProcess";
 }

--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -29,7 +29,7 @@
     <!-- When using a new major or minor version of ParatextData, update where dependencies.yml copies the
          InternetSettings.xml file. Also update server config scriptureforge.org_v2.yml. -->
     <PackageReference Include="ParatextData" Version="9.3.0.9" />
-    <PackageReference Include="Serval.Client" Version="0.5.1" />
+    <PackageReference Include="Serval.Client" Version="0.5.2" />
     <PackageReference Include="SIL.Machine.WebApi" Version="$(MachineVersion)" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -627,12 +627,19 @@ public class MachineProjectService : IMachineProjectService
             || (string.IsNullOrWhiteSpace(projectSecret.ServalData?.TranslationEngineId) && !preTranslate)
         )
         {
+            bool useEcho = await _featureManager.IsEnabledAsync(FeatureFlags.UseEchoForPreTranslation);
+            string type = preTranslate switch
+            {
+                true when useEcho => "Echo",
+                true => "Nmt",
+                false => "SmtTransfer",
+            };
             TranslationEngineConfig engineConfig = new TranslationEngineConfig
             {
                 Name = sfProject.Id,
                 SourceLanguage = sfProject.TranslateConfig.Source.WritingSystem.Tag,
                 TargetLanguage = sfProject.WritingSystem.Tag,
-                Type = preTranslate ? "Nmt" : "SmtTransfer",
+                Type = type,
             };
             // Add the project to Serval
             TranslationEngine translationEngine = await _translationEnginesClient.CreateAsync(


### PR DESCRIPTION
This Pull Request adds support for developers to use the Echo engine for Pre-Translation Drafting.

The Echo engine "echos" the source text for the pre-translation draft, which removes the requirement to wait for the pre-translation draft to be generated in Nmt. This means that when the Echo engine is enabled on the developer's machine, the UI for pre-translation drafting can be more rapidly tested.

**Enabling Echo for Pre-Translation**
Echo is enabled via a feature flag. Enabling this feature flag will only affect new pre-translation translation engines, not existing ones.
```
dotnet user-secrets set "FeatureManagement:UseEchoForPreTranslation" true
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/1997)
<!-- Reviewable:end -->
