### PR TITLE
SF-2207 Leave breadcrumbs only if Bugsnag has started

### DIFF
--- a/src/RealtimeServer/package-lock.json
+++ b/src/RealtimeServer/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "@bugsnag/js": "^7.16.5",
+        "@bugsnag/js": "^7.21.0",
         "@sillsdev/scripture": "^1.4.0",
         "express": "^4.18.1",
         "jsonwebtoken": "^9.0.0",
@@ -662,17 +662,17 @@
       "dev": true
     },
     "node_modules/@bugsnag/browser": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.16.5.tgz",
-      "integrity": "sha512-EftyLRfUgQL/7leHhlfL756KlcBsG8C7wwMRRoyzGnAIH0Uu/l1RfBi5Tf1Fhk+LOwkDedTxDtQOa70EC8oS8A==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.21.0.tgz",
+      "integrity": "sha512-mJ6r6SXpts+hdSnDNmTR35lZ+95BthqXpgBrDwquDCoY++zQ4OuzrkA/HZYD/rfpdSpgb7lO+AAlD7qrd9IylA==",
       "dependencies": {
-        "@bugsnag/core": "^7.16.1"
+        "@bugsnag/core": "^7.19.0"
       }
     },
     "node_modules/@bugsnag/core": {
-      "version": "7.16.1",
-      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.16.1.tgz",
-      "integrity": "sha512-zuBnL7B329VldItRqhXYrp1hjmjZnltJwNXMysi9WtY4t29WKk5LVwgWb1mPM9clJ0FoObZ7kvvQMUTKh3ezFQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.19.0.tgz",
+      "integrity": "sha512-2KGwdaLD9PhR7Wk7xPi3jGuGsKTatc/28U4TOZIDU3CgC2QhGjubwiXSECel5gwxhZ3jACKcMKSV2ovHhv1NrA==",
       "dependencies": {
         "@bugsnag/cuid": "^3.0.0",
         "@bugsnag/safe-json-stringify": "^6.0.0",
@@ -682,25 +682,25 @@
       }
     },
     "node_modules/@bugsnag/cuid": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.0.tgz",
-      "integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.2.tgz",
+      "integrity": "sha512-cIwzC93r3PQ/INeuwtZwkZIG2K8WWN0rRLZQhu+mr48Ay+i6sEki4GYfTsflse7hZ1BeDWrNb/Q9vgY3B31xHQ=="
     },
     "node_modules/@bugsnag/js": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.16.5.tgz",
-      "integrity": "sha512-IzFkRRhisAdfAG5ihKbd9c2YtBmYWuA3Yw+KnzwVwQ/dDZKpWMPzQOv9uVznA1u8Dqv9347e/uUbRzudlGUJog==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.21.0.tgz",
+      "integrity": "sha512-fFTR7cRBSlLtwa1wPTse92igZUEX2V95KyGGCXq2qb2F2w6hJ6oJDxA0BMPS8qqsciYXRjbfn8HX+TFgO1oErg==",
       "dependencies": {
-        "@bugsnag/browser": "^7.16.5",
-        "@bugsnag/node": "^7.16.2"
+        "@bugsnag/browser": "^7.21.0",
+        "@bugsnag/node": "^7.19.0"
       }
     },
     "node_modules/@bugsnag/node": {
-      "version": "7.16.2",
-      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.16.2.tgz",
-      "integrity": "sha512-V5pND701cIYGzjjTwt0tuvAU1YyPB9h7vo5F/DzrDHRPmCINA/oVbc0Twco87knc2VPe8ntGFqTicTY65iOWzg==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.19.0.tgz",
+      "integrity": "sha512-c4snyxx5d/fsMogmgehFBGc//daH6+4XCplia4zrEQYltjaQ+l8ud0dPx623DgJl/2j1+2zlRc7y7IHSd7Gm5w==",
       "dependencies": {
-        "@bugsnag/core": "^7.16.1",
+        "@bugsnag/core": "^7.19.0",
         "byline": "^5.0.0",
         "error-stack-parser": "^2.0.2",
         "iserror": "^0.0.2",
@@ -2729,11 +2729,11 @@
       }
     },
     "node_modules/error-stack-parser": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.7.tgz",
-      "integrity": "sha512-chLOW0ZGRf4s8raLrDxa5sdkvPec5YdvwbFnqJme4rk0rFajP8mPtrDL1+I+CwrQDCjswDA5sREX7jYQDQs9vA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
       "dependencies": {
-        "stackframe": "^1.1.1"
+        "stackframe": "^1.3.4"
       }
     },
     "node_modules/es-abstract": {
@@ -4285,7 +4285,7 @@
     "node_modules/iserror": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
-      "integrity": "sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U="
+      "integrity": "sha512-oKGGrFVaWwETimP3SiWwjDeY27ovZoyZPHtxblC4hCq9fXxed/jasx+ATWFFjCVSRZng8VTMsN1nDnGo6zMBSw=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6490,11 +6490,11 @@
       "dev": true
     },
     "node_modules/stack-generator": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
-      "integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
       "dependencies": {
-        "stackframe": "^1.1.1"
+        "stackframe": "^1.3.4"
       }
     },
     "node_modules/stack-utils": {
@@ -6519,9 +6519,9 @@
       }
     },
     "node_modules/stackframe": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.1.tgz",
-      "integrity": "sha512-h88QkzREN/hy8eRdyNhhsO7RSJ5oyTqxxmmn0dzBIMUclZsjpfmrsg81vp8mjjAs2vAZ72nyWxRUwSwmh0e4xg=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -7608,17 +7608,17 @@
       "dev": true
     },
     "@bugsnag/browser": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.16.5.tgz",
-      "integrity": "sha512-EftyLRfUgQL/7leHhlfL756KlcBsG8C7wwMRRoyzGnAIH0Uu/l1RfBi5Tf1Fhk+LOwkDedTxDtQOa70EC8oS8A==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.21.0.tgz",
+      "integrity": "sha512-mJ6r6SXpts+hdSnDNmTR35lZ+95BthqXpgBrDwquDCoY++zQ4OuzrkA/HZYD/rfpdSpgb7lO+AAlD7qrd9IylA==",
       "requires": {
-        "@bugsnag/core": "^7.16.1"
+        "@bugsnag/core": "^7.19.0"
       }
     },
     "@bugsnag/core": {
-      "version": "7.16.1",
-      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.16.1.tgz",
-      "integrity": "sha512-zuBnL7B329VldItRqhXYrp1hjmjZnltJwNXMysi9WtY4t29WKk5LVwgWb1mPM9clJ0FoObZ7kvvQMUTKh3ezFQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.19.0.tgz",
+      "integrity": "sha512-2KGwdaLD9PhR7Wk7xPi3jGuGsKTatc/28U4TOZIDU3CgC2QhGjubwiXSECel5gwxhZ3jACKcMKSV2ovHhv1NrA==",
       "requires": {
         "@bugsnag/cuid": "^3.0.0",
         "@bugsnag/safe-json-stringify": "^6.0.0",
@@ -7628,25 +7628,25 @@
       }
     },
     "@bugsnag/cuid": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.0.tgz",
-      "integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.2.tgz",
+      "integrity": "sha512-cIwzC93r3PQ/INeuwtZwkZIG2K8WWN0rRLZQhu+mr48Ay+i6sEki4GYfTsflse7hZ1BeDWrNb/Q9vgY3B31xHQ=="
     },
     "@bugsnag/js": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.16.5.tgz",
-      "integrity": "sha512-IzFkRRhisAdfAG5ihKbd9c2YtBmYWuA3Yw+KnzwVwQ/dDZKpWMPzQOv9uVznA1u8Dqv9347e/uUbRzudlGUJog==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.21.0.tgz",
+      "integrity": "sha512-fFTR7cRBSlLtwa1wPTse92igZUEX2V95KyGGCXq2qb2F2w6hJ6oJDxA0BMPS8qqsciYXRjbfn8HX+TFgO1oErg==",
       "requires": {
-        "@bugsnag/browser": "^7.16.5",
-        "@bugsnag/node": "^7.16.2"
+        "@bugsnag/browser": "^7.21.0",
+        "@bugsnag/node": "^7.19.0"
       }
     },
     "@bugsnag/node": {
-      "version": "7.16.2",
-      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.16.2.tgz",
-      "integrity": "sha512-V5pND701cIYGzjjTwt0tuvAU1YyPB9h7vo5F/DzrDHRPmCINA/oVbc0Twco87knc2VPe8ntGFqTicTY65iOWzg==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.19.0.tgz",
+      "integrity": "sha512-c4snyxx5d/fsMogmgehFBGc//daH6+4XCplia4zrEQYltjaQ+l8ud0dPx623DgJl/2j1+2zlRc7y7IHSd7Gm5w==",
       "requires": {
-        "@bugsnag/core": "^7.16.1",
+        "@bugsnag/core": "^7.19.0",
         "byline": "^5.0.0",
         "error-stack-parser": "^2.0.2",
         "iserror": "^0.0.2",
@@ -9170,11 +9170,11 @@
       }
     },
     "error-stack-parser": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.7.tgz",
-      "integrity": "sha512-chLOW0ZGRf4s8raLrDxa5sdkvPec5YdvwbFnqJme4rk0rFajP8mPtrDL1+I+CwrQDCjswDA5sREX7jYQDQs9vA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
       "requires": {
-        "stackframe": "^1.1.1"
+        "stackframe": "^1.3.4"
       }
     },
     "es-abstract": {
@@ -10306,7 +10306,7 @@
     "iserror": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
-      "integrity": "sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U="
+      "integrity": "sha512-oKGGrFVaWwETimP3SiWwjDeY27ovZoyZPHtxblC4hCq9fXxed/jasx+ATWFFjCVSRZng8VTMsN1nDnGo6zMBSw=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -11990,11 +11990,11 @@
       "dev": true
     },
     "stack-generator": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
-      "integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
       "requires": {
-        "stackframe": "^1.1.1"
+        "stackframe": "^1.3.4"
       }
     },
     "stack-utils": {
@@ -12015,9 +12015,9 @@
       }
     },
     "stackframe": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.1.tgz",
-      "integrity": "sha512-h88QkzREN/hy8eRdyNhhsO7RSJ5oyTqxxmmn0dzBIMUclZsjpfmrsg81vp8mjjAs2vAZ72nyWxRUwSwmh0e4xg=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
     },
     "statuses": {
       "version": "2.0.1",

--- a/src/RealtimeServer/package.json
+++ b/src/RealtimeServer/package.json
@@ -21,7 +21,7 @@
   "types": "lib/cjs/common/index.d.ts",
   "private": true,
   "dependencies": {
-    "@bugsnag/js": "^7.16.5",
+    "@bugsnag/js": "^7.21.0",
     "@sillsdev/scripture": "^1.4.0",
     "express": "^4.18.1",
     "jsonwebtoken": "^9.0.0",

--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -23,7 +23,7 @@
         "@angular/router": "^14.2.12",
         "@angular/service-worker": "^14.2.12",
         "@auth0/auth0-spa-js": "^2.0.4",
-        "@bugsnag/js": "^7.16.5",
+        "@bugsnag/js": "^7.21.0",
         "@bugsnag/plugin-angular": "^7.16.5",
         "@microsoft/signalr": "^7.0.0",
         "@ngneat/transloco": "^3.2.0",
@@ -132,7 +132,7 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "@bugsnag/js": "^7.16.5",
+        "@bugsnag/js": "^7.21.0",
         "@sillsdev/scripture": "^1.4.0",
         "express": "^4.18.1",
         "jsonwebtoken": "^9.0.0",
@@ -801,15 +801,17 @@
       "dev": true
     },
     "../../RealtimeServer/node_modules/@bugsnag/browser": {
-      "version": "7.16.5",
-      "license": "MIT",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.21.0.tgz",
+      "integrity": "sha512-mJ6r6SXpts+hdSnDNmTR35lZ+95BthqXpgBrDwquDCoY++zQ4OuzrkA/HZYD/rfpdSpgb7lO+AAlD7qrd9IylA==",
       "dependencies": {
-        "@bugsnag/core": "^7.16.1"
+        "@bugsnag/core": "^7.19.0"
       }
     },
     "../../RealtimeServer/node_modules/@bugsnag/core": {
-      "version": "7.16.1",
-      "license": "MIT",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.19.0.tgz",
+      "integrity": "sha512-2KGwdaLD9PhR7Wk7xPi3jGuGsKTatc/28U4TOZIDU3CgC2QhGjubwiXSECel5gwxhZ3jACKcMKSV2ovHhv1NrA==",
       "dependencies": {
         "@bugsnag/cuid": "^3.0.0",
         "@bugsnag/safe-json-stringify": "^6.0.0",
@@ -819,22 +821,25 @@
       }
     },
     "../../RealtimeServer/node_modules/@bugsnag/cuid": {
-      "version": "3.0.0",
-      "license": "MIT"
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.2.tgz",
+      "integrity": "sha512-cIwzC93r3PQ/INeuwtZwkZIG2K8WWN0rRLZQhu+mr48Ay+i6sEki4GYfTsflse7hZ1BeDWrNb/Q9vgY3B31xHQ=="
     },
     "../../RealtimeServer/node_modules/@bugsnag/js": {
-      "version": "7.16.5",
-      "license": "MIT",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.21.0.tgz",
+      "integrity": "sha512-fFTR7cRBSlLtwa1wPTse92igZUEX2V95KyGGCXq2qb2F2w6hJ6oJDxA0BMPS8qqsciYXRjbfn8HX+TFgO1oErg==",
       "dependencies": {
-        "@bugsnag/browser": "^7.16.5",
-        "@bugsnag/node": "^7.16.2"
+        "@bugsnag/browser": "^7.21.0",
+        "@bugsnag/node": "^7.19.0"
       }
     },
     "../../RealtimeServer/node_modules/@bugsnag/node": {
-      "version": "7.16.2",
-      "license": "MIT",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.19.0.tgz",
+      "integrity": "sha512-c4snyxx5d/fsMogmgehFBGc//daH6+4XCplia4zrEQYltjaQ+l8ud0dPx623DgJl/2j1+2zlRc7y7IHSd7Gm5w==",
       "dependencies": {
-        "@bugsnag/core": "^7.16.1",
+        "@bugsnag/core": "^7.19.0",
         "byline": "^5.0.0",
         "error-stack-parser": "^2.0.2",
         "iserror": "^0.0.2",
@@ -844,7 +849,8 @@
     },
     "../../RealtimeServer/node_modules/@bugsnag/safe-json-stringify": {
       "version": "6.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz",
+      "integrity": "sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA=="
     },
     "../../RealtimeServer/node_modules/@es-joy/jsdoccomment": {
       "version": "0.36.1",
@@ -1406,6 +1412,11 @@
         "node": ">=10.13.0"
       }
     },
+    "../../RealtimeServer/node_modules/@sillsdev/scripture": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sillsdev/scripture/-/scripture-1.4.0.tgz",
+      "integrity": "sha512-Fwf1+OWfYYS5HmxbBev70dzZHL1a/B/+9c+zxcI76QZaeUEy7hG3BBL/hi1aaWuHC419XX+RaASL6tFng9g7Qg=="
+    },
     "../../RealtimeServer/node_modules/@sinclair/typebox": {
       "version": "0.24.51",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
@@ -1565,6 +1576,21 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "../../RealtimeServer/node_modules/@types/lodash": {
+      "version": "4.14.197",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.197.tgz",
+      "integrity": "sha512-BMVOiWs0uNxHVlHBgzTIqJYmj+PgCo4euloGF+5m4okL3rEYzM2EEv78mw8zWSMM57dM7kVIgJ2QDvwHSoCI5g==",
+      "dev": true
+    },
+    "../../RealtimeServer/node_modules/@types/lodash-es": {
+      "version": "4.17.8",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.8.tgz",
+      "integrity": "sha512-euY3XQcZmIzSy7YH5+Unb3b2X12Wtk54YWINBvvGQ5SmMvwb11JQskGsfkH/5HXK77Kr8GF0wkVDIxzAisWtog==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
       }
     },
     "../../RealtimeServer/node_modules/@types/mime": {
@@ -2400,7 +2426,8 @@
     },
     "../../RealtimeServer/node_modules/byline": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2765,7 +2792,8 @@
     },
     "../../RealtimeServer/node_modules/end-of-stream": {
       "version": "1.4.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -2780,10 +2808,11 @@
       }
     },
     "../../RealtimeServer/node_modules/error-stack-parser": {
-      "version": "2.0.7",
-      "license": "MIT",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
       "dependencies": {
-        "stackframe": "^1.1.1"
+        "stackframe": "^1.3.4"
       }
     },
     "../../RealtimeServer/node_modules/es-abstract": {
@@ -4217,7 +4246,8 @@
     },
     "../../RealtimeServer/node_modules/iserror": {
       "version": "0.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
+      "integrity": "sha512-oKGGrFVaWwETimP3SiWwjDeY27ovZoyZPHtxblC4hCq9fXxed/jasx+ATWFFjCVSRZng8VTMsN1nDnGo6zMBSw=="
     },
     "../../RealtimeServer/node_modules/isexe": {
       "version": "2.0.0",
@@ -5104,6 +5134,11 @@
       "version": "4.17.21",
       "license": "MIT"
     },
+    "../../RealtimeServer/node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "../../RealtimeServer/node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "license": "MIT"
@@ -5794,7 +5829,8 @@
     },
     "../../RealtimeServer/node_modules/pump": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -6154,6 +6190,15 @@
         "lodash": "*"
       }
     },
+    "../../RealtimeServer/node_modules/sharedb-milestone-mongo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/sharedb-milestone-mongo/-/sharedb-milestone-mongo-1.0.0.tgz",
+      "integrity": "sha512-5rkL61bEZR0YwXe7PUWKLQFe7wJb1GkLrMtRSW3tQiprJnAZHagDPbJhMOQNgXFFLgOWgfyzF4FtslX6+/DWoQ==",
+      "dependencies": {
+        "mongodb": "^3.0.0 || ^4.0.0 || ^5.0.0",
+        "sharedb": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
     "../../RealtimeServer/node_modules/sharedb-mingo-memory": {
       "version": "1.2.0",
       "dev": true,
@@ -6303,10 +6348,11 @@
       "dev": true
     },
     "../../RealtimeServer/node_modules/stack-generator": {
-      "version": "2.0.5",
-      "license": "MIT",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
       "dependencies": {
-        "stackframe": "^1.1.1"
+        "stackframe": "^1.3.4"
       }
     },
     "../../RealtimeServer/node_modules/stack-utils": {
@@ -6331,8 +6377,9 @@
       }
     },
     "../../RealtimeServer/node_modules/stackframe": {
-      "version": "1.2.1",
-      "license": "MIT"
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
     },
     "../../RealtimeServer/node_modules/statuses": {
       "version": "2.0.1",
@@ -6665,9 +6712,10 @@
       }
     },
     "../../RealtimeServer/node_modules/typescript": {
-      "version": "4.6.4",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10710,15 +10758,17 @@
       "dev": true
     },
     "node_modules/@bugsnag/browser": {
-      "version": "7.16.5",
-      "license": "MIT",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.21.0.tgz",
+      "integrity": "sha512-mJ6r6SXpts+hdSnDNmTR35lZ+95BthqXpgBrDwquDCoY++zQ4OuzrkA/HZYD/rfpdSpgb7lO+AAlD7qrd9IylA==",
       "dependencies": {
-        "@bugsnag/core": "^7.16.1"
+        "@bugsnag/core": "^7.19.0"
       }
     },
     "node_modules/@bugsnag/core": {
-      "version": "7.16.1",
-      "license": "MIT",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.19.0.tgz",
+      "integrity": "sha512-2KGwdaLD9PhR7Wk7xPi3jGuGsKTatc/28U4TOZIDU3CgC2QhGjubwiXSECel5gwxhZ3jACKcMKSV2ovHhv1NrA==",
       "dependencies": {
         "@bugsnag/cuid": "^3.0.0",
         "@bugsnag/safe-json-stringify": "^6.0.0",
@@ -10728,22 +10778,25 @@
       }
     },
     "node_modules/@bugsnag/cuid": {
-      "version": "3.0.0",
-      "license": "MIT"
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.2.tgz",
+      "integrity": "sha512-cIwzC93r3PQ/INeuwtZwkZIG2K8WWN0rRLZQhu+mr48Ay+i6sEki4GYfTsflse7hZ1BeDWrNb/Q9vgY3B31xHQ=="
     },
     "node_modules/@bugsnag/js": {
-      "version": "7.16.5",
-      "license": "MIT",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.21.0.tgz",
+      "integrity": "sha512-fFTR7cRBSlLtwa1wPTse92igZUEX2V95KyGGCXq2qb2F2w6hJ6oJDxA0BMPS8qqsciYXRjbfn8HX+TFgO1oErg==",
       "dependencies": {
-        "@bugsnag/browser": "^7.16.5",
-        "@bugsnag/node": "^7.16.2"
+        "@bugsnag/browser": "^7.21.0",
+        "@bugsnag/node": "^7.19.0"
       }
     },
     "node_modules/@bugsnag/node": {
-      "version": "7.16.2",
-      "license": "MIT",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.19.0.tgz",
+      "integrity": "sha512-c4snyxx5d/fsMogmgehFBGc//daH6+4XCplia4zrEQYltjaQ+l8ud0dPx623DgJl/2j1+2zlRc7y7IHSd7Gm5w==",
       "dependencies": {
-        "@bugsnag/core": "^7.16.1",
+        "@bugsnag/core": "^7.19.0",
         "byline": "^5.0.0",
         "error-stack-parser": "^2.0.2",
         "iserror": "^0.0.2",
@@ -10760,7 +10813,8 @@
     },
     "node_modules/@bugsnag/safe-json-stringify": {
       "version": "6.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz",
+      "integrity": "sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA=="
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -21340,7 +21394,8 @@
     },
     "node_modules/byline": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -23777,10 +23832,11 @@
       }
     },
     "node_modules/error-stack-parser": {
-      "version": "2.0.7",
-      "license": "MIT",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
       "dependencies": {
-        "stackframe": "^1.1.1"
+        "stackframe": "^1.3.4"
       }
     },
     "node_modules/es-abstract": {
@@ -28146,7 +28202,8 @@
     },
     "node_modules/iserror": {
       "version": "0.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
+      "integrity": "sha512-oKGGrFVaWwETimP3SiWwjDeY27ovZoyZPHtxblC4hCq9fXxed/jasx+ATWFFjCVSRZng8VTMsN1nDnGo6zMBSw=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -40574,10 +40631,11 @@
       }
     },
     "node_modules/stack-generator": {
-      "version": "2.0.5",
-      "license": "MIT",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
       "dependencies": {
-        "stackframe": "^1.1.1"
+        "stackframe": "^1.3.4"
       }
     },
     "node_modules/stack-utils": {
@@ -40602,8 +40660,9 @@
       }
     },
     "node_modules/stackframe": {
-      "version": "1.2.1",
-      "license": "MIT"
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
     },
     "node_modules/static-eval": {
       "version": "2.1.0",
@@ -45747,13 +45806,17 @@
       "dev": true
     },
     "@bugsnag/browser": {
-      "version": "7.16.5",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.21.0.tgz",
+      "integrity": "sha512-mJ6r6SXpts+hdSnDNmTR35lZ+95BthqXpgBrDwquDCoY++zQ4OuzrkA/HZYD/rfpdSpgb7lO+AAlD7qrd9IylA==",
       "requires": {
-        "@bugsnag/core": "^7.16.1"
+        "@bugsnag/core": "^7.19.0"
       }
     },
     "@bugsnag/core": {
-      "version": "7.16.1",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.19.0.tgz",
+      "integrity": "sha512-2KGwdaLD9PhR7Wk7xPi3jGuGsKTatc/28U4TOZIDU3CgC2QhGjubwiXSECel5gwxhZ3jACKcMKSV2ovHhv1NrA==",
       "requires": {
         "@bugsnag/cuid": "^3.0.0",
         "@bugsnag/safe-json-stringify": "^6.0.0",
@@ -45763,19 +45826,25 @@
       }
     },
     "@bugsnag/cuid": {
-      "version": "3.0.0"
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.2.tgz",
+      "integrity": "sha512-cIwzC93r3PQ/INeuwtZwkZIG2K8WWN0rRLZQhu+mr48Ay+i6sEki4GYfTsflse7hZ1BeDWrNb/Q9vgY3B31xHQ=="
     },
     "@bugsnag/js": {
-      "version": "7.16.5",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.21.0.tgz",
+      "integrity": "sha512-fFTR7cRBSlLtwa1wPTse92igZUEX2V95KyGGCXq2qb2F2w6hJ6oJDxA0BMPS8qqsciYXRjbfn8HX+TFgO1oErg==",
       "requires": {
-        "@bugsnag/browser": "^7.16.5",
-        "@bugsnag/node": "^7.16.2"
+        "@bugsnag/browser": "^7.21.0",
+        "@bugsnag/node": "^7.19.0"
       }
     },
     "@bugsnag/node": {
-      "version": "7.16.2",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.19.0.tgz",
+      "integrity": "sha512-c4snyxx5d/fsMogmgehFBGc//daH6+4XCplia4zrEQYltjaQ+l8ud0dPx623DgJl/2j1+2zlRc7y7IHSd7Gm5w==",
       "requires": {
-        "@bugsnag/core": "^7.16.1",
+        "@bugsnag/core": "^7.19.0",
         "byline": "^5.0.0",
         "error-stack-parser": "^2.0.2",
         "iserror": "^0.0.2",
@@ -45787,7 +45856,9 @@
       "version": "7.16.5"
     },
     "@bugsnag/safe-json-stringify": {
-      "version": "6.0.0"
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz",
+      "integrity": "sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA=="
     },
     "@colors/colors": {
       "version": "1.5.0",
@@ -53497,7 +53568,9 @@
       }
     },
     "byline": {
-      "version": "5.0.0"
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q=="
     },
     "bytes": {
       "version": "3.1.2",
@@ -55180,9 +55253,11 @@
       }
     },
     "error-stack-parser": {
-      "version": "2.0.7",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
       "requires": {
-        "stackframe": "^1.1.1"
+        "stackframe": "^1.3.4"
       }
     },
     "es-abstract": {
@@ -58054,7 +58129,9 @@
       "dev": true
     },
     "iserror": {
-      "version": "0.0.2"
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
+      "integrity": "sha512-oKGGrFVaWwETimP3SiWwjDeY27ovZoyZPHtxblC4hCq9fXxed/jasx+ATWFFjCVSRZng8VTMsN1nDnGo6zMBSw=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -65730,7 +65807,7 @@
     "realtime-server": {
       "version": "file:../../RealtimeServer",
       "requires": {
-        "@bugsnag/js": "^7.16.5",
+        "@bugsnag/js": "^7.21.0",
         "@sillsdev/scripture": "^1.4.0",
         "@types/jest": "^29.2.4",
         "@types/jsonwebtoken": "^9.0.0",
@@ -66250,13 +66327,17 @@
           "dev": true
         },
         "@bugsnag/browser": {
-          "version": "7.16.5",
+          "version": "7.21.0",
+          "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.21.0.tgz",
+          "integrity": "sha512-mJ6r6SXpts+hdSnDNmTR35lZ+95BthqXpgBrDwquDCoY++zQ4OuzrkA/HZYD/rfpdSpgb7lO+AAlD7qrd9IylA==",
           "requires": {
-            "@bugsnag/core": "^7.16.1"
+            "@bugsnag/core": "^7.19.0"
           }
         },
         "@bugsnag/core": {
-          "version": "7.16.1",
+          "version": "7.19.0",
+          "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.19.0.tgz",
+          "integrity": "sha512-2KGwdaLD9PhR7Wk7xPi3jGuGsKTatc/28U4TOZIDU3CgC2QhGjubwiXSECel5gwxhZ3jACKcMKSV2ovHhv1NrA==",
           "requires": {
             "@bugsnag/cuid": "^3.0.0",
             "@bugsnag/safe-json-stringify": "^6.0.0",
@@ -66266,19 +66347,25 @@
           }
         },
         "@bugsnag/cuid": {
-          "version": "3.0.0"
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.2.tgz",
+          "integrity": "sha512-cIwzC93r3PQ/INeuwtZwkZIG2K8WWN0rRLZQhu+mr48Ay+i6sEki4GYfTsflse7hZ1BeDWrNb/Q9vgY3B31xHQ=="
         },
         "@bugsnag/js": {
-          "version": "7.16.5",
+          "version": "7.21.0",
+          "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.21.0.tgz",
+          "integrity": "sha512-fFTR7cRBSlLtwa1wPTse92igZUEX2V95KyGGCXq2qb2F2w6hJ6oJDxA0BMPS8qqsciYXRjbfn8HX+TFgO1oErg==",
           "requires": {
-            "@bugsnag/browser": "^7.16.5",
-            "@bugsnag/node": "^7.16.2"
+            "@bugsnag/browser": "^7.21.0",
+            "@bugsnag/node": "^7.19.0"
           }
         },
         "@bugsnag/node": {
-          "version": "7.16.2",
+          "version": "7.19.0",
+          "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.19.0.tgz",
+          "integrity": "sha512-c4snyxx5d/fsMogmgehFBGc//daH6+4XCplia4zrEQYltjaQ+l8ud0dPx623DgJl/2j1+2zlRc7y7IHSd7Gm5w==",
           "requires": {
-            "@bugsnag/core": "^7.16.1",
+            "@bugsnag/core": "^7.19.0",
             "byline": "^5.0.0",
             "error-stack-parser": "^2.0.2",
             "iserror": "^0.0.2",
@@ -66287,7 +66374,9 @@
           }
         },
         "@bugsnag/safe-json-stringify": {
-          "version": "6.0.0"
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz",
+          "integrity": "sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA=="
         },
         "@es-joy/jsdoccomment": {
           "version": "0.36.1",
@@ -66716,6 +66805,11 @@
         "@panva/asn1.js": {
           "version": "1.0.0"
         },
+        "@sillsdev/scripture": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@sillsdev/scripture/-/scripture-1.4.0.tgz",
+          "integrity": "sha512-Fwf1+OWfYYS5HmxbBev70dzZHL1a/B/+9c+zxcI76QZaeUEy7hG3BBL/hi1aaWuHC419XX+RaASL6tFng9g7Qg=="
+        },
         "@sinclair/typebox": {
           "version": "0.24.51",
           "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
@@ -66869,6 +66963,21 @@
           "dev": true,
           "requires": {
             "@types/node": "*"
+          }
+        },
+        "@types/lodash": {
+          "version": "4.14.197",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.197.tgz",
+          "integrity": "sha512-BMVOiWs0uNxHVlHBgzTIqJYmj+PgCo4euloGF+5m4okL3rEYzM2EEv78mw8zWSMM57dM7kVIgJ2QDvwHSoCI5g==",
+          "dev": true
+        },
+        "@types/lodash-es": {
+          "version": "4.17.8",
+          "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.8.tgz",
+          "integrity": "sha512-euY3XQcZmIzSy7YH5+Unb3b2X12Wtk54YWINBvvGQ5SmMvwb11JQskGsfkH/5HXK77Kr8GF0wkVDIxzAisWtog==",
+          "dev": true,
+          "requires": {
+            "@types/lodash": "*"
           }
         },
         "@types/mime": {
@@ -67400,7 +67509,9 @@
           "dev": true
         },
         "byline": {
-          "version": "5.0.0"
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+          "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q=="
         },
         "bytes": {
           "version": "3.1.2"
@@ -67627,6 +67738,8 @@
         },
         "end-of-stream": {
           "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+          "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
           "requires": {
             "once": "^1.4.0"
           }
@@ -67641,9 +67754,11 @@
           }
         },
         "error-stack-parser": {
-          "version": "2.0.7",
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+          "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
           "requires": {
-            "stackframe": "^1.1.1"
+            "stackframe": "^1.3.4"
           }
         },
         "es-abstract": {
@@ -68583,7 +68698,9 @@
           }
         },
         "iserror": {
-          "version": "0.0.2"
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
+          "integrity": "sha512-oKGGrFVaWwETimP3SiWwjDeY27ovZoyZPHtxblC4hCq9fXxed/jasx+ATWFFjCVSRZng8VTMsN1nDnGo6zMBSw=="
         },
         "isexe": {
           "version": "2.0.0",
@@ -69254,6 +69371,11 @@
         "lodash": {
           "version": "4.17.21"
         },
+        "lodash-es": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+          "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+        },
         "lodash.clonedeep": {
           "version": "4.5.0"
         },
@@ -69713,6 +69835,8 @@
         },
         "pump": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -69938,6 +70062,15 @@
             "lodash": "*"
           }
         },
+        "sharedb-milestone-mongo": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/sharedb-milestone-mongo/-/sharedb-milestone-mongo-1.0.0.tgz",
+          "integrity": "sha512-5rkL61bEZR0YwXe7PUWKLQFe7wJb1GkLrMtRSW3tQiprJnAZHagDPbJhMOQNgXFFLgOWgfyzF4FtslX6+/DWoQ==",
+          "requires": {
+            "mongodb": "^3.0.0 || ^4.0.0 || ^5.0.0",
+            "sharedb": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+          }
+        },
         "sharedb-mingo-memory": {
           "version": "1.2.0",
           "dev": true,
@@ -70045,9 +70178,11 @@
           "dev": true
         },
         "stack-generator": {
-          "version": "2.0.5",
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+          "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
           "requires": {
-            "stackframe": "^1.1.1"
+            "stackframe": "^1.3.4"
           }
         },
         "stack-utils": {
@@ -70068,7 +70203,9 @@
           }
         },
         "stackframe": {
-          "version": "1.2.1"
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+          "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
         },
         "statuses": {
           "version": "2.0.1"
@@ -70278,7 +70415,9 @@
           }
         },
         "typescript": {
-          "version": "4.6.4",
+          "version": "4.8.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+          "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
           "dev": true
         },
         "unbox-primitive": {
@@ -71514,9 +71653,11 @@
       }
     },
     "stack-generator": {
-      "version": "2.0.5",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
       "requires": {
-        "stackframe": "^1.1.1"
+        "stackframe": "^1.3.4"
       }
     },
     "stack-utils": {
@@ -71537,7 +71678,9 @@
       }
     },
     "stackframe": {
-      "version": "1.2.1"
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
     },
     "static-eval": {
       "version": "2.1.0",

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -43,7 +43,7 @@
     "@angular/router": "^14.2.12",
     "@angular/service-worker": "^14.2.12",
     "@auth0/auth0-spa-js": "^2.0.4",
-    "@bugsnag/js": "^7.16.5",
+    "@bugsnag/js": "^7.21.0",
     "@bugsnag/plugin-angular": "^7.16.5",
     "@microsoft/signalr": "^7.0.0",
     "@ngneat/transloco": "^3.2.0",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/bugsnag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/bugsnag.service.ts
@@ -14,7 +14,7 @@ export class BugsnagService {
   }
 
   leaveBreadcrumb(message: string, metadata?: { [key: string]: any }, type?: BreadcrumbType): void {
-    Bugsnag.leaveBreadcrumb(message, metadata, type);
+    if (Bugsnag.isStarted()) Bugsnag.leaveBreadcrumb(message, metadata, type);
   }
 
   setUser(id?: string, email?: string, name?: string): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-reporting.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-reporting.service.ts
@@ -51,7 +51,8 @@ export class ErrorReportingService {
   }
 
   notify(error: NotifiableError, callback?: (err: any, report: any) => void): void {
-    Bugsnag.notify(error, event => ErrorReportingService.beforeSend(this.metadata, event), callback);
+    if (Bugsnag.isStarted())
+      Bugsnag.notify(error, event => ErrorReportingService.beforeSend(this.metadata, event), callback);
   }
 
   silentError(message: string, metadata?: object): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
@@ -24,7 +24,7 @@ export interface BreadcrumbSelector {
 export class AppError extends Error {
   constructor(message: string, private readonly data?: any) {
     super(message);
-    Bugsnag.leaveBreadcrumb(message, this.data, 'log');
+    if (Bugsnag.isStarted()) Bugsnag.leaveBreadcrumb(message, this.data, 'log');
     console.error(message, this.data);
   }
 }


### PR DESCRIPTION
Currently when running the unit tests, there is a lot of noise in the console from Bugsnag:

```
INFO: 'Bugsnag.leaveBreadcrumb() was called before Bugsnag.start()', [[[]]]
INFO: 'Bugsnag.notify() was called before Bugsnag.start()', [[[]]]
```

This PR fixes these messages by updating Bugsnag, and checking if Bugsnag has been initialized using `Bugsnag.isStarted()` before calling `Bugsnag.leaveBreadcrumb{}` or `Bugsnag.notify()`.

See https://docs.bugsnag.com/platforms/javascript/faq/#how-can-i-tell-if-bugsnag-has-finished-initializing for details.

As this affects unit test output, success is determined by successful unit test passing, with none of the following messages in the test output:
* `INFO: 'Bugsnag.leaveBreadcrumb() was called before Bugsnag.start()', [[[]]]`
* `INFO: 'Bugsnag.notify() was called before Bugsnag.start()', [[[]]]`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2019)
<!-- Reviewable:end -->
