### PR TITLE
SF-1986 Enable adding notes feature

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.spec.ts
@@ -8,7 +8,6 @@ import { CheckingAnswerExport, CheckingConfig } from 'realtime-server/lib/esm/sc
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { BehaviorSubject } from 'rxjs';
 import { anything, capture, mock, verify, when } from 'ts-mockito';
-import { FeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { LocationService } from 'xforge-common/location.service';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -31,7 +30,6 @@ const mockedOnlineStatusService = mock(OnlineStatusService);
 const mockedI18nService = mock(I18nService);
 const mockedLocationService = mock(LocationService);
 const mockedUserService = mock(UserService);
-const mockedFeatureFlagService = mock(FeatureFlagService);
 
 describe('ShareControlComponent', () => {
   configureTestingModule(() => ({
@@ -43,8 +41,7 @@ describe('ShareControlComponent', () => {
       { provide: OnlineStatusService, useMock: mockedOnlineStatusService },
       { provide: I18nService, useMock: mockedI18nService },
       { provide: LocationService, useMock: mockedLocationService },
-      { provide: UserService, useMock: mockedUserService },
-      { provide: FeatureFlagService, useMock: mockedFeatureFlagService }
+      { provide: UserService, useMock: mockedUserService }
     ]
   }));
 
@@ -362,7 +359,6 @@ class TestEnvironment {
     when(mockedProjectService.onlineIsAlreadyInvited(anything(), 'unknown-address@example.com')).thenResolve(false);
     when(mockedProjectService.onlineIsAlreadyInvited(anything(), 'already@example.com')).thenResolve(true);
     when(mockedLocationService.origin).thenReturn('https://scriptureforge.org');
-    when(mockedFeatureFlagService.allowAddingNotes).thenReturn({ enabled: true } as FeatureFlag);
 
     this.fixture.detectChanges();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
@@ -5,7 +5,6 @@ import { Operation } from 'realtime-server/lib/esm/common/models/project-rights'
 import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { BehaviorSubject, combineLatest } from 'rxjs';
-import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { ProjectRoleInfo } from 'xforge-common/models/project-role-info';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -58,8 +57,7 @@ export class ShareControlComponent extends SubscriptionDisposable {
     private readonly projectService: SFProjectService,
     private readonly onlineStatusService: OnlineStatusService,
     private readonly changeDetector: ChangeDetectorRef,
-    private readonly userService: UserService,
-    private readonly featureFlags: FeatureFlagService
+    private readonly userService: UserService
   ) {
     super();
     this.subscribe(combineLatest([this.projectId$, this.onlineStatusService.onlineStatus$]), async ([projectId]) => {
@@ -147,7 +145,7 @@ export class ShareControlComponent extends SubscriptionDisposable {
       },
       {
         role: SFProjectRole.Commenter,
-        available: this.featureFlags.allowAddingNotes.enabled,
+        available: true,
         permission: this.isProjectAdmin
       }
     ]

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.spec.ts
@@ -369,7 +369,6 @@ class TestEnvironment {
         }`
     );
     when(mockedProjectService.isProjectAdmin(projectId, TestUsers.Admin)).thenResolve(true);
-    when(mockedFeatureFlagService.allowAddingNotes).thenReturn({ enabled: true } as FeatureFlag);
     when(mockedFeatureFlagService.showNonPublishedLocalizations).thenReturn({ enabled: true } as FeatureFlag);
 
     const config: MatDialogConfig<ShareDialogData> = {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
@@ -5,7 +5,6 @@ import { Operation } from 'realtime-server/lib/esm/common/models/project-rights'
 import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { NAVIGATOR } from 'xforge-common/browser-globals';
-import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { Locale } from 'xforge-common/models/i18n-locale';
 import { UserDoc } from 'xforge-common/models/user-doc';
@@ -50,7 +49,6 @@ export class ShareDialogComponent extends SubscriptionDisposable {
   constructor(
     readonly dialogRef: MatDialogRef<ShareDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public readonly data: ShareDialogData,
-    private readonly featureFlags: FeatureFlagService,
     readonly i18n: I18nService,
     @Inject(NAVIGATOR) private readonly navigator: Navigator,
     private readonly noticeService: NoticeService,
@@ -259,7 +257,7 @@ export class ShareDialogComponent extends SubscriptionDisposable {
       },
       {
         role: SFProjectRole.Commenter,
-        available: this.featureFlags.allowAddingNotes.enabled,
+        available: true,
         permission: this.isProjectAdmin
       }
     ]

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3526,7 +3526,6 @@ class TestEnvironment {
       this.openNoteDialogs.forEach(dialog => dialog.close());
       this.openNoteDialogs = [];
     });
-    when(mockedFeatureFlagService.allowAddingNotes).thenReturn({ enabled: true } as FeatureFlag);
     when(mockedMatDialog.open(GenericDialogComponent, anything())).thenReturn(instance(this.mockedDialogRef));
     when(this.mockedDialogRef.afterClosed()).thenReturn(of());
     when(mockedMediaObserver.isActive(anything())).thenReturn(false);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -379,7 +379,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   get canInsertNote(): boolean {
     if (this.projectDoc?.data == null) return false;
-    return this.isAddNotesEnabled && canInsertNote(this.projectDoc.data, this.userService.currentUserId);
+    return canInsertNote(this.projectDoc.data, this.userService.currentUserId);
   }
 
   get canShare(): boolean {
@@ -450,7 +450,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
    * This will be true any time the user has the right to add notes
    */
   get showAddCommentUI(): boolean {
-    if (!this.isAddNotesEnabled || this.projectDoc?.data == null) return false;
+    if (this.projectDoc?.data == null) return false;
 
     return SF_PROJECT_RIGHTS.hasRight(
       this.projectDoc.data,
@@ -478,12 +478,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
   }
 
-  private get isAddNotesEnabled(): boolean {
-    return this.featureFlags.allowAddingNotes.enabled;
-  }
-
   private get isInsertNoteFabEnabled(): boolean {
-    return this.isAddNotesEnabled && this.canShowInsertNoteFab && !this.isCommenterOnMobileDevice;
+    return this.canShowInsertNoteFab && !this.isCommenterOnMobileDevice;
   }
 
   private get isCommenterOnMobileDevice(): boolean {
@@ -1471,7 +1467,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       () => {
         this.toggleNoteThreadVerses(false);
         this.toggleNoteThreadVerses(true);
-        if (this.userRole != null && this.showAddCommentUI && this.isAddNotesEnabled) {
+        if (this.userRole != null && this.showAddCommentUI) {
           this.subscribeCommentingSelectionEvents();
         }
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -5,9 +5,11 @@ import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { VerseRef } from '@sillsdev/scripture';
 import { cloneDeep } from 'lodash-es';
 import { CookieService } from 'ngx-cookie-service';
 import { Note, REATTACH_SEPARATOR } from 'realtime-server/lib/esm/scriptureforge/models/note';
+import { SF_TAG_ICON } from 'realtime-server/lib/esm/scriptureforge/models/note-tag';
 import {
   AssignedUsers,
   getNoteThreadDocId,
@@ -16,21 +18,24 @@ import {
   NoteThread,
   NoteType
 } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
+import { ParatextUserProfile } from 'realtime-server/lib/esm/scriptureforge/models/paratext-user-profile';
 import { SFProject, SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { isParatextRole, SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
+import {
+  createTestProject,
+  createTestProjectProfile
+} from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import {
   getSFProjectUserConfigDocId,
   SFProjectUserConfig
 } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config';
 import { TextData } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
 import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
-import { ParatextUserProfile } from 'realtime-server/lib/esm/scriptureforge/models/paratext-user-profile';
-import { VerseRef } from '@sillsdev/scripture';
+
 import * as RichText from 'rich-text';
 import { anything, mock, verify, when } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
 import { DialogService } from 'xforge-common/dialog.service';
-import { FeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import {
@@ -41,11 +46,6 @@ import {
 } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
-import { SF_TAG_ICON } from 'realtime-server/lib/esm/scriptureforge/models/note-tag';
-import {
-  createTestProject,
-  createTestProjectProfile
-} from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { NoteThreadDoc } from '../../../core/models/note-thread-doc';
 import { SFProjectDoc } from '../../../core/models/sf-project-doc';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
@@ -62,7 +62,6 @@ const mockedCookieService = mock(CookieService);
 const mockedHttpClient = mock(HttpClient);
 const mockedProjectService = mock(SFProjectService);
 const mockedUserService = mock(UserService);
-const mockedFeatureFlagService = mock(FeatureFlagService);
 const mockedDialogService = mock(DialogService);
 
 describe('NoteDialogComponent', () => {
@@ -74,7 +73,6 @@ describe('NoteDialogComponent', () => {
       { provide: HttpClient, useMock: mockedHttpClient },
       { provide: SFProjectService, useMock: mockedProjectService },
       { provide: UserService, useMock: mockedUserService },
-      { provide: FeatureFlagService, useMock: mockedFeatureFlagService },
       { provide: DialogService, useMock: mockedDialogService }
     ]
   }));
@@ -806,8 +804,6 @@ class TestEnvironment {
       .afterClosed()
       .toPromise()
       .then(result => (this.dialogResult = result));
-
-    when(mockedFeatureFlagService.allowAddingNotes).thenReturn({ enabled: true } as FeatureFlag);
 
     when(mockedDialogService.confirm(anything(), anything())).thenResolve(true);
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -13,7 +13,6 @@ import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scri
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { UserService } from 'xforge-common/user.service';
-import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { isParatextRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { defaultNoteThreadIcon, NoteThreadDoc } from '../../../core/models/note-thread-doc';
 import { SFProjectDoc } from '../../../core/models/sf-project-doc';
@@ -72,8 +71,7 @@ export class NoteDialogComponent implements OnInit {
     private readonly i18n: I18nService,
     private readonly projectService: SFProjectService,
     private readonly userService: UserService,
-    private readonly dialogService: DialogService,
-    private readonly featureFlags: FeatureFlagService
+    private readonly dialogService: DialogService
   ) {}
 
   async ngOnInit(): Promise<void> {
@@ -161,7 +159,7 @@ export class NoteDialogComponent implements OnInit {
 
   get canInsertNote(): boolean {
     if (this.projectProfileDoc?.data == null) return false;
-    return this.isAddNotesEnabled && canInsertNote(this.projectProfileDoc.data, this.userService.currentUserId);
+    return canInsertNote(this.projectProfileDoc.data, this.userService.currentUserId);
   }
 
   private get defaultNoteTagId(): number | undefined {
@@ -189,10 +187,6 @@ export class NoteDialogComponent implements OnInit {
       return this.data.verseRef == null ? undefined : this.data.verseRef;
     }
     return toVerseRef(this.threadDoc.data.verseRef);
-  }
-
-  private get isAddNotesEnabled(): boolean {
-    return this.featureFlags.allowAddingNotes.enabled;
   }
 
   editNote(note: Note): void {
@@ -328,7 +322,6 @@ export class NoteDialogComponent implements OnInit {
   private isNoteEditable(note: Note): boolean {
     if (this.projectProfileDoc?.data == null) return false;
     return (
-      this.isAddNotesEnabled &&
       note.editable === true &&
       this.noteIdBeingEdited == null &&
       SF_PROJECT_RIGHTS.hasRight(

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -61,11 +61,6 @@ export class FeatureFlagService {
     'Show non-published localizations'
   );
 
-  allowAddingNotes: FeatureFlag = new FeatureFlag(
-    new LocalStorageFlagStore('ALLOW_ADDING_NOTES'),
-    'Allow adding notes'
-  );
-
   showNmtDrafting: FeatureFlag = new FeatureFlag(new LocalStorageFlagStore('SHOW_NMT_DRAFTING'), 'Show NMT drafting');
 
   scriptureAudio: FeatureFlag = new FeatureFlag(new LocalStorageFlagStore('SCRIPTURE_AUDIO'), 'Scripture audio');

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1365,8 +1365,8 @@ public class ParatextService : DisposableBase, IParatextService
             ptProjectUsers
         );
 
-        // TODO: Remove these warning logs once the feature is tested and implemented
-        string sfCommentWarning = "SF Comment Warning:";
+        // TODO: Remove these logs once the feature public and stable
+        string sfCommentLog = "SF Comment:";
         ScrText scrText =
             ScrTextCollection.FindById(username, paratextId)
             ?? throw new DataNotFoundException("Can't get access to cloned project.");
@@ -1378,22 +1378,16 @@ public class ParatextService : DisposableBase, IParatextService
             {
                 var existingComment = existingThread?.Comments.FirstOrDefault(c => c.Id == comment.Id);
                 if (existingComment == null)
-                    _logger.LogWarning(
-                        $"{sfCommentWarning} Adding sf comment before feature enabled. ID: {comment.Thread}"
-                    );
+                    _logger.LogWarning($"{sfCommentLog} Adding sf comment on thread with ID {comment.Thread}");
                 else if (comment.Deleted)
-                    _logger.LogWarning(
-                        $"{sfCommentWarning} Deleting sf comment before feature enabled. ID: {comment.Thread}"
-                    );
+                    _logger.LogWarning($"{sfCommentLog} Deleting sf comment on thread with ID {comment.Thread}");
                 else
                 {
                     if (existingComment.Contents?.OuterXml != comment.Contents?.OuterXml)
                         _logger.LogWarning(
-                            $"{sfCommentWarning} Comment contents differ\n{existingComment.Contents?.OuterXml}\n{comment.Contents?.OuterXml}"
+                            $"{sfCommentLog} Comment contents differ\n{existingComment.Contents?.OuterXml}\n{comment.Contents?.OuterXml}"
                         );
-                    _logger.LogWarning(
-                        $"{sfCommentWarning} Updating SF comment before feature enabled. ID: " + comment.Thread
-                    );
+                    _logger.LogWarning($"{sfCommentLog} Updating SF comment on thread with ID {comment.Thread}");
                 }
             }
         }


### PR DESCRIPTION
This enables the adding notes feature. However, the synchronizing of notes SF notes to Paratext will only work if we enable the dotnet feature on QA and live. I've decided to leave the code for the dotnet write notes to Paratext feature in place, and we can enable the feature. Then if we need to turn it off, we can do that by turning off the feature.

The SF release notes doc has been updated to include steps to monitor the SF server logs for SF Comment changes. We can tell early on if note synchronizing is not behaving as expected. Once we get this onto QA, testers will be able to run their tests on notes synchronization.