### PR TITLE
SF-2212 Allow updating of audio timing data

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
@@ -125,6 +125,37 @@ describe('ChapterAudioDialogComponent', () => {
     expect(env.component.selectionHasAudioAlready).toBeTruthy();
   }));
 
+  it('detects if first chapter has audio already', fakeAsync(async () => {
+    // Get the first chapter with audio
+    const firstChapterWithAudio: Chapter = Object.entries(TestEnvironment.textsByBookId)
+      .map(([, value]) => value.chapters)
+      .flat(1)
+      .find(c => c.hasAudio)!;
+    const containingBook: TextInfo = Object.entries(TestEnvironment.textsByBookId).find(([, value]) =>
+      value.chapters.includes(firstChapterWithAudio!)
+    )?.[1]!;
+
+    // Configure the dialog to show that chapter
+    const config: MatDialogConfig<ChapterAudioDialogData> = {
+      data: {
+        projectId: 'project01',
+        textsByBookId: TestEnvironment.textsByBookId,
+        questionsSorted: env.questions,
+        currentBook: containingBook.bookNum,
+        currentChapter: firstChapterWithAudio.number
+      }
+    };
+
+    env = new TestEnvironment(config);
+
+    // Ensure that the UI shows that hte chapter has audio
+    expect(env.component.book).toEqual(containingBook.bookNum);
+    expect(env.component.chapter).toEqual(firstChapterWithAudio.number);
+    expect(env.component.selectionHasAudioAlready).toBeTruthy();
+
+    flush();
+  }));
+
   it('populates books and chapters', fakeAsync(async () => {
     expect(env.component.books.length).toEqual(2);
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
@@ -56,6 +56,7 @@ export class ChapterAudioDialogComponent {
     private readonly dialogService: DialogService
   ) {
     this.getStartingLocation();
+    this.checkForPreexistingAudio();
   }
 
   private getStartingLocation(): void {


### PR DESCRIPTION
This PR fixes a bug where the create audio timing data endpoint would cause an error if the audio timing data was updated.

In addition, this PR adds unit tests for the creating and deleting audio timing data (including this use case).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2027)
<!-- Reviewable:end -->
