### PR TITLE
SF-2241 Fix project name overflowing in project select

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -36,6 +36,9 @@
       // KHSV05 is one example that will cause overflow, which looks particularly bad in RTL mode because it
       // overflows to the left in a menu that is layed out in LTR.
       overflow-wrap: anywhere;
+
+      height: unset;
+      min-height: 48px;
     }
   }
 


### PR DESCRIPTION
This regressed in 22995b91d83b5ffb8d9424d8c05a56a78bafcad8 (#1868)

Before | After
-------|------
![project_select_before](https://github.com/sillsdev/web-xforge/assets/6140710/c392ba71-150d-4f27-a868-24bde92b0356) | ![project_select_after](https://github.com/sillsdev/web-xforge/assets/6140710/c8d3cead-cb08-4449-aee2-0f8b3cafe3ea)

Since this regression got to QA, it is holding up our ability to release (QA hasn't passed testing, but it won't pass due to this). In the interest of getting back to a non-regressed state, this doesn't need to be formally tested until after merging.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2065)
<!-- Reviewable:end -->
