### PR TITLE
SF-2222 Fix verse too long error for suggestions

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/translation-engine.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/translation-engine.service.ts
@@ -1,10 +1,5 @@
 import { Injectable } from '@angular/core';
-import {
-  InteractiveTranslator,
-  InteractiveTranslatorFactory,
-  LatinWordTokenizer,
-  MAX_SEGMENT_LENGTH
-} from '@sillsdev/machine';
+import { InteractiveTranslator, InteractiveTranslatorFactory, LatinWordTokenizer } from '@sillsdev/machine';
 import { Canon } from '@sillsdev/scripture';
 import * as crc from 'crc-32';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
@@ -159,12 +154,11 @@ export class TranslationEngineService extends SubscriptionDisposable {
       return;
     }
 
-    if (sourceText.length > MAX_SEGMENT_LENGTH) {
-      return;
-    }
-
     const factory: InteractiveTranslatorFactory = this.createInteractiveTranslatorFactory(projectRef);
     const translator: InteractiveTranslator = await factory.create(sourceText);
+    if (!translator.isSegmentValid) {
+      return;
+    }
     translator.setPrefix(targetText);
     await translator.approve(true);
     console.log('Segment ' + segment + ' of document ' + Canon.bookNumberToId(bookNum) + ' was trained successfully.');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.spec.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { NgModule, NgZone } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { MAX_SEGMENT_LENGTH, TranslationSources, WordGraph } from '@sillsdev/machine';
+import { TranslationSources, WordGraph } from '@sillsdev/machine';
 import { of, throwError } from 'rxjs';
 import { anything, instance, mock, when } from 'ts-mockito';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -110,17 +110,6 @@ describe('RemoteTranslationEngine', () => {
     expect(arc.alignment.get(1, 1)).toBe(true);
     arc = wordGraph.arcs[2];
     expect(arc.sources).toEqual([TranslationSources.None]);
-  });
-
-  it('get word graph with a too long segment', async () => {
-    const env = new TestEnvironment();
-    const segment = 'x'.repeat(MAX_SEGMENT_LENGTH + 1);
-
-    const wordGraph = await env.client.getWordGraph(segment);
-    expect(wordGraph.initialStateScore).toEqual(0);
-    expect(wordGraph.sourceTokens).toEqual([]);
-    expect(Array.from(wordGraph.finalStates)).toEqual([]);
-    expect(wordGraph.arcs.length).toEqual(0);
   });
 
   it('get stats is successful when engine exists', async () => {
@@ -320,21 +309,6 @@ describe('RemoteTranslationEngine', () => {
     expect(translationResult.translation).toEqual(translation);
   });
 
-  it('translate with a too long segment', async () => {
-    const env = new TestEnvironment();
-    const segment = 'x'.repeat(MAX_SEGMENT_LENGTH + 1);
-
-    const translationResult = await env.client.translate(segment);
-    expect(translationResult.alignment.columnCount).toEqual(0);
-    expect(translationResult.alignment.rowCount).toEqual(0);
-    expect(translationResult.confidences).toEqual([]);
-    expect(translationResult.phrases).toEqual([]);
-    expect(translationResult.sourceTokens).toEqual([]);
-    expect(translationResult.sources).toEqual([]);
-    expect(translationResult.targetTokens).toEqual([]);
-    expect(translationResult.translation).toEqual(segment);
-  });
-
   it('translate n executes successfully', async () => {
     const env = new TestEnvironment();
     const n = 1;
@@ -405,14 +379,6 @@ describe('RemoteTranslationEngine', () => {
     );
     expect(translationResults[0].targetTokens).toEqual(targetTokens);
     expect(translationResults[0].translation).toEqual(translation);
-  });
-
-  it('translate n with a too long segment', async () => {
-    const env = new TestEnvironment();
-    const segment = 'x'.repeat(MAX_SEGMENT_LENGTH + 1);
-
-    const translationResults = await env.client.translateN(1, segment);
-    expect(translationResults).toEqual([]);
   });
 
   it('listen for training status with 404 error', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.ts
@@ -1,11 +1,9 @@
 import {
   createRange,
-  MAX_SEGMENT_LENGTH,
   InteractiveTranslationEngine,
   Phrase,
   ProgressStatus,
   TranslationResult,
-  TranslationResultBuilder,
   WordAlignmentMatrix,
   WordGraph,
   WordGraphArc,
@@ -37,10 +35,6 @@ export class RemoteTranslationEngine implements InteractiveTranslationEngine {
   ) {}
 
   async translate(segment: string): Promise<TranslationResult> {
-    if (segment.length > MAX_SEGMENT_LENGTH) {
-      const builder = new TranslationResultBuilder([]);
-      return builder.toResult(segment);
-    }
     const response = await this.httpClient
       .post<TranslationResultDto>(
         `translation/engines/project:${this.projectId}/actions/translate`,
@@ -51,9 +45,6 @@ export class RemoteTranslationEngine implements InteractiveTranslationEngine {
   }
 
   async translateN(n: number, segment: string): Promise<TranslationResult[]> {
-    if (segment.length > MAX_SEGMENT_LENGTH) {
-      return [];
-    }
     const response = await this.httpClient
       .post<TranslationResultDto[]>(
         `translation/engines/project:${this.projectId}/actions/translate/${n}`,
@@ -65,10 +56,6 @@ export class RemoteTranslationEngine implements InteractiveTranslationEngine {
   }
 
   async getWordGraph(segment: string): Promise<WordGraph> {
-    if (segment.length > MAX_SEGMENT_LENGTH) {
-      return new WordGraph([]);
-    }
-
     try {
       const response = await this.httpClient
         .post<WordGraphDto>(


### PR DESCRIPTION
Scripture Forge is incorrectly checking the length of the string instead of checking the number of word tokens.

This PR updates Scripture Forge to use the `InteractiveTranslator.isSegmentValid` property to determine if the segment is too long instead, as recommended by the Serval team.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2083)
<!-- Reviewable:end -->
