### PR TITLE
SF-2192 Optimize note thread query and display

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -164,10 +164,12 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
     return url;
   }
 
-  queryNoteThreads(sfProjectId: string): Promise<RealtimeQuery<NoteThreadDoc>> {
+  queryNoteThreads(sfProjectId: string, bookNum: number, chapterNum: number): Promise<RealtimeQuery<NoteThreadDoc>> {
     const queryParams: QueryParameters = {
       [obj<NoteThread>().pathStr(t => t.projectRef)]: sfProjectId,
-      [obj<NoteThread>().pathStr(t => t.status)]: NoteStatus.Todo
+      [obj<NoteThread>().pathStr(t => t.status)]: NoteStatus.Todo,
+      [obj<NoteThread>().pathStr(t => t.verseRef.bookNum)]: bookNum,
+      [obj<NoteThread>().pathStr(t => t.verseRef.chapterNum)]: chapterNum
     };
     return this.realtimeService.subscribeQuery(NoteThreadDoc.COLLECTION, queryParams);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3493,11 +3493,14 @@ class TestEnvironment {
       this.realtimeService.subscribe(TextDoc.COLLECTION, id.toString())
     );
     when(mockedSFProjectService.isProjectAdmin('project01', 'user04')).thenResolve(true);
-    when(mockedSFProjectService.queryNoteThreads(anything())).thenCall((id, _) =>
-      this.realtimeService.subscribeQuery(NoteThreadDoc.COLLECTION, {
-        [obj<NoteThread>().pathStr(t => t.projectRef)]: id,
-        [obj<NoteThread>().pathStr(t => t.status)]: NoteStatus.Todo
-      })
+    when(mockedSFProjectService.queryNoteThreads(anything(), anything(), anything())).thenCall(
+      (id, bookNum, chapterNum, _) =>
+        this.realtimeService.subscribeQuery(NoteThreadDoc.COLLECTION, {
+          [obj<NoteThread>().pathStr(t => t.projectRef)]: id,
+          [obj<NoteThread>().pathStr(t => t.status)]: NoteStatus.Todo,
+          [obj<NoteThread>().pathStr(t => t.verseRef.bookNum)]: bookNum,
+          [obj<NoteThread>().pathStr(t => t.verseRef.chapterNum)]: chapterNum
+        })
     );
     when(mockedSFProjectService.createNoteThread(anything(), anything())).thenCall(
       (projectId: string, noteThread: NoteThread) => {
@@ -3670,12 +3673,15 @@ class TestEnvironment {
   }
   setCommenterUser(userId: 'user02' | 'user05' = 'user05'): void {
     this.setCurrentUser(userId);
-    when(mockedSFProjectService.queryNoteThreads('project01')).thenCall((id, _) =>
-      this.realtimeService.subscribeQuery(NoteThreadDoc.COLLECTION, {
-        [obj<NoteThread>().pathStr(t => t.publishedToSF)]: userId === 'user05',
-        [obj<NoteThread>().pathStr(t => t.status)]: NoteStatus.Todo,
-        [obj<NoteThread>().pathStr(t => t.projectRef)]: id
-      })
+    when(mockedSFProjectService.queryNoteThreads('project01', anything(), anything())).thenCall(
+      (id, bookNum, chapterNum, _) =>
+        this.realtimeService.subscribeQuery(NoteThreadDoc.COLLECTION, {
+          [obj<NoteThread>().pathStr(t => t.publishedToSF)]: userId === 'user05',
+          [obj<NoteThread>().pathStr(t => t.status)]: NoteStatus.Todo,
+          [obj<NoteThread>().pathStr(t => t.projectRef)]: id,
+          [obj<NoteThread>().pathStr(t => t.verseRef.bookNum)]: bookNum,
+          [obj<NoteThread>().pathStr(t => t.verseRef.chapterNum)]: chapterNum
+        })
     );
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -568,7 +568,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
           return;
         }
         this.text = this.projectDoc.data.texts.find(t => t.bookNum === bookNum);
-        await this.loadNoteThreadDocs(this.projectDoc.id);
         if (this.sourceProjectDoc?.data != null) {
           this.sourceText = this.sourceProjectDoc.data.texts.find(t => t.bookNum === bookNum);
         }
@@ -1228,6 +1227,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         this.router.navigateByUrl('/projects/' + this.projectDoc!.id + '/translate', { replaceUrl: true });
       });
     });
+    await this.loadNoteThreadDocs(this.projectDoc.id, this.text.bookNum, this._chapter);
     setTimeout(() => this.setTextHeight());
   }
 
@@ -1453,10 +1453,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
   }
 
-  private async loadNoteThreadDocs(sfProjectId: string): Promise<void> {
+  private async loadNoteThreadDocs(sfProjectId: string, bookNum: number, chapterNum: number): Promise<void> {
     this.noteThreadQuery?.dispose();
-
-    this.noteThreadQuery = await this.projectService.queryNoteThreads(sfProjectId);
+    this.noteThreadQuery = await this.projectService.queryNoteThreads(sfProjectId, bookNum, chapterNum);
     this.toggleNoteThreadSub?.unsubscribe();
     this.toggleNoteThreadSub = this.subscribe(
       merge(
@@ -1889,8 +1888,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     return this.noteThreadQuery.docs.filter(
       nt =>
         nt.data != null &&
-        nt.data.verseRef.bookNum === this.bookNum &&
-        nt.data.verseRef.chapterNum === this.chapter &&
         nt.data.notes.filter(n => !n.deleted).length > 0 &&
         nt.data.notes[0].type !== NoteType.Conflict
     );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
@@ -28,23 +28,25 @@
       </mat-menu>
     </div>
     <div class="notes">
-      <div *ngFor="let note of notesToDisplay" class="note">
+      <div *ngFor="let noteInfo of notesToDisplay" class="note">
         <div class="content">
-          <div *ngIf="note.assignment != null" class="assigned-user">>{{ getAssignedUserString(note.assignment) }}</div>
-          <div *ngIf="note.reattached" class="verse-reattached">{{ reattachedVerse(note) }}</div>
-          <div *ngIf="note.reattached" class="text" [innerHTML]="reattachedText(note)"></div>
+          <div *ngIf="noteInfo.assignment != null" class="assigned-user">>{{ noteInfo.assignment }}</div>
+          <div *ngIf="noteInfo.reattachedVerse != null" class="verse-reattached">{{ noteInfo.reattachedVerse }}</div>
+          <div *ngIf="noteInfo.reattachedText != null" class="text" [innerHTML]="noteInfo.reattachedText"></div>
           <div class="note-content-and-actions">
-            <div class="note-content" [innerHTML]="contentForDisplay(note)" [ngStyle]="{ fontSize }"></div>
-            <div *ngIf="isNoteEditable(note)" class="edit-actions">
-              <button mat-icon-button class="edit-button" (click)="editNote(note)"><mat-icon>edit</mat-icon></button>
-              <button mat-icon-button class="delete-button" (click)="deleteNote(note)">
+            <div class="note-content" [innerHTML]="noteInfo.content" [ngStyle]="{ fontSize }"></div>
+            <div *ngIf="noteInfo.editable" class="edit-actions">
+              <button mat-icon-button class="edit-button" (click)="editNote(noteInfo.note)">
+                <mat-icon>edit</mat-icon>
+              </button>
+              <button mat-icon-button class="delete-button" (click)="deleteNote(noteInfo.note)">
                 <mat-icon>delete</mat-icon>
               </button>
             </div>
           </div>
         </div>
-        <img [src]="noteIcon(note)" alt="" [title]="noteTitle(note)" />
-        <app-owner [ownerRef]="note.ownerRef" [dateTime]="note.dateCreated"></app-owner>
+        <img [src]="noteInfo.icon" alt="" [title]="noteInfo.title" />
+        <app-owner [ownerRef]="noteInfo.note.ownerRef" [dateTime]="noteInfo.note.dateCreated"></app-owner>
       </div>
     </div>
     <mat-form-field *ngIf="canInsertNote" class="full-width" appearance="outline">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -126,43 +126,6 @@ describe('NoteDialogComponent', () => {
     expect(env.notes.length).toBe(4);
   }));
 
-  it('should style notes', fakeAsync(() => {
-    env = new TestEnvironment({ noteThread: TestEnvironment.getNoteThread() });
-    const tests: { text: string | undefined; expected: string }[] = [
-      {
-        text: 'turn <bold>text bold</bold>',
-        expected: 'turn <b>text bold</b>'
-      },
-      {
-        text: 'turn <italic>text italic</italic>',
-        expected: 'turn <i>text italic</i>'
-      },
-      {
-        text: 'Alpha <unknown><bold>Bravo</bold></unknown> Charlie',
-        expected: 'Alpha <b>Bravo</b> Charlie'
-      },
-      {
-        text: '<p>this is a paragraph</p>',
-        expected: 'this is a paragraph<br />'
-      },
-      {
-        text: 'check <unknown id="anything">unknown</unknown> <italic>text</italic>',
-        expected: 'check unknown <i>text</i>'
-      },
-      {
-        text: '',
-        expected: ''
-      },
-      {
-        text: undefined,
-        expected: ''
-      }
-    ];
-    tests.forEach(test => {
-      expect(env.component.parseNote(test.text)).toEqual(test.expected);
-    });
-  }));
-
   it('produce correct default note icon', fakeAsync(() => {
     env = new TestEnvironment({ noteThread: TestEnvironment.getNoteThread() });
     expect(env.component.flagIcon).toEqual('/assets/icons/TagIcons/flag01.png');
@@ -308,8 +271,6 @@ describe('NoteDialogComponent', () => {
   it('should gracefully return when data not ready', fakeAsync(() => {
     env = new TestEnvironment({ noteThread: TestEnvironment.getNoteThread(), includeSnapshots: false });
     expect(env.component.segmentText).toEqual('');
-    const noteThread: NoteThread = TestEnvironment.getNoteThread();
-    expect(env.component.noteIcon(noteThread[0])).toEqual('');
   }));
 
   it('uses rtl direction with rtl project', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -35,6 +35,17 @@ export interface NoteDialogResult {
   noteDataId?: string;
 }
 
+interface NoteDisplayInfo {
+  note: Note;
+  content: string;
+  icon: string;
+  title: string;
+  editable: boolean;
+  assignment?: string;
+  reattachedVerse?: string;
+  reattachedText?: string;
+}
+
 // TODO: Implement a diff - there is an accepted solution here that might be a good starting point:
 // https://codereview.stackexchange.com/questions/133586/a-string-prototype-diff-implementation-text-diff
 
@@ -45,6 +56,8 @@ export interface NoteDialogResult {
 export class NoteDialogComponent implements OnInit {
   showSegmentText: boolean = false;
   currentNoteContent: string = '';
+  notesToDisplay: NoteDisplayInfo[] = [];
+
   private isAssignedToOtherUser: boolean = false;
   private threadDoc?: NoteThreadDoc;
   private projectProfileDoc?: SFProjectProfileDoc;
@@ -87,6 +100,8 @@ export class NoteDialogComponent implements OnInit {
         );
       }
     }
+    // extract note info and content for display
+    this.updateNotesForDisplay();
   }
 
   get canViewAssignedUser(): boolean {
@@ -127,16 +142,6 @@ export class NoteDialogComponent implements OnInit {
     return this.getNoteContextText(true) !== this.segmentText;
   }
 
-  get notesToDisplay(): Note[] {
-    if (this.threadDoc?.data == null) {
-      return [];
-    }
-    return sortBy(
-      this.threadDoc.data.notes.filter(n => !n.deleted && n.dataId !== this.noteIdBeingEdited),
-      n => new Date(n.dateCreated)
-    );
-  }
-
   get verseRefDisplay(): string {
     const verseRef: VerseRef | undefined = this.verseRef;
     return verseRef == null ? '' : this.i18n.localizeReference(verseRef);
@@ -167,27 +172,6 @@ export class NoteDialogComponent implements OnInit {
     return this.projectProfileDoc?.data?.noteTags ?? [];
   }
 
-  /** What to display for note content. Will be transformed for display. */
-  contentForDisplay(note: Note): string {
-    if (note.content == null) {
-      return '';
-    }
-    return this.parseNote(note.content);
-  }
-
-  getNoteContextText(plainText: boolean = false): string {
-    if (this.threadDoc?.data == null) {
-      return '';
-    }
-    return (
-      this.threadDoc.data.originalContextBefore +
-      (plainText ? '' : '<b>') +
-      this.threadDoc.data.originalSelectedText +
-      (plainText ? '' : '</b>') +
-      this.threadDoc.data.originalContextAfter
-    );
-  }
-
   private get projectId(): string {
     return this.data.projectId;
   }
@@ -198,11 +182,6 @@ export class NoteDialogComponent implements OnInit {
 
   private get threadDataId(): string | undefined {
     return this.data.threadDataId;
-  }
-
-  private get lastNoteId(): string | undefined {
-    const notesCount: number = this.notesToDisplay.length;
-    return notesCount > 0 ? this.notesToDisplay[notesCount - 1].dataId : undefined;
   }
 
   private get verseRef(): VerseRef | undefined {
@@ -219,6 +198,7 @@ export class NoteDialogComponent implements OnInit {
   editNote(note: Note): void {
     this.noteIdBeingEdited = note.dataId;
     this.currentNoteContent = XmlUtils.decodeFromXml(note.content ?? '');
+    this.notesToDisplay.pop();
   }
 
   async deleteNote(note: Note): Promise<void> {
@@ -233,87 +213,27 @@ export class NoteDialogComponent implements OnInit {
       await this.threadDoc!.submitJson0Op(op => op.set(nt => nt.notes[index].deleted, true));
     }
 
+    this.updateNotesForDisplay();
     if (this.notesToDisplay.length === 0) {
       this.dialogRef.close({ deleted: true });
     }
   }
 
-  parseNote(content: string | undefined): string {
-    if (content == null) return '';
-    return XmlUtils.convertXmlToHtml(content);
-  }
-
-  toggleSegmentText(): void {
-    this.showSegmentText = !this.showSegmentText;
-  }
-
-  noteIcon(note: Note): string {
+  getNoteContextText(plainText: boolean = false): string {
     if (this.threadDoc?.data == null) {
       return '';
     }
-    switch (note.status) {
-      case NoteStatus.Todo:
-        return this.threadDoc.getNoteIcon(note, this.noteTags).url;
-      case NoteStatus.Done:
-      case NoteStatus.Resolved:
-        return this.threadDoc.getNoteResolvedIcon(note, this.noteTags).url;
-    }
-    const noteIcon: string = this.threadDoc.getNoteIcon(note, this.noteTags).url;
-    return note.reattached != null && noteIcon === '' ? this.threadDoc.iconReattached.url : noteIcon;
-  }
-
-  noteTitle(note: Note): string {
-    switch (note.status) {
-      case NoteStatus.Todo:
-        return translate('note_dialog.status_to_do');
-      case NoteStatus.Done:
-      case NoteStatus.Resolved:
-        return translate('note_dialog.status_resolved');
-    }
-    return note.reattached != null ? translate('note_dialog.note_reattached') : '';
-  }
-
-  isNoteEditable(note: Note): boolean {
-    if (this.projectProfileDoc?.data == null) return false;
     return (
-      this.isAddNotesEnabled &&
-      note.dataId === this.lastNoteId &&
-      note.editable === true &&
-      this.noteIdBeingEdited == null &&
-      SF_PROJECT_RIGHTS.hasRight(
-        this.projectProfileDoc.data,
-        this.userService.currentUserId,
-        SFProjectDomain.Notes,
-        Operation.Edit,
-        note
-      )
+      this.threadDoc.data.originalContextBefore +
+      (plainText ? '' : '<b>') +
+      this.threadDoc.data.originalSelectedText +
+      (plainText ? '' : '</b>') +
+      this.threadDoc.data.originalContextAfter
     );
   }
 
-  reattachedText(note: Note): string {
-    if (note.reattached == null) {
-      return '';
-    }
-    const reattachedParts: string[] = note.reattached.split(REATTACH_SEPARATOR);
-    const selectedText: string = reattachedParts[1];
-    const contextBefore: string = reattachedParts[3];
-    const contextAfter: string = reattachedParts[4];
-    return contextBefore + '<b>' + selectedText + '</b>' + contextAfter;
-  }
-
-  reattachedVerse(note: Note): string {
-    if (note.reattached == null) {
-      return '';
-    }
-    const reattachedParts: string[] = note.reattached.split(REATTACH_SEPARATOR);
-    const verseStr: string = reattachedParts[0];
-    const vref: VerseRef = new VerseRef(verseStr);
-    const verseRef: string = this.i18n.localizeReference(vref);
-    const reattached: string = translate('note_dialog.reattached');
-    return `${verseRef} ${reattached}`;
-  }
-
-  getAssignedUserString(assignedNoteUserRef: string): string {
+  getAssignedUserString(assignedNoteUserRef: string | undefined): string | undefined {
+    if (assignedNoteUserRef == null) return;
     switch (assignedNoteUserRef) {
       case AssignedUsers.TeamUser:
         return translate('note_dialog.team');
@@ -336,5 +256,113 @@ export class NoteDialogComponent implements OnInit {
       noteContent: XmlUtils.encodeForXml(this.currentNoteContent),
       noteDataId: this.noteIdBeingEdited
     });
+  }
+
+  updateNotesForDisplay(): void {
+    if (this.threadDoc?.data == null) return;
+    const notesToDisplay: Note[] = sortBy(
+      this.threadDoc.data.notes.filter(n => !n.deleted),
+      n => new Date(n.dateCreated)
+    );
+    this.notesToDisplay = [];
+    if (notesToDisplay.length === 0) return;
+
+    const lastNoteId: string = notesToDisplay[notesToDisplay.length - 1].dataId;
+    for (const note of notesToDisplay) {
+      this.notesToDisplay.push({
+        note,
+        content: this.contentForDisplay(note),
+        icon: this.noteIcon(note),
+        title: this.noteTitle(note),
+        editable: this.isNoteEditable(note) && note.dataId === lastNoteId,
+        assignment: this.getAssignedUserString(note.assignment),
+        reattachedVerse: this.reattachedVerse(note),
+        reattachedText: this.reattachedText(note)
+      });
+    }
+  }
+
+  toggleSegmentText(): void {
+    this.showSegmentText = !this.showSegmentText;
+  }
+
+  /** What to display for note content. Will be transformed for display, especially for a conflict note. */
+  private contentForDisplay(note: Note): string {
+    if (note == null) {
+      return '';
+    }
+    return this.parseNote(note.content);
+  }
+
+  private parseNote(content: string | undefined): string {
+    const replace = new Map<RegExp, string>();
+    replace.set(/<bold>(.*?)<\/bold>/gim, '<b>$1</b>'); // Bold style
+    replace.set(/<italic>(.*?)<\/italic>/gim, '<i>$1</i>'); // Italic style
+    replace.set(/<p>(.*?)<\/p>/gim, '$1<br />'); // Turn paragraphs into line breaks
+    // Strip out any tags that don't match the above replacements
+    replace.set(/<((?!(\/?)(i|b|br|span)))(.*?)>/gim, '');
+    replace.forEach((replacement, regEx) => (content = content?.replace(regEx, replacement)));
+    return content ?? '';
+  }
+
+  private noteIcon(note: Note): string {
+    if (this.threadDoc?.data == null) {
+      return '';
+    }
+    switch (note.status) {
+      case NoteStatus.Todo:
+        return this.threadDoc.getNoteIcon(note, this.noteTags).url;
+      case NoteStatus.Done:
+      case NoteStatus.Resolved:
+        return this.threadDoc.getNoteResolvedIcon(note, this.noteTags).url;
+    }
+    const noteIcon: string = this.threadDoc.getNoteIcon(note, this.noteTags).url;
+    return note.reattached != null && noteIcon === '' ? this.threadDoc.iconReattached.url : noteIcon;
+  }
+
+  private noteTitle(note: Note): string {
+    switch (note.status) {
+      case NoteStatus.Todo:
+        return translate('note_dialog.status_to_do');
+      case NoteStatus.Done:
+      case NoteStatus.Resolved:
+        return translate('note_dialog.status_resolved');
+    }
+    return note.reattached != null ? translate('note_dialog.note_reattached') : '';
+  }
+
+  private isNoteEditable(note: Note): boolean {
+    if (this.projectProfileDoc?.data == null) return false;
+    return (
+      this.isAddNotesEnabled &&
+      note.editable === true &&
+      this.noteIdBeingEdited == null &&
+      SF_PROJECT_RIGHTS.hasRight(
+        this.projectProfileDoc.data,
+        this.userService.currentUserId,
+        SFProjectDomain.Notes,
+        Operation.Edit,
+        note
+      )
+    );
+  }
+
+  private reattachedText(note: Note): string | undefined {
+    if (note.reattached == null) return;
+    const reattachedParts: string[] = note.reattached.split(REATTACH_SEPARATOR);
+    const selectedText: string = reattachedParts[1];
+    const contextBefore: string = reattachedParts[3];
+    const contextAfter: string = reattachedParts[4];
+    return contextBefore + '<b>' + selectedText + '</b>' + contextAfter;
+  }
+
+  private reattachedVerse(note: Note): string | undefined {
+    if (note.reattached == null) return;
+    const reattachedParts: string[] = note.reattached.split(REATTACH_SEPARATOR);
+    const verseStr: string = reattachedParts[0];
+    const vref: VerseRef = new VerseRef(verseStr);
+    const verseRef: string = this.i18n.localizeReference(vref);
+    const reattached: string = translate('note_dialog.reattached');
+    return `${verseRef} ${reattached}`;
   }
 }


### PR DESCRIPTION
* query the chapter specific notes each time the text changes
* extract note display information when the dialog opens
* remove test for html display of note content

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2011)
<!-- Reviewable:end -->
