### PR TITLE
Add Forward Translation Drafting feature flag

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -23,12 +23,12 @@
     <!-- TODO Find better link to languages or include in-app table with link to "learn more" -->
     <h3 class="requirements-header">Requirements</h3>
     <ul class="requirements">
-      <li>
+      <li *ngIf="!isForwardTranslationEnabled || isBackTranslation">
         <mat-icon *ngIf="isBackTranslation" class="criteria-met">check</mat-icon>
         <mat-icon *ngIf="!isBackTranslation" class="criteria-not-met">clear</mat-icon>
         <p>Your project type is <span *ngIf="!isBackTranslation">not</span> a back translation project.</p>
       </li>
-      <li>
+      <li *ngIf="!isForwardTranslationEnabled || isTargetLanguageSupported">
         <mat-icon *ngIf="isTargetLanguageSupported" class="criteria-met">check</mat-icon>
         <mat-icon *ngIf="!isTargetLanguageSupported" class="criteria-not-met">clear</mat-icon>
         <p>
@@ -51,6 +51,10 @@
         <mat-icon *ngIf="!isSourceProjectSet" class="criteria-not-met">clear</mat-icon>
         <p *ngIf="isSourceProjectSet">Your project has source text selected.</p>
         <p *ngIf="!isSourceProjectSet">Your project has no source text selected.</p>
+      </li>
+      <li *ngIf="isForwardTranslationEnabled">
+        <mat-icon class="criteria-met">check</mat-icon>
+        <p>Forward translation drafting is enabled.</p>
       </li>
     </ul>
   </section>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -6,6 +6,7 @@ import { Observable, of, Subscription } from 'rxjs';
 import { map, switchMap, tap } from 'rxjs/operators';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { DialogService } from 'xforge-common/dialog.service';
+import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
@@ -66,8 +67,7 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
 
   get isGenerationSupported(): boolean {
     return (
-      this.isBackTranslation &&
-      this.isTargetLanguageSupported &&
+      ((this.isBackTranslation && this.isTargetLanguageSupported) || this.isForwardTranslationEnabled) &&
       this.isSourceProjectSet &&
       this.isSourceAndTargetDifferent
     );
@@ -77,6 +77,7 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
     private readonly dialogService: DialogService,
     public readonly activatedProject: ActivatedProjectService,
     private readonly draftGenerationService: DraftGenerationService,
+    private readonly featureFlags: FeatureFlagService,
     private readonly nllbService: NllbLanguageService,
     private readonly i18n: I18nService,
     private readonly onlineStatusService: OnlineStatusService
@@ -115,6 +116,10 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
         this.pollBuild();
       }
     });
+  }
+
+  get isForwardTranslationEnabled(): boolean {
+    return this.featureFlags.allowForwardTranslationNmtDrafting.enabled;
   }
 
   // TODO: update i18n
@@ -172,11 +177,11 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
   getInfoAlert(): InfoAlert {
     // In order of priority...
 
-    if (!this.isBackTranslation) {
+    if (!this.isBackTranslation && !this.isForwardTranslationEnabled) {
       return InfoAlert.NotBackTranslation;
     }
 
-    if (!this.isTargetLanguageSupported) {
+    if (!this.isTargetLanguageSupported && !this.isForwardTranslationEnabled) {
       return InfoAlert.NotSupportedLanguage;
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -63,6 +63,11 @@ export class FeatureFlagService {
 
   showNmtDrafting: FeatureFlag = new FeatureFlag(new LocalStorageFlagStore('SHOW_NMT_DRAFTING'), 'Show NMT drafting');
 
+  allowForwardTranslationNmtDrafting: FeatureFlag = new FeatureFlag(
+    new LocalStorageFlagStore('ALLOW_FORWARD_TRANSLATION_NMT_DRAFTING'),
+    'Allow Forward Translation NMT drafting'
+  );
+
   scriptureAudio: FeatureFlag = new FeatureFlag(new LocalStorageFlagStore('SCRIPTURE_AUDIO'), 'Scripture audio');
 
   preventOpSubmission: FeatureFlag = new FeatureFlag(


### PR DESCRIPTION
This PR adds a feature flag that overrides the checks in back translation drafting for:

 * Whether the translation is a back translation
 * Whether the language is in the NLLB

This means that when this feature flag is enabled, testing of forward translation drafting can be done using Serval.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2087)
<!-- Reviewable:end -->
