### PR TITLE
SF-2197 Chapter Audio Error Handling for Bad Timing Files

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
@@ -142,6 +142,14 @@ xdescribe('ScriptureAudioComponent', () => {
     expect(pauseSpy).toHaveBeenCalled();
     expect(count).toEqual(1);
   });
+
+  it('can skip to previous verse', async () => {});
+
+  it('skipping to previous verse remains on the current verse if within grace period', async () => {});
+
+  it('skipping to the next verse will skip to the start of the current timing data if it has not started yet', async () => {});
+
+  it('skipping beyond the last timing data will stop the player ', async () => {});
 });
 
 @Component({ selector: 'app-host', template: '' })

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
@@ -117,10 +117,10 @@ xdescribe('ScriptureAudioComponent', () => {
     env.component.audioPlayer.currentVerseChanged.subscribe(verseChangedSpy);
     env.playButton.nativeElement.click();
     await env.waitForPlayer(1400);
-    expect(env.component.audioPlayer.audioPlayer!.audio!.currentTime).toBeGreaterThan(timings[1].from);
+    expect(env.currentTime).toBeGreaterThan(timings[1].from);
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:1');
     await env.waitForPlayer(1400);
-    expect(env.component.audioPlayer.audioPlayer!.audio!.currentTime).toBeGreaterThan(timings[3].from);
+    expect(env.currentTime).toBeGreaterThan(timings[3].from);
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:2');
     expect(verseChangedSpy).toHaveBeenCalledWith('s_1');
     expect(verseChangedSpy).toHaveBeenCalledWith('s_2');
@@ -143,13 +143,61 @@ xdescribe('ScriptureAudioComponent', () => {
     expect(count).toEqual(1);
   });
 
-  it('can skip to previous verse', async () => {});
+  it('can skip to previous verse', async () => {
+    const template = `<app-checking-scripture-audio-player source="${audioFile}"></app-checking-scripture-audio-player>`;
+    const env = new TestEnvironment(template);
+    env.fixture.detectChanges();
+    await env.waitForPlayer(500);
 
-  it('skipping to previous verse remains on the current verse if within grace period', async () => {});
+    env.component.audioPlayer.textDocId = textDocId;
+    env.component.audioPlayer.timing = getAudioTimings();
+    await env.waitForPlayer();
 
-  it('skipping to the next verse will skip to the start of the current timing data if it has not started yet', async () => {});
+    env.currentTime = 2;
+    expect(env.currentTime).toEqual(2);
+    env.clickPreviousRef();
+    expect(env.currentTime).toEqual(1);
+  });
 
-  it('skipping beyond the last timing data will stop the player ', async () => {});
+  it('skipping to previous verse remains on the current verse if within grace period', async () => {
+    const template = `<app-checking-scripture-audio-player source="${audioFile}"></app-checking-scripture-audio-player>`;
+    const env = new TestEnvironment(template);
+    env.fixture.detectChanges();
+    await env.waitForPlayer(500);
+
+    env.component.audioPlayer.textDocId = textDocId;
+    env.component.audioPlayer.timing = [
+      { textRef: '1', from: 0.0, to: 1.0 },
+      { textRef: '2', from: 1.0, to: 4.5 },
+      { textRef: '3', from: 4.5, to: 5.0 }
+    ];
+    await env.waitForPlayer();
+
+    env.currentTime = 4.1;
+    expect(env.currentTime).toBeGreaterThan(4);
+    env.clickPreviousRef();
+    expect(env.currentTime).toEqual(1);
+    env.clickPreviousRef();
+    expect(env.currentTime).toEqual(0);
+  });
+
+  it('skipping to the next verse will skip to the start of the current timing data if it has not started yet', async () => {
+    const template = `<app-checking-scripture-audio-player source="${audioFile}"></app-checking-scripture-audio-player>`;
+    const env = new TestEnvironment(template);
+    env.fixture.detectChanges();
+    await env.waitForPlayer(500);
+
+    env.component.audioPlayer.textDocId = textDocId;
+    env.component.audioPlayer.timing = [
+      { textRef: '1', from: 3.0, to: 4.0 },
+      { textRef: '2', from: 4.0, to: 5.0 }
+    ];
+    await env.waitForPlayer();
+
+    expect(env.currentTime).toEqual(0);
+    env.clickNextRef();
+    expect(env.currentTime).toEqual(3);
+  });
 });
 
 @Component({ selector: 'app-host', template: '' })
@@ -180,6 +228,16 @@ class TestEnvironment {
     this.component = this.fixture.componentInstance;
   }
 
+  get currentTime(): number {
+    return this.component.audioPlayer.audioPlayer!.audio!.currentTime;
+  }
+
+  set currentTime(value: number) {
+    if (this.component.audioPlayer?.audioPlayer?.audio?.currentTime != null) {
+      this.component.audioPlayer.audioPlayer.audio.currentTime = value;
+    }
+  }
+
   get playButton(): DebugElement {
     return this.fixture.debugElement.query(By.css('.play-pause-button'));
   }
@@ -198,6 +256,14 @@ class TestEnvironment {
 
   get isPlaying(): boolean {
     return this.component.audioPlayer.isPlaying;
+  }
+
+  clickNextRef(): void {
+    this.nextRefButton.nativeElement.click();
+  }
+
+  clickPreviousRef(): void {
+    this.previousRefButton.nativeElement.click();
   }
 
   async waitForPlayer(ms: number = 50): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
@@ -49,13 +49,13 @@ xdescribe('ScriptureAudioComponent', () => {
     env.component.audioPlayer.textDocId = textDocId;
     env.component.audioPlayer.timing = getAudioTimings();
     await env.waitForPlayer();
-    env.nextRefButton.nativeElement.click();
+    env.clickNextRef();
     await env.waitForPlayer();
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:2');
-    env.previousRefButton.nativeElement.click();
+    env.clickPreviousRef();
     await env.waitForPlayer();
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:1');
-    env.previousRefButton.nativeElement.click();
+    env.clickPreviousRef();
     await env.waitForPlayer();
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:1');
   });
@@ -69,19 +69,19 @@ xdescribe('ScriptureAudioComponent', () => {
     env.component.audioPlayer.textDocId = textDocId;
     env.component.audioPlayer.timing = getAudioTimingWithHeadings();
     await env.waitForPlayer();
-    env.nextRefButton.nativeElement.click();
+    env.clickNextRef();
     await env.waitForPlayer();
     // section heading before verse 2
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:1');
-    env.nextRefButton.nativeElement.click();
+    env.clickNextRef();
     await env.waitForPlayer();
     // verse 2
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:2');
-    env.previousRefButton.nativeElement.click();
+    env.clickPreviousRef();
     await env.waitForPlayer();
     // move back to the section heading before verse 2
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:1');
-    env.previousRefButton.nativeElement.click();
+    env.clickPreviousRef();
     await env.waitForPlayer();
     // verse 1
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:1');
@@ -141,22 +141,6 @@ xdescribe('ScriptureAudioComponent', () => {
     await env.waitForPlayer();
     expect(pauseSpy).toHaveBeenCalled();
     expect(count).toEqual(1);
-  });
-
-  it('can skip to previous verse', async () => {
-    const template = `<app-checking-scripture-audio-player source="${audioFile}"></app-checking-scripture-audio-player>`;
-    const env = new TestEnvironment(template);
-    env.fixture.detectChanges();
-    await env.waitForPlayer(500);
-
-    env.component.audioPlayer.textDocId = textDocId;
-    env.component.audioPlayer.timing = getAudioTimings();
-    await env.waitForPlayer();
-
-    env.currentTime = 2;
-    expect(env.currentTime).toEqual(2);
-    env.clickPreviousRef();
-    expect(env.currentTime).toEqual(1);
   });
 
   it('skipping to previous verse remains on the current verse if within grace period', async () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
@@ -96,7 +96,7 @@ export class CheckingScriptureAudioPlayerComponent extends SubscriptionDisposabl
 
     const currentTimingIndex: number = this.getRefIndexInTimings(currentRef);
     if (currentTimingIndex < 0) {
-      this.audioPlayer.audio.stop();
+      this.stop();
     } else if (this.audioPlayer.audio.currentTime < this._timing[currentTimingIndex].from) {
       // The first timing index doesn't always start at zero so this allows skipping to the start of the first reference
       this.audioPlayer.audio.currentTime = this._timing[currentTimingIndex].from;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
@@ -90,15 +90,18 @@ export class CheckingScriptureAudioPlayerComponent extends SubscriptionDisposabl
   }
 
   nextRef(): void {
-    if (this.audioPlayer?.audio == null || this.timing == null) return;
-    const currentTimingIndex: number = this.timing.findIndex(t => t.textRef === this.currentRef);
+    if (this.audioPlayer?.audio == null || this._timing.length < 1) return;
+    const currentRef = this.currentRef;
+    if (currentRef == null) return;
+
+    const currentTimingIndex: number = this.getRefIndexInTimings(currentRef);
     if (currentTimingIndex < 0) {
       this.audioPlayer.audio.stop();
-    } else if (this.audioPlayer.audio.currentTime < this.timing[currentTimingIndex].from) {
+    } else if (this.audioPlayer.audio.currentTime < this._timing[currentTimingIndex].from) {
       // The first timing index doesn't always start at zero so this allows skipping to the start of the first reference
-      this.audioPlayer.audio.currentTime = this.timing[currentTimingIndex].from;
+      this.audioPlayer.audio.currentTime = this._timing[currentTimingIndex].from;
     } else {
-      this.audioPlayer.audio.currentTime = this.timing[currentTimingIndex].to;
+      this.audioPlayer.audio.currentTime = this._timing[currentTimingIndex].to;
     }
     this.verseLabel = this.currentVerseLabel;
   }
@@ -114,20 +117,23 @@ export class CheckingScriptureAudioPlayerComponent extends SubscriptionDisposabl
   }
 
   previousRef(): void {
-    if (this.audioPlayer?.audio == null || this.timing == null) return;
+    if (this.audioPlayer?.audio == null || this._timing.length < 1) return;
     const skipBackGracePeriod = 3;
-    const currentTimingIndex: number = this.timing.findIndex(t => t.textRef === this.currentRef);
+    const currentRef = this.currentRef;
+    if (currentRef == null) return;
+
+    const currentTimingIndex: number = this.getRefIndexInTimings(currentRef);
     if (currentTimingIndex < 0) {
       this.audioPlayer.audio.currentTime = 0;
-    } else if (this.audioPlayer.audio.currentTime > this.timing[currentTimingIndex].from + skipBackGracePeriod) {
+    } else if (this.audioPlayer.audio.currentTime > this._timing[currentTimingIndex].from + skipBackGracePeriod) {
       // Move to the start of the reference that had already been playing
       // rather than the start of the previous reference - this mimics Spotify previous track logic
-      this.audioPlayer.audio.currentTime = this.timing[currentTimingIndex].from;
+      this.audioPlayer.audio.currentTime = this._timing[currentTimingIndex].from;
     } else if (currentTimingIndex === 0) {
       // The first timing index doesn't always start at zero so this forces it to the beginning of the audio
       this.audioPlayer.audio.currentTime = 0;
     } else {
-      this.audioPlayer.audio.currentTime = this.timing[currentTimingIndex - 1].from;
+      this.audioPlayer.audio.currentTime = this._timing[currentTimingIndex - 1].from;
     }
     this.verseLabel = this.currentVerseLabel;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player.ts
@@ -156,6 +156,11 @@ export class AudioPlayer extends SubscriptionDisposable {
     this.currentTime = value > 0 ? this.duration * (value / 100) : 0;
   }
 
+  stop(): void {
+    this.audio.pause();
+    this.currentTime = 0;
+  }
+
   private audioIsReady(): void {
     this.currentTime = 0;
     this.audioDataLoaded = true;


### PR DESCRIPTION
* Introduced a grace period for skipping to previous verses
* Skipping to the next verse can now skip to the start of the current verse if it hasn't started yet
* Fixed bug when skipping to the start of the first timing data

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2037)
<!-- Reviewable:end -->
