### PR TITLE
SF-2242 Fix verse not selected when undo moves cursor to another verse

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -752,8 +752,15 @@ export function registerScripture(): string[] {
       for (const op of delta.ops) {
         const modelOp: DeltaOperation = cloneDeep(op);
         const attrs = modelOp.attributes;
-        if (attrs != null && attrs['segment'] != null && attrs['highlight-segment'] == null) {
-          attrs['highlight-segment'] = false;
+        if (attrs != null && attrs['segment'] != null) {
+          if (attrs['highlight-segment'] == null) {
+            attrs['highlight-segment'] = false;
+          }
+          if (attrs['commenter-selection'] != null) {
+            // if this delta is applied to a verse that is not the current selection, this attribute
+            // should be null so when the selection changes, the verse will be correctly selected
+            attrs['commenter-selection'] = null;
+          }
         }
         if (typeof modelOp.insert === 'object') {
           // clear the formatting attributes on embeds to prevent dom elements from being corrupted,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -4,7 +4,7 @@ import { Component, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { TranslocoService } from '@ngneat/transloco';
 import { VerseRef } from '@sillsdev/scripture';
-import Quill, { DeltaStatic, RangeStatic, Sources, StringMap } from 'quill';
+import Quill, { DeltaStatic, RangeStatic, Sources } from 'quill';
 import QuillCursors from 'quill-cursors';
 import { User } from 'realtime-server/lib/esm/common/models/user';
 import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-data';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1298,8 +1298,7 @@ describe('EditorComponent', () => {
         .toEqual({
           'para-contents': true,
           segment: 'verse_1_2',
-          'highlight-segment': true,
-          'commenter-selection': true
+          'highlight-segment': true
         });
       // check to make sure that data after the affected segment hasn't gotten corrupted
       expect(contents.ops![verse3EmbedIndex].insert).toEqual({ verse: { number: '3', style: 'v' } });


### PR DESCRIPTION
The editor was correctly trying to apply an undo operation to a verse, but there was a bug that appeared if the undo causes the selection to change to another verse. This only seemed to happen if the undo deleted all of the text and introduced a blank. The solution I found was to set the commenter-selection attribute on the undo delta to be null. Then when the selection changes to the original verse, it gets the verse highlighting as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2085)
<!-- Reviewable:end -->
