### PR TITLE
hotfix: SF-2186 Skip syncing notes with invalid content to prevent sync failure

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2291,8 +2291,16 @@ public class ParatextService : DisposableBase, IParatextService
                     {
                         if (comment.Contents == null)
                             comment.AddTextToContent(string.Empty, false);
-                        comment.Contents.InnerXml = xml;
-                        commentUpdated = true;
+                        try
+                        {
+                            comment.Contents.InnerXml = xml;
+                            commentUpdated = true;
+                        }
+                        catch (XmlException)
+                        {
+                            // FIXME Properly handle characters that need to be escaped instead of just logging an error
+                            _logger.LogError($"Could not update comment xml for note {note.DataId}.\n{xml}");
+                        }
                     }
                     if (commentUpdated)
                         thread.Add(comment);


### PR DESCRIPTION
This is a PR against sf-live to hotfix #2000.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2002)
<!-- Reviewable:end -->
