### PR TITLE
Generate .scss instead of .css file when generating component with ng-cli

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/angular.json
+++ b/src/SIL.XForge.Scripture/ClientApp/angular.json
@@ -10,7 +10,8 @@
       "prefix": "app",
       "schematics": {
         "@schematics/angular:component": {
-          "prefix": "app"
+          "prefix": "app",
+          "style": "scss"
         },
         "@schematics/angular:directive": {
           "prefix": "app"


### PR DESCRIPTION
Small fix so that angular cli uses .scss file extension when generating a new component.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2034)
<!-- Reviewable:end -->
