### PR TITLE
SF-2053b Fix Build State case during Serval upload

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -39,8 +39,21 @@ namespace SIL.XForge.Scripture.Services;
 /// </summary>
 public class MachineApiService : IMachineApiService
 {
-    internal const string BuildStateFaulted = "Faulted";
-    internal const string BuildStateQueued = "Queued";
+    /// <summary>
+    /// The Faulted build state.
+    /// </summary>
+    /// <remarks>
+    /// NOTE: Serval returns states in TitleCase, while the frontend requires uppercase.
+    /// </remarks>
+    internal const string BuildStateFaulted = "FAULTED";
+
+    /// <summary>
+    /// The Queued build state.
+    /// </summary>
+    /// <remarks>
+    /// SF returns this state while the files are being uploaded to Serval.
+    /// </remarks>
+    internal const string BuildStateQueued = "QUEUED";
     private readonly IBackgroundJobClient _backgroundJobClient;
     private readonly IBuildRepository _builds;
     private readonly IEngineRepository _engines;


### PR DESCRIPTION
This PR fixes the build state returned from the Machine API while Serval is being updated to be upper case, so that the frontend does not need to change the case of the string before reading it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2004)
<!-- Reviewable:end -->
