### PR TITLE
SF-2258 Fix uploading of Biblical Terms to Serval

### DIFF
--- a/src/SIL.XForge.Scripture/Services/SFBiblicalTermsText.cs
+++ b/src/SIL.XForge.Scripture/Services/SFBiblicalTermsText.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using SIL.Machine.Corpora;
 using SIL.Machine.Tokenization;
+using SIL.XForge.Scripture.Models;
 
 namespace SIL.XForge.Scripture.Services;
 
@@ -13,6 +14,17 @@ public class SFBiblicalTermsText : IText
     private static readonly Regex BracketedTextRegex = new Regex(@"\([^)]*\)", RegexOptions.Compiled);
     private static readonly Regex WhitespaceRegex = new Regex(@"\s+", RegexOptions.Compiled);
     private readonly IEnumerable<TextSegment> _segments;
+
+    public SFBiblicalTermsText(
+        ITokenizer<string, int, string> wordTokenizer,
+        string projectId,
+        IList<BiblicalTerm> biblicalTerms
+    )
+    {
+        Id = $"{projectId}_biblical_terms";
+
+        _segments = GetSegments(wordTokenizer, biblicalTerms).OrderBy(s => s.SegmentRef).ToArray();
+    }
 
     public SFBiblicalTermsText(
         ITokenizer<string, int, string> wordTokenizer,
@@ -31,6 +43,61 @@ public class SFBiblicalTermsText : IText
 
     public IEnumerable<TextSegment> GetSegments(bool includeText = true, IText? basedOn = null) => _segments;
 
+    /// <summary>
+    /// Removes Paratext specific codes from the Biblical Term Rendering.
+    /// </summary>
+    /// <param name="rendering">The BT rendering.</param>
+    /// <returns>The cleaned rendering.</returns>
+    /// <remarks>
+    /// This method removes text in brackets, asterisks, forward slashes, and normalizes the whitespace.
+    /// See the Guide in the Edit Biblical Term Rendering dialog in Paratext for details on these codes.
+    /// </remarks>
+    private static string RemoveParatextSyntaxFromRendering(string rendering)
+    {
+        rendering = rendering.Replace("*", string.Empty);
+        rendering = BracketedTextRegex.Replace(rendering, string.Empty);
+        rendering = rendering.Replace("/", " ");
+        rendering = WhitespaceRegex.Replace(rendering, " ");
+        return rendering.Trim();
+    }
+
+    private IEnumerable<TextSegment> GetSegments(
+        ITokenizer<string, int, string> wordTokenizer,
+        IList<BiblicalTerm> biblicalTerms
+    )
+    {
+        if (!biblicalTerms.Any())
+        {
+            yield break;
+        }
+
+        foreach (BiblicalTerm biblicalTerm in biblicalTerms.OrderBy(t => t.TermId))
+        {
+            foreach (string rendering in biblicalTerm.Renderings.Select(RemoveParatextSyntaxFromRendering))
+            {
+                // Do not add blank renderings
+                if (string.IsNullOrWhiteSpace(rendering))
+                {
+                    continue;
+                }
+
+                // Get the words in the rendering
+                string[] segment = wordTokenizer.Tokenize(rendering).ToArray();
+
+                // Sentence placement is not essential for biblical terms. Set all to false
+                yield return new TextSegment(
+                    Id,
+                    new TextSegmentRef(biblicalTerm.TermId),
+                    segment,
+                    false,
+                    false,
+                    false,
+                    segment.Length == 0
+                );
+            }
+        }
+    }
+
     private IEnumerable<TextSegment> GetSegments(
         ITokenizer<string, int, string> wordTokenizer,
         XDocument termRenderingsDoc
@@ -44,25 +111,30 @@ public class SFBiblicalTermsText : IText
         foreach (
             XElement termRenderingElem in termRenderingsDoc.Root
                 .Elements("TermRendering")
-                .Where(tre => !(bool)tre.Attribute("Guess"))
+                .Where(t => !(bool)t.Attribute("Guess"))
+                .OrderBy(t => t.Attribute("Id")?.Value)
         )
         {
-            var id = (string)termRenderingElem.Attribute("Id");
+            string id = termRenderingElem.Attribute("Id")?.Value;
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                continue;
+            }
+
             var renderingsStr = (string?)termRenderingElem.Element("Renderings");
             string[] renderings =
                 renderingsStr?.Trim().Split("||", StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
 
-            foreach (string rendering in renderings)
+            foreach (string rendering in renderings.Select(RemoveParatextSyntaxFromRendering))
             {
-                // Clean up characters used for biblical term matching that we do not need
-                string data = rendering.Replace("*", string.Empty);
-                data = BracketedTextRegex.Replace(data, string.Empty);
-                data = data.Replace("/", " ");
-                data = WhitespaceRegex.Replace(data, " ");
-                data = data.Trim();
+                // Do not add blank renderings
+                if (string.IsNullOrWhiteSpace(rendering))
+                {
+                    continue;
+                }
 
                 // Get the words in the rendering
-                string[] segment = wordTokenizer.Tokenize(data).ToArray();
+                string[] segment = wordTokenizer.Tokenize(rendering).ToArray();
 
                 // Sentence placement is not essential for biblical terms. Set all to false
                 yield return new TextSegment(

--- a/src/SIL.XForge.Scripture/Services/SFBiblicalTermsText.cs
+++ b/src/SIL.XForge.Scripture/Services/SFBiblicalTermsText.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using SIL.Machine.Corpora;
 using SIL.Machine.Tokenization;
@@ -9,6 +10,8 @@ namespace SIL.XForge.Scripture.Services;
 
 public class SFBiblicalTermsText : IText
 {
+    private static readonly Regex BracketedTextRegex = new Regex(@"\([^)]*\)", RegexOptions.Compiled);
+    private static readonly Regex WhitespaceRegex = new Regex(@"\s+", RegexOptions.Compiled);
     private readonly IEnumerable<TextSegment> _segments;
 
     public SFBiblicalTermsText(
@@ -51,7 +54,16 @@ public class SFBiblicalTermsText : IText
 
             foreach (string rendering in renderings)
             {
-                string[] segment = wordTokenizer.Tokenize(rendering.Trim()).ToArray();
+                // Clean up characters used for biblical term matching that we do not need
+                string data = rendering.Replace("*", string.Empty);
+                data = BracketedTextRegex.Replace(data, string.Empty);
+                data = data.Replace("/", " ");
+                data = WhitespaceRegex.Replace(data, " ");
+                data = data.Trim();
+
+                // Get the words in the rendering
+                string[] segment = wordTokenizer.Tokenize(data).ToArray();
+
                 // Sentence placement is not essential for biblical terms. Set all to false
                 yield return new TextSegment(
                     Id,

--- a/test/SIL.XForge.Scripture.Tests/Services/SFBiblicalTermsTextTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFBiblicalTermsTextTests.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
 using NUnit.Framework;
 using SIL.Machine.Corpora;
 using SIL.Machine.Tokenization;
+using SIL.XForge.Scripture.Models;
 
 namespace SIL.XForge.Scripture.Services;
 
@@ -50,6 +52,24 @@ public class SFBiblicalTermsTextTests
     }
 
     [Test]
+    public void Segments_InvalidDocument()
+    {
+        var tokenizer = new LatinWordTokenizer();
+        var doc = new XDocument();
+        var text = new SFBiblicalTermsText(tokenizer, "project01", doc);
+        Assert.That(text.GetSegments(), Is.Empty);
+    }
+
+    [Test]
+    public void Segments_InvalidId()
+    {
+        var tokenizer = new LatinWordTokenizer();
+        var doc = new XDocument(new XElement("TermRenderingsList", TermRendering(string.Empty, guess: false, "Term1")));
+        var text = new SFBiblicalTermsText(tokenizer, "project01", doc);
+        Assert.That(text.GetSegments(), Is.Empty);
+    }
+
+    [Test]
     public void Segments_Renderings()
     {
         var tokenizer = new LatinWordTokenizer();
@@ -63,9 +83,14 @@ public class SFBiblicalTermsTextTests
         var text = new SFBiblicalTermsText(tokenizer, "project01", doc);
         TextSegment[] segments = text.GetSegments().ToArray();
         Assert.That(segments.Length, Is.EqualTo(2));
+
         Assert.That(segments[0].SegmentRef.ToString(), Is.EqualTo("term1"));
-        Assert.That(string.Join(" ", segments[0].Segment), Is.EqualTo("Term1"));
-        Assert.That(string.Join(" ", segments[1].Segment), Is.EqualTo("Term2"));
+        Assert.That(segments[0].Segment.Count, Is.EqualTo(1));
+        Assert.That(segments[0].Segment[0], Is.EqualTo("Term1"));
+
+        Assert.That(segments[1].SegmentRef.ToString(), Is.EqualTo("term2"));
+        Assert.That(segments[1].Segment.Count, Is.EqualTo(1));
+        Assert.That(segments[1].Segment[0], Is.EqualTo("Term2"));
     }
 
     [Test]
@@ -76,37 +101,44 @@ public class SFBiblicalTermsTextTests
             new XElement(
                 "TermRenderingsList",
                 TermRendering("term2", guess: false, "Term2-1", "Term2-2"),
-                TermRendering("term1", guess: false, "Term1", "\n")
+                TermRendering("term1", guess: false, "Term1", "\n", " ")
             )
         );
         var text = new SFBiblicalTermsText(tokenizer, "project01", doc);
         TextSegment[] segments = text.GetSegments().ToArray();
         Assert.That(segments.Length, Is.EqualTo(3));
-        Assert.That(string.Join(" ", segments[0].Segment), Is.EqualTo("Term1"));
+
+        Assert.That(segments[0].SegmentRef.ToString(), Is.EqualTo("term1"));
+        Assert.That(segments[0].Segment.Count, Is.EqualTo(1));
+        Assert.That(segments[0].Segment[0], Is.EqualTo("Term1"));
+
         Assert.That(segments[1].SegmentRef.ToString(), Is.EqualTo("term2"));
-        Assert.That(string.Join(" ", segments[1].Segment), Is.EqualTo("Term2-1"));
+        Assert.That(segments[1].Segment.Count, Is.EqualTo(1));
+        Assert.That(segments[1].Segment[0], Is.EqualTo("Term2-1"));
+
         Assert.That(segments[2].SegmentRef.ToString(), Is.EqualTo("term2"));
-        Assert.That(string.Join(" ", segments[2].Segment), Is.EqualTo("Term2-2"));
+        Assert.That(segments[2].Segment.Count, Is.EqualTo(1));
+        Assert.That(segments[2].Segment[0], Is.EqualTo("Term2-2"));
     }
 
     [Test]
     public void Segments_ComplexRenderings()
     {
         // These examples are drawn from the Paratext in-app documentation
-        var renderings = new List<(string rendering, string expected)>
+        var renderings = new List<(string rendering, string[] expected)>
         {
-            ("word1", "word1"),
-            ("word1 word2", "word1 word2"),
-            ("word1/word2", "word1 word2"),
-            ("word1 / word2", "word1 word2"),
-            ("word1 * word2", "word1 word2"),
-            ("word1 ** word2", "word1 word2"),
-            ("word1 * * word2", "word1 word2"),
-            ("word1*", "word1"),
-            ("*word1", "word1"),
-            ("*word1*", "word1"),
-            ("w*rd1", "wrd1"),
-            ("word1 (information)", "word1"),
+            ("word1", new[] { "word1" }),
+            ("word1 word2", new[] { "word1", "word2" }),
+            ("word1/word2", new[] { "word1", "word2" }),
+            ("word1 / word2", new[] { "word1", "word2" }),
+            ("word1 * word2", new[] { "word1", "word2" }),
+            ("word1 ** word2", new[] { "word1", "word2" }),
+            ("word1 * * word2", new[] { "word1", "word2" }),
+            ("word1*", new[] { "word1" }),
+            ("*word1", new[] { "word1" }),
+            ("*word1*", new[] { "word1" }),
+            ("w*rd1", new[] { "wrd1" }),
+            ("word1 (information)", new[] { "word1" }),
         };
 
         var tokenizer = new LatinWordTokenizer();
@@ -133,8 +165,47 @@ public class SFBiblicalTermsTextTests
         for (int i = 0; i < renderings.Count; i++)
         {
             Assert.That(segments[i].SegmentRef.ToString(), Is.EqualTo("Term" + (i + 1).ToString("D2")));
-            Assert.That(string.Join(" ", segments[i].Segment), Is.EqualTo(renderings[i].expected));
+            Assert.That(segments[i].Segment.Count, Is.EqualTo(renderings[i].expected.Length));
+            for (int j = 0; j < renderings[i].expected.Length; j++)
+            {
+                Assert.That(segments[i].Segment[j], Is.EqualTo(renderings[i].expected[j]));
+            }
         }
+    }
+
+    [Test]
+    public void Segments_BiblicalTermsFromMongo()
+    {
+        var tokenizer = new LatinWordTokenizer();
+        var biblicalTerms = new List<BiblicalTerm>
+        {
+            new BiblicalTerm { TermId = "term2", Renderings = { "Term2-1", "Term2-2" } },
+            new BiblicalTerm { TermId = "term1", Renderings = { "Term1", "\n" } },
+        };
+        var text = new SFBiblicalTermsText(tokenizer, "project01", biblicalTerms);
+        TextSegment[] segments = text.GetSegments().ToArray();
+        Assert.That(segments.Length, Is.EqualTo(3));
+
+        Assert.That(segments[0].SegmentRef.ToString(), Is.EqualTo("term1"));
+        Assert.That(segments[0].Segment.Count, Is.EqualTo(1));
+        Assert.That(segments[0].Segment[0], Is.EqualTo("Term1"));
+
+        Assert.That(segments[1].SegmentRef.ToString(), Is.EqualTo("term2"));
+        Assert.That(segments[1].Segment.Count, Is.EqualTo(1));
+        Assert.That(segments[1].Segment[0], Is.EqualTo("Term2-1"));
+
+        Assert.That(segments[2].SegmentRef.ToString(), Is.EqualTo("term2"));
+        Assert.That(segments[2].Segment.Count, Is.EqualTo(1));
+        Assert.That(segments[2].Segment[0], Is.EqualTo("Term2-2"));
+    }
+
+    [Test]
+    public void Segments_NoBiblicalTerms()
+    {
+        var tokenizer = new LatinWordTokenizer();
+        var biblicalTerms = Array.Empty<BiblicalTerm>();
+        var text = new SFBiblicalTermsText(tokenizer, "project01", biblicalTerms);
+        Assert.That(text.GetSegments(), Is.Empty);
     }
 
     private static XElement TermRendering(string id, bool guess, params string[] renderings) =>


### PR DESCRIPTION
This Pull Request fixes the upload of Biblical Terms to Serval based on feedback from the Serval team. In particular it:

 * Cleans renderings to not contain Paratext specific syntax
 * Loads Biblical Terms from MongoDB with fallback to the XML file if the terms are not yet populated in the database

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2091)
<!-- Reviewable:end -->
