### PR TITLE
Disable flaky test of SingleButtonAudioPlayer

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.spec.ts
@@ -37,12 +37,12 @@ describe('SingleButtonAudioPlayerComponent', () => {
     providers: [{ provide: PwaService, useMock: mockedPwaService }]
   }));
 
-  it('shows content when audio is available', async () => {
+  xit('shows content when audio is available', async () => {
     const env = new TestEnvironment();
     await env.wait();
     await env.wait();
 
-    expect(env.content).not.toBeNull();
+    expect(env.content).not.toBeNull(); // FIXME This assertion is flaky
     expect(window.getComputedStyle(env.content.nativeElement)['display']).not.toBe('none');
   });
 


### PR DESCRIPTION
This has been causing a lot of build failures. We need to fix the test, but in the meantime we don't want our builds constantly failing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2045)
<!-- Reviewable:end -->
