### PR TITLE
SF-2223 Use the timeupdate event listen to get time updates

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
@@ -132,7 +132,7 @@ export class CheckingScriptureAudioPlayerComponent extends SubscriptionDisposabl
 
   private subscribePlayerVerseChange(audio: AudioPlayer): void {
     this.subscribe(
-      audio.playing$.pipe(
+      audio.timeUpdated$.pipe(
         map(() => this.currentRef),
         distinctUntilChanged()
       ),


### PR DESCRIPTION
The time update event fires about 4 times each second. We don't necessarily need that level of granularity, but it is a logical place to emit the timeUpdated$ EventEmitter from.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2032)
<!-- Reviewable:end -->
