### PR TITLE
SF-2240 Fixed pre-translation builds not returning build status when Serval and In-Process feature flags enabled

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -179,9 +179,9 @@ public class MachineApiService : IMachineApiService
         // Ensure that the user has permission
         await EnsurePermissionAsync(curUserId, sfProjectId);
 
-        // Execute the In Process Machine instance, if it is enabled
+        // Execute the In Process Machine instance, if it is enabled and this is not a pre-translation build
         // We can only use In Process or the API - not both or unnecessary delays will result
-        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess) && !preTranslate)
         {
             buildDto = await GetInProcessBuildAsync(BuildLocatorType.Id, buildId, minRevision, cancellationToken);
         }
@@ -289,9 +289,9 @@ public class MachineApiService : IMachineApiService
         await EnsurePermissionAsync(curUserId, sfProjectId);
 
         // We can only use In Process or the API - not both or unnecessary delays will result
-        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess))
+        if (await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess) && !preTranslate)
         {
-            // Execute the In Process Machine instance, if it is enabled
+            // Execute the In Process Machine instance, if it is enabled and this is not a pre-translation build
             Engine engine = await GetInProcessEngineAsync(sfProjectId, cancellationToken);
             buildDto = await GetInProcessBuildAsync(BuildLocatorType.Engine, engine.Id, minRevision, cancellationToken);
         }

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -418,6 +418,33 @@ public class MachineApiServiceTests
     }
 
     [Test]
+    public async Task GetBuildAsync_DoesNotExecuteInProcessIfBothEnabledForPreTranslations()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.TranslationEnginesClient
+            .GetBuildAsync(TranslationEngine01, Build01, minRevision: null, CancellationToken.None)
+            .Returns(Task.FromResult(new TranslationBuild()));
+
+        // SUT
+        _ = await env.Service.GetBuildAsync(
+            User01,
+            Project01,
+            Build01,
+            minRevision: null,
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        await env.Builds
+            .DidNotReceiveWithAnyArgs()
+            .GetByLocatorAsync(BuildLocatorType.Id, Build01, CancellationToken.None);
+        await env.TranslationEnginesClient
+            .Received(1)
+            .GetBuildAsync(TranslationEngine01, Build01, minRevision: null, CancellationToken.None);
+    }
+
+    [Test]
     public async Task GetBuildAsync_ExecutesOnlyInProcessIfBothEnabled()
     {
         // Set up test environment
@@ -807,6 +834,32 @@ public class MachineApiServiceTests
                     CancellationToken.None
                 )
         );
+    }
+
+    [Test]
+    public async Task GetCurrentBuildAsync_DoesNotExecuteInProcessIfBothEnabledForPreTranslations()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.TranslationEnginesClient
+            .GetCurrentBuildAsync(TranslationEngine01, minRevision: null, CancellationToken.None)
+            .Returns(Task.FromResult(new TranslationBuild()));
+
+        // SUT
+        _ = await env.Service.GetCurrentBuildAsync(
+            User01,
+            Project01,
+            minRevision: null,
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        await env.Builds
+            .DidNotReceiveWithAnyArgs()
+            .GetByLocatorAsync(BuildLocatorType.Engine, TranslationEngine01, CancellationToken.None);
+        await env.TranslationEnginesClient
+            .Received(1)
+            .GetCurrentBuildAsync(TranslationEngine01, minRevision: null, CancellationToken.None);
     }
 
     [Test]


### PR DESCRIPTION
When both the Serval and InProcessMachine feature flags are enabled, the Generate Draft screen does not return the build status for the pre-translation builds.

This PR fixes that by ensuring that the InProcess Machine instance is not queried for the build status of pre-translation builds.

See the Acceptance Test for [SF-2240](https://jira.sil.org/browse/SF-2240) for details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2063)
<!-- Reviewable:end -->
