### PR TITLE
Only require 7 taps on version to enable feature flags

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -46,7 +46,7 @@
           </a>
           <a mat-menu-item target="_blank" href="/3rdpartylicenses.txt">{{ t("open_source_licenses") }}</a>
           <button
-            *ngIf="versionNumberClickCount >= 10 || featureFlags.showFeatureFlags.enabled"
+            *ngIf="versionNumberClickCount >= 7 || featureFlags.showFeatureFlags.enabled"
             mat-menu-item
             (click)="openFeatureFlagDialog()"
           >


### PR DESCRIPTION
This makes the behavior consistent with Android 12 and Paratext Lite.

This PR probably wins some record for triviality. 

I picked 10 because I thought that's what Android did. However, after experimentation, I discovered I was mistaken.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2071)
<!-- Reviewable:end -->
