### PR TITLE
SF-2231 Flaky audio tests

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -2,7 +2,7 @@ import { MdcDialog } from '@angular-mdc/web';
 import { CommonModule, Location } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement, NgModule, NgZone } from '@angular/core';
-import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, discardPeriodicTasks, fakeAsync, flush, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Route, Router } from '@angular/router';
@@ -11,7 +11,7 @@ import { CookieService } from 'ngx-cookie-service';
 import { User } from 'realtime-server/lib/esm/common/models/user';
 import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-data';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
-import { getQuestionDocId, Question } from 'realtime-server/lib/esm/scriptureforge/models/question';
+import { Question, getQuestionDocId } from 'realtime-server/lib/esm/scriptureforge/models/question';
 import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
@@ -32,7 +32,7 @@ import { PwaService } from 'xforge-common/pwa.service';
 import { QueryParameters } from 'xforge-common/query-parameters';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
-import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { TestTranslocoModule, configureTestingModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
 import { objectId } from 'xforge-common/utils';
@@ -110,6 +110,10 @@ describe('AppComponent', () => {
       { provide: MdcDialog, useMock: mockedMdcDialog },
       { provide: DialogService, useMock: mockedDialogService }
     ]
+  }));
+
+  afterEach(fakeAsync(() => {
+    discardPeriodicTasks();
   }));
 
   it('navigate to last project', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-test.utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-test.utils.ts
@@ -1,4 +1,7 @@
 import { AudioTiming } from 'realtime-server/lib/esm/scriptureforge/models/audio-timing';
+import { mock, instance, when } from 'ts-mockito';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { AudioPlayer } from '../shared/audio/audio-player';
 
 export function getAudioTimings(): AudioTiming[] {
   return [
@@ -16,4 +19,37 @@ export function getAudioTimingWithHeadings(): AudioTiming[] {
     { textRef: 's', from: 2.25, to: 3.0 },
     { textRef: '3', from: 3.0, to: 4.0 }
   ];
+}
+
+export class AudioPlayerStub extends AudioPlayer {
+  htmlAudioMock: HTMLAudioElement = mock(HTMLAudioElement);
+  protected override audio: HTMLAudioElement = instance(this.htmlAudioMock);
+
+  private _isPlaying = false;
+
+  constructor(audioUrl: string, onlineService: OnlineStatusService) {
+    super(audioUrl, onlineService);
+    when(this.htmlAudioMock.src).thenReturn(audioUrl);
+    when(this.htmlAudioMock.currentTime).thenReturn(0);
+  }
+
+  override get isPlaying(): boolean {
+    return this._isPlaying;
+  }
+
+  override play(): void {
+    this._isPlaying = true;
+  }
+
+  override pause(): void {
+    this._isPlaying = false;
+  }
+
+  override get currentTime(): number {
+    return this.audio.currentTime;
+  }
+
+  override set currentTime(time: number) {
+    when(this.htmlAudioMock.currentTime).thenReturn(time);
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.html
@@ -1,4 +1,4 @@
-<div class="scripture-audio-player" [dir]="i18n.direction">
+<div class="scripture-audio-player" [dir]="i18n.direction" *transloco="let t; read: 'checking_audio_player'">
   <div class="audio-action-buttons">
     <button mat-icon-button class="previous-ref-button" (click)="previousRef()">
       <mat-icon class="mirror-rtl">skip_previous</mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
@@ -3,7 +3,6 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { By } from '@angular/platform-browser';
 import { AudioTiming } from 'realtime-server/scriptureforge/models/audio-timing';
 import { BehaviorSubject, of } from 'rxjs';
-import { AudioPlayer } from 'src/app/shared/audio/audio-player';
 import { instance, mock, when } from 'ts-mockito';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestTranslocoModule } from 'xforge-common/test-utils';
@@ -11,7 +10,7 @@ import { UICommonModule } from 'xforge-common/ui-common.module';
 import { TextDocId } from '../../../core/models/text-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { AudioTimePipe } from '../../../shared/audio/audio-time-pipe';
-import { getAudioTimingWithHeadings, getAudioTimings } from '../../checking-test.utils';
+import { AudioPlayerStub, getAudioTimingWithHeadings, getAudioTimings } from '../../checking-test.utils';
 import { CheckingScriptureAudioPlayerComponent } from './checking-scripture-audio-player.component';
 
 const audioFile = 'test-audio-player.webm';
@@ -172,43 +171,10 @@ class AudioPlayerStubComponent {
 
   constructor() {
     when(AudioPlayerStubComponent.onlineStatusService.onlineStatus$).thenReturn(new BehaviorSubject(false));
-    this.audio = new AudioPlayerStub(instance(AudioPlayerStubComponent.onlineStatusService));
+    this.audio = new AudioPlayerStub(audioFile, instance(AudioPlayerStubComponent.onlineStatusService));
   }
 
   @Input() set source(source: string | undefined) {}
-}
-
-class AudioPlayerStub extends AudioPlayer {
-  htmlAudioMock: HTMLAudioElement = mock(HTMLAudioElement);
-  protected override audio: HTMLAudioElement = instance(this.htmlAudioMock);
-
-  private _isPlaying = false;
-
-  constructor(onlineService: OnlineStatusService) {
-    super(audioFile, onlineService);
-    when(this.htmlAudioMock.src).thenReturn(audioFile);
-    when(this.htmlAudioMock.currentTime).thenReturn(0);
-  }
-
-  override get isPlaying(): boolean {
-    return this._isPlaying;
-  }
-
-  override play(): void {
-    this._isPlaying = true;
-  }
-
-  override pause(): void {
-    this._isPlaying = false;
-  }
-
-  override get currentTime(): number {
-    return this.audio.currentTime;
-  }
-
-  override set currentTime(time: number) {
-    when(this.htmlAudioMock.currentTime).thenReturn(time);
-  }
 }
 
 class TestEnvironment {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
@@ -1,74 +1,72 @@
-import { Component, DebugElement, NgZone, ViewChild } from '@angular/core';
+import { Component, DebugElement, Input, NgZone, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { AudioTiming } from 'realtime-server/scriptureforge/models/audio-timing';
-import { of } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
+import { AudioPlayer } from 'src/app/shared/audio/audio-player';
 import { instance, mock, when } from 'ts-mockito';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { TextDocId } from '../../../core/models/text-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
-import { AudioPlayerComponent } from '../../../shared/audio/audio-player/audio-player.component';
 import { AudioTimePipe } from '../../../shared/audio/audio-time-pipe';
-import { getAudioTimings, getAudioTimingWithHeadings } from '../../checking-test.utils';
+import { getAudioTimingWithHeadings, getAudioTimings } from '../../checking-test.utils';
 import { CheckingScriptureAudioPlayerComponent } from './checking-scripture-audio-player.component';
 
 const audioFile = 'test-audio-player.webm';
 const textDocId: TextDocId = new TextDocId('project01', 1, 1);
 
-// FIXME Tests are flaky
-xdescribe('ScriptureAudioComponent', () => {
-  it('can play and pause audio', async () => {
+describe('ScriptureAudioComponent', () => {
+  let env: TestEnvironment;
+  beforeEach(async () => {
     const template = `<app-checking-scripture-audio-player source="${audioFile}"></app-checking-scripture-audio-player>`;
-    const env = new TestEnvironment(template);
+    env = new TestEnvironment(template);
     env.fixture.detectChanges();
-    await env.waitForPlayer(500);
 
     env.component.audioPlayer.textDocId = textDocId;
     env.component.audioPlayer.timing = getAudioTimings();
     await env.waitForPlayer();
-    env.playButton.nativeElement.click();
-    await env.waitForPlayer();
-    env.fixture.detectChanges();
-    expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:1');
-    expect(env.isPlaying).toBe(true);
+  });
+
+  it('can play and pause audio', async () => {
+    const play = spyOn(env.audioPlayer.audio, 'play').and.callThrough();
+    const pause = spyOn(env.audioPlayer.audio, 'pause').and.callThrough();
 
     env.playButton.nativeElement.click();
     await env.waitForPlayer();
-    env.fixture.detectChanges();
-    expect(env.isPlaying).toBe(false);
+
+    expect(env.isPlaying).toBe(true);
+    expect(play).toHaveBeenCalledTimes(1);
+    expect(pause).toHaveBeenCalledTimes(0);
+
+    env.playButton.nativeElement.click();
+    await env.waitForPlayer();
+
+    expect(play).toHaveBeenCalledTimes(1);
+    expect(pause).toHaveBeenCalledTimes(1);
   });
 
   it('can skip to next and previous verse', async () => {
-    const template = `<app-checking-scripture-audio-player source="${audioFile}"></app-checking-scripture-audio-player>`;
-    const env = new TestEnvironment(template);
-    env.fixture.detectChanges();
-    await env.waitForPlayer(500);
+    expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:1');
 
-    env.component.audioPlayer.textDocId = textDocId;
-    env.component.audioPlayer.timing = getAudioTimings();
-    await env.waitForPlayer();
     env.clickNextRef();
     await env.waitForPlayer();
+    expect(env.audioPlayer.audio.currentTime).toBe(1);
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:2');
     env.clickPreviousRef();
     await env.waitForPlayer();
+    expect(env.audioPlayer.audio.currentTime).toBe(0);
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:1');
     env.clickPreviousRef();
     await env.waitForPlayer();
+    expect(env.audioPlayer.audio.currentTime).toBe(0);
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:1');
   });
 
   it('can skip forward and back through section headings', async () => {
-    const template = `<app-checking-scripture-audio-player source="${audioFile}"></app-checking-scripture-audio-player>`;
-    const env = new TestEnvironment(template);
-    env.fixture.detectChanges();
-    await env.waitForPlayer(500);
-
-    env.component.audioPlayer.textDocId = textDocId;
     env.component.audioPlayer.timing = getAudioTimingWithHeadings();
-    await env.waitForPlayer();
+
     env.clickNextRef();
     await env.waitForPlayer();
     // section heading before verse 2
@@ -88,50 +86,39 @@ xdescribe('ScriptureAudioComponent', () => {
   });
 
   it('emits verse changed event', async () => {
-    const template = `<app-checking-scripture-audio-player source="${audioFile}"></app-checking-scripture-audio-player>`;
-    const env = new TestEnvironment(template);
-    env.fixture.detectChanges();
-    await env.waitForPlayer(500);
-
-    env.component.audioPlayer.textDocId = textDocId;
-    env.component.audioPlayer.timing = getAudioTimings();
-    await env.waitForPlayer();
     const verseChangedSpy = jasmine.createSpy('verseChanged');
     env.component.audioPlayer.currentVerseChanged.subscribe(verseChangedSpy);
-    env.playButton.nativeElement.click();
-    await env.waitForPlayer(2000);
+    expect(verseChangedSpy).toHaveBeenCalledTimes(0);
+
+    env.audioPlayer.audio.currentTime = 1.5;
+    env.audioPlayer.audio.timeUpdated$.next();
+    expect(verseChangedSpy).toHaveBeenCalledTimes(1);
     expect(verseChangedSpy).toHaveBeenCalledWith('verse_1_2');
   });
 
   it('emits verse changed event for section headings', async () => {
-    const template = `<app-checking-scripture-audio-player source="${audioFile}"></app-checking-scripture-audio-player>`;
-    const env = new TestEnvironment(template);
-    env.fixture.detectChanges();
-    await env.waitForPlayer(500);
-
     const timings: AudioTiming[] = getAudioTimingWithHeadings();
-    env.component.audioPlayer.textDocId = textDocId;
     env.component.audioPlayer.timing = timings;
-    await env.waitForPlayer();
+
     const verseChangedSpy = jasmine.createSpy('verseChanged');
     env.component.audioPlayer.currentVerseChanged.subscribe(verseChangedSpy);
-    env.playButton.nativeElement.click();
-    await env.waitForPlayer(1400);
+
+    env.audioPlayer.audio.currentTime = 1;
+    env.audioPlayer.audio.timeUpdated$.next();
+    await env.waitForPlayer();
     expect(env.currentTime).toBeGreaterThan(timings[1].from);
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:1');
-    await env.waitForPlayer(1400);
+    expect(verseChangedSpy).toHaveBeenCalledWith('s_1');
+
+    env.audioPlayer.audio.currentTime = 2.5;
+    env.audioPlayer.audio.timeUpdated$.next();
+    await env.waitForPlayer();
     expect(env.currentTime).toBeGreaterThan(timings[3].from);
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:2');
-    expect(verseChangedSpy).toHaveBeenCalledWith('s_1');
     expect(verseChangedSpy).toHaveBeenCalledWith('s_2');
   });
 
   it('pauses and emits on close', async () => {
-    const template = `<app-checking-scripture-audio-player source="${audioFile}"></app-checking-scripture-audio-player>`;
-    const env = new TestEnvironment(template);
-    env.fixture.detectChanges();
-    await env.waitForPlayer(500);
-
     const pauseSpy = spyOn(env.component.audioPlayer, 'pause').and.callThrough();
     let count = 0;
     env.component.audioPlayer.closed.subscribe(() => count++);
@@ -144,18 +131,11 @@ xdescribe('ScriptureAudioComponent', () => {
   });
 
   it('skipping to previous verse remains on the current verse if within grace period', async () => {
-    const template = `<app-checking-scripture-audio-player source="${audioFile}"></app-checking-scripture-audio-player>`;
-    const env = new TestEnvironment(template);
-    env.fixture.detectChanges();
-    await env.waitForPlayer(500);
-
-    env.component.audioPlayer.textDocId = textDocId;
     env.component.audioPlayer.timing = [
       { textRef: '1', from: 0.0, to: 1.0 },
       { textRef: '2', from: 1.0, to: 4.5 },
       { textRef: '3', from: 4.5, to: 5.0 }
     ];
-    await env.waitForPlayer();
 
     env.currentTime = 4.1;
     expect(env.currentTime).toBeGreaterThan(4);
@@ -166,17 +146,10 @@ xdescribe('ScriptureAudioComponent', () => {
   });
 
   it('skipping to the next verse will skip to the start of the current timing data if it has not started yet', async () => {
-    const template = `<app-checking-scripture-audio-player source="${audioFile}"></app-checking-scripture-audio-player>`;
-    const env = new TestEnvironment(template);
-    env.fixture.detectChanges();
-    await env.waitForPlayer(500);
-
-    env.component.audioPlayer.textDocId = textDocId;
     env.component.audioPlayer.timing = [
       { textRef: '1', from: 3.0, to: 4.0 },
       { textRef: '2', from: 4.0, to: 5.0 }
     ];
-    await env.waitForPlayer();
 
     expect(env.currentTime).toEqual(0);
     env.clickNextRef();
@@ -189,6 +162,55 @@ class HostComponent {
   @ViewChild(CheckingScriptureAudioPlayerComponent) audioPlayer!: CheckingScriptureAudioPlayerComponent;
 }
 
+@Component({
+  selector: 'app-audio-player',
+  template: '<p>Mock Audio Player</p>'
+})
+class AudioPlayerStubComponent {
+  static onlineStatusService = mock(OnlineStatusService);
+  audio: AudioPlayerStub;
+
+  constructor() {
+    when(AudioPlayerStubComponent.onlineStatusService.onlineStatus$).thenReturn(new BehaviorSubject(false));
+    this.audio = new AudioPlayerStub(instance(AudioPlayerStubComponent.onlineStatusService));
+  }
+
+  @Input() set source(source: string | undefined) {}
+}
+
+class AudioPlayerStub extends AudioPlayer {
+  htmlAudioMock: HTMLAudioElement = mock(HTMLAudioElement);
+  protected override audio: HTMLAudioElement = instance(this.htmlAudioMock);
+
+  private _isPlaying = false;
+
+  constructor(onlineService: OnlineStatusService) {
+    super(audioFile, onlineService);
+    when(this.htmlAudioMock.src).thenReturn(audioFile);
+    when(this.htmlAudioMock.currentTime).thenReturn(0);
+  }
+
+  override get isPlaying(): boolean {
+    return this._isPlaying;
+  }
+
+  override play(): void {
+    this._isPlaying = true;
+  }
+
+  override pause(): void {
+    this._isPlaying = false;
+  }
+
+  override get currentTime(): number {
+    return this.audio.currentTime;
+  }
+
+  override set currentTime(time: number) {
+    when(this.htmlAudioMock.currentTime).thenReturn(time);
+  }
+}
+
 class TestEnvironment {
   readonly mockOnlineStatusService = mock(OnlineStatusService);
   readonly mockedProjectService = mock(SFProjectService);
@@ -198,7 +220,7 @@ class TestEnvironment {
 
   constructor(template: string) {
     TestBed.configureTestingModule({
-      declarations: [HostComponent, CheckingScriptureAudioPlayerComponent, AudioPlayerComponent, AudioTimePipe],
+      declarations: [HostComponent, CheckingScriptureAudioPlayerComponent, AudioPlayerStubComponent, AudioTimePipe],
       providers: [
         { provide: OnlineStatusService, useFactory: () => instance(this.mockOnlineStatusService) },
         { provide: SFProjectService, useFactory: () => instance(this.mockedProjectService) }
@@ -210,6 +232,10 @@ class TestEnvironment {
     this.ngZone = TestBed.inject(NgZone);
     this.fixture = TestBed.createComponent(HostComponent);
     this.component = this.fixture.componentInstance;
+  }
+
+  get audioPlayer(): AudioPlayerStubComponent {
+    return this.component.audioPlayer.audioPlayer! as unknown as AudioPlayerStubComponent;
   }
 
   get currentTime(): number {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
@@ -278,7 +278,7 @@ class TestEnvironment {
     this.previousRefButton.nativeElement.click();
   }
 
-  async waitForPlayer(ms: number = 100): Promise<void> {
+  async waitForPlayer(ms: number = 1000): Promise<void> {
     await new Promise(resolve => this.ngZone.runOutsideAngular(() => setTimeout(resolve, ms)));
     this.fixture.detectChanges();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
@@ -278,7 +278,7 @@ class TestEnvironment {
     this.previousRefButton.nativeElement.click();
   }
 
-  async waitForPlayer(ms: number = 50): Promise<void> {
+  async waitForPlayer(ms: number = 100): Promise<void> {
     await new Promise(resolve => this.ngZone.runOutsideAngular(() => setTimeout(resolve, ms)));
     this.fixture.detectChanges();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
@@ -27,6 +27,7 @@ describe('ScriptureAudioComponent', () => {
     env.component.audioPlayer.textDocId = textDocId;
     env.component.audioPlayer.timing = getAudioTimings();
     await env.waitForPlayer();
+    await env.waitForPlayer();
   });
 
   it('can play and pause audio', async () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
@@ -27,6 +27,7 @@ describe('ScriptureAudioComponent', () => {
     env.component.audioPlayer.textDocId = textDocId;
     env.component.audioPlayer.timing = getAudioTimings();
     await env.waitForPlayer();
+    env.fixture.detectChanges();
     await env.waitForPlayer();
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { Canon, VerseRef } from '@sillsdev/scripture';
 import { AudioTiming } from 'realtime-server/lib/esm/scriptureforge/models/audio-timing';
 import { distinctUntilChanged, map } from 'rxjs/operators';
@@ -8,14 +8,14 @@ import { TextDocId } from '../../../core/models/text-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { AudioPlayer } from '../../../shared/audio/audio-player';
 import { AudioPlayerComponent } from '../../../shared/audio/audio-player/audio-player.component';
-import { AudioTextRef, AudioHeadingRef, CheckingUtils } from '../../checking.utils';
+import { AudioHeadingRef, AudioTextRef, CheckingUtils } from '../../checking.utils';
 
 @Component({
   selector: 'app-checking-scripture-audio-player',
   templateUrl: './checking-scripture-audio-player.component.html',
   styleUrls: ['./checking-scripture-audio-player.component.scss']
 })
-export class CheckingScriptureAudioPlayerComponent extends SubscriptionDisposable {
+export class CheckingScriptureAudioPlayerComponent extends SubscriptionDisposable implements AfterViewInit {
   @Input() source?: string;
   @Input() canDelete: boolean = false;
   @Output() currentVerseChanged = new EventEmitter<string>();
@@ -39,6 +39,10 @@ export class CheckingScriptureAudioPlayerComponent extends SubscriptionDisposabl
 
   constructor(readonly i18n: I18nService, private readonly projectService: SFProjectService) {
     super();
+  }
+
+  ngAfterViewInit(): void {
+    this.subscribePlayerVerseChange(this.audioPlayer!.audio!);
   }
 
   get isPlaying(): boolean {
@@ -98,7 +102,6 @@ export class CheckingScriptureAudioPlayerComponent extends SubscriptionDisposabl
   play(): void {
     if (this.audioPlayer?.audio == null) return;
     this.audioPlayer.audio.play();
-    this.subscribePlayerVerseChange(this.audioPlayer.audio);
   }
 
   previousRef(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -2,7 +2,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Location } from '@angular/common';
 import { DebugElement, NgZone } from '@angular/core';
-import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatDialogRef } from '@angular/material/dialog';
 import { MatMenuHarness } from '@angular/material/menu/testing';
@@ -21,18 +21,19 @@ import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { AnswerStatus } from 'realtime-server/lib/esm/scriptureforge/models/answer';
 import { Comment } from 'realtime-server/lib/esm/scriptureforge/models/comment';
-import { getQuestionDocId, Question } from 'realtime-server/lib/esm/scriptureforge/models/question';
+import { Question, getQuestionDocId } from 'realtime-server/lib/esm/scriptureforge/models/question';
 import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import {
-  getSFProjectUserConfigDocId,
-  SFProjectUserConfig
+  SFProjectUserConfig,
+  getSFProjectUserConfigDocId
 } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config';
-import { getTextDocId, TextData } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
+import { TextAudio } from 'realtime-server/lib/esm/scriptureforge/models/text-audio';
+import { TextData, getTextDocId } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
 import { fromVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import * as RichText from 'rich-text';
-import { BehaviorSubject, of, Subject } from 'rxjs';
+import { BehaviorSubject, Subject, of } from 'rxjs';
 import { first } from 'rxjs/operators';
 import { anyString, anything, instance, mock, reset, resetCalls, spy, verify, when } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
@@ -41,7 +42,7 @@ import { BugsnagService } from 'xforge-common/bugsnag.service';
 import { DialogService } from 'xforge-common/dialog.service';
 import { FeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { FileService } from 'xforge-common/file.service';
-import { createStorageFileData, FileOfflineData, FileType } from 'xforge-common/models/file-offline-data';
+import { FileOfflineData, FileType, createStorageFileData } from 'xforge-common/models/file-offline-data';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { Snapshot } from 'xforge-common/models/snapshot';
 import { UserDoc } from 'xforge-common/models/user-doc';
@@ -52,7 +53,7 @@ import { OwnerComponent } from 'xforge-common/owner/owner.component';
 import { QueryParameters } from 'xforge-common/query-parameters';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
-import { configureTestingModule, getAudioBlob, TestTranslocoModule } from 'xforge-common/test-utils';
+import { TestTranslocoModule, configureTestingModule, getAudioBlob } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
 import { objectId } from 'xforge-common/utils';
@@ -1878,7 +1879,13 @@ class TestEnvironment {
 
     const query = mock(RealtimeQuery<TextAudioDoc>) as RealtimeQuery<TextAudioDoc>;
     when(query.remoteChanges$).thenReturn(new BehaviorSubject<void>(undefined));
-    when(query.docs).thenReturn([]);
+    const doc = mock(TextAudioDoc);
+    const textAudio = mock<TextAudio>();
+    when(textAudio.audioUrl).thenReturn('something');
+    when(textAudio.timings).thenReturn([]);
+    when(doc.id).thenReturn('project01:43:1:target');
+    when(doc.data).thenReturn(instance(textAudio));
+    when(query.docs).thenReturn([instance(doc)]);
     when(mockedProjectService.queryAudioText('project01')).thenResolve(instance(query));
     this.fixture = TestBed.createComponent(CheckingComponent);
     this.component = this.fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.spec.ts
@@ -1,106 +1,95 @@
 import { Component, DebugElement, NgZone, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { of } from 'rxjs';
-import { mock, when } from 'ts-mockito';
+import { BehaviorSubject, of } from 'rxjs';
+import { instance, mock, resetCalls, verify, when } from 'ts-mockito';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { TestTranslocoModule, configureTestingModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { AudioPlayer } from '../../../shared/audio/audio-player';
+import { AudioPlayer, AudioStatus } from '../../../shared/audio/audio-player';
 import { AudioSegmentPlayer } from '../../../shared/audio/audio-segment-player';
 import { SingleButtonAudioPlayerComponent } from './single-button-audio-player.component';
 
 const mockedOnlineStatusService = mock(OnlineStatusService);
+const audioMock = mock(AudioPlayer);
+when(audioMock.status$).thenReturn(new BehaviorSubject<AudioStatus>(AudioStatus.Available));
 
-@Component({
-  template: `<app-single-button-audio-player #player [source]="source" [start]="start" [end]="end">
-    <mat-icon id="content">play</mat-icon>
-  </app-single-button-audio-player>`
-})
-class MockComponent {
-  @ViewChild('player') player!: SingleButtonAudioPlayerComponent;
-  source: string;
-  start: number | undefined;
-  end: number | undefined;
-  constructor() {
-    this.source = 'test-audio-player.webm';
-  }
-}
-
-const AlmostDone = 98;
-
-// FIXME Tests are flaky
-xdescribe('SingleButtonAudioPlayerComponent', () => {
+describe('SingleButtonAudioPlayerComponent', () => {
   configureTestingModule(() => ({
     imports: [UICommonModule, TestTranslocoModule, NoopAnimationsModule],
-    declarations: [SingleButtonAudioPlayerComponent, MockComponent],
+    declarations: [TestComponent, MockComponent],
     providers: [{ provide: OnlineStatusService, useMock: mockedOnlineStatusService }]
   }));
 
-  it('shows content when audio is available', async () => {
-    const env = new TestEnvironment();
-    await env.wait();
-    await env.wait();
+  let env: TestEnvironment;
+  beforeEach(fakeAsync(() => {
+    env = new TestEnvironment();
+    env.wait();
+  }));
 
-    expect(env.content).not.toBeNull();
-    expect(window.getComputedStyle(env.content.nativeElement)['display']).not.toBe('none');
-  });
-
-  it('creates full audio player by default', async () => {
-    const env = new TestEnvironment();
-    await env.wait();
-    await env.wait();
-
+  it('creates full audio player by default', fakeAsync(() => {
     expect(env.component.player.audio instanceof AudioPlayer).toBe(true);
     expect(env.component.player.audio instanceof AudioSegmentPlayer).toBe(false);
-  });
+  }));
 
-  it('creates segment audio player when given range', async () => {
-    const env = new TestEnvironment();
-
+  it('creates segment audio player when given range', fakeAsync(() => {
     env.component.start = 2;
     env.component.end = 4;
 
-    await env.wait();
-    await env.wait();
+    env.wait();
 
     expect(env.component.player.audio instanceof AudioSegmentPlayer).toBe(true);
-  });
+  }));
 
-  it('resets when stopped', async () => {
-    const env = new TestEnvironment();
-    await env.wait();
-    await env.wait();
+  it('shows content when audio is available', fakeAsync(() => {
+    env.component.player.isAudioAvailable$.next(true);
+    env.wait();
+
+    expect(env.content).not.toBeNull();
+    expect(window.getComputedStyle(env.content.nativeElement)['display']).not.toBe('none');
+  }));
+
+  it('plays and stops', fakeAsync(() => {
+    env.component.player.setAudio(instance(audioMock));
 
     env.component.player.play();
-
-    await env.wait();
-    expect(env.component.player.audio?.currentTime).not.toBe(0);
+    verify(audioMock.play()).once();
 
     env.component.player.stop();
-    expect(env.component.player.audio?.currentTime).toBe(0);
-  });
+    verify(audioMock.stop()).once();
+  }));
 
-  it('does not reset when playing finishes', async () => {
-    const env = new TestEnvironment();
-    await env.wait();
-    await env.wait();
+  it('does not reset when playing finishes', fakeAsync(() => {
+    env.component.player.setAudio(instance(audioMock));
+    resetCalls();
 
-    env.component.player.audio?.setSeek(AlmostDone);
-    await env.wait();
-    env.component.player.play();
-    await env.wait(1000);
+    env.component.player.hasFinishedPlayingOnce$.next(true);
 
+    verify(audioMock.stop()).never();
+  }));
+
+  it('reflects audio.isPlaying', fakeAsync(() => {
+    env.component.player.setAudio(instance(audioMock));
+
+    when(audioMock.isPlaying).thenReturn(false);
     expect(env.component.player.playing).toBe(false);
-    expect(env.component.player.audio?.currentTime).not.toBe(0);
-  });
 
-  it('fires first time finished event only once', async () => {
-    const env = new TestEnvironment();
-    await env.wait();
-    await env.wait();
+    when(audioMock.isPlaying).thenReturn(true);
+    expect(env.component.player.playing).toBe(true);
+  }));
 
+  it('progressInDegrees reflects seek position', fakeAsync(() => {
+    env.component.player.setAudio(instance(audioMock));
+
+    when(audioMock.seek).thenReturn(75);
+    expect(env.component.player.progressInDegrees).toBe('270deg');
+
+    when(audioMock.seek).thenReturn(100);
+    expect(env.component.player.progressInDegrees).toBe('360deg');
+  }));
+
+  it('fires first time finished event only once', fakeAsync(() => {
     let count = 0;
     env.component.player.hasFinishedPlayingOnce$.subscribe(newVal => {
       if (newVal) {
@@ -108,28 +97,14 @@ xdescribe('SingleButtonAudioPlayerComponent', () => {
       }
     });
 
-    env.component.player.audio?.setSeek(AlmostDone);
-    await env.wait();
-    env.component.player.play();
-    await env.wait(1000);
+    env.component.player.audio?.finishedPlaying$.emit();
+    env.component.player.audio?.finishedPlaying$.emit();
+    env.component.player.audio?.finishedPlaying$.emit();
 
-    expect(env.component.player.playing).toBe(false);
     expect(count).toBe(1);
+  }));
 
-    env.component.player.audio?.setSeek(AlmostDone);
-    await env.wait();
-    env.component.player.play();
-    await env.wait(1000);
-
-    expect(env.component.player.playing).toBe(false);
-    expect(count).toBe(1);
-  });
-
-  it('fires first time finished event as false when input changes', async () => {
-    const env = new TestEnvironment();
-    await env.wait();
-    await env.wait();
-
+  it('fires first time finished event as false when input changes', fakeAsync(() => {
     let count = 0;
     env.component.player.hasFinishedPlayingOnce$.subscribe(newVal => {
       if (!newVal) {
@@ -140,12 +115,10 @@ xdescribe('SingleButtonAudioPlayerComponent', () => {
     expect(count).toBe(1); //called on subscribe
 
     env.component.source = 'test-audio-player-b.webm';
-
-    await env.wait();
-    await env.wait();
+    env.wait();
 
     expect(count).toBe(2);
-  });
+  }));
 });
 
 class TestEnvironment {
@@ -165,8 +138,30 @@ class TestEnvironment {
     return this.fixture.debugElement.query(By.css('#content'));
   }
 
-  async wait(ms: number = 300): Promise<void> {
-    await new Promise(resolve => this.ngZone.runOutsideAngular(() => setTimeout(resolve, ms)));
+  wait(): void {
     this.fixture.detectChanges();
+    tick();
+    this.fixture.detectChanges();
+  }
+}
+
+@Component({
+  template: `<app-single-button-audio-player #player [source]="source" [start]="start" [end]="end">
+    <mat-icon id="content">play</mat-icon>
+  </app-single-button-audio-player>`
+})
+class MockComponent {
+  @ViewChild('player') player!: TestComponent;
+  source: string;
+  start: number | undefined;
+  end: number | undefined;
+  constructor() {
+    this.source = 'test-audio-player.webm';
+  }
+}
+
+class TestComponent extends SingleButtonAudioPlayerComponent {
+  public setAudio(audioPlayer: AudioPlayer): void {
+    this.audio = audioPlayer;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.spec.ts
@@ -62,7 +62,7 @@ describe('SingleButtonAudioPlayerComponent', () => {
 
   it('does not reset when playing finishes', fakeAsync(() => {
     env.component.player.setAudio(instance(audioMock));
-    resetCalls();
+    resetCalls(audioMock);
 
     env.component.player.hasFinishedPlayingOnce$.next(true);
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.ts
@@ -38,8 +38,7 @@ export class SingleButtonAudioPlayerComponent extends AudioPlayerBaseComponent i
   }
 
   stop(): void {
-    this.audio?.pause();
-    this.audio?.setSeek(0);
+    this.audio?.stop();
   }
 
   ngOnChanges(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { AudioPlayer, AudioStatus } from '../../../shared/audio/audio-player';
+import { AudioPlayer } from '../../../shared/audio/audio-player';
 import { AudioPlayerBaseComponent } from '../../../shared/audio/audio-player-base/audio-player-base.component';
 import { AudioSegmentPlayer } from '../../../shared/audio/audio-segment-player';
 
@@ -53,11 +53,6 @@ export class SingleButtonAudioPlayerComponent extends AudioPlayerBaseComponent i
         this.audio = new AudioPlayer(this._source, this.onlineStatusService);
       }
 
-      this.subscribe(this.audio.status$, newVal => {
-        if (newVal === AudioStatus.Available) {
-          this.isAudioAvailable$.next(true);
-        }
-      });
       this.subscribe(this.audio.finishedPlaying$, () => {
         if (!this.hasFinishedPlayingOnce$.value) {
           this.hasFinishedPlayingOnce$.next(true);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { AudioPlayer } from '../../../shared/audio/audio-player';
+import { AudioPlayer, AudioStatus } from '../../../shared/audio/audio-player';
 import { AudioPlayerBaseComponent } from '../../../shared/audio/audio-player-base/audio-player-base.component';
 import { AudioSegmentPlayer } from '../../../shared/audio/audio-segment-player';
 
@@ -52,6 +52,11 @@ export class SingleButtonAudioPlayerComponent extends AudioPlayerBaseComponent i
         this.audio = new AudioPlayer(this._source, this.onlineStatusService);
       }
 
+      this.subscribe(this.audio.status$, newVal => {
+        if (newVal === AudioStatus.Available) {
+          this.isAudioAvailable$.next(true);
+        }
+      });
       this.subscribe(this.audio.finishedPlaying$, () => {
         if (!this.hasFinishedPlayingOnce$.value) {
           this.hasFinishedPlayingOnce$.next(true);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player-base/audio-player-base.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player-base/audio-player-base.component.spec.ts
@@ -1,0 +1,149 @@
+import { Component, NgZone, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { AudioPlayerStub } from 'src/app/checking/checking-test.utils';
+import { CheckingScriptureAudioPlayerComponent } from 'src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component';
+import { SFProjectService } from 'src/app/core/sf-project.service';
+import { instance, mock, when } from 'ts-mockito';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestTranslocoModule } from 'xforge-common/test-utils';
+import { UICommonModule } from 'xforge-common/ui-common.module';
+import { AudioPlayer, AudioStatus } from '../audio-player';
+import { AudioTimePipe } from '../audio-time-pipe';
+import { AudioPlayerBaseComponent } from './audio-player-base.component';
+
+const audioFile = 'test-audio-player.webm';
+
+describe('AudioPlayerBaseComponent', () => {
+  let env: TestEnvironment;
+  beforeEach(fakeAsync(() => {
+    const template = `<app-audio-player source="${audioFile}"></app-audio-player>`;
+    env = new TestEnvironment(template);
+    env.wait();
+  }));
+
+  it('creates AudioPlayer when source is set', fakeAsync(() => {
+    expect(env.component.baseComponent.audio).toBeInstanceOf(AudioPlayer);
+    expect(env.component.baseComponent.audio).not.toBeInstanceOf(AudioPlayerStub);
+  }));
+
+  it('clears audio when source is cleared', fakeAsync(() => {
+    env.component.baseComponent.source = '';
+    env.wait();
+
+    expect(env.component.baseComponent.audio).toBe(undefined);
+  }));
+
+  it('fires isAudioAvailable when audio becomes available', fakeAsync(() => {
+    env.component.baseComponent.setAudio(new AudioPlayerStub(audioFile, instance(env.mockOnlineStatusService)));
+    const spy = jasmine.createSpy();
+    env.component.baseComponent.isAudioAvailable$.subscribe(spy);
+
+    env.component.baseComponent.fireStatusChange(AudioStatus.Available);
+
+    expect(spy.calls.allArgs()).toEqual([[false], [true]]);
+    expect(env.component.baseComponent.isAudioInitComplete).toBe(true);
+  }));
+
+  it('sets isAudioInitComplete when status changes from Init', fakeAsync(() => {
+    env.component.baseComponent.setAudio(new AudioPlayerStub(audioFile, instance(env.mockOnlineStatusService)));
+    expect(env.component.baseComponent.isAudioInitComplete).toBe(false);
+
+    env.component.baseComponent.fireStatusChange(AudioStatus.Unavailable);
+
+    expect(env.component.baseComponent.isAudioInitComplete).toBe(true);
+  }));
+
+  it('resets seek when audio becomes available', fakeAsync(() => {
+    env.component.baseComponent.setAudio(new AudioPlayerStub(audioFile, instance(env.mockOnlineStatusService)));
+    env.component.baseComponent.audio!.currentTime = 1;
+    expect(env.component.baseComponent.audio!.currentTime).toBe(1);
+    env.component.baseComponent.fireStatusChange(AudioStatus.Available);
+
+    expect(env.component.baseComponent.audio!.currentTime).toBe(0);
+  }));
+
+  it('reflects status if it exists', fakeAsync(() => {
+    env.component.baseComponent.setAudio(new AudioPlayerStub(audioFile, instance(env.mockOnlineStatusService)));
+
+    env.component.baseComponent.fireStatusChange(AudioStatus.Available);
+    expect(env.component.baseComponent.audioStatus).toBe(AudioStatus.Available);
+
+    env.component.baseComponent.fireStatusChange(AudioStatus.LocalNotAvailable);
+    expect(env.component.baseComponent.audioStatus).toBe(AudioStatus.LocalNotAvailable);
+  }));
+
+  it('displays unavailable if online and audio status is null', fakeAsync(() => {
+    env.component.baseComponent.source = '';
+    env.wait();
+
+    expect(instance(env.mockOnlineStatusService).isOnline).toBe(true);
+    expect(env.component.baseComponent.audioStatus).toBe(AudioStatus.Unavailable);
+  }));
+
+  it('displays offline if offline and audio status is null', fakeAsync(() => {
+    env.component.baseComponent.source = '';
+    env.wait();
+
+    when(env.mockOnlineStatusService.isOnline).thenReturn(false);
+    expect(env.component.baseComponent.audioStatus).toBe(AudioStatus.Offline);
+  }));
+
+  it('pauses audio on destroy', fakeAsync(() => {
+    const pause = spyOn<any>(env.component.baseComponent.audio, 'pause');
+
+    env.component.baseComponent.ngOnDestroy();
+
+    expect(pause).toHaveBeenCalledTimes(1);
+  }));
+});
+
+class TestEnvironment {
+  readonly mockOnlineStatusService = mock(OnlineStatusService);
+  readonly mockedProjectService = mock(SFProjectService);
+  fixture: ComponentFixture<HostComponent>;
+  component: HostComponent;
+  ngZone: NgZone;
+
+  constructor(template: string) {
+    TestBed.configureTestingModule({
+      declarations: [HostComponent, CheckingScriptureAudioPlayerComponent, AudioTimePipe, AudioTestComponent],
+      providers: [
+        { provide: OnlineStatusService, useFactory: () => instance(this.mockOnlineStatusService) },
+        { provide: SFProjectService, useFactory: () => instance(this.mockedProjectService) }
+      ],
+      imports: [UICommonModule, TestTranslocoModule]
+    });
+    when(this.mockOnlineStatusService.onlineStatus$).thenReturn(of(true));
+    when(this.mockOnlineStatusService.isOnline).thenReturn(true);
+    TestBed.overrideComponent(HostComponent, { set: { template: template } });
+    this.ngZone = TestBed.inject(NgZone);
+    this.fixture = TestBed.createComponent(HostComponent);
+    this.component = this.fixture.componentInstance;
+  }
+
+  wait(): void {
+    this.fixture.detectChanges();
+    tick();
+    this.fixture.detectChanges();
+  }
+}
+
+@Component({
+  selector: 'app-audio-player',
+  template: '<p>Mock Audio Player</p>'
+})
+class AudioTestComponent extends AudioPlayerBaseComponent {
+  setAudio(audio: AudioPlayer): void {
+    this.audio = audio;
+  }
+
+  fireStatusChange(status: AudioStatus): void {
+    this.audio?.status$.next(status);
+  }
+}
+
+@Component({ selector: 'app-host', template: '' })
+class HostComponent {
+  @ViewChild(AudioTestComponent) baseComponent!: AudioTestComponent;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player-base/audio-player-base.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player-base/audio-player-base.component.ts
@@ -26,6 +26,16 @@ export abstract class AudioPlayerBaseComponent extends SubscriptionDisposable im
 
   protected set audio(value: AudioPlayer | undefined) {
     this._audio = value;
+    if (this.audio !== undefined) {
+      this.subscribe(this.audio.status$, newVal => {
+        if (newVal === AudioStatus.Available) {
+          this.isAudioAvailable$.next(true);
+        }
+        if (newVal !== AudioStatus.Init) {
+          this._isAudioInitComplete = true;
+        }
+      });
+    }
   }
 
   get audioStatus(): AudioStatus {
@@ -42,17 +52,9 @@ export abstract class AudioPlayerBaseComponent extends SubscriptionDisposable im
     this.isAudioAvailable$.next(false);
     this.audio?.dispose();
     if (source != null && source !== '') {
-      this._audio = new AudioPlayer(source, this.onlineStatusService);
-      this.subscribe(this._audio.status$, newVal => {
-        if (newVal === AudioStatus.Available) {
-          this.isAudioAvailable$.next(true);
-        }
-        if (newVal !== AudioStatus.Init) {
-          this._isAudioInitComplete = true;
-        }
-      });
+      this.audio = new AudioPlayer(source, this.onlineStatusService);
     } else {
-      this._audio = undefined;
+      this.audio = undefined;
     }
   }
 


### PR DESCRIPTION
This greatly improves performance for these tests. Theoretically it removes the flakiness, as well, since we no longer depend on playing actual audio files.

The new tests use a stub child component, which itself uses (via implicit override) a stub audio player, which itself uses a mocked html audio element. This all was necessary to work around the inabiliity to mock Angular child components and the limitations in ts-mockito surrounding property setters. ts-mockito doesn't allow verification on property set actions, and it frequently fails at runtime often ever reaching the verification. The current setup subclasses (you could use Partial, as well) AudioPlayer and overrides the critical methods and properties. This effectively removes any dependency on realtime audio data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2061)
<!-- Reviewable:end -->
