### PR TITLE
Remove autosize attribute from mat-drawer-container

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -99,12 +99,7 @@
     </mat-toolbar>
   </header>
 
-  <mat-drawer-container
-    class="top-app-bar-adjust"
-    [class.top-app-bar-adjust-double]="hasUpdate"
-    [dir]="i18n.direction"
-    autosize
-  >
+  <mat-drawer-container class="top-app-bar-adjust" [class.top-app-bar-adjust-double]="hasUpdate" [dir]="i18n.direction">
     <mat-drawer
       #drawer
       id="menu-drawer"


### PR DESCRIPTION
It was added by mistake, and the documentation warns about potential layout thrashing.

See https://v14.material.angular.io/components/sidenav/api#MatDrawerContainer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2072)
<!-- Reviewable:end -->
