### PR TITLE
SF-2234 Fix number flipped on icon badge for RTL UI

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
@@ -137,6 +137,9 @@ button.mdc-icon-button {
 
 body[dir='rtl'] .mirror-rtl {
   transform: scaleX(-1);
+  .mat-badge-content {
+    transform: scaleX(-1);
+  }
 }
 
 app-root {


### PR DESCRIPTION
Before
![Icon badge before](https://github.com/sillsdev/web-xforge/assets/17931130/13b4cb5d-4f63-4e84-86c7-2968f7c8f7cd)

After
![Icon badge after](https://github.com/sillsdev/web-xforge/assets/17931130/b58e598b-5faf-49c2-8857-e1a4ecf15010)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2054)
<!-- Reviewable:end -->
