### PR TITLE
SF-2187 Fix app height on mobile

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -6,9 +6,19 @@
 
 @import 'src/variables';
 
+// Set height of the app to 100% so that the app will fill the entire screen.
+// Don't use 100vh because that will cause the app to be too tall on mobile devices when the browser's address bar is
+// visible.
+// Newer browsers support dvh (dynamic viewport height) units, but they are not supported in Safari 15.4 and Chrome 108.
+// Setting the height to 100% seems to work just as well.
+::ng-deep html,
+::ng-deep body,
+:host {
+  height: 100%;
+}
+
 :host {
   display: flex;
-  height: 100vh;
   position: relative;
 
   > mat-progress-bar {


### PR DESCRIPTION
The height of the app is set to 100vh, but on mobile this is (generally, in most browsers) too tall and requires the user to scroll because of the browser UI elements.

See:
- https://developer.chrome.com/blog/url-bar-resizing/
- https://www.youtube.com/watch?v=xl9R8aTOW_I

This needs to be tested on a physical device, which is beyond the ability of the test team, before the code is on QA, so we'll want to have the reviewer test it well before merging.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2001)
<!-- Reviewable:end -->
