### PR TITLE
Fix: Optimized Docker Build Order

### DIFF
--- a/src/.dockerignore
+++ b/src/.dockerignore
@@ -24,5 +24,6 @@
 **/RealtimeServer/lib/
 **/secrets.dev.yaml
 **/values.dev.yaml
+ClientApp
 LICENSE
 README.md

--- a/src/SIL.XForge.Scripture/Dockerfile
+++ b/src/SIL.XForge.Scripture/Dockerfile
@@ -51,14 +51,20 @@ RUN update-ca-certificates \
 RUN apt-get install -y \
     nodejs \
     && rm -rf /var/lib/apt/lists/*
-COPY ../RealtimeServer/ ./RealtimeServer/
-COPY ../SIL.XForge/ ./SIL.XForge/
-COPY ../SIL.XForge.Scripture/ ./SIL.XForge.Scripture/
+# Build the Realtime Server
+COPY ../RealtimeServer/ /src/RealtimeServer/
 WORKDIR /src/RealtimeServer
 RUN npm ci
+# Build the Angular Frontend
+COPY ../SIL.XForge.Scripture/locales.json /src/SIL.XForge.Scripture/locales.json
+COPY ../SIL.XForge.Scripture/version.json /src/SIL.XForge.Scripture/version.json
+COPY ../SIL.XForge.Scripture/ClientApp/ /src/SIL.XForge.Scripture/ClientApp/
 WORKDIR /src/SIL.XForge.Scripture/ClientApp
 RUN npm ci
 RUN npm run build
+# Build the .NET Backend
+COPY ../SIL.XForge/ /src/SIL.XForge/
+COPY ../SIL.XForge.Scripture/ /src/SIL.XForge.Scripture/
 WORKDIR /src/SIL.XForge.Scripture
 RUN dotnet restore SIL.XForge.Scripture.csproj
 RUN dotnet build SIL.XForge.Scripture.csproj -c $configuration -o /app/build


### PR DESCRIPTION
Based on feedback I have optimized the build order in Docker so that modifications to C# code do not result in the rebuilding of the Angular front end, and that modifications to the Angular frontend.

This Pull Request fixes the Docker build order to run in the following order:

1. Realtime Server
2. Angular Frontend
3. Dotnet Backend

What this means is:

* Changes to the Realtime server will rebuild the Realtime server, the Angular frontend, and the Dotnet backend.
* Changes to the Angular frontend will rebuild the Angular frontend and the Dotnet backend, but not the Realtime server.
* Changes to the Dotnet backend will rebuild the Dotnet backend, but not the Realtime server and the Angular frontend.

Note: The dotnet project will still execute `npm run build` on the Realtime server, as a part of its MSBuild configuration, but it will not execute `npm ci` in the Realtime server directory if the Docker cache is still valid (i.e. if no files have changed in the Realtime server).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2042)
<!-- Reviewable:end -->
