### PR TITLE
SF-1627 Fix audio player in RTL UI

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.html
@@ -1,8 +1,16 @@
 <ng-container *transloco="let t; read: 'checking_audio_player'">
   <div *ngIf="isAudioInitComplete">
-    <div *ngIf="audio !== undefined && (isAudioAvailable$ | async)" class="content" dir="ltr">
+    <div *ngIf="audio !== undefined && (isAudioAvailable$ | async)" class="content">
       <div class="current-time">{{ audio.currentTime | audioTime }}</div>
-      <mat-slider class="slider" [min]="0" [max]="100" [step]="1" [value]="seek" (input)="onSeek($event)"></mat-slider>
+      <mat-slider
+        class="slider"
+        [min]="0"
+        [max]="100"
+        [step]="1"
+        [value]="seek"
+        (input)="onSeek($event)"
+        [dir]="direction"
+      ></mat-slider>
       <div class="duration">{{ duration | audioTime }}</div>
     </div>
     <div *ngIf="(isAudioAvailable$ | async) !== true" class="audio-not-available">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; read: 'checking_audio_player'">
   <div *ngIf="isAudioInitComplete">
-    <div *ngIf="audio !== undefined && (isAudioAvailable$ | async)" class="content">
+    <div *ngIf="audio !== undefined && (isAudioAvailable$ | async)" class="content" dir="ltr">
       <div class="current-time">{{ audio.currentTime | audioTime }}</div>
       <mat-slider
         class="slider"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.html
@@ -9,7 +9,7 @@
         [step]="1"
         [value]="seek"
         (input)="onSeek($event)"
-        [dir]="direction"
+        [dir]="i18n.direction"
       ></mat-slider>
       <div class="duration">{{ duration | audioTime }}</div>
     </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.scss
@@ -16,6 +16,9 @@
     ::ng-deep .mat-slider-thumb {
       background-color: #000;
     }
+    &[dir='rtl'] {
+      transform: rotateY(180deg);
+    }
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.ts
@@ -22,15 +22,13 @@ export class AudioPlayerComponent extends AudioPlayerBaseComponent {
     return this.audio?.seek ?? 0;
   }
 
-  get direction(): 'ltr' | 'rtl' {
-    return this.i18n.direction;
-  }
-
   onSeek(event: MatSliderChange): void {
     let seek: number | null = event.value;
     if (seek == null) return;
-    if (this.direction === 'rtl') {
-      // The slider is reversed for RTL languages so the seek is the inverse of the value that is emitted
+    if (this.i18n.direction === 'rtl') {
+      // It appears that a bug in @angular/material@14.x prevents the slider from working in RTL environments.
+      // The workaround is to flip the slider over the y-axis (so it appears LTR). But to allow seeking to work,
+      // the seek value is set to the inverse of the value that is emitted from the slider.
       seek = 100 - seek;
     }
     this.audio?.setSeek(seek);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.ts
@@ -27,8 +27,12 @@ export class AudioPlayerComponent extends AudioPlayerBaseComponent {
   }
 
   onSeek(event: MatSliderChange): void {
-    if (event?.value !== null) {
-      this.audio?.setSeek(event.value);
+    let seek: number | null = event.value;
+    if (seek == null) return;
+    if (this.direction === 'rtl') {
+      // The slider is reversed for RTL languages so the seek is the inverse of the value that is emitted
+      seek = 100 - seek;
     }
+    this.audio?.setSeek(seek);
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.ts
@@ -22,6 +22,10 @@ export class AudioPlayerComponent extends AudioPlayerBaseComponent {
     return this.audio?.seek ?? 0;
   }
 
+  get direction(): 'ltr' | 'rtl' {
+    return this.i18n.direction;
+  }
+
   onSeek(event: MatSliderChange): void {
     if (event?.value !== null) {
       this.audio?.setSeek(event.value);


### PR DESCRIPTION
The audio player uses a mat-slide for UI to indicate the progress of the audio clip. In RTL, we forced the mat-slider to be in LTR mode so that it plays left to right. However, there seems to be some bug and the slider players left to right, but the green fill goes right to left.
This sets the slider to the direction indicated by the locale, but in RTL languages, it rotates the slider so that it plays equivalent to the LTR mode.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2048)
<!-- Reviewable:end -->
