### PR TITLE
dev: Specify default solution for dotnet

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -65,6 +65,7 @@
     "xfvalidators",
     "xlink"
   ],
+  "dotnet.defaultSolution": "xForge.sln",
   "dotnet-test-explorer.testProjectPath": "test/**/*.Tests.csproj",
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",


### PR DESCRIPTION
The latest C# extension for Visual Studio Code (v2.0.413) prompts for the default solution.

This PR specifies the main xForge.sln file as the default solution in settings.json.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2024)
<!-- Reviewable:end -->
