### PR TITLE
SF-2214 Update SyncMetrics on Note Thread Deletion

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1131,6 +1131,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
         if (!hasNotesInThread)
         {
             await threadDoc.DeleteAsync();
+            _syncMetrics.NoteThreads.Deleted++;
             return;
         }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -2082,6 +2082,12 @@ public class ParatextSyncRunnerTests
 
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
+
+        // Verify that the note thread does not exist
         Assert.Throws<KeyNotFoundException>(() => env.GetNoteThread("project01", "thread01"));
     }
 


### PR DESCRIPTION
Currently when a note thread is deleted in SF because it no longer contains any notes (i.e. it was deleted in Paratext), then the `sync_metrics` collection will not be updated with a count of the thread being deleted. This PR fixes this issue.

As this is not a frontend user facing bug, developer acceptance testing is sufficient (see acceptance criteria in the JIRA ticket SF-2214).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2025)
<!-- Reviewable:end -->
