### PR TITLE
SF-2211 Do not show the verse too long error when suggestions are disabled

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1273,7 +1273,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       return;
     } else if (sourceSegment.length > MAX_SEGMENT_LENGTH) {
       this.translator = undefined;
-      this.noticeService.show(translate('editor.verse_too_long_for_suggestions'));
+      if (this.translationSuggestionsEnabled) {
+        this.noticeService.show(translate('editor.verse_too_long_for_suggestions'));
+      }
       return;
     }
 


### PR DESCRIPTION
When translation suggestions are disabled by the user, training still occurs in the background.

Because of this, the "verse too long" error message can appear when the user does not expect it (due to their having disabled translation suggestions in the Translation Settings dialog).

Included in this PR are two unit tests confirming the correct behavior for the "verse too long" notice when a verse is too long.

Please see [SF-1656](https://jira.sil.org/browse/SF-1656) for details on how to recreate this issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2059)
<!-- Reviewable:end -->
