### PR TITLE
Disable Chromatic snapshot of playing audio player

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player-new.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player-new.stories.ts
@@ -43,5 +43,8 @@ export const Playing: Story = {
     await new Promise(resolve => setTimeout(resolve, 100));
     const play = await canvas.findByRole('button');
     userEvent.click(play);
+  },
+  parameters: {
+    chromatic: { disableSnapshot: true }
   }
 };


### PR DESCRIPTION
This story has  been creating very inconsistent snapshots because it's taking screenshots while the slider is updating, and the timing isn't always the same.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2044)
<!-- Reviewable:end -->
