### PR TITLE
Remove unneeded references to MDC top app bar

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -1,9 +1,10 @@
 @use 'src/variables';
 
 @use '@material/icon-button/mixins' as icon-button;
-@use '@material/top-app-bar/variables' as top-app-bar;
 
 @import 'bootstrap/scss/mixins/breakpoints';
+
+$toolbar-height: 56px;
 
 // Set height of the app to 100% so that the app will fill the entire screen.
 // Don't use 100vh because that will cause the app to be too tall on mobile devices when the browser's address bar is
@@ -50,11 +51,11 @@
   }
 
   .top-app-bar-adjust {
-    margin-top: top-app-bar.$mobile-row-height;
+    margin-top: $toolbar-height;
   }
 
   .top-app-bar-adjust-double {
-    margin-top: top-app-bar.$mobile-row-height * 2;
+    margin-top: $toolbar-height * 2;
   }
 
   .app-content {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -1,6 +1,5 @@
 import { MdcIconRegistry } from '@angular-mdc/web';
 import { MdcSelect } from '@angular-mdc/web/select';
-import { MdcTopAppBar } from '@angular-mdc/web/top-app-bar';
 import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { MediaChange, MediaObserver } from '@angular/flex-layout';
 import { DomSanitizer } from '@angular/platform-browser';
@@ -77,7 +76,6 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   private currentUserDoc?: UserDoc;
   private isLoggedInUserAnonymous: boolean = false;
   private _projectSelect?: MdcSelect;
-  private _topAppBar?: MdcTopAppBar;
   private selectedProjectDoc?: SFProjectProfileDoc;
   private selectedProjectDeleteSub?: Subscription;
   private removedFromProjectSub?: Subscription;
@@ -174,12 +172,6 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     return environment.releaseStage === 'live';
   }
 
-  @ViewChild('topAppBar', { static: true })
-  set topAppBar(value: MdcTopAppBar) {
-    this._topAppBar = value;
-    this.setTopAppBarVariant();
-  }
-
   get projectSelect(): MdcSelect | undefined {
     return this._projectSelect;
   }
@@ -206,7 +198,6 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       if (!this._isDrawerPermanent) {
         this.collapseDrawer();
       }
-      this.setTopAppBarVariant();
     }
   }
 
@@ -375,7 +366,6 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       }
 
       this.selectedProjectDoc = selectedProjectDoc;
-      this.setTopAppBarVariant();
       if (this.selectedProjectDoc == null || !this.selectedProjectDoc.isLoaded) {
         return;
       }
@@ -577,17 +567,6 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
 
   private navigateToStart(): void {
     setTimeout(() => this.router.navigateByUrl('/projects', { replaceUrl: true }));
-  }
-
-  private setTopAppBarVariant(): void {
-    if (this._topAppBar == null) {
-      return;
-    }
-
-    const isShort = this._isDrawerPermanent && this.selectedProjectDoc != null;
-    if (isShort !== this._topAppBar.short) {
-      this._topAppBar.setShort(isShort, true);
-    }
   }
 
   private checkDeviceStorage(): void {


### PR DESCRIPTION
This is doing two things:
1. Removing dead code in `src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts`
2. Removing a reference in the SCSS to `top-app-bar.$mobile-row-height`, and replacing it with `56px`, which is what the value was anyway.

I have marked this as "testing not required" because in order to test it the "update available" banner needs to be present. I tested it myself manually by turning the banner on and making sure it worked as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2068)
<!-- Reviewable:end -->
