### PR TITLE
Remove unused SCSS imports from MDC-related packages

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -1,7 +1,6 @@
 @use 'src/variables';
 
 @use '@material/icon-button/mixins' as icon-button;
-@use '@material/typography/mixins' as typography;
 @use '@material/top-app-bar/variables' as top-app-bar;
 
 @import 'bootstrap/scss/mixins/breakpoints';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.scss
@@ -1,6 +1,3 @@
-@use '@material/icon-button/mixins' as icon-button;
-@use '@material/select/mixins' as select;
-
 :host {
   display: flex;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/chapter-nav/chapter-nav.component.scss
@@ -1,6 +1,3 @@
-@use '@material/icon-button/mixins' as icon-button;
-@use '@material/select/mixins' as select;
-
 :host {
   display: flex;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -1,5 +1,3 @@
-@use '@material/button/mixins' as button;
-
 @import 'src/variables';
 @import 'bootstrap/scss/mixins/breakpoints';
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
@@ -1,5 +1,3 @@
-@use '@material/list/mixins' as list;
-
 @import 'src/variables';
 
 .title {


### PR DESCRIPTION
All the package names are in the `@material` namespace, but they need to be removed because they are only installed due to being dependencies of `@angular-mdc/web`

I'm pretty sure because these are `@use` statements, there shouldn't be any changes caused by removing them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2067)
<!-- Reviewable:end -->
