### PR TITLE
Allow answers to scroll up closer to splitter

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -203,7 +203,6 @@ $questionsPanelBreakpoint: 600px;
   }
 
   #answer-panel {
-    height: 100%;
     padding-top: 12px;
     padding-bottom: 12px;
     padding-inline-start: 15px;


### PR DESCRIPTION
A white padding was maintained at the top and bottom of the answer area. Unlike for the Scripture text area.

Maintain having the same padding, but allow the padding itself to scroll up and down with the answer area.

---

Video of behaviour before:
[answer-panel-before.webm](https://github.com/sillsdev/web-xforge/assets/7265309/ee0bd682-811d-4122-ae6c-577b098cc1cb)

Video of behaviour with this patch:
[answer-panel-after.webm](https://github.com/sillsdev/web-xforge/assets/7265309/1e5ffbb1-3722-4bf8-b23e-8737b90c11a3)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2047)
<!-- Reviewable:end -->
