### PR TITLE
Remove obsolete test condition for MDC

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -2268,12 +2268,7 @@ class TestEnvironment {
   }
 
   setTextFieldValue(textField: DebugElement, value: string): void {
-    // The text field may be either an input/textarea, or a component with an input/textarea within it.
-    // This differs between MDC and Material
-    const input = ['input', 'textarea'].includes(textField.name)
-      ? textField
-      : textField.query(By.css('input, textarea'));
-    const inputElem = input.nativeElement as HTMLInputElement;
+    const inputElem = textField.nativeElement as HTMLInputElement;
     inputElem.value = value;
     inputElem.dispatchEvent(new Event('input'));
     inputElem.dispatchEvent(new Event('change'));


### PR DESCRIPTION
A few months ago I added this condition in the tests so this method could support Material and MDC at the same time. It's no longer needed (as proven by the fact that the tests are still passing after I've removed the path that was there to accommodate MDC).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2070)
<!-- Reviewable:end -->
