### PR TITLE
SF-2218 Fix audio player covering scripture scrollbar

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.scss
@@ -1,8 +1,8 @@
 @import '../checking-global-vars';
 
 :host {
+  height: 100%;
   display: flex;
-  overflow-y: auto;
 }
 
 app-text {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.scss
@@ -3,6 +3,7 @@
 :host {
   height: 100%;
   display: flex;
+  overflow-y: auto;
 }
 
 app-text {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.scss
@@ -1,10 +1,8 @@
 @import '../checking-global-vars';
 
 :host {
-  position: absolute;
-  height: 100%;
-  width: 100%;
   display: flex;
+  overflow-y: auto;
 }
 
 app-text {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -149,6 +149,8 @@ header {
 
     .panel-content {
       height: 100%;
+      display: flex;
+      flex-direction: column-reverse;
     }
 
     .panel-nav {
@@ -293,11 +295,7 @@ header {
 }
 
 .scripture-audio-player-wrapper {
-  position: absolute;
-  bottom: 0;
   background: #e8eae6;
-  width: 100%;
-  z-index: 1;
   padding: 0.25rem;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.scss
@@ -46,7 +46,7 @@ app-text {
   font-size: 0.85em;
 }
 
-::ng-deep app-text quill-editor > .ql-container > .ql-editor {
+:host ::ng-deep app-text quill-editor > .ql-container > .ql-editor {
   padding: 0 1em 1em;
   min-height: 300px;
 }


### PR DESCRIPTION
Before | After
-------|------
![](https://github.com/sillsdev/web-xforge/assets/6140710/c73a75e3-0bc0-494e-9107-54e9bae46f0f) | ![](https://github.com/sillsdev/web-xforge/assets/6140710/38b41cdd-470b-499f-8167-8d52c90ea5b7)

Note the difference in scrollbar. In the "before" screenshot, the scripture goes below the audio player, and you can't scroll all the way to the bottom.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2026)
<!-- Reviewable:end -->
