### PR TITLE
SF-2186 Skip syncing notes with invalid content to prevent sync failure

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2291,8 +2291,15 @@ public class ParatextService : DisposableBase, IParatextService
                     {
                         if (comment.Contents == null)
                             comment.AddTextToContent(string.Empty, false);
-                        comment.Contents.InnerXml = xml;
-                        commentUpdated = true;
+                        try
+                        {
+                            comment.Contents.InnerXml = xml;
+                            commentUpdated = true;
+                        }
+                        catch (XmlException)
+                        {
+                            _logger.LogError($"Could not update comment xml for note {note.DataId}.\n{xml}");
+                        }
                     }
                     if (commentUpdated)
                         thread.Add(comment);

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2298,6 +2298,7 @@ public class ParatextService : DisposableBase, IParatextService
                         }
                         catch (XmlException)
                         {
+                            // FIXME Properly handle characters that need to be escaped instead of just logging an error
                             _logger.LogError($"Could not update comment xml for note {note.DataId}.\n{xml}");
                         }
                     }


### PR DESCRIPTION
This change logs the content of notes that are storing xml that is not correctly being encoded to be set to the InnerXml of the Contents note of a Paratext Comment. Since SF notes are not currently being exported to PT, this code is only run to provide warnings in the logs, so it is OK to modify it and skip over updating those comments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2000)
<!-- Reviewable:end -->
