### PR TITLE
Fix sidebar not closing when opening back translation drafting

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -149,6 +149,7 @@
             *ngIf="featureFlags.showNmtDrafting.enabled"
             mat-list-item
             [appRouterLink]="getRouterLink('draft-generation')"
+            (click)="itemSelected()"
           >
             <mat-icon mat-list-icon>edit_note</mat-icon>
             Generate draft <span class="nav-label">beta</span>


### PR DESCRIPTION
In mobile view, when selecting an item, the drawer closes, _except_ for when back translation drafting is clicked. This fixes that.

I didn't deem it worth creating a test or manually testing this. This entire sidebar is about to be replaced anyway, and it's a super trivial issue.

(And in case you're wondering, this bug does not exist in #1825. So maybe I shouldn't have even tried to fix it).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2069)
<!-- Reviewable:end -->
