### PR TITLE
SF-2255 Show biblical terms in default locale when blank

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/biblical-term-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/biblical-term-doc.ts
@@ -11,7 +11,11 @@ export class BiblicalTermDoc extends ProjectDataDoc<BiblicalTerm> {
 
   getBiblicalTermCategory(userLocaleCode: string, defaultLocaleCode: string): string {
     if (this.data?.definitions.hasOwnProperty(userLocaleCode)) {
-      return this.data.definitions[userLocaleCode].categories.join(', ');
+      let category = this.data.definitions[userLocaleCode].categories.join(', ');
+      if (category.trim() === '' && this.data?.definitions.hasOwnProperty(defaultLocaleCode)) {
+        category = this.data.definitions[defaultLocaleCode].categories.join(', ');
+      }
+      return category;
     } else if (this.data?.definitions.hasOwnProperty(defaultLocaleCode)) {
       return this.data.definitions[defaultLocaleCode].categories.join(', ');
     } else {
@@ -20,7 +24,7 @@ export class BiblicalTermDoc extends ProjectDataDoc<BiblicalTerm> {
   }
 
   getBiblicalTermGloss(userLocaleCode: string, defaultLocaleCode: string): string {
-    if (this.data?.definitions.hasOwnProperty(userLocaleCode)) {
+    if (this.data?.definitions.hasOwnProperty(userLocaleCode) && this.data.definitions[userLocaleCode].gloss !== '') {
       return this.data.definitions[userLocaleCode].gloss;
     } else if (this.data?.definitions.hasOwnProperty(defaultLocaleCode)) {
       return this.data.definitions[defaultLocaleCode].gloss;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.spec.ts
@@ -76,6 +76,19 @@ describe('BiblicalTermDialogComponent', () => {
     env.closeDialog();
   }));
 
+  it('should display the biblical term in the default language if the specified language has blank values', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.setupProjectData('es');
+    env.wait();
+
+    env.openDialog('id01');
+    expect(I18nService.defaultLocale.canonicalTag).toBe('en');
+    expect(env.definition).toBe('termId01 --- gloss01_en --- notes01_en');
+    expect(env.renderings.value).toBe('rendering01');
+    expect(env.description.value).toBe('description01');
+    env.closeDialog();
+  }));
+
   it('should display a biblical term with missing data', fakeAsync(() => {
     const env = new TestEnvironment();
     env.setupProjectData('en');
@@ -270,8 +283,8 @@ class TestEnvironment {
           es: {
             categories: [],
             domains: [],
-            gloss: 'gloss01_es',
-            notes: 'notes01_es'
+            gloss: '',
+            notes: ''
           },
           fr: {
             categories: ['category01_fr'],

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.ts
@@ -82,6 +82,16 @@ export class BiblicalTermDialogComponent extends SubscriptionDisposable {
     if (this.biblicalTermDoc?.data?.definitions.hasOwnProperty(this.i18n.localeCode)) {
       gloss = this.biblicalTermDoc?.data.definitions[this.i18n.localeCode].gloss;
       notes = this.biblicalTermDoc?.data.definitions[this.i18n.localeCode].notes;
+
+      // If the locale does not have the gloss or notes, get these from the default language, if we can
+      if (this.biblicalTermDoc?.data?.definitions.hasOwnProperty(I18nService.defaultLocale.canonicalTag)) {
+        if (gloss === '') {
+          gloss = this.biblicalTermDoc?.data.definitions[I18nService.defaultLocale.canonicalTag].gloss;
+        }
+        if (notes === '') {
+          notes = this.biblicalTermDoc?.data.definitions[I18nService.defaultLocale.canonicalTag].notes;
+        }
+      }
     } else if (this.biblicalTermDoc?.data?.definitions.hasOwnProperty(I18nService.defaultLocale.canonicalTag)) {
       gloss = this.biblicalTermDoc?.data.definitions[I18nService.defaultLocale.canonicalTag].gloss;
       notes = this.biblicalTermDoc?.data.definitions[I18nService.defaultLocale.canonicalTag].notes;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.spec.ts
@@ -86,6 +86,16 @@ describe('BiblicalTermsComponent', () => {
     expect((env.biblicalTermsCategory[0] as HTMLElement).innerText).toBe('category01_en');
   }));
 
+  it('should display biblical terms in the default language if the specified language has blank values', fakeAsync(() => {
+    const env = new TestEnvironment('project01', 1, 1);
+    env.setupProjectData('es');
+    env.wait();
+    expect(I18nService.defaultLocale.canonicalTag).toBe('en');
+    expect(env.biblicalTermsTerm.length).toBe(1);
+    expect((env.biblicalTermsTerm[0] as HTMLElement).innerText).toBe('termId01');
+    expect((env.biblicalTermsCategory[0] as HTMLElement).innerText).toBe('category01_en');
+  }));
+
   it('should display biblical terms with missing data', fakeAsync(() => {
     const env = new TestEnvironment('project01', 2, 2);
     env.setupProjectData('en');
@@ -379,8 +389,8 @@ class TestEnvironment {
           es: {
             categories: [],
             domains: [],
-            gloss: 'gloss01_es',
-            notes: 'notes01_es'
+            gloss: '',
+            notes: ''
           },
           fr: {
             categories: ['category01_fr'],


### PR DESCRIPTION
When changing to a language that does not have a gloss translated for a Biblical Term (i.e. ἅγιος-1 in Romans 1:2 in Spanish), a blank definition is shown. Instead, it should show the definition in the default language (English).

This PR provides fallbacks for blank Biblical Term translations for glosses, categories, and notes where they are blank in the translation file. This occurs most often for Spanish, as the Spanish XML file only has some translations where French is more complete.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2084)
<!-- Reviewable:end -->
