### PR TITLE
SF-2246 Disallow typing or pasting backslashes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -699,6 +699,8 @@ export function registerScripture(): string[] {
       let text = e.clipboardData.getData('text/plain');
       // do not allow pasting new lines
       text = text.replace(/(?:\r?\n)+/, ' ');
+      // do not allow pasting backslashes
+      text = text.replace(/\\/g, '');
       setTimeout(() => {
         this.container.innerHTML = text;
         const pasteDelta: DeltaStatic = this.convert();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -894,6 +894,7 @@ describe('TextComponent', () => {
     env.fixture.detectChanges();
 
     const range: RangeStatic = env.component.getSegmentRange('verse_1_1')!;
+    const initialContents: string = env.component.getSegmentText('verse_1_1');
     env.component.editor!.setSelection(range.index, 'user');
     tick();
     env.fixture.detectChanges();
@@ -907,6 +908,8 @@ describe('TextComponent', () => {
     // the selection should not have changed
     const currentSelection: RangeStatic = env.component.editor!.getSelection()!;
     expect(currentSelection.index).toEqual(range.index);
+    const currentContents: string = env.component.getSegmentText('verse_1_1');
+    expect(currentContents).withContext('document text should not have changed').toEqual(initialContents);
   }));
 
   it('removes backslashes when pasting text', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -886,6 +886,56 @@ describe('TextComponent', () => {
     TestEnvironment.waitForPresenceTimer();
   }));
 
+  it('disallows typing a backslash', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.fixture.detectChanges();
+    env.component.id = new TextDocId('project01', 40, 1);
+    tick();
+    env.fixture.detectChanges();
+
+    const range: RangeStatic = env.component.getSegmentRange('verse_1_1')!;
+    env.component.editor!.setSelection(range.index, 'user');
+    tick();
+    env.fixture.detectChanges();
+    const backslashKeyCode = 220;
+    const backslashBindings = env.component.editor!.keyboard['bindings'][backslashKeyCode];
+    expect(backslashBindings.length).withContext('should have a backslash key handler').toEqual(1);
+    backslashBindings[0].handler();
+    tick();
+    env.fixture.detectChanges();
+
+    // the selection should not have changed
+    const currentSelection: RangeStatic = env.component.editor!.getSelection()!;
+    expect(currentSelection.index).toEqual(range.index);
+  }));
+
+  it('removes backslashes when pasting text', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.fixture.detectChanges();
+    env.component.id = new TextDocId('project01', 40, 1);
+    tick();
+    env.fixture.detectChanges();
+
+    const range: RangeStatic = env.component.getSegmentRange('verse_1_1')!;
+    env.component.editor!.setSelection(range.index, 0, 'user');
+    tick();
+    env.fixture.detectChanges();
+    const pasteText = '\\back\\slash';
+    let contents: DeltaStatic = env.component.getSegmentContents('verse_1_1')!;
+    expect(contents.ops![0].insert).toEqual('target: chapter 1, verse 1.');
+    const dataTransfer = new DataTransfer();
+    dataTransfer.setData('text/plain', pasteText);
+    const pasteEvent = new ClipboardEvent('paste', { clipboardData: dataTransfer });
+    env.component.editor!.root.dispatchEvent(pasteEvent);
+    tick(10);
+    env.fixture.detectChanges();
+
+    // the text is pasted with the backslashes removed
+    contents = env.component.getSegmentContents('verse_1_1')!;
+    expect(contents.ops![0].insert).toEqual('backslashtarget: chapter 1, verse 1.');
+    TestEnvironment.waitForPresenceTimer();
+  }));
+
   it('does not cancel paste when valid selection', fakeAsync(() => {
     const { env }: { env: TestEnvironment; segmentRange: RangeStatic } = basicSimpleText();
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -146,6 +146,11 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
           shiftKey: null,
           handler: () => false
         },
+        'disable backslash': {
+          key: 220,
+          shiftKey: null,
+          handler: () => false
+        },
         'move next, tab': {
           key: 'tab',
           shiftKey: false,


### PR DESCRIPTION
Backslashes can cause problems when we synchronize to Paratext. PT will show backslashes as errors in the editor, so it is better if we disallow backslashes altogether in SF.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2089)
<!-- Reviewable:end -->
