### PR TITLE
SF-2261 Set Scripture audio player max size when hiding text

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -125,7 +125,7 @@
                 [useTransition]="true"
               >
                 <!-- Splitter area sizes are controlled programmatically. -->
-                <as-split-area [size]="100">
+                <as-split-area [size]="100" [maxSize]="scriptureAreaMaxSize">
                   <div class="panel-content" #scripturePanelContainer>
                     <!-- TODO (scripture audio) Instead of covering scripture panel, move the audio player below it -->
                     <div class="scripture-audio-player-wrapper" *ngIf="showScriptureAudioPlayer">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -150,6 +150,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
   private text?: TextInfo;
   private isProjectAdmin: boolean = false;
   private _scriptureAudioPlayer?: CheckingScriptureAudioPlayerComponent;
+  private _scriptureAreaMaxSize: number | null = null;
 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
@@ -445,6 +446,15 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
   /** Percentage of the vertical space of the as-splitter, needed by just the Scripture audio player. */
   private get scriptureAudioPlayerHeightPercent(): number {
     return (this.scriptureAudioPlayerAreaHeight / this.splitContainerElementHeight) * 100;
+  }
+
+  /** maxSize for as-split-area for the Scripture+audio area. */
+  public get scriptureAreaMaxSize(): number | null {
+    return this._scriptureAreaMaxSize;
+  }
+
+  private set scriptureAreaMaxSize(value: number | null) {
+    this._scriptureAreaMaxSize = value;
   }
 
   ngOnInit(): void {
@@ -1131,6 +1141,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
       if (this.hideChapterText) {
         const answerPanelHeight = 100 - this.scriptureAudioPlayerHeightPercent;
         this.splitComponent?.setVisibleAreaSizes([this.scriptureAudioPlayerHeightPercent, answerPanelHeight]);
+        this.scriptureAreaMaxSize = this.scriptureAudioPlayerHeightPercent;
       } else {
         let answerPanelHeight: number;
         if (maximizeAnswerPanel) {
@@ -1143,6 +1154,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
         const scripturePanelHeight = 100 - answerPanelHeight;
 
         this.splitComponent.setVisibleAreaSizes([scripturePanelHeight, answerPanelHeight]);
+        this.scriptureAreaMaxSize = null;
       }
     }, changeUpdateDelayMs);
   }


### PR DESCRIPTION
Note that attempting to simplify this by putting the logic in `get
scriptureAreaMaxSize` resulted in "Expression has changed after it was
checked".

---

Following up from #1967, this PR sets `maxSize`. Please note that this PR is temporarily targeting unmerged branch `task/745682c8` for code review reasons, but is ultimately intended for master. 

Video showing new behaviour:
[scripture-audio-max-size.webm](https://github.com/sillsdev/web-xforge/assets/7265309/02381a52-a9e8-4d3f-9ae0-75fa33fd2619)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2090)
<!-- Reviewable:end -->
