### PR TITLE
SF-2227 Fixed Echo Pre-Translation Engine support

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -523,6 +523,11 @@ public class MachineProjectService : IMachineProjectService
         // If the corpus should be updated
         if (corpusUpdated)
         {
+            // Echo requires the target and source language to be the same, as it outputs your source texts
+            bool useEcho = await _featureManager.IsEnabledAsync(FeatureFlags.UseEchoForPreTranslation);
+            string targetLanguage = project.WritingSystem.Tag;
+            string sourceLanguage = project.TranslateConfig.Source!.WritingSystem.Tag;
+
             // Create or update the corpus
             TranslationCorpus corpus;
             TranslationCorpusConfig corpusConfig = new TranslationCorpusConfig
@@ -531,11 +536,11 @@ public class MachineProjectService : IMachineProjectService
                 SourceFiles = newSourceCorpusFiles
                     .Select(f => new TranslationCorpusFileConfig { FileId = f.FileId, TextId = f.TextId })
                     .ToList(),
-                SourceLanguage = project.TranslateConfig.Source.WritingSystem.Tag,
+                SourceLanguage = sourceLanguage,
                 TargetFiles = newTargetCorpusFiles
                     .Select(f => new TranslationCorpusFileConfig { FileId = f.FileId, TextId = f.TextId })
                     .ToList(),
-                TargetLanguage = project.WritingSystem.Tag,
+                TargetLanguage = useEcho ? sourceLanguage : targetLanguage,
             };
             if (string.IsNullOrEmpty(corpusId))
             {
@@ -675,11 +680,13 @@ public class MachineProjectService : IMachineProjectService
                 true => "Nmt",
                 false => "SmtTransfer",
             };
+            string targetLanguage = sfProject.WritingSystem.Tag;
+            string sourceLanguage = sfProject.TranslateConfig.Source!.WritingSystem.Tag;
             TranslationEngineConfig engineConfig = new TranslationEngineConfig
             {
                 Name = sfProject.Id,
-                SourceLanguage = sfProject.TranslateConfig.Source.WritingSystem.Tag,
-                TargetLanguage = sfProject.WritingSystem.Tag,
+                SourceLanguage = sourceLanguage,
+                TargetLanguage = useEcho ? sourceLanguage : targetLanguage,
                 Type = type,
             };
             // Add the project to Serval

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -130,6 +130,50 @@ public class MachineProjectServiceTests
     }
 
     [Test]
+    public async Task BuildProjectAsync_CreatesServalProjectIfMissing()
+    {
+        // Set up test environment
+        var env = new TestEnvironment(new TestEnvironmentOptions());
+        string sourceLanguage = env.Projects.Get(Project01).TranslateConfig.Source!.WritingSystem.Tag;
+        string targetLanguage = env.Projects.Get(Project01).WritingSystem.Tag;
+        Assert.AreNotEqual(sourceLanguage, targetLanguage);
+
+        // SUT
+        await env.Service.BuildProjectAsync(User01, Project01, preTranslate: true, CancellationToken.None);
+
+        await env.TranslationEnginesClient
+            .Received()
+            .CreateAsync(
+                Arg.Is<TranslationEngineConfig>(
+                    t => t.SourceLanguage == sourceLanguage && t.TargetLanguage == targetLanguage
+                ),
+                CancellationToken.None
+            );
+    }
+
+    [Test]
+    public async Task BuildProjectAsync_SpecifiesTheSameSourceAndTargetLanguageForEcho()
+    {
+        // Set up test environment
+        var env = new TestEnvironment(new TestEnvironmentOptions { UseEchoForPreTranslation = true });
+        string sourceLanguage = env.Projects.Get(Project01).TranslateConfig.Source!.WritingSystem.Tag;
+        string targetLanguage = env.Projects.Get(Project01).WritingSystem.Tag;
+        Assert.AreNotEqual(sourceLanguage, targetLanguage);
+
+        // SUT
+        await env.Service.BuildProjectAsync(User01, Project01, preTranslate: true, CancellationToken.None);
+
+        await env.TranslationEnginesClient
+            .Received()
+            .CreateAsync(
+                Arg.Is<TranslationEngineConfig>(
+                    t => t.SourceLanguage == sourceLanguage && t.TargetLanguage == sourceLanguage
+                ),
+                CancellationToken.None
+            );
+    }
+
+    [Test]
     public async Task BuildProjectAsync_RunsPreTranslationBuildIfNoTextChangesAndNoPendingBuild()
     {
         // Set up test environment
@@ -429,6 +473,9 @@ public class MachineProjectServiceTests
         // Set up test environment
         var env = new TestEnvironment(new TestEnvironmentOptions { LocalSourceTextHasData = true });
         await env.BeforeFirstSync(Project01);
+        string sourceLanguage = env.Projects.Get(Project01).TranslateConfig.Source!.WritingSystem.Tag;
+        string targetLanguage = env.Projects.Get(Project01).WritingSystem.Tag;
+        Assert.AreNotEqual(sourceLanguage, targetLanguage);
 
         // SUT
         bool actual = await env.Service.SyncProjectCorporaAsync(
@@ -438,10 +485,55 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
         Assert.IsTrue(actual);
+        await env.TranslationEnginesClient
+            .Received(1)
+            .AddCorpusAsync(
+                Arg.Any<string>(),
+                Arg.Is<TranslationCorpusConfig>(
+                    t => t.SourceLanguage == sourceLanguage && t.TargetLanguage == targetLanguage
+                ),
+                CancellationToken.None
+            );
         await env.DataFilesClient.DidNotReceiveWithAnyArgs().DeleteAsync(string.Empty, CancellationToken.None);
         await env.DataFilesClient
-            .ReceivedWithAnyArgs(1)
-            .CreateAsync(Arg.Any<FileParameter>(), FileFormat.Text, string.Empty, CancellationToken.None);
+            .Received(1)
+            .CreateAsync(Arg.Any<FileParameter>(), FileFormat.Text, Arg.Any<string>(), CancellationToken.None);
+        Assert.AreEqual(1, env.ProjectSecrets.Get(Project01).ServalData?.Corpora[Corpus01].SourceFiles.Count);
+    }
+
+    [Test]
+    public async Task SyncProjectCorporaAsync_CreatesRemoteCorpusWithTheSameSourceAndTargetLanguageForEcho()
+    {
+        // Set up test environment
+        var env = new TestEnvironment(
+            new TestEnvironmentOptions { LocalSourceTextHasData = true, UseEchoForPreTranslation = true }
+        );
+        await env.BeforeFirstSync(Project01);
+        string sourceLanguage = env.Projects.Get(Project01).TranslateConfig.Source!.WritingSystem.Tag;
+        string targetLanguage = env.Projects.Get(Project01).WritingSystem.Tag;
+        Assert.AreNotEqual(sourceLanguage, targetLanguage);
+
+        // SUT
+        bool actual = await env.Service.SyncProjectCorporaAsync(
+            User01,
+            Project01,
+            preTranslate: false,
+            CancellationToken.None
+        );
+        Assert.IsTrue(actual);
+        await env.TranslationEnginesClient
+            .Received(1)
+            .AddCorpusAsync(
+                Arg.Any<string>(),
+                Arg.Is<TranslationCorpusConfig>(
+                    t => t.SourceLanguage == sourceLanguage && t.TargetLanguage == sourceLanguage
+                ),
+                CancellationToken.None
+            );
+        await env.DataFilesClient.DidNotReceiveWithAnyArgs().DeleteAsync(string.Empty, CancellationToken.None);
+        await env.DataFilesClient
+            .Received(1)
+            .CreateAsync(Arg.Any<FileParameter>(), FileFormat.Text, Arg.Any<string>(), CancellationToken.None);
         Assert.AreEqual(1, env.ProjectSecrets.Get(Project01).ServalData?.Corpora[Corpus01].SourceFiles.Count);
     }
 
@@ -698,6 +790,7 @@ public class MachineProjectServiceTests
     {
         public bool BuildIsPending { get; init; }
         public bool PreTranslationBuildIsQueued { get; init; }
+        public bool UseEchoForPreTranslation { get; init; }
         public bool MachineSupport { get; init; } = true;
         public bool ServalSupport { get; init; } = true;
         public bool LocalSourceTextHasData { get; init; }
@@ -776,6 +869,9 @@ public class MachineProjectServiceTests
             }
 
             var featureManager = Substitute.For<IFeatureManager>();
+            featureManager
+                .IsEnabledAsync(FeatureFlags.UseEchoForPreTranslation)
+                .Returns(Task.FromResult(options.UseEchoForPreTranslation));
             featureManager.IsEnabledAsync(FeatureFlags.Serval).Returns(Task.FromResult(options.ServalSupport));
             featureManager
                 .IsEnabledAsync(FeatureFlags.MachineInProcess)
@@ -834,7 +930,7 @@ public class MachineProjectServiceTests
 
             var userSecrets = new MemoryRepository<UserSecret>(new[] { new UserSecret { Id = User01 } });
 
-            var projects = new MemoryRepository<SFProject>(
+            Projects = new MemoryRepository<SFProject>(
                 new[]
                 {
                     new SFProject
@@ -885,7 +981,7 @@ public class MachineProjectServiceTests
             );
 
             var realtimeService = new SFMemoryRealtimeService();
-            realtimeService.AddRepository("sf_projects", OTType.Json0, projects);
+            realtimeService.AddRepository("sf_projects", OTType.Json0, Projects);
 
             Service = new MachineProjectService(
                 DataFilesClient,
@@ -934,6 +1030,7 @@ public class MachineProjectServiceTests
         public IEngineService EngineService { get; }
         public IDataFilesClient DataFilesClient { get; }
         public ITranslationEnginesClient TranslationEnginesClient { get; }
+        public MemoryRepository<SFProject> Projects { get; }
         public MemoryRepository<SFProjectSecret> ProjectSecrets { get; }
         public MockLogger<MachineProjectService> MockLogger { get; }
         public IExceptionHandler ExceptionHandler { get; }


### PR DESCRIPTION
For the Echo translation engine to work correctly, the source and target language must be the same.

This PR updates `CreateServalProjectAsync()` so that it sets the source and target language to the same value on Serval if the Echo Pre-Translation engine is enabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2036)
<!-- Reviewable:end -->
