### PR TITLE
SF-2185 Fix error when user creates notes with invalid xml symbols

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.spec.ts
@@ -1,7 +1,7 @@
 import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { DeltaOperation } from 'rich-text';
 import { SelectableProject } from '../core/paratext.service';
-import { compareProjectsForSorting, isBadDelta, projectLabel } from './utils';
+import { compareProjectsForSorting, isBadDelta, projectLabel, XmlUtils } from './utils';
 
 describe('shared utils', () => {
   describe('projectLabel function', () => {
@@ -80,5 +80,59 @@ describe('shared utils', () => {
     const projects = [{ shortName: 'bbb' }, { shortName: 'CCC' }, { shortName: 'AAA' }] as SFProject[];
     projects.sort(compareProjectsForSorting);
     expect(projects.map(project => project.shortName)).toEqual(['AAA', 'bbb', 'CCC']);
+  });
+
+  describe('Xml Utils', () => {
+    it('should convert plain text to xml', () => {
+      expect(XmlUtils.encodeForXml('')).toEqual('');
+      expect(XmlUtils.encodeForXml('string without formatting')).toEqual('string without formatting');
+      expect(XmlUtils.encodeForXml('string with & and <symbols>.')).toEqual('string with &amp; and &lt;symbols&gt;.');
+      expect(XmlUtils.encodeForXml('content in paragraph.\nsecond paragraph')).toEqual(
+        'content in paragraph.\nsecond paragraph'
+      );
+    });
+
+    it('should decode from xml to plain text', () => {
+      expect(XmlUtils.decodeFromXml('')).toEqual('');
+      expect(XmlUtils.decodeFromXml('string without formatting')).toEqual('string without formatting');
+      expect(XmlUtils.decodeFromXml('string with &amp; and &lt;symbols&gt;.')).toEqual('string with & and <symbols>.');
+      expect(XmlUtils.decodeFromXml('content in paragraph.\nsecond paragraph')).toEqual(
+        'content in paragraph.\nsecond paragraph'
+      );
+      // we do not expect to decode xml tags since Paratext notes will not be editable. Just show the text content
+      expect(XmlUtils.decodeFromXml('<p>content in paragraph.</p><p>second paragraph</p>')).toEqual(
+        'content in paragraph.second paragraph'
+      );
+    });
+
+    it('should convert xml to html', () => {
+      expect(XmlUtils.convertXmlToHtml('')).toEqual('');
+      expect(XmlUtils.convertXmlToHtml('string without formatting')).toEqual('string without formatting');
+      expect(XmlUtils.convertXmlToHtml('<p>Here is text</p>')).toEqual('Here is text<br />');
+      expect(XmlUtils.convertXmlToHtml('<p>Here is text</p><p>Second paragraph text</p>')).toEqual(
+        'Here is text<br />Second paragraph text<br />'
+      );
+      expect(XmlUtils.convertXmlToHtml('<bold>Here is text</bold>')).toEqual('<b>Here is text</b>');
+      expect(XmlUtils.convertXmlToHtml('<italic>Here is text</italic>')).toEqual('<i>Here is text</i>');
+      expect(XmlUtils.convertXmlToHtml('<p>Text with <bold>bold</bold> and <italic>italic</italic></p>')).toEqual(
+        'Text with <b>bold</b> and <i>italic</i><br />'
+      );
+      expect(XmlUtils.convertXmlToHtml('<p>Paragraph with <bold><italic>nested</italic> styles</bold></p>')).toEqual(
+        'Paragraph with <b><i>nested</i> styles</b><br />'
+      );
+      expect(XmlUtils.convertXmlToHtml('<p>Paragraph with <bold></bold>empty bold tag</p>')).toEqual(
+        'Paragraph with empty bold tag<br />'
+      );
+      expect(XmlUtils.convertXmlToHtml('<p>Text in <span>span</span> tag</p>')).toEqual(
+        'Text in <span>span</span> tag<br />'
+      );
+      expect(XmlUtils.convertXmlToHtml('<p>\nNode with whitespace\n</p>')).toEqual('\nNode with whitespace\n<br />');
+      expect(XmlUtils.convertXmlToHtml('Alpha <unknown><bold>Bravo</bold></unknown> Charlie')).toEqual(
+        'Alpha <b>Bravo</b> Charlie'
+      );
+      expect(XmlUtils.convertXmlToHtml('check <unknown id="anything">unknown</unknown> <italic>text</italic>')).toEqual(
+        'check unknown <i>text</i>'
+      );
+    });
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.spec.ts
@@ -103,6 +103,10 @@ describe('shared utils', () => {
       expect(XmlUtils.decodeFromXml('<p>content in paragraph.</p><p>second paragraph</p>')).toEqual(
         'content in paragraph.second paragraph'
       );
+
+      // malformed xml
+      expect(() => XmlUtils.decodeFromXml('<p')).toThrow();
+      expect(() => XmlUtils.decodeFromXml('<p>')).toThrow();
     });
 
     it('should convert xml to html', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -166,31 +166,25 @@ export function canInsertNote(project: SFProjectProfile, userId: string): boolea
 export class XmlUtils {
   /** Encode text to be valid xml text node. Escape reserved xml characters such as & and < >. */
   static encodeForXml(text: string): string {
-    const content = `<root></root>`;
-    const parser: DOMParser = new DOMParser();
-    const xmlDoc: Document = parser.parseFromString(content, 'text/xml');
-    xmlDoc.firstElementChild!.textContent = text;
-    return xmlDoc.firstElementChild!.innerHTML;
+    const xmlDoc: XMLDocument = document.implementation.createDocument(null, 'root');
+    xmlDoc.documentElement.textContent = text;
+    return xmlDoc.documentElement.innerHTML;
   }
 
   /** Decode xml text node to plain text. */
   static decodeFromXml(xml: string): string {
-    const content = `<root></root>`;
-    const parser: DOMParser = new DOMParser();
-    const xmlDoc: Document = parser.parseFromString(content, 'text/xml');
-    xmlDoc.firstElementChild!.innerHTML = xml;
-    return xmlDoc.firstElementChild!.textContent!;
+    const xmlDoc: XMLDocument = document.implementation.createDocument(null, 'root');
+    xmlDoc.documentElement.innerHTML = xml;
+    return xmlDoc.documentElement.textContent!;
   }
 
   /** Convert xml note content to html to display in the browser. */
   static convertXmlToHtml(xml: string): string {
-    const content = `<root></root>`;
-    const parser: DOMParser = new DOMParser();
-    const xmlDoc: Document = parser.parseFromString(content, 'text/xml');
-    xmlDoc.firstElementChild!.innerHTML = xml;
-    const treeWalker: TreeWalker = xmlDoc.createTreeWalker(xmlDoc.firstElementChild!);
+    const xmlDoc: XMLDocument = document.implementation.createDocument(null, 'root');
+    xmlDoc.documentElement.innerHTML = xml;
+    const treeWalker: TreeWalker = xmlDoc.createTreeWalker(xmlDoc.documentElement);
     let htmlString = '';
-    const nodeTypes = [Node.ELEMENT_NODE, Node.TEXT_NODE];
+    const nodeTypes: number[] = [Node.ELEMENT_NODE, Node.TEXT_NODE];
     while (treeWalker.nextNode() != null) {
       if (nodeTypes.includes(treeWalker.currentNode.nodeType)) {
         htmlString += this.processNode(treeWalker);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -162,3 +162,87 @@ export function formatFontSizeToRems(fontSize: number | undefined): string | und
 export function canInsertNote(project: SFProjectProfile, userId: string): boolean {
   return SF_PROJECT_RIGHTS.hasRight(project, userId, SFProjectDomain.SFNoteThreads, Operation.Create);
 }
+
+export class XmlUtils {
+  /** Encode text to be valid xml text node. Escape reserved xml characters such as & and < >. */
+  static encodeForXml(text: string): string {
+    const content = `<root></root>`;
+    const parser: DOMParser = new DOMParser();
+    const xmlDoc: Document = parser.parseFromString(content, 'text/xml');
+    xmlDoc.firstElementChild!.textContent = text;
+    return xmlDoc.firstElementChild!.innerHTML;
+  }
+
+  /** Decode xml text node to plain text. */
+  static decodeFromXml(xml: string): string {
+    const content = `<root></root>`;
+    const parser: DOMParser = new DOMParser();
+    const xmlDoc: Document = parser.parseFromString(content, 'text/xml');
+    xmlDoc.firstElementChild!.innerHTML = xml;
+    return xmlDoc.firstElementChild!.textContent!;
+  }
+
+  /** Convert xml note content to html to display in the browser. */
+  static convertXmlToHtml(xml: string): string {
+    const content = `<root></root>`;
+    const parser: DOMParser = new DOMParser();
+    const xmlDoc: Document = parser.parseFromString(content, 'text/xml');
+    xmlDoc.firstElementChild!.innerHTML = xml;
+    const treeWalker: TreeWalker = xmlDoc.createTreeWalker(xmlDoc.firstElementChild!);
+    let htmlString = '';
+    const nodeTypes = [Node.ELEMENT_NODE, Node.TEXT_NODE];
+    while (treeWalker.nextNode() != null) {
+      if (nodeTypes.includes(treeWalker.currentNode.nodeType)) {
+        htmlString += this.processNode(treeWalker);
+      }
+    }
+    return htmlString;
+  }
+
+  /** Get the html contents of the current node and siblings. */
+  private static processNodeAndSiblings(treeWalker: TreeWalker): string {
+    if (treeWalker.currentNode.nextSibling == null) {
+      return this.processNode(treeWalker);
+    }
+    let htmlString = '';
+    while (treeWalker.currentNode.nextSibling != null) {
+      htmlString += this.processNode(treeWalker);
+      // move to the next sibling node
+      treeWalker.nextNode();
+    }
+    htmlString += this.processNode(treeWalker);
+    return htmlString;
+  }
+
+  private static processNode(treeWalker: TreeWalker): string {
+    switch (treeWalker.currentNode.nodeName.toLowerCase()) {
+      case 'p':
+        if (!treeWalker.currentNode.hasChildNodes()) return '';
+        treeWalker.nextNode();
+        return this.processNodeAndSiblings(treeWalker) + '<br />';
+      case 'bold':
+        if (!treeWalker.currentNode.hasChildNodes()) return '';
+        treeWalker.nextNode();
+        return '<b>' + this.processNodeAndSiblings(treeWalker) + '</b>';
+      case 'italic':
+        if (!treeWalker.currentNode.hasChildNodes()) return '';
+        treeWalker.nextNode();
+        return '<i>' + this.processNodeAndSiblings(treeWalker) + '</i>';
+      case 'span':
+        if (!treeWalker.currentNode.hasChildNodes()) return '';
+        treeWalker.nextNode();
+        return '<span>' + this.processNodeAndSiblings(treeWalker) + '</span>';
+      case '#text':
+        // get the inner html of the span element to get the encoded text so that < and > symbols are
+        // not lost during html sanitation
+        const span = document.createElement('span');
+        span.textContent = treeWalker.currentNode.nodeValue;
+        return span.innerHTML;
+      default:
+        // the node is for a tag we do not recognize. Show just the text content.
+        if (!treeWalker.currentNode.hasChildNodes()) return '';
+        treeWalker.nextNode();
+        return this.processNodeAndSiblings(treeWalker);
+    }
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -349,6 +349,22 @@ describe('NoteDialogComponent', () => {
     expect(env.dialogResult).toEqual({ noteContent: 'Enter note content', noteDataId: undefined });
   }));
 
+  it('can insert a note and encode for xml', fakeAsync(() => {
+    const verseRef = new VerseRef('MAT 1:3');
+    env = new TestEnvironment({ verseRef, noteTagId: 2 });
+    expect(env.noteInputElement).toBeTruthy();
+    expect(env.verseRef).toEqual('Matthew 1:3');
+    env.enterNoteContent('Enter note & have <xml> invalid content');
+    expect(env.component.currentNoteContent).toEqual('Enter note & have <xml> invalid content');
+    expect(env.component.segmentText).toEqual('target: chapter 1, verse 3.');
+    env.submit();
+
+    expect(env.dialogResult).toEqual({
+      noteContent: 'Enter note &amp; have &lt;xml&gt; invalid content',
+      noteDataId: undefined
+    });
+  }));
+
   it('show sf note tag on notes with undefined tag id', fakeAsync(() => {
     const noteThread: NoteThread = TestEnvironment.getNoteThread(undefined, true);
     env = new TestEnvironment({ noteThread });
@@ -407,6 +423,22 @@ describe('NoteDialogComponent', () => {
     env.enterNoteContent(content);
     env.submit();
     expect(env.dialogResult).toEqual({ noteContent: content, noteDataId: 'note05' });
+  }));
+
+  it('allows user to edit the content with xml reserved symbols', fakeAsync(() => {
+    const noteThread: NoteThread = TestEnvironment.getNoteThread(undefined, undefined, true);
+    // note03 is marked as deleted
+    const encodedContent = 'note05 &amp; &lt;content&gt; in note';
+    noteThread.notes[4].content = encodedContent;
+    env = new TestEnvironment({ noteThread });
+    expect(env.getNoteContent(4)).toEqual('note05 & <content> in note');
+    expect(env.noteHasEditActions(4)).toBe(true);
+    env.clickEditNote();
+    expect(env.component.currentNoteContent).toEqual('note05 & <content> in note');
+    const content = 'note05 & <content> in note (edited)';
+    env.enterNoteContent(content);
+    env.submit();
+    expect(env.dialogResult).toEqual({ noteContent: encodedContent + ' (edited)', noteDataId: 'note05' });
   }));
 
   it('does not allow user to edit the last note in the thread if it is not editable', fakeAsync(() => {
@@ -897,6 +929,10 @@ class TestEnvironment {
   getProjectUserConfigDoc(projectId: string, userId: string): SFProjectUserConfigDoc {
     const id: string = getSFProjectUserConfigDocId(projectId, userId);
     return this.realtimeService.get<SFProjectUserConfigDoc>(SFProjectUserConfigDoc.COLLECTION, id);
+  }
+
+  getNoteContent(noteNumber: number): string {
+    return this.notes[noteNumber - 1].query(By.css('.note-content')).nativeElement.textContent;
   }
 
   noteHasEditActions(noteNumber: number): boolean {


### PR DESCRIPTION
* encode note content to be valid xml to be stored in mongo
* parse xml to html for display using a tree walker
* remove regex used for html display

This change makes improvements for how we display and save note content. Previously, if a user entered a reserved symbol like & into their SF note, the result would be an error would occur while synchronizing the data because Paratext expects comment content to be valid xml. This change ensures that notes are saved as valid xml. This also replaces the existing method for parsing html from note content which used regular expressions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2010)
<!-- Reviewable:end -->
