### PR TITLE
Remove comment form from Chromatic diff due to rendering inconsistencies

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comment-form/checking-comment-form.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comment-form/checking-comment-form.stories.ts
@@ -15,22 +15,19 @@ export default meta;
 
 type Story = StoryObj<CheckingCommentFormComponent>;
 
-// The outlined form field has inconsistencies in how it renders the outline when focused.
-// Using Chromatic's diff tool at
-// https://6262c53f521620003ac2ff49-ukmsdlppcb.chromatic.com/?path=/story/stories-diff-threshold-check--test-yours-out
-// it appears a diff threshold of about 0.66 is needed to ignore the differences. For good measure it's rounded up to
-// 0.7. It may be possible to remove this after updating @angular/material.
-
 export const NewForm: Story = {
   parameters: {
-    chromatic: { diffThreshold: 0.7 }
+    // Disabled due to inconsistent rendering of Material outlined form field (the outline sometimes comes closer to the
+    // label than at other times)
+    chromatic: { disableSnapshot: true }
   }
 };
 
 export const EditForm: Story = {
   args: { text: 'This is a comment' },
   parameters: {
-    chromatic: { diffThreshold: 0.7 }
+    // Disabled for the same reason the story above
+    chromatic: { disableSnapshot: true }
   }
 };
 


### PR DESCRIPTION
The Material input with the outlined appearance renders inconsistently, and that's caused it to constantly show up as a change in Chromatic. Try opening these two images, A and B, in different tabs, and switching between them, and you should see the difference.

### A
![](https://github.com/sillsdev/web-xforge/assets/6140710/ae15758c-e91a-45ce-b0b6-6d4fcf519bcd)
### B
![](https://github.com/sillsdev/web-xforge/assets/6140710/caf81c4a-f557-4693-8fa3-3998eafc1e19)

The line sometimes gets closer to the label than at other times. This is a bug, but not one we care about that much, and hopefully it's been fixed in newer versions of Material.

In any case, Chromatic lets us set a diff threshold, and has a tool that lets you upload two screenshots and see what changes are found with a given threshold. I previously "solved" the problem by changing the threshold to 0.7, which I found to be sufficient.

But then the problem came back, and I think I know why. I recently updated the Material theme, and the outline changed from blue to grey, which has a higher contrast against white. So now the threshold is insufficient.

So, I used the tool and tried finding a higher diff threshold, and found setting it to 0.8 was sufficient. I thought the threshold was a sophisticated threshold, where it took into consideration how many pixels changed, and by how much. To test this, I tried comparing this image with one of the screenshots:

![](https://github.com/sillsdev/web-xforge/assets/6140710/bbad9eec-05ca-4dc3-a502-d70e5eec5358)

And it turns out, if you set the threshold to 0.8, it doesn't see any change at all, even though there's clearly a large change. It appears the threshold is used only on a per-pixel basis, and it's looking to see if any single pixel changed by more than that threshold. So by setting the threshold to 0.8, it ignores any change that isn't black against white, and setting it to that would be almost like having no diff at all.

Having learned that, I'm just turning off Chromatic snapshots for these stories.

Hopefully Material fixes the bug in a future version and we can re-enable it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2052)
<!-- Reviewable:end -->
