### PR TITLE
Removed check for queued Pre-Translation builds

### DIFF
--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -130,20 +130,6 @@ public class MachineProjectServiceTests
     }
 
     [Test]
-    public async Task BuildProjectAsync_DoesNotBuildIfPendingPreTranslationBuild()
-    {
-        // Set up test environment
-        var env = new TestEnvironment(new TestEnvironmentOptions { BuildIsPending = true });
-
-        // SUT
-        await env.Service.BuildProjectAsync(User01, Project02, preTranslate: true, CancellationToken.None);
-
-        await env.TranslationEnginesClient
-            .DidNotReceive()
-            .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None);
-    }
-
-    [Test]
     public async Task BuildProjectAsync_RunsPreTranslationBuildIfNoTextChangesAndNoPendingBuild()
     {
         // Set up test environment


### PR DESCRIPTION
Previously Serval would remove the pre-translations when a pre-translation build is queued. This behavior has since been changed so that the pre-translations are only removed when a build completes.

As such, we no longer need this check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2040)
<!-- Reviewable:end -->
